### PR TITLE
Rename KeyStore to HashStore to reduce confusion

### DIFF
--- a/BootloaderCommonPkg/Library/SecureBootLib/SecureBootHash.c
+++ b/BootloaderCommonPkg/Library/SecureBootLib/SecureBootHash.c
@@ -67,7 +67,7 @@ DoHashVerify (
     DEBUG ((DEBUG_INFO, "Image Digest\n"));
     DumpHex (2, 0, SHA256_DIGEST_SIZE, (VOID *)Digest);
 
-    DEBUG ((DEBUG_INFO, "KeyStore Digest\n"));
+    DEBUG ((DEBUG_INFO, "HashStore Digest\n"));
     DumpHex (2, 0, SHA256_DIGEST_SIZE, (VOID *)PubKeyHash);
 
     DEBUG_CODE_END();

--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -132,7 +132,7 @@
   gPlatformModuleTokenSpaceGuid.PcdGraphicsVbtAddress     | 0xFF000000 | UINT32 | 0x20000113
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegBase          | 0xFF000000 | UINT32 | 0x20000120
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegSize          | 0x00000000 | UINT32 | 0x20000121
-  gPlatformModuleTokenSpaceGuid.PcdKeyStoreBase           | 0xFF000000 | UINT32 | 0x20000181
+  gPlatformModuleTokenSpaceGuid.PcdHashStoreBase          | 0xFF000000 | UINT32 | 0x20000181
   gPlatformModuleTokenSpaceGuid.PcdDeviceTreeBase         | 0xFF000000 | UINT32 | 0x20000183
   gPlatformModuleTokenSpaceGuid.PcdSplashLogoAddress      | 0xFF000000 | UINT32 | 0x20000184
   gPlatformModuleTokenSpaceGuid.PcdFileDataBase           | 0xFF000000 | UINT32 | 0x20000185

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -247,7 +247,7 @@
   gPlatformModuleTokenSpaceGuid.PcdGraphicsVbtAddress| 0xFF000000
   gPlatformModuleTokenSpaceGuid.PcdDeviceTreeBase    | 0xFF000000
   gPlatformCommonLibTokenSpaceGuid.PcdAcpiPmTimerBase   | $(ACPI_PM_TIMER_BASE)
-  gPlatformModuleTokenSpaceGuid.PcdKeyStoreBase      | 0xFF000000
+  gPlatformModuleTokenSpaceGuid.PcdHashStoreBase     | 0xFF000000
   gPlatformModuleTokenSpaceGuid.PcdVerInfoBase       | 0xFF000000
   gPlatformModuleTokenSpaceGuid.PcdFileDataBase      | 0xFF000000
   gPlatformModuleTokenSpaceGuid.PcdFSPSBase          | $(FSP_S_BASE)

--- a/BootloaderCorePkg/Include/HashStore.h
+++ b/BootloaderCorePkg/Include/HashStore.h
@@ -11,11 +11,11 @@
 
 **/
 
-#ifndef __KEY_STORE_H__
-#define __KEY_STORE_H__
+#ifndef __HASH_STORE_H__
+#define __HASH_STORE_H__
 
-#define  KEYSTORE_SIGNATURE                SIGNATURE_32('_', 'K', 'S', '_')
-#define  KEYSTORE_DIGEST_LENGTH            32
+#define  HASH_STORE_SIGNATURE                SIGNATURE_32('_', 'H', 'S', '_')
+#define  HASH_STORE_DIGEST_LENGTH            32
 
 #define  HASH_INDEX_STAGE_1B               0
 #define  HASH_INDEX_STAGE_2                1
@@ -30,14 +30,14 @@
 
 #pragma pack(1)
 typedef struct {
-  UINT8  Data[KEYSTORE_DIGEST_LENGTH];
-} KEYSTORE_DATA;
+  UINT8  Data[HASH_STORE_DIGEST_LENGTH];
+} HASH_STORE_DATA;
 
 typedef struct {
   UINT32             Signature;
   UINT32             Valid;
-  KEYSTORE_DATA      Data[HASH_INDEX_MAX_NUM];
-} KEYSTORE_TABLE;
+  HASH_STORE_DATA    Data[HASH_INDEX_MAX_NUM];
+} HASH_STORE_TABLE;
 #pragma pack()
 
-#endif /* __KEY_STORE_H__ */
+#endif /* __HASH_STORE_H__ */

