### PR TITLE
Add pre-OS checker support

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -1,7 +1,7 @@
 ## @file
 # Provides bootloader driver related package definitions.
 #
-# Copyright (c) 2016 - 2017, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
 # This program and the accompanying materials are licensed and made available under
 # the terms and conditions of the BSD License that accompanies this distribution.
 # The full text of the license may be found at
@@ -149,12 +149,15 @@
   gPlatformModuleTokenSpaceGuid.PcdFramebufferInitEnabled | FALSE      | BOOLEAN | 0x20000201
   # Determine if the splash screen should be displayed or not.
   gPlatformModuleTokenSpaceGuid.PcdSplashEnabled          | FALSE      | BOOLEAN | 0x20000202
+  # Determine if the Pre-OS checker should be executed or not.
+  gPlatformModuleTokenSpaceGuid.PcdPreOsCheckerEnabled    | FALSE      | BOOLEAN | 0x20000203
 
-  gPlatformModuleTokenSpaceGuid.PcdAcpiEnabled            | TRUE       | BOOLEAN | 0x20000203
-  gPlatformModuleTokenSpaceGuid.PcdSmpEnabled             | TRUE       | BOOLEAN | 0x20000204
-  gPlatformModuleTokenSpaceGuid.PcdPciEnumEnabled         | TRUE       | BOOLEAN | 0x20000205
-  gPlatformModuleTokenSpaceGuid.PcdStage1BXip             | TRUE       | BOOLEAN | 0x20000206
-  gPlatformModuleTokenSpaceGuid.PcdStage1AXip             | TRUE       | BOOLEAN | 0x20000207
+
+  gPlatformModuleTokenSpaceGuid.PcdAcpiEnabled            | TRUE       | BOOLEAN | 0x20000204
+  gPlatformModuleTokenSpaceGuid.PcdSmpEnabled             | TRUE       | BOOLEAN | 0x20000205
+  gPlatformModuleTokenSpaceGuid.PcdPciEnumEnabled         | TRUE       | BOOLEAN | 0x20000206
+  gPlatformModuleTokenSpaceGuid.PcdStage1BXip             | TRUE       | BOOLEAN | 0x20000207
+  gPlatformModuleTokenSpaceGuid.PcdStage1AXip             | TRUE       | BOOLEAN | 0x20000208
   gPlatformModuleTokenSpaceGuid.PcdLoadImageUseFsp        | FALSE      | BOOLEAN | 0x20000209
   gPlatformModuleTokenSpaceGuid.PcdVtdEnabled             | FALSE      | BOOLEAN | 0x2000020B
   gPlatformModuleTokenSpaceGuid.PcdFlashMapEnabled        | FALSE      | BOOLEAN | 0x2000020C

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -1,7 +1,7 @@
 ## @file
 # Provides driver and definitions to build bootloader.
 #
-# Copyright (c) 2016 - 2017, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
 # This program and the accompanying materials are licensed and made available under
 # the terms and conditions of the BSD License that accompanies this distribution.
 # The full text of the license may be found at
@@ -279,6 +279,7 @@
   gPlatformModuleTokenSpaceGuid.PcdLoadImageUseFsp        | $(ENABLE_FSP_LOAD_IMAGE)
   gPlatformModuleTokenSpaceGuid.PcdSplashEnabled          | $(ENABLE_SPLASH)
   gPlatformModuleTokenSpaceGuid.PcdFramebufferInitEnabled | $(ENABLE_FRAMEBUFFER_INIT)
+  gPlatformModuleTokenSpaceGuid.PcdPreOsCheckerEnabled    | $(ENABLE_PRE_OS_CHECKER)
   gPlatformModuleTokenSpaceGuid.PcdVtdEnabled             | $(ENABLE_VTD)
   gPlatformModuleTokenSpaceGuid.PcdFlashMapEnabled        | $(HAVE_FLASH_MAP)
   gPlatformModuleTokenSpaceGuid.PcdPsdBiosEnabled         | $(HAVE_PSD_TABLE)

--- a/BootloaderCorePkg/BootloaderCorePkg.fdf
+++ b/BootloaderCorePkg/BootloaderCorePkg.fdf
@@ -1,7 +1,7 @@
 ## @file
 #  FDF file of Platform.
 #
-# Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
 # This program and the accompanying materials are licensed and made available under
 # the terms and conditions of the BSD License that accompanies this distribution.
 # The full text of the license may be found at
@@ -73,6 +73,19 @@ FV = STAGE2
 $(FSP_S_OFFSET) | $(FSP_S_SIZE)
 FILE = $(FV_DIR)/FSP_S.bin
 !endif
