### PR TITLE
[QEMU] Allow select UEFI payload from QEMU command line

### DIFF
--- a/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
+++ b/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
@@ -22,6 +22,7 @@
 
 #define  STACK_DEBUG_FILL_PATTERN     0x5AA55AA5
 #define  UEFI_PAYLOAD_ID_SIGNATURE    SIGNATURE_32('U', 'E', 'F', 'I')
+#define  AUTO_PAYLOAD_ID_SIGNATURE    SIGNATURE_32('A', 'U', 'T', 'O')
 
 #define  ALIGN_UP(address, align)     (((address) + ((align) - 1)) & ~((align)-1))
 #define  ALIGN_DOWN(address, align)   ((address) & ~((align)-1))
@@ -472,7 +473,7 @@ GetRegionOffsetSize (
 /**
   This function retrieves a GUIDed HOB data and size.
 
-  This function will search the HobListPtr to find the first GUIDed HOB that 
+  This function will search the HobListPtr to find the first GUIDed HOB that
   its GUID matches Guid, and return the GUID size in Length if Lengh is no NULL.
   If HobListPtr is NULL, it will use the loader HOB list.
 

--- a/Platform/QemuBoardPkg/CfgData/CfgDataExt_Brd1.dlt
+++ b/Platform/QemuBoardPkg/CfgData/CfgDataExt_Brd1.dlt
@@ -8,6 +8,8 @@
 
 PLATFORMID_CFG_DATA.PlatformId | 1
 
-PLAT_NAME_CFG_DATA.PlatformName          | 'QEMU_01'
+PLAT_NAME_CFG_DATA.PlatformName            | 'QEMU_01'
+
+GEN_CFG_DATA.PayloadId                     | 'AUTO'
 
 GPIO_CFG_DATA.GpioConfPad1_GPP_A1.GPIOSkip | 1


### PR DESCRIPTION
Current SBL depends on GEN_CFG_DATA.PayloadId to determine which payload
to boot if multiple payloads exist. With this patch, when PayloadId is
set to "AUTO", QEMU will use the QEMU command line parameter
'-boot order' to determine which payload to boot.

For example, adding '-boot order=dba' in QEMU commadn line will boot to
UEFI payload. This provides a simple way to test different payloads using
the same SBL image.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>