### PR TITLE
Integrate external fastboot code as a boot option

### DIFF
--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -72,8 +72,8 @@ class Board(BaseBoard):
 		# BIT0:Serial  BIT1:GFX
 		self.CONSOLE_OUT_DEVICE_MASK = 0x00000001
 
-		# NVMe | Usb | Spi | Ufs | eMMC | SD | Sata
-		self.BOOT_MEDIA_SUPPORT_MASK  = 0x3F
+		# Mem | NVMe | Usb | Spi | Ufs | eMMC | SD | Sata
+		self.BOOT_MEDIA_SUPPORT_MASK  = 0xBF
 
 		# EXT | FAT
 		self.FILE_SYSTEM_SUPPORT_MASK  = 3

--- a/Platform/ApollolakeBoardPkg/Script/StitchLoader.py
+++ b/Platform/ApollolakeBoardPkg/Script/StitchLoader.py
@@ -804,7 +804,7 @@ def CreateIfwiImage (IfwiIn, IfwiOut, BiosOut, PlatformData, StitchDir, Redundan
         ]
 
         ObbList = [
-          ('PROV' , ''),
+          ('PROV' , 'FB'),
           ('EPLD' , 'EPLD'),
           ('PLD'  , 'PLD'),
 


### PR DESCRIPTION
fastboot protocol allows communication between host and device bootloader
via USB or Ethernet. This patch provides initial configuration in SBL
so that device can enter fastboot mode on device when all previous boot
options are failed.

Typically fastboot is used to provision OS images to eMMC with fastboot
client tool.

The fastboot executable is required to be packaged in IAS format
then integrated into SPI image or copied into the first FAT partition on
a USB key.

This change fixed build configuration to load fastboot code either from
SPI or USB.

Signed-off-by: Huang Jin <huang.jin@intel.com>