### PR TITLE
[APL] Enlarge payload heap size from 64MB to 128MB

### DIFF
--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -132,7 +132,7 @@ class Board(BaseBoard):
 		self.PLD_RSVD_MEM_SIZE    = 0x00500000
 		self.PAYLOAD_LOAD_HIGH    = 1
 
-		self.PLD_HEAP_SIZE        = 0x04000000
+		self.PLD_HEAP_SIZE        = 0x08000000
 
 		self.FWUPDATE_SIZE        = 0x00030000
 		self.CFGDATA_SIZE         = 0x00004000


### PR DESCRIPTION
This change makes more space for SBL paylaod to load
larger IAS image (e.g. Ubuntu kernel + initrd ~ 33MB)

The payload heap memory is reusable as long as crash mode
is disabled.

TEST=Loaded and booted IAS image containing Ubuntu kernel and
     initrd from USB flash drive on UP2 board.

Signed-off-by: Huang Jin <huang.jin@intel.com>