### PR TITLE
Set PYTHON_HOME env variable for Windows build

### DIFF
--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -44,12 +44,12 @@ def rebuild_basetools ():
 			ret = subprocess.call(['make', '-C', 'BaseTools'])
 
 	elif os.name == 'nt':
+		if 'PYTHON_HOME' not in os.environ:
+			os.environ['PYTHON_HOME'] = 'C:\\Python27'
 		genffs_exe_path = os.path.join(sblsource, 'BaseTools', 'Bin', 'Win32', 'GenFfs.exe')
 		genffs_exist = os.path.exists(genffs_exe_path)
 		if not genffs_exist:
 			print "Could not find pre-built BaseTools binaries, try to rebuild BaseTools ..."
-			if 'PYTHON_HOME' not in os.environ:
-				os.environ['PYTHON_HOME'] = 'C:\\Python27'
 			ret = subprocess.call(['BaseTools\\toolsetup.bat', 'forcerebuild'])
 
 	if ret:


### PR DESCRIPTION
The latest SBL source code does not build on certain environment.
For example, when PYTHON_HOME is not set manually, it will cause
build failure due to invalid path for python.exe.  This patch will
set the PYTHON_HOME env variable if it has not been set already.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>