### PR TITLE
Refactor LiteFvLib/LitePeCoffLib implementation

### DIFF
--- a/BootloaderCommonPkg/Include/Library/LiteFvLib.h
+++ b/BootloaderCommonPkg/Include/Library/LiteFvLib.h
@@ -1,7 +1,7 @@
 /** @file
   Basic graphics rendering support
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -14,6 +14,43 @@
 
 #ifndef __LITE_FV_LIB_H__
 #define __LITE_FV_LIB_H__
+
+/**
+  Check if buffer contains a valid FV header.
+
+  @param[in]        Pointer to a data buffer
+
+  @retval TRUE      The data block contains a valid FV header.
+  @retval FALSE     The data block does not contain a valid FV header.
+**/
+BOOLEAN
+EFIAPI
+IsValidFvHeader (
+  IN    VOID *Buffer
+);
+
+/**
+  Load FV to preferred location and return entry point of SEC core.
+
+  This function will search whole FV to find SEC core file, and then check SEC core
+  file if relocation is required. If relocation is required, this function will copy
+  the whole FV to preferred location and SEC core entry point will be returned if
+  success.
+
+  @param[in]  FvBase                   Point to the boot firmware volume.
+  @param[in]  FvLength                 The actural length of FV.
+  @param[out] EntryPoint               The pointer to receive SecCore entry point.
+
+  @retval RETURN_SUCCESS               The FV is loaded successfully.
+  @retval Others                       Failed to load the FV.
+**/
+EFI_STATUS
+EFIAPI
+LoadFvImage (
+  IN  UINT32                            *FvBase,
+  IN  UINT32                             FvLength,
+  OUT VOID                             **EntryPoint
+  );
 
 /**
   Find a file within a volume by its name.
@@ -33,10 +70,39 @@
 
 **/
 EFI_STATUS
+EFIAPI
 GetFfsFileByName (
   IN      EFI_FIRMWARE_VOLUME_HEADER   *FvHeader,
   IN      EFI_GUID                     *FileName,
   IN  OUT EFI_FFS_FILE_HEADER         **File
+  );
+
+
+/**
+  Find a file within a volume by its type.
+
+  This service searches for files with a specific name, within
+  either the specified firmware volume or all firmware volumes.
+
+  @param[in]       FvHeader    Pointer to a firmware volume header
+  @param[in]       FileType    The file type to search for.
+  @param[in]       Instance    0 based instance of the matched file.
+  @param[in, out]  File        Return pointer.  In the case of an error,
+                               contents are undefined.
+
+  @retval EFI_SUCCESS             The function completed successfully.
+  @retval EFI_ABORTED             An error was encountered.
+  @retval EFI_NOT_FOUND           File not found.
+  @retval EFI_INVALID_PARAMETER   One of the parameters was NULL.
+
+**/
+EFI_STATUS
+EFIAPI
+GetFfsFileByType (
+  IN  EFI_FIRMWARE_VOLUME_HEADER      *FvHeader,
+  IN  EFI_FV_FILETYPE                  FileType,
+  IN  UINT32                           Instance,
+  IN  OUT EFI_FFS_FILE_HEADER        **File
   );
 
 /**

--- a/BootloaderCommonPkg/Include/Library/LitePeCoffLib.h
+++ b/BootloaderCommonPkg/Include/Library/LitePeCoffLib.h
@@ -2,7 +2,7 @@
   Base PE/COFF loader supports loading any PE32/PE32+ or TE image, but
   only supports relocating IA32, x64, IPF, and EBC images.
 
-  Copyright (c) 2006 - 2008, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
   Portions copyright (c) 2008-2009 Apple Inc. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -43,8 +43,6 @@ IsTePe32Image (
   Retrieves the entry point to the PE/COFF image specified by Pe32Data and returns this entry
   point in EntryPoint.  If the entry point could not be retrieved from the PE/COFF image, then
   return RETURN_INVALID_PARAMETER.  Otherwise return RETURN_SUCCESS.
-  If Pe32Data is NULL, then ASSERT().
-  If EntryPoint is NULL, then ASSERT().
 
   @param  Pe32Data                  The pointer to the PE/COFF image that is loaded in system memory.
   @param  EntryPoint                The pointer to entry point to the PE/COFF image to return.
@@ -60,19 +58,6 @@ PeCoffLoaderGetEntryPoint (
   OUT VOID  **EntryPoint
   );
 
-/**
-  Performs an specific relocation fpr PECOFF images. The caller needs to
-  allocate enough buffer at the PreferedImageBase
-
-  @param  CurrentImageBase        Pointer to the current image base.
-
-  @return Status code.
-
-**/
-RETURN_STATUS
-PeCoffRelocateImage (
-  IN     UINT32   CurrentImageBase
-  );
 
 /**
   Performs an specific relocation fpr PECOFF images. The caller needs to
@@ -84,30 +69,46 @@ PeCoffRelocateImage (
 
 **/
 RETURN_STATUS
