### PR TITLE
Add GRUB config file support to boot Ubuntu

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -281,6 +281,7 @@
   gPlatformModuleTokenSpaceGuid.PcdVtdEnabled             | $(ENABLE_VTD)
   gPlatformModuleTokenSpaceGuid.PcdFlashMapEnabled        | $(HAVE_FLASH_MAP)
   gPlatformModuleTokenSpaceGuid.PcdPsdBiosEnabled         | $(HAVE_PSD_TABLE)
+  gPayloadTokenSpaceGuid.PcdGrubBootCfgEnabled            | $(ENABLE_GRUB_CONFIG)
 
 !ifdef $(S3_DEBUG)
   gPlatformModuleTokenSpaceGuid.PcdS3DebugEnabled         | $(S3_DEBUG)

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -186,6 +186,7 @@ class BaseBoard(object):
 		self.ENABLE_FWU            = 0
 		self.ENABLE_SOURCE_DEBUG   = 0
 		self.ENABLE_SMM_REBASE     = 0
+		self.ENABLE_GRUB_CONFIG    = 0
 
 		self.ACM_SIZE              = 0
 		self.UCODE_SIZE            = 0

--- a/PayloadPkg/OsLoader/BootConfig.c
+++ b/PayloadPkg/OsLoader/BootConfig.c
@@ -1,0 +1,369 @@
+/** @file
+
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php.
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+
+#include "OsLoader.h"
+
+/**
+  Get next line start pointer.
+
+  @param[in]   Start    The pointer for current line.
+  @param[out]  Length   The UINT32 pointer to receive the length of current line.
+
+  @retval      The pointer for next line.
+               NULL if no more line is available.
+**/
+STATIC
+CHAR8 *
+GetNextLine (
+  IN   CHAR8    *Start,
+  OUT  UINT32   *Length
+  )
+{
+  CHAR8 *Ptr;
+
+  Ptr = Start;
+  while ((Ptr[0] != 0) && (Ptr[0] != '\n')) {
+    Ptr++;
+  }
+
+  *Length = Ptr - Start;
+  if (Ptr[0] == 0) {
+    return NULL;
+  } else {
+    return Ptr + 1;
+  }
+}
+
+
+/**
+  Trim leading white space for a line.
+
+  @param[in]   Line     The pointer to the line buffer.
+
+  @retval      The pointer to the trimmed line.
+
+**/
+STATIC
+CHAR8 *
+TrimLeft (
+  IN  CHAR8  *Line
+  )
+{
+  while ((Line[0] == ' ') || (Line[0] == '\t')) {
+    Line++;
+  }
+  return Line;
+}
+
+
+/**
+  Get next space for the start of a line.
+
+  @param[in]   LineStart   The pointer to the start of the line buffer.
+  @param[in]   LineEnd     The pointer to the end of the line buffer.
+
+  @retval      The pointer to the trimmed line.
+
+**/
+STATIC
+CHAR8 *
+GetNextSpace (
+  IN  CHAR8  *LineStart,
+  IN  CHAR8  *LineEnd
+  )
+{
+  CHAR8  *Line;
+
+  Line = LineStart;
+  while ((Line[0] != 0) && (Line[0] != ' ') && (Line[0] != '\t') && (Line < LineEnd)) {
+    Line++;
+  }
+  return Line;
+}
+
+
+/**
+  Trim trailing white space for a line.
+
+  @param[in]   Line     The pointer to the line buffer.
+
+  @retval      The pointer to the trimmed line.
+
+**/
+STATIC
+CHAR8 *
+TrimRight (
+  IN  CHAR8  *Line
+  )
+{
+  while ((Line[0] == ' ') || (Line[0] == '\t') || (Line[0] == '\r')) {
+    Line--;
+  }
+  return Line;
+}
+
+
+/**
+  Check if a line starts with a known keyword.
+
+  @param[in]   Line     The pointer to the line buffer.
+  @param[in]   Keyword  The pointer to the keyword.
+
+  @retval      Length of the matched keyword.
+               0 if there is no match.
+
+**/
+STATIC
+UINT32
+MatchKeyWord (
+  IN  CHAR8  *Line,
+  IN  CHAR8  *Keyword
+  )
+{
+  UINT32 KeywordLen;
+
+  KeywordLen = AsciiStrLen (Keyword);
+  if (AsciiStrnCmp (Line, Keyword, KeywordLen) == 0) {
+    // A separator is required to follow the keyword
+    if (((Line[KeywordLen] == 0)) || (Line[KeywordLen] == ' ') || (Line[KeywordLen] == '\t')) {
+      return KeywordLen;
+    }
+  }
+  return 0;
+}
+
+
+/**
+  Check if a line matches varaible assignment syntax.
+
+  @param[in]   Line      The pointer to the line buffer.
+  @param[in]   Variable  The pointer to the variable name.
+
+  @retval      Length of the matched variable name.
+               0 if there is no match.
+
+**/
+STATIC
+UINT32
+MatchAssignment (
+  IN  CHAR8  *Line,
+  IN  CHAR8  *Variable
+  )
+{
+  UINT32 VarLen;
+
+  VarLen = AsciiStrLen (Variable);
+  if (AsciiStrnCmp (Line, Variable, VarLen) == 0) {
+    if (Line[VarLen] == '=') {
+      return VarLen;
+    }
+  }
+  return 0;
+}
+
+
+/**
+  Parse the Linux boot configuration file.
+
+  @param[in]    CfgBuffer     The configuration buffer.
+  @param[out]   LinuxBootCfg  The pointer to hold the parse results.
+
+**/
+VOID
+ParseLinuxBootConfig (
+  IN   CHAR8            *CfgBuffer,
+  OUT  LINUX_BOOT_CFG   *LinuxBootCfg
+  )
+{
+  CHAR8      *CurrLine;
+  CHAR8      *NextLine;
+  CHAR8      *StartLine;
+  CHAR8      *EndLine;
+  MENU_ENTRY *MenuEntry;
+  UINT32      Idx;
+  UINT32      LineLen;
+  INT32       EntryNum;
+
+  MenuEntry = LinuxBootCfg->MenuEntry;
+
+  EntryNum = -1;
+  CurrLine = CfgBuffer;
+  while (CurrLine != NULL) {
+    NextLine = GetNextLine (CurrLine, &LineLen);
+    EndLine  = CurrLine + LineLen;
+    CurrLine = TrimLeft (CurrLine);
+    if (MatchKeyWord (CurrLine, "set") > 0) {
+      CurrLine += 3;
+
+      // Handle "set" varaible statement
+      // Only support "timeout" and "default" now
+      CurrLine  = TrimLeft (CurrLine);
+      StartLine = CurrLine;
+      while ((CurrLine[0] != 0) && (CurrLine[0] != '=') && (CurrLine < EndLine)) {
+        CurrLine++;
+      }
+      if (CurrLine[0] == '=') {
+        CurrLine++;
+        if (MatchAssignment (StartLine, "timeout") > 0) {
+          LinuxBootCfg->Settings.Timeout = AsciiStrDecimalToUintn (CurrLine);
+        } else if (MatchAssignment (StartLine, "default") > 0) {
+          if (CurrLine[0] == '"') {
+            CurrLine++;
+          }
+          // Support boot option number string only
+          LinuxBootCfg->Settings.Default = AsciiStrDecimalToUintn (CurrLine);
+        }
+      }
+    } else if (MatchKeyWord (CurrLine, "menuentry") > 0) {
+      if (EntryNum >= MAX_BOOT_MENU_ENTRY) {
+        NextLine = NULL;
+        break;
+      }
+
+      // Mark boot option name
+      EntryNum++;
+      CurrLine += 9;
+      CurrLine  = TrimLeft (CurrLine);
+      for (Idx = 0; Idx < 2; Idx++) {
+        while ((CurrLine[0] != 0) && (CurrLine[0] != '"') && (CurrLine < EndLine)) {
+          CurrLine++;
+        }
+        if (CurrLine[0] == '"') {
+          if (Idx == 0) {
+            MenuEntry[EntryNum].Name.Pos = CurrLine - CfgBuffer + 1;
+          } else {
+            MenuEntry[EntryNum].Name.Len = CurrLine - CfgBuffer - MenuEntry[EntryNum].Name.Pos;
+          }
+          CurrLine++;
+        }
+      }
+    } else if (MatchKeyWord (CurrLine, "linux") > 0) {
+      CurrLine += 5;
+
+      // Mark kernel path
+      CurrLine  = TrimLeft (CurrLine);
+      MenuEntry[EntryNum].Kernel.Pos = CurrLine - CfgBuffer;
+      CurrLine  = GetNextSpace (CurrLine, EndLine);
+      MenuEntry[EntryNum].Kernel.Len = CurrLine - CfgBuffer - MenuEntry[EntryNum].Kernel.Pos;
+
+      // Mark command line
+      CurrLine = TrimLeft (CurrLine);
+      MenuEntry[EntryNum].Command.Pos = CurrLine - CfgBuffer;
+      EndLine  = TrimRight (EndLine);
+      MenuEntry[EntryNum].Command.Len = EndLine - CfgBuffer - MenuEntry[EntryNum].Command.Pos;
+    } else if (MatchKeyWord (CurrLine, "initrd") > 0) {
+      CurrLine += 6;
+
+      // Mark initrd path
+      CurrLine = TrimLeft (CurrLine);
+      MenuEntry[EntryNum].InitRd.Pos = CurrLine - CfgBuffer;
+      CurrLine = GetNextSpace (CurrLine, EndLine);
+      MenuEntry[EntryNum].InitRd.Len = CurrLine - CfgBuffer - MenuEntry[EntryNum].InitRd.Pos;
+    }
+
+    CurrLine = NextLine;
+  }
+
+  if (EntryNum >= 0) {
+    EntryNum++;
+  } else {
+    EntryNum = 0;
+  }
+
+  // Make sure the settings are reasonable
+  LinuxBootCfg->EntryNum = EntryNum;
+  if (LinuxBootCfg->Settings.Default >= (UINT32)EntryNum) {
+    LinuxBootCfg->Settings.Default = 0;
+  }
+  if (LinuxBootCfg->Settings.Timeout >= 60) {
+    LinuxBootCfg->Settings.Timeout = 3;
+  }
+}
+
+
+/**
+  Print Linux boot options.
+
+  @param[in]    CfgBuffer     The configuration buffer.
+  @param[out]   LinuxBootCfg  The pointer to hold the parse results.
+
+**/
+VOID
+PrintLinuxBootConfig (
+  CHAR8                    *CfgBuffer,
+  LINUX_BOOT_CFG           *LinuxBootCfg
+  )
+{
+  UINTN  Idx;
+  CHAR8 *CurrLine;
+  UINT32 LineLen;
+  CHAR8  Val;
+
+  ShellPrint (L"\nBoot Menu:\n");
+  for (Idx = 0; Idx < LinuxBootCfg->EntryNum; Idx++) {
+    if (LinuxBootCfg->MenuEntry[Idx].Name.Buf[0] == 0) {
+      CurrLine = CfgBuffer + LinuxBootCfg->MenuEntry[Idx].Name.Pos;
+    } else {
+      CurrLine = LinuxBootCfg->MenuEntry[Idx].Name.Buf;
+    }
+    LineLen  = LinuxBootCfg->MenuEntry[Idx].Name.Len;
+    Val = CfgBuffer[LineLen];
+    CurrLine[LineLen] = 0;
+    ShellPrint (L"  %d - %c %a\n", Idx, (Idx == LinuxBootCfg->Settings.Default) ? '*' : ' ', CurrLine);
+    CurrLine[LineLen] = Val;
+  }
+}
+
+
+/**
+  Get Linux boot option from user input.
+
+  @param[in]    CfgBuffer     The configuration buffer.
+  @param[out]   LinuxBootCfg  The pointer to hold the parse results.
+
+  @retval       0 based boot option index.
+
+**/
+UINT32
+GetLinuxBootOption (
+  CHAR8                    *CfgBuffer,
+  LINUX_BOOT_CFG           *LinuxBootCfg
+  )
+{
+  UINT32     EntryIdx;
+  UINT32     Timeout;
+  UINT32     Index;
+  UINT8      Key;
+
+  EntryIdx = LinuxBootCfg->Settings.Default;
+  Timeout  = LinuxBootCfg->Settings.Timeout;
+  if ((Timeout > 0) && (LinuxBootCfg->EntryNum > 0)) {
+    ShellPrint (L"Press '0' ~ '%d' to select boot option: ", LinuxBootCfg->EntryNum - 1);
+    for (Index = 0; Index < Timeout * 100; Index++) {
+      if (ConsolePoll ()) {
+        if (ConsoleRead (&Key, 1) > 0) {
+          if ((Key >= '0') && (Key < '0' + LinuxBootCfg->EntryNum)) {
+            ShellPrint (L"%c", Key);
+            EntryIdx = Key - '0';
+            break;
+          }
+        }
+      }
+      MicroSecondDelay (10 * 1000);
+    }
+    ShellPrint (L"\nBoot from option %d\n", EntryIdx);
+  }
+
+  return EntryIdx;
+}
+

