### PR TITLE
Added support for FWST OEM ACPI table

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -45,6 +45,7 @@
   gEfiDebugAgentGuid                            = { 0x865a5a9b, 0xb85d, 0x474c, { 0x84, 0x55, 0x65, 0xd1, 0xbe, 0x84, 0x4b, 0xe2 } }
   gDeviceTableHobGuid                           = { 0xd21fc32c, 0x7fd2, 0x435b, { 0xb8, 0xef, 0xc0, 0x42, 0x66, 0xa8, 0xf4, 0xf5 } }
   gSmmInformationGuid                           = { 0x2d939d66, 0xceec, 0x4244, { 0x94, 0x97, 0x6e, 0x1c, 0x6f, 0x92, 0x54, 0x2c } }
+  gEsrtSystemFirmwareGuid                       = { 0xbfbaf62d, 0x0a27, 0x4390, { 0x99, 0xf6, 0x8a, 0xe1, 0xca, 0x62, 0x62, 0x77 } }
 
 [PcdsFixedAtBuild]
   gPlatformCommonLibTokenSpaceGuid.PcdMaxLibraryDataEntry    |          8 | UINT32 | 0x20000100
@@ -79,6 +80,8 @@
   # Options to limit framebuffer console size (it will be centered if smaller than screen resolution)
   gPlatformCommonLibTokenSpaceGuid.PcdFrameBufferMaxConsoleWidth  | 0xFFFFFFFF | UINT32 | 0x20000501
   gPlatformCommonLibTokenSpaceGuid.PcdFrameBufferMaxConsoleHeight | 0xFFFFFFFF | UINT32 | 0x20000502
+
+  gPlatformCommonLibTokenSpaceGuid.PcdLowestSupportedFwVer		  | 0x00000000 | UINT32 | 0x20000601
 
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   # For patchable PCDs, try to set the default as none-zero

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -238,6 +238,7 @@
 
   gPlatformCommonLibTokenSpaceGuid.PcdSeedListEnabled     | $(HAVE_SEED_LIST)
   gPlatformCommonLibTokenSpaceGuid.PcdUsbKeyboardPollingTimeout | $(USB_KB_POLLING_TIMEOUT)
+  gPlatformCommonLibTokenSpaceGuid.PcdLowestSupportedFwVer		| $(LOWEST_SUPPORTED_FW_VER)
 
 [PcdsPatchableInModule]
   gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel   | 0x8000004F

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
@@ -46,7 +46,7 @@
   TimeStampLib
 
 [Guids]
-
+  gEsrtSystemFirmwareGuid
 
 [Pcd]
   gPlatformModuleTokenSpaceGuid.PcdAcpiTablesRsdp
@@ -57,3 +57,4 @@
   gPlatformModuleTokenSpaceGuid.PcdS3DebugEnabled
   gPlatformModuleTokenSpaceGuid.PcdAcpiGnvsAddress
   gPlatformModuleTokenSpaceGuid.PcdLoaderAcpiReclaimSize
+  gPlatformCommonLibTokenSpaceGuid.PcdLowestSupportedFwVer

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -152,6 +152,8 @@ class BaseBoard(object):
 		self.VERINFO_SVN            = 1
 		self.VERINFO_BUILD_DATE     = '01/01/2018'
 
+		self.LOWEST_SUPPORTED_FW_VER = 1
+
 		self.FLASH_BLOCK_SIZE       = 0x1000
 		self.FLASH_LAYOUT_START     = 0x100000000
 		self.FLASH_BASE             = 0