+
+#------------------------------------------------------------------------------
+# OsLoader FD
+#------------------------------------------------------------------------------
+[FD.OsLoader]
+BaseAddress   = $(PAYLOAD_EXE_BASE)
+Size          = $(OS_LOADER_FD_SIZE)
+BlockSize     = $(FLASH_BLOCK_SIZE)
+NumBlocks     = $(OS_LOADER_FD_NUMBLK)
+ErasePolarity = $(FLASH_ERASE_POLARITY)
+
+0x00000000 | $(OS_LOADER_FD_SIZE)
+FV = OsLoader
 
 #------------------------------------------------------------------------------
 # STAGE1A FV
@@ -193,9 +206,9 @@ FILE = $(FV_DIR)/FSP_S.bin
 !endif
 
 #------------------------------------------------------------------------------
-# Dummy FV to make PCDs visible to modules
+# OS Loader Payload as an FV
 #------------------------------------------------------------------------------
-[FV.MISC]
+[FV.OsLoader]
   BlockSize          = $(FLASH_BLOCK_SIZE)
   FvAlignment        = 16
   ERASE_POLARITY     = 1
@@ -215,6 +228,34 @@ FILE = $(FV_DIR)/FSP_S.bin
   READ_LOCK_STATUS   = TRUE
 
   INF PayloadPkg/OsLoader/OsLoader.inf
+
+!if $(ENABLE_PRE_OS_CHECKER)
+  FILE FREEFORM = 01C46D7E-00A2-48E8-A50F-17467D1CA0C5 {
+    SECTION RAW = Platform/$(BOARD_PKG_NAME)/Binaries/PreOsChecker.bin
+  }
+!endif
+
+#------------------------------------------------------------------------------
+# FwUpdate FV to make FirmwareUpdate.efi visible to modules
+#------------------------------------------------------------------------------
+[FV.FwUpdate]
+  BlockSize          = $(FLASH_BLOCK_SIZE)
+  FvAlignment        = 16
+  ERASE_POLARITY     = 1
+  MEMORY_MAPPED      = TRUE
+  STICKY_WRITE       = TRUE
+  LOCK_CAP           = TRUE
+  LOCK_STATUS        = TRUE
+  WRITE_DISABLED_CAP = TRUE
+  WRITE_ENABLED_CAP  = TRUE
+  WRITE_STATUS       = TRUE
+  WRITE_LOCK_CAP     = TRUE
+  WRITE_LOCK_STATUS  = TRUE
+  READ_DISABLED_CAP  = TRUE
+  READ_ENABLED_CAP   = TRUE
+  READ_STATUS        = TRUE
+  READ_LOCK_CAP      = TRUE
+  READ_LOCK_STATUS   = TRUE
 
 !if $(ENABLE_FWU)
   INF PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf

--- a/BootloaderCorePkg/Stage2/Stage2.inf
+++ b/BootloaderCorePkg/Stage2/Stage2.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
 #
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
@@ -120,6 +120,7 @@
   gPlatformModuleTokenSpaceGuid.PcdFlashSize
   gPlatformModuleTokenSpaceGuid.PcdSplashEnabled
   gPlatformModuleTokenSpaceGuid.PcdSplashLogoAddress
+  gPlatformModuleTokenSpaceGuid.PcdPreOsCheckerEnabled
   gPlatformModuleTokenSpaceGuid.PcdOsBootOptionNumber
   gPlatformModuleTokenSpaceGuid.PcdServiceNumber
   gPlatformModuleTokenSpaceGuid.PcdFlashMapEnabled

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -2,7 +2,7 @@
 ## @ BuildLoader.py
 # Build bootloader main script
 #
-# Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
 # This program and the accompanying materials are licensed and made available under
 # the terms and conditions of the BSD License that accompanies this distribution.
 # The full text of the license may be found at
@@ -187,6 +187,7 @@ class BaseBoard(object):
 		self.ENABLE_FSP_LOAD_IMAGE = 0
 		self.ENABLE_SPLASH         = 0
 		self.ENABLE_FRAMEBUFFER_INIT = 0
+		self.ENABLE_PRE_OS_CHECKER = 0
 		self.ENABLE_CRYPTO_SHA_NI  = 0
 		self.ENABLE_FWU            = 0
 		self.ENABLE_SOURCE_DEBUG   = 0
@@ -219,6 +220,10 @@ class BaseBoard(object):
 		# other: Load image into memory address
 		self.PAYLOAD_LOAD_BASE     = 0
 		self.FWUPDATE_LOAD_BASE    = 0