--- a/PayloadPkg/OsLoader/OsLoader.h
+++ b/PayloadPkg/OsLoader/OsLoader.h
@@ -16,6 +16,7 @@
 
 #include <Library/LiteFvLib.h>
 #include <Library/PartitionLib.h>
+#include <Library/TimerLib.h>
 #include <Library/FileSystemLib.h>
 #include <Library/PayloadMemoryAllocationLib.h>
 #include <Library/DebugPrintErrorLevelLib.h>
@@ -81,6 +82,33 @@
 #define LOADED_IMAGE_FV          BIT4
 
 #define MAX_EXTRA_FILE_NUMBER    16
+
+#define MAX_BOOT_MENU_ENTRY      8
+#define MAX_STR_SLICE_LEN        16
+
+typedef struct {
+  UINT32       Pos;
+  UINT32       Len;
+  CHAR8        Buf[MAX_STR_SLICE_LEN];
+} STR_SLICE;
+
+typedef struct {
+  STR_SLICE    Name;
+  STR_SLICE    Command;
+  STR_SLICE    Kernel;
+  STR_SLICE    InitRd;
+} MENU_ENTRY;
+
+typedef struct {
+  UINT32       Default;
+  UINT32       Timeout;
+} CFG_SETTING;
+
+typedef struct {
+  UINT32       EntryNum;
+  CFG_SETTING  Settings;
+  MENU_ENTRY   MenuEntry[MAX_BOOT_MENU_ENTRY];
+} LINUX_BOOT_CFG;
 
 typedef struct {
   IMAGE_DATA              BootFile;
@@ -378,6 +406,49 @@ EFI_STATUS
 RpmbKeyProvisioning (
   IN     OS_BOOT_OPTION      *CurrentBootOption,
   IN     LOADER_SEED_LIST    *SeedList
+  );
+
+
+/**
+  Parse the Linux boot configuration file.
+
+  @param[in]    CfgBuffer     The configuration buffer.
+  @param[out]   LinuxBootCfg  The pointer to hold the parse results.
+
+**/
+VOID
+ParseLinuxBootConfig (
+  IN   CHAR8            *CfgBuffer,
+  OUT  LINUX_BOOT_CFG   *LinuxBootCfg
+  );
+
+
+/**
+  Print Linux boot options.
+
+  @param[in]    CfgBuffer     The configuration buffer.
+  @param[out]   LinuxBootCfg  The pointer to hold the parse results.
+
+**/
+VOID
+PrintLinuxBootConfig (
+  CHAR8                    *CfgBuffer,
+  LINUX_BOOT_CFG           *LinuxBootCfg
+  );
+
+/**
+  Get Linux boot option from user input.
+
+  @param[in]    CfgBuffer     The configuration buffer.
+  @param[out]   LinuxBootCfg  The pointer to hold the parse results.
+
+  @retval       0 based boot option index.
+
+**/
+UINT32
+GetLinuxBootOption (
+  CHAR8                    *CfgBuffer,
+  LINUX_BOOT_CFG           *LinuxBootCfg
   );
 
 #endif

--- a/PayloadPkg/OsLoader/OsLoader.inf
+++ b/PayloadPkg/OsLoader/OsLoader.inf
@@ -32,6 +32,7 @@
 [Sources]
   OsLoader.c
   BootOption.c
+  BootConfig.c
   LoadImage.c
   Linux.c
   PerformanceData.c
@@ -107,6 +108,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdConsoleOutDeviceMask
   gPlatformCommonLibTokenSpaceGuid.PcdFrameBufferMaxConsoleWidth
   gPlatformCommonLibTokenSpaceGuid.PcdFrameBufferMaxConsoleHeight
+  gPayloadTokenSpaceGuid.PcdGrubBootCfgEnabled
 
 [Depex]
   TRUE

--- a/PayloadPkg/PayloadPkg.dec
+++ b/PayloadPkg/PayloadPkg.dec
@@ -37,3 +37,6 @@
   gPayloadTokenSpaceGuid.PcdPayloadStackSize  | 0x00000000 | UINT32 | 0x10001002
   gPayloadTokenSpaceGuid.PcdPayloadHeapSize   | 0x00000000 | UINT32 | 0x10001003
   gPayloadTokenSpaceGuid.PcdGlobalDataAddress | 0x00000000 | UINT32 | 0x10001004
+
+[PcdsFeatureFlag]
+  gPayloadTokenSpaceGuid.PcdGrubBootCfgEnabled  | FALSE    | BOOLEAN | 0x2001000

--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -56,6 +56,7 @@ class Board(BaseBoard):
 		self.ENABLE_FWU               = 1
 		self.ENABLE_SPLASH            = 1
 		self.ENABLE_FRAMEBUFFER_INIT  = 1
+		self.ENABLE_GRUB_CONFIG       = 1
 
 		# To enable source debug, set 1 to self.ENABLE_SOURCE_DEBUG
 		# self.ENABLE_SOURCE_DEBUG   = 1
@@ -215,7 +216,7 @@ class Board(BaseBoard):
 		img_list.extend ([
 					# Padding to ensure all other components in OBB partition will be aligned at 4KB boundary
 					# 0xB00 assumes (IBBP.man, BPM.met) + (IPAD, IBBL, IBBM,  OBB, FWUP, CFGD, PLD, VAR, MRCD) in BpdtIBB
-					# 0x180 assumes (OPAD,  PROV, EPLD) in BpdtOBB 
+					# 0x180 assumes (OPAD,  PROV, EPLD) in BpdtOBB
 					# If more files are added, the offset needs to be adjusted accordingly
 					('Stitch_IPAD.bin', [
 						('PADDING.bin',  '',                0xB00,    STITCH_OPS.MODE_FILE_PAD, STITCH_OPS.MODE_POS_TAIL)]

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -51,6 +51,7 @@ class Board(BaseBoard):
 		self.ENABLE_SPLASH            = 1
 		self.ENABLE_FRAMEBUFFER_INIT  = 1
 		self.ENABLE_FWU               = 1
+		self.ENABLE_GRUB_CONFIG       = 1
 
 		# To enable source debug, set 1 to self.ENABLE_SOURCE_DEBUG
 		# self.ENABLE_SOURCE_DEBUG  = 1


### PR DESCRIPTION
This patch added a simple parser for grub.cfg to make it easy to boot
Ubuntu ISO image using OsLoader payload. Without it, it is required to
copy vmlinuz/initrd to root directory and create a config.cfg to list
the kernel boot command line in order to boot the ISO image. This patch
makes it possible to boot the original Ubuntu ISO (16.04 or 18.04)
directly. It provides better user experience for people who wants to
try out SBL.

Please note, same as before, when verified boot is enabled, only debug
build will support this feature. Release build will disable this feature
due to security concern, please use IAS image boot mechnism instead.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>