### PR TITLE
Add Device table

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -1,7 +1,7 @@
 ## @file
 # Provides bootloader driver related package definitions.
 #
-# Copyright (c) 2016 - 2017, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
 # This program and the accompanying materials are licensed and made available under
 # the terms and conditions of the BSD License that accompanies this distribution.
 # The full text of the license may be found at
@@ -43,6 +43,7 @@
   gSeedListInfoHobGuid                          = { 0x5e9f5b2f, 0xfeeb, 0x4344, { 0xb3, 0x0e, 0x4e, 0xf2, 0x17, 0xa3, 0x91, 0xcc } }
   gBootLoaderVersionFileGuid                    = { 0x3473a022, 0xc3c2, 0x4964, { 0xb3, 0x09, 0x22, 0xb3, 0xdf, 0xb0, 0xb6, 0xca } }
   gEfiDebugAgentGuid                            = { 0x865a5a9b, 0xb85d, 0x474c, { 0x84, 0x55, 0x65, 0xd1, 0xbe, 0x84, 0x4b, 0xe2 } }
+  gDeviceTableHobGuid                           = { 0xd21fc32c, 0x7fd2, 0x435b, { 0xb8, 0xef, 0xc0, 0x42, 0x66, 0xa8, 0xf4, 0xf5 } }
 
 [PcdsFixedAtBuild]
   gPlatformCommonLibTokenSpaceGuid.PcdMaxLibraryDataEntry    |          8 | UINT32 | 0x20000100

--- a/BootloaderCommonPkg/Include/Guid/DeviceTableHobGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/DeviceTableHobGuid.h
@@ -1,0 +1,46 @@
+/** @file
+  This file defines the hob structure for the device table.
+
+  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php.
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+
+#ifndef __DEVICE_TABLE_HOB_GUID_H__
+#define __DEVICE_TABLE_HOB_GUID_H__
+
+///
+/// Device table Hob GUID
+///
+extern EFI_GUID gDeviceTableHobGuid;
+
+typedef struct {
+  UINT32        PciFunctionNumber:8;
+  UINT32        PciDeviceNumber:8;
+  UINT32        PciBusNumber:8;
+  UINT32        IsMmioDevice:8;
+} PLT_PCI_DEVICE;
+
+typedef struct {
+  union {
+    UINT32          DevAddr;
+    PLT_PCI_DEVICE  PciDev;
+  } Dev;
+  UINT8             Type;
+  UINT8             Instance;
+  UINT16            Reserved;
+} PLT_DEVICE;
+
+typedef struct {
+  UINT16          DeviceNumber;
+  UINT16          Reserved;
+  PLT_DEVICE      Device[0];
+} PLT_DEVICE_TABLE;
+
+#endif

--- a/BootloaderCommonPkg/Include/Guid/OsBootOptionGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/OsBootOptionGuid.h
@@ -1,7 +1,7 @@
 /** @file
   This file defines the hob structure for the OS boot configuration.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -117,11 +117,6 @@ typedef struct {
 } BOOT_IMAGE;
 
 typedef struct {
-  ///
-  /// For PCI device, its value is 0x00BBDDFF
-  /// For other device, its value is MMIO address (The highest bytes is not zero).
-  ///
-  UINT32               DevAddr;
 
   ///
   /// Image type for Image[0]. Refer BOOT_IMAGE_TYPE
@@ -132,13 +127,18 @@ typedef struct {
   /// Zero means normal boot.
   ///
   UINT8                BootFlags;
-
-  UINT8                Reserved[2];
+  UINT8                Reserved;
 
   ///
   /// Boot medium type, Refer OS_BOOT_MEDIUM_TYPE
   ///
   UINT8                DevType;
+
+  ///
+  /// If there are multiple controllers, it indicate which 
+  /// controller instance the boot medium belong to.
+  ///
+  UINT8                DevInstance;
 
   ///
   /// Zero-based hardware partition number

--- a/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
+++ b/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -18,6 +18,7 @@
 #include <Guid/BootLoaderServiceGuid.h>
 #include <Guid/FlashMapInfoGuid.h>
 #include <Guid/LoaderPlatformDataGuid.h>
+#include <Guid/DeviceTableHobGuid.h>
 
 #define  STACK_DEBUG_FILL_PATTERN     0x5AA55AA5
 
@@ -48,6 +49,17 @@ typedef struct {
 #define        FEATURE_MEASURED_BOOT            BIT1
 #define        FEATURE_MMC_TUNING               BIT2
 #define        FEATURE_MMC_FORCE_TUNING         BIT3
+
+#define MM_PCI_ADDRESS( Bus, Device, Function, Register ) \
+  ( (UINTN)PcdGet64(PcdPciExpressBaseAddress) + \
+    (UINTN)((Bus) << 20) + \
+    (UINTN)((Device) << 15) + \
+    (UINTN)((Function) << 12) + \
+    (UINTN)(Register) \
+  )
+
+#define TO_MM_PCI_ADDRESS( Addr ) \
+  MM_PCI_ADDRESS ( ((Addr) >> 16) & 0xFF, ((Addr) >> 8) & 0xFF, (Addr) & 0xFF, 0)
 
 //
 // Enumeration of stages of bootloader execution.
@@ -467,6 +479,51 @@ GetGuidHobData (
   IN CONST VOID          *HobListPtr, OPTIONAL
   OUT      UINT32        *Length, OPTIONAL
   IN       EFI_GUID      *Guid
+  );
+
+/**
+  This function sets device table.
+
+  @param DeviceTable   The pointer to device table.
+
+**/
+VOID
+EFIAPI
+SetDeviceTable (
+  IN VOID                 *DeviceTable
+  );
+
+/**
+  This function retrieves the platform device table.
+
+  @retval    The platform device table.
+
+**/
+VOID *
+EFIAPI
+GetDeviceTable (
+  VOID
+  );
+
+/**
+  Get device address
+
+  If the device is PCI device, the device address format is 0x00BBDDFF, where
+  BB, DD and FF are PCI bus, device and function number.
+  If the device is MMIO device, the device address format is 0xMMxxxxxx, where
+  MM should be non-zero value, xxxxxx could be any value.
+
+  @param[in]  DeviceType         The device type, refer OS_BOOT_MEDIUM_TYPE.
+  @param[in]  DeviceInstance     The device instance number starting from 0.
+
+  @retval     Device address for a given device instance, return 0 if the device
+              could not be found from device table.
+**/
+UINT32
+EFIAPI
+GetDeviceAddr (
+  IN  UINT8          DeviceType,
+  IN  UINT8          DeviceInstance
   );
 
 #endif

--- a/BootloaderCommonPkg/Library/BootloaderCommonLib/BootloaderCommonLib.c
+++ b/BootloaderCommonPkg/Library/BootloaderCommonLib/BootloaderCommonLib.c
@@ -503,3 +503,45 @@ GetGuidHobData (
   return NULL;
 }
 
