### PR TITLE
Fix firmware update bug to load capsule from USB

### DIFF
--- a/BootloaderCommonPkg/Library/FileSystemLib/FileSystemLib.c
+++ b/BootloaderCommonPkg/Library/FileSystemLib/FileSystemLib.c
@@ -91,10 +91,6 @@ InitFileSystem (
     return Status;
   }
 
-  if (FsType == EnumFileSystemTypeAuto) {
-    FsType = 0xFFFFFFFF;
-  }
-
   if (mCurrentFsType == EnumFileSystemMax) {
     Type = EnumFileSystemTypeFat;
     if (FixedPcdGet32 (PcdSupportedFileSystemMask) & (1 << Type)) {
@@ -111,7 +107,10 @@ InitFileSystem (
   }
 
   for (Type = EnumFileSystemTypeFat; Type < EnumFileSystemTypeAuto; Type++) {
-    if (((FsType & (1 << Type)) != 0) && (mFileSystemFuncs[Type].InitFileSystem != NULL)) {
+    if (mFileSystemFuncs[Type].InitFileSystem == NULL) {
+      continue;
+    }
+    if ((FsType == EnumFileSystemTypeAuto) || (FsType == Type)) {
       Status = mFileSystemFuncs[Type].InitFileSystem (SwPart, PartHandle, FsHandle);
       if (!EFI_ERROR (Status)) {
         mCurrentFsType = Type;

--- a/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
+++ b/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
@@ -271,7 +271,7 @@ LoadCapsuleImage (
   }
 
   FsHandle = NULL;
-  Status = InitFileSystem (CapsuleInfo->SwPart, EnumFileSystemTypeFat, HwPartHandle, &FsHandle);
+  Status = InitFileSystem (CapsuleInfo->SwPart, EnumFileSystemTypeAuto, HwPartHandle, &FsHandle);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_INFO, "No partitions found, Status = %r\n", Status));
     goto Done;

--- a/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
+++ b/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
@@ -271,7 +271,7 @@ LoadCapsuleImage (
   }
 
   FsHandle = NULL;
-  Status = InitFileSystem (CapsuleInfo->SwPart, EnumFileSystemTypeAuto, HwPartHandle, &FsHandle);
+  Status = InitFileSystem (CapsuleInfo->SwPart, EnumFileSystemTypeFat, HwPartHandle, &FsHandle);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_INFO, "No partitions found, Status = %r\n", Status));
     goto Done;


### PR DESCRIPTION
File system is not initialized when invalid parameter is
given to InitFileSystem(). This bug causes FWU payload
fails to load capsule using shell command fwupdate.

Signed-off-by: Huang Jin <huang.jin@intel.com>