### PR TITLE
BaseTools: Fix build failure on Fedora29 with gcc 8.2.1

### DIFF
--- a/BaseTools/Source/C/GenVtf/GenVtf.c
+++ b/BaseTools/Source/C/GenVtf/GenVtf.c
@@ -129,9 +129,9 @@ Returns:
   } else {
     Length = strlen(Str);
     if (Length < 4) {
-      strncpy (TemStr + 4 - Length, Str, Length);
+      memcpy (TemStr + 4 - Length, Str, Length);
     } else {
-      strncpy (TemStr, Str + Length - 4, 4);
+      memcpy (TemStr, Str + Length - 4, 4);
     }
   
     sscanf (

--- a/BaseTools/Source/C/Makefiles/header.makefile
+++ b/BaseTools/Source/C/Makefiles/header.makefile
@@ -71,9 +71,9 @@ INCLUDE = $(TOOL_INCLUDE) -I $(MAKEROOT) -I $(MAKEROOT)/Include/Common -I $(MAKE
 BUILD_CPPFLAGS = $(INCLUDE) -O2
 ifeq ($(DARWIN),Darwin)
 # assume clang or clang compatible flags on OS X
-BUILD_CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-self-assign -Wno-unused-result -nostdlib -c -g
+BUILD_CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-self-assign -Wno-unused-result -nostdlib -g
 else
-BUILD_CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-unused-result -nostdlib -c -g
+BUILD_CFLAGS = -MD -fshort-wchar -fno-strict-aliasing -Wall -Werror -Wno-deprecated-declarations -Wno-stringop-truncation -Wno-restrict -Wno-unused-result -nostdlib -g
 endif
 BUILD_LFLAGS =
 BUILD_CXXFLAGS = -Wno-unused-result


### PR DESCRIPTION
This change includes below commits from the latest EDKII.
- The build failure has been identified on Fedora 29 with gcc version
  8.2.1 20181215 (Red Hat 8.2.1-6).
- Verified no compile errors with below changes from EDKII.

commit 9de306701312f986c9638cb819d3f1f848d55cab
Author: Laszlo Ersek <lersek@redhat.com>
Date:   Fri Mar 2 17:11:52 2018 +0100
    BaseTools/GenVtf: silence false "stringop-overflow" warning with memcpy()

commit 03252ae287c4a61983b3793ff71baeabe2ff3df7
Author: Laszlo Ersek <lersek@redhat.com>
Date:   Wed Jul 25 22:40:09 2018 +0200
    BaseTools/header.makefile: remove "-c" from BUILD_CFLAGS

commit 9222154ae7b3eef75ae88cdb56158256227cb929
Author: Laszlo Ersek <lersek@redhat.com>
Date:   Fri Mar 2 17:11:52 2018 +0100
    BaseTools/header.makefile: add "-Wno-restrict"

commit 1d212a83df0eaf32a6f5d4159beb2d77832e0231
Author: Laszlo Ersek <lersek@redhat.com>
Date:   Fri Mar 2 17:11:52 2018 +0100
    BaseTools/header.makefile: add "-Wno-stringop-truncation"

Signed-off-by: Aiden Park <aiden.park@intel.com>