### PR TITLE
[APL] Add BP1 partition size check in StitchLoader.py

### DIFF
--- a/Platform/ApollolakeBoardPkg/Script/StitchLoader.py
+++ b/Platform/ApollolakeBoardPkg/Script/StitchLoader.py
@@ -543,6 +543,10 @@ def CopyComponent (Root, Path, IfwiData):
     Bp1SBpdtEndOffset = Bp1SBpdtOffset + Bp1SBpdt.Length
     IfwiData[Bp1SBpdtOffset:Bp1SBpdtEndOffset] = Bp1SBpdtData
     Padding = Bp1.Offset + Bp1.Length - Bp1SBpdtEndOffset
+    if Padding < 0:
+        print ('Insufficiant space in BP1 partition !')
+        return -1
+
     IfwiData[Bp1SBpdtEndOffset:Bp1SBpdtEndOffset+Padding] = '\xff' * Padding
 
     # Fix Sbpdt length in BP1 BPDT
@@ -632,7 +636,6 @@ def CreateDirData (Dir, IfwiData):
 
 
 def RefreshIfwiForDir (Dir, IfwiData):
-    print Dir.Name
     # Claculate new DIR length and creaet new DIR data
     DirData = CreateDirData (Dir, IfwiData)
     Length  = len (DirData)


### PR DESCRIPTION
Current SitchLoader.py does not verify if the BP1 partition size
is big enough to hold a duplicated BPDT from BP0. And it will
result in invalid BPDT partition format if it occurs. This patch
added a check so that it will error out if insufficient space is
detected.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>