### PR TITLE
Add basic SMM rebasing support

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -117,14 +117,21 @@
   gPlatformModuleTokenSpaceGuid.PcdSeedListBufferSize     | 0x00000400 | UINT32 | 0x200000E2
 
 [PcdsFixedAtBuild, PcdsPatchableInModule]
-  # For patchable PCDs, try to set the default as none-zero
-  # It is to prevent it from being put into BSS section, thus cause patching issue
+  #
+  # For module patchable PCDs, if it is required to do static patching during the build
+  # process using PatchFv.py script, then they should be set to non-zero default values.
+  # It is to prevent it from being put into BSS section, thus cause issue during pacting
+  # because the PCD symbol won't be available in MAP file.
+  # If static patching is not required, zero default value can be used with no issue.
+  #
   gPlatformModuleTokenSpaceGuid.PcdFSPSBase               | 0xFF000000 | UINT32 | 0x20000100
   gPlatformModuleTokenSpaceGuid.PcdAcpiTablesMaxEntry     |         32 | UINT32 | 0x2000000C
   gPlatformModuleTokenSpaceGuid.PcdAcpiTablesRsdp         | 0x00000000 | UINT32 | 0x2000000D
   gPlatformModuleTokenSpaceGuid.PcdAcpiTablesAddress      | 0xFF000000 | UINT32 | 0x20000110
   gPlatformModuleTokenSpaceGuid.PcdAcpiGnvsAddress        | 0xFF000000 | UINT32 | 0x20000112
   gPlatformModuleTokenSpaceGuid.PcdGraphicsVbtAddress     | 0xFF000000 | UINT32 | 0x20000113
+  gPlatformModuleTokenSpaceGuid.PcdSmramTsegBase          | 0xFF000000 | UINT32 | 0x20000120
+  gPlatformModuleTokenSpaceGuid.PcdSmramTsegSize          | 0x00000000 | UINT32 | 0x20000121
   gPlatformModuleTokenSpaceGuid.PcdKeyStoreBase           | 0xFF000000 | UINT32 | 0x20000181
   gPlatformModuleTokenSpaceGuid.PcdDeviceTreeBase         | 0xFF000000 | UINT32 | 0x20000183
   gPlatformModuleTokenSpaceGuid.PcdSplashLogoAddress      | 0xFF000000 | UINT32 | 0x20000184
@@ -153,4 +160,4 @@
   gPlatformModuleTokenSpaceGuid.PcdFlashMapEnabled        | FALSE      | BOOLEAN | 0x2000020C
   gPlatformModuleTokenSpaceGuid.PcdS3DebugEnabled         | FALSE      | BOOLEAN | 0x2000020D
   gPlatformModuleTokenSpaceGuid.PcdPsdBiosEnabled         | FALSE      | BOOLEAN | 0x2000020E
-
+  gPlatformModuleTokenSpaceGuid.PcdSmmRebaseEnabled       | FALSE      | BOOLEAN | 0x2000020F

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -254,6 +254,8 @@
   gPlatformModuleTokenSpaceGuid.PcdSplashLogoAddress | 0xFF000000
   gPlatformCommonLibTokenSpaceGuid.PcdEmmcMaxRwBlockNumber     | 0xFFFF
   gPlatformModuleTokenSpaceGuid.PcdPayloadReservedMemSize | $(PLD_RSVD_MEM_SIZE)
+  gPlatformModuleTokenSpaceGuid.PcdSmramTsegBase     | 0xFF000000
+  gPlatformModuleTokenSpaceGuid.PcdSmramTsegSize     | 0x00000000
 
   gPayloadTokenSpaceGuid.PcdPayloadHobList           | 0x00000000
   gPayloadTokenSpaceGuid.PcdPayloadHeapSize          | $(PLD_HEAP_SIZE)
@@ -276,6 +278,8 @@
   gPlatformModuleTokenSpaceGuid.PcdVtdEnabled             | $(VTD_ENABLED)
   gPlatformModuleTokenSpaceGuid.PcdFlashMapEnabled        | $(HAVE_FLASH_MAP)
   gPlatformModuleTokenSpaceGuid.PcdPsdBiosEnabled         | $(HAVE_PSD_TABLE)
+  gPlatformModuleTokenSpaceGuid.PcdSmmRebaseEnabled       | $(ENABLE_SMM_REBASE)
+
 !ifdef $(S3_DEBUG)
   gPlatformModuleTokenSpaceGuid.PcdS3DebugEnabled         | $(S3_DEBUG)
 !endif

