### PR TITLE
Add ConsoleInLib to abstract console input

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -53,11 +53,13 @@
   gPlatformCommonLibTokenSpaceGuid.PcdHeciLibId              |          5 |  UINT8 | 0x20000106
   gPlatformCommonLibTokenSpaceGuid.PcdMmcTuningLibId         |          6 |  UINT8 | 0x20000107
 
-  gPlatformCommonLibTokenSpaceGuid.PcdCpuLocalApicBaseAddress| 0xFEE00000 | UINT32 | 0x20000186
-  gPlatformCommonLibTokenSpaceGuid.PcdSupportedMediaTypeMask | 0xFFFFFFFF | UINT32 | 0x20000187
-  gPlatformCommonLibTokenSpaceGuid.PcdMmcTuningLba           | 0x00000040 | UINT32 | 0x20000188
+  gPlatformCommonLibTokenSpaceGuid.PcdCpuLocalApicBaseAddress| 0xFEE00000 | UINT32  | 0x20000186
+  gPlatformCommonLibTokenSpaceGuid.PcdSupportedMediaTypeMask | 0xFFFFFFFF | UINT32  | 0x20000187
+  gPlatformCommonLibTokenSpaceGuid.PcdMmcTuningLba           | 0x00000040 | UINT32  | 0x20000188
   gPlatformCommonLibTokenSpaceGuid.PcdCryptoShaNiEnabled     | FALSE      | BOOLEAN | 0x20000200
   gPlatformCommonLibTokenSpaceGuid.PcdSeedListEnabled        | FALSE      | BOOLEAN | 0x20000203
+  gPlatformCommonLibTokenSpaceGuid.PcdConsoleInDeviceMask    | 0x00000001 | UINT32  | 0x20000300
+  gPlatformCommonLibTokenSpaceGuid.PcdConsoleOutDeviceMask   | 0x00000001 | UINT32  | 0x20000301
 
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   # For patchable PCDs, try to set the default as none-zero

--- a/BootloaderCommonPkg/Include/Library/ConsoleInLib.h
+++ b/BootloaderCommonPkg/Include/Library/ConsoleInLib.h
@@ -1,0 +1,55 @@
+/** @file
+Header file for console input library
+
+Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+This program and the accompanying materials
+are licensed and made available under the terms and conditions of the BSD License
+which accompanies this distribution.  The full text of the license may be found at
+http://opensource.org/licenses/bsd-license.php
+
+THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+
+#ifndef __CONSOLE_IN_H__
+#define __CONSOLE_IN_H__
+
+typedef enum {
+  ConsoleInSerialPort  = BIT0,
+  ConsoleInUsbKeyboard = BIT1,
+  ConsoleInAll         = 0xFFFFFFFF,
+} CONSOLE_IN_DEVICE_TYPE;
+
+
+/**
+  Poll a console to see if there is any data waiting to be read.
+
+  @retval FALSE                There is no data waiting to be read from the console.
+  @retval TRUE                 Data is waiting to be read from the console.
+
+**/
+BOOLEAN
+EFIAPI
+ConsolePoll (
+  VOID
+  );
+
+/**
+  Read data from a console device into a buffer.
+
+  @param  Buffer           Pointer to the data buffer to store the data read from the console device.
+  @param  NumberOfBytes    Number of bytes to read from the console device.
+
+  @retval 0                NumberOfBytes is 0.
+  @retval >0               The number of bytes read from the console device.
+                           If this value is less than NumberOfBytes, then the read operation failed.
+**/
+UINTN
+EFIAPI
+ConsoleRead (
+  OUT UINT8 *Buffer,
+  IN UINTN  NumberOfBytes
+  );
+
+#endif

