### PR TITLE
[APL] Add SMBUS access library

### DIFF
--- a/MdePkg/Include/IndustryStandard/SmBus.h
+++ b/MdePkg/Include/IndustryStandard/SmBus.h
@@ -1,0 +1,81 @@
+/** @file
+  This file declares the SMBus definitions defined in SmBus Specifciation V2.0
+  and defined in PI1.0 specification volume 5.
+
+  Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+
+#ifndef _SMBUS_H_
+#define _SMBUS_H_
+
+
+///
+/// UDID of SMBUS device.
+///
+typedef struct {
+  UINT32  VendorSpecificId;
+  UINT16  SubsystemDeviceId;
+  UINT16  SubsystemVendorId;
+  UINT16  Interface;
+  UINT16  DeviceId;
+  UINT16  VendorId;
+  UINT8   VendorRevision;
+  UINT8   DeviceCapabilities;
+} EFI_SMBUS_UDID;
+
+///
+/// Smbus Device Address
+///
+typedef struct {
+  ///
+  /// The SMBUS hardware address to which the SMBUS device is preassigned or allocated.
+  ///
+  UINTN SmbusDeviceAddress : 7;
+} EFI_SMBUS_DEVICE_ADDRESS;
+
+typedef struct {
+  ///
+  /// The SMBUS hardware address to which the SMBUS device is preassigned or
+  /// allocated. Type EFI_SMBUS_DEVICE_ADDRESS is defined in EFI_PEI_SMBUS2_PPI.Execute().
+  ///
+  EFI_SMBUS_DEVICE_ADDRESS  SmbusDeviceAddress;
+  ///
+  /// The SMBUS Unique Device Identifier (UDID) as defined in EFI_SMBUS_UDID.
+  /// Type EFI_SMBUS_UDID is defined in EFI_PEI_SMBUS2_PPI.ArpDevice().
+  ///
+  EFI_SMBUS_UDID            SmbusDeviceUdid;
+} EFI_SMBUS_DEVICE_MAP;
+
+///
+/// Smbus Operations
+///
+typedef enum _EFI_SMBUS_OPERATION {
+  EfiSmbusQuickRead,
+  EfiSmbusQuickWrite,
+  EfiSmbusReceiveByte,
+  EfiSmbusSendByte,
+  EfiSmbusReadByte,
+  EfiSmbusWriteByte,
+  EfiSmbusReadWord,
+  EfiSmbusWriteWord,
+  EfiSmbusReadBlock,
+  EfiSmbusWriteBlock,
+  EfiSmbusProcessCall,
+  EfiSmbusBWBRProcessCall
+} EFI_SMBUS_OPERATION;
+
+///
+/// EFI_SMBUS_DEVICE_COMMAND
+///
+typedef UINTN   EFI_SMBUS_DEVICE_COMMAND;
+
+#endif
+

--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -171,7 +171,8 @@ class Board(BaseBoard):
 			'ShellExtensionLib|Platform/$(BOARD_PKG_NAME)/Library/ShellExtensionLib/ShellExtensionLib.inf',
 			'BootMediaLib|Silicon/ApollolakePkg/Library/BootMediaLib/BootMediaLib.inf',
 			'FlashDescriptorLib|Silicon/ApollolakePkg/Library/FlashDescriptorLib/FlashDescriptorLib.inf',
-			'VtdLib|Silicon/$(SILICON_PKG_NAME)/Library/VtdLib/VtdLib.inf'
+			'VtdLib|Silicon/$(SILICON_PKG_NAME)/Library/VtdLib/VtdLib.inf',
+			'SmbusLib|Silicon/$(SILICON_PKG_NAME)/Library/SmbusLib/SmbusLib.inf'
 		]
 		return dsc_libs
 

--- a/Silicon/ApollolakePkg/Include/Library/SmbusLib.h
+++ b/Silicon/ApollolakePkg/Include/Library/SmbusLib.h
@@ -1,0 +1,57 @@
+/** @file
+  Header file for the Smbus Library.
+
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php.
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+
+#ifndef _SMBUS_LIB_H_
+#define _SMBUS_LIB_H_
+
+#include <IndustryStandard/SmBus.h>
+
+/**
+  This function provides a standard way to execute Smbus protocols
+  as defined in the SMBus Specification. The data can either be of
+  the Length byte, word, or a block of data. The resulting transaction will be
+  either the SMBus Slave Device accepts this transaction or this function
+  returns with an error
+
+  @param[in] SlaveAddress         Smbus Slave device the command is directed at
+  @param[in] Command              Slave Device dependent
+  @param[in] Operation            Which SMBus protocol will be used
+  @param[in] PecCheck             Defines if Packet Error Code Checking is to be used
+  @param[in, out] Length          How many bytes to read. Must be 0 <= Length <= 32 depending on Operation
+                                  It will contain the actual number of bytes read/written.
+  @param[in, out] Buffer          Contain the data read/written.
+
+  @retval EFI_SUCCESS             The operation completed successfully.
+  @exception EFI_UNSUPPORTED      The operation is unsupported.
+
+  @retval EFI_INVALID_PARAMETER   Length or Buffer is NULL for any operation besides
+                                  quick read or quick write.
+  @retval EFI_TIMEOUT             The transaction did not complete within an internally
+                                  specified timeout period, or the controller is not
+                                  available for use.
+  @retval EFI_DEVICE_ERROR        There was an Smbus error (NACK) during the operation.
+                                  This could indicate the slave device is not present
+                                  or is in a hung condition.
+**/
+EFI_STATUS
+SmbusExec (
+  IN      EFI_SMBUS_DEVICE_ADDRESS  SlaveAddress,
+  IN      EFI_SMBUS_DEVICE_COMMAND  Command,
+  IN      EFI_SMBUS_OPERATION       Operation,
+  IN      BOOLEAN                   PecCheck,
+  IN OUT  UINTN                     *Length,
+  IN OUT  VOID                      *Buffer
+  );
+
+#endif

