### PR TITLE
Update the pre-OS payload/checker parameter

### DIFF
--- a/PayloadPkg/Include/Library/PayloadLib.h
+++ b/PayloadPkg/Include/Library/PayloadLib.h
@@ -41,13 +41,23 @@ typedef struct {
 #pragma pack (1)
 
 typedef struct {
-  UINT32 Eip;
   UINT32 Eax;
   UINT32 Ebx;
+  UINT32 Ecx;
+  UINT32 Edx;
   UINT32 Esi;
   UINT32 Edi;
-  UINT32 Ecx;
-} CPU_BOOT_STATE;
+  UINT32 Ebp;
+  UINT32 Eip;
+  UINT32 Eflags;
+} OS_BOOT_STATE;
+
+typedef struct {
+  UINT32        Version;
+  UINT32        HeapSize;
+  UINT32        HeapAddr;
+  OS_BOOT_STATE OsBootState;
+} PRE_OS_PAYLOAD_PARAM;
 
 #pragma pack ()
 

--- a/PayloadPkg/Library/TrustyBootLib/TrustyBoot.h
+++ b/PayloadPkg/Library/TrustyBootLib/TrustyBoot.h
@@ -43,6 +43,15 @@ typedef enum {
 #pragma pack (1)
 
 typedef struct {
+  UINT32 Eip;
+  UINT32 Eax;
+  UINT32 Ebx;
+  UINT32 Esi;
+  UINT32 Edi;
+  UINT32 Ecx;
+} CPU_BOOT_STATE;
+
+typedef struct {
   // use size as version. In future, we can only add members in the structure
   UINT32         SizeOfThisStruct;
   UINT32         Version;

--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -478,11 +478,11 @@ StartBooting (
   IN LOADED_IMAGE            *LoadedImage
   )
 {
-  EFI_STATUS                 Status;
   MULTIBOOT_IMAGE            *MultiBoot;
   BOOT_PARAMS                *BootParams;
-  CPU_BOOT_STATE             OsBootState;
+  PRE_OS_PAYLOAD_PARAM       PreOsParams;
   PRE_OS_CHECKER_ENTRY       EntryPoint;
+  EFI_STATUS                 Status;
 
   DEBUG_CODE_BEGIN();
   PrintStackHeapInfo ();
@@ -497,10 +497,15 @@ StartBooting (
       EntryPoint = (PRE_OS_CHECKER_ENTRY) (UINTN)mPreOsCheckerEntry;
       BeforeOSJump ("Starting Pre-OS Checker ...");
 
-      OsBootState.Esi = (UINT32) BootParams;
-      OsBootState.Eip = BootParams->Hdr.Code32Start;
+      PreOsParams.Version  = 0x1;
+      PreOsParams.HeapSize = EFI_SIZE_TO_PAGES (0);
+      PreOsParams.HeapAddr = (UINT32) AllocatePages (PreOsParams.HeapSize);
 
-      EntryPoint (&OsBootState);
+      PreOsParams.OsBootState.Esi = (UINT32) BootParams;
+      PreOsParams.OsBootState.Eip = BootParams->Hdr.Code32Start;
+      PreOsParams.OsBootState.Eflags = 0;
+
+      EntryPoint (&PreOsParams);
     } else {
       BeforeOSJump ("Starting Kernel ...");
       JumpToKernel ((VOID *)BootParams->Hdr.Code32Start, (VOID *) BootParams);


### PR DESCRIPTION
For the pre-OS payload/checker pass in a parameter
that contains additional information for heap space,
heap address, and additional CPU registers that may
need to be set before the pre-OS payload/checker
passes control to the OS.

Signed-off-by: James Gutbub <james.gutbub@intel.com>