### PR TITLE
Enable graphics framebuffer as WriteCombining

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -136,15 +136,21 @@
 
 
 [PcdsFeatureFlag]
-  gPlatformModuleTokenSpaceGuid.PcdIntelGfxEnabled        | FALSE      | BOOLEAN | 0x20000202
+  # Determine if the Intel GFX device should be enabled or not in system
+  gPlatformModuleTokenSpaceGuid.PcdIntelGfxEnabled        | TRUE       | BOOLEAN | 0x20000200
+  # Determine if the GFX framebuffer should be initialized or not.
+  gPlatformModuleTokenSpaceGuid.PcdFramebufferInitEnabled | FALSE      | BOOLEAN | 0x20000201
+  # Determine if the splash screen should be displayed or not.
+  gPlatformModuleTokenSpaceGuid.PcdSplashEnabled          | FALSE      | BOOLEAN | 0x20000202
+
   gPlatformModuleTokenSpaceGuid.PcdAcpiEnabled            | TRUE       | BOOLEAN | 0x20000203
   gPlatformModuleTokenSpaceGuid.PcdSmpEnabled             | TRUE       | BOOLEAN | 0x20000204
   gPlatformModuleTokenSpaceGuid.PcdPciEnumEnabled         | TRUE       | BOOLEAN | 0x20000205
   gPlatformModuleTokenSpaceGuid.PcdStage1BXip             | TRUE       | BOOLEAN | 0x20000206
   gPlatformModuleTokenSpaceGuid.PcdStage1AXip             | TRUE       | BOOLEAN | 0x20000207
   gPlatformModuleTokenSpaceGuid.PcdLoadImageUseFsp        | FALSE      | BOOLEAN | 0x20000209
-  gPlatformModuleTokenSpaceGuid.PcdSplashEnabled          | TRUE       | BOOLEAN | 0x2000020A
   gPlatformModuleTokenSpaceGuid.PcdVtdEnabled             | FALSE      | BOOLEAN | 0x2000020B
   gPlatformModuleTokenSpaceGuid.PcdFlashMapEnabled        | FALSE      | BOOLEAN | 0x2000020C
   gPlatformModuleTokenSpaceGuid.PcdS3DebugEnabled         | FALSE      | BOOLEAN | 0x2000020D
   gPlatformModuleTokenSpaceGuid.PcdPsdBiosEnabled         | FALSE      | BOOLEAN | 0x2000020E
+

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -271,6 +271,7 @@
   gPlatformModuleTokenSpaceGuid.PcdStage1BXip             | $(STAGE1B_XIP)
   gPlatformModuleTokenSpaceGuid.PcdLoadImageUseFsp        | $(ENABLE_FSP_LOAD_IMAGE)
   gPlatformModuleTokenSpaceGuid.PcdSplashEnabled          | $(ENABLE_SPLASH)
+  gPlatformModuleTokenSpaceGuid.PcdFramebufferInitEnabled | $(ENABLE_FRAMEBUFFER_INIT)
   gPlatformModuleTokenSpaceGuid.PcdVtdEnabled             | $(VTD_ENABLED)
   gPlatformModuleTokenSpaceGuid.PcdFlashMapEnabled        | $(HAVE_FLASH_MAP)
   gPlatformModuleTokenSpaceGuid.PcdPsdBiosEnabled         | $(HAVE_PSD_TABLE)

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -184,6 +184,7 @@ class BaseBoard(object):
 		self.ENABLE_SMP_INIT       = 1
 		self.ENABLE_FSP_LOAD_IMAGE = 0
 		self.ENABLE_SPLASH         = 0
+		self.ENABLE_FRAMEBUFFER_INIT = 0
 		self.ENABLE_CRYPTO_SHA_NI  = 0
 		self.ENABLE_FWU            = 0
 		self.ENABLE_SOURCE_DEBUG   = 0

--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -50,11 +50,12 @@ class Board(BaseBoard):
 		self.HAVE_SEED_LIST       = 0
 		self.HAVE_PSD_TABLE       = 1
 
-		self.ENABLE_FSP_LOAD_IMAGE = 0
-		self.ENABLE_CRYPTO_SHA_NI  = 1
-		self.VTD_ENABLED           = 1
-		self.ENABLE_FWU            = 1
-		self.ENABLE_SPLASH         = 1
+		self.ENABLE_FSP_LOAD_IMAGE    = 0
+		self.ENABLE_CRYPTO_SHA_NI     = 1
+		self.VTD_ENABLED              = 1
+		self.ENABLE_FWU               = 1
+		self.ENABLE_SPLASH            = 1
+		self.ENABLE_FRAMEBUFFER_INIT  = 1
 
 		# To enable source debug, set 1 to self.ENABLE_SOURCE_DEBUG
 		# self.ENABLE_SOURCE_DEBUG   = 1

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -93,4 +93,5 @@
   gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootEnabled
   gPlatformModuleTokenSpaceGuid.PcdSplashEnabled
+  gPlatformModuleTokenSpaceGuid.PcdFramebufferInitEnabled
 

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -44,12 +44,12 @@ class Board(BaseBoard):
 		self.PCI_IO_BASE          = 0x00002000
 		self.PCI_MEM32_BASE       = 0x80000000
 
-		self.HAVE_VERIFIED_BOOT   = 1
-		self.HAVE_VBT_BIN         = 1
-		self.ENABLE_SPLASH        = 1
-		self.HAVE_FLASH_MAP       = 1
-
-		self.ENABLE_FWU           = 1
+		self.HAVE_VERIFIED_BOOT       = 1
+		self.HAVE_VBT_BIN             = 1
+		self.HAVE_FLASH_MAP           = 1
+		self.ENABLE_SPLASH            = 1
+		self.ENABLE_FRAMEBUFFER_INIT  = 1
+		self.ENABLE_FWU               = 1
 
 		# To enable source debug, set 1 to self.ENABLE_SOURCE_DEBUG
 		# self.ENABLE_SOURCE_DEBUG  = 1

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -240,7 +240,11 @@ UpdateFspConfig (
   FspsUpd    = (FSPS_UPD *)FspUpdRgnPtr;
   FspsConfig = &FspsUpd->FspsConfig;
 
-  FspsConfig->GraphicsConfigPtr = PcdGet32(PcdGraphicsVbtAddress);
+  if (PcdGetBool (PcdFramebufferInitEnabled)) {
+    FspsConfig->GraphicsConfigPtr = PcdGet32 (PcdGraphicsVbtAddress);
+  } else {
+    FspsConfig->GraphicsConfigPtr = 0;
+  }
 
   SilCfgData = (SILICON_CFG_DATA *)FindConfigDataByTag (CDATA_SILICON_TAG);
   if (SilCfgData == NULL) {

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -59,5 +59,6 @@
   gPlatformModuleTokenSpaceGuid.PcdMaxServiceNumber
   gPlatformModuleTokenSpaceGuid.PcdVariableRegionBase
   gPlatformModuleTokenSpaceGuid.PcdVariableRegionSize
+  gPlatformModuleTokenSpaceGuid.PcdFramebufferInitEnabled
 
 


### PR DESCRIPTION
On APL platform, all PCI MMIO range is set to UC in current
implementation. It includes graphics framebuffer MMIO. It
caused the system performance issue due to large mount of
framebuffer write access. This patch set framebuffer as
WC (WriteCombining) per recommendation to enhance system
performance.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>