--- a/Silicon/ApollolakePkg/Include/ScRegs/RegsSmbus.h
+++ b/Silicon/ApollolakePkg/Include/ScRegs/RegsSmbus.h
@@ -1,0 +1,225 @@
+/** @file
+  Register names for Smbus Device.
+
+  Conventions:
+
+  - Prefixes:
+    Definitions beginning with "R_" are registers
+    Definitions beginning with "B_" are bits within registers
+    Definitions beginning with "V_" are meaningful values of bits within the registers
+    Definitions beginning with "S_" are register sizes
+    Definitions beginning with "N_" are the bit position
+  - In general, SC registers are denoted by "_SC_" in register names
+  - Registers / bits that are different between SC generations are denoted by
+    "_SC_<generation_name>_" in register/bit names.
+  - Registers / bits that are different between SKUs are denoted by "_<SKU_name>"
+    at the end of the register/bit names
+  - Registers / bits of new devices introduced in a SC generation will be just named
+    as "_SC_" without <generation_name> inserted.
+
+  Copyright (c) 1999 - 2016, Intel Corporation. All rights reserved.<BR>
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php.
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+
+#ifndef _REGS_SMBUS_H_
+#define _REGS_SMBUS_H_
+
+///
+/// SMBus Controller Registers (D31:F3)
+///
+#define PCI_DEVICE_NUMBER_SMBUS        31
+#define PCI_FUNCTION_NUMBER_SMBUS      1
+
+#define R_SMBUS_VENDOR_ID              0x00  ///< Vendor ID
+#define V_SMBUS_VENDOR_ID              V_INTEL_VENDOR_ID ///< Intel Vendor ID
+
+#define R_SMBUS_DEVICE_ID              0x02  ///< Device ID
+#define V_SMBUS_DEVICE_ID              0x5AD4
+
+#define R_SMBUS_PCICMD                 0x04  ///< CMD register enables/disables, Memory/IO space access and interrupt
+#define B_SMBUS_PCICMD_INTR_DIS        BIT10 ///< Interrupt Disable
+#define B_SMBUS_PCICMD_FBE             BIT9  ///< FBE - reserved as '0'
+#define B_SMBUS_PCICMD_SERR_EN         BIT8  ///< SERR Enable - reserved as '0'
+#define B_SMBUS_PCICMD_WCC             BIT7  ///< Wait Cycle Control - reserved as '0'
+#define B_SMBUS_PCICMD_PER             BIT6  ///< Parity Error - reserved as '0'
+#define B_SMBUS_PCICMD_VPS             BIT5  ///< VGA Palette Snoop - reserved as '0'
+#define B_SMBUS_PCICMD_PMWE            BIT4  ///< Postable Memory Write Enable - reserved as '0'
+#define B_SMBUS_PCICMD_SCE             BIT3  ///< Special Cycle Enable - reserved as '0'
+#define B_SMBUS_PCICMD_BME             BIT2  ///< Bus Master Enable - reserved as '0'
+#define B_SMBUS_PCICMD_MSE             BIT1  ///< Memory Space Enable
+#define B_SMBUS_PCICMD_IOSE            BIT0  ///< I/O Space Enable
+
+#define R_SMBUS_PCISTS                 0x06  ///< Configuration status register
+#define B_SMBUS_PCISTS_DPE             BIT15 ///< Detect Parity Error - reserved as '0'
+#define B_SMBUS_PCISTS_SSE             BIT14 ///< Signaled System Error - reserved as '0'
+#define B_SMBUS_PCISTS_RMA             BIT13 ///< Received Master Abort - reserved as '0'
+#define B_SMBUS_PCISTS_RTA             BIT12 ///< Received Target Abort - reserved as '0'
+#define B_SMBUS_PCISTS_STA             BIT11 ///< Signaled Target Abort - reserved as '0'
+#define B_SMBUS_PCISTS_DEVT            (BIT10 | BIT9) ///< Devsel Timing Status
+#define B_SMBUS_PCISTS_DPED            BIT8  ///< Data Parity Error Detected - reserved as '0'
+#define B_SMBUS_PCISTS_FB2BC           BIT7  ///< Fast Back To Back Capable - reserved as '1'
+#define B_SMBUS_PCISTS_UDF             BIT6  ///< User Defined Features - reserved as '0'
+#define B_SMBUS_PCISTS_66MHZ_CAP       BIT5  ///< 66 MHz Capable - reserved as '0'
+#define B_SMBUS_PCISTS_CAP_LIST        BIT4  ///< Capabilities List Indicator - reserved as '0'
+#define B_SMBUS_PCISTS_INTS            BIT3  ///< Interrupt Status
+
+#define R_SMBUS_RID                    0x08  ///< Revision ID
+#define B_SMBUS_RID                    0xFF  ///< Revision ID
+
+#define R_SMBUS_PRGIF                  0x09  ///< Programming Interface
+#define B_SMBUS_PRGIF                  0xFF  ///< Programming Interface
+
+#define R_SMBUS_SCC                    0x0A  ///< Sub Class Code
+#define V_SMBUS_SCC                    0x05  ///< A value of 05h indicates that this device is a SM Bus serial controller
+
+#define R_SMBUS_BCC                    0x0B  ///< Base Class Code
+#define V_SMBUS_BCC                    0x0C  ///< A value of 0Ch indicates that this device is a serial controller
+
+#define R_SMBUS_BAR0                   0x10  ///< The memory bar low
+#define B_SMBUS_BAR0_BAR               0xFFFFFFE0 ///< Base Address
+#define B_SMBUS_BAR0_PREF              BIT3  ///< Hardwired to 0. Indicated that SMBMBAR is not prefetchable
+#define B_SMBUS_BAR0_ADDRNG            (BIT2 | BIT1)
+#define B_SMBUS_BAR0_MSI               BIT0  ///< Memory Space Indicator
+
+#define R_SMBUS_BAR1                   0x14  ///< The memory bar high
+#define B_SMBUS_BAR1_BAR               0xFFFFFFFF ///< Base Address
+
+#define R_SMBUS_BASE                   0x20  ///< The I/O memory bar
+#define B_SMBUS_BASE_BAR               0x0000FFE0 ///< Base Address
+#define B_SMBUS_BASE_IOSI              BIT0  ///< IO Space Indicator
+
+#define R_SMBUS_SVID                   0x2C  ///< Subsystem Vendor ID
+#define B_SMBUS_SVID                   0xFFFF ///< Subsystem Vendor ID
+
+#define R_SMBUS_SID                    0x2E  ///< Subsystem ID
+#define B_SMBUS_SID                    0xFFFF ///< Subsystem ID
+
+#define R_SMBUS_INT_LN                 0x3C  ///< Interrupt Line
+#define B_SMBUS_INT_LN                 0xFF  ///< Interrupt Line
+
+#define R_SMBUS_INT_PN                 0x3D  ///< Interrupt Pin
+#define B_SMBUS_INT_PN                 0xFF  ///< Interrupt Pin
+
+#define R_PCH_SMBUS_HSTS               0x00  // Host Status Register R/W
+#define B_PCH_SMBUS_HBSY               0x01
+#define R_PCH_SMBUS_HCTL               0x02  // Host Control Register R/W
+#define B_PCH_SMBUS_START              BIT6  // Start
+#define B_PCH_SMBUS_DERR               0x04
+#define B_PCH_SMBUS_BERR               0x08
+#define B_PCH_SMBUS_IUS                0x40
+#define B_PCH_SMBUS_BYTE_DONE_STS      0x80
+#define B_PCH_SMBUS_HSTS_ALL           0xFF
+#define V_PCH_SMBUS_SMB_CMD_BYTE_DATA  0x08  // Byte Data
+#define V_PCH_SMBUS_SMB_CMD_BLOCK      0x14  // Block
+
+#define R_SMBUS_HOSTC                  0x40  ///< Host Configuration Register
+#define B_SMBUS_HOSTC_SPD_WD           BIT4  ///< SPD Write Disable
+#define B_SMBUS_HOSTC_SSRESET          BIT3  ///< Soft SMBus Reset
+#define B_SMBUS_HOSTC_I2C_EN           BIT2  ///< I2C Enable Bit
+#define B_SMBUS_HOSTC_SMI_EN           BIT1  ///< SMI Enable Bit
+#define B_SMBUS_HOSTC_HST_EN           BIT0  ///< Host Controller Enable Bit
+
+#define R_SMBUS_TCOBASE                0x50 ///< TCO Base Address
+#define B_SMBUS_TCOBASE_BAR            0x0000FFE0
+
+#define R_SMBUS_TCOCTL                 0x54 ///< TCO Control
+#define B_SMBUS_TCOCTL_TCO_BASE_EN     BIT8  ///< TCO Base Enable
+#define R_SMBUS_TCOCTL_TCO_BASE_LOCK   BIT0  ///< TCO Base Lock
+
+#define R_SMBUS_MANID                  0xF8  ///< Manufacturer's ID Register
+#define B_SMBUS_MANID_DOTID            0x0F000000 ///< DOT ID
+#define B_SMBUS_MANID_SID              0x00FF0000 ///< Stepping ID
+#define B_SMBUS_MANID_MID              0x0000FF00 ///< Manufacturer ID
+#define B_SMBUS_MANID_PPID             0x000000FF ///< Process ID
+
+///
+/// SMBus I/O Registers
+///
+#define R_SMBUS_HSTS                   0x00  ///< Host Status Register R/W
+#define B_SMBUS_HSTS_ALL               0xFF
+#define B_SMBUS_BYTE_DONE_STS          BIT7  ///< Byte Done Status
+#define B_SMBUS_IUS                    BIT6  ///< In Use Status
+#define B_SMBUS_SMBALERT_STS           BIT5  ///< SMBUS Alert
+#define B_SMBUS_FAIL                   BIT4  ///< Failed
+#define B_SMBUS_BERR                   BIT3  ///< Bus Error
+#define B_SMBUS_DERR                   BIT2  ///< Device Error
+#define B_SMBUS_ERRORS                 (B_SMBUS_FAIL | B_SMBUS_BERR | B_SMBUS_DERR)
+#define B_SMBUS_INTR                   BIT1  ///< Interrupt
+#define B_SMBUS_HBSY                   BIT0  ///< Host Busy
+
+#define R_SMBUS_HCTL                   0x02  ///< Host Control Register R/W
+#define B_SMBUS_PEC_EN                 BIT7  ///< Packet Error Checking Enable
+#define B_SMBUS_START                  BIT6  ///< Start
+#define B_SMBUS_LAST_BYTE              BIT5  ///< Last Byte
+#define B_SMBUS_SMB_CMD                0x1C  ///< SMB Command
+#define V_SMBUS_SMB_CMD_BLOCK_PROCESS  0x1C  ///< Block Process
+#define V_SMBUS_SMB_CMD_IIC_READ       0x18  ///< I2C Read
+#define V_SMBUS_SMB_CMD_BLOCK          0x14  ///< Block
+#define V_SMBUS_SMB_CMD_PROCESS_CALL   0x10  ///< Process Call
+#define V_SMBUS_SMB_CMD_WORD_DATA      0x0C  ///< Word Data
+#define V_SMBUS_SMB_CMD_BYTE_DATA      0x08  ///< Byte Data
+#define V_SMBUS_SMB_CMD_BYTE           0x04  ///< Byte
+#define V_SMBUS_SMB_CMD_QUICK          0x00  ///< Quick
+#define B_SMBUS_KILL                   BIT1  ///< Kill
+#define B_SMBUS_INTREN                 BIT0  ///< Interrupt Enable
+
+#define R_SMBUS_HCMD                   0x03  ///< Host Command Register R/W
+#define B_SMBUS_HCMD                   0xFF  ///< Command to be transmitted
+
+#define R_SMBUS_TSA                    0x04  ///< Transmit Slave Address Register R/W
+#define B_SMBUS_ADDRESS                0xFE  ///< 7-bit address of the targeted slave
+#define B_SMBUS_RW_SEL                 BIT0  ///< Direction of the host transfer, 1 = read, 0 = write
+#define B_SMBUS_RW_SEL_READ            0x01  ///< Read
+#define B_SMBUS_RW_SEL_WRITE           0x00  ///< Write
+
+#define R_SMBUS_HD0                    0x05  ///< Data 0 Register R/W
+#define R_SMBUS_HD1                    0x06  ///< Data 1 Register R/W
+#define R_SMBUS_HBD                    0x07  ///< Host Block Data Register R/W
+#define R_SMBUS_PEC                    0x08  ///< Packet Error Check Data Register R/W
+
+#define R_SMBUS_RSA                    0x09  ///< Receive Slave Address Register R/W
+#define B_SMBUS_SLAVE_ADDR             0x7F  ///< TCO slave address (Not used, reserved)
+
+#define R_SMBUS_SD                     0x0A  ///< Receive Slave Data Register R/W
+
+#define R_SMBUS_AUXS                   0x0C  ///< Auxiliary Status Register R/WC
+#define B_SMBUS_CRCE                   BIT0  ///< CRC Error
+
+#define R_SMBUS_AUXC                   0x0D  ///< Auxiliary Control Register R/W
+#define B_SMBUS_E32B                   BIT1  ///< Enable 32-byte Buffer
+#define B_SMBUS_AAC                    BIT0  ///< Automatically Append CRC
+
+#define R_SMBUS_SMLC                   0x0E  ///< SMLINK Pin Control Register R/W
+#define B_SMBUS_SMLINK_CLK_CTL         BIT2  ///< Not supported
+#define B_SMBUS_SMLINK1_CUR_STS        BIT1  ///< Not supported
+#define B_SMBUS_SMLINK0_CUR_STS        BIT0  ///< Not supported
+
+#define R_SMBUS_SMBC                   0x0F  ///< SMBus Pin Control Register R/W
+#define B_SMBUS_SMBCLK_CTL             BIT2  ///< SMBCLK Control
+#define B_SMBUS_SMBDATA_CUR_STS        BIT1  ///< SMBDATA Current Status
+#define B_SMBUS_SMBCLK_CUR_STS         BIT0  ///< SMBCLK Current Status
+
+#define R_SMBUS_SSTS                   0x10  ///< Slave Status Register R/WC
+#define B_SMBUS_HOST_NOTIFY_STS        BIT0  ///< Host Notify Status
+
+#define R_SMBUS_SCMD                   0x11  ///< Slave Command Register R/W
+#define B_SMBUS_SMBALERT_DIS           BIT2  ///< Not supported
+#define B_SMBUS_HOST_NOTIFY_WKEN       BIT1  ///< Host Notify Wake Enable
+#define B_SMBUS_HOST_NOTIFY_INTREN     BIT0  ///< Host Notify Interrupt Enable
+
+#define R_SMBUS_NDA                    0x14  ///< Notify Device Address Register RO
+#define B_SMBUS_DEVICE_ADDRESS         0xFE  ///< Device Address
+
+#define R_SMBUS_NDLB                   0x16  ///< Notify Data Low Byte Register RO
+#define R_SMBUS_NDHB                   0x17  ///< Notify Data High Byte Register RO
+
+#endif
+

--- a/Silicon/ApollolakePkg/Include/SocRegs.h
+++ b/Silicon/ApollolakePkg/Include/SocRegs.h
@@ -44,6 +44,7 @@
 #include <ScRegs/RegsPcie.h>
 #include <ScRegs/RegsGpio.h>
 #include <ScRegs/RegsPcr.h>
+#include <ScRegs/RegsSmbus.h>
 
 #define SC_PCIE_ROOT_PORT_BUS(RpNumber)       ((RpNumber < 2) ? PCI_DEVICE_NUMBER_SC_PCIE_DEVICE_1 : PCI_DEVICE_NUMBER_SC_PCIE_DEVICE_2)
 #define SC_PCIE_ROOT_PORT_FUNC(RpNumber)      ((RpNumber < 2) ? RpNumber : RpNumber - 2)

--- a/Silicon/ApollolakePkg/Library/SmbusLib/SmbusLib.c
+++ b/Silicon/ApollolakePkg/Library/SmbusLib/SmbusLib.c
@@ -1,0 +1,656 @@
+/** @file
+  Apollo Lake South Cluster Smbus Executive Code (common PEI/DXE/SMM code).
+
+  Copyright (c) 2014 - 2018, Intel Corporation. All rights reserved.<BR>
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php.
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+
+#include <Uefi/UefiBaseType.h>
+#include <Library/IoLib.h>
+#include <Library/DebugLib.h>
+#include <Library/TimerLib.h>
+#include <IndustryStandard/SmBus.h>
+#include <IndustryStandard/Pci30.h>
+#include <RegAccess.h>
+
+#define STALL_ONE_MICRO_SECOND      1
+#define STALL_PERIOD                10 * STALL_ONE_MICRO_SECOND     ///< 10 microseconds
+#define STALL_TIME                  1000000                         ///< 1 second
+#define BUS_TRIES                   3                               ///< How many times to retry on Bus Errors
+
+/**
+  Get SMBUS IO Base address.
+
+  @param[in]  None
+
+  @retval UINT32                  The SMBUS IO Base Address
+**/
+UINT32
+SmbusGetIoBase (
+  VOID
+  )
+{
+  UINT32  SmbusIoBase;
+
+  SmbusIoBase = MmioRead32 (
+                     MmPciBase (
+                     DEFAULT_PCI_BUS_NUMBER_SC,
+                     PCI_DEVICE_NUMBER_SMBUS,
+                     PCI_FUNCTION_NUMBER_SMBUS)
+                     + R_SMBUS_BASE) & B_SMBUS_BASE_BAR;
+
+  ASSERT (SmbusIoBase != B_SMBUS_BASE_BAR && SmbusIoBase != 0);
+
+  return SmbusIoBase;
+}
+
+/**
+  This function provides a standard way to read PCH Smbus IO registers.
+
+  @param[in] Offset               Register offset from Smbus base IO address.
+
+  @retval UINT8                   Returns data read from IO.
+**/
+UINT8
+EFIAPI
+SmbusIoRead (
+  IN      UINT8           Offset
+  )
+{
+  return IoRead8 (SmbusGetIoBase () + Offset);
+}
+
+/**
+  This function provides a standard way to write PCH Smbus IO registers.
+
+  @param[in] Offset               Register offset from Smbus base IO address.
+  @param[in] Data                 Data to write to register.
+
+**/
+VOID
+EFIAPI
+SmbusIoWrite (
+  IN      UINT8           Offset,
+  IN      UINT8           Data
+  )
+{
+
+  IoWrite8 (SmbusGetIoBase () + Offset, Data);
+  return;
+}
+
+/**
+  This function provides a standard way to check if a SMBus transaction has
+  completed.
+
+  @param[in] StsReg               Not used for input. On return, contains the
+                                  value of the SMBus status register.
+
+  @retval TRUE                    Transaction is complete
+  @retval FALSE                   Otherwise.
+**/
+BOOLEAN
+EFIAPI
+IoDone (
+  IN      UINT8           *StsReg
+  )
+{
+  UINTN StallIndex;
+  UINTN StallTries;
+
+  StallTries = STALL_TIME / STALL_PERIOD;
+
+  for (StallIndex = 0; StallIndex < StallTries; StallIndex++) {
+    *StsReg = SmbusIoRead (R_SMBUS_HSTS);
+    if (*StsReg & (B_SMBUS_INTR | B_SMBUS_BYTE_DONE_STS | B_SMBUS_DERR | B_SMBUS_BERR)) {
+      return TRUE;
+    } else {
+      MicroSecondDelay (STALL_PERIOD);
+    }
+  }
+
+  return FALSE;
+}
+
+/**
+  Check if it's ok to use the bus.
+
+
+  @retval EFI_SUCCESS             SmBus is acquired and it's safe to send commands.
+  @retval EFI_TIMEOUT             SmBus is busy, it's not safe to send commands.
+**/
+EFI_STATUS
+AcquireBus (
+  VOID
+  )
+{
+  UINT8 StsReg;
+
+  StsReg  = 0;
+  StsReg  = SmbusIoRead (R_SMBUS_HSTS);
+  if (StsReg & B_SMBUS_IUS) {
+    return EFI_TIMEOUT;
+  } else if (StsReg & B_SMBUS_HBSY) {
+    ///
+    /// Clear Status Register and exit
+    ///
+    SmbusIoWrite (R_SMBUS_HSTS, B_SMBUS_HSTS_ALL);
+    return EFI_TIMEOUT;
+  } else {
+    ///
+    /// Clear out any odd status information (Will Not Clear In Use)
+    ///
+    SmbusIoWrite (R_SMBUS_HSTS, StsReg);
+    return EFI_SUCCESS;
+  }
+}
+
+/**
+  This function provides a standard way to execute Smbus protocols
+  as defined in the SMBus Specification. The data can either be of
+  the Length byte, word, or a block of data. The resulting transaction will be
+  either the SMBus Slave Device accepts this transaction or this function
+  returns with an error
+
+  @param[in] SlaveAddress         Smbus Slave device the command is directed at
+  @param[in] Command              Slave Device dependent
+  @param[in] Operation            Which SMBus protocol will be used
+  @param[in] PecCheck             Defines if Packet Error Code Checking is to be used
+  @param[in, out] Length          How many bytes to read. Must be 0 <= Length <= 32 depending on Operation
+                                  It will contain the actual number of bytes read/written.
+  @param[in, out] Buffer          Contain the data read/written.
+
+  @retval EFI_SUCCESS             The operation completed successfully.
+  @exception EFI_UNSUPPORTED      The operation is unsupported.
+
+  @retval EFI_INVALID_PARAMETER   Length or Buffer is NULL for any operation besides
+                                  quick read or quick write.
+  @retval EFI_TIMEOUT             The transaction did not complete within an internally
+                                  specified timeout period, or the controller is not
+                                  available for use.
+  @retval EFI_DEVICE_ERROR        There was an Smbus error (NACK) during the operation.
+                                  This could indicate the slave device is not present
+                                  or is in a hung condition.
+**/
+EFI_STATUS
+SmbusExec (
+  IN      EFI_SMBUS_DEVICE_ADDRESS  SlaveAddress,
+  IN      EFI_SMBUS_DEVICE_COMMAND  Command,
+  IN      EFI_SMBUS_OPERATION       Operation,
+  IN      BOOLEAN                   PecCheck,
+  IN OUT  UINTN                     *Length,
+  IN OUT  VOID                      *Buffer
+  )
+{
+  EFI_STATUS  Status;
+  UINT8       AuxcReg;
+  UINT8       AuxStsReg;
+  UINT8       SmbusOperation;
+  UINT8       StsReg;
+  UINT8       SlvAddrReg;
+  UINT8       HostCmdReg;
+  UINT8       BlockCount;
+  BOOLEAN     BufferTooSmall;
+  UINTN       Index;
+  UINTN       BusIndex;
+  UINT8       *CallBuffer;
+  UINT8       SmbusHctl;
+  UINT32      Timeout;
+
+  CallBuffer  = Buffer;
+  BlockCount  = 0;
+
+  ///
+  /// For any operations besides quick read & write, the pointers to
+  /// Length and Buffer must not be NULL.
+  ///
+  if ((Operation != EfiSmbusQuickRead) && (Operation != EfiSmbusQuickWrite)) {
+    if ((Length == NULL) || (Buffer == NULL)) {
+      return EFI_INVALID_PARAMETER;
+    }
+  }
+  ///
+  /// See if its ok to use the bus based upon INUSE_STS bit.
+  ///
+  Status = AcquireBus ();
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+  ///
+  /// This is the main operation loop.  If the operation results in a Smbus
+  /// collision with another master on the bus, it attempts the requested
+  /// transaction again at least BUS_TRIES attempts.
+  ///
+  for (BusIndex = 0; BusIndex < BUS_TRIES; BusIndex++) {
+    ///
+    /// Operation Specifics (pre-execution)
+    ///
+    Status          = EFI_SUCCESS;
+    SmbusOperation  = V_SMBUS_SMB_CMD_QUICK;
+    SlvAddrReg      = (UINT8) ((SlaveAddress.SmbusDeviceAddress << 1) | 1);
+    HostCmdReg      = (UINT8) Command;
+    AuxcReg         = 0;
+
+    switch (Operation) {
+
+    case EfiSmbusQuickWrite:
+      SlvAddrReg--;
+
+    ///
+    /// The "break;" command is not present here to allow code execution
+    /// do drop into the next case, which contains common code to this case.
+    ///
+    case EfiSmbusQuickRead:
+      if (PecCheck == TRUE) {
+        Status = EFI_UNSUPPORTED;
+      }
+      break;
+
+    case EfiSmbusSendByte:
+      HostCmdReg = CallBuffer[0];
+      SlvAddrReg--;
+
+    ///
+    /// The "break;" command is not present here to allow code execution
+    /// do drop into the next case, which contains common code to this case.
+    ///
+    case EfiSmbusReceiveByte:
+      SmbusOperation = V_SMBUS_SMB_CMD_BYTE;
+      if (*Length < 1) {
+        Status = EFI_BUFFER_TOO_SMALL;
+      }
+
+      *Length = 1;
+      break;
+
+    case EfiSmbusWriteByte:
+      SmbusIoWrite (R_SMBUS_HD0, CallBuffer[0]);
+      SlvAddrReg--;
+      *Length = 1;
+
+    ///
+    /// The "break;" command is not present here to allow code execution
+    /// do drop into the next case, which contains common code to this case.
+    ///
+    case EfiSmbusReadByte:
+      if (*Length < 1) {
+        Status = EFI_BUFFER_TOO_SMALL;
+      } else if (*Length == 1) {
+        SmbusOperation = V_SMBUS_SMB_CMD_BYTE_DATA;
+      } else if (*Length <= 256) {
+        if (PecCheck == TRUE) {
+          ///
+          /// The I2C Read command with either PEC_EN or AAC bit set
+          /// produces undefined results.
+          ///
+          Status = EFI_UNSUPPORTED;
+        }
+
+        SmbusOperation = V_SMBUS_SMB_CMD_IIC_READ;
+      } else {
+        Status = EFI_INVALID_PARAMETER;
+      }
+
+      break;
+
+    case EfiSmbusReadWord:
+      SmbusOperation = V_SMBUS_SMB_CMD_WORD_DATA;
+      if (*Length < 2) {
+        Status = EFI_BUFFER_TOO_SMALL;
+      }
+
+      *Length = 2;
+      break;
+
+    case EfiSmbusWriteWord:
+      SmbusOperation = V_SMBUS_SMB_CMD_WORD_DATA;
+      SlvAddrReg--;
+      SmbusIoWrite (R_SMBUS_HD1, CallBuffer[1]);
+      SmbusIoWrite (R_SMBUS_HD0, CallBuffer[0]);
+      if (*Length < 2) {
+        Status = EFI_BUFFER_TOO_SMALL;
+      }
+
+      *Length = 2;
+      break;
+
+    case EfiSmbusWriteBlock:
+      SmbusIoWrite (R_SMBUS_HD0, *(UINT8 *) Length);
+      SlvAddrReg--;
+      BlockCount = (UINT8) (*Length);
+
+    ///
+    /// The "break;" command is not present here to allow code execution
+    /// do drop into the next case, which contains common code to this case.
+    ///
+    case EfiSmbusReadBlock:
+      SmbusOperation = V_SMBUS_SMB_CMD_BLOCK;
+      if ((*Length < 1) || (*Length > 32)) {
+        Status = EFI_INVALID_PARAMETER;
+        break;
+      }
+
+      AuxcReg |= B_SMBUS_E32B;
+      break;
+
+    case EfiSmbusProcessCall:
+      SmbusOperation = V_SMBUS_SMB_CMD_PROCESS_CALL;
+      SmbusIoWrite (R_SMBUS_HD1, CallBuffer[1]);
+      SmbusIoWrite (R_SMBUS_HD0, CallBuffer[0]);
+      if (*Length < 2) {
+        Status = EFI_BUFFER_TOO_SMALL;
+      }
+
+      *Length = 2;
+      break;
+
+    case EfiSmbusBWBRProcessCall:
+      ///
+      /// The write byte count cannot be zero or more than
+      /// 32 bytes.
+      ///
+      if ((*Length < 1) || (*Length > 32)) {
+        Status = EFI_INVALID_PARAMETER;
+        break;
+      }
+
+      SmbusIoWrite (R_SMBUS_HD0, *(UINT8 *) Length);
+      BlockCount      = (UINT8) (*Length);
+      SmbusOperation  = V_SMBUS_SMB_CMD_BLOCK_PROCESS;
+
+      AuxcReg |= B_SMBUS_E32B;
+      break;
+
+    default:
+      Status = EFI_INVALID_PARAMETER;
+      break;
+    }
+
+    if (EFI_ERROR (Status)) {
+      break;
+    }
+
+    if (PecCheck == TRUE) {
+      AuxcReg |= B_SMBUS_AAC;
+    }
+    ///
+    /// Set Auxiliary Control register
+    ///
+    SmbusIoWrite (R_SMBUS_AUXC, AuxcReg);
+
+    ///
+    /// Reset the pointer of the internal buffer
+    ///
+    SmbusIoRead (R_SMBUS_HCTL);
+
+    ///
+    /// Now that the 32 byte buffer is turned on, we can write th block data
+    /// into it
+    ///
+    if ((Operation == EfiSmbusWriteBlock) || (Operation == EfiSmbusBWBRProcessCall)) {
+      for (Index = 0; Index < BlockCount; Index++) {
+        ///
+        /// Write next byte
+        ///
+        SmbusIoWrite (R_SMBUS_HBD, CallBuffer[Index]);
+      }
+    }
+    ///
+    /// Set SMBus slave address for the device to send/receive from
+    ///
+    SmbusIoWrite (R_SMBUS_TSA, SlvAddrReg);
+
+    ///
+    /// For I2C read, send DATA1 register for the offset (address)
+    /// within the serial memory chips
+    ///
+    if ((Operation == EfiSmbusReadByte) && (*Length > 1)) {
+      SmbusIoWrite (R_SMBUS_HD1, HostCmdReg);
+    } else {
+      ///
+      /// Set Command register
+      ///
+      SmbusIoWrite (R_SMBUS_HCMD, HostCmdReg);
+    }
+    ///
+    /// Set Control Register (Initiate Operation, Interrupt disabled)
+    ///
+    SmbusIoWrite (R_SMBUS_HCTL, (UINT8) (SmbusOperation + B_SMBUS_START));
+
+    ///
+    /// Wait for IO to complete
+    ///
+    if (!IoDone (&StsReg)) {
+      Status = EFI_TIMEOUT;
+      break;
+    } else if (StsReg & B_SMBUS_DERR) {
+      AuxStsReg = SmbusIoRead (R_SMBUS_AUXS);
+      if (AuxStsReg & B_SMBUS_CRCE) {
+        Status = EFI_CRC_ERROR;
+      } else {
+        Status = EFI_DEVICE_ERROR;
+      }
+      break;
+    } else if (StsReg & B_SMBUS_BERR) {
+      ///
+      /// Clear the Bus Error for another try
+      ///
+      Status = EFI_DEVICE_ERROR;
+      SmbusIoWrite (R_SMBUS_HSTS, B_SMBUS_BERR);
+      ///
+      /// Clear Status Registers
+      ///
+      SmbusIoWrite (R_SMBUS_HSTS, B_SMBUS_HSTS_ALL);
+      SmbusIoWrite (R_SMBUS_AUXS, B_SMBUS_CRCE);
+      ///
+      /// If bus collision happens, stall some time, then try again
+      /// Here we choose 10 milliseconds to avoid MTCP transfer.
+      ///
+      MicroSecondDelay (STALL_PERIOD);
+      continue;
+    }
+    ///
+    /// successfull completion
+    /// Operation Specifics (post-execution)
+    ///
+    switch (Operation) {
+
+    case EfiSmbusReadWord:
+    ///
+    /// The "break;" command is not present here to allow code execution
+    /// do drop into the next case, which contains common code to this case.
+    ///
+    case EfiSmbusProcessCall:
+      CallBuffer[1] = SmbusIoRead (R_SMBUS_HD1);
+      CallBuffer[0] = SmbusIoRead (R_SMBUS_HD0);
+      break;
+
+    case EfiSmbusReadByte:
+      if (*Length > 1) {
+        for (Index = 0; Index < *Length; Index++) {
+          ///
+          /// Read the byte
+          ///
+          CallBuffer[Index] = SmbusIoRead (R_SMBUS_HBD);
+          ///
+          /// After receiving byte n-1 (1-base) of the message, the
+          /// software will then set the LAST BYTE bit. The software
+          /// will then clear the BYTE_DONE_STS bit.
+          ///
+          if (Index == ((*Length - 1) - 1)) {
+            SmbusHctl = SmbusIoRead (R_SMBUS_HCTL) | (UINT8) B_SMBUS_LAST_BYTE;
+            SmbusIoWrite (R_SMBUS_HCTL, SmbusHctl);
+          } else if (Index == (*Length - 1)) {
+            ///
+            /// Clear the LAST BYTE bit after receiving byte n (1-base) of the message
+            ///
+            SmbusHctl = SmbusIoRead (R_SMBUS_HCTL) & (UINT8) ~B_SMBUS_LAST_BYTE;
+            SmbusIoWrite (R_SMBUS_HCTL, SmbusHctl);
+          }
+          ///
+          /// Clear the BYTE_DONE_STS bit
+          ///
+          SmbusIoWrite (R_SMBUS_HSTS, B_SMBUS_BYTE_DONE_STS);
+          ///
+          /// Check BYTE_DONE_STS bit to know if it has completed transmission
+          /// of a byte. No need to check it for the last byte.
+          ///
+          if (Index < (*Length - 1)) {
+            ///
+            /// If somehow board operates at 10Khz, it will take 0.9 ms (9/10Khz) for another byte.
+            /// Add 10 us delay for a loop of 100 that the total timeout is 1 ms to take care of
+            /// the slowest case.
+            ///
+            for (Timeout = 0; Timeout < 100; Timeout++) {
+              if ((SmbusIoRead (R_SMBUS_HSTS) & (UINT8) B_SMBUS_BYTE_DONE_STS) != 0) {
+                break;
+              }
+              ///
+              /// Delay 10 us
+              ///
+              MicroSecondDelay (STALL_PERIOD);
+            }
+
+            if (Timeout >= 100) {
+              Status = EFI_TIMEOUT;
+              break;
+            }
+          }
+        }
+        break;
+      }
+
+    case EfiSmbusReceiveByte:
+      CallBuffer[0] = SmbusIoRead (R_SMBUS_HD0);
+      break;
+
+    case EfiSmbusWriteBlock:
+      SmbusIoWrite (R_SMBUS_HSTS, B_SMBUS_BYTE_DONE_STS);
+      break;
+
+    case EfiSmbusReadBlock:
+      BufferTooSmall = FALSE;
+      ///
+      /// Find out how many bytes will be in the block
+      ///
+      BlockCount = SmbusIoRead (R_SMBUS_HD0);
+      if (*Length < BlockCount) {
+        BufferTooSmall = TRUE;
+      } else {
+        for (Index = 0; Index < BlockCount; Index++) {
+          ///
+          /// Read the byte
+          ///
+          CallBuffer[Index] = SmbusIoRead (R_SMBUS_HBD);
+        }
+      }
+
+      *Length = BlockCount;
+      if (BufferTooSmall) {
+        Status = EFI_BUFFER_TOO_SMALL;
+      }
+      break;
+
+    case EfiSmbusBWBRProcessCall:
+      ///
+      /// Find out how many bytes will be in the block
+      ///
+      BlockCount = SmbusIoRead (R_SMBUS_HD0);
+      ///
+      /// The read byte count cannot be zero.
+      ///
+      if (BlockCount < 1) {
+        Status = EFI_BUFFER_TOO_SMALL;
+        break;
+      }
+      ///
+      /// The combined data payload (the write byte count + the read byte count)
+      /// must not exceed 32 bytes
+      ///
+      if (((UINT8) (*Length) + BlockCount) > 32) {
+        Status = EFI_DEVICE_ERROR;
+        break;
+      }
+
+      for (Index = 0; Index < BlockCount; Index++) {
+        ///
+        /// Read the byte
+        ///
+        CallBuffer[Index] = SmbusIoRead (R_SMBUS_HBD);
+      }
+
+      *Length = BlockCount;
+      break;
+
+    default:
+      break;
+    };
+
+    if ((StsReg & B_SMBUS_BERR) && (Status != EFI_BUFFER_TOO_SMALL)) {
+      ///
+      /// Clear the Bus Error for another try
+      ///
+      Status = EFI_DEVICE_ERROR;
+      SmbusIoWrite (R_SMBUS_HSTS, B_SMBUS_BERR);
+      ///
+      /// If bus collision happens, stall some time, then try again
+      /// Here we choose 10 milliseconds to avoid MTCP transfer.
+      ///
+      MicroSecondDelay (STALL_PERIOD);
+      continue;
+    } else {
+      break;
+    }
+  }
+  ///
+  /// Clear Status Registers and exit
+  ///
+  SmbusIoWrite (R_SMBUS_HSTS, B_SMBUS_HSTS_ALL);
+  SmbusIoWrite (R_SMBUS_AUXS, B_SMBUS_CRCE);
+  SmbusIoWrite (R_SMBUS_AUXC, 0);
+  return Status;
+}
+
+/**
+  This function initializes the Smbus Registers.
+
+  @param[in]  None
+
+  @retval[in]  None
+**/
+VOID
+InitializeSmbusRegisters (
+  VOID
+  )
+{
+  UINTN SmbusRegBase;
+
+  SmbusRegBase = MmPciBase (
+                  DEFAULT_PCI_BUS_NUMBER_SC,
+                  PCI_DEVICE_NUMBER_SMBUS,
+                  PCI_FUNCTION_NUMBER_SMBUS
+                  );
+  ///
+  /// Enable the Smbus I/O Enable
+  ///
+  MmioOr8 (SmbusRegBase + PCI_COMMAND_OFFSET, (UINT8) EFI_PCI_COMMAND_IO_SPACE);
+
+  ///
+  /// Enable the Smbus host controller
+  ///
+  MmioAndThenOr8 (
+    SmbusRegBase + R_SMBUS_HOSTC,
+    (UINT8) (~(B_SMBUS_HOSTC_SMI_EN | B_SMBUS_HOSTC_I2C_EN)),
+    B_SMBUS_HOSTC_HST_EN
+    );
+
+  SmbusIoWrite (R_SMBUS_HSTS, B_SMBUS_HSTS_ALL);
+}

--- a/Silicon/ApollolakePkg/Library/SmbusLib/SmbusLib.inf
+++ b/Silicon/ApollolakePkg/Library/SmbusLib/SmbusLib.inf
@@ -1,0 +1,43 @@
+## @file
+#  Component description file for SmBus Library
+#
+#  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+#  This program and the accompanying materials
+#  are licensed and made available under the terms and conditions of the BSD License
+#  which accompanies this distribution.  The full text of the license may be found at
+#  http://opensource.org/licenses/bsd-license.php
+#
+#  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = SmbusLib
+  FILE_GUID                      = 222738BF-D3A4-48BE-866B-629463750FB2
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = SmbusLib
+
+[Sources]
+  SmbusLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCorePkg/BootloaderCorePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+  Silicon/ApollolakePkg/ApollolakePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  IoLib
+  PcdLib
+  DebugLib
+  HobLib
+  MemoryAllocationLib
+  ScSbiAccessLib
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
+


### PR DESCRIPTION
For APL, the board might need SMBUS communication to talk to some
devices, such as PMIC. This patch ported the SMBUS library from
open sourced EDK2 Minnowboard3. Basic test was done on LeafHill
CRB to read/write PMIC registers through SMBUS.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>