### PR TITLE
There is a compiler issue when use Visual studio 2015.

### DIFF
--- a/Silicon/ApollolakePkg/Include/Library/HeciLib.h
+++ b/Silicon/ApollolakePkg/Include/Library/HeciLib.h
@@ -146,7 +146,7 @@ typedef union {
     UINT32  HostAddress : 8;        // This is the logical address of the Host client of the message.
     UINT32  Length : 9;             // This is the message length in bytes, not including the HECI_MESSAGE_HEADER
     UINT32  Reserved : 6;
-    UINT32  MessageComplete : 1;    // This bit is used to indicate that this is the last message of a multi message HECI transfer of a client’s message that is larger than HECI circular buffer.
+    UINT32  MessageComplete : 1;    // This bit is used to indicate that this is the last message of a multi message HECI transfer of a client's message that is larger than HECI circular buffer.
   } Fields;
 } HeciMessageHeader;
 


### PR DESCRIPTION
Root-cause is Special characters (comma) exist in the header file.

Silicon\ApollolakePkg\Include\Library/HeciLib.h: warning C4819: The file contains a character that cannot be represented in the current code page (950). Save the file in Unicode format to prevent data loss

Sincerely,
Ethan Hsu