### PR TITLE
Revert "[APL] Enlarge payload heap size from 64MB to 128MB (#68)"

### DIFF
--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -133,7 +133,7 @@ class Board(BaseBoard):
 
 		self.PLD_RSVD_MEM_SIZE    = 0x00500000
 
-		self.PLD_HEAP_SIZE        = 0x08000000
+		self.PLD_HEAP_SIZE        = 0x04000000
 
 		self.FWUPDATE_SIZE        = 0x00020000
 		self.CFGDATA_SIZE         = 0x00004000


### PR DESCRIPTION
A work-around for ACRN hypervisor hang loaded by SBL.  The complete
fix requires iasimage tool to support correct alignment for subcomponents

This reverts commit c467303715a6b0358a3ad9a53744ba2706de3fd9.