### PR TITLE
Revert '[DebugAgent] Fix image info loading failure in QEMU CAR stage'

### DIFF
--- a/BootloaderCommonPkg/Library/DebugAgentLib/DebugAgentLib.c
+++ b/BootloaderCommonPkg/Library/DebugAgentLib/DebugAgentLib.c
@@ -517,18 +517,6 @@ InitializeDebugAgentPhase2 (
 
   if (Phase2Context->InitFlag == DEBUG_AGENT_INIT_PREMEM_SEC) {
     //
-    // If Temporary RAM region is below 128 MB, then send message to
-    // host to disable low memory filtering.
-    // Check a stack variable address simply.
-    //
-    if (((UINTN) &NewDebugPortHandle < BASE_128MB) && (IsHostAttached () == TRUE)) {
-      SetDebugFlag (DEBUG_AGENT_FLAG_MEMORY_READY, 1);
-      //
-      // Trigger one software interrupt to inform HOST
-      //
-      TriggerSoftInterrupt (MEMORY_READY_SIGNATURE);
-    }
-    //
     // Enable Debug Timer interrupt
     //
     SaveAndSetDebugTimerInterrupt (TRUE);


### PR DESCRIPTION
This reverts commit 8cba382774c2300a8e4c603029f875826f7adb54.

The original fix still has the issue on Windows UDK Debugger and
a simpler way can resolve the QEMU specific issue. In UDK debugger
configuration, 'NoAccessLimit = 0' is required for QEMU only.
  [Target System]
  NoAccessLimit = 0x0

This change has been verified on both Linux and Windows UDK Debuggers
and user guide will include this information.

Change-Id: I09de713d7a9a892230475cbc4aca70b1a5c11b3c
Signed-off-by: Aiden Park <aiden.park@intel.com>