### PR TITLE
Allow more flexible config.cfg format

### DIFF
--- a/PayloadPkg/OsLoader/BootConfig.c
+++ b/PayloadPkg/OsLoader/BootConfig.c
@@ -235,10 +235,10 @@ ParseLinuxBootConfig (
       CurrLine += 9;
       CurrLine  = TrimLeft (CurrLine);
       for (Idx = 0; Idx < 2; Idx++) {
-        while ((CurrLine[0] != 0) && (CurrLine[0] != '"') && (CurrLine < EndLine)) {
+        while ((CurrLine[0] != 0) && (CurrLine[0] != '"') && (CurrLine[0] != '\'') && (CurrLine < EndLine)) {
           CurrLine++;
         }
-        if (CurrLine[0] == '"') {
+        if ((CurrLine[0] == '"') || (CurrLine[0] == '\'')) {
           if (Idx == 0) {
             MenuEntry[EntryNum].Name.Pos = CurrLine - CfgBuffer + 1;
           } else {


### PR DESCRIPTION
Since grub.cfg is already supported in SBL. It makes sense to support
the similar syntax in config.cfg. This patch enabled config.cfg to
follow grub.cfg format to provide multiple boot options. The old
config.cfg format will still be supported. This patch also added
support for single/double quote around boot menu entry name.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>