### PR TITLE
Security Flags updates to LOADER_PLATFORM_INFO

### DIFF
--- a/BootloaderCommonPkg/Include/Guid/LoaderPlatformInfoGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/LoaderPlatformInfoGuid.h
@@ -24,6 +24,34 @@ extern EFI_GUID gLoaderPlatformInfoGuid;
 
 #pragma pack(1)
 
+//Definition for LOADER_PLATFORM_INFO.LdrFeatures
+
+#define        FEATURE_ACPI                     BIT0
+#define        FEATURE_MEASURED_BOOT            BIT1
+#define        FEATURE_MMC_TUNING               BIT2
+#define        FEATURE_MMC_FORCE_TUNING         BIT3
+#define        FEATURE_VERIFIED_BOOT            BIT4
+
+//
+//Definition for LOADER_PLATFORM_INFO.HwState
+//
+
+/// Verified boot state (0- disabled, 1 - enabled), based on boot guard profile.
+#define        HWSTATE_VERIFIED_BOOT            BIT0
+
+// Measured boot state (0- disabled, 1 - enabled), based on boot guard profile.
+#define        HWSTATE_MEASURED_BOOT            BIT1
+
+// Manufacturing state (0 - ready for production; 1 - not ready for production)
+//  (This comes from CSE. When this bit is 1, it is still in manufacturing mode. Host
+//  can use this bit to inform user that platform is NOT ready for production yet.
+//  when this bit is 0, then it is ready for production)
+#define        HWSTATE_IN_MANUFACTURING_MODE     BIT2
+
+//Secure debug (0 - disabled, 1 - enabled)
+#define        HWSTATE_SECURE_DEBUG              BIT3
+
+
 typedef struct {
   UINT8          Revision;
   UINT8          Reserved[3];
@@ -31,16 +59,10 @@ typedef struct {
   UINT8          BootMode;
   UINT16         PlatformId;
   UINT32         CpuCount;
-  UINT16         SecurityFlags; // Bit 0: Vb (0- disabled, 1 - enabled)
-                                // Bit 1: Mb (0- disabled, 1 - enabled)
-                                // Bit 2: Manufacturing state (0 - ready for production; 1 - not ready for production)
-                                // (This comes from CSE. When this bit is 1, it is still in manufacturing mode. Host 
-                                // can use this bit to inform user that platform is NOT ready for production yet.
-                                // when this bit is 0, then it is ready for production)
-                                // Bit 3: Secure debug enabled/disabled
-  UINT8           Reserved1[2];
-  UINT32          LdrFeatures;
-  CHAR8           SerialNumber[MAX_SERIAL_NUMBER_LENGTH];
+  UINT16         HwState;
+  UINT8          Reserved1[2];
+  UINT32         LdrFeatures;
+  CHAR8          SerialNumber[MAX_SERIAL_NUMBER_LENGTH];
 } LOADER_PLATFORM_INFO;
 
 #pragma pack()

--- a/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
+++ b/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
@@ -50,6 +50,7 @@ typedef struct {
 #define        FEATURE_MEASURED_BOOT            BIT1
 #define        FEATURE_MMC_TUNING               BIT2
 #define        FEATURE_MMC_FORCE_TUNING         BIT3
+#define        FEATURE_VERIFIED_BOOT            BIT4
 
 #define MM_PCI_ADDRESS( Bus, Device, Function, Register ) \
   ( (UINTN)PcdGet64(PcdPciExpressBaseAddress) + \

--- a/PayloadPkg/OsLoader/KeyManagement.c
+++ b/PayloadPkg/OsLoader/KeyManagement.c
@@ -256,10 +256,10 @@ RpmbKeyProvisioning (
   }
 
   // Get manufacturing state
-  Eom = (LoaderPlatformInfo->SecurityFlags & BIT2) >> BIT1;
+  Eom = ((LoaderPlatformInfo->HwState & HWSTATE_IN_MANUFACTURING_MODE) == 0) ?TRUE:FALSE;
 
   // Proceed further only if its in production mode and if the verified boot is enabled
-  if((Eom == 1) || ((LoaderPlatformInfo->SecurityFlags & 0x1) != 1)) {
+  if((Eom) || ((LoaderPlatformInfo->LdrFeatures & FEATURE_VERIFIED_BOOT) == FEATURE_VERIFIED_BOOT)) {
     return EFI_UNSUPPORTED;
   }
 

--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -306,7 +306,7 @@ LoadAndSetupImage (
     if (LoaderPlatformInfo == NULL) {
       return EFI_NOT_FOUND;
     }
-    if (FeaturePcdGet (PcdMeasuredBootEnabled) && (LoaderPlatformInfo->SecurityFlags && BIT1)) {
+    if (FeaturePcdGet (PcdMeasuredBootEnabled) && (LoaderPlatformInfo->LdrFeatures & FEATURE_MEASURED_BOOT)) {
       // Extend hash of the image into TPM.
       TpmExtendPcrAndLogEvent ( 8, TPM_ALG_SHA256, LoadedImage->ImageHash,
         EV_COMPACT_HASH, sizeof("LinuxLoaderPkg: OS Image"), (UINT8 *)"LinuxLoaderPkg: OS Image");
@@ -396,7 +396,7 @@ BeforeOSJump (
   if (LoaderPlatformInfo == NULL) {
     return ;
   }
-  if (FeaturePcdGet (PcdMeasuredBootEnabled) && (LoaderPlatformInfo->SecurityFlags && BIT1)) {
+  if (FeaturePcdGet (PcdMeasuredBootEnabled) && (LoaderPlatformInfo->LdrFeatures & FEATURE_MEASURED_BOOT)) {
     TpmIndicateReadyToBoot ();
   }
   AddMeasurePoint (0x4100);

--- a/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -1660,24 +1660,38 @@ PlatformFeaturesInit (
   LOADER_GLOBAL_DATA          *LdrGlobal;
   PLAT_FEATURES               *PlatformFeatures;
   DYNAMIC_CFG_DATA            *DynamicCfgData;
+  PLATFORM_DATA               *PlatformData;
   UINT32                      Features;
 
   Features        = 0;
   FeaturesCfgData = (FEATURES_CFG_DATA *) FindConfigDataByTag(CDATA_FEATURES_TAG);
   if (FeaturesCfgData != NULL) {
+
     if (FeaturesCfgData->Features.Acpi != 0) {
       Features |= FEATURE_ACPI;
     } else {
       Features &= ~FEATURE_ACPI;
     }
-    if (FeaturesCfgData->Features.MeasuredBoot != 0) {
+
+    if (FeaturesCfgData->Features.eMMCTuning != 0) {
+      Features |= FEATURE_MMC_TUNING;
+    }
+
+    PlatformData  = (PLATFORM_DATA *)GetPlatformDataPtr ();
+
+    if ((PlatformData != NULL) && (FeaturesCfgData->Features.MeasuredBoot != 0) &&
+              (PlatformData->BtGuardInfo.Bpm.Mb != 0) && MEASURED_BOOT_ENABLED()) {
       Features |= FEATURE_MEASURED_BOOT;
     } else {
       Features &= ~FEATURE_MEASURED_BOOT;
     }
-    if (FeaturesCfgData->Features.eMMCTuning != 0) {
-      Features |= FEATURE_MMC_TUNING;
+
+    if ((PlatformData != NULL) && (PlatformData->BtGuardInfo.Bpm.Vb != 0) && FeaturePcdGet(PcdVerifiedBootEnabled)) {
+      Features |= FEATURE_VERIFIED_BOOT;
+    } else {
+      Features &= ~FEATURE_VERIFIED_BOOT;
     }
+
     PlatformFeatures           = &((PLATFORM_DATA *)GetPlatformDataPtr ())->PlatformFeatures;
     PlatformFeatures->Vt       = FeaturesCfgData->Features.Vt;
     PlatformFeatures->DciDebug = FeaturesCfgData->Features.DciDebug;

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1294,12 +1294,12 @@ UpdateLoaderPlatformInfo (
 
   PlatformData  = (PLATFORM_DATA *)GetPlatformDataPtr ();
   if(PlatformData != NULL) {
-    LoaderPlatformInfo->SecurityFlags = (PlatformData->BtGuardInfo.Bpm.Vb & FeaturePcdGet(PcdVerifiedBootEnabled)) |
-                                        ((PlatformData->BtGuardInfo.Bpm.Mb & FeaturePcdGet(PcdMeasuredBootEnabled) & MEASURED_BOOT_ENABLED() ) << 1);
+    LoaderPlatformInfo->HwState = (PlatformData->BtGuardInfo.Bpm.Vb) |
+                                        ((PlatformData->BtGuardInfo.Bpm.Mb) << 1);
 
     // Get Manufacturing Mode from Heci
     ReadHeciFwStatus(&HeciFwSts);
-    LoaderPlatformInfo->SecurityFlags |= (HeciFwSts & BIT4) >> 2;
+    LoaderPlatformInfo->HwState |= (HeciFwSts & BIT4) >> 2;
   }
 }
 


### PR DESCRIPTION
LOADER_PLATFORM_INFO.LdrFeatures is used to for feature updates
and this need to be checked by loader and payloads.

LOADER_PLATFORM_INFO.HwState for Hw supported features as
Boot guard profiles.

Signed-off-by: Subash Lakkimsetti <subashx.lakkimsetti@intel.com>