### PR TITLE
Adding print for EXT CFG data and payload ID

### DIFF
--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -191,6 +191,7 @@ CreateConfigDatabase (
         Status  = DoRsaVerify ((UINT8 *)CfgBlob, CfgBlob->UsedLength, COMP_TYPE_PUBKEY_CFG_DATA,
                      SigPtr, KeyPtr, Stage1bHob->ConfigDataHash);
         if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_INFO, "EXT CFG Data ignored ... %r\n", Status));
           ExtCfgAddPtr = NULL;
         }
       }

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -50,6 +50,7 @@ PreparePayload (
 
   // Load payload to PcdPayloadLoadBase.
   PayloadId   = GetPayloadId ();
+  DEBUG ((DEBUG_INFO, "Loading Payload ID 0x%08X\n", PayloadId));
   IsNormalPld = (PayloadId == 0) ? TRUE : FALSE;
   BootMode = GetBootMode();
   if (BootMode == BOOT_ON_FLASH_UPDATE) {


### PR DESCRIPTION
Print a debug message if EXT CFG Data fails to append
in the config database. ALso, print the Payload ID in
stage2.

Signed-off-by: Sai Talamudupula <sai.kiran.talamudupula@intel.com>