### PR TITLE
Log startup locality only when Boot Guard is not enabled

### DIFF
--- a/BootloaderCommonPkg/Library/TpmLib/TpmLib.c
+++ b/BootloaderCommonPkg/Library/TpmLib/TpmLib.c
@@ -385,10 +385,8 @@ TpmInit(
   } else {
     Status = TpmTcgLogInit();
     if (Status == EFI_SUCCESS) {
-      if (BypassTpmInit) {
-        // TPM_Start was done by ACM via Locality 3
-        TpmLogLocalityEvent (3);
-      } else {
+      if (!BypassTpmInit) {
+        // TPM_Start was done by SBL via Locality 0
         TpmLogLocalityEvent (0);
       }
     }


### PR DESCRIPTION
When Boot guard is enabled, Locality event would be
logged from Boot guard library.

Signed-off-by: Subash Lakkimsetti <subashx.lakkimsetti@intel.com>