### PR TITLE
Retrieve version info from proper platform repo

### DIFF
--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -721,9 +721,9 @@ def get_verinfo_via_file (file):
 	return ver_info
 
 
-def get_verinfo_via_git (ver_dict):
+def get_verinfo_via_git (ver_dict, repo_dir = '.'):
 	gitcmd   = 'git describe --dirty --abbrev=16 --always'
-	command  = subprocess.Popen(gitcmd, shell=True, stdout=subprocess.PIPE)
+	command  = subprocess.Popen(gitcmd, shell=True, cwd=repo_dir, stdout=subprocess.PIPE)
 	line     = command.stdout.readline().strip()
 	commitid = 0
 	dirty    = 0

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -1007,7 +1007,7 @@ class Build(object):
 			ver_dict = {}
 			for key in keys:
 				ver_dict[key] = getattr (self._board, key)
-			ver_info = get_verinfo_via_git  (ver_dict)
+			ver_info = get_verinfo_via_git  (ver_dict, os.environ['PLT_SOURCE'])
 			gen_ver_info_txt (ver_txt_file, ver_info)
 		gen_file_from_object (ver_bin_file, ver_info)
 


### PR DESCRIPTION
SBL supports putting platform packages in a separate repo tree
defined by environment variable PLT_SOURCE. Current build process
will always retrieve the latest commit id info from open source
repo as version even when the platform uses a separate repo tree.
This patch corrected this behavior. When a platform package is in
a separate repo, the git commit id info will be retrieved from that
platform repo instead.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>