### PR TITLE
[APL] Fix ConfigEditor error on changing Boot Option

### DIFF
--- a/Platform/ApollolakeBoardPkg/CfgData/CfgData_BootOption.dsc
+++ b/Platform/ApollolakeBoardPkg/CfgData/CfgData_BootOption.dsc
@@ -32,13 +32,13 @@
   # eMMC boot P1
   # !BSF SUBT:{OS_TMPL:0 :  0    :  0 :   2   :  0   :   0  :    0 :    0 :'iasimage.bin' :       0 :      0 :     0         :     0   :  0     :     0         :     0   :   0    }
   # eMMC boot P2
-  # !BSF SUBT:{OS_TMPL:1 :  0    :  0 :   2   :  0   :   0  :    0 :    3 :       0       :       1 :      0 :     0         :     0   :  0     :     0         :     0   :   0    }
+  # !BSF SUBT:{OS_TMPL:1 :  0    :  0 :   2   :  0   :   0  :    0 :    3 :      ''       :       1 :      0 :     0         :     0   :  0     :     0         :     0   :   0    }
   # SATA boot
   # !BSF SUBT:{OS_TMPL:2 :  0    :  0 :   0   :  0   :   0  :    0 :    0 :'iasimage.bin' :       0 :      0 :     0         :     0   :  0     :     0         :     0   :   0    }
   # USB boot
   # !BSF SUBT:{OS_TMPL:3 :  0    :  0 :   5   :  0   :   0  :    0 :    0 :'iasimage.bin' :       0 :      0 :     0         :     0   :  0     :     0         :     8   :   0    }
   # SPI boot (for fastboot recovery)
-  # !BSF SUBT:{OS_TMPL:4 :  4    :  0 :   7   :  0   :   0  :    0 :    3 :      0        :       0 :      0 :     0         :     0   :  0     :     0         :     0   :   0    }
+  # !BSF SUBT:{OS_TMPL:4 :  4    :  0 :   7   :  0   :   0  :    0 :    3 :      ''       :       0 :      0 :     0         :     0   :  0     :     0         :     0   :   0    }
 
   # !HDR EMBED:{OS_CFG_DATA:TAG_700:END}
 


### PR DESCRIPTION
To ensure ConfigEditor can handle the configuration data type properly,
the default value needs to be valid. For string type configuration item,
the value should start with single quote. The APL default value for OS
image name is set to number 0 instead of '' to indicate empty string.
This patch corrected this and fixed #151.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>