### PR TITLE
Add ACPI Firmware Performance Data Table (FPDT) support

### DIFF
--- a/BootloaderCorePkg/Include/Library/AcpiInitLib.h
+++ b/BootloaderCorePkg/Include/Library/AcpiInitLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -14,6 +14,54 @@
 #ifndef __ACPI_INIT_LIB_H__
 #define __ACPI_INIT_LIB_H__
 
+#include <Uefi/UefiBaseType.h>
+#include <IndustryStandard/Acpi.h>
+
+#pragma pack(1)
+///
+/// Firmware Performance Data Table.
+///
+typedef struct {
+  EFI_ACPI_DESCRIPTION_HEADER                             Header;            ///< Common ACPI description table header.
+  EFI_ACPI_5_0_FPDT_BOOT_PERFORMANCE_TABLE_POINTER_RECORD BootPointerRecord; ///< Basic Boot Performance Table Pointer record.
+  EFI_ACPI_5_0_FPDT_S3_PERFORMANCE_TABLE_POINTER_RECORD   S3PointerRecord;   ///< S3 Performance Table Pointer record.
+} FIRMWARE_PERFORMANCE_TABLE;
+
+///
+/// Basic Boot Performance Data Table.
+/// This structure contains BasicBoot performance record.
+///
+typedef struct {
+  EFI_ACPI_5_0_FPDT_PERFORMANCE_TABLE_HEADER   Header;     ///< Common ACPI table header.
+  EFI_ACPI_5_0_FPDT_FIRMWARE_BASIC_BOOT_RECORD BasicBoot;  ///< Basic Boot Resume performance record.
+  //
+  // one or more boot performance records.
+  //
+} BOOT_PERFORMANCE_TABLE;
+
+///
+/// S3 Performance Data Table.
+/// This structure contains S3 performance records which will be updated in S3
+/// suspend and S3 resume boot path.
+///
+typedef struct {
+  EFI_ACPI_5_0_FPDT_PERFORMANCE_TABLE_HEADER  Header;    ///< Common ACPI table header.
+  EFI_ACPI_5_0_FPDT_S3_RESUME_RECORD          S3Resume;  ///< Basic S3 Resume performance record.
+} S3_PERFORMANCE_TABLE;
+
+///
+/// This table includes all FPDT related tables.
+/// Make sure the first table is FIRMWARE_PERFORMANCE_TABLE table which would be visible to others.
+/// The other tables would are implementation specific
+///
+typedef struct {
+  FIRMWARE_PERFORMANCE_TABLE             FirmwarePerfTable;
+  BOOT_PERFORMANCE_TABLE                 BootPointerRecord;
+  S3_PERFORMANCE_TABLE                   S3PointerRecord;
+} INTERNAL_FIRMWARE_PERFORMANCE_TABLE;
+
+#pragma pack()
+
 /**
   This function is called on S3 boot flow only.
 
@@ -24,6 +72,7 @@
 
 **/
 VOID
+EFIAPI
 FindAcpiWakeVectorAndJump (
   IN  UINT32    AcpiBase
   );
