### PR TITLE
Add full path support for FAT file loading

### DIFF
--- a/BootloaderCommonPkg/Library/FatLib/FatLiteLib.c
+++ b/BootloaderCommonPkg/Library/FatLib/FatLiteLib.c
@@ -363,35 +363,39 @@ EngFatToStr (
 
 
 /**
-  Performs a case-insensitive comparison of two Null-terminated Unicode strings.
+  Performs a case-insensitive comparison of two Null-terminated Unicode strings
+  for specific length.
 
   @param  PrivateData       Global memory map for accessing global variables
   @param  Str1              First string to perform case insensitive comparison.
   @param  Str2              Second string to perform case insensitive comparison.
+  @param  Len               Length to compare.
 
 **/
 BOOLEAN
-EngStriColl (
-  IN  PEI_FAT_PRIVATE_DATA  *PrivateData,
+EngStrniColl (
   IN CHAR16                 *Str1,
-  IN CHAR16                 *Str2
+  IN CHAR16                 *Str2,
+  IN UINT32                  Len
   )
 {
   CHAR16  UpperS1;
   CHAR16  UpperS2;
 
-  UpperS1 = ToUpper (*Str1);
-  UpperS2 = ToUpper (*Str2);
-  while (*Str1 != 0) {
+  while (Len > 0) {
+    if ((*Str1 == 0) || (*Str2 == 0)) {
+      return FALSE;
+    }
+    UpperS1 = ToUpper (*Str1);
+    UpperS2 = ToUpper (*Str2);
     if (UpperS1 != UpperS2) {
       return FALSE;
     }
-
     Str1++;
     Str2++;
-    UpperS1 = ToUpper (*Str1);
-    UpperS2 = ToUpper (*Str2);
+    Len--;
   }
 
-  return (BOOLEAN) ((*Str2 != 0) ? FALSE : TRUE);
+  return TRUE;
 }
+

--- a/BootloaderCommonPkg/Library/FatLib/FatLitePeim.h
+++ b/BootloaderCommonPkg/Library/FatLib/FatLitePeim.h
@@ -254,20 +254,21 @@ EngFatToStr (
 
 
 /**
-  Performs a case-insensitive comparison of two Null-terminated Unicode strings.
+  Performs a case-insensitive comparison of two Null-terminated Unicode strings
+  for specific length.
 
   @param  PrivateData       Global memory map for accessing global variables
   @param  Str1              First string to perform case insensitive comparison.
   @param  Str2              Second string to perform case insensitive comparison.
+  @param  Len               Length to compare.
 
 **/
 BOOLEAN
-EngStriColl (
-  IN  PEI_FAT_PRIVATE_DATA  *PrivateData,
+EngStrniColl (
   IN CHAR16                 *Str1,
-  IN CHAR16                 *Str2
+  IN CHAR16                 *Str2,
+  IN UINT32                  Len
   );
-
 
 /**
   Reads a block of data from the block device by calling
@@ -417,6 +418,7 @@ FatReadFile (
 
   @param  PrivateData            Global memory map for accessing global variables
   @param  ParentDir              The parent directory.
+  @param  Attributes             The file attribute (file or dir) to find.
   @param  SubFile                The File structure containing the sub file that
                                  is caught.
 
@@ -430,6 +432,7 @@ EFI_STATUS
 FatReadNextDirectoryEntry (
   IN  PEI_FAT_PRIVATE_DATA  *PrivateData,
   IN  PEI_FAT_FILE          *ParentDir,
+  IN  UINT32                 Attributes,
   OUT PEI_FAT_FILE          *SubFile
   );
 


### PR DESCRIPTION
Current FAT library can only support loading file from the root
directory of FAT file system. This patch enhanced it to support
load file from FAT file system with any give full path. Both unix
and Windows style path are supported. For example, "efi\boot.cfg",
"\efi\boot.cfg", "/efi/boot.cfg", etc, all are valid path string.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>