+
+/**
+  Get device address
+
+  If the device is PCI device, the device address format is 0x00BBDDFF, where
+  BB, DD and FF are PCI bus, device and function number.
+  If the device is MMIO device, the device address format is 0xMMxxxxxx, where
+  MM should be non-zero value, xxxxxx could be any value.
+
+  @param[in]  DeviceType         The device type, refer OS_BOOT_MEDIUM_TYPE.
+  @param[in]  DeviceInstance     The device instance number starting from 0.
+
+  @retval     Device address for a given device instance, return 0 if the device
+              could not be found from device table.
+**/
+UINT32
+EFIAPI
+GetDeviceAddr (
+  IN  UINT8          DeviceType,
+  IN  UINT8          DeviceInstance
+  )
+{
+  PLT_DEVICE_TABLE   *DeviceTable;
+  PLT_DEVICE         *Device;
+  UINT32             DeviceBase;
+  UINT32             Index;
+
+  DeviceBase  = 0;
+  DeviceTable = (PLT_DEVICE_TABLE *)GetDeviceTable();
+  for (Index = 0; Index < DeviceTable->DeviceNumber; Index++) {
+    Device = &DeviceTable->Device[Index];
+    if ((Device->Type == DeviceType) && (Device->Instance == DeviceInstance)){
+      break;
+    }
+  }
+
+  if (DeviceTable->DeviceNumber != Index) {
+    DeviceBase = Device->Dev.DevAddr;
+  }
+  return DeviceBase;
+}
+

--- a/BootloaderCommonPkg/Library/ShellLib/CmdBoot.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdBoot.c
@@ -1,7 +1,7 @@
 /** @file
   Shell command `boot` to print or modify the OS boot option list.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -159,16 +159,16 @@ GetBootDeviceInfo (
   } while (1);
 
   do {
-    ShellPrint (L"Enter DevAddr (uint)\n");
+    ShellPrint (L"Enter DevInstance (uint)\n");
     Status = ShellReadUintn (Shell, Buffer, BufferSize, &IsHex);
     if (EFI_ERROR (Status)) {
       return Status;
     }
-    BootOption->DevAddr = (IsHex) ? StrHexToUintn (Buffer) : StrDecimalToUintn (Buffer);
-    if ((BootOption->DevAddr > 0) && (StrLen (Buffer) > 0)) {
+    BootOption->DevInstance = (UINT8)((IsHex) ? StrHexToUintn (Buffer) : StrDecimalToUintn (Buffer));
+    if (StrLen (Buffer) > 0) {
       break;
     }
-    ShellPrint (L"Invalid DevAddr value '%s', please re-enter\n", Buffer);
+    ShellPrint (L"Invalid DevInstance value '%s', please re-enter\n", Buffer);
   } while (1);
 
   do {
@@ -331,28 +331,28 @@ PrintBootOption (
 
   ShellPrint (L"Boot options (in HEX):\n\n");
 
-  ShellPrint (L"Idx|ImgType|DevType|Flags|DevAddr |HwPart|FsType|SwPart|File/Lbaoffset\n");
+  ShellPrint (L"Idx|ImgType|DevType|DevNum|Flags|HwPart|FsType|SwPart|File/Lbaoffset\n");
   for (Index = 0; Index < OsBootOptionList->OsBootOptionCount; Index++) {
     BootOption = &OsBootOptionList->OsBootOption[Index];
     if (BootOption->FsType < EnumFileSystemMax) {
-      ShellPrint (L"%3x|%7x| %5a | %3x |%8x| %4x | %4a | %4x | %a\n", \
+      ShellPrint (L"%3x|%7x| %5a | %4x | %3x | %4x | %4a | %4x | %a\n", \
                  Index, \
                  BootOption->ImageType, \
                  GetBootDeviceNameString(BootOption->DevType), \
+                 BootOption->DevInstance, \
                  BootOption->BootFlags, \
-                 BootOption->DevAddr, \
                  BootOption->HwPart,  \
                  GetFsTypeString (BootOption->FsType), \
                  BootOption->SwPart,  \
                  BootOption->Image[0].FileName \
                  );
     } else {
-      ShellPrint (L"%3x|%7x| %5a | %3x |%8x| %4x | %4a | %4x | 0x%x\n", \
+      ShellPrint (L"%3x|%7x| %5a | %4x | %3x | %4x | %4a | %4x | 0x%x\n", \
                  Index, \
                  BootOption->ImageType, \
                  GetBootDeviceNameString(BootOption->DevType), \
+                 BootOption->DevInstance, \
                  BootOption->BootFlags, \
-                 BootOption->DevAddr, \
                  BootOption->HwPart,  \
                  GetFsTypeString (BootOption->FsType), \
                  BootOption->Image[0].LbaImage.SwPart, \

--- a/BootloaderCommonPkg/Library/ShellLib/CmdMmcDll.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdMmcDll.c
@@ -1,7 +1,7 @@
 /** @file
   Shell command `mmcdll` to display system performance data.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -74,30 +74,10 @@ GetMmcBaseAddress (
   VOID
   )
 {
-  EFI_HOB_GUID_TYPE             *GuidHob;
-  OS_BOOT_OPTION_LIST           *OsBootOptionList;
-  OS_BOOT_OPTION                *OsBootOption;
   UINTN                         MmcBaseAddress;
-  UINT8                         Index;
 
-  GuidHob = GetNextGuidHob (&gOsBootOptionGuid, GetHobListPtr());
-  if (GuidHob == NULL) {
-    return 0;
-  }
-
-  MmcBaseAddress = 0;
-  OsBootOptionList = (OS_BOOT_OPTION_LIST *) GET_GUID_HOB_DATA (GuidHob);
-  for (Index = 0; Index < OsBootOptionList->OsBootOptionCount; Index++) {
-    OsBootOption = &OsBootOptionList->OsBootOption[Index];
-    if (OsBootOption->DevType == OsBootDeviceEmmc) {
-      MmcBaseAddress = (UINTN) ( PcdGet64 (PcdPciExpressBaseAddress)  + \
-                                 (((OsBootOption->DevAddr >> 16) & 0xFF) << 20) + \
-                                 (((OsBootOption->DevAddr >> 8)  & 0xFF) << 15) + \
-                                 ((OsBootOption->DevAddr & 0xFF) << 12) \
-                                 );
-      break;
-    }
-  }
+  MmcBaseAddress = GetDeviceAddr (OsBootDeviceEmmc, 0);
+  MmcBaseAddress = TO_MM_PCI_ADDRESS (MmcBaseAddress);
 
   return MmcBaseAddress;
 }

--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -184,6 +184,7 @@ typedef struct {
   VOID             *ServicePtr;
   VOID             *PcdDataPtr;
   VOID             *LogBufPtr;
+  VOID             *DeviceTable;
   UINT8             PlatformName[PLATFORM_NAME_SIZE];
   UINT32            LdrFeatures;
   BL_PERF_DATA      PerfData;

--- a/BootloaderCorePkg/Library/BootloaderLib/BootloaderLib.c
+++ b/BootloaderCorePkg/Library/BootloaderLib/BootloaderLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2016 - 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -350,5 +350,36 @@ GetFeatureCfg (
   )
 {
   return GetLoaderGlobalDataPointer()->LdrFeatures;
+}
+
+
+/**
+  This function sets device table.
+
+  @param DeviceTable   The pointer to device table.
+
+**/
+VOID
+EFIAPI
+SetDeviceTable (
+  IN VOID         *DeviceTable
+  )
+{
+  GetLoaderGlobalDataPointer()->DeviceTable = DeviceTable;
+}
+
+/**
+  This function retrieves the platform device table.
+
+  @retval    The platform device table.
+
+**/
+VOID *
+EFIAPI
+GetDeviceTable (
+  VOID
+  )
+{
+  return GetLoaderGlobalDataPointer()->DeviceTable;
 }
 