--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -58,7 +58,7 @@ typedef struct {
 typedef struct {
   UINT32        CarBase;
   UINT32        CarTop;
-  UINT32        KeyStoreBase;
+  UINT32        HashStoreBase;
   UINT32        VerInfoBase;
   UINT32        AllocDataBase;
   UINT32        AllocDataLen;
@@ -174,7 +174,7 @@ typedef struct {
   VOID             *FspHobList;
   VOID             *LdrHobList;
   VOID             *VerInfoPtr;
-  VOID             *KeyStorePtr;
+  VOID             *HashStorePtr;
   VOID             *ConfDataPtr;
   VOID             *S3DataPtr;
   VOID             *DebugDataPtr;

--- a/BootloaderCorePkg/Library/BootloaderCoreLib/BootloaderCoreLib.c
+++ b/BootloaderCorePkg/Library/BootloaderCoreLib/BootloaderCoreLib.c
@@ -17,7 +17,7 @@
 #include <Library/DebugLib.h>
 #include <Library/HobLib.h>
 #include <Library/BootloaderCoreLib.h>
-#include <KeyStore.h>
+#include <HashStore.h>
 #include <Guid/FlashMapInfoGuid.h>
 
 /**

--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -154,7 +154,7 @@ SecStartup2 (
                 + LibDataLen + ServiceDataLen + PcdDatabaseLen + PlatformDataLen \
                 + LogBufLen + sizeof (UINTN) * 16;
   if (FeaturePcdGet (PcdVerifiedBootEnabled)) {
-    AllocateLen += sizeof (KEYSTORE_TABLE);
+    AllocateLen += sizeof (HASH_STORE_TABLE);
   }
   if (FeaturePcdGet (PcdFlashMapEnabled) == TRUE) {
     FlashMap = (FLASH_MAP *) (* (UINT32 *)FLASH_MAP_ADDRESS);
@@ -186,9 +186,9 @@ SecStartup2 (
 
     // Key Store
     if (FeaturePcdGet (PcdVerifiedBootEnabled)) {
-      CopyMem (BufPtr, (VOID *)PcdGet32 (PcdKeyStoreBase), sizeof (KEYSTORE_TABLE));
-      LdrGlobal->KeyStorePtr = BufPtr;
-      BufPtr += ALIGN_UP (sizeof (KEYSTORE_TABLE), sizeof (UINTN));
+      CopyMem (BufPtr, (VOID *)PcdGet32 (PcdHashStoreBase), sizeof (HASH_STORE_TABLE));
+      LdrGlobal->HashStorePtr = BufPtr;
+      BufPtr += ALIGN_UP (sizeof (HASH_STORE_TABLE), sizeof (UINTN));
     }
 
     // Library data

--- a/BootloaderCorePkg/Stage1A/Stage1A.h
+++ b/BootloaderCorePkg/Stage1A/Stage1A.h
@@ -36,7 +36,7 @@
 #include <Guid/LoaderPlatformDataGuid.h>
 #include <Guid/PcdDataBaseSignatureGuid.h>
 #include <VerInfo.h>
-#include <KeyStore.h>
+#include <HashStore.h>
 
 /**
   Load IDT table for current processor.

--- a/BootloaderCorePkg/Stage1A/Stage1A.inf
+++ b/BootloaderCorePkg/Stage1A/Stage1A.inf
@@ -66,7 +66,7 @@
   gPlatformModuleTokenSpaceGuid.PcdStage1StackSize
   gPlatformModuleTokenSpaceGuid.PcdStage1BFdBase
   gPlatformModuleTokenSpaceGuid.PcdStage1BLoadBase
-  gPlatformModuleTokenSpaceGuid.PcdKeyStoreBase
+  gPlatformModuleTokenSpaceGuid.PcdHashStoreBase
   gPlatformModuleTokenSpaceGuid.PcdVerInfoBase
   gPlatformModuleTokenSpaceGuid.PcdStage1DataSize
   gPlatformModuleTokenSpaceGuid.PcdStage1StackSize

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -410,8 +410,8 @@ SecStartup2 (
   if (LdrGlobal->VerInfoPtr) {
     LdrGlobal->VerInfoPtr = (UINT8 *)LdrGlobal->VerInfoPtr + Delta;
   }
-  if (LdrGlobal->KeyStorePtr) {
-    LdrGlobal->KeyStorePtr = (UINT8 *)LdrGlobal->KeyStorePtr + Delta;
+  if (LdrGlobal->HashStorePtr) {
+    LdrGlobal->HashStorePtr = (UINT8 *)LdrGlobal->HashStorePtr + Delta;
   }
   if (LdrGlobal->ConfDataPtr) {
     LdrGlobal->ConfDataPtr = (UINT8 *)LdrGlobal->ConfDataPtr + Delta;

--- a/BootloaderCorePkg/Stage1B/Stage1B.h
+++ b/BootloaderCorePkg/Stage1B/Stage1B.h
@@ -39,11 +39,12 @@
 #include <Library/DebugLogBufferLib.h>
 #include <Library/LocalApicLib.h>
 #include <Library/DebugAgentLib.h>
+#include <Library/TpmLib.h>
 #include <Guid/PcdDataBaseSignatureGuid.h>
 #include <Guid/LoaderPlatformDataGuid.h>
 #include <VerInfo.h>
-#include <KeyStore.h>
-#include <Library/TpmLib.h>
+#include <HashStore.h>
+
 
 /**
   Continue Stage1B execution.

--- a/BootloaderCorePkg/Stage2/Stage2.h
+++ b/BootloaderCorePkg/Stage2/Stage2.h
@@ -56,8 +56,7 @@
 #include <Library/ConfigDataLib.h>
 #include <Library/DebugAgentLib.h>
 #include <Library/ElfLib.h>
-
-#include <KeyStore.h>
+#include <HashStore.h>
 #include <VerInfo.h>
 
 #define UIMAGE_FIT_MAGIC               (0x56190527)

--- a/BootloaderCorePkg/Stage2/Stage2Support.c
+++ b/BootloaderCorePkg/Stage2/Stage2Support.c
@@ -446,7 +446,7 @@ BuildBaseInfoHob (
   }
 
   // Build key hash Hob for Payload
-  if (LdrGlobal->KeyStorePtr != NULL) {
+  if (LdrGlobal->HashStorePtr != NULL) {
     HobDataSize = sizeof (PAYLOAD_KEY_HASH) + sizeof (KEY_HASH_ITEM) * MAX_KEY_DIGEST_COUNT;
     HashHob     = BuildGuidHob (&gPayloadKeyHashGuid, HobDataSize);
     if (HashHob != NULL) {

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -630,7 +630,7 @@ class Build(object):
 				])
 		if self._board.HAVE_VERIFIED_BOOT:
 			extra_cmd.append (
-				"<Stage1A:__gPcd_BinaryPatch_PcdKeyStoreBase>, {18EDB1DF-1DBE-4EC5-8E26-C44808B546E1:0x1C}, @Patch KeyStore",
+				"<Stage1A:__gPcd_BinaryPatch_PcdHashStoreBase>, {18EDB1DF-1DBE-4EC5-8E26-C44808B546E1:0x1C}, @Patch HashStore",
 			)
 		patch_fv(self._fv_dir, *extra_cmd)
 

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -720,7 +720,7 @@ AfterUpdateEnforceFwUpdatePolicy (
   Verify the capsule image against its signature.
 
   This function first gets the hash of the processed public key, then compare it
-  with the saved one from keystore. If they are same, the pre-processed key is
+  with the saved one from hash store. If they are same, the pre-processed key is
   verified.
   Then using the pre-process key to verify capsule image, if it passed verification,
   the capsule image can be trusted.

--- a/Silicon/ApollolakePkg/Library/PsdLib/PsdLib.c
+++ b/Silicon/ApollolakePkg/Library/PsdLib/PsdLib.c
@@ -180,7 +180,7 @@ GetIbbHashDataFromBpm (
   DEBUG ((DEBUG_INFO, "BpmData->IbbmHash IBB Hash: 0x%08x\n", BpmData->IbbmHash));
   DumpHex (2, 0, BpmData->IbbmHashSize, (VOID *)BpmData->IbbmHash);
 
-  //OBB Hash, we will calculate Stage-2 HASH from keystore ( OBB = Stage2 + padding ),
+  //OBB Hash, we will calculate Stage-2 HASH from hash store ( OBB = Stage2 + padding ),
 
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
Current code refers hash store as "key store". It is confusing
since there is no key stored in the image at all.  Instead, the
public key hash is stored.  The patch renames the KeyStore
to HashStore.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>