### PR TITLE
Relocate SMM bases on S3 resume path

### DIFF
--- a/BootloaderCommonPkg/Include/Guid/SmmInformationGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/SmmInformationGuid.h
@@ -16,16 +16,52 @@
 #define __SMM_INFORMATION_GUID_H__
 
 ///
-/// Serial Port Information GUID
+/// SMM Information GUID
 ///
 extern EFI_GUID gSmmInformationGuid;
 
+//
+// Set this flag if 4KB SMRAM at SmmBase used for communication
+// between bootloader and UEFI payload.
+//
+#define   SMM_FLAGS_4KB_COMMUNICATION  BIT0
+
+typedef enum {
+  MEM,
+  IO,
+  PCICFG
+} REG_TYPE;
+
+typedef enum {
+  WIDE8,
+  WIDE16,
+  WIDE32
+} REG_WIDTH;
+
+#pragma pack(1)
+
+///
+/// Generic Address Space
+///
 typedef struct {
-  UINT8    Revision;
-  UINT8    Flags;
-  UINT8    Reserved[2];
-  UINT32   SmmBase;
-  UINT32   SmmSize;
-} SMM_INFORMATION;
+  UINT8   RegType;
+  UINT8   RegWidth;
+  UINT8   SmiGblPos;
+  UINT8   SmiApmPos;
+  UINT8   SmiEosPos;
+  UINT8   Rsvd[3];
+  UINT32  Address;
+} SMI_CTRL_REG;
+
+typedef struct {
+  UINT8                       Revision;
+  UINT8                       Flags;
+  UINT8                       Reserved[2];
+  UINT32                      SmmBase;
+  UINT32                      SmmSize;
+  SMI_CTRL_REG                SmiCtrlReg;
+} LDR_SMM_INFO;
+
+#pragma pack()
 
 #endif

--- a/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
+++ b/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
@@ -73,6 +73,15 @@ typedef enum {
   LOADER_STAGE_PAYLOAD
 } LOADER_STAGE;
 