+
+		# OS Loader FD/FV sizes
+		self.OS_LOADER_FD_SIZE     = 0x00037000
+		self.OS_LOADER_FD_NUMBLK   = self.OS_LOADER_FD_SIZE / self.FLASH_BLOCK_SIZE
 
 		self.PLD_HEAP_SIZE         = 0x02000000
 		self.PLD_STACK_SIZE        = 0x00010000

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -956,12 +956,14 @@ GetRegionInfo (
   This function will continue Payload execution with a new memory based stack.
 
   @param  Param           parameter passed from SwitchStack().
+  @param  PldBase         payload base passed from SwitchStack().
 
 **/
 VOID
 EFIAPI
 PayloadMain (
-  IN  VOID  *Param
+  IN  VOID  *Param,
+  IN  VOID  *PldBase
   )
 {
   UINT32        RsvdBase;

--- a/PayloadPkg/Include/Library/PayloadEntryLib.h
+++ b/PayloadPkg/Include/Library/PayloadEntryLib.h
@@ -18,12 +18,14 @@
   The payload common Entry Point for C code.
 
   @param[in] Params         The HOB list pointer for payload.
+  @param[in] PldBase        Address of the payload image base.
 
 **/
 VOID
 EFIAPI
 SecStartup (
-  IN VOID     *Params
+  IN VOID     *Params,
+  IN VOID     *PldBase
   );
 
 #endif /* __PAYLOAD_ENTRY_LIB_H__ */

--- a/PayloadPkg/Include/Library/PayloadLib.h
+++ b/PayloadPkg/Include/Library/PayloadLib.h
@@ -38,6 +38,18 @@ typedef struct {
   BL_PERF_DATA     PerfData;
 } PAYLOAD_GLOBAL_DATA;
 
+#pragma pack (1)
+
+typedef struct {
+  UINT32 Eip;
+  UINT32 Eax;
+  UINT32 Ebx;
+  UINT32 Esi;
+  UINT32 Edi;
+  UINT32 Ecx;
+} CPU_BOOT_STATE;
+
+#pragma pack ()
 
 /**
   Returns the System table info HOB data.
@@ -150,7 +162,8 @@ GetLoaderPerformanceInfo (
 VOID
 EFIAPI
 PayloadMain (
-  IN  VOID *Param
+  IN  VOID *Param,
+  IN  VOID *PldBase
   );
 
 #endif /* __PAYLOADLIB_H__ */

--- a/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
+++ b/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
@@ -131,12 +131,14 @@ PayloadInit (
   The payload common Entry Point for C code.
 
   @param[in] Params         The HOB list pointer for payload.
+  @param[in] PldBase        Address of the payload image base.
 
 **/
 VOID
 EFIAPI
 SecStartup (
-  IN VOID                   *Params
+  IN VOID                   *Params,
+  IN VOID                   *PldBase
   )
 {
   PAYLOAD_GLOBAL_DATA       *GlobalDataPtr;
@@ -237,5 +239,5 @@ SecStartup (
     );
   DEBUG_CODE_END ();
 
-  SwitchStack ((SWITCH_STACK_ENTRY_POINT)PayloadMain, &Params, NULL, (VOID *) (UINTN)HeapBase);
+  SwitchStack ((SWITCH_STACK_ENTRY_POINT)PayloadMain, &Params, PldBase, (VOID *) (UINTN)HeapBase);
 }

--- a/PayloadPkg/Library/TrustyBootLib/TrustyBoot.h
+++ b/PayloadPkg/Library/TrustyBootLib/TrustyBoot.h
@@ -43,15 +43,6 @@ typedef enum {
 #pragma pack (1)
 
 typedef struct {
-  UINT32 Eip;
-  UINT32 Eax;
-  UINT32 Ebx;
-  UINT32 Esi;
-  UINT32 Edi;
-  UINT32 Ecx;
-} CPU_BOOT_STATE;
-
-typedef struct {
   // use size as version. In future, we can only add members in the structure
   UINT32         SizeOfThisStruct;
   UINT32         Version;

--- a/PayloadPkg/OsLoader/OsLoader.h
+++ b/PayloadPkg/OsLoader/OsLoader.h
@@ -142,6 +142,7 @@ typedef struct {
   UINT8                   ImageHash[SHA256_DIGEST_SIZE];
 } LOADED_IMAGE;
 
+typedef  VOID   (*PRE_OS_CHECKER_ENTRY) (VOID *Params);
 
 /**
 Print out the Multiboot information block.


### PR DESCRIPTION
Some OSes may require a pre-OS checker executable
to run before actually jumping to the OS. Add
support for this pre-OS checker loading & execution
as part of the OS Loader payload when it is compiled
as an FV and when ENABLE_PRE_OS_CHECKER option is
enabled in BoardConfig.py (per the following command):

SblBuild.py build <plat> -p Misc.Fv:LLDR:Lz4

The pre-OS checker entry point takes in a single
parameter which provides a handle to the loaded
OS for the pre-OS checker to launch after it executes
(e.g. pre-OS checker does not return to Slim Bootloader).

Signed-off-by: James Gutbub <james.gutbub@intel.com>