### PR TITLE
Fix a compile error when VTD is disabled on APL

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -275,7 +275,7 @@
   gPlatformModuleTokenSpaceGuid.PcdLoadImageUseFsp        | $(ENABLE_FSP_LOAD_IMAGE)
   gPlatformModuleTokenSpaceGuid.PcdSplashEnabled          | $(ENABLE_SPLASH)
   gPlatformModuleTokenSpaceGuid.PcdFramebufferInitEnabled | $(ENABLE_FRAMEBUFFER_INIT)
-  gPlatformModuleTokenSpaceGuid.PcdVtdEnabled             | $(VTD_ENABLED)
+  gPlatformModuleTokenSpaceGuid.PcdVtdEnabled             | $(ENABLE_VTD)
   gPlatformModuleTokenSpaceGuid.PcdFlashMapEnabled        | $(HAVE_FLASH_MAP)
   gPlatformModuleTokenSpaceGuid.PcdPsdBiosEnabled         | $(HAVE_PSD_TABLE)
   gPlatformModuleTokenSpaceGuid.PcdSmmRebaseEnabled       | $(ENABLE_SMM_REBASE)

--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -1,7 +1,7 @@
 ## @file
 # This file is used to provide board specific image information.
 #
-#  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
 #
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
@@ -152,7 +152,7 @@ class Board(BaseBoard):
 			'ShellExtensionLib|Platform/$(BOARD_PKG_NAME)/Library/ShellExtensionLib/ShellExtensionLib.inf',
 			'BootMediaLib|Silicon/ApollolakePkg/Library/BootMediaLib/BootMediaLib.inf',
 			'FlashDescriptorLib|Silicon/ApollolakePkg/Library/FlashDescriptorLib/FlashDescriptorLib.inf',
-			'VTdLib|Silicon/$(SILICON_PKG_NAME)/Library/VTdLib/VTdLib.inf'
+			'VtdLib|Silicon/$(SILICON_PKG_NAME)/Library/VtdLib/VtdLib.inf'
 		]
 		return dsc_libs
 

--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -52,7 +52,7 @@ class Board(BaseBoard):
 
 		self.ENABLE_FSP_LOAD_IMAGE    = 0
 		self.ENABLE_CRYPTO_SHA_NI     = 1
-		self.VTD_ENABLED              = 1
+		self.ENABLE_VTD               = 1
 		self.ENABLE_FWU               = 1
 		self.ENABLE_SPLASH            = 1
 		self.ENABLE_FRAMEBUFFER_INIT  = 1
@@ -152,10 +152,8 @@ class Board(BaseBoard):
 			'ShellExtensionLib|Platform/$(BOARD_PKG_NAME)/Library/ShellExtensionLib/ShellExtensionLib.inf',
 			'BootMediaLib|Silicon/ApollolakePkg/Library/BootMediaLib/BootMediaLib.inf',
 			'FlashDescriptorLib|Silicon/ApollolakePkg/Library/FlashDescriptorLib/FlashDescriptorLib.inf',
+			'VTdLib|Silicon/$(SILICON_PKG_NAME)/Library/VTdLib/VTdLib.inf'
 		]
-		if self.VTD_ENABLED == 1:
-			dsc_libs['IA32'].extend (['VTdLib|Silicon/$(SILICON_PKG_NAME)/Library/VTdLib/VTdLib.inf'])
-
 		return dsc_libs
 
 	def GetFlashMapList (self):

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -410,34 +410,6 @@ AssignPciIrqs (
   }
 }
 
-/**
-  Init UART2 BAR
-
-  Current ACRN is using fixed UART address for GP MRB target.
-  So here init UART2 BAR to 0xFC000000
-  And make sure it will be invoked in both normal and S3 path.
-
-**/
-VOID
-InitUart2Bar (
-  VOID
-  )
-{
-  UINT32      PciBase;
-  UINT32      Base;
-
-  if (FeaturePcdGet (PcdVtdEnabled)) {
-    Base    = 0xFC000000;
-    PciBase = MmPciBase (DEFAULT_PCI_BUS_NUMBER_SC, \
-                         PCI_DEVICE_NUMBER_LPSS_HSUART, \
-                         (PCI_FUNCTION_NUMBER_LPSS_HSUART0 + 2));
-
-    MmioAnd32   (PciBase + PCI_COMMAND_OFFSET, (UINT32)~ (EFI_PCI_COMMAND_MEMORY_SPACE));
-    MmioWrite32 (PciBase + PCI_BASE_ADDRESSREG_OFFSET, Base);
-    MmioOr32    (PciBase + PCI_COMMAND_OFFSET, EFI_PCI_COMMAND_MEMORY_SPACE);
-  }
-}
-
 VOID
 SaveOtgRole (
   VOID
@@ -689,7 +661,6 @@ BoardInit (
         DEBUG ((DEBUG_ERROR, "Error in seeds generation: %r\n", Status));
       }
     }
