### PR TITLE
Enhance GRUB config file parser

### DIFF
--- a/PayloadPkg/OsLoader/BootConfig.c
+++ b/PayloadPkg/OsLoader/BootConfig.c
@@ -106,7 +106,7 @@ TrimRight (
   IN  CHAR8  *Line
   )
 {
-  while ((Line[0] == ' ') || (Line[0] == '\t') || (Line[0] == '\r')) {
+  while ((Line[0] == ' ') || (Line[0] == '\t') || (Line[0] == '\r') || (Line[0] == '\n')) {
     Line--;
   }
   return Line;
@@ -267,8 +267,8 @@ ParseLinuxBootConfig (
       // Mark initrd path
       CurrLine = TrimLeft (CurrLine);
       MenuEntry[EntryNum].InitRd.Pos = CurrLine - CfgBuffer;
-      CurrLine = GetNextSpace (CurrLine, EndLine);
-      MenuEntry[EntryNum].InitRd.Len = CurrLine - CfgBuffer - MenuEntry[EntryNum].InitRd.Pos;
+      EndLine  = TrimRight (EndLine);
+      MenuEntry[EntryNum].InitRd.Len = EndLine - CfgBuffer - MenuEntry[EntryNum].InitRd.Pos;
     }
 
     CurrLine = NextLine;


### PR DESCRIPTION
Current GRUB config parser can only handle UNIX EOL style. For DOS
EOL style config file, an extra '\r' will be left at the line end
which might cause failure for initrd file loading due to incorrect
file name string. This patch enhanced the GRUB config file parser
to handle both UNIX and DOS EOL style.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>