### PR TITLE
Adding Pre-OS boot option support

### DIFF
--- a/BootloaderCommonPkg/Include/Guid/OsBootOptionGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/OsBootOptionGuid.h
@@ -25,6 +25,7 @@
 #define BOOT_FLAGS_CRASH_OS        BIT1
 #define BOOT_FLAGS_TRUSTY          BIT2
 #define BOOT_FLAGS_EXTRA           BIT3
+#define BOOT_FLAGS_PRE_OS_BOOT     BIT4
 
 // This bit is used dynamically.
 #define LOAD_IMAGE_FROM_BACKUP     BIT7

--- a/PayloadPkg/OsLoader/OsLoader.h
+++ b/PayloadPkg/OsLoader/OsLoader.h
@@ -142,6 +142,18 @@ typedef struct {
   UINT8                   ImageHash[SHA256_DIGEST_SIZE];
 } LOADED_IMAGE;
 
+typedef struct {
+  UINT32    EaxGpr;
+  UINT32    EcxGpr;
+  UINT32    EdxGpr;
+  UINT32    EbxGpr;
+  UINT32    EspGpr;
+  UINT32    EbpGpr;
+  UINT32    EsiGpr;
+  UINT32    EdiGpr;
+} PRE_OS_BOOT_PARAMS;
+
+typedef  VOID   (*PRE_OS_BOOT_ENTRY) (VOID *Params);
 
 /**
 Print out the Multiboot information block.


### PR DESCRIPTION
Slim Bootloader needs to add support for booting
pre-OS images that will execute before booting to
the actual OS; Slim Bootloader will load both the
pre-OS image and OS image into memory and pass the
OS information to the pre-OS image so that after
the pre-OS image finishes execution it will launch
the OS itself without returning to Slim Bootloader.

Signed-off-by: James Gutbub <james.gutbub@intel.com>