### PR TITLE
[APL] Enable GFX OpRegion in ACPI

### DIFF
--- a/Platform/ApollolakeBoardPkg/AcpiTables/Dsdt/Dsdt.asl
+++ b/Platform/ApollolakeBoardPkg/AcpiTables/Dsdt/Dsdt.asl
@@ -46,9 +46,7 @@ DefinitionBlock (
   include ("Cpu0Ist.asl")
   include ("ApIst.asl")
 
-//win10 boot error:
-//  include ("IgfxOpRn.asl")
-
+  include ("Gfx.asl")
 
 // Sleep states supported by Chipset/Board.
 //----------------------------------------------------------------------

--- a/Platform/ApollolakeBoardPkg/AcpiTables/Dsdt/Gfx.asl
+++ b/Platform/ApollolakeBoardPkg/AcpiTables/Dsdt/Gfx.asl
@@ -1,0 +1,21 @@
+/** @file
+  Graphics device table
+
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php.
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+
+Scope (\_SB.PCI0)
+{
+  Device (GFX0) {
+    Name (_ADR, 0x00020000)
+    include ("IgfxOpRn.asl")
+  }
+}

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -657,7 +657,6 @@ BoardInit (
     BuildOsConfigDataHob ();
     break;
   case PostPciEnumeration:
-    IgdOpRegionInit();
     if (PcdGetBool (PcdSeedListEnabled)) {
       Status = GenerateSeeds ();
       if (EFI_ERROR (Status)) {
@@ -1600,6 +1599,8 @@ PlatformUpdateAcpiGnvs (
   SetMem (Gnvs, sizeof (GLOBAL_NVS_AREA), 0);
 
   Pnvs->BoardId = (UINT8)GetPlatformId ();
+
+  IgdOpRegionInit ();
 
   SysCpuInfo = MpGetInfo ();
   if (SysCpuInfo != NULL) {


### PR DESCRIPTION
This patch enabled APL GFX OpRegion in ACPI table. The OpRegion ASL code
was commented out in current DSDT.  It was causing Windows boot issue
due to invalid ASLB field value in ACPI GNVS. This patch addressed this
issue, and it fixed #88 .

Signed-off-by: Maurice Ma <maurice.ma@intel.com>