### PR TITLE
Fix the GCC OS Loader FV build error

### DIFF
--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -222,7 +222,7 @@ class BaseBoard(object):
 		self.FWUPDATE_LOAD_BASE    = 0
 
 		# OS Loader FD/FV sizes
-		self.OS_LOADER_FD_SIZE     = 0x00037000
+		self.OS_LOADER_FD_SIZE     = 0x00040000
 		self.OS_LOADER_FD_NUMBLK   = self.OS_LOADER_FD_SIZE / self.FLASH_BLOCK_SIZE
 
 		self.PLD_HEAP_SIZE         = 0x02000000


### PR DESCRIPTION
The GCC build is failing due to recent check-in for OS Loader FV
building. GCC5 is throwing an error that the required fv size
of 0x37718 is exceeding the set fv size of 0x37000. Bump up the FV
size (by 36KB) to address this issue.

Signed-off-by: James Gutbub <james.gutbub@intel.com>