@@ -42,6 +91,20 @@ EFI_STATUS
 EFIAPI
 AcpiInit (
   IN  UINT32    *AcpiMemTop
+  );
+
+/**
+  Update ACPI FPDT S3 performance record table.
+
+  @param[in] AcpiTableBase     ACPI base address
+
+  @retval EFI_SUCCESS          Update the S3 performance table successfully.
+  @retval Others               Failed to update the table.
+ **/
+EFI_STATUS
+EFIAPI
+UpdateFpdtS3Table (
+  IN  UINT32                   AcpiTableBase
   );
 
 #endif

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiFpdt.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiFpdt.c
@@ -1,0 +1,233 @@
+/** @file
+
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php.
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+
+#include <PiPei.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/BootloaderCoreLib.h>
+#include <Library/AcpiInitLib.h>
+#include <Library/TimeStampLib.h>
+
+#define DEBUG_PRINT_FPDT_DATA   0
+
+BOOT_PERFORMANCE_TABLE mBootPerformanceTableTemplate = {
+  {
+    EFI_ACPI_5_0_FPDT_BOOT_PERFORMANCE_TABLE_SIGNATURE,
+    sizeof (BOOT_PERFORMANCE_TABLE)
+  },
+  {
+    {
+      EFI_ACPI_5_0_FPDT_RUNTIME_RECORD_TYPE_FIRMWARE_BASIC_BOOT,    // Type
+      sizeof (EFI_ACPI_5_0_FPDT_FIRMWARE_BASIC_BOOT_RECORD),        // Length
+      EFI_ACPI_5_0_FPDT_RUNTIME_RECORD_REVISION_FIRMWARE_BASIC_BOOT // Revision
+    },
+    0,  // Reserved
+    //
+    // These values will be updated at runtime.
+    //
+    0,  // ResetEnd
+    0,  // OsLoaderLoadImageStart
+    0,  // OsLoaderStartImageStart
+    0,  // ExitBootServicesEntry
+    0   // ExitBootServicesExit
+  }
+};
+
+S3_PERFORMANCE_TABLE        mS3PerformanceTableTemplate = {
+  {
+    EFI_ACPI_5_0_FPDT_S3_PERFORMANCE_TABLE_SIGNATURE,
+    sizeof (S3_PERFORMANCE_TABLE)
+  },
+  {
+    {
+      EFI_ACPI_5_0_FPDT_RUNTIME_RECORD_TYPE_S3_RESUME,     // Type
+      sizeof (EFI_ACPI_5_0_FPDT_S3_RESUME_RECORD),         // Length
+      EFI_ACPI_5_0_FPDT_RUNTIME_RECORD_REVISION_S3_RESUME  // Revision
+    },
+    //
+    // These values will be updated at runtime.
+    //
+    0,  // ResumeCount
+    0,  // FullResume
+    0   // AverageResume
+  }
+};
+
+
+/**
+  Update boot performance record table.
+
+  @param[out] BootPerfTable     Pointer of boot performance record table.
+
+  @retval EFI_SUCCESS           Update the boot performance table successfully.
+  @retval Others                Failed to update the table.
+ **/
+EFI_STATUS
+UpdateFpdtBootTable (
+  OUT BOOT_PERFORMANCE_TABLE          *BootPerfTable
+  )
+{
+  BL_PERF_DATA                        *PerfData;
+  UINT64                              TscValue;
+  UINT64                              TimeInMs;
+
+  // update ResetEnd (in ns)
+  PerfData = GetPerfDataPtr();
+  TscValue = PerfData->TimeStamp[0];
+  ((UINT16 *)&TscValue)[3] = 0;
+  TimeInMs  = DivU64x32 (TscValue, PerfData->FreqKhz);
+  BootPerfTable->BasicBoot.ResetEnd = MultU64x32 (TimeInMs, 1000000);
+
+  return  EFI_SUCCESS;
+}
+
+
+/**
+  Get FPDT S3 performance table by searching ACPI table
+
+  @param[in]  AcpiTableBase    ACPI table base address
+
+  @retval S3 performance table address     Value 0 means not found.
+**/
+UINTN
+GetFpdtS3Table (
+  IN  UINT32                                   AcpiTableBase
+  )
+{
+  EFI_ACPI_5_0_ROOT_SYSTEM_DESCRIPTION_POINTER *Rsdp;
+  EFI_ACPI_DESCRIPTION_HEADER                  *Rsdt;
+  EFI_ACPI_COMMON_HEADER                       *Hdr;
+  UINT32                                       *RsdtEntry;
+  UINT32                                       NumEntries;
+  FIRMWARE_PERFORMANCE_TABLE                   *Fpdt;
+  UINT8                                        Index;
+
+  Rsdp = (EFI_ACPI_5_0_ROOT_SYSTEM_DESCRIPTION_POINTER *) AcpiTableBase;
+  Rsdt = (EFI_ACPI_DESCRIPTION_HEADER *) (UINTN) Rsdp->RsdtAddress;
+
+  NumEntries = (Rsdt->Length - sizeof(EFI_ACPI_DESCRIPTION_HEADER)) / sizeof(UINT32);
+  RsdtEntry  = (UINT32 *) ((UINT8 *)Rsdt + sizeof (EFI_ACPI_DESCRIPTION_HEADER));
+  for (Index = 0; Index < NumEntries; Index++) {
+    Hdr = (EFI_ACPI_COMMON_HEADER *) (UINTN) RsdtEntry[Index];
+    if (Hdr->Signature == EFI_ACPI_5_0_FIRMWARE_PERFORMANCE_DATA_TABLE_SIGNATURE) {
+      Fpdt = (FIRMWARE_PERFORMANCE_TABLE *) Hdr;
+      if (DEBUG_PRINT_FPDT_DATA == 1) {
+        BOOT_PERFORMANCE_TABLE  *BootTable;
+        BootTable = (BOOT_PERFORMANCE_TABLE *)(UINTN)Fpdt->BootPointerRecord.BootPerformanceTablePointer;
+        DEBUG ((EFI_D_INFO, "FPDT: ResetEnd                = %ld\n", BootTable->BasicBoot.ResetEnd));
+        DEBUG ((EFI_D_INFO, "FPDT: OsLoaderLoadImageStart  = %ld\n", BootTable->BasicBoot.OsLoaderLoadImageStart));
+        DEBUG ((EFI_D_INFO, "FPDT: OsLoaderStartImageStart = %ld\n", BootTable->BasicBoot.OsLoaderStartImageStart));
+        DEBUG ((EFI_D_INFO, "FPDT: ExitBootServicesEntry   = %ld\n", BootTable->BasicBoot.ExitBootServicesEntry));
+        DEBUG ((EFI_D_INFO, "FPDT: ExitBootServicesExit    = %ld\n", BootTable->BasicBoot.ExitBootServicesExit));
+      }
+      return (UINTN)Fpdt->S3PointerRecord.S3PerformanceTablePointer;
+    }
+  }
+
+  return 0;
+}
+
+
+/**
+  Update ACPI FPDT S3 performance record table.
+
+  @param[in] AcpiTableBase     ACPI base address
+
+  @retval EFI_SUCCESS          Update the S3 performance table successfully.
+  @retval Others               Failed to update the table.
+ **/
+EFI_STATUS
+EFIAPI
+UpdateFpdtS3Table (
+  IN  UINT32                          AcpiTableBase
+  )
+{
+  S3_PERFORMANCE_TABLE                *S3PerfTable;
+  BL_PERF_DATA                        *PerfData;
+  UINT64                              TscValue;
+  UINT64                              TimeInMs;
+  UINT64                              TotalResumeTime;
+  EFI_ACPI_5_0_FPDT_S3_RESUME_RECORD  *S3Resume;
+
+  S3PerfTable = (S3_PERFORMANCE_TABLE *)GetFpdtS3Table (AcpiTableBase);
+  if (S3PerfTable == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  ASSERT (S3PerfTable->Header.Signature == EFI_ACPI_5_0_FPDT_S3_PERFORMANCE_TABLE_SIGNATURE);
+
+  // Get current time
+  TscValue = ReadTimeStamp();
+  PerfData = GetPerfDataPtr();
+  TimeInMs = DivU64x32 (TscValue, PerfData->FreqKhz);
+
+  // Update S3 performance data
+  S3Resume                = &S3PerfTable->S3Resume;
+  S3Resume->FullResume    = MultU64x32 (TimeInMs, 1000000);
+  TotalResumeTime         = MultU64x32 (S3Resume->AverageResume, S3Resume->ResumeCount);
+  TotalResumeTime        += S3Resume->FullResume;
+  S3Resume->ResumeCount++;
+  S3Resume->AverageResume = DivU64x32 (TotalResumeTime, S3Resume->ResumeCount);
+
+  if (DEBUG_PRINT_FPDT_DATA == 1) {
+    DEBUG ((EFI_D_INFO, "FPDT: S3Resume->AverageResume = %ld\n", S3Resume->AverageResume));
+    DEBUG ((EFI_D_INFO, "FPDT: S3Resume->ResumeCount   = %d\n",  S3Resume->ResumeCount));
+    DEBUG ((EFI_D_INFO, "FPDT: S3Resume->FullResume    = %ld\n", S3Resume->FullResume));
+  }
+  return  EFI_SUCCESS;
+}
+
+
+/**
+  Update Firmware Performance Data Table (FPDT).
+
+  @param[in] Table          Pointer of ACPI FPDT Table.
+
+  @retval EFI_SUCCESS       Update ACPI FPDT table successfully.
+  @retval Others            Failed to update FPDT table.
+ **/
+EFI_STATUS
+UpdateFpdt (
+  IN VOID                             *Table
+  )
+{
+  FIRMWARE_PERFORMANCE_TABLE          *Fpdt;
+  UINT8                               BootMode;
+  BOOT_PERFORMANCE_TABLE              *BootPerfTable;
+  S3_PERFORMANCE_TABLE                *S3PerfTable;
+
+  if ( Table == NULL) {
+    DEBUG((EFI_D_WARN, "TABLE is NULL\n"));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  BootMode = GetBootMode ();
+  if (BootMode != BOOT_ON_S3_RESUME) {
+    Fpdt          = (FIRMWARE_PERFORMANCE_TABLE *)Table;
+    BootPerfTable = (BOOT_PERFORMANCE_TABLE *) (Fpdt + 1);
+    S3PerfTable   = (S3_PERFORMANCE_TABLE *) (BootPerfTable + 1);
+
+    Fpdt->BootPointerRecord.BootPerformanceTablePointer = (UINT64) (UINTN) BootPerfTable;
+    Fpdt->S3PointerRecord.S3PerformanceTablePointer     = (UINT64) (UINTN) S3PerfTable;
+    CopyMem (BootPerfTable, &mBootPerformanceTableTemplate, sizeof (mBootPerformanceTableTemplate));
+    CopyMem (S3PerfTable, &mS3PerformanceTableTemplate, sizeof (mS3PerformanceTableTemplate));
+    UpdateFpdtBootTable (BootPerfTable);
+
+    // Fixup FPDT table length
+    Fpdt->Header.Length = sizeof (FIRMWARE_PERFORMANCE_TABLE);
+  }
+
+  return  EFI_SUCCESS;
+}
+

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -45,6 +45,19 @@
 extern  UINT32          WakeUpBuffer;
 extern  CHAR8           WakeUp;
 extern  UINT32          WakeUpSize;
+
+/**
+  Update Firmware Performance Data Table (FPDT).
+
+  @param[in] Table          Pointer of ACPI FPDT Table.
+
+  @retval EFI_SUCCESS       Update ACPI FPDT table successfully.
+  @retval Others            Failed to update FPDT table.
+ **/
+EFI_STATUS
+UpdateFpdt (
+  IN VOID                             *Table
+  );
 
 const EFI_ACPI_5_0_ROOT_SYSTEM_DESCRIPTION_POINTER RsdpTmp = {
   .Signature = EFI_ACPI_5_0_ROOT_SYSTEM_DESCRIPTION_POINTER_SIGNATURE,
@@ -314,7 +327,6 @@ AcpiTableUpdate (
               EFI_OUT_OF_RESOURCES  If less MADT entries
 **/
 EFI_STATUS
-EFIAPI
 UpdateMadt (
   IN UINT8   *Current
   )
@@ -482,6 +494,13 @@ AcpiInit (
         return Status;
       }
       break;
+    case EFI_ACPI_5_0_FIRMWARE_PERFORMANCE_DATA_TABLE_SIGNATURE:
+      // FPDT
+      Status = UpdateFpdt (Current);
+      if (Status != EFI_SUCCESS) {
+        return Status;
+      }
+      break;
     default:
       // Misc
       break;
@@ -561,6 +580,7 @@ typedef VOID (*DOWAKEUP) (UINT32 WakeVector);
 
 **/
 VOID
+EFIAPI
 FindAcpiWakeVectorAndJump (
   IN  UINT32    AcpiTableBase
   )

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
 #  which accompanies this distribution.  The full text of the license may be found at
@@ -29,6 +29,7 @@
 
 [Sources]
   AcpiInitLib.c
+  AcpiFpdt.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -42,6 +43,7 @@
   BootloaderCoreLib
   DebugDataLib
   MpInitLib
+  TimeStampLib
 
 [Guids]
 

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -333,6 +333,9 @@ S3ResumePath (
   PrintStackHeapInfo ();
   DEBUG_CODE_END ();
 
+  // Update FPDT table
+  UpdateFpdtS3Table (S3Data->AcpiBase);
+
   // Find Wake Vector and Jump to OS
   FindAcpiWakeVectorAndJump (S3Data->AcpiBase);
 

--- a/Platform/ApollolakeBoardPkg/AcpiTables/AcpiTables.inf
+++ b/Platform/ApollolakeBoardPkg/AcpiTables/AcpiTables.inf
@@ -5,7 +5,7 @@
 #  All .asi files tagged with "ToolCode="DUMMY"" in following file list are device description and are included
 #  by top level ASL file which will be dealed with by asl.exe application.
 #
-# Copyright (c)  1999  - 2016, Intel Corporation. All rights reserved
+# Copyright (c)  1999  - 2019, Intel Corporation. All rights reserved
 #
 # This program and the accompanying materials are licensed and made available under
 # the terms and conditions of the BSD License that accompanies this distribution.
@@ -39,6 +39,7 @@
   Dmar/Dmar.h
   Platform/CommonBoardPkg/AcpiTables/Tpm/Tpm2.aslc
   Platform/CommonBoardPkg/AcpiTables/Tpm/TpmSsdt.asl
+  Platform/CommonBoardPkg/AcpiTables/Fpdt/Fpdt.aslc
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/Platform/CommonBoardPkg/AcpiTables/Fpdt/Fpdt.aslc
+++ b/Platform/CommonBoardPkg/AcpiTables/Fpdt/Fpdt.aslc
@@ -1,0 +1,86 @@
+/**@file
+  This file contains a structure definition for the ACPI FPDT Table.
+
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php.
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+
+//
+// Statements that include other files
+//
+#include <IndustryStandard/Acpi.h>
+#include <Library/AcpiInitLib.h>
+
+//
+// ACPI table information used to initialize FPDT tables.
+//
+#define EFI_ACPI_FPDT_OEM_ID           {'I','N','T','E','L',' '}
+#define EFI_ACPI_FPDT_OEM_TABLE_ID     SIGNATURE_64('O','E','M','T','A','B','L','E')
+#define EFI_ACPI_FPDT_OEM_REVISION     0x00000005
+#define EFI_ACPI_FPDT_CREATOR_ID       SIGNATURE_32('C','R','E','A')
+#define EFI_ACPI_FPDT_CREATOR_REVISION 0x0100000D
+
+INTERNAL_FIRMWARE_PERFORMANCE_TABLE  FPDT = {
+  { //FIRMWARE_PERFORMANCE_TABLE
+    {
+      EFI_ACPI_5_0_FIRMWARE_PERFORMANCE_DATA_TABLE_SIGNATURE,
+      //
+      // The FPDT table length should be sizeof (FIRMWARE_PERFORMANCE_TABLE).
+      // Here INTERNAL_FIRMWARE_PERFORMANCE_TABLE includes other tables,  later code will
+      // update the tables and this length in runtime.
+      //
+      sizeof (INTERNAL_FIRMWARE_PERFORMANCE_TABLE),
+      EFI_ACPI_5_0_FIRMWARE_PERFORMANCE_DATA_TABLE_REVISION,    // Revision
+      0x00,                             // Checksum will be updated at runtime
+      EFI_ACPI_FPDT_OEM_ID,             // OEMID, a 6 bytes long field
+      EFI_ACPI_FPDT_OEM_TABLE_ID,       // OEM table identification(8 bytes long)
+      EFI_ACPI_FPDT_OEM_REVISION,       // OEM revision
+      EFI_ACPI_FPDT_CREATOR_ID,         // ASL compiler vendor ID
+      EFI_ACPI_FPDT_CREATOR_REVISION,   // ASL compiler revision number
+    },
+    //
+    // Firmware Basic Boot Performance Table Pointer Record.
+    //
+    {
+      {
+        EFI_ACPI_5_0_FPDT_RECORD_TYPE_FIRMWARE_BASIC_BOOT_POINTER ,       // Type
+        sizeof (EFI_ACPI_5_0_FPDT_BOOT_PERFORMANCE_TABLE_POINTER_RECORD), // Length
+        EFI_ACPI_5_0_FPDT_RECORD_REVISION_FIRMWARE_BASIC_BOOT_POINTER     // Revision
+      },
+      0,  // Reserved
+      0   // BootPerformanceTablePointer will be updated at runtime.
+    },
+    //
+    // S3 Performance Table Pointer Record.
+    //
+    {
+      {
+        EFI_ACPI_5_0_FPDT_RECORD_TYPE_S3_PERFORMANCE_TABLE_POINTER,     // Type
+        sizeof (EFI_ACPI_5_0_FPDT_S3_PERFORMANCE_TABLE_POINTER_RECORD), // Length
+        EFI_ACPI_5_0_FPDT_RECORD_REVISION_S3_PERFORMANCE_TABLE_POINTER  // Revision
+      },
+      0,  // Reserved
+      0   // S3PerformanceTablePointer will be updated at runtime.
+    }
+  }
+};
+
+
+VOID *
+ReferenceAcpiTable (
+  VOID
+  )
+{
+  //
+  // Reference the table being generated to prevent the optimizer from
+  // removing the data structure from the executable
+  //
+  return (VOID*)&FPDT;
+}

--- a/Platform/QemuBoardPkg/AcpiTables/AcpiTables.inf
+++ b/Platform/QemuBoardPkg/AcpiTables/AcpiTables.inf
@@ -28,10 +28,11 @@
   Madt/Madt30.aslc
   Mcfg/Mcfg.aslc
   Hpet/Hpet.aslc  
+  Platform/CommonBoardPkg/AcpiTables/Fpdt/Fpdt.aslc
 
 [Packages]
   MdePkg/MdePkg.dec
   Silicon/QemuSocPkg/QemuSocPkg.dec
   Platform/QemuBoardPkg/QemuBoardPkg.dec
   BootloaderCommonPkg/BootloaderCommonPkg.dec
-  
+  BootloaderCorePkg/BootloaderCorePkg.dec  


### PR DESCRIPTION
This patch adds FPDT table into ACPI table, and updates all the performance data for S3 path. Some other
It also update basic boot performance data for reset end. other basic boot performance data could be updated by UEFI payload.

Signed-off-by: Guo Dong <guo.dong@intel.com>