-    InitUart2Bar ();
     AssignPciIrqs ();
     RestoreOtgRole ();
     break;

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.h
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -45,7 +45,7 @@
 #include <IndustryStandard/Acpi.h>
 #include <Library/SpiFlashLib.h>
 #include <Library/TpmLib.h>
-#include <Library/VTdLib.h>
+#include <Library/VtdLib.h>
 #include <RegAccess.h>
 #include <IndustryStandard/Pci.h>
 #include <IndustryStandard/Acpi.h>

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
 #  which accompanies this distribution.  The full text of the license may be found at
@@ -52,7 +52,7 @@
   IoLib
   SpiFlashLib
   TpmLib
-  VTdLib
+  VtdLib
   ConfigDataLib
   RleCompressLib
   SeedListInfoLib

--- a/Silicon/ApollolakePkg/Include/Library/VtdLib.h
+++ b/Silicon/ApollolakePkg/Include/Library/VtdLib.h
@@ -1,7 +1,7 @@
 /** @file
   This code provides a initialization of intel VT-d (Virtualization Technology for Directed I/O).
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -12,8 +12,8 @@
 
 **/
 
-#ifndef _VT_D_LIB_H_
-#define _VT_D_LIB_H_
+#ifndef __VTD_LIB_H__
+#define __VTD_LIB_H__
 
 #define VTD_RMRR_USB_LENGTH                   0x20000
 
@@ -30,4 +30,5 @@ VOID
 UpdateDmarAcpi (
   EFI_ACPI_DESCRIPTION_HEADER *Table
   );
-#endif
+
+#endif /* __VTD_LIB_H__ */

--- a/Silicon/ApollolakePkg/Library/VtdLib/VtdLib.c
+++ b/Silicon/ApollolakePkg/Library/VtdLib/VtdLib.c
@@ -1,7 +1,7 @@
 /** @file
   This code provides a initialization of intel VT-d (Virtualization Technology for Directed I/O).
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -17,7 +17,7 @@
 #include <Library/IoLib.h>
 #include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
-#include <Library/VTdLib.h>
+#include <Library/VtdLib.h>
 #include <RegAccess.h>
 #include <Library/DmaRemappingTable.h>
 #include <Library/PciLib.h>
@@ -189,7 +189,7 @@ UpdateDrhd2 (
       // Update source id for IoApic's device scope entry
       //
       Data16 = MmioRead16 (P2sbMmbase + R_PCH_P2SB_IBDF);
-      DEBUG ((EFI_D_INFO, " VTD Lib: P2sbMmbase = 0x%X, IBDF = 0x%X\n", P2sbMmbase, Data16));
+      DEBUG ((EFI_D_INFO, " VtdLib: P2sbMmbase = 0x%X, IBDF = 0x%X\n", P2sbMmbase, Data16));
       Bus     = (UINT8) (Data16 >> 8);
       Path[0] = (UINT8) ((Data16 & 0xff) >> 3);
       Path[1] = (UINT8) (Data16 & 0x7);
@@ -202,7 +202,7 @@ UpdateDrhd2 (
       // Update APIC ID
       //
       DrhdEngine->DeviceScope[Index].EnumId = GetIoApicId();
-      DEBUG ((EFI_D_INFO, " VTd check IoApicId : 0x%x\n", GetIoApicId()));
+      DEBUG ((EFI_D_INFO, " VtdLib: IoApicId 0x%x\n", GetIoApicId()));
     }
 
     if (Index == 1) {

--- a/Silicon/ApollolakePkg/Library/VtdLib/VtdLib.inf
+++ b/Silicon/ApollolakePkg/Library/VtdLib/VtdLib.inf
@@ -1,5 +1,5 @@
 ## @file
-#  Component description file for VTd Library
+#  Component description file for Vtd Library
 #
 #  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
 #  This program and the accompanying materials
@@ -25,7 +25,7 @@
 #
 
 [Sources]
-  VTdLib.c
+  VtdLib.c
 
 [Packages]
   MdePkg/MdePkg.dec


### PR DESCRIPTION
When VTD_ENABLE sets to '0', a compile error occurs because some .inf
files refer to VtdLib. Therefore, VtdLib is included to default
libraries - dsc_libs['IA32'].

Additionaly,
- Rename VTD_ENABLED to ENABLE_VTD to make feature enabling name
  consistent
- Remove hard-coded UART2 BAR for ACRN

Change-Id: I22969c0e4509ab0a0dc21d50e6afbdfb893f25a8
Signed-off-by: Aiden Park <aiden.park@intel.com>