### PR TITLE
Fix incorrect image base for TE image

### DIFF
--- a/BootloaderCommonPkg/Library/LitePeCoffLib/LitePeCoffLib.c
+++ b/BootloaderCommonPkg/Library/LitePeCoffLib/LitePeCoffLib.c
@@ -292,7 +292,7 @@ PeCoffGetPreferredBase (
   // Common for PE32 & PE32+
   //
   if (Hdr.Te->Signature == EFI_TE_IMAGE_HEADER_SIGNATURE) {
-    ImageBase = (UINT32)Hdr.Te->ImageBase;
+    ImageBase = (UINT32)Hdr.Te->ImageBase + Hdr.Te->StrippedSize - sizeof (EFI_TE_IMAGE_HEADER);
   } else if (Hdr.Pe32->Signature == EFI_IMAGE_NT_SIGNATURE) {
     ImageBase = Hdr.Pe32->OptionalHeader.ImageBase;
   } else {


### PR DESCRIPTION
TE image has stripped header to reduce the image size. When calculating
the preferred base for TE image, the gap should be added back in order
to match the actual TE image base. This patch fixed #133.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>