### PR TITLE
[APL] Fix size bug when copy BootOption

### DIFF
--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1194,7 +1194,7 @@ UpdateOsBootMediumInfo (
       OsBootCfgData->OsBootOptionCount, PcdGet32(PcdOsBootOptionNumber)));
   }
 
-  Length = sizeof(OS_BOOT_OPTION_LIST) + sizeof (OS_BOOT_OPTION) * Count;
+  Length = sizeof (OS_BOOT_OPTION) * Count;
   CopyMem(OsBootOptionList->OsBootOption, OsBootCfgData->OsBootOptions, Length);
 
   //


### PR DESCRIPTION
When copying boot option from configuration data to
internal boot option structure, the code should just
copy exact size required for boot options.

Signed-off-by: Guo Dong <guo.dong@intel.com>