### PR TITLE
Add basic pre-build check for OpenSSL/NASM

### DIFF
--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -819,6 +819,29 @@ def gen_ver_info_txt (ver_file, ver_info):
 	h_file.write('Dirty         = %d\n'    % ver_info.ImageVersion.Dirty)
 	h_file.close()
 
+def check_for_openssl():
+	'''
+	Verify OpenSSL executable is available
+	'''
+	cmdline = os.path.join(os.environ.get('OPENSSL_PATH', ''), 'openssl')
+	try:
+		version = subprocess.check_output([cmdline, 'version'])
+	except:
+		print 'ERROR: OpenSSL not available. Please set OPENSSL_PATH.'
+		sys.exit(1)
+	return version
+
+def check_for_nasm():
+	'''
+	Verify NASM executable is available
+	'''
+	cmdline = os.path.join(os.environ.get('NASM_PREFIX', ''), 'nasm')
+	try:
+		version = subprocess.check_output([cmdline, '-v'])
+	except:
+		print 'ERROR: NASM not available. Please set NASM_PREFIX.'
+		sys.exit(1)
+	return version
 
 def rsa_sign_file (priv_key, pub_key, in_file, out_file, inc_dat = False, inc_key = False):
 	cmdline = os.path.join(os.environ.get ('OPENSSL_PATH', ''), 'openssl')

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -105,6 +105,9 @@ def prep_env ():
 		print "Unsupported operating system !"
 		sys.exit(1)
 
+	check_for_openssl()
+	check_for_nasm()
+
 	# Update Environment vars
 	os.environ['SBL_SOURCE']     = sblsource
 	os.environ['EDK_TOOLS_PATH'] = os.path.join(sblsource, 'BaseTools')


### PR DESCRIPTION
Fixes #95 by adding a simple check for OpenSSL and NASM before building.

The Build`*`.py scripts could really use some refactoring in general, but especially around parts that invoke external tools Such refactoring should be handled by a follow-up PR, as the focus of this PR is to just inform the user that OpenSSL/NASM cannot be found.