### PR TITLE
Enable QEMU firmware update test

### DIFF
--- a/Platform/QemuBoardPkg/CfgData/CfgData_CapsuleInformation.dsc
+++ b/Platform/QemuBoardPkg/CfgData/CfgData_CapsuleInformation.dsc
@@ -14,7 +14,7 @@
   # !BSF OPTION:{0:Device 0, 1:Device 1, 2:Device 2, 3:Device 3}
   # !BSF HELP:{Specify boot device instance when then are multple instances}
   # !BSF ORDER:{0000.0000}
-  gCfgData.DevInstance                  |      * | 0x01 | 5
+  gCfgData.DevInstance                  |      * | 0x01 | 0
 
   gCfgData.Reserved                     |      * | 0x03 | 0
 
@@ -33,7 +33,7 @@
   # !BSF TYPE:{Combo}
   # !BSF OPTION:{0:FAT, 1:EXT2, 2:AUTO, 3:RAW}
   # !BSF HELP:{Image is loaded from file system instead of raw data}
-  gCfgData.FsType                       |      * | 0x01 | 2
+  gCfgData.FsType                       |      * | 0x01 | 0
 
   # !BSF NAME:{Capsule File Name}
   # !BSF TYPE:{EditText}

--- a/Platform/QemuBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
@@ -54,7 +54,6 @@ BoardInit (
     DisableWatchDogTimer ();
     PlatformHookSerialPortInitialize ();
     SerialPortInitialize ();
-    SetCurrentBootPartition (*(UINT8 *)0xFFFFFFF4 == 0x90 ? 0 : 1);
     break;
   default:
     break;

--- a/Silicon/QemuSocPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/QemuSocPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -471,7 +471,7 @@ EndFirmwareUpdate (
 {
   UINT8    Data;
 
-  DEBUG ((EFI_D_INFO, "Firmware update Done! clear FWU flag to normal boot mode.\n"));
+  DEBUG ((EFI_D_INIT, "Firmware update Done! clear FWU flag to normal boot mode.\n"));
 
   //
   // This is platform specific method.


### PR DESCRIPTION
This patch fixed some QEMU firmware update related issues.
It enabled firmware update testing on QEMU using script.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>