--- a/BootloaderCorePkg/Library/MpInitLib/Ia32/MpFuncs.nasm
+++ b/BootloaderCorePkg/Library/MpInitLib/Ia32/MpFuncs.nasm
@@ -12,9 +12,9 @@
 ; Module Name:
 ;
 ;   MpFuncs.asm
-; 
+;
 ; Abstract:
-; 
+;
 ;   This is the assembly code for initializing the APs in IA32 Protected Mode
 ;
 ;-------------------------------------------------------------------------------
@@ -23,23 +23,36 @@ SECTION .text
 ;-------------------------------------------------------------------------------------
 ;RendezvousFunnelProc  procedure follows. All APs execute their procedure. This
 ;procedure does NOT serialize the AP processors. So this procedure cannot be the
-;vector for a boradcast IPI. 
-; 
+;vector for a boradcast IPI.
+;
 ;It must be noted that APs arrive here very raw...ie: real mode, no stack.
 ;-------------------------------------------------------------------------------------
 SPIN_LOCK_RELEASED   EQU   0
 SPIN_LOCK_ACQUIRED   EQU   1
 
- 
+
 global ASM_PFX(RendezvousFunnelProc)
 ASM_PFX(RendezvousFunnelProc):
 RendezvousFunnelProcStart:
 ; At this point CS = 0x(vv00) and ip= 0x0.
-  
+  db 0fh,  20h, 0d0h            ; mov        eax, cr2
+  db 66h,  09h, 0c0h            ; or         eax, eax
+
+  ; For SMM rebase flow, CR2 will be pre-filled with SMBASE
+  ; The same stub code will be shared for SMM rebasing and start IPI.
+  jz StartIpi
+
+  ; The ASM code needs to use same 0x3800 segment as start IPI.
+  ; At initial SMM entry the segment is 0x3000, so force a long jump.
+  db 0eah                       ; jmp        0x3800:StartIpi
+  dw StartIpi - RendezvousFunnelProcStart
+  dw 0x3800
+
+StartIpi:
   db 8ch,  0c8h                 ; mov        ax,  cs
   db 8eh,  0d8h                 ; mov        ds,  ax
   db 8eh,  0c0h                 ; mov        es,  ax
-  db 8eh,  0d0h                 ; mov        ss,  ax 
+  db 8eh,  0d0h                 ; mov        ss,  ax
   db 33h,  0c0h                 ; xor        ax,  ax
   db 8eh,  0e0h                 ; mov        fs,  ax
   db 8eh,  0e8h                 ; mov        gs,  ax
@@ -49,7 +62,7 @@ RendezvousFunnelProcStart:
   db 66h,  8Bh, 14h             ; mov        edx,dword ptr [si]          ; EDX is keeping the start address of wakeup buffer
 
   ; Since CS and DS point to the start of the buffer, we can just use the offset in SI
-  
+
   db 0BEh
   dw GdtrLocation               ; mov        si, GdtrProfile
   db 66h                        ; db         66h
@@ -59,7 +72,7 @@ RendezvousFunnelProcStart:
   dw IdtrLocation               ; mov        si, IdtrProfile
   db 66h                        ; db         66h
   db 2Eh,  0Fh, 01h, 1Ch        ; lidt       fword ptr cs:[si]