--- a/BootloaderCorePkg/Library/BootloaderLib/BootloaderLib.inf
+++ b/BootloaderCorePkg/Library/BootloaderLib/BootloaderLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
 #  which accompanies this distribution.  The full text of the license may be found at
@@ -43,4 +43,5 @@
 
 [Pcd]
   gPlatformModuleTokenSpaceGuid.PcdFlashMapEnabled
+  gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
 

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2016 - 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -270,6 +270,7 @@ SecStartup2 (
   DEBUG_LOG_BUFFER_HEADER  *NewLogBuf;
   DEBUG_LOG_BUFFER_HEADER  *OldLogBuf;
   BOOLEAN                   OldStatus;
+  PLT_DEVICE_TABLE         *DeviceTable;
 
   LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
   ASSERT (LdrGlobal != NULL);
@@ -461,6 +462,14 @@ SecStartup2 (
       NewLogBuf->TotalLength = PcdGet32 (PcdLogBufferSize);
       LdrGlobal->LogBufPtr = NewLogBuf;
     }
+  }
+
+  // Copy device table to memory
+  if (LdrGlobal->DeviceTable != NULL) {
+    DeviceTable = (PLT_DEVICE_TABLE *) LdrGlobal->DeviceTable;
+    AllocateLen = DeviceTable->DeviceNumber * sizeof (PLT_DEVICE) + sizeof (PLT_DEVICE_TABLE);
+    LdrGlobal->DeviceTable = AllocatePool (AllocateLen);
+    CopyMem (LdrGlobal->DeviceTable, DeviceTable, AllocateLen);
   }
 
   BoardInit (PostMemoryInit);

--- a/BootloaderCorePkg/Stage2/Stage2.inf
+++ b/BootloaderCorePkg/Stage2/Stage2.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2016 - 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
 #
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
@@ -91,6 +91,7 @@
   gLoaderPlatformInfoGuid
   gSeedListInfoHobGuid
   gLoaderPlatformDataGuid
+  gDeviceTableHobGuid
 
 [Pcd]
   gPlatformCommonLibTokenSpaceGuid.PcdMaxLibraryDataEntry

--- a/BootloaderCorePkg/Stage2/Stage2Support.c
+++ b/BootloaderCorePkg/Stage2/Stage2Support.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2016 - 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -522,6 +522,8 @@ BuildExtraInfoHob (
   FLASH_MAP                 *FlashMapHob;
   UINTN                      Index;
   SEED_LIST_INFO_HOB        *SeedListInfoHob;
+  PLT_DEVICE_TABLE          *DeviceTable;
+  VOID                      *DeviceTableHob;
 
   LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer();
   S3Data    = (S3_DATA *)LdrGlobal->S3DataPtr;
@@ -605,6 +607,14 @@ BuildExtraInfoHob (
         }
       }
     }
+  }
+
+  // Build device table Hob
+  DeviceTable  = (PLT_DEVICE_TABLE *)LdrGlobal->DeviceTable;
+  Length = sizeof (PLT_DEVICE_TABLE) + sizeof (PLT_DEVICE) * DeviceTable->DeviceNumber;
+  DeviceTableHob = BuildGuidHob (&gDeviceTableHobGuid, Length);
+  if (DeviceTableHob != NULL) {
+    CopyMem (DeviceTableHob, DeviceTable, Length);
   }
 
   // Build Performance Hob

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
@@ -1,5 +1,5 @@
 ## @file
-#  Copyright (c) 2008 - 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2008 - 2018, Intel Corporation. All rights reserved.<BR>
 #
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
@@ -31,7 +31,6 @@
 
 [Packages]
   MdePkg/MdePkg.dec
-  BootloaderCorePkg/BootloaderCorePkg.dec
   BootloaderCommonPkg/BootloaderCommonPkg.dec
   PayloadPkg/PayloadPkg.dec
 

