### PR TITLE
Enable UEFI payload boot from IAS image

### DIFF
--- a/PayloadPkg/OsLoader/BootParameters.c
+++ b/PayloadPkg/OsLoader/BootParameters.c
@@ -199,9 +199,7 @@ DisplayInfo (
   if ((LoadedImage->Flags & LOADED_IMAGE_MULTIBOOT) != 0) {
     DumpMbInfo (&LoadedImage->Image.MultiBoot.MbInfo);
     DumpMbBootState (&LoadedImage->Image.MultiBoot.BootState);
-  } else if ((LoadedImage->Flags & LOADED_IMAGE_PE32) != 0) {
-    // For PE32 image, no extra info to display
-  } else {
+  } else if ((LoadedImage->Flags & LOADED_IMAGE_LINUX) != 0) {
     DumpBootParameters (LoadedImage->Image.Linux.BootParams);
   }
 }
@@ -304,4 +302,3 @@ UpdateOsParameters (
 
   return Status;
 }
-

--- a/PayloadPkg/OsLoader/OsLoader.h
+++ b/PayloadPkg/OsLoader/OsLoader.h
@@ -14,6 +14,7 @@
 #ifndef __LINUX_LOADER_H__
 #define __LINUX_LOADER_H__
 
+#include <Library/LiteFvLib.h>
 #include <Library/PartitionLib.h>
 #include <Library/FileSystemLib.h>
 #include <Library/PayloadMemoryAllocationLib.h>
@@ -77,6 +78,7 @@
 #define LOADED_IMAGE_MULTIBOOT   BIT1
 #define LOADED_IMAGE_LINUX       BIT2
 #define LOADED_IMAGE_PE32        BIT3
+#define LOADED_IMAGE_FV          BIT4
 
 #define MAX_EXTRA_FILE_NUMBER    16
 

--- a/PayloadPkg/OsLoader/OsLoader.inf
+++ b/PayloadPkg/OsLoader/OsLoader.inf
@@ -82,6 +82,7 @@
   UsbIoLib
   UsbKbLib
   ElfLib
+  LiteFvLib
 
 [Guids]
   gOsConfigDataGuid


### PR DESCRIPTION
This is a feature implementation to enabled chained payloads loading
for UEFI. Current SBL boot flow requires UEFI payload to be built in
flash in order to boot UEFI payload. However, for convenience, if
somebody just wants to try UEFI payload, it is better to allow them to
chain-loading the UEFI payload from media devices such as USB, SATA, etc,
and then boot to UEFI payload directly. This patch enabled this feature.
The new supported boot flow is:  SBL->OsLoader->UefiPayload->OS. The
same applies to other ELF/PE32 based other payloads.

To do this the UEFI payload needs to be packed into IAS image using
iasimage script. The command line is as below:
  python iasimage.py create -d TestSigningIasPrivateKey.pem UefiPld.fd
         -o iasimage.bin -i 0x30000
Please use the latest iasimage script from
  http://github.com/intel/iasimage

Signed-off-by: Maurice Ma <maurice.ma@intel.com>