-        
+
   db 0Fh,  20h, 0C0h            ; mov        eax, cr0                    ; Get control register 0
   db 66h,  83h, 0C8h, 03h       ; or         eax, 000000003h             ; Set PE bit (bit #0) and MP
   db 0Fh,  22h, 0C0h            ; mov        cr0, eax
@@ -70,13 +83,19 @@ FLAT32_JUMP:
   dd 0h                         ; 32-bit offset
   dw 0h                         ; 16-bit selector
 
-ProtModeStart:                 ; protected mode entry point
+SmmRebase:
+  mov         edi,  0x3fef8     ; SMBASE offset
+  mov         dword [edi], eax  ; change to new  SMBASE
+  mov         dword [eax + 0x8000], 0x9090AA0F  ; write 'RSM' at new SMM handler entry
+  rsm
+  jmp         $
 
+ProtModeStart:                  ; protected mode entry point
   ; Since CS and DS base is set to 0, we need to add the buffer start to use the offset
 
   mov        esi, edx           ; EDX is keeping the start address of wakeup buffer
-  
-  mov        ax, word [cs:esi + DSSelectorLocation]                      
+
+  mov        ax, word [cs:esi + DSSelectorLocation]
   mov		     ds, ax
 
   mov        ax, word [cs:esi + ESSelectorLocation]
@@ -93,6 +112,10 @@ ProtModeStart:                 ; protected mode entry point
 
   cli
 
+  mov        eax, cr2           ; CR2 will be set to the new SMBASE before SMI IPI is generated
+  or         eax, eax
+  jnz        SmmRebase
+
   mov        eax, cr0           ; Enable cache
   and        eax, 09fffffffh
   mov        cr0, eax
@@ -100,7 +123,7 @@ ProtModeStart:                 ; protected mode entry point
   mov        eax, cr4           ; ENABLE_SSE
   or         eax, 00000600h
   mov        cr4, eax
-  
+
 CallApFunc:
   ;
   ; Acquire Lock
@@ -109,22 +132,22 @@ CallApFunc:
   mov            edx, SPIN_LOCK_ACQUIRED
   lock cmpxchg   dword [esi + SpinLockLocation], edx
   jnz            CallApFunc
-  
+
   ;
   ; Calculate stack
-  ;  
+  ;
   inc            dword [esi + ApCounterLocation]
   mov            eax, dword [esi + ApCounterLocation]
   mov            ebx, eax
-  
-  ; 
+
+  ;
   ; Program AP stack for each thread
-  ;    
-  mov            ecx, dword [esi + ApStackSizeLocation]  
+  ;
+  mov            ecx, dword [esi + ApStackSizeLocation]
   shl            eax, cl
-  add            eax, dword [esi + StackStartLocation]  
+  add            eax, dword [esi + StackStartLocation]
   lea            esp, [eax - 4]
-  
+
   ;
   ; Release Lock
   ;
@@ -137,15 +160,15 @@ CallApFunc:
   mov            eax, dword [esi + CProcedureLocation]
   test           eax, eax
   jz             GoToSleep
-  
+
   mov            eax, dword [esi + MpDataStructureLocation]
   push           eax
   push           ebx
-  
+
   mov            eax, dword [esi + CProcedureLocation]
   call           eax
   add            esp, 8
-   
+
   wbinvd
 
 GoToSleep:
@@ -153,7 +176,7 @@ GoToSleep:
   cli
   hlt
   jmp         $-2
-        
+
 
 RendezvousFunnelProcEnd:
 
@@ -167,46 +190,50 @@ db		0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 IdtrLocation                  equ        BufferStartLocation + 0Eh
 db		0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
-ReservedDDLocation            equ        BufferStartLocation + 18h 
+ReservedDDLocation            equ        BufferStartLocation + 18h
 dd    0
 
-CSSelectorLocation            equ        BufferStartLocation + 1Ch 
+CSSelectorLocation            equ        BufferStartLocation + 1Ch
 dw		0
 
-DSSelectorLocation            equ        BufferStartLocation + 1Eh 
+DSSelectorLocation            equ        BufferStartLocation + 1Eh
 dw		0
 
-ESSelectorLocation            equ        BufferStartLocation + 20h 
+ESSelectorLocation            equ        BufferStartLocation + 20h
 dw		0
 
-SSSelectorLocation            equ        BufferStartLocation + 22h 
+SSSelectorLocation            equ        BufferStartLocation + 22h
 dw		0
 
-FSSelectorLocation            equ        BufferStartLocation + 24h 
+FSSelectorLocation            equ        BufferStartLocation + 24h
 dw		0
 
-GSSelectorLocation            equ        BufferStartLocation + 26h 
+GSSelectorLocation            equ        BufferStartLocation + 26h
 dw		0
 
-StackStartLocation            equ        BufferStartLocation + 28h 
+StackStartLocation            equ        BufferStartLocation + 28h
 dd		0
 
-CProcedureLocation            equ        BufferStartLocation + 2Ch 
+CProcedureLocation            equ        BufferStartLocation + 2Ch
 dd      0
 
-SpinLockLocation              equ        BufferStartLocation + 30h 
+SpinLockLocation              equ        BufferStartLocation + 30h
 dd      0
 
-ApCounterLocation             equ        BufferStartLocation + 34h 
+ApCounterLocation             equ        BufferStartLocation + 34h
 dd      0
 
-ApStackSizeLocation           equ        BufferStartLocation + 38h 
+ApStackSizeLocation           equ        BufferStartLocation + 38h
 dd      0
 
-MpDataStructureLocation       equ        BufferStartLocation + 3Ch 
+MpDataStructureLocation       equ        BufferStartLocation + 3Ch
 dd      0
 
 MpDataAreaEnd:
+
+%if (MpDataAreaEnd - RendezvousFunnelProcStart) > 0x8000   ;AP_BUFFER_SIZE
+%error "MP waking up stub combined code & data size should be less than 32KB !"
+%endif
 
 ;-------------------------------------------------------------------------------------
 ;  AsmGetAddressMap (&AddressMap);
@@ -218,11 +245,11 @@ MpDataAreaEnd:
 ;  UINT32 ProtModeStartOffset;
 ;  UINT32 ProtModeJmpPatchOffset;
 ;} MP_ASSEMBLY_ADDRESS_MAP;
-global ASM_PFX(AsmGetHotAddCodeAddressMap)
-ASM_PFX(AsmGetHotAddCodeAddressMap):
+global ASM_PFX(AsmGetAddressMap)
+ASM_PFX(AsmGetAddressMap):
         mov         eax, dword [esp + 4]
         mov         dword [eax], RendezvousFunnelProcStart
-        mov         dword [eax+4h], RendezvousFunnelProcEnd - RendezvousFunnelProcStart        
+        mov         dword [eax+4h], RendezvousFunnelProcEnd - RendezvousFunnelProcStart
         mov         dword [eax+8h], MpDataAreaEnd - MpDataAreaStart
         mov         dword [eax+0ch], ProtModeStart - RendezvousFunnelProcStart
         mov         dword [eax+10h], FLAT32_JUMP - RendezvousFunnelProcStart
@@ -259,7 +286,7 @@ ASM_PFX(AsmGetBspSelectors):
         mov         word [edi + 10], ax
         pop         edi
         ret
-        
+
 
 
 global ASM_PFX(AsmCliHlt)
@@ -267,13 +294,13 @@ ASM_PFX(AsmCliHlt):
         cli
         hlt
         jmp         $-2
-        
+
 
 
 global ASM_PFX(AsmMtrrSynchUpEntry)
 ASM_PFX(AsmMtrrSynchUpEntry):
     push eax
-    
+
     ;
     ; Disable Cache in CR0
     ;
@@ -281,18 +308,18 @@ ASM_PFX(AsmMtrrSynchUpEntry):
     bts     eax, 30
     btr     eax, 29
     mov     cr0, eax
-    
+
     ;
     ; Flush cache
     ;
     wbinvd
-    
+
     ;
     ; Flush all TLBs
     ;
     mov eax, cr3
     mov cr3, eax
-    
+
     pop eax
 
     ret
@@ -301,20 +328,20 @@ ASM_PFX(AsmMtrrSynchUpEntry):
 global ASM_PFX(AsmMtrrSynchUpExit)
 ASM_PFX(AsmMtrrSynchUpExit):
     push eax
-    
+
     ;
     ; Flush all TLBs the second time
     ;
     mov eax, cr3
     mov cr3, eax
-    
+
     ;
     ; Enable Normal Mode caching CD=NW=0, CD(Bit30), NW(Bit29)
     ;
     mov eax, cr0
     and eax, 09FFFFFFFh
     mov cr0, eax
-    
+
     pop eax
     ret
 

--- a/BootloaderCorePkg/Library/MpInitLib/Ia32/MpInitLibInternal.h
+++ b/BootloaderCorePkg/Library/MpInitLib/Ia32/MpInitLibInternal.h
@@ -23,14 +23,19 @@
 #include <Library/SynchronizationLib.h>
 #include <Library/LocalApicLib.h>
 #include <Library/MemoryAllocationLib.h>
+#include <Library/BootloaderCommonLib.h>
 #include <Library/MpInitLib.h>
 
-#define   AP_BUFFER_ADDRESS        0x60000
+#define   AP_BUFFER_ADDRESS        0x38000
+#define   AP_BUFFER_SIZE           0x8000
+
 #define   AP_STACK_SIZE_SHIFT_BITS 12
 #define   AP_STACK_SIZE            (1<<AP_STACK_SIZE_SHIFT_BITS)
 #define   AP_TASK_TIMEOUT_UNIT     15
 #define   AP_TASK_TIMEOUT_CNT      1000
 
+#define   SMM_BASE_GAP             0x1000
+#define   SMM_BASE_MIN_SIZE        0x10000
 
 #pragma pack(1)
 typedef struct {
@@ -66,6 +71,8 @@ typedef struct {
 
 typedef struct {
   UINT32           ApDoneCounter;
+  UINT32           SmmRebaseDoneCounter;
+  SPIN_LOCK        SpinLock;
 } MP_DATA_EXCHANGE_STRUCT;
 #pragma pack()
 
@@ -87,7 +94,7 @@ typedef struct {
  **/
 VOID
 EFIAPI
-AsmGetHotAddCodeAddressMap (
+AsmGetAddressMap (
   OUT MP_ASSEMBLY_ADDRESS_MAP    *AddressMap
   );
 

--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
@@ -14,7 +14,7 @@
 [Defines]
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = MpInitLib
-  FILE_GUID                      = 9C33ED3D-923B-40b4-B3AA-3F24FE7DD1C8  
+  FILE_GUID                      = 9C33ED3D-923B-40b4-B3AA-3F24FE7DD1C8
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = MpInitLib
@@ -31,22 +31,26 @@
   Ia32/MpFuncs.nasm
 
 [Packages]
-  MdePkg/MdePkg.dec  
+  MdePkg/MdePkg.dec
   IntelFsp2Pkg/IntelFsp2Pkg.dec
   BootloaderCorePkg/BootloaderCorePkg.dec
   BootloaderCommonPkg/BootloaderCommonPkg.dec
-  
+
 [LibraryClasses]
   BaseLib
-  DebugLib  
-  
+  DebugLib
+
 [LibraryClasses.IA32]
   LocalApicLib
   SynchronizationLib
 
 [Guids]
-  
-  
+
+
 [FixedPcd]
   gPlatformModuleTokenSpaceGuid.PcdCpuMaxLogicalProcessorNumber
-  
+
+[Pcd]
+  gPlatformModuleTokenSpaceGuid.PcdSmramTsegBase
+  gPlatformModuleTokenSpaceGuid.PcdSmramTsegSize
+  gPlatformModuleTokenSpaceGuid.PcdSmmRebaseEnabled

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -189,6 +189,7 @@ class BaseBoard(object):
 		self.ENABLE_CRYPTO_SHA_NI  = 0
 		self.ENABLE_FWU            = 0
 		self.ENABLE_SOURCE_DEBUG   = 0
+		self.ENABLE_SMM_REBASE     = 0
 
 		self.ACM_SIZE              = 0
 		self.UCODE_SIZE            = 0

--- a/Platform/ApollolakeBoardPkg/ApollolakeBoardPkg.dec
+++ b/Platform/ApollolakeBoardPkg/ApollolakeBoardPkg.dec
@@ -20,8 +20,8 @@
 [Includes]
   Include
 
-[Guids]  
-  
-  
+[Guids]
+  gReservedMemoryResourceHobTsegGuid    = { 0xd038747c, 0xd00c, 0x4980, { 0xb3, 0x19, 0x49, 0x01, 0x99, 0xa4, 0x7d, 0x55}}
+
 [PcdsFixedAtBuild]
-  
+

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.h
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.h
@@ -29,6 +29,7 @@
 #include <Library/RleCompressLib.h>
 #include <Library/VariableLib.h>
 #include <Library/DebugPrintErrorLevelLib.h>
+#include <Library/FspSupportLib.h>
 #include <Guid/FrameBufferInfoGuid.h>
 #include <Guid/SystemTableInfoGuid.h>
 #include <Guid/SerialPortInfoGuid.h>
@@ -67,6 +68,7 @@
 #include <Library/MpInitLib.h>
 #include <Library/BootOptionLib.h>
 #include <ConfigDataCommonStruct.h>
+#include <PsdLib.h>
 
 #define IOC_UART_PPR_CLK_N_DIV        0x64
 #define IOC_UART_PPR_CLK_M_DIV        0x40

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -66,6 +66,7 @@
   gOsConfigDataGuid
   gFspVariableNvDataHobGuid
   gEfiHeciMbpDataHobGuid
+  gReservedMemoryResourceHobTsegGuid
 
 [Pcd]
   gPlatformModuleTokenSpaceGuid.PcdPciResourceIoBase
@@ -94,4 +95,6 @@
   gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootEnabled
   gPlatformModuleTokenSpaceGuid.PcdSplashEnabled
   gPlatformModuleTokenSpaceGuid.PcdFramebufferInitEnabled
-
+  gPlatformModuleTokenSpaceGuid.PcdSmmRebaseEnabled
+  gPlatformModuleTokenSpaceGuid.PcdSmramTsegBase
+  gPlatformModuleTokenSpaceGuid.PcdSmramTsegSize


### PR DESCRIPTION
SBL has no intention to support SMI. However, on many hardware
platform, there is no reliable way to prevent SMI from generating
through SMI SPI.  In case it occurs, CPU will jump to the default
0x38000 location for execution, which exposes huge security issues.

The recommended solution is to do basic SMM base relocation and put
a dummy SMI handler (RSM) there. In this way, the SMI will be ignored,
and it also closes the security concerns. This patch implemented
basic SMM relocation.

It is under the control of a new PCD PcdSmmRebaseEnabled. By default,
it is disabled.  To enable it, please set ENABLE_SMM_REBASE in
BoardConfig.py. As part of it, platform library needs to set
PcdSmramTsegBase and PcdSmramTsegSize properly in PreSiliconInit board
hook. Please take APL platform for reference.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>