### PR TITLE
Report APL SoC reserved MMIO resources through ACPI

### DIFF
--- a/Platform/ApollolakeBoardPkg/AcpiTables/Dsdt/PciDrc.asl
+++ b/Platform/ApollolakeBoardPkg/AcpiTables/Dsdt/PciDrc.asl
@@ -75,5 +75,11 @@ Scope (\_SB.PCI0) {
       //
       Memory32Fixed (ReadOnly, 0x0FEE00000, 0x0100000, LIOH)
     })
+
+    Method(_CRS,0,Serialized)
+    {
+        Return(BUF0)
+    }
+
   }
 }


### PR DESCRIPTION
On APL platform, the chipset SoC reserved MMIO resources are not
reported properly to OS through ACPI. It should report it using
_CRS method. This patch fixes #28.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>