--- a/BootloaderCommonPkg/Library/ConsoleInLib/ConsoleInLib.c
+++ b/BootloaderCommonPkg/Library/ConsoleInLib/ConsoleInLib.c
@@ -1,0 +1,74 @@
+/** @file
+Implementation for console input library
+
+Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+This program and the accompanying materials
+are licensed and made available under the terms and conditions of the BSD License
+which accompanies this distribution.  The full text of the license may be found at
+http://opensource.org/licenses/bsd-license.php
+
+THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+
+#include <Library/SerialPortLib.h>
+#include <Library/ConsoleInLib.h>
+
+/**
+  Poll a console to see if there is any data waiting to be read.
+
+  @retval FALSE                There is no data waiting to be read from the console.
+  @retval TRUE                 Data is waiting to be read from the console.
+
+**/
+BOOLEAN
+EFIAPI
+ConsolePoll (
+  VOID
+  )
+{
+
+  if ((PcdGet32 (PcdConsoleInDeviceMask) & ConsoleInSerialPort) != 0) {
+    if (SerialPortPoll ()) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
+  Read data from a console device into a buffer.
+
+  @param  Buffer           Pointer to the data buffer to store the data read from the console device.
+  @param  NumberOfBytes    Number of bytes to read from the console device.
+
+  @retval 0                NumberOfBytes is 0.
+  @retval >0               The number of bytes read from the console device.
+                           If this value is less than NumberOfBytes, then the read operation failed.
+**/
+UINTN
+EFIAPI
+ConsoleRead (
+  OUT UINT8 *Buffer,
+  IN UINTN  NumberOfBytes
+  )
+{
+  UINTN    Count;
+  UINTN    ReadCount;
+
+  Count = 0;
+  while (Count < NumberOfBytes) {
+    if ((PcdGet32 (PcdConsoleInDeviceMask) & ConsoleInSerialPort) != 0) {
+      if (SerialPortPoll ()) {
+        ReadCount = SerialPortRead (Buffer, 1);
+        Buffer += ReadCount;
+        Count  += ReadCount;
+      }
+    }
+  }
+
+  return NumberOfBytes;
+}
+

--- a/BootloaderCommonPkg/Library/ConsoleInLib/ConsoleInLib.inf
+++ b/BootloaderCommonPkg/Library/ConsoleInLib/ConsoleInLib.inf
@@ -1,0 +1,37 @@
+## @file
+#  INF for console input library
+#
+#  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+#
+#  This program and the accompanying materials are licensed and made available
+#  under the terms and conditions of the BSD License which accompanies this
+#  distribution. The full text of the license may be found at
+#  http://opensource.org/licenses/bsd-license.php
+#
+#  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = ConsoleInLib
+  FILE_GUID                      = 1F78F562-79BB-4090-9110-729E870B84F4
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = ConsoleInLib
+
+[Sources]
+  ConsoleInLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+
+[LibraryClasses]
+  BaseLib
+
+[Guids]
+
+[Pcd]
+  gPlatformCommonLibTokenSpaceGuid.PcdConsoleInDeviceMask

--- a/BootloaderCommonPkg/Library/ShellLib/Shell.c
+++ b/BootloaderCommonPkg/Library/ShellLib/Shell.c
@@ -13,7 +13,7 @@
 **/
 
 #include <Library/ShellLib.h>
-#include <Library/SerialPortLib.h>
+#include <Library/ConsoleInLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/TimerLib.h>
@@ -126,7 +126,7 @@ Shell (
     for (Index = Timeout; Index > 0; Index--) {
       ShellPrint (L"%c[80DPress any key within %d second(s) to enter the command shell", 0x1b, Index);
       for (Index1 = 0; Index1 < 10; Index1++) {
-        Start = SerialPortPoll();
+        Start = ConsolePoll ();
         if (Start) {
           break;
         }
@@ -215,7 +215,7 @@ ReadShellCommand (
 
     // Get next character from serial port
     Char = 0;
-    if (SerialPortRead (&Char, 1) < 1) {
+    if (ConsoleRead (&Char, 1) < 1) {
       return EFI_TIMEOUT;
     }
 
@@ -238,12 +238,12 @@ ReadShellCommand (
     // Handle key codes of the form: ESC [ x
     if (Char == ESC) {
       // Expect '[' character
-      if (SerialPortRead (&Char, 1) < 1) {
+      if (ConsoleRead (&Char, 1) < 1) {
         return EFI_TIMEOUT;
       }
       if (Char == '[') {
         // Expect command
-        if (SerialPortRead (&Char, 1) < 1) {
+        if (ConsoleRead (&Char, 1) < 1) {
           return EFI_TIMEOUT;
         }
 
@@ -305,7 +305,7 @@ ShellReadLine (
 
     // Get next character from serial port
     Char = 0;
-    if (SerialPortRead (&Char, 1) < 1) {
+    if (ConsoleRead (&Char, 1) < 1) {
       return EFI_TIMEOUT;
     }
 
@@ -328,12 +328,12 @@ ShellReadLine (
     // Handle key codes of the form: ESC [ x
     if (Char == ESC) {
       // Expect '[' character
-      if (SerialPortRead (&Char, 1) < 1) {
+      if (ConsoleRead (&Char, 1) < 1) {
         return EFI_TIMEOUT;
       }
       if (Char == '[') {
         // Expect command
-        if (SerialPortRead (&Char, 1) < 1) {
+        if (ConsoleRead (&Char, 1) < 1) {
           return EFI_TIMEOUT;
         }
 
@@ -399,7 +399,7 @@ ShellReadUintn (
 
     // Get next character from serial port
     Char = 0;
-    if (SerialPortRead (&Char, 1) < 1) {
+    if (ConsoleRead (&Char, 1) < 1) {
       return EFI_TIMEOUT;
     }
 

--- a/BootloaderCommonPkg/Library/ShellLib/ShellLib.inf
+++ b/BootloaderCommonPkg/Library/ShellLib/ShellLib.inf
@@ -55,7 +55,7 @@
   BaseLib
   BaseMemoryLib
   DebugLib
-  SerialPortLib
+  ConsoleInLib
   PrintLib
   IoLib
   MmcAccessLib

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -118,6 +118,7 @@
   ShellExtensionLib|BootloaderCommonPkg/Library/ShellExtensionLibNull/ShellExtensionLibNull.inf
   DebugLogBufferLib|BootloaderCommonPkg/Library/DebugLogBufferLib/DebugLogBufferLib.inf
   DebugLib|BootloaderCommonPkg/Library/BootloaderDebugLib/BootloaderDebugLib.inf
+  ConsoleInLib|BootloaderCommonPkg/Library/ConsoleInLib/ConsoleInLib.inf
 !if $(HAVE_FSP_BIN)
   FspApiLib|$(PLATFORM_PACKAGE)/Library/FspApiLib/FspApiLib.inf
 !endif
@@ -209,6 +210,9 @@
   gPlatformModuleTokenSpaceGuid.PcdRedundantRegionSize    | $(REDUNDANT_SIZE)
   gPlatformModuleTokenSpaceGuid.PcdCfgDataLoadSource      | $(CFGDATA_REGION_TYPE)
   gPlatformModuleTokenSpaceGuid.PcdCfgDatabaseSize        | $(CFG_DATABASE_SIZE)
+
+  gPlatformCommonLibTokenSpaceGuid.PcdConsoleInDeviceMask  | $(CONSOLE_IN_DEVICE_MASK)
+  gPlatformCommonLibTokenSpaceGuid.PcdConsoleOutDeviceMask | $(CONSOLE_OUT_DEVICE_MASK)
 
   gPlatformModuleTokenSpaceGuid.PcdVerifiedBootHashMask   | $(VERIFIED_BOOT_HASH_MASK)
   gPlatformCommonLibTokenSpaceGuid.PcdCryptoShaNiEnabled  | $(ENABLE_CRYPTO_SHA_NI)

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -114,7 +114,7 @@ def prep_env ():
 		os.environ['WORKSPACE'] = sblsource
 	os.environ['CONF_PATH']     = os.path.join(os.environ['WORKSPACE'], 'Conf')
 	os.environ['TOOL_CHAIN']    = toolchain
-	
+
 	# Check if BaseTools has been compiled
 	rebuild_basetools ()
 
@@ -164,6 +164,8 @@ class BaseBoard(object):
 
 		self.VERIFIED_BOOT_HASH_MASK  = 0x00000000
 		self.BOOT_MEDIA_SUPPORT_MASK  = 0xFFFFFFFF
+		self.CONSOLE_IN_DEVICE_MASK   = 0x00000001
+		self.CONSOLE_OUT_DEVICE_MASK  = 0x00000001
 
 		self.HAVE_VBT_BIN          = 0
 		self.HAVE_FIT_TABLE        = 0


### PR DESCRIPTION
Current implementation assumes serial port is the only input console
device supported.  But other input console devices can be added later
on. This patch added a ConsoleInLib to abstract the input console
interfaces.  It also added PCDs to control enabled input console
devices.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>