### PR TITLE
Enhance UEFI payload support

### DIFF
--- a/BootloaderCommonPkg/Include/Library/LitePeCoffLib.h
+++ b/BootloaderCommonPkg/Include/Library/LitePeCoffLib.h
@@ -88,4 +88,26 @@ PeCoffRelocateImage (
   IN     UINT32   CurrentImageBase
   );
 
+/**
+  Get PE/TE relocation address gap
+
+  Based on current image location Pe32Data, check if it is same with expected location to run the
+  image. If it is not same, it means the image need relocate to expected location. This function
+  will return the gap between expected location and current location.
+
+  If Pe32Data is NULL, then ASSERT().
+
+  @param[in]   Pe32Data             The pointer to the PE/COFF image that is loaded in system memory.
+  @param[out]  Gap                  The gap value between expected location and current location.
+
+  @retval RETURN_SUCCESS            Gap was returned.
+  @retval RETURN_UNSUPPORTED        It is not PE/COFF image.
+**/
+EFI_STATUS
+EFIAPI
+PeCoffRelocateGap (
+  IN  VOID                             *Pe32Data,
+  OUT INT32                            *Gap
+  );
+
 #endif

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -246,11 +246,8 @@ NormalBootPath (
   } else if (Dst[10] == EFI_FVH_SIGNATURE) {
     // It is a FV format
     DEBUG ((DEBUG_INFO, "FV Format Payload\n"));
-    // If loading base is not as expected, copy it over
-    PldEntry = (PAYLOAD_ENTRY)Dst[0];
-    if ((UINT32)Dst != Dst[1]) {
-      CopyMem ((VOID *)Dst[1], Dst, Stage2Hob->PayloadActualLength);
-    }
+    Status = LoadFvImage (Dst, Stage2Hob->PayloadActualLength, (VOID **)&PldEntry);
+    ASSERT_EFI_ERROR (Status);
   } else if (IsElfImage (Dst)) {
     PldEntry = (PAYLOAD_ENTRY) (UINTN) LoadElfImage (Dst);
     ASSERT (PldEntry != NULL);

--- a/BootloaderCorePkg/Stage2/Stage2.h
+++ b/BootloaderCorePkg/Stage2/Stage2.h
@@ -160,4 +160,25 @@ BoardNotifyPhase (
   IN BOARD_INIT_PHASE   Phase
   );
 
+/**
+  Load FV to expected location and return entry point of SEC core.
+
+  This function will search whole FV to find SEC core file, and then check SEC core file if
+  relocation is required. If relocation is required, this function will relocation whole FV
+  to expected location and SEC core entry point will be returned if success.
+
+  @param[in]  FvBase                   Point to the boot firmware volume.
+  @param[in]  FvActualLength           The actural length of FV.
+  @param[out] EntryPoint               The sec core entry point.
+
+  @retval RETURN_SUCCESS               The FV is loaded successfully.
+  @retval Others                       Failed to load the FV.
+**/
+EFI_STATUS
+LoadFvImage (
+  IN  UINT32                           *FvBase,
+  IN  UINT32                           FvActualLength,
+  OUT VOID                             **EntryPoint
+  );
+
 #endif

--- a/BootloaderCorePkg/Stage2/Stage2Support.c
+++ b/BootloaderCorePkg/Stage2/Stage2Support.c
@@ -722,3 +722,96 @@ InitializeService (
   RegisterService ((VOID *)&mPlatformService);
 
 }
+
+
+/**
+  Load FV to expected location and return entry point of SEC core.
+
+  This function will search whole FV to find SEC core file, and then check SEC core file if
+  relocation is required. If relocation is required, this function will relocation whole FV
+  to expected location and SEC core entry point will be returned if success.
+
+  @param[in]  FvBase                   Point to the boot firmware volume.
+  @param[in]  FvActualLength           The actural length of FV.
+  @param[out] EntryPoint               The sec core entry point.
+
+  @retval RETURN_SUCCESS               The FV is loaded successfully.
+  @retval Others                       Failed to load the FV.
+**/
+EFI_STATUS
+LoadFvImage (
+  IN  UINT32                           *FvBase,
+  IN  UINT32                           FvActualLength,
+  OUT VOID                             **EntryPoint
+  )
+{
+  EFI_STATUS                            Status;
+  EFI_FIRMWARE_VOLUME_HEADER            *FvHeader;
+  EFI_FIRMWARE_VOLUME_EXT_HEADER        *FvExHeader;
+  EFI_FFS_FILE_HEADER                   *FfsFileHeader;
+  EFI_COMMON_SECTION_HEADER             *Section;
+  UINTN                                 SectionEnd;
+  UINT32                                SecCoreImageBase;
+  INT32                                 Gap;
+
+  FvHeader = (EFI_FIRMWARE_VOLUME_HEADER *)FvBase;
+  Status   = EFI_NOT_FOUND;
+
+  //
+  // Get first FFS file
+  //
+  FfsFileHeader = (EFI_FFS_FILE_HEADER *)((UINT8 *)FvHeader + FvHeader->HeaderLength);
+  if (FvHeader->ExtHeaderOffset != 0) {
+    FvExHeader = (EFI_FIRMWARE_VOLUME_EXT_HEADER *)(((UINT8 *)FvHeader) + FvHeader->ExtHeaderOffset);
+    FfsFileHeader = (EFI_FFS_FILE_HEADER *)(((UINT8 *)FvExHeader) + FvExHeader->ExtHeaderSize);
+  }
+
+  //
+  // Loop through the FV to find the SEC core file
+  //
+  FfsFileHeader = ALIGN_POINTER (FfsFileHeader, 8);
+  while (FfsFileHeader->Type != EFI_FV_FILETYPE_SECURITY_CORE) {
+    FfsFileHeader = ALIGN_POINTER ((UINTN)FfsFileHeader + FFS_FILE_SIZE (FfsFileHeader), 8);
+    if ((UINTN)FfsFileHeader >= (UINTN)FvHeader + FvHeader->FvLength) {
+      return Status;
+    }
+  }
+
+  //
+  // Loop through the file to find a executable section
+  //
+  Section    = ALIGN_POINTER ((UINTN)FfsFileHeader + sizeof (EFI_FFS_FILE_HEADER), 4);
+  SectionEnd = (UINTN)ALIGN_POINTER ((UINTN)FfsFileHeader + FFS_FILE_SIZE (FfsFileHeader), 4);
+  while (TRUE) {
+    if (Section->Type == EFI_SECTION_PE32 || Section->Type == EFI_SECTION_TE) {
+      break;
+    }
+    if (SECTION_SIZE (Section) < sizeof (EFI_COMMON_SECTION_HEADER)) {
+      return Status;
+    }
+
+    Section = ALIGN_POINTER ((UINTN)Section + SECTION_SIZE (Section), 4);
+    if ((UINTN)Section > SectionEnd) {
+      return Status;
+    }
+  }
+
+  //
+  // Reloacte FV if required
+  //
+  SecCoreImageBase = (UINTN)Section + sizeof (EFI_COMMON_SECTION_HEADER);
+  Status = PeCoffRelocateGap ((VOID *)SecCoreImageBase, &Gap);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if (Gap != 0) {
+    CopyMem ((UINT8 *)FvHeader + Gap, FvHeader, FvActualLength);
+    SecCoreImageBase += Gap;
+  }
+
+  Status = PeCoffLoaderGetEntryPoint ((VOID *)SecCoreImageBase, EntryPoint);
+
+  return Status;
+}
+


### PR DESCRIPTION
Previously SBL expects UEFI payload entrypoint and base at
hardcoded address of FV header. With this patch, SBL could
parse FV to get these info.

TEST=Tested on Leafhill and boot UEFI payload success.

Signed-off-by: Guo Dong <guo.dong@intel.com>