### PR TITLE
Enable payload loading to high memory by default

### DIFF
--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -158,7 +158,9 @@ PreparePayload (
   if (IS_COMPRESSED (Hdr)) {
     // Determine if Payload needs to be loaded into high mem
     ActualLength = Hdr->Size;
-    if (FixedPcdGetBool (PcdPayloadLoadHigh)) {
+    // For UEFI payload, it is big and need to run at pre-compiled address,
+    // so leave it at the required address even when PcdPayloadLoadHigh is requested.
+    if (FixedPcdGetBool (PcdPayloadLoadHigh) && (GetPayloadId() != UEFI_PAYLOAD_ID_SIGNATURE)) {
       Dst = (UINT32)AllocatePages (EFI_SIZE_TO_PAGES (ActualLength));
     } else {
       Dst = PcdGet32 (PcdPayloadExeBase);

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -206,7 +206,7 @@ class BaseBoard(object):
 		self.STAGE1B_XIP           = 1
 		self.STAGE2_XIP            = 0
 		self.STAGE2_LOAD_HIGH      = 1
-		self.PAYLOAD_LOAD_HIGH     = 0
+		self.PAYLOAD_LOAD_HIGH     = 1
 		self.PAYLOAD_EXE_BASE      = 0x00800000
 
 		#     0: Direct access from flash

--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -132,7 +132,6 @@ class Board(BaseBoard):
 		self.LOADER_RSVD_MEM_SIZE = 0x00B8C000
 
 		self.PLD_RSVD_MEM_SIZE    = 0x00500000
-		self.PAYLOAD_LOAD_HIGH    = 1
 
 		self.PLD_HEAP_SIZE        = 0x08000000
 


### PR DESCRIPTION
This patch enabled payload loading into high memory by default. It
is a more general way to allocate memory for payload image instead
of hard-coded base address.  However, in some special cases, such
as UEFI payload, it still needs to be executed at pre-compiled address.
This patch also handled this special case in the flow.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>