--- a/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
+++ b/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
@@ -1,7 +1,7 @@
 /** @file
   This file contains the implementation of FirmwareUpdateLib library.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -57,15 +57,8 @@ FindBootPartition (
   //
   // Get OS boot device address
   //
-  if ((BootOption->DevAddr & 0xFF000000) == 0) {
-    BootMediumPciBase = (UINTN)MM_PCI_BASE (
-                          ((BootOption->DevAddr >> 16) & 0xFF), \
-                          ((BootOption->DevAddr >> 8)  & 0xFF), \
-                          (BootOption->DevAddr & 0xFF)      \
-                          );
-  } else {
-    BootMediumPciBase = BootOption->DevAddr;
-  }
+  BootMediumPciBase = GetDeviceAddr (BootOption->DevType, BootOption->DevInstance);
+  BootMediumPciBase = TO_MM_PCI_ADDRESS (BootMediumPciBase);
   DEBUG ((DEBUG_INFO, "BootMediumPciBase(0x%x)\n", BootMediumPciBase));
 
   //

--- a/PayloadPkg/Include/Library/FirmwareUpdateLib.h
+++ b/PayloadPkg/Include/Library/FirmwareUpdateLib.h
@@ -1,7 +1,7 @@
 /** @file
 The header file for firmware update library.
 
-Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
 This program and the accompanying materials
 are licensed and made available under the terms and conditions of the BSD License
 which accompanies this distribution.  The full text of the license may be found at
@@ -99,16 +99,18 @@ typedef struct {
 // It may include multiple regions
 //
 typedef struct {
-  ///
-  /// For PCI device, its value is 0x00BBDDFF
-  /// For other device, its value is MMIO address (The highest bytes is not zero).
-  ///
-  UINT32               DevAddr;
 
   ///
   /// Boot medium type, Refer OS_BOOT_MEDIUM_TYPE
   ///
   UINT8                DevType;
+
+  ///
+  /// If there are multiple controllers, it indicate which 
+  /// controller instance the boot medium belong to.
+  ///
+  UINT8                DevInstance;
+  UINT8                Reserved[3];
 
   ///
   /// Zero-based hardware partition number

--- a/PayloadPkg/Include/Library/PayloadLib.h
+++ b/PayloadPkg/Include/Library/PayloadLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-Copyright (c) 2006 - 2017, Intel Corporation. All rights reserved.
+Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.
 
 This program and the accompanying materials are licensed and made available
 under the terms and conditions of the BSD License which accompanies this
@@ -33,20 +33,11 @@ typedef struct {
   VOID             *PcdDataPtr;
   VOID             *LogBufPtr;
   VOID             *CfgDataPtr;
+  VOID             *DeviceTable;
   UINT32           LdrFeatures;
   BL_PERF_DATA     PerfData;
 } PAYLOAD_GLOBAL_DATA;
 
-#define MM_PCI_ADDRESS( Segment, Bus, Device, Function, Register ) \
-  ( (UINTN)PcdGet64(PcdPciExpressBaseAddress) + \
-    (UINTN)(Bus << 20) + \
-    (UINTN)(Device << 15) + \
-    (UINTN)(Function << 12) + \
-    (UINTN)(Register) \
-  )
-
-#define MM_PCI_BASE(Bus, Device, Function) \
-  MM_PCI_ADDRESS(0, Bus, Device, Function, 0)
 
 /**
   Returns the System table info HOB data.

--- a/PayloadPkg/Library/AbSupportLib/AbSupportLib.inf
+++ b/PayloadPkg/Library/AbSupportLib/AbSupportLib.inf
@@ -28,7 +28,6 @@
 [Packages]
   MdePkg/MdePkg.dec
   PayloadPkg/PayloadPkg.dec
-  BootloaderCorePkg/BootloaderCorePkg.dec
   BootloaderCommonPkg/BootloaderCommonPkg.dec
 
 [Guids]

--- a/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
+++ b/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
@@ -212,6 +212,9 @@ SecStartup (
     GlobalDataPtr->LdrFeatures = LoaderPlatformInfo->LdrFeatures;
   }
 
+  // Init device table
+  GlobalDataPtr->DeviceTable =  GetGuidHobData (NULL, NULL, &gDeviceTableHobGuid);
+
   //
   // GetLoaderPerformanceInfo() function
   //

--- a/PayloadPkg/Library/PayloadLib/PayloadLib.c
+++ b/PayloadPkg/Library/PayloadLib/PayloadLib.c
@@ -1,7 +1,7 @@
 /** @file
   This file provides payload common library interfaces.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -360,3 +360,43 @@ GetLoaderStage (
 {
   return LOADER_STAGE_PAYLOAD;
 }
+
+
+/**
+  This function sets device table.
+
+  @param DeviceTable   The pointer to device table.
+
+**/
+VOID
+EFIAPI
+SetDeviceTable (
+  IN VOID                 *DeviceTable
+  )
+{
+  PAYLOAD_GLOBAL_DATA     *PayloadGlobalDataPtr;
+
+  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *) PcdGet32 (PcdGlobalDataAddress);
+
+  PayloadGlobalDataPtr->DeviceTable = DeviceTable;
+}
+
+/**
+  This function retrieves the platform device table.
+
+  @retval    The platform device table.
+
+**/
+VOID *
+EFIAPI
+GetDeviceTable (
+  VOID
+  )
+{
+  PAYLOAD_GLOBAL_DATA     *PayloadGlobalDataPtr;
+
+  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *) PcdGet32 (PcdGlobalDataAddress);
+
+  return PayloadGlobalDataPtr->DeviceTable;
+}
+

--- a/PayloadPkg/Library/PayloadLib/PayloadLib.inf
+++ b/PayloadPkg/Library/PayloadLib/PayloadLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
 #  which accompanies this distribution.  The full text of the license may be found at
@@ -30,7 +30,6 @@
 
 [Packages]
   MdePkg/MdePkg.dec
-  BootloaderCorePkg/BootloaderCorePkg.dec
   BootloaderCommonPkg/BootloaderCommonPkg.dec
   PayloadPkg/PayloadPkg.dec
 
@@ -42,7 +41,9 @@
 [Guids]
   gPayloadKeyHashGuid
   gFlashMapInfoGuid
+  gDeviceTableHobGuid
 
 [Pcd]
   gPayloadTokenSpaceGuid.PcdPayloadHobList
   gPayloadTokenSpaceGuid.PcdGlobalDataAddress
+  gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress

--- a/PayloadPkg/Library/PayloadSupportLib/PayloadSupportLib.inf
+++ b/PayloadPkg/Library/PayloadSupportLib/PayloadSupportLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
 #  which accompanies this distribution.  The full text of the license may be found at
@@ -30,7 +30,6 @@
 
 [Packages]
   MdePkg/MdePkg.dec
-  BootloaderCorePkg/BootloaderCorePkg.dec
   BootloaderCommonPkg/BootloaderCommonPkg.dec
   PayloadPkg/PayloadPkg.dec
   IntelFsp2Pkg/IntelFsp2Pkg.dec

--- a/PayloadPkg/Library/PlatformHookLib/PlatformHookLib.inf
+++ b/PayloadPkg/Library/PlatformHookLib/PlatformHookLib.inf
@@ -1,7 +1,7 @@
 ## @file
 #  Platform Hook Library instance for UART device.
 #
-#  Copyright (c) 2015 - 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
 #
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
@@ -30,7 +30,6 @@
 [Packages]
   MdePkg/MdePkg.dec
   PayloadPkg/PayloadPkg.dec
-  BootloaderCorePkg/BootloaderCorePkg.dec
   BootloaderCommonPkg/BootloaderCommonPkg.dec
 
 [Guids]

