### PR TITLE
Allow SATA boot option to boot from any AHCI port

### DIFF
--- a/BootloaderCommonPkg/Library/AhciLib/AhciBlkIo.c
+++ b/BootloaderCommonPkg/Library/AhciLib/AhciBlkIo.c
@@ -115,7 +115,7 @@ AhciFindDeviceData (
        Link != &AhciController->DeviceList;
        Link  = Link->ForwardLink) {
     AhciDeviceData = EFI_ATA_DEVICE_FROM_LINK (Link);
-    if (((AhciDeviceData->Port == PortNumber) || (PortNumber == 0xFFFFFFFF)) &&
+    if (((AhciDeviceData->Port == PortNumber) || (PortNumber == 0xFF)) &&
         ((AhciDeviceData->PortMultiplier == PortMulNumber) || (PortMulNumber == 0xFFFFFFFF))) {
       return AhciDeviceData;
     }


### PR DESCRIPTION
For SATA boot option, the hardware partition is mapped into AHCI
port. Current implementation requires a specific AHCI port in order
to boot from that hard drive. This patch added support to boot
from the first detected AHCI port when the hardware partition is
set to 0xFF.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>