### PR TITLE
[GCC] Fix gcc compile errors

### DIFF
--- a/BootloaderCommonPkg/Library/BootloaderCommonLib/BootloaderCommonLib.c
+++ b/BootloaderCommonPkg/Library/BootloaderCommonLib/BootloaderCommonLib.c
@@ -531,6 +531,7 @@ GetDeviceAddr (
   UINT32             Index;
 
   DeviceBase  = 0;
+  Device = NULL;
   DeviceTable = (PLT_DEVICE_TABLE *)GetDeviceTable();
   for (Index = 0; Index < DeviceTable->DeviceNumber; Index++) {
     Device = &DeviceTable->Device[Index];

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -368,11 +368,13 @@ VerifyFwVersion (
   //
   // Get base address of Stage 1A in capsule Image
   //
+  Status = EFI_INVALID_PARAMETER;
   if (FwPolicy.Fields.UpdatePartitionB == 0x1) {
     Status = GetComponentInfoByPartition(FLASH_MAP_SIG_STAGE1A, FALSE, &CompBase, &CompSize);
   } else if (FwPolicy.Fields.UpdatePartitionA == 0x1) {
     Status = GetComponentInfoByPartition(FLASH_MAP_SIG_STAGE1A, TRUE, &CompBase, &CompSize);
   }
+
   if (EFI_ERROR(Status)) {
     DEBUG((DEBUG_ERROR, "GetComponentInfoByPartition: %r\n", Status));
     return Status;

--- a/PayloadPkg/OsLoader/BootParameters.c
+++ b/PayloadPkg/OsLoader/BootParameters.c
@@ -237,6 +237,7 @@ UpdateOsParameters (
 
   // Check storage serial number validity. eMMC only for now.
   if (PcdGetBool (PcdSeedListEnabled)) {
+    SerialNumValidity = FALSE;
     if (CurrentBootOption->DevType == OsBootDeviceEmmc) {
       Status = EmmcSerialNumCheck();
       if (EFI_ERROR (Status)) {

--- a/PayloadPkg/OsLoader/KeyManagement.c
+++ b/PayloadPkg/OsLoader/KeyManagement.c
@@ -264,6 +264,7 @@ RpmbKeyProvisioning (
   }
 
   // Copy 32 bytes for APL
+  Status = EFI_UNSUPPORTED;
   for(Index = 0;Index < mRpmbKeyCount; Index++) {
     RpmbSeedInfo = (UINT8 *)&SeedList->RpmbHeciSeeds[Index];
     Status = RpmbProgramKey(CurrentBootOption->DevType, 0, RpmbSeedInfo, 32, &Result);

--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -103,7 +103,7 @@ class Board(BaseBoard):
 		self.STAGE1B_FD_SIZE      = 0x0006B000
 		if self.RELEASE_MODE == 0:
 			self.STAGE1B_FD_SIZE += 0x00002000
-			self.PAYLOAD_SIZE    += 0x00002000
+			self.PAYLOAD_SIZE    += 0x00003000
 		# For Stage2, it is always compressed.
 		# if STAGE2_LOAD_HIGH is 1, STAGE2_FD_BASE will be ignored
 		self.STAGE2_FD_BASE       = 0x01000000

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/SeedSupport.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/SeedSupport.c
@@ -374,6 +374,7 @@ UpdateSeedListInfo (
     return EFI_NOT_FOUND;
   }
 
+  Status = EFI_NOT_FOUND;
   if (LdrSeedList->NumofSeeds > 0) {
     for (Index = 0; Index < LdrSeedList->NumofSeeds; Index++) {
       // Fill SeedListHOB with one USeed at a time


### PR DESCRIPTION
There are 'uninitialized' errors and size exceed error in PAYLOAD
with old gcc versions. This change has been verified with gcc-4.8,
gcc-5, gcc-7 and gcc-8 on Ubuntu 18.04 LTS.

Signed-off-by: Aiden Park <aiden.park@intel.com>