### PR TITLE
Fix firmware update failure

### DIFF
--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -55,6 +55,8 @@ PreparePayload (
   if (BootMode == BOOT_ON_FLASH_UPDATE) {
     Status = GetComponentInfo (FLASH_MAP_SIG_FWUPDATE, &Src, &Length);
     LoadBase = PcdGet32 (PcdFwuPayloadLoadBase);
+    // Consider firmware update payload as normal payload
+    IsNormalPld = TRUE;
   } else {
     if (IsNormalPld) {
       Status = GetComponentInfo (FLASH_MAP_SIG_PAYLOAD, &Src, &Length);


### PR DESCRIPTION
When UEFI payload or epayload is enabled and firmware update mode
is enabled, current code in prepare payload function will consider
firmware update payload as multi payload. This is causing failure
and end up as halting cpu.

This patch will add an additional check for firmware update mode
and do hash verification

TEST=Verified that firmware update is working when UEFI payload
	 is enabled.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>