### PR TITLE
Remove Debug/Release field from VerInfo.txt file

### DIFF
--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -688,14 +688,13 @@ def align_pad_file (src, dst, val, mode = STITCH_OPS.MODE_FILE_ALIGN, pos = STIT
 	fo.close()
 
 
-def get_verinfo_via_file (file):
+def get_verinfo_via_file (ver_dict, file):
 	if not os.path.exists(file):
 		raise Exception ("Version TXT file '%s' does not exist!" % file)
 	hfile = open(file)
 	lines = hfile.readlines()
 	hfile.close()
 
-	ver_dict = dict()
 	for line in lines:
 		elements = line.strip().split('=')
 		if len(elements) == 2:
@@ -716,8 +715,8 @@ def get_verinfo_via_file (file):
 		ver_info.ImageVersion.CoreMajorVersion = int(ver_dict['CoreMajorVersion'])
 		ver_info.ImageVersion.BuildNumber  = int(ver_dict['BuildNumber'])
 		ver_info.ImageVersion.SecureVerNum = int(ver_dict['SecureVerNum'])
-		ver_info.ImageVersion.FspDebug     = int(ver_dict['FspDebug'])
-		ver_info.ImageVersion.BldDebug     = int(ver_dict['BldDebug'])
+		ver_info.ImageVersion.FspDebug     = 1 if ver_dict['FSPDEBUG_MODE'] else 0;
+		ver_info.ImageVersion.BldDebug     = 0 if ver_dict['RELEASE_MODE']  else 1;
 		ver_info.ImageVersion.Dirty        = int(ver_dict['Dirty'])
 	except KeyError:
 		raise Exception ("Invalid version TXT file format!")
@@ -784,8 +783,6 @@ def gen_ver_info_txt (ver_file, ver_info):
 	h_file.write('CoreMajorVersion  = %03d\n'  % ver_info.ImageVersion.CoreMajorVersion)
 	h_file.write('CoreMinorVersion  = %03d\n'  % ver_info.ImageVersion.CoreMinorVersion)
 	h_file.write('BuildNumber   = %05d\n'  % ver_info.ImageVersion.BuildNumber)
-	h_file.write('FspDebug      = %d\n'    % ver_info.ImageVersion.FspDebug)
-	h_file.write('BldDebug      = %d\n'    % ver_info.ImageVersion.BldDebug)
 	h_file.write('Dirty         = %d\n'    % ver_info.ImageVersion.Dirty)
 	h_file.close()
 

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -999,15 +999,16 @@ class Build(object):
 		ver_info_name = 'VerInfo'
 		ver_bin_file = os.path.join(self._fv_dir, ver_info_name + '.bin')
 		ver_txt_file = os.path.join(os.environ['PLT_SOURCE'], 'Platform', self._board.BOARD_PKG_NAME, ver_info_name + '.txt')
+
+		keys = ['VERINFO_IMAGE_ID', 'VERINFO_BUILD_DATE', 'VERINFO_PROJ_MINOR_VER',
+						'VERINFO_PROJ_MAJOR_VER', 'VERINFO_CORE_MINOR_VER', 'VERINFO_CORE_MAJOR_VER',
+						'VERINFO_SVN', 'FSPDEBUG_MODE', 'RELEASE_MODE']
+		ver_dict = {}
+		for key in keys:
+			ver_dict[key] = getattr (self._board, key)
 		if self._board.USE_VERSION:
-			ver_info = get_verinfo_via_file (ver_txt_file)
+			ver_info = get_verinfo_via_file (ver_dict, ver_txt_file)
 		else:
-			keys = ['VERINFO_IMAGE_ID', 'VERINFO_BUILD_DATE', 'VERINFO_PROJ_MINOR_VER',
-							'VERINFO_PROJ_MAJOR_VER', 'VERINFO_CORE_MINOR_VER', 'VERINFO_CORE_MAJOR_VER',
-							'VERINFO_SVN', 'FSPDEBUG_MODE', 'RELEASE_MODE']
-			ver_dict = {}
-			for key in keys:
-				ver_dict[key] = getattr (self._board, key)
 			ver_info = get_verinfo_via_git  (ver_dict, os.environ['PLT_SOURCE'])
 			gen_ver_info_txt (ver_txt_file, ver_info)
 		gen_file_from_object (ver_bin_file, ver_info)


### PR DESCRIPTION
In current implementation, FspDebug/BldDebug flag is saved into
VerInfo.txt. But it should be always determined by the build flags
instead of the VerInfo.txt file. This patch fixed #84 .

Signed-off-by: Maurice Ma <maurice.ma@intel.com>