### PR TITLE
[DebugAgent] Fix image info loading failure in QEMU CAR stage

### DIFF
--- a/BootloaderCommonPkg/Library/DebugAgentLib/DebugAgentLib.c
+++ b/BootloaderCommonPkg/Library/DebugAgentLib/DebugAgentLib.c
@@ -517,6 +517,18 @@ InitializeDebugAgentPhase2 (
 
   if (Phase2Context->InitFlag == DEBUG_AGENT_INIT_PREMEM_SEC) {
     //
+    // If Temporary RAM region is below 128 MB, then send message to
+    // host to disable low memory filtering.
+    // Check a stack variable address simply.
+    //
+    if (((UINTN) &NewDebugPortHandle < BASE_128MB) && (IsHostAttached () == TRUE)) {
+      SetDebugFlag (DEBUG_AGENT_FLAG_MEMORY_READY, 1);
+      //
+      // Trigger one software interrupt to inform HOST
+      //
+      TriggerSoftInterrupt (MEMORY_READY_SIGNATURE);
+    }
+    //
     // Enable Debug Timer interrupt
     //
     SaveAndSetDebugTimerInterrupt (TRUE);


### PR DESCRIPTION
QEMU FSP reports that CAR base is 0x0, but DebugAgent cannot access
the memory space since MEMORY_READY is not set.
In order to disable low memory filtering, simply check CAR space and
then trigger MEMORY_READY.

Change-Id: I9e1703215c95fd64e2a0be3afd001c59f736e81b
Signed-off-by: Aiden Park <aiden.park@intel.com>