### PR TITLE
Allow searching payload file in build FV folder

### DIFF
--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -563,6 +563,9 @@ def gen_payload_bin (fv_dir, pld_list, pld_bin, priv_key, brd_name = None):
 			src_file = os.path.join(os.environ['PLT_SOURCE'], 'Platform', brd_name, 'Binaries', pld['file'])
 			if (brd_name is None) or (not os.path.exists(src_file)):
 				src_file = os.path.join("PayloadPkg", "PayloadBins", pld['file'])
+				if not os.path.exists(src_file):
+						src_file = os.path.join(fv_dir, pld['file'])
+
 		if idx == 0:
 			dst_path = pld_bin
 		else :


### PR DESCRIPTION
When specify a payload file in the build command line, the current
searching folder is: PayloadPkg/PayloadBins, Platform/$(PlatformBoardPkg)
/Binaries. This patch added another searching folder in the Build FV
if the payload file cannot be found in the listed folders above. This
is useful when the payload image itself is generated from the build
process.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>