--- a/PayloadPkg/Library/SblParameterLib/SblParameterLib.c
+++ b/PayloadPkg/Library/SblParameterLib/SblParameterLib.c
@@ -75,6 +75,7 @@ AppendBootDevices (
   UINT32                    BootDevicesSize;
   UINT32                    Index;
   CHAR8                     ParamValue[64];
+  OS_BOOT_OPTION            *OsBootOption;
 
   if ((BootOption->DevType != OsBootDeviceSpi) && (BootOption->DevType != OsBootDeviceMemory)) {
     return EFI_SUCCESS;
@@ -103,9 +104,10 @@ AppendBootDevices (
   BootDevicesData->Revision        = OsBootOptionList->Revision;
   BootDevicesData->BootDeviceCount = OsBootOptionList->OsBootOptionCount;
   for (Index = 0; Index < BootDevicesData->BootDeviceCount; Index++) {
-    BootDevicesData->BootDevice[Index].DevType = (UINT8) OsBootOptionList->OsBootOption[Index].DevType;
-    BootDevicesData->BootDevice[Index].HwPart  = OsBootOptionList->OsBootOption[Index].HwPart;
-    BootDevicesData->BootDevice[Index].DevAddr = OsBootOptionList->OsBootOption[Index].DevAddr;
+    OsBootOption = &OsBootOptionList->OsBootOption[Index];
+    BootDevicesData->BootDevice[Index].DevType = (UINT8) OsBootOption->DevType;
+    BootDevicesData->BootDevice[Index].HwPart  = OsBootOption->HwPart;
+    BootDevicesData->BootDevice[Index].DevAddr = GetDeviceAddr (OsBootOption->DevType, OsBootOption->DevInstance);
   }
 
   AsciiSPrint (ParamValue, sizeof (ParamValue), " bootdevices=0x%x", BootDevicesData);
@@ -255,7 +257,7 @@ AddSblCommandLine (
   UINT8                     ResetReason;
   UINT32                    SerialNumberLength;
   UINT8                     Data8;
-//  IMAGE_BOOT_PARAM          *BootParams;
+  UINT32                    DiskBus;
   UINT32                    MaxCmdSize;
 
   if (BootOption->ImageType != EnumImageTypeAdroid) {
@@ -327,7 +329,8 @@ AddSblCommandLine (
   AsciiSPrint (ParamValue, sizeof (ParamValue), " bdev=%a", GetBootDeviceNameString (BootOption->DevType));
   AsciiStrCatS (CommandLine, MaxCmdSize, ParamValue);
 
-  AsciiSPrint (ParamValue, sizeof (ParamValue), " diskbus=0x%x", BootOption->DevAddr);
+  DiskBus = GetDeviceAddr (BootOption->DevType, BootOption->DevInstance);
+  AsciiSPrint (ParamValue, sizeof (ParamValue), " diskbus=0x%x", DiskBus);
   AsciiStrCatS (CommandLine, MaxCmdSize, ParamValue);
 
   //

--- a/PayloadPkg/Library/SblParameterLib/SblParameterLib.inf
+++ b/PayloadPkg/Library/SblParameterLib/SblParameterLib.inf
@@ -28,7 +28,6 @@
 [Packages]
   MdePkg/MdePkg.dec
   PayloadPkg/PayloadPkg.dec
-  BootloaderCorePkg/BootloaderCorePkg.dec
   BootloaderCommonPkg/BootloaderCommonPkg.dec
 
 [Guids]

--- a/PayloadPkg/Library/TrustyBootLib/TrustyBootLib.inf
+++ b/PayloadPkg/Library/TrustyBootLib/TrustyBootLib.inf
@@ -29,7 +29,6 @@
 [Packages]
   MdePkg/MdePkg.dec
   PayloadPkg/PayloadPkg.dec
-  BootloaderCorePkg/BootloaderCorePkg.dec
   BootloaderCommonPkg/BootloaderCommonPkg.dec
 
 [Guids]

--- a/PayloadPkg/OsLoader/BlockIoTest.c
+++ b/PayloadPkg/OsLoader/BlockIoTest.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -41,7 +41,8 @@ TestDevBlocks (
   //
   // Get OS boot device address
   //
-  BootMediumPciBase = GetBootDeviceBase (BootOption);
+  BootMediumPciBase = GetDeviceAddr (OsBootOption->DevType, OsBootOption->DevInstance);
+  BootMediumPciBase = TO_MM_PCI_ADDRESS (BootMediumPciBase);
   DEBUG ((DEBUG_INFO, "BootMediumPciBase(0x%x)\n", BootMediumPciBase));
 
   //

--- a/PayloadPkg/OsLoader/BootOption.c
+++ b/PayloadPkg/OsLoader/BootOption.c
@@ -30,28 +30,28 @@ PrintBootOptions (
 
   DEBUG ((DEBUG_INFO, "Boot options (in HEX):\n\n"));
 
-  DEBUG ((DEBUG_INFO, "Idx|ImgType|DevType|Flags|DevAddr |HwPart|FsType|SwPart|File/Lbaoffset\n"));
+  DEBUG ((DEBUG_INFO, "Idx|ImgType|DevType|DevNum|Flags|HwPart|FsType|SwPart|File/Lbaoffset\n"));
   for (Index = 0; Index < OsBootOptionList->OsBootOptionCount; Index++) {
     BootOption = &OsBootOptionList->OsBootOption[Index];
     if (BootOption->FsType < EnumFileSystemMax) {
-      DEBUG ((DEBUG_INFO, "%3x|%7x| %5a | %3x |%8x| %4x | %4a | %4x | %a\n", \
+      DEBUG ((DEBUG_INFO, "%3x|%7x| %5a | %4x | %3x | %4x | %4a | %4x | %a\n", \
                  Index, \
                  BootOption->ImageType, \
                  GetBootDeviceNameString(BootOption->DevType), \
+                 BootOption->DevInstance, \
                  BootOption->BootFlags, \
-                 BootOption->DevAddr, \
                  BootOption->HwPart,  \
                  GetFsTypeString (BootOption->FsType), \
                  BootOption->SwPart,  \
                  BootOption->Image[0].FileName \
                  ));
     } else {
-      DEBUG ((DEBUG_INFO, "%3x|%7x| %5a | %3x |%8x| %4x | %4a | %4x | 0x%x\n", \
+      DEBUG ((DEBUG_INFO, "%3x|%7x| %5a | %4x | %3x | %4x | %4a | %4x | 0x%x\n", \
                  Index, \
                  BootOption->ImageType, \
                  GetBootDeviceNameString(BootOption->DevType), \
+                 BootOption->DevInstance, \
                  BootOption->BootFlags, \
-                 BootOption->DevAddr, \
                  BootOption->HwPart,  \
                  GetFsTypeString (BootOption->FsType), \
                  BootOption->Image[0].LbaImage.SwPart, \
@@ -152,32 +152,3 @@ GetNextBootOption (
   return Index;
 }
 
-/**
-  Get boot device base address from a given boot option
-
-  @param[in]  BootOption         Current boot option
-
-  @retval     Boot device base address for a given boot option
-**/
-UINT32
-GetBootDeviceBase (
-  IN  OS_BOOT_OPTION         *BootOption
-  )
-{
-  UINT32   BootDeviceBase;
-
-  BootDeviceBase = 0;
-  if (BootOption != NULL) {
-    if ((BootOption->DevAddr & 0xFF000000) == 0) {
-      BootDeviceBase = (UINTN)MM_PCI_ADDRESS (0,
-                          ((BootOption->DevAddr >> 16) & 0xFF),
-                          ((BootOption->DevAddr >> 8)  & 0xFF),
-                          (BootOption->DevAddr & 0xFF),
-                          0);
-    } else {
-      BootDeviceBase = BootOption->DevAddr;
-    }
-  }
-
-  return BootDeviceBase;
-}

--- a/PayloadPkg/OsLoader/LoadImage.c
+++ b/PayloadPkg/OsLoader/LoadImage.c
@@ -38,8 +38,9 @@ FindBootPartition (
   //
   // Get OS boot device address
   //
-  BootMediumPciBase = GetBootDeviceBase (BootOption);
+  BootMediumPciBase = GetDeviceAddr (BootOption->DevType, BootOption->DevInstance);
   DEBUG ((DEBUG_INFO, "BootMediumPciBase(0x%x)\n", BootMediumPciBase));
+  BootMediumPciBase = TO_MM_PCI_ADDRESS (BootMediumPciBase);
 
   //
   // Init Boot device functions

--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -596,7 +596,8 @@ InitConsole (
       for (Index = 0; Index < OsBootOptionList->OsBootOptionCount; Index++) {
         OsBootOption = &OsBootOptionList->OsBootOption[Index];
         if (OsBootOption->DevType == OsBootDeviceUsb) {
-          CtrlPciBase = GetBootDeviceBase (OsBootOption);
+          CtrlPciBase = GetDeviceAddr (OsBootOption->DevType, OsBootOption->DevInstance);
+          CtrlPciBase = TO_MM_PCI_ADDRESS (CtrlPciBase);
         }
       }
     }

--- a/PayloadPkg/OsLoader/OsLoader.h
+++ b/PayloadPkg/OsLoader/OsLoader.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -376,19 +376,6 @@ EFI_STATUS
 RpmbKeyProvisioning (
   IN     OS_BOOT_OPTION      *CurrentBootOption,
   IN     LOADER_SEED_LIST    *SeedList
-  );
-
-
-/**
-  Get boot device base address from a given boot option
-
-  @param[in]  BootOption         Current boot option
-
-  @retval     Boot device base address for a given boot option
-**/
-UINT32
-GetBootDeviceBase (
-  IN  OS_BOOT_OPTION         *BootOption
   );
 
 #endif

--- a/PayloadPkg/OsLoader/OsLoader.inf
+++ b/PayloadPkg/OsLoader/OsLoader.inf
@@ -1,5 +1,5 @@
 ## @file
-#  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
 #
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
@@ -47,7 +47,6 @@
   BootloaderCommonPkg/BootloaderCommonPkg.dec
   IntelFsp2Pkg/IntelFsp2Pkg.dec
   PayloadPkg/PayloadPkg.dec
-  BootloaderCorePkg/BootloaderCorePkg.dec
   Platform/CommonBoardPkg/CommonBoardPkg.dec
 
 [LibraryClasses]

--- a/Platform/ApollolakeBoardPkg/CfgData/CfgData_BootOption.dsc
+++ b/Platform/ApollolakeBoardPkg/CfgData/CfgData_BootOption.dsc
@@ -28,15 +28,15 @@
   # !HDR EMBED:{OS_CFG_BOOT:OsBootList:END}
   # !HDR HEADER:{OFF}
 
-  # AOS boot from EMMC # |    addr    |ImgType|flag|dev_type|hw_part|sw_part|fs_type|  image0 name  | sw0 part| sw0 lba|  image1 name  | sw1 part| sw1 lba|  image2 name  | sw2 part| sw2 lba|
+  # AOS boot from EMMC # |ImgType|flag|DevType|DevNum|HwPart|SwPart|FsType|  image0 name  | sw0 part| sw0 lba|  image1 name  | sw1 part| sw1 lba|  image2 name  | sw2 part| sw2 lba|
   # eMMC boot P1
-  # !BSF SUBT:{OS_TMPL:0 : 0x00001C00 : 0    :  0 :    2   :     0 :     0 :     0 :'iasimage.bin' :       0 :      0 :     0         :     0   :  0     :     0         :     0   :   0    }
+  # !BSF SUBT:{OS_TMPL:0 :  0    :  0 :   2   :  0   :   0  :    0 :    0 :'iasimage.bin' :       0 :      0 :     0         :     0   :  0     :     0         :     0   :   0    }
   # eMMC boot P2
-  # !BSF SUBT:{OS_TMPL:1 : 0x00001C00 : 0    :  0 :    2   :     0 :     1 :     2 :'iasimage.bin' :       0 :      0 :     0         :     0   :  0     :     0         :     0   :   0    }
+  # !BSF SUBT:{OS_TMPL:1 :  0    :  0 :   2   :  0   :   0  :    1 :    2 :'iasimage.bin' :       0 :      0 :     0         :     0   :  0     :     0         :     0   :   0    }
   # SATA boot
-  # !BSF SUBT:{OS_TMPL:2 : 0x00001200 : 0    :  0 :    0   :     0 :     0 :     0 :'iasimage.bin' :       0 :      0 :     0         :     0   :  0     :     0         :     0   :   0    }
+  # !BSF SUBT:{OS_TMPL:2 :  0    :  0 :   0   :  0   :   0  :    0 :    0 :'iasimage.bin' :       0 :      0 :     0         :     0   :  0     :     0         :     0   :   0    }
   # USB  boot
-  # !BSF SUBT:{OS_TMPL:3 : 0x00001500 : 0    :  0 :    5   :     0 :     0 :     0 :'iasimage.bin' :       0 :      0 :     0         :     0   :  0     :     0         :     8   :   0    }
+  # !BSF SUBT:{OS_TMPL:3 :  0    :  0 :   5   :  0   :   0  :    0 :    0 :'iasimage.bin' :       0 :      0 :     0         :     0   :  0     :     0         :     8   :   0    }
   # !HDR EMBED:{OS_CFG_DATA:TAG_700:END}
 
   # !HDR HEADER:{ON}

--- a/Platform/ApollolakeBoardPkg/Library/ShellExtensionLib/CmdFwUpdate.c
+++ b/Platform/ApollolakeBoardPkg/Library/ShellExtensionLib/CmdFwUpdate.c
@@ -1,7 +1,7 @@
 /** @file
   Shell command `fwupdate` to reset the system.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -114,12 +114,12 @@ ShellCommandFwUpdateFunc (
   // Populate firmware update user configuration data structure
   //
   FwUpdUserCfgData = (FW_UPD_USER_CFG_DATA *)(&Data[sizeof(CDATA_BLOB) + CDATA_HEADER_LENGTH]);
-  FwUpdUserCfgData->DevAddr = 0x00001500;
-  FwUpdUserCfgData->DevType = 5;
-  FwUpdUserCfgData->HwPart = 0;
-  FwUpdUserCfgData->SwPart = 0;
-  FwUpdUserCfgData->FsType = 2;
-  FwUpdUserCfgData->LbaAddr = 0;
+  FwUpdUserCfgData->DevType     = 5;
+  FwUpdUserCfgData->DevInstance = 0;
+  FwUpdUserCfgData->HwPart      = 0;
+  FwUpdUserCfgData->SwPart      = 0;
+  FwUpdUserCfgData->FsType      = 2;
+  FwUpdUserCfgData->LbaAddr     = 0;
 
   AsciiStrCpy(FwUpdUserCfgData->FileName, "FwuImage.bin");
 

--- a/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -39,6 +39,7 @@
 #include <Library/TpmLib.h>
 #include <Library/LoaderLib.h>
 #include <Library/HeciLib.h>
+#include <Library/BootloaderCommonLib.h>
 
 #include <FspmUpd.h>
 #include <GpioDefines.h>
@@ -55,6 +56,16 @@
 #include <PlatformData.h>
 
 #define MRC_PARAMS_BYTE_OFFSET_MRC_VERSION 14
+
+CONST PLT_DEVICE  mPlatformDevices[]= {
+  {{0x00001200}, OsBootDeviceSata  , 0 },
+  {{0x00001B00}, OsBootDeviceSd    , 0 },
+  {{0x00001C00}, OsBootDeviceEmmc  , 0 },
+  {{0x00001D00}, OsBootDeviceUfs   , 0 },
+  {{0x00000D00}, OsBootDeviceSpi   , 0 },
+  {{0x00001500}, OsBootDeviceUsb   , 0 },
+  {{0x01000000}, OsBootDeviceMemory, 0 }
+};
 
 CONST CHAR16 *BootDeviceType[] = { L"eMMC", L"UFS", L"SPI" };
 
@@ -1697,9 +1708,14 @@ BoardInit (
   PLATFORM_DATA            *PlatformData;
   HECI_INSTANCE            *HeciInstance;
   EFI_STATUS                Status;
+  PLT_DEVICE_TABLE         *PltDeviceTable;
 
   switch (InitPhase) {
   case PreConfigInit:
+    PltDeviceTable = (PLT_DEVICE_TABLE *)AllocatePool (sizeof (PLT_DEVICE_TABLE) + sizeof (mPlatformDevices));
+    PltDeviceTable->DeviceNumber = sizeof (mPlatformDevices) /sizeof (PLT_DEVICE);
+    CopyMem (PltDeviceTable->Device, mPlatformDevices, sizeof (mPlatformDevices));
+    SetDeviceTable (PltDeviceTable);
     PrintBoardInfo ();
     EarlyBootDeviceInit ();
     SpiControllerInitialize ();

--- a/Platform/CommonBoardPkg/CfgData/Template_BootOption.dsc
+++ b/Platform/CommonBoardPkg/CfgData/Template_BootOption.dsc
@@ -19,49 +19,32 @@
     # !BSF PAGES:{OS_$(1):OS:"Boot Option $(1)"}
     # !BSF PAGE:{OS_$(1)}
 
-    # !BSF NAME:{Boot Device PCI Address}
-    gCfgData.DevAddr_$(1)                 |        * | 0x04 | $(2)
-      # !BSF NAME:{Boot Device PCI Function Number}
-      # !BSF TYPE:{EditNum, DEC, (0,7)}
-      # !BSF HELP:{Specify PCI function number for the boot device}
-      # !BSF ORDER:{0000.0030}
-      # !BSF FIELD:{FunctionNumber:8bD}
-
-      # !BSF NAME:{Boot Device PCI Device Number}
-      # !BSF TYPE:{EditNum, DEC, (0,31)}
-      # !BSF HELP:{Specify PCI device number for the boot device}
-      # !BSF ORDER:{0000.0020}
-      # !BSF FIELD:{DeviceNumber:8bD}
-
-      # !BSF NAME:{Boot Device PCI Bus Number}
-      # !BSF TYPE:{EditNum, HEX, (0,255)}
-      # !BSF HELP:{Specify PCI bus number for the boot device}
-      # !BSF ORDER:{0000.0010}
-      # !BSF FIELD:{BusNumber:8bD}
-
-      # !BSF NAME:{Reserved} TYPE:{Reserved}
-      # !BSF FIELD:{Rsvd:8bD}
-
     # !BSF NAME:{Image Type}
     # !BSF TYPE:{Combo}
     # !BSF OPTION:{0:Default, 1:Android, 2:ClearLinux, 3:Acrn, 4:Fastboot}
     # !BSF HELP:{Specify boot image type}
-    gCfgData.ImageType_$(1)                 |      * | 0x01 | $(3)
+    gCfgData.ImageType_$(1)                 |      * | 0x01 | $(2)
 
     # !BSF NAME:{Boot Flags}
     # !BSF TYPE:{Combo}
     # !BSF OPTION:{0:Normal, 1:A/B support, 2:Crash OS, 4:Trusty support, 5:Trusty and A/B support}
     # !BSF HELP:{Specify boot flags (options)}
-    gCfgData.BootFlags_$(1)                 |      * | 0x01 | $(4)
+    gCfgData.BootFlags_$(1)                 |      * | 0x01 | $(3)
 
-    gCfgData.Reserved_$(1)                  |      * | 0x02 | 0x55AA
-
-    # !BSF NAME:{Boot Device}
+    gCfgData.Reserved_$(1)                  |      * | 0x01 | 0x5A
+    # !BSF NAME:{Boot Device type}
     # !BSF TYPE:{Combo}
     # !BSF OPTION:{0:SATA, 1:SD, 2:EMMC, 3:UFS, 4:SPI, 5:USB, 6:NVME, 7:MAX}
-    # !BSF HELP:{Specify boot device}
+    # !BSF HELP:{Specify boot device type}
     # !BSF ORDER:{0000.0000}
-    gCfgData.BootDevice_$(1)                |      * | 0x01 | $(5)
+    gCfgData.BootDeviceType_$(1)            |      * | 0x01 | $(4)
+
+    # !BSF NAME:{Boot Device instance}
+    # !BSF TYPE:{Combo}
+    # !BSF OPTION:{0:Device 0, 1:Device 1, 2:Device 2, 3:Device 3}
+    # !BSF HELP:{Specify boot device instance when then are multple instances}
+    # !BSF ORDER:{0000.0000}
+    gCfgData.BootDeviceInstance_$(1)        |      * | 0x01 | $(5)
 
     # !BSF NAME:{Hardware Partition}
     # !BSF TYPE:{Combo}

--- a/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -18,6 +18,7 @@
 #include <Library/DebugLib.h>
 #include <Library/PciLib.h>
 #include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
 #include <Library/GpioLib.h>
 #include <Library/CryptoLib.h>
 #include <Library/BoardInitLib.h>
@@ -32,6 +33,14 @@
 #include <BlCommon.h>
 #include <ConfigDataDefs.h>
 #include "GpioTbl.h"
+
+CONST PLT_DEVICE  mPlatformDevices[]= {
+  {{0x00001F02}, OsBootDeviceSata  , 0 },
+  {{0x00000300}, OsBootDeviceSd    , 0 },
+  {{0x00000300}, OsBootDeviceNvme  , 0 },
+  {{0x00000400}, OsBootDeviceUsb   , 0 },
+  {{0x01000000}, OsBootDeviceMemory, 0 }
+};
 
 /**
   This function overrides the default configurations in the FSP-M UPD data region.
@@ -196,9 +205,14 @@ BoardInit (
 )
 {
   EFI_STATUS            Status;
+  PLT_DEVICE_TABLE      *PltDeviceTable;
 
   switch (InitPhase) {
   case PreConfigInit:
+    PltDeviceTable = (PLT_DEVICE_TABLE *)AllocatePool (sizeof (PLT_DEVICE_TABLE) + sizeof (mPlatformDevices));
+    PltDeviceTable->DeviceNumber = sizeof (mPlatformDevices) /sizeof (PLT_DEVICE);
+    CopyMem (PltDeviceTable->Device, mPlatformDevices, sizeof (mPlatformDevices));
+    SetDeviceTable (PltDeviceTable);
     BoardDetection ();
     UpdateBootMode ();
     SpiConstructor ();

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -38,12 +38,6 @@
 #include "GpioTbl.h"
 
 #define GRAPHICS_DATA_SIG    SIGNATURE_32 ('Q', 'G', 'F', 'X')
-
-CONST CHAR8  *mBootList[] = {
-  "DevType=1  DevAddr=0x00000300  HwPart=0  FilePath=iasimage.bin", // SD card
-  "DevType=0  DevAddr=0x00001F02  HwPart=5  FilePath=iasimage.bin", // SATA
-  "DevType=6  DevAddr=0x00000300  HwPart=0  FilePath=iasimage.bin"  // NVMe
-};
 
 typedef struct {
   UINT32     Signature;
@@ -308,45 +302,45 @@ UpdateOsBootMediumInfo (
   BootOption = &OsBootOptionList->OsBootOption[0];
 
   // Boot file image from SD
-  BootOption->DevType   = OsBootDeviceSd;
-  BootOption->DevAddr   = 0x00000300;
-  BootOption->HwPart    = 0;
-  BootOption->BootFlags = 0;
-  BootOption->FsType    = EnumFileSystemTypeAuto;
-  BootOption->SwPart    = 0;
+  BootOption->DevType     = OsBootDeviceSd;
+  BootOption->DevInstance = 0;
+  BootOption->HwPart      = 0;
+  BootOption->BootFlags   = 0;
+  BootOption->FsType      = EnumFileSystemTypeAuto;
+  BootOption->SwPart      = 0;
   CopyMem (BootOption->Image[0].FileName, "iasimage.bin", sizeof ("iasimage.bin"));
   OsBootOptionList->OsBootOptionCount++;
   BootOption++;
 
   // Boot file image from SATA
-  BootOption->DevType   = OsBootDeviceSata;
-  BootOption->DevAddr   = 0x00001F02;
-  BootOption->HwPart    = 5;
-  BootOption->BootFlags = 0;
-  BootOption->FsType    = EnumFileSystemTypeAuto;
-  BootOption->SwPart    = 0;
+  BootOption->DevType     = OsBootDeviceSata;
+  BootOption->DevInstance = 0;
+  BootOption->HwPart      = 5;
+  BootOption->BootFlags   = 0;
+  BootOption->FsType      = EnumFileSystemTypeAuto;
+  BootOption->SwPart      = 0;
   CopyMem (BootOption->Image[0].FileName, "iasimage.bin", sizeof ("iasimage.bin"));
   OsBootOptionList->OsBootOptionCount++;
   BootOption++;
 
   // Boot file image from NVMe
-  BootOption->DevType   = OsBootDeviceNvme;
-  BootOption->DevAddr   = 0x00000300;
-  BootOption->HwPart    = 0;
-  BootOption->BootFlags = 0;
-  BootOption->FsType    = EnumFileSystemTypeAuto;
-  BootOption->SwPart    = 0;
+  BootOption->DevType     = OsBootDeviceNvme;
+  BootOption->DevInstance = 0;
+  BootOption->HwPart      = 0;
+  BootOption->BootFlags   = 0;
+  BootOption->FsType      = EnumFileSystemTypeAuto;
+  BootOption->SwPart      = 0;
   CopyMem (BootOption->Image[0].FileName, "iasimage.bin", sizeof ("iasimage.bin"));
   OsBootOptionList->OsBootOptionCount++;
   BootOption++;
 
   // Boot file image from USB
-  BootOption->DevType   = OsBootDeviceUsb;
-  BootOption->DevAddr   = 0x00000400;
-  BootOption->HwPart    = 0;
-  BootOption->BootFlags = 0;
-  BootOption->FsType    = EnumFileSystemTypeAuto;
-  BootOption->SwPart    = 0;
+  BootOption->DevType     = OsBootDeviceUsb;
+  BootOption->DevInstance = 0;
+  BootOption->HwPart      = 0;
+  BootOption->BootFlags   = 0;
+  BootOption->FsType      = EnumFileSystemTypeAuto;
+  BootOption->SwPart      = 0;
   CopyMem (BootOption->Image[0].FileName, "iasimage.bin", sizeof ("iasimage.bin"));
   OsBootOptionList->OsBootOptionCount++;
   BootOption++;

--- a/Silicon/ApollolakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/ApollolakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -1,7 +1,7 @@
 /** @file
   This file contains the implementation of FirmwareUpdateLib library.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -192,18 +192,12 @@ AplFindBootPartition (
   RETURN_STATUS   Status;
   UINTN           BootMediumPciBase;
 
+
   //
-  // Get OS boot device address
+  // Get device address for capsule image
   //
-  if ((UserCfgData->DevAddr & 0xFF000000) == 0) {
-    BootMediumPciBase = (UINTN) MM_PCI_BASE (                   \
-                        ((UserCfgData->DevAddr >> 16) & 0xFF), \
-                        ((UserCfgData->DevAddr >> 8)  & 0xFF), \
-                        (UserCfgData->DevAddr & 0xFF)          \
-                        );
-  } else {
-    BootMediumPciBase = UserCfgData->DevAddr;
-  }
+  BootMediumPciBase = GetDeviceAddr (UserCfgData->DevType, UserCfgData->DevInstance);
+  BootMediumPciBase = TO_MM_PCI_ADDRESS (BootMediumPciBase);
   DEBUG ((DEBUG_INFO, "BootMediumPciBase(0x%x)\n", BootMediumPciBase));
 
   //


### PR DESCRIPTION
Update core code to support device table.
Updated boot option to consume device table.
Update firmware update to consume device table.
Update shell command on boot option changes.
Add device table for APL and Qemu.
Remove unnecessary code.

Signed-off-by: Guo Dong <guo.dong@intel.com>