### PR TITLE
Fix MRC NVS data reading issue

### DIFF
--- a/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -1932,6 +1932,10 @@ FindNvsData (
 
     ActIdx = 0xFF;
     if (MrcVarHdr->Signature == MRC_VAR_SIGNATURE) {
+      if (MrcVarHdr->SlotNum > 0) {
+        // Set default slot to be the last entry
+        ActIdx = MrcVarHdr->SlotNum;
+      }
       for (Idx = 0; Idx < MrcVarHdr->SlotNum >> 3; Idx++) {
         Data8 = MrcVarHdr->SlotMap[Idx];
         if (Data8 != 0) {
@@ -1949,9 +1953,12 @@ FindNvsData (
       break;
     }
 
-    // Read NV data from the slot
+    // Adjust index to be 0 based
+    ActIdx--;
     DEBUG ((DEBUG_INFO, "Use slot %d\n", ActIdx));
-    Offset = MrcNvDataOffset + sizeof (MRC_VAR_HDR) + (ActIdx - 1) * MRC_VAR_SLOT_LENGTH;
+
+    // Read NV data from the slot
+    Offset = MrcNvDataOffset + sizeof (MRC_VAR_HDR) + ActIdx * MRC_VAR_SLOT_LENGTH;
     CopyMem ((UINT8 *)MrcVarData, (UINT8 *)MrcDataBase + Offset, MRC_VAR_LENGTH);
 
   } while (EFI_ERROR (Status));

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1129,7 +1129,7 @@ SaveNvsData (
       }
       SetMem (MrcVarHdr, sizeof (MRC_VAR_HDR), 0xFF);
       MrcVarHdr->Signature  = MRC_VAR_SIGNATURE;
-      MrcVarHdr->SlotNum    = (SIZE_4KB - sizeof (MRC_VAR_HDR)) / MRC_VAR_SLOT_LENGTH;
+      MrcVarHdr->SlotNum    = ALIGN_DOWN (((SIZE_4KB - sizeof (MRC_VAR_HDR)) / MRC_VAR_SLOT_LENGTH), 8);
       MrcVarHdr->SlotLen    = MRC_VAR_SLOT_LENGTH;
       MrcVarHdr->SlotMap[0] = 0xFE;
       Status = SpiFlashWrite (FlashRegionBios, BiosOffset + MrcNvDataOffset + sizeof (UINT32),


### PR DESCRIPTION
An issue was reported on APL that MRC will start to do full training
after 119 boot cycles. APL MRC training data contains two parts. One
part will not change, and the other part will change for every boot.
To avoid frequently erasing flash, a rolling method was applied to
save this data into different slot for each boot. When all slots are
full, the whole block will be reclaimed. However, some boundary
condition was not handled properly which caused the NVS data cannot
be located when the slot is close to the end of the block.

This patch addressed this issue by:
 - Force the max slot number to be 8 aligned so that the map is always
   at byte boundary (1 bit for 1 slot in the slot map).
 - When all slots are marked with 0 (all slots are full), set default
   slot to be the last slot so that the last slot will be used to get
   the MRC NVS data.

It fixed #TBD.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>