--- a/MdePkg/Include/Guid/SystemResourceTable.h
+++ b/MdePkg/Include/Guid/SystemResourceTable.h
@@ -1,0 +1,125 @@
+/** @file
+  Guid & data structure used for EFI System Resource Table (ESRT)
+
+  Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution. The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+  @par Revision Reference:
+  GUIDs defined in UEFI 2.5 spec.
+
+**/
+
+
+#ifndef _SYSTEM_RESOURCE_TABLE_H__
+#define _SYSTEM_RESOURCE_TABLE_H__
+
+#define EFI_SYSTEM_RESOURCE_TABLE_GUID \
+  { \
+    0xb122a263, 0x3661, 0x4f68, {0x99, 0x29, 0x78, 0xf8, 0xb0, 0xd6, 0x21, 0x80 } \
+  }
+
+///
+/// Current Entry Version
+///
+#define EFI_SYSTEM_RESOURCE_TABLE_FIRMWARE_RESOURCE_VERSION  1
+
+///
+/// Firmware Type Definitions
+///
+#define ESRT_FW_TYPE_UNKNOWN         0x00000000
+#define ESRT_FW_TYPE_SYSTEMFIRMWARE  0x00000001
+#define ESRT_FW_TYPE_DEVICEFIRMWARE  0x00000002
+#define ESRT_FW_TYPE_UEFIDRIVER      0x00000003
+
+///
+/// Last Attempt Status Values
+///
+#define LAST_ATTEMPT_STATUS_SUCCESS                       0x00000000
+#define LAST_ATTEMPT_STATUS_ERROR_UNSUCCESSFUL            0x00000001
+#define LAST_ATTEMPT_STATUS_ERROR_INSUFFICIENT_RESOURCES  0x00000002
+#define LAST_ATTEMPT_STATUS_ERROR_INCORRECT_VERSION       0x00000003
+#define LAST_ATTEMPT_STATUS_ERROR_INVALID_FORMAT          0x00000004
+#define LAST_ATTEMPT_STATUS_ERROR_AUTH_ERROR              0x00000005
+#define LAST_ATTEMPT_STATUS_ERROR_PWR_EVT_AC              0x00000006
+#define LAST_ATTEMPT_STATUS_ERROR_PWR_EVT_BATT            0x00000007
+
+typedef struct {
+  ///
+  /// The firmware class field contains a GUID that identifies a firmware component
+  /// that can be updated via UpdateCapsule(). This GUID must be unique within all
+  /// entries of the ESRT.
+  ///
+  EFI_GUID                   FwClass;
+  ///
+  /// Identifies the type of firmware resource.
+  ///
+  UINT32                     FwType;
+  ///
+  /// The firmware version field represents the current version of the firmware
+  /// resource, value must always increase as a larger number represents a newer
+  /// version.
+  ///
+  UINT32                     FwVersion;
+  ///
+  /// The lowest firmware resource version to which a firmware resource can be
+  /// rolled back for the given system/device. Generally this is used to protect
+  /// against known and fixed security issues.
+  ///
+  UINT32                     LowestSupportedFwVersion;
+  ///
+  /// The capsule flags field contains the CapsuleGuid flags (bits 0- 15) as defined
+  /// in the EFI_CAPSULE_HEADER that will be set in the capsule header.
+  ///
+  UINT32                     CapsuleFlags;
+  ///
+  /// The last attempt version field describes the last firmware version for which
+  /// an update was attempted (uses the same format as Firmware Version).
+  /// Last Attempt Version is updated each time an UpdateCapsule() is attempted for
+  /// an ESRT entry and is preserved across reboots (non-volatile). However, in
+  /// cases where the attempt version is not recorded due to limitations in the
+  /// update process, the field shall set to zero after a failed update. Similarly,
+  /// in the case of a removable device, this value is set to 0 in cases where the
+  /// device has not been updated since being added to the system.
+  ///
+  UINT32                     LastAttemptVersion;
+  ///
+  /// The last attempt status field describes the result of the last firmware update
+  /// attempt for the firmware resource entry.
+  /// LastAttemptStatus is updated each time an UpdateCapsule() is attempted for an
+  /// ESRT entry and is preserved across reboots (non-volatile).
+  /// If a firmware update has never been attempted or is unknown, for example after
+  /// fresh insertion of a removable device, LastAttemptStatus must be set to Success.
+  ///
+  UINT32                     LastAttemptStatus;
+} EFI_SYSTEM_RESOURCE_ENTRY;
+
+typedef struct {
+  ///
+  /// The number of firmware resources in the table, must not be zero.
+  ///
+  UINT32                     FwResourceCount;
+  ///
+  /// The maximum number of resource array entries that can be within the table
+  /// without reallocating the table, must not be zero.
+  ///
+  UINT32                     FwResourceCountMax;
+  ///
+  /// The version of the EFI_SYSTEM_RESOURCE_ENTRY entities used in this table.
+  /// This field should be set to 1.
+  ///
+  UINT64                     FwResourceVersion;
+  ///
+  /// Array of EFI_SYSTEM_RESOURCE_ENTRY
+  ///
+  //EFI_SYSTEM_RESOURCE_ENTRY  Entries[];
+} EFI_SYSTEM_RESOURCE_TABLE;
+
+extern EFI_GUID gEfiSystemResourceTableGuid;
+
+#endif

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
@@ -43,12 +43,8 @@
   PayloadEntryLib
   BaseLib
   BaseMemoryLib
-  PcdLib
-  CryptoLib
   ResetSystemLib
   SecureBootLib
-  BootloaderCommonLib
-  PayloadSupportLib
   LiteFvLib
   ConfigDataLib
 
@@ -65,7 +61,9 @@
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
   gPayloadTokenSpaceGuid.PcdPayloadHobList
   gPlatformCommonLibTokenSpaceGuid.PcdAcpiPmTimerBase
-
+  gPayloadTokenSpaceGuid.PcdFwUpdStatusBase
+  gPayloadTokenSpaceGuid.PcdRsvdRegionBase
+  gPlatformCommonLibTokenSpaceGuid.PcdLowestSupportedFwVer
 
 [Depex]
   TRUE

--- a/PayloadPkg/PayloadPkg.dec
+++ b/PayloadPkg/PayloadPkg.dec
@@ -38,5 +38,9 @@
   gPayloadTokenSpaceGuid.PcdPayloadHeapSize   | 0x00000000 | UINT32 | 0x10001003
   gPayloadTokenSpaceGuid.PcdGlobalDataAddress | 0x00000000 | UINT32 | 0x10001004
 
+[PcdsPatchableInModule]
+  gPayloadTokenSpaceGuid.PcdFwUpdStatusBase   | 0x00000000 | UINT32 | 0x10001005
+  gPayloadTokenSpaceGuid.PcdRsvdRegionBase    | 0x00000000 | UINT32 | 0x10001006
+
 [PcdsFeatureFlag]
   gPayloadTokenSpaceGuid.PcdGrubBootCfgEnabled  | FALSE    | BOOLEAN | 0x2001000


### PR DESCRIPTION
This patch added support for FWST ACPI table. This table
contains generic address structure which has pointer to the
EFI System Resource Table.

ESRT table for now supports only system firmware. This table
will provide the operating system and tools knowledge of what
is the last attempt status and version of the system firmare
update.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>