### PR TITLE
Add duplicated CFGDATA check in GenCfgData.py

### DIFF
--- a/BootloaderCorePkg/Tools/GenCfgData.py
+++ b/BootloaderCorePkg/Tools/GenCfgData.py
@@ -1538,6 +1538,32 @@ EndList
 
         return 0
 
+    def CheckCfgData (self):
+        # Check if CfgData contains any duplicated name
+        def  AddItem (Item, ChkList):
+            Name = Item['cname']
+            if Name in ChkList:
+                return Item
+            if Name not in ['Dummy', 'Reserved', 'CfgHeader', 'CondValue']:
+                ChkList.append(Name)
+            return None
+
+        Duplicate = None
+        ChkList   = []
+        for  Item in self._CfgItemList:
+            Duplicate = AddItem (Item, ChkList)
+            if not Duplicate:
+                for SubItem in Item['subreg']:
+                    Duplicate = AddItem (SubItem, ChkList)
+                    if Duplicate:
+                        break
+            if Duplicate:
+                break
+        if Duplicate:
+            self.Error = "Duplicated CFGDATA '%s' found !\n" % Duplicate['cname']
+            return -1
+        return 0
+
     def PrintData (self):
         for  Item in self._CfgItemList:
             if not Item['length']:
@@ -1924,6 +1950,9 @@ def Main():
             GenCfgData.__dict__ = marshal.load(PklFile)
     else:
         if GenCfgData.ParseDscFile(DscFile) != 0:
+            raise Exception (GenCfgData.Error)
+
+        if GenCfgData.CheckCfgData() != 0:
             raise Exception (GenCfgData.Error)
 
         if GenCfgData.CreateVarDict() != 0:


### PR DESCRIPTION
CFGDATA name should be unique in the whole CFGDATA database. Current
tool does not check this and will keep silent for this error. This
brings issue into later development stage. The build process should
be enhanced to check this and error out if duplicated CFGDATA item is
found. This patch added this check.  It fixed #81 .

Signed-off-by: Maurice Ma <maurice.ma@intel.com>