+EFIAPI
 PeCoffRelocateImage (
   IN     UINT32   CurrentImageBase
   );
 
+
 /**
-  Get PE/TE relocation address gap
+  Performs an specific relocation fpr PECOFF images. The caller needs to
+  allocate enough buffer at the PreferedImageBase
+
+  @param  CurrentImageBase        Pointer to the current image base.
+
+  @return Status code.
+
+**/
+RETURN_STATUS
+EFIAPI
+PeCoffRelocateImage (
+  IN     UINT32   CurrentImageBase
+  );
+
+
+/**
+  Get PE/TE image preferred image base address
 
   Based on current image location Pe32Data, check if it is same with expected location to run the
   image. If it is not same, it means the image need relocate to expected location. This function
-  will return the gap between expected location and current location.
-
-  If Pe32Data is NULL, then ASSERT().
+  will return the preferred image base.
 
   @param[in]   Pe32Data             The pointer to the PE/COFF image that is loaded in system memory.
-  @param[out]  Gap                  The gap value between expected location and current location.
+  @param[out]  Base                 The pointer to receive image base.
 
-  @retval RETURN_SUCCESS            Gap was returned.
+  @retval RETURN_SUCCESS            Base was returned successfully.
   @retval RETURN_UNSUPPORTED        It is not PE/COFF image.
 **/
-EFI_STATUS
+RETURN_STATUS
 EFIAPI
-PeCoffRelocateGap (
+PeCoffGetPreferredBase (
   IN  VOID                             *Pe32Data,
-  OUT INT32                            *Gap
+  OUT UINT32                           *Base       OPTIONAL
   );
 
 #endif

--- a/BootloaderCommonPkg/Library/LiteFvLib/FvLib.h
+++ b/BootloaderCommonPkg/Library/LiteFvLib/FvLib.h
@@ -18,6 +18,8 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 #include <PiPei.h>
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
+#include <Library/LitePeCoffLib.h>
+#include <Library/BootloaderCommonLib.h>
 
 #define  THREE_BYTE_LEN(x)    ((*(UINT32 *)(UINTN)(x)) & 0xFFFFFF)
 #define  GET_FFS_LENGTH(x)    THREE_BYTE_LEN((x)->Size)

--- a/BootloaderCommonPkg/Library/LiteFvLib/LiteFvLib.inf
+++ b/BootloaderCommonPkg/Library/LiteFvLib/LiteFvLib.inf
@@ -36,6 +36,7 @@
 
 [LibraryClasses]
   BaseLib
+  LitePeCoffLib
 
 [Guids]
 

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2016 - 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at

--- a/BootloaderCorePkg/Stage2/Stage2.h
+++ b/BootloaderCorePkg/Stage2/Stage2.h
@@ -40,6 +40,7 @@
 #include <Library/SecureBootLib.h>
 #include <Library/TpmLib.h>
 #include <Library/DebugLogBufferLib.h>
+#include <Library/LiteFvLib.h>
 #include <Guid/BootLoaderServiceGuid.h>
 #include <Guid/BootLoaderVersionGuid.h>
 #include <Guid/LoaderPlatformInfoGuid.h>
@@ -158,27 +159,6 @@ InitializeService (
 VOID
 BoardNotifyPhase (
   IN BOARD_INIT_PHASE   Phase
-  );
-
-/**
-  Load FV to expected location and return entry point of SEC core.
-
-  This function will search whole FV to find SEC core file, and then check SEC core file if
-  relocation is required. If relocation is required, this function will relocation whole FV
-  to expected location and SEC core entry point will be returned if success.
-
-  @param[in]  FvBase                   Point to the boot firmware volume.
-  @param[in]  FvActualLength           The actural length of FV.
-  @param[out] EntryPoint               The sec core entry point.
-
-  @retval RETURN_SUCCESS               The FV is loaded successfully.
-  @retval Others                       Failed to load the FV.
-**/
-EFI_STATUS
-LoadFvImage (
-  IN  UINT32                           *FvBase,
-  IN  UINT32                           FvActualLength,
-  OUT VOID                             **EntryPoint
   );
 
 #endif

--- a/BootloaderCorePkg/Stage2/Stage2.inf
+++ b/BootloaderCorePkg/Stage2/Stage2.inf
@@ -70,6 +70,7 @@
   ResetSystemLib
   ConfigDataLib
   DebugAgentLib
+  LiteFvLib
   ElfLib
 
 [Guids]


### PR DESCRIPTION
This patch did some clean up for LiteFvLib and LitePeCoffLib.  It
also moved LoadFvImage() API from Stage2 core code into the LiteFvLib.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>