### PR TITLE
Disable deprecated EDKII API interfaces

### DIFF
--- a/BootloaderCommonPkg/Include/Library/MmcAccessLib.h
+++ b/BootloaderCommonPkg/Include/Library/MmcAccessLib.h
@@ -172,7 +172,8 @@ EmmcModeSelection (
 /**
   This function gets serial number of eMMC card.
 
-  @param[out] SerialNumber              Serial Number of Device.
+  @param[out] SerialNumber              Serial Number buffer.
+  @param[in]  Length                    Serial Number buffer length.
 
   @retval EFI_SUCCESS                   Serial Number Valid.
   @retval Others                        A parameter was incorrect.
@@ -180,7 +181,8 @@ EmmcModeSelection (
 EFI_STATUS
 EFIAPI
 EmmcGetSerialNumber (
-  OUT CHAR8*                            SerialNumber
+  IN  CHAR8*                            SerialNumber,
+  IN  UINT32                            Length
   );
 
 /**

--- a/BootloaderCommonPkg/Include/Library/MultibootLib.h
+++ b/BootloaderCommonPkg/Include/Library/MultibootLib.h
@@ -219,7 +219,7 @@ typedef struct {
   IMAGE_DATA              CmdFile;
   MULTIBOOT_INFO          MbInfo;
   IA32_BOOT_STATE         BootState;
-  UINT16                  Reserved;
+  UINT16                  CmdBufferSize;
   UINT16                  MbModuleNumber;
   MULTIBOOT_MODULE        MbModule[MAX_MULTIBOOT_MODULE_NUMBER];
 } MULTIBOOT_IMAGE;

--- a/BootloaderCommonPkg/Library/MmcAccessLib/MmcAccessLibGeneric.c
+++ b/BootloaderCommonPkg/Library/MmcAccessLib/MmcAccessLibGeneric.c
@@ -1993,7 +1993,8 @@ Done:
 /**
   This function gets serial number of eMMC card.
 
-  @param[out] SerialNumber              Serial Number of Device.
+  @param[out] SerialNumber              Serial Number buffer.
+  @param[in]  Length                    Serial Number buffer length.
 
   @retval EFI_SUCCESS                   Serial Number Valid.
   @retval Others                        A parameter was incorrect.
@@ -2001,8 +2002,9 @@ Done:
 EFI_STATUS
 EFIAPI
 EmmcGetSerialNumber (
-  OUT CHAR8*              SerialNumber
-)
+  IN  CHAR8*                            SerialNumber,
+  IN  UINT32                            Length
+  )
 {
   EFI_STATUS               Status;
   SD_MMC_HC_PRIVATE_DATA  *Private;
@@ -2013,7 +2015,7 @@ EmmcGetSerialNumber (
   Status      = EFI_SUCCESS;
 
   if (!MmcIsInitialized()) {
-    AsciiStrCpy(SerialNumber, "badbadbadbadba");
+    AsciiStrCpyS (SerialNumber, Length, "badbadbadbadba");
     Status = EFI_NOT_READY;
     goto Done;
   }
@@ -2038,7 +2040,7 @@ EmmcGetSerialNumber (
   SerialNumber[Index++] = CardData->Cid.ProductName[1];
   SerialNumber[Index++] = CardData->Cid.ProductName[0];
 
-  AsciiValueToString (&SerialNumber[Index], PREFIX_ZERO | RADIX_HEX, ProductNumber, 8);
+  AsciiValueToStringS (&SerialNumber[Index], Length - Index, PREFIX_ZERO | RADIX_HEX, ProductNumber, 8);
   do {
     if (('A' <= SerialNumber[Index]) && (SerialNumber[Index] <= 'Z')) {
       SerialNumber[Index] += 0x20;

--- a/BootloaderCommonPkg/Library/MmcTuningLib/MmcTuningLib.c
+++ b/BootloaderCommonPkg/Library/MmcTuningLib/MmcTuningLib.c
@@ -988,7 +988,7 @@ MmcTuning (
     EmmcTuningData.Hs400RxStrobe1Dll, EmmcTuningData.Hs400TxDataDll));
 
   // Todo: Serial number should be removed from this function later.
-  Status = EmmcGetSerialNumber (EmmcTuningData.SerialNumber);
+  Status = EmmcGetSerialNumber (EmmcTuningData.SerialNumber, sizeof(EmmcTuningData.SerialNumber));
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "ERRORL: MMC serial number invalid, status = %r\n", Status));
   }

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -375,7 +375,10 @@
   *_GCC5_IA32_ASLDLINK_FLAGS = -no-pie
   # Force synchronous PDB writes for parallel builds
   *_VS2015x86_IA32_CC_FLAGS = /FS
+
+  *_*_*_CC_FLAGS = -DDISABLE_NEW_DEPRECATED_INTERFACES
 !if $(TARGET) == RELEASE
   *_*_*_CC_FLAGS = -DLITE_PRINT
 !endif
+
 

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
@@ -555,7 +555,7 @@ AcpiInit (
   //
   // Keep a copy at F segment so that non-UEFI OS will find ACPI tables
   //
-  PcdSet32 (PcdAcpiTablesRsdp, (UINT32)Rsdp);
+  Status = PcdSet32S (PcdAcpiTablesRsdp, (UINT32)Rsdp);
   CopyMem ((VOID *)0xFFF80, Rsdp, sizeof (RsdpTmp));
 
   // Update ACPI update service so that payload can have opportunity to update ACPI tables

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -393,10 +393,10 @@ SecStartup (
   // Update Patchable PCD in case Stage2 is loaded into high mem
   Stage2Hob = (STAGE2_HOB *)Params;
   Delta = Stage2Hob->Stage2ExeBase - PCD_GET32_WITH_ADJUST (PcdStage2FdBase);
-  PcdSet32 (PcdFSPSBase,             PCD_GET32_WITH_ADJUST (PcdFSPSBase) + Delta);
-  PcdSet32 (PcdAcpiTablesAddress,    PCD_GET32_WITH_ADJUST (PcdAcpiTablesAddress) + Delta);
-  PcdSet32 (PcdGraphicsVbtAddress,   PCD_GET32_WITH_ADJUST (PcdGraphicsVbtAddress) + Delta);
-  PcdSet32 (PcdSplashLogoAddress,    PCD_GET32_WITH_ADJUST (PcdSplashLogoAddress) + Delta);
+  Status = PcdSet32S (PcdFSPSBase,             PCD_GET32_WITH_ADJUST (PcdFSPSBase) + Delta);
+  Status = PcdSet32S (PcdAcpiTablesAddress,    PCD_GET32_WITH_ADJUST (PcdAcpiTablesAddress) + Delta);
+  Status = PcdSet32S (PcdGraphicsVbtAddress,   PCD_GET32_WITH_ADJUST (PcdGraphicsVbtAddress) + Delta);
+  Status = PcdSet32S (PcdSplashLogoAddress,    PCD_GET32_WITH_ADJUST (PcdSplashLogoAddress) + Delta);
 
   LdrGlobal->LdrHobList = (VOID *)LdrGlobal->MemPoolEnd;
   BuildHobHandoffInfoTable (
@@ -484,8 +484,8 @@ SecStartup (
       AcpiTop  = AcpiGnvs;
     }
 
-    S3Data   = (S3_DATA *)LdrGlobal->S3DataPtr;
-    PcdSet32 (PcdAcpiGnvsAddress, AcpiGnvs);
+    S3Data = (S3_DATA *)LdrGlobal->S3DataPtr;
+    Status = PcdSet32S (PcdAcpiGnvsAddress, AcpiGnvs);
     if (BootMode != BOOT_ON_S3_RESUME) {
       if ((AcpiGnvs > 0) && (AcpiTop > 0)) {
         PlatformUpdateAcpiGnvs ((VOID *)AcpiGnvs);

--- a/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
+++ b/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
@@ -287,7 +287,7 @@ LoadCapsuleImage (
   // Find capsule using the name provided in configuration data
   //
   if (CapsuleInfo->FileName[0] != 0) {
-    AsciiStrToUnicodeStr((CONST CHAR8 *)(&CapsuleInfo->FileName), FileName);
+    AsciiStrToUnicodeStrS ((CONST CHAR8 *)(&CapsuleInfo->FileName), FileName, MAX_FILE_LEN);
     Status = GetFileByName(FsHandle, FileName, CapsuleImage, CapsuleImageSize);
     if (EFI_ERROR(Status)) {
       DEBUG((DEBUG_ERROR, " Capsule File '%a' Status : %r\n", FileName, Status));
@@ -372,7 +372,7 @@ GetCapsuleImage (
   //
   CapsuleInfo = (CAPSULE_INFO_CFG_DATA *) FindConfigDataByTag (CDATA_CAPSULE_INFO_TAG);
   //
-  // If we do not find capsule information, return error 
+  // If we do not find capsule information, return error
   //
   if (CapsuleInfo == NULL) {
     DEBUG((DEBUG_ERROR, " CapsuleInfo not found \n"));

--- a/PayloadPkg/Library/DebugPrintErrorLevelLib/DebugPrintErrorLevelLib.c
+++ b/PayloadPkg/Library/DebugPrintErrorLevelLib/DebugPrintErrorLevelLib.c
@@ -51,10 +51,12 @@ SetDebugPrintErrorLevel (
   UINT32  ErrorLevel
   )
 {
+  EFI_STATUS Status;
+
   //
   // This library uinstance does not support setting the global debug print error
   // level mask.
   //
-  PcdSet32S (PcdDebugPrintErrorLevel, ErrorLevel);
+  Status = PcdSet32S (PcdDebugPrintErrorLevel, ErrorLevel);
   return TRUE;
 }

--- a/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
+++ b/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
@@ -60,8 +60,10 @@ PayloadInit (
   UINT32                    StackBase;
   UINT32                    StackSize;
   LOADER_PLATFORM_DATA      *LoaderPlatformData;
+  EFI_STATUS                PcdStatus1;
+  EFI_STATUS                PcdStatus2;
 
-  PcdSet32 (PcdPayloadHobList, (UINT32)HobList);
+  PcdStatus1 = PcdSet32S (PcdPayloadHobList, (UINT32)HobList);
 
   //
   // Payload Memmap
@@ -93,7 +95,8 @@ PayloadInit (
 
   GlobalDataPtr = AllocateZeroPool (sizeof (PAYLOAD_GLOBAL_DATA));
   GlobalDataPtr->Signature = PLD_GDATA_SIGNATURE;
-  PcdSet32 (PcdGlobalDataAddress, (UINT32) (UINTN)GlobalDataPtr);
+  PcdStatus2 = PcdSet32S (PcdGlobalDataAddress, (UINT32) (UINTN)GlobalDataPtr);
+  ASSERT_EFI_ERROR (PcdStatus1 | PcdStatus2);
 
   // Create Debug Log Buffer and init configuration data
   GuidHob = GetNextGuidHob (&gLoaderPlatformDataGuid, (VOID *)PcdGet32 (PcdPayloadHobList));

--- a/PayloadPkg/Library/TrustyBootLib/TrustyBootLib.c
+++ b/PayloadPkg/Library/TrustyBootLib/TrustyBootLib.c
@@ -235,19 +235,21 @@ SetAttestationKeyboxInRpmb (
   @param[in,out] CmdFile        Pointer to IMAGE_DATA for Command file
   @param[in]     BootParams     Pointer to the IMAGE_BOOT_PARAM structure
                                 that needs to be passed via command line
+  @param[in]     CmdBufLen      Command buffer length.
 
   @retval  EFI_SUCCESS          Command line was succesffuly modified.
 **/
 EFI_STATUS
 UpdateCmdLine (
   IN OUT IMAGE_DATA        *CmdFile,
-  IN     IMAGE_BOOT_PARAM  *BootParams
+  IN     IMAGE_BOOT_PARAM  *BootParams,
+  IN     UINT32             CmdBufLen
   )
 {
   CHAR8 ParamValue[32];
 
   AsciiSPrint (ParamValue, sizeof (ParamValue), " ImageBootParamsAddr=0x%x", BootParams);
-  AsciiStrCat ((CHAR8 *)CmdFile->Addr, ParamValue);
+  AsciiStrCatS ((CHAR8 *)CmdFile->Addr, CmdBufLen, ParamValue);
   CmdFile->Size = AsciiStrLen ((CHAR8 *)CmdFile->Addr);
   return EFI_SUCCESS;
 }
@@ -321,7 +323,7 @@ SetupTrustyBoot (
     SetCpuState (& (VmmBootParams->CpuState), &BootOsImage->BootState);
     BootParams->VmmBootParamAddr  = (UINT64) (UINTN)VmmBootParams;
   }
-  Status = UpdateCmdLine (&TrustyImage->CmdFile, BootParams);
+  Status = UpdateCmdLine (&TrustyImage->CmdFile, BootParams, TrustyImage->CmdBufferSize);
   if (EFI_ERROR (Status)) {
     return Status;
   }
@@ -336,7 +338,7 @@ SetupTrustyBoot (
     return RETURN_OUT_OF_RESOURCES;
   }
 
-  Status = UpdateCmdLine (&BootOsImage->CmdFile, BootParams);
+  Status = UpdateCmdLine (&BootOsImage->CmdFile, BootParams, BootOsImage->CmdBufferSize);
   if (EFI_ERROR (Status)) {
     return Status;
   }

--- a/PayloadPkg/OsLoader/BootParameters.c
+++ b/PayloadPkg/OsLoader/BootParameters.c
@@ -274,6 +274,8 @@ UpdateOsParameters (
   // Update Trusty image if it is loaded.
   //
   if ((CurrentBootOption->BootFlags & BOOT_FLAGS_TRUSTY) != 0) {
+    LoadedImage->Image.MultiBoot.CmdBufferSize       = CMDLINE_LENGTH_MAX;
+    LoadedTrustyImage->Image.MultiBoot.CmdBufferSize = CMDLINE_LENGTH_MAX;
     Status = SetupTrustyBoot (&LoadedTrustyImage->Image.MultiBoot, &LoadedImage->Image.MultiBoot);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "ERROR Setting up Trusty Boot!\n"));

--- a/PayloadPkg/OsLoader/KeyManagement.c
+++ b/PayloadPkg/OsLoader/KeyManagement.c
@@ -55,7 +55,7 @@ EmmcSerialNumCheck (
 
   // Compare serial number from the card and SPI flash
   if (AsciiStriCmp (LoaderPlatformInfo->SerialNumber, EmmcTuningData.SerialNumber) != 0) {
-    AsciiStrCpy (EmmcTuningData.SerialNumber, LoaderPlatformInfo->SerialNumber);
+    AsciiStrCpyS (EmmcTuningData.SerialNumber, sizeof(EmmcTuningData.SerialNumber), LoaderPlatformInfo->SerialNumber);
 
     // Save new serial number into SPI flash
     Status = SetVariable ((CHAR8 *)mMmcDllStr, 0, sizeof (EMMC_TUNING_DATA), (VOID *)&EmmcTuningData);
@@ -242,7 +242,7 @@ RpmbKeyProvisioning (
 
   // Get Rpmb Key provisioning flag from Cfg Data
   GenCfgData = (GEN_CFG_DATA *) FindConfigDataByTag (CDATA_GEN_TAG);
-  if (GenCfgData == NULL) { 
+  if (GenCfgData == NULL) {
     return EFI_NOT_FOUND;
   }
 

--- a/PayloadPkg/OsLoader/LoadImage.c
+++ b/PayloadPkg/OsLoader/LoadImage.c
@@ -295,7 +295,7 @@ LoadLinuxFile (
   }
 
   Ptr[FileInfo->Len] = 0;
-  AsciiStrToUnicodeStr (Ptr, FileName);
+  AsciiStrToUnicodeStrS (Ptr, FileName, sizeof(FileName) / sizeof(CHAR16));
   FileSize   = 0;
   FileBuffer = NULL;
   Status = GetFileByName (FsHandle, FileName, &FileBuffer, &FileSize);
@@ -373,13 +373,13 @@ GetTraditionalLinux (
     MenuEntry = LinuxBootCfg.MenuEntry;
     MenuEntry[0].Name.Pos    = 0;
     MenuEntry[0].Name.Len    = 5;
-    AsciiStrCpy (MenuEntry[0].Name.Buf, "Linux");
+    AsciiStrCpyS (MenuEntry[0].Name.Buf, sizeof(MenuEntry[0].Name.Buf), "Linux");
     MenuEntry[0].InitRd.Pos  = 0;
     MenuEntry[0].InitRd.Len  = 6;
-    AsciiStrCpy (MenuEntry[0].InitRd.Buf, "initrd");
+    AsciiStrCpyS (MenuEntry[0].InitRd.Buf, sizeof(MenuEntry[0].InitRd.Buf), "initrd");
     MenuEntry[0].Kernel.Pos  = 0;
     MenuEntry[0].Kernel.Len  = 7;
-    AsciiStrCpy (MenuEntry[0].Kernel.Buf, "vmlinuz");
+    AsciiStrCpyS (MenuEntry[0].Kernel.Buf, sizeof(MenuEntry[0].Kernel.Buf), "vmlinuz");
     MenuEntry[0].Command.Pos = 0;
     MenuEntry[0].Command.Len = ConfigFileSize;
     EntryIdx = 0;

--- a/Platform/ApollolakeBoardPkg/Library/ShellExtensionLib/CmdFwUpdate.c
+++ b/Platform/ApollolakeBoardPkg/Library/ShellExtensionLib/CmdFwUpdate.c
@@ -120,7 +120,7 @@ ShellCommandFwUpdateFunc (
   FwUpdUserCfgData->FsType      = 2;
   FwUpdUserCfgData->LbaAddr     = 0;
 
-  AsciiStrCpy((CHAR8 *)FwUpdUserCfgData->FileName, "FwuImage.bin");
+  AsciiStrCpyS ((CHAR8 *)FwUpdUserCfgData->FileName, sizeof(FwUpdUserCfgData->FileName), "FwuImage.bin");
 
   //
   // Send HECI user command to save IBB signal data

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/SeedSupport.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/SeedSupport.c
@@ -261,7 +261,7 @@ GenerateSeeds (
   if ((Status != EFI_SUCCESS) || (AsciiStrCmp(EmmcTuningData.SerialNumber,"badbadbadbadba") == 0)) {
     RpmbSerialNumberValid = FALSE;
   } else {
-    AsciiStrCpy (SerialNum, EmmcTuningData.SerialNumber);
+    AsciiStrCpyS (SerialNum, sizeof(SerialNum), EmmcTuningData.SerialNumber);
     RpmbSerialNumberValid = TRUE;
   }
 

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -270,7 +270,7 @@ BoardInit (
     if (PlatformCfgData != NULL) {
       VbtAddress = LocateVbtByImageId (PlatformCfgData->VbtImageId);
       if (VbtAddress != 0) {
-        PcdSet32 (PcdGraphicsVbtAddress,  VbtAddress);
+        Status = PcdSet32S (PcdGraphicsVbtAddress,  VbtAddress);
       }
     }
     break;


### PR DESCRIPTION
This patch enabled DISABLE_NEW_DEPRECATED_INTERFACES build option by
default so that the deprecated APIs cannot be used in SBL source tree.
It is to enhance the coding for security.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>