+//
+// Enum type for SMM rebase enabling
+//
+typedef enum {
+  SMM_REBASE_DISABLE,
+  SMM_REBASE_ENABLE,
+  SMM_REBASE_ENABLE_ON_S3_RESUME_ONLY
+} SMM_REBASE_MODE;
+
 /**
   Returns the current stage of Bootloader execution.
 

--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -139,7 +139,7 @@
   gPlatformModuleTokenSpaceGuid.PcdVerInfoBase            | 0xFF000000 | UINT32 | 0x20000190
   gPlatformModuleTokenSpaceGuid.PcdCfgDataLoadSource      | 0x00000002 | UINT32 | 0x20000194
   gPlatformModuleTokenSpaceGuid.PcdPayloadReservedMemSize | 0x00004000 | UINT32 | 0x20000195
-
+  gPlatformModuleTokenSpaceGuid.PcdSmmRebaseMode          | 0x00000000 | UINT8  | 0x20000196
 
 
 [PcdsFeatureFlag]
@@ -160,4 +160,3 @@
   gPlatformModuleTokenSpaceGuid.PcdFlashMapEnabled        | FALSE      | BOOLEAN | 0x2000020C
   gPlatformModuleTokenSpaceGuid.PcdS3DebugEnabled         | FALSE      | BOOLEAN | 0x2000020D
   gPlatformModuleTokenSpaceGuid.PcdPsdBiosEnabled         | FALSE      | BOOLEAN | 0x2000020E
-  gPlatformModuleTokenSpaceGuid.PcdSmmRebaseEnabled       | FALSE      | BOOLEAN | 0x2000020F

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -263,6 +263,8 @@
   gPayloadTokenSpaceGuid.PcdPayloadStackSize         | $(PLD_STACK_SIZE)
   gPayloadTokenSpaceGuid.PcdGlobalDataAddress        | 0x00000000
 
+  gPlatformModuleTokenSpaceGuid.PcdSmmRebaseMode     | $(ENABLE_SMM_REBASE)
+
 [PcdsFeatureFlag]
   gPlatformCommonLibTokenSpaceGuid.PcdMinDecompression    | FALSE
   gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootEnabled | $(HAVE_MEASURED_BOOT)
@@ -279,7 +281,6 @@
   gPlatformModuleTokenSpaceGuid.PcdVtdEnabled             | $(ENABLE_VTD)
   gPlatformModuleTokenSpaceGuid.PcdFlashMapEnabled        | $(HAVE_FLASH_MAP)
   gPlatformModuleTokenSpaceGuid.PcdPsdBiosEnabled         | $(HAVE_PSD_TABLE)
-  gPlatformModuleTokenSpaceGuid.PcdSmmRebaseEnabled       | $(ENABLE_SMM_REBASE)
 
 !ifdef $(S3_DEBUG)
   gPlatformModuleTokenSpaceGuid.PcdS3DebugEnabled         | $(S3_DEBUG)

--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -126,6 +126,22 @@ typedef struct {
   UINT8         BootPartition;
 } S3_DATA;
 
+typedef struct {
+  UINT32  ApicId;
+  UINT32  SmmBase;
+} CPU_SMMBASE;
+
+typedef struct {
+  UINT32       Signature;
+  UINT8        CpuEntry;
+  UINT8        RegType;
+  UINT8        RegWidth;
+  UINT8        Unused;
+  UINT32       SmiEnReg;
+  UINT32       SmiEnVal;
+  CPU_SMMBASE  SmmBase[];
+} SMMBASE_INFO;
+
 #pragma pack()
 
 #define ACPI_FEATURE_ENABLED()    (GetFeatureCfg() & FEATURE_ACPI)

--- a/BootloaderCorePkg/Library/MpInitLib/Ia32/MpFuncs.nasm
+++ b/BootloaderCorePkg/Library/MpInitLib/Ia32/MpFuncs.nasm
@@ -81,7 +81,6 @@ BITS 32
 SmmRebase:
     mov         edi,  0x3fef8     ; SMBASE offset
     mov         dword [edi], eax  ; change to new  SMBASE
-    mov         dword [eax + 0x8000], 0x9090AA0F  ; write 'RSM' at new SMM handler entry
     rsm
     jmp         $
 

--- a/BootloaderCorePkg/Library/MpInitLib/Ia32/MpInitLibInternal.h
+++ b/BootloaderCorePkg/Library/MpInitLib/Ia32/MpInitLibInternal.h
@@ -37,6 +37,9 @@
 #define   SMM_BASE_GAP             0x1000
 #define   SMM_BASE_MIN_SIZE        0x10000
 
+#define   PLD_TO_LDR_SMM_SIG       SIGNATURE_32('S', 'C', 'O', 'M')
+#define   RSM_SIG                  0x9090AA0F  /// Opcode for 'rsm'
+
 #pragma pack(1)
 typedef struct {
   UINT16 CSSelector;
@@ -85,6 +88,7 @@ typedef struct {
   UINT32           CpuCount;
   CPU_TASK         CpuTask[FixedPcdGet32 (PcdCpuMaxLogicalProcessorNumber)];
 } ALL_CPU_TASK;
+
 
 /**
   Assembly function to get the address map of MP.

--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
@@ -53,4 +53,4 @@
 [Pcd]
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegBase
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegSize
-  gPlatformModuleTokenSpaceGuid.PcdSmmRebaseEnabled
+  gPlatformModuleTokenSpaceGuid.PcdSmmRebaseMode

--- a/BootloaderCorePkg/Stage2/Stage2Support.c
+++ b/BootloaderCorePkg/Stage2/Stage2Support.c
@@ -524,7 +524,7 @@ BuildExtraInfoHob (
   SEED_LIST_INFO_HOB        *SeedListInfoHob;
   PLT_DEVICE_TABLE          *DeviceTable;
   VOID                      *DeviceTableHob;
-  SMM_INFORMATION           *SmmInfoHob;
+  LDR_SMM_INFO              *SmmInfoHob;
 
   LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer();
   S3Data    = (S3_DATA *)LdrGlobal->S3DataPtr;
@@ -619,7 +619,7 @@ BuildExtraInfoHob (
   }
 
   // Build SMMRAM info Hob
-  SmmInfoHob = BuildGuidHob (&gSmmInformationGuid, sizeof (SMM_INFORMATION));
+  SmmInfoHob = BuildGuidHob (&gSmmInformationGuid, sizeof (LDR_SMM_INFO));
   if (SmmInfoHob != NULL) {
     PlatformUpdateHobInfo (&gSmmInformationGuid, SmmInfoHob);
   }

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -621,19 +621,17 @@ BoardInit (
       VariableConstructor (VarBase, VarSize);
     }
 
-    if (PcdGetBool (PcdSmmRebaseEnabled)) {
-      // Get TSEG info from FSP HOB
-      // It will be consumed in MpInit if SMM rebase is enabled
-      LdrGlobal  = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
-      TsegBase = (UINT32)GetFspReservedMemoryFromGuid (
-                         LdrGlobal->FspHobList,
-                         &TsegSize,
-                         &gReservedMemoryResourceHobTsegGuid
-                         );
-      if (TsegBase != 0) {
-        Status = PcdSet32S (PcdSmramTsegBase, TsegBase);
-        Status = PcdSet32S (PcdSmramTsegSize, (UINT32)TsegSize);
-      }
+    // Get TSEG info from FSP HOB
+    // It will be consumed in MpInit if SMM rebase is enabled
+    LdrGlobal  = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
+    TsegBase = (UINT32)GetFspReservedMemoryFromGuid (
+                       LdrGlobal->FspHobList,
+                       &TsegSize,
+                       &gReservedMemoryResourceHobTsegGuid
+                       );
+    if (TsegBase != 0) {
+      Status = PcdSet32S (PcdSmramTsegBase, TsegBase);
+      Status = PcdSet32S (PcdSmramTsegSize, (UINT32)TsegSize);
     }
 
     SaveOtgRole();
@@ -1313,7 +1311,7 @@ UpdateLoaderPlatformInfo (
 **/
 VOID
 UpdateSmmInfo (
-  OUT  SMM_INFORMATION           *SmmInfoHob
+  OUT  LDR_SMM_INFO           *SmmInfoHob
 )
 {
 

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -96,6 +96,6 @@
   gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootEnabled
   gPlatformModuleTokenSpaceGuid.PcdSplashEnabled
   gPlatformModuleTokenSpaceGuid.PcdFramebufferInitEnabled
-  gPlatformModuleTokenSpaceGuid.PcdSmmRebaseEnabled
+  gPlatformModuleTokenSpaceGuid.PcdSmmRebaseMode
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegBase
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegSize

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -473,7 +473,7 @@ UpdateFrameBufferInfo (
 **/
 VOID
 UpdateSmmInfo (
-  OUT  SMM_INFORMATION           *SmmInfoHob
+  OUT  LDR_SMM_INFO           *SmmInfoHob
 )
 {
   UINT32  TsegSize;

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -60,7 +60,7 @@
   gPlatformModuleTokenSpaceGuid.PcdVariableRegionBase
   gPlatformModuleTokenSpaceGuid.PcdVariableRegionSize
   gPlatformModuleTokenSpaceGuid.PcdFramebufferInitEnabled
-  gPlatformModuleTokenSpaceGuid.PcdSmmRebaseEnabled
+  gPlatformModuleTokenSpaceGuid.PcdSmmRebaseMode
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegBase
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegSize
   


### PR DESCRIPTION
Smm bases for all the procs need to be relocated on the
S3 resume path (as payload is not run) for Windows boot.

Signed-off-by: Sai Talamudupula <sai.kiran.talamudupula@intel.com>