### PR TITLE
Convert ASM opcode to instructions in MpFuncs

### DIFF
--- a/BootloaderCorePkg/Library/MpInitLib/Ia32/MpFuncs.nasm
+++ b/BootloaderCorePkg/Library/MpInitLib/Ia32/MpFuncs.nasm
@@ -35,8 +35,10 @@ global ASM_PFX(RendezvousFunnelProc)
 ASM_PFX(RendezvousFunnelProc):
 RendezvousFunnelProcStart:
 ; At this point CS = 0x(vv00) and ip= 0x0.
-  db 0fh,  20h, 0d0h            ; mov        eax, cr2
-  db 66h,  09h, 0c0h            ; or         eax, eax
+BITS 16
+
+  mov eax, cr2
+  or  eax, eax
 
   ; For SMM rebase flow, CR2 will be pre-filled with SMBASE
   ; The same stub code will be shared for SMM rebasing and start IPI.
@@ -44,181 +46,162 @@ RendezvousFunnelProcStart:
 
   ; The ASM code needs to use same 0x3800 segment as start IPI.
   ; At initial SMM entry the segment is 0x3000, so force a long jump.
-  db 0eah                       ; jmp        0x3800:StartIpi
-  dw StartIpi - RendezvousFunnelProcStart
-  dw 0x3800
+  jmp 0x3800:(StartIpi - RendezvousFunnelProcStart)
 
 StartIpi:
-  db 8ch,  0c8h                 ; mov        ax,  cs
-  db 8eh,  0d8h                 ; mov        ds,  ax
-  db 8eh,  0c0h                 ; mov        es,  ax
-  db 8eh,  0d0h                 ; mov        ss,  ax
-  db 33h,  0c0h                 ; xor        ax,  ax
-  db 8eh,  0e0h                 ; mov        fs,  ax
-  db 8eh,  0e8h                 ; mov        gs,  ax
+    mov        ax,  cs
+    mov        ds,  ax
+    mov        es,  ax
+    mov        ss,  ax
+    xor        ax,  ax
+    mov        fs,  ax
+    mov        gs,  ax
 
-  db 0BEh
-  dw BufferStartLocation        ; mov        si, BufferStartLocation
-  db 66h,  8Bh, 14h             ; mov        edx,dword ptr [si]          ; EDX is keeping the start address of wakeup buffer
+    mov        si, BufferStartLocation
+    mov        edx, dword [si]    ; EDX is keeping the start address of wakeup buffer
 
-  ; Since CS and DS point to the start of the buffer, we can just use the offset in SI
+    mov        si, GdtrLocation
+o32 lgdt       [cs:si]
 
-  db 0BEh
-  dw GdtrLocation               ; mov        si, GdtrProfile
-  db 66h                        ; db         66h
-  db 2Eh,  0Fh, 01h, 14h        ; lgdt       fword ptr cs:[si]
+    mov        si, IdtrLocation
+o32 lidt       [cs:si]
 
-  db 0BEh
-  dw IdtrLocation               ; mov        si, IdtrProfile
-  db 66h                        ; db         66h
-  db 2Eh,  0Fh, 01h, 1Ch        ; lidt       fword ptr cs:[si]
-
-  db 0Fh,  20h, 0C0h            ; mov        eax, cr0                    ; Get control register 0
-  db 66h,  83h, 0C8h, 03h       ; or         eax, 000000003h             ; Set PE bit (bit #0) and MP
-  db 0Fh,  22h, 0C0h            ; mov        cr0, eax
+    ; Switch to protected mode
+    mov        eax, cr0           ; Get control register 0
+    or         eax, 000000003h    ; Set PE bit (bit #0) & MP
+    mov        cr0, eax
 
 FLAT32_JUMP:
 
-  db 66h, 67h, 0EAh             ; far jump
-  dd 0h                         ; 32-bit offset
-  dw 0h                         ; 16-bit selector
+    db 66h, 67h, 0EAh             ; far jump
+    dd 0h                         ; 32-bit offset
+    dw 0h                         ; 16-bit selector
 
+BITS 32
 SmmRebase:
-  mov         edi,  0x3fef8     ; SMBASE offset
-  mov         dword [edi], eax  ; change to new  SMBASE
-  mov         dword [eax + 0x8000], 0x9090AA0F  ; write 'RSM' at new SMM handler entry
-  rsm
-  jmp         $
+    mov         edi,  0x3fef8     ; SMBASE offset
+    mov         dword [edi], eax  ; change to new  SMBASE
+    mov         dword [eax + 0x8000], 0x9090AA0F  ; write 'RSM' at new SMM handler entry
+    rsm
+    jmp         $
 
-ProtModeStart:                  ; protected mode entry point
-  ; Since CS and DS base is set to 0, we need to add the buffer start to use the offset
+ProtModeStart:                    ; protected mode entry point
+    ; Since CS and DS base is set to 0, we need to add the buffer start to use the offset
 
-  mov        esi, edx           ; EDX is keeping the start address of wakeup buffer
+    mov        esi, edx           ; EDX is keeping the start address of wakeup buffer
 
-  mov        ax, word [cs:esi + DSSelectorLocation]
-  mov		     ds, ax
+    mov        ax, word [cs:esi + DSSelectorLocation]
+    mov        ds, ax
 
-  mov        ax, word [cs:esi + ESSelectorLocation]
-  mov	    	 es, ax
+    mov        ax, word [cs:esi + ESSelectorLocation]
+    mov        es, ax
 
-  mov        ax, word [cs:esi + FSSelectorLocation]
-  mov		     fs, ax
+    mov        ax, word [cs:esi + FSSelectorLocation]
+    mov        fs, ax
 
-  mov        ax, word [cs:esi + GSSelectorLocation]
-  mov		     gs, ax
+    mov        ax, word [cs:esi + GSSelectorLocation]
+    mov        gs, ax
 
-  mov        ax, word [cs:esi + SSSelectorLocation]
-  mov		     ss, ax
+    mov        ax, word [cs:esi + SSSelectorLocation]
+    mov        ss, ax
 
-  cli
+    cli
 
-  mov        eax, cr2           ; CR2 will be set to the new SMBASE before SMI IPI is generated
-  or         eax, eax
-  jnz        SmmRebase
+    mov        eax, cr2           ; CR2 will be set to the new SMBASE before SMI IPI is generated
+    or         eax, eax
+    jnz        SmmRebase
 
-  mov        eax, cr0           ; Enable cache
-  and        eax, 09fffffffh
-  mov        cr0, eax
+    mov        eax, cr0           ; Enable cache
+    and        eax, 09fffffffh
+    mov        cr0, eax
 
-  mov        eax, cr4           ; ENABLE_SSE
-  or         eax, 00000600h
-  mov        cr4, eax
+    mov        eax, cr4           ; ENABLE_SSE
+    or         eax, 00000600h
+    mov        cr4, eax
 
 CallApFunc:
-  ;
-  ; Acquire Lock
-  ;
-  mov            eax, SPIN_LOCK_RELEASED
-  mov            edx, SPIN_LOCK_ACQUIRED
-  lock cmpxchg   dword [esi + SpinLockLocation], edx
-  jnz            CallApFunc
+    ; Acquire Lock
+    mov            eax, SPIN_LOCK_RELEASED
+    mov            edx, SPIN_LOCK_ACQUIRED
+    lock cmpxchg   dword [esi + SpinLockLocation], edx
+    jnz            CallApFunc
 
-  ;
-  ; Calculate stack
-  ;
-  inc            dword [esi + ApCounterLocation]
-  mov            eax, dword [esi + ApCounterLocation]
-  mov            ebx, eax
+    ; Calculate stack
+    inc            dword [esi + ApCounterLocation]
+    mov            eax, dword [esi + ApCounterLocation]
+    mov            ebx, eax
 
-  ;
-  ; Program AP stack for each thread
-  ;
-  mov            ecx, dword [esi + ApStackSizeLocation]
-  shl            eax, cl
-  add            eax, dword [esi + StackStartLocation]
-  lea            esp, [eax - 4]
+    ; Program AP stack for each thread
+    mov            ecx, dword [esi + ApStackSizeLocation]
+    shl            eax, cl
+    add            eax, dword [esi + StackStartLocation]
+    lea            esp, [eax - 4]
 
-  ;
-  ; Release Lock
-  ;
-  mov            eax, SPIN_LOCK_RELEASED
-  mov            dword [esi + SpinLockLocation], eax
+    ; Release Lock
+    mov            eax, SPIN_LOCK_RELEASED
+    mov            dword [esi + SpinLockLocation], eax
 
-  ;
-  ; Call C Function
-  ;
-  mov            eax, dword [esi + CProcedureLocation]
-  test           eax, eax
-  jz             GoToSleep
+    ; Call C Function
+    mov            eax, dword [esi + CProcedureLocation]
+    test           eax, eax
+    jz             GoToSleep
 
-  mov            eax, dword [esi + MpDataStructureLocation]
-  push           eax
-  push           ebx
+    mov            eax, dword [esi + MpDataStructureLocation]
+    push           eax
+    push           ebx
 
-  mov            eax, dword [esi + CProcedureLocation]
-  call           eax
-  add            esp, 8
+    mov            eax, dword [esi + CProcedureLocation]
+    call           eax
+    add            esp, 8
 
-  wbinvd
+    wbinvd
 
 GoToSleep:
-
-  cli
-  hlt
-  jmp         $-2
-
+    cli
+    hlt
+    jmp         $-2
 
 RendezvousFunnelProcEnd:
 
 MpDataAreaStart:
 BufferStartLocation           equ        RendezvousFunnelProcEnd - RendezvousFunnelProcStart
-dd		0
+dd    0
 
 GdtrLocation                  equ        BufferStartLocation + 04h
-db		0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+db    0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 IdtrLocation                  equ        BufferStartLocation + 0Eh
-db		0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+db    0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 
 ReservedDDLocation            equ        BufferStartLocation + 18h
 dd    0
 
 CSSelectorLocation            equ        BufferStartLocation + 1Ch
-dw		0
+dw    0
 
 DSSelectorLocation            equ        BufferStartLocation + 1Eh
-dw		0
+dw    0
 
 ESSelectorLocation            equ        BufferStartLocation + 20h
-dw		0
+dw    0
 
 SSSelectorLocation            equ        BufferStartLocation + 22h
-dw		0
+dw    0
 
 FSSelectorLocation            equ        BufferStartLocation + 24h
-dw		0
+dw    0
 
 GSSelectorLocation            equ        BufferStartLocation + 26h
-dw		0
+dw    0
 
 StackStartLocation            equ        BufferStartLocation + 28h
-dd		0
+dd    0
 
 CProcedureLocation            equ        BufferStartLocation + 2Ch
-dd      0
+dd    0
 
 SpinLockLocation              equ        BufferStartLocation + 30h
-dd      0
+dd    0
 
 ApCounterLocation             equ        BufferStartLocation + 34h
 dd      0
@@ -272,21 +255,20 @@ global ASM_PFX(AsmGetBspSelectors)
 ASM_PFX(AsmGetBspSelectors):
         push        edi
         mov         edi, dword [esp + 8]
-        mov	        ax, cs
+        mov         ax, cs
         mov         word [edi + 0], ax
-        mov	        ax, ds
+        mov         ax, ds
         mov         word [edi + 2], ax
-        mov	        ax, es
+        mov         ax, es
         mov         word [edi + 4], ax
-        mov	        ax, ds
+        mov         ax, ds
         mov         word [edi + 6], ax
-        mov	        ax, fs
+        mov         ax, fs
         mov         word [edi + 8], ax
-        mov	        ax, gs
+        mov         ax, gs
         mov         word [edi + 10], ax
         pop         edi
         ret
-
 
 
 global ASM_PFX(AsmCliHlt)


### PR DESCRIPTION
Current MpFuncs.nasm used hard coded opcodes to support 16bit ASM.
It makes it difficult to maintain. Per suggestion, this patch
convered the 16bit opcodes into instruction directly.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>