### PR TITLE
Add BaseMemoryLibSse2 library

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -59,7 +59,7 @@
   PciExpressLib|MdePkg/Library/BasePciExpressLib/BasePciExpressLib.inf
   DebugPrintErrorLevelLib|$(PLATFORM_PACKAGE)/Library/DebugPrintErrorLevelLib/DebugPrintErrorLevelLib.inf
   PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
-  BaseMemoryLib|MdePkg/Library/BaseMemoryLibRepStr/BaseMemoryLibRepStr.inf
+  BaseMemoryLib|MdePkg/Library/BaseMemoryLibSse2/BaseMemoryLibSse2.inf
   SynchronizationLib|MdePkg/Library/BaseSynchronizationLib/BaseSynchronizationLib.inf
   TimeStampLib|BootloaderCommonPkg/Library/TimeStampLib/TimeStampLib.inf
   ExtraBaseLib|BootloaderCommonPkg/Library/ExtraBaseLib/ExtraBaseLib.inf
@@ -324,6 +324,7 @@
     <PcdsFeatureFlag>
       gPlatformCommonLibTokenSpaceGuid.PcdMinDecompression | TRUE
     <LibraryClasses>
+      BaseMemoryLib| MdePkg/Library/BaseMemoryLibRepStr/BaseMemoryLibRepStr.inf
       SocInitLib   | Silicon/$(SILICON_PKG_NAME)/Library/Stage1ASocInitLib/Stage1ASocInitLib.inf
       BoardInitLib | Platform/$(BOARD_PKG_NAME)/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.inf
 !if $(SKIP_STAGE1A_SOURCE_DEBUG)
@@ -333,6 +334,7 @@
 
   $(PLATFORM_PACKAGE)/Stage1B/Stage1B.inf {
     <LibraryClasses>
+      BaseMemoryLib| MdePkg/Library/BaseMemoryLibRepStr/BaseMemoryLibRepStr.inf
       SocInitLib   | Silicon/$(SILICON_PKG_NAME)/Library/Stage1BSocInitLib/Stage1BSocInitLib.inf
       BoardInitLib | Platform/$(BOARD_PKG_NAME)/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
   }

--- a/MdePkg/Library/BaseMemoryLibSse2/BaseMemoryLibSse2.inf
+++ b/MdePkg/Library/BaseMemoryLibSse2/BaseMemoryLibSse2.inf
@@ -1,0 +1,74 @@
+## @file
+#  Instance of Base Memory Library using SSE2 registers.
+#
+#  Base Memory Library that uses SSE2 registers for high performance.
+#
+#  Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = BaseMemoryLibSse2
+  MODULE_UNI_FILE                = BaseMemoryLibSse2.uni
+  FILE_GUID                      = 65a18235-5096-4032-8c63-214f0249ce8d
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = BaseMemoryLib
+
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MemLibInternals.h
+  ScanMem64Wrapper.c
+  ScanMem32Wrapper.c
+  ScanMem16Wrapper.c
+  ScanMem8Wrapper.c
+  ZeroMemWrapper.c
+  CompareMemWrapper.c
+  SetMem64Wrapper.c
+  SetMem32Wrapper.c
+  SetMem16Wrapper.c
+  SetMemWrapper.c
+  CopyMemWrapper.c
+  IsZeroBufferWrapper.c
+  MemLibGuid.c
+
+[Sources.Ia32]
+  Ia32/ScanMem64.nasm
+  Ia32/ScanMem32.nasm
+  Ia32/ScanMem16.nasm
+  Ia32/ScanMem8.nasm
+  Ia32/CompareMem.nasm
+  Ia32/ZeroMem.nasm
+  Ia32/SetMem64.nasm
+  Ia32/SetMem32.nasm
+  Ia32/SetMem16.nasm
+  Ia32/SetMem.nasm
+  Ia32/CopyMem.nasm
+  Ia32/ScanMem64.nasm
+  Ia32/ScanMem32.nasm
+  Ia32/ScanMem16.nasm
+  Ia32/ScanMem8.nasm
+  Ia32/CompareMem.nasm
+  Ia32/ZeroMem.nasm
+  Ia32/SetMem64.nasm
+  Ia32/SetMem32.nasm
+  Ia32/SetMem16.nasm
+  Ia32/SetMem.nasm
+  Ia32/CopyMem.nasm
+  Ia32/IsZeroBuffer.nasm
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  DebugLib
+  BaseLib
+

--- a/MdePkg/Library/BaseMemoryLibSse2/BaseMemoryLibSse2.uni
+++ b/MdePkg/Library/BaseMemoryLibSse2/BaseMemoryLibSse2.uni
@@ -1,0 +1,16 @@
+// /** @file
+// Instance of Base Memory Library using SSE2 registers.
+//
+// Base Memory Library that uses SSE2 registers for high performance.
+//
+// Copyright (c) 2007 - 2014, Intel Corporation. All rights reserved.<BR>
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+
+#string STR_MODULE_ABSTRACT             #language en-US "Instance of Base Memory Library using SSE2 registers"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "Base Memory Library that uses SSE2 registers for high performance."
+

--- a/MdePkg/Library/BaseMemoryLibSse2/CompareMemWrapper.c
+++ b/MdePkg/Library/BaseMemoryLibSse2/CompareMemWrapper.c
@@ -1,0 +1,60 @@
+/** @file
+  CompareMem() implementation.
+
+  The following BaseMemoryLib instances contain the same copy of this file:
+    BaseMemoryLib
+    BaseMemoryLibMmx
+    BaseMemoryLibSse2
+    BaseMemoryLibRepStr
+    BaseMemoryLibOptDxe
+    BaseMemoryLibOptPei
+    PeiMemoryLib
+    UefiMemoryLib
+
+Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "MemLibInternals.h"
+
+/**
+  Compares the contents of two buffers.
+
+  This function compares Length bytes of SourceBuffer to Length bytes of DestinationBuffer.
+  If all Length bytes of the two buffers are identical, then 0 is returned.  Otherwise, the
+  value returned is the first mismatched byte in SourceBuffer subtracted from the first
+  mismatched byte in DestinationBuffer.
+
+  If Length > 0 and DestinationBuffer is NULL, then ASSERT().
+  If Length > 0 and SourceBuffer is NULL, then ASSERT().
+  If Length is greater than (MAX_ADDRESS - DestinationBuffer + 1), then ASSERT().
+  If Length is greater than (MAX_ADDRESS - SourceBuffer + 1), then ASSERT().
+
+  @param  DestinationBuffer The pointer to the destination buffer to compare.
+  @param  SourceBuffer      The pointer to the source buffer to compare.
+  @param  Length            The number of bytes to compare.
+
+  @return 0                 All Length bytes of the two buffers are identical.
+  @retval Non-zero          The first mismatched byte in SourceBuffer subtracted from the first
+                            mismatched byte in DestinationBuffer.
+
+**/
+INTN
+EFIAPI
+CompareMem (
+  IN CONST VOID  *DestinationBuffer,
+  IN CONST VOID  *SourceBuffer,
+  IN UINTN       Length
+  )
+{
+  if (Length == 0 || DestinationBuffer == SourceBuffer) {
+    return 0;
+  }
+  ASSERT (DestinationBuffer != NULL);
+  ASSERT (SourceBuffer != NULL);
+  ASSERT ((Length - 1) <= (MAX_ADDRESS - (UINTN)DestinationBuffer));
+  ASSERT ((Length - 1) <= (MAX_ADDRESS - (UINTN)SourceBuffer));
+
+  return InternalMemCompareMem (DestinationBuffer, SourceBuffer, Length);
+}

--- a/MdePkg/Library/BaseMemoryLibSse2/CopyMemWrapper.c
+++ b/MdePkg/Library/BaseMemoryLibSse2/CopyMemWrapper.c
@@ -1,0 +1,57 @@
+/** @file
+  CopyMem() implementation.
+
+  The following BaseMemoryLib instances contain the same copy of this file:
+
+    BaseMemoryLib
+    BaseMemoryLibMmx
+    BaseMemoryLibSse2
+    BaseMemoryLibRepStr
+    BaseMemoryLibOptDxe
+    BaseMemoryLibOptPei
+    PeiMemoryLib
+    UefiMemoryLib
+
+  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "MemLibInternals.h"
+
+/**
+  Copies a source buffer to a destination buffer, and returns the destination buffer.
+
+  This function copies Length bytes from SourceBuffer to DestinationBuffer, and returns
+  DestinationBuffer.  The implementation must be reentrant, and it must handle the case
+  where SourceBuffer overlaps DestinationBuffer.
+
+  If Length is greater than (MAX_ADDRESS - DestinationBuffer + 1), then ASSERT().
+  If Length is greater than (MAX_ADDRESS - SourceBuffer + 1), then ASSERT().
+
+  @param  DestinationBuffer   The pointer to the destination buffer of the memory copy.
+  @param  SourceBuffer        The pointer to the source buffer of the memory copy.
+  @param  Length              The number of bytes to copy from SourceBuffer to DestinationBuffer.
+
+  @return DestinationBuffer.
+
+**/
+VOID *
+EFIAPI
+CopyMem (
+  OUT VOID       *DestinationBuffer,
+  IN CONST VOID  *SourceBuffer,
+  IN UINTN       Length
+  )
+{
+  if (Length == 0) {
+    return DestinationBuffer;
+  }
+  ASSERT ((Length - 1) <= (MAX_ADDRESS - (UINTN)DestinationBuffer));
+  ASSERT ((Length - 1) <= (MAX_ADDRESS - (UINTN)SourceBuffer));
+
+  if (DestinationBuffer == SourceBuffer) {
+    return DestinationBuffer;
+  }
+  return InternalMemCopyMem (DestinationBuffer, SourceBuffer, Length);
+}

--- a/MdePkg/Library/BaseMemoryLibSse2/Ia32/CompareMem.nasm
+++ b/MdePkg/Library/BaseMemoryLibSse2/Ia32/CompareMem.nasm
@@ -1,0 +1,51 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2006 - 2008, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Module Name:
+;
+;   CompareMem.Asm
+;
+; Abstract:
+;
+;   CompareMem function
+;
+; Notes:
+;
+;   The following BaseMemoryLib instances contain the same copy of this file:
+;
+;       BaseMemoryLibRepStr
+;       BaseMemoryLibMmx
+;       BaseMemoryLibSse2
+;       BaseMemoryLibOptDxe
+;       BaseMemoryLibOptPei
+;
+;------------------------------------------------------------------------------
+
+    SECTION .text
+
+;------------------------------------------------------------------------------
+; INTN
+; EFIAPI
+; InternalMemCompareMem (
+;   IN      CONST VOID                *DestinationBuffer,
+;   IN      CONST VOID                *SourceBuffer,
+;   IN      UINTN                     Length
+;   );
+;------------------------------------------------------------------------------
+global ASM_PFX(InternalMemCompareMem)
+ASM_PFX(InternalMemCompareMem):
+    push    esi
+    push    edi
+    mov     esi, [esp + 12]
+    mov     edi, [esp + 16]
+    mov     ecx, [esp + 20]
+    repe    cmpsb
+    movzx   eax, byte [esi - 1]
+    movzx   edx, byte [edi - 1]
+    sub     eax, edx
+    pop     edi
+    pop     esi
+    ret
+

--- a/MdePkg/Library/BaseMemoryLibSse2/Ia32/CopyMem.nasm
+++ b/MdePkg/Library/BaseMemoryLibSse2/Ia32/CopyMem.nasm
@@ -1,0 +1,78 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Module Name:
+;
+;   CopyMem.nasm
+;
+; Abstract:
+;
+;   CopyMem function
+;
+; Notes:
+;
+;------------------------------------------------------------------------------
+
+    SECTION .text
+
+;------------------------------------------------------------------------------
+;  VOID *
+;  InternalMemCopyMem (
+;    IN VOID   *Destination,
+;    IN VOID   *Source,
+;    IN UINTN  Count
+;    );
+;------------------------------------------------------------------------------
+global ASM_PFX(InternalMemCopyMem)
+ASM_PFX(InternalMemCopyMem):
+    push    esi
+    push    edi
+    mov     esi, [esp + 16]             ; esi <- Source
+    mov     edi, [esp + 12]             ; edi <- Destination
+    mov     edx, [esp + 20]             ; edx <- Count
+    lea     eax, [esi + edx - 1]        ; eax <- End of Source
+    cmp     esi, edi
+    jae     .0
+    cmp     eax, edi                    ; Overlapped?
+    jae     @CopyBackward               ; Copy backward if overlapped
+.0:
+    xor     ecx, ecx
+    sub     ecx, edi
+    and     ecx, 15                     ; ecx + edi aligns on 16-byte boundary
+    jz      .1
+    cmp     ecx, edx
+    cmova   ecx, edx
+    sub     edx, ecx                    ; edx <- remaining bytes to copy
+    rep     movsb
+.1:
+    mov     ecx, edx
+    and     edx, 15
+    shr     ecx, 4                      ; ecx <- # of DQwords to copy
+    jz      @CopyBytes
+    add     esp, -16
+    movdqu  [esp], xmm0                 ; save xmm0
+.2:
+    movdqu  xmm0, [esi]                 ; esi may not be 16-bytes aligned
+    movntdq [edi], xmm0                 ; edi should be 16-bytes aligned
+    add     esi, 16
+    add     edi, 16
+    loop    .2
+    mfence
+    movdqu  xmm0, [esp]                 ; restore xmm0
+    add     esp, 16                     ; stack cleanup
+    jmp     @CopyBytes
+@CopyBackward:
+    mov     esi, eax                    ; esi <- Last byte in Source
+    lea     edi, [edi + edx - 1]        ; edi <- Last byte in Destination
+    std
+@CopyBytes:
+    mov     ecx, edx
+    rep     movsb
+    cld
+    mov     eax, [esp + 12]             ; eax <- Destination as return value
+    pop     edi
+    pop     esi
+    ret
+

--- a/MdePkg/Library/BaseMemoryLibSse2/Ia32/IsZeroBuffer.nasm
+++ b/MdePkg/Library/BaseMemoryLibSse2/Ia32/IsZeroBuffer.nasm
@@ -1,0 +1,68 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2016, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Module Name:
+;
+;   IsZeroBuffer.nasm
+;
+; Abstract:
+;
+;   IsZeroBuffer function
+;
+; Notes:
+;
+;------------------------------------------------------------------------------
+
+    SECTION .text
+
+;------------------------------------------------------------------------------
+;  BOOLEAN
+;  EFIAPI
+;  InternalMemIsZeroBuffer (
+;    IN CONST VOID  *Buffer,
+;    IN UINTN       Length
+;    );
+;------------------------------------------------------------------------------
+global ASM_PFX(InternalMemIsZeroBuffer)
+ASM_PFX(InternalMemIsZeroBuffer):
+    push         edi
+    mov          edi, [esp + 8]        ; edi <- Buffer
+    mov          edx, [esp + 12]       ; edx <- Length
+    xor          ecx, ecx              ; ecx <- 0
+    sub          ecx, edi
+    and          ecx, 15               ; ecx + edi aligns on 16-byte boundary
+    jz           @Is16BytesZero
+    cmp          ecx, edx
+    cmova        ecx, edx              ; bytes before the 16-byte boundary
+    sub          edx, ecx
+    xor          eax, eax              ; eax <- 0, also set ZF
+    repe         scasb
+    jnz          @ReturnFalse          ; ZF=0 means non-zero element found
+@Is16BytesZero:
+    mov          ecx, edx
+    and          edx, 15
+    shr          ecx, 4
+    jz           @IsBytesZero
+.0:
+    pxor         xmm0, xmm0            ; xmm0 <- 0
+    pcmpeqb      xmm0, [edi]           ; check zero for 16 bytes
+    pmovmskb     eax, xmm0             ; eax <- compare results
+    cmp          eax, 0xffff
+    jnz          @ReturnFalse
+    add          edi, 16
+    loop         .0
+@IsBytesZero:
+    mov          ecx, edx
+    xor          eax, eax              ; eax <- 0, also set ZF
+    repe         scasb
+    jnz          @ReturnFalse          ; ZF=0 means non-zero element found
+    pop          edi
+    mov          eax, 1                ; return TRUE
+    ret
+@ReturnFalse:
+    pop          edi
+    xor          eax, eax
+    ret                                ; return FALSE
+

--- a/MdePkg/Library/BaseMemoryLibSse2/Ia32/ScanMem16.nasm
+++ b/MdePkg/Library/BaseMemoryLibSse2/Ia32/ScanMem16.nasm
@@ -1,0 +1,48 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2006 - 2008, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Module Name:
+;
+;   ScanMem16.Asm
+;
+; Abstract:
+;
+;   ScanMem16 function
+;
+; Notes:
+;
+;   The following BaseMemoryLib instances contain the same copy of this file:
+;
+;       BaseMemoryLibRepStr
+;       BaseMemoryLibMmx
+;       BaseMemoryLibSse2
+;       BaseMemoryLibOptDxe
+;       BaseMemoryLibOptPei
+;
+;------------------------------------------------------------------------------
+
+    SECTION .text
+
+;------------------------------------------------------------------------------
+; CONST VOID *
+; EFIAPI
+; InternalMemScanMem16 (
+;   IN      CONST VOID                *Buffer,
+;   IN      UINTN                     Length,
+;   IN      UINT16                    Value
+;   );
+;------------------------------------------------------------------------------
+global ASM_PFX(InternalMemScanMem16)
+ASM_PFX(InternalMemScanMem16):
+    push    edi
+    mov     ecx, [esp + 12]
+    mov     edi, [esp + 8]
+    mov     eax, [esp + 16]
+    repne   scasw
+    lea     eax, [edi - 2]
+    cmovnz  eax, ecx
+    pop     edi
+    ret
+

--- a/MdePkg/Library/BaseMemoryLibSse2/Ia32/ScanMem32.nasm
+++ b/MdePkg/Library/BaseMemoryLibSse2/Ia32/ScanMem32.nasm
@@ -1,0 +1,48 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2006 - 2008, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Module Name:
+;
+;   ScanMem32.Asm
+;
+; Abstract:
+;
+;   ScanMem32 function
+;
+; Notes:
+;
+;   The following BaseMemoryLib instances contain the same copy of this file:
+;
+;       BaseMemoryLibRepStr
+;       BaseMemoryLibMmx
+;       BaseMemoryLibSse2
+;       BaseMemoryLibOptDxe
+;       BaseMemoryLibOptPei
+;
+;------------------------------------------------------------------------------
+
+    SECTION .text
+
+;------------------------------------------------------------------------------
+; CONST VOID *
+; EFIAPI
+; InternalMemScanMem32 (
+;   IN      CONST VOID                *Buffer,
+;   IN      UINTN                     Length,
+;   IN      UINT32                    Value
+;   );
+;------------------------------------------------------------------------------
+global ASM_PFX(InternalMemScanMem32)
+ASM_PFX(InternalMemScanMem32):
+    push    edi
+    mov     ecx, [esp + 12]
+    mov     edi, [esp + 8]
+    mov     eax, [esp + 16]
+    repne   scasd
+    lea     eax, [edi - 4]
+    cmovnz  eax, ecx
+    pop     edi
+    ret
+

--- a/MdePkg/Library/BaseMemoryLibSse2/Ia32/ScanMem64.nasm
+++ b/MdePkg/Library/BaseMemoryLibSse2/Ia32/ScanMem64.nasm
@@ -1,0 +1,57 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2006 - 2008, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Module Name:
+;
+;   ScanMem64.Asm
+;
+; Abstract:
+;
+;   ScanMem64 function
+;
+; Notes:
+;
+;   The following BaseMemoryLib instances contain the same copy of this file:
+;
+;       BaseMemoryLibRepStr
+;       BaseMemoryLibMmx
+;       BaseMemoryLibSse2
+;       BaseMemoryLibOptDxe
+;       BaseMemoryLibOptPei
+;
+;------------------------------------------------------------------------------
+
+    SECTION .text
+
+;------------------------------------------------------------------------------
+; CONST VOID *
+; EFIAPI
+; InternalMemScanMem64 (
+;   IN      CONST VOID                *Buffer,
+;   IN      UINTN                     Length,
+;   IN      UINT64                    Value
+;   );
+;------------------------------------------------------------------------------
+global ASM_PFX(InternalMemScanMem64)
+ASM_PFX(InternalMemScanMem64):
+    push    edi
+    mov     ecx, [esp + 12]
+    mov     eax, [esp + 16]
+    mov     edx, [esp + 20]
+    mov     edi, [esp + 8]
+.0:
+    cmp     eax, [edi]
+    lea     edi, [edi + 8]
+    loopne  .0
+    jne     .1
+    cmp     edx, [edi - 4]
+    jecxz   .1
+    jne     .0
+.1:
+    lea     eax, [edi - 8]
+    cmovne  eax, ecx
+    pop     edi
+    ret
+

--- a/MdePkg/Library/BaseMemoryLibSse2/Ia32/ScanMem8.nasm
+++ b/MdePkg/Library/BaseMemoryLibSse2/Ia32/ScanMem8.nasm
@@ -1,0 +1,48 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2006 - 2008, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Module Name:
+;
+;   ScanMem8.Asm
+;
+; Abstract:
+;
+;   ScanMem8 function
+;
+; Notes:
+;
+;   The following BaseMemoryLib instances contain the same copy of this file:
+;
+;       BaseMemoryLibRepStr
+;       BaseMemoryLibMmx
+;       BaseMemoryLibSse2
+;       BaseMemoryLibOptDxe
+;       BaseMemoryLibOptPei
+;
+;------------------------------------------------------------------------------
+
+    SECTION .text
+
+;------------------------------------------------------------------------------
+; CONST VOID *
+; EFIAPI
+; InternalMemScanMem8 (
+;   IN      CONST VOID                *Buffer,
+;   IN      UINTN                     Length,
+;   IN      UINT8                     Value
+;   );
+;------------------------------------------------------------------------------
+global ASM_PFX(InternalMemScanMem8)
+ASM_PFX(InternalMemScanMem8):
+    push    edi
+    mov     ecx, [esp + 12]
+    mov     edi, [esp + 8]
+    mov     al, [esp + 16]
+    repne   scasb
+    lea     eax, [edi - 1]
+    cmovnz  eax, ecx
+    pop     edi
+    ret
+

--- a/MdePkg/Library/BaseMemoryLibSse2/Ia32/SetMem.nasm
+++ b/MdePkg/Library/BaseMemoryLibSse2/Ia32/SetMem.nasm
@@ -1,0 +1,67 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Module Name:
+;
+;   SetMem.nasm
+;
+; Abstract:
+;
+;   SetMem function
+;
+; Notes:
+;
+;------------------------------------------------------------------------------
+
+    SECTION .text
+
+;------------------------------------------------------------------------------
+;  VOID *
+;  EFIAPI
+;  InternalMemSetMem (
+;    IN VOID   *Buffer,
+;    IN UINTN  Count,
+;    IN UINT8  Value
+;    );
+;------------------------------------------------------------------------------
+global ASM_PFX(InternalMemSetMem)
+ASM_PFX(InternalMemSetMem):
+    push    edi
+    mov     edx, [esp + 12]             ; edx <- Count
+    mov     edi, [esp + 8]              ; edi <- Buffer
+    mov     al, [esp + 16]              ; al <- Value
+    xor     ecx, ecx
+    sub     ecx, edi
+    and     ecx, 15                     ; ecx + edi aligns on 16-byte boundary
+    jz      .0
+    cmp     ecx, edx
+    cmova   ecx, edx
+    sub     edx, ecx
+    rep     stosb
+.0:
+    mov     ecx, edx
+    and     edx, 15
+    shr     ecx, 4                      ; ecx <- # of DQwords to set
+    jz      @SetBytes
+    mov     ah, al                      ; ax <- Value | (Value << 8)
+    add     esp, -16
+    movdqu  [esp], xmm0                 ; save xmm0
+    movd    xmm0, eax
+    pshuflw xmm0, xmm0, 0               ; xmm0[0..63] <- Value repeats 8 times
+    movlhps xmm0, xmm0                  ; xmm0 <- Value repeats 16 times
+.1:
+    movntdq [edi], xmm0                 ; edi should be 16-byte aligned
+    add     edi, 16
+    loop    .1
+    mfence
+    movdqu  xmm0, [esp]                 ; restore xmm0
+    add     esp, 16                     ; stack cleanup
+@SetBytes:
+    mov     ecx, edx
+    rep     stosb
+    mov     eax, [esp + 8]              ; eax <- Buffer as return value
+    pop     edi
+    ret
+

--- a/MdePkg/Library/BaseMemoryLibSse2/Ia32/SetMem16.nasm
+++ b/MdePkg/Library/BaseMemoryLibSse2/Ia32/SetMem16.nasm
@@ -1,0 +1,63 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Module Name:
+;
+;   SetMem16.nasm
+;
+; Abstract:
+;
+;   SetMem16 function
+;
+; Notes:
+;
+;------------------------------------------------------------------------------
+
+    SECTION .text
+
+;------------------------------------------------------------------------------
+;  VOID *
+;  EFIAPI
+;  InternalMemSetMem16 (
+;    IN VOID   *Buffer,
+;    IN UINTN  Count,
+;    IN UINT16 Value
+;    );
+;------------------------------------------------------------------------------
+global ASM_PFX(InternalMemSetMem16)
+ASM_PFX(InternalMemSetMem16):
+    push    edi
+    mov     edx, [esp + 12]
+    mov     edi, [esp + 8]
+    xor     ecx, ecx
+    sub     ecx, edi
+    and     ecx, 15                     ; ecx + edi aligns on 16-byte boundary
+    mov     eax, [esp + 16]
+    jz      .0
+    shr     ecx, 1
+    cmp     ecx, edx
+    cmova   ecx, edx
+    sub     edx, ecx
+    rep     stosw
+.0:
+    mov     ecx, edx
+    and     edx, 7
+    shr     ecx, 3
+    jz      @SetWords
+    movd    xmm0, eax
+    pshuflw xmm0, xmm0, 0
+    movlhps xmm0, xmm0
+.1:
+    movntdq [edi], xmm0                 ; edi should be 16-byte aligned
+    add     edi, 16
+    loop    .1
+    mfence
+@SetWords:
+    mov     ecx, edx
+    rep     stosw
+    mov     eax, [esp + 8]
+    pop     edi
+    ret
+

--- a/MdePkg/Library/BaseMemoryLibSse2/Ia32/SetMem32.nasm
+++ b/MdePkg/Library/BaseMemoryLibSse2/Ia32/SetMem32.nasm
@@ -1,0 +1,62 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Module Name:
+;
+;   SetMem32.nasm
+;
+; Abstract:
+;
+;   SetMem32 function
+;
+; Notes:
+;
+;------------------------------------------------------------------------------
+
+    SECTION .text
+
+;------------------------------------------------------------------------------
+;  VOID *
+;  EFIAPI
+;  InternalMemSetMem32 (
+;    IN VOID   *Buffer,
+;    IN UINTN  Count,
+;    IN UINT32 Value
+;    );
+;------------------------------------------------------------------------------
+global ASM_PFX(InternalMemSetMem32)
+ASM_PFX(InternalMemSetMem32):
+    push    edi
+    mov     edx, [esp + 12]
+    mov     edi, [esp + 8]
+    xor     ecx, ecx
+    sub     ecx, edi
+    and     ecx, 15                     ; ecx + edi aligns on 16-byte boundary
+    mov     eax, [esp + 16]
+    jz      .0
+    shr     ecx, 2
+    cmp     ecx, edx
+    cmova   ecx, edx
+    sub     edx, ecx
+    rep     stosd
+.0:
+    mov     ecx, edx
+    and     edx, 3
+    shr     ecx, 2
+    jz      @SetDwords
+    movd    xmm0, eax
+    pshufd  xmm0, xmm0, 0
+.1:
+    movntdq [edi], xmm0
+    add     edi, 16
+    loop    .1
+    mfence
+@SetDwords:
+    mov     ecx, edx
+    rep     stosd
+    mov     eax, [esp + 8]
+    pop     edi
+    ret
+

--- a/MdePkg/Library/BaseMemoryLibSse2/Ia32/SetMem64.nasm
+++ b/MdePkg/Library/BaseMemoryLibSse2/Ia32/SetMem64.nasm
@@ -1,0 +1,54 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Module Name:
+;
+;   SetMem64.nasm
+;
+; Abstract:
+;
+;   SetMem64 function
+;
+; Notes:
+;
+;------------------------------------------------------------------------------
+
+    SECTION .text
+
+;------------------------------------------------------------------------------
+;  VOID *
+;  EFIAPI
+;  InternalMemSetMem64 (
+;    IN VOID   *Buffer,
+;    IN UINTN  Count,
+;    IN UINT64 Value
+;    )
+;------------------------------------------------------------------------------
+global ASM_PFX(InternalMemSetMem64)
+ASM_PFX(InternalMemSetMem64):
+    mov     eax, [esp + 4]              ; eax <- Buffer
+    mov     ecx, [esp + 8]              ; ecx <- Count
+    test    al, 8
+    mov     edx, eax
+    movq    xmm0, qword [esp + 12]
+    jz      .0
+    movq    qword [edx], xmm0
+    add     edx, 8
+    dec     ecx
+.0:
+    shr     ecx, 1
+    jz      @SetQwords
+    movlhps xmm0, xmm0
+.1:
+    movntdq [edx], xmm0
+    lea     edx, [edx + 16]
+    loop    .1
+    mfence
+@SetQwords:
+    jnc     .2
+    movq    qword [edx], xmm0
+.2:
+    ret
+

--- a/MdePkg/Library/BaseMemoryLibSse2/Ia32/ZeroMem.nasm
+++ b/MdePkg/Library/BaseMemoryLibSse2/Ia32/ZeroMem.nasm
@@ -1,0 +1,59 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Module Name:
+;
+;   ZeroMem.nasm
+;
+; Abstract:
+;
+;   ZeroMem function
+;
+; Notes:
+;
+;------------------------------------------------------------------------------
+
+    SECTION .text
+
+;------------------------------------------------------------------------------
+;  VOID *
+;  EFIAPI
+;  InternalMemZeroMem (
+;    IN VOID   *Buffer,
+;    IN UINTN  Count
+;    );
+;------------------------------------------------------------------------------
+global ASM_PFX(InternalMemZeroMem)
+ASM_PFX(InternalMemZeroMem):
+    push    edi
+    mov     edi, [esp + 8]
+    mov     edx, [esp + 12]
+    xor     ecx, ecx
+    sub     ecx, edi
+    xor     eax, eax
+    and     ecx, 15
+    jz      .0
+    cmp     ecx, edx
+    cmova   ecx, edx
+    sub     edx, ecx
+    rep     stosb
+.0:
+    mov     ecx, edx
+    and     edx, 15
+    shr     ecx, 4
+    jz      @ZeroBytes
+    pxor    xmm0, xmm0
+.1:
+    movntdq [edi], xmm0
+    add     edi, 16
+    loop    .1
+    mfence
+@ZeroBytes:
+    mov     ecx, edx
+    rep     stosb
+    mov     eax, [esp + 8]
+    pop     edi
+    ret
+

--- a/MdePkg/Library/BaseMemoryLibSse2/IsZeroBufferWrapper.c
+++ b/MdePkg/Library/BaseMemoryLibSse2/IsZeroBufferWrapper.c
@@ -1,0 +1,48 @@
+/** @file
+  Implementation of IsZeroBuffer function.
+
+  The following BaseMemoryLib instances contain the same copy of this file:
+
+    BaseMemoryLib
+    BaseMemoryLibMmx
+    BaseMemoryLibSse2
+    BaseMemoryLibRepStr
+    BaseMemoryLibOptDxe
+    BaseMemoryLibOptPei
+    PeiMemoryLib
+    UefiMemoryLib
+
+  Copyright (c) 2016, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "MemLibInternals.h"
+
+/**
+  Checks if the contents of a buffer are all zeros.
+
+  This function checks whether the contents of a buffer are all zeros. If the
+  contents are all zeros, return TRUE. Otherwise, return FALSE.
+
+  If Length > 0 and Buffer is NULL, then ASSERT().
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+
+  @param  Buffer      The pointer to the buffer to be checked.
+  @param  Length      The size of the buffer (in bytes) to be checked.
+
+  @retval TRUE        Contents of the buffer are all zeros.
+  @retval FALSE       Contents of the buffer are not all zeros.
+
+**/
+BOOLEAN
+EFIAPI
+IsZeroBuffer (
+  IN CONST VOID  *Buffer,
+  IN UINTN       Length
+  )
+{
+  ASSERT (!(Buffer == NULL && Length > 0));
+  ASSERT ((Length - 1) <= (MAX_ADDRESS - (UINTN)Buffer));
+  return InternalMemIsZeroBuffer (Buffer, Length);
+}

--- a/MdePkg/Library/BaseMemoryLibSse2/MemLibGuid.c
+++ b/MdePkg/Library/BaseMemoryLibSse2/MemLibGuid.c
@@ -1,0 +1,165 @@
+/** @file
+  Implementation of GUID functions.
+
+  The following BaseMemoryLib instances contain the same copy of this file:
+
+    BaseMemoryLib
+    BaseMemoryLibMmx
+    BaseMemoryLibSse2
+    BaseMemoryLibRepStr
+    BaseMemoryLibOptDxe
+    BaseMemoryLibOptPei
+    PeiMemoryLib
+    UefiMemoryLib
+
+  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "MemLibInternals.h"
+
+/**
+  Copies a source GUID to a destination GUID.
+
+  This function copies the contents of the 128-bit GUID specified by SourceGuid to
+  DestinationGuid, and returns DestinationGuid.
+
+  If DestinationGuid is NULL, then ASSERT().
+  If SourceGuid is NULL, then ASSERT().
+
+  @param  DestinationGuid   The pointer to the destination GUID.
+  @param  SourceGuid        The pointer to the source GUID.
+
+  @return DestinationGuid.
+
+**/
+GUID *
+EFIAPI
+CopyGuid (
+  OUT GUID       *DestinationGuid,
+  IN CONST GUID  *SourceGuid
+  )
+{
+  WriteUnaligned64 (
+    (UINT64*)DestinationGuid,
+    ReadUnaligned64 ((CONST UINT64*)SourceGuid)
+    );
+  WriteUnaligned64 (
+    (UINT64*)DestinationGuid + 1,
+    ReadUnaligned64 ((CONST UINT64*)SourceGuid + 1)
+    );
+  return DestinationGuid;
+}
+
+/**
+  Compares two GUIDs.
+
+  This function compares Guid1 to Guid2.  If the GUIDs are identical then TRUE is returned.
+  If there are any bit differences in the two GUIDs, then FALSE is returned.
+
+  If Guid1 is NULL, then ASSERT().
+  If Guid2 is NULL, then ASSERT().
+
+  @param  Guid1       A pointer to a 128 bit GUID.
+  @param  Guid2       A pointer to a 128 bit GUID.
+
+  @retval TRUE        Guid1 and Guid2 are identical.
+  @retval FALSE       Guid1 and Guid2 are not identical.
+
+**/
+BOOLEAN
+EFIAPI
+CompareGuid (
+  IN CONST GUID  *Guid1,
+  IN CONST GUID  *Guid2
+  )
+{
+  UINT64  LowPartOfGuid1;
+  UINT64  LowPartOfGuid2;
+  UINT64  HighPartOfGuid1;
+  UINT64  HighPartOfGuid2;
+
+  LowPartOfGuid1  = ReadUnaligned64 ((CONST UINT64*) Guid1);
+  LowPartOfGuid2  = ReadUnaligned64 ((CONST UINT64*) Guid2);
+  HighPartOfGuid1 = ReadUnaligned64 ((CONST UINT64*) Guid1 + 1);
+  HighPartOfGuid2 = ReadUnaligned64 ((CONST UINT64*) Guid2 + 1);
+
+  return (BOOLEAN) (LowPartOfGuid1 == LowPartOfGuid2 && HighPartOfGuid1 == HighPartOfGuid2);
+}
+
+/**
+  Scans a target buffer for a GUID, and returns a pointer to the matching GUID
+  in the target buffer.
+
+  This function searches the target buffer specified by Buffer and Length from
+  the lowest address to the highest address at 128-bit increments for the 128-bit
+  GUID value that matches Guid.  If a match is found, then a pointer to the matching
+  GUID in the target buffer is returned.  If no match is found, then NULL is returned.
+  If Length is 0, then NULL is returned.
+
+  If Length > 0 and Buffer is NULL, then ASSERT().
+  If Buffer is not aligned on a 32-bit boundary, then ASSERT().
+  If Length is not aligned on a 128-bit boundary, then ASSERT().
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+
+  @param  Buffer  The pointer to the target buffer to scan.
+  @param  Length  The number of bytes in Buffer to scan.
+  @param  Guid    The value to search for in the target buffer.
+
+  @return A pointer to the matching Guid in the target buffer or NULL otherwise.
+
+**/
+VOID *
+EFIAPI
+ScanGuid (
+  IN CONST VOID  *Buffer,
+  IN UINTN       Length,
+  IN CONST GUID  *Guid
+  )
+{
+  CONST GUID                        *GuidPtr;
+
+  ASSERT (((UINTN)Buffer & (sizeof (Guid->Data1) - 1)) == 0);
+  ASSERT (Length <= (MAX_ADDRESS - (UINTN)Buffer + 1));
+  ASSERT ((Length & (sizeof (*GuidPtr) - 1)) == 0);
+
+  GuidPtr = (GUID*)Buffer;
+  Buffer  = GuidPtr + Length / sizeof (*GuidPtr);
+  while (GuidPtr < (CONST GUID*)Buffer) {
+    if (CompareGuid (GuidPtr, Guid)) {
+      return (VOID*)GuidPtr;
+    }
+    GuidPtr++;
+  }
+  return NULL;
+}
+
+/**
+  Checks if the given GUID is a zero GUID.
+
+  This function checks whether the given GUID is a zero GUID. If the GUID is
+  identical to a zero GUID then TRUE is returned. Otherwise, FALSE is returned.
+
+  If Guid is NULL, then ASSERT().
+
+  @param  Guid        The pointer to a 128 bit GUID.
+
+  @retval TRUE        Guid is a zero GUID.
+  @retval FALSE       Guid is not a zero GUID.
+
+**/
+BOOLEAN
+EFIAPI
+IsZeroGuid (
+  IN CONST GUID  *Guid
+  )
+{
+  UINT64  LowPartOfGuid;
+  UINT64  HighPartOfGuid;
+
+  LowPartOfGuid  = ReadUnaligned64 ((CONST UINT64*) Guid);
+  HighPartOfGuid = ReadUnaligned64 ((CONST UINT64*) Guid + 1);
+
+  return (BOOLEAN) (LowPartOfGuid == 0 && HighPartOfGuid == 0);
+}

--- a/MdePkg/Library/BaseMemoryLibSse2/MemLibInternals.h
+++ b/MdePkg/Library/BaseMemoryLibSse2/MemLibInternals.h
@@ -1,0 +1,245 @@
+/** @file
+  Declaration of internal functions for Base Memory Library.
+
+  The following BaseMemoryLib instances contain the same copy of this file:
+    BaseMemoryLib
+    BaseMemoryLibMmx
+    BaseMemoryLibSse2
+    BaseMemoryLibRepStr
+    BaseMemoryLibOptDxe
+    BaseMemoryLibOptPei
+
+  Copyright (c) 2006 - 2016, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __MEM_LIB_INTERNALS__
+#define __MEM_LIB_INTERNALS__
+
+#include <Base.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+
+/**
+  Copy Length bytes from Source to Destination.
+
+  @param  DestinationBuffer The target of the copy request.
+  @param  SourceBuffer      The place to copy from.
+  @param  Length            The number of bytes to copy.
+
+  @return Destination
+
+**/
+VOID *
+EFIAPI
+InternalMemCopyMem (
+  OUT     VOID                      *DestinationBuffer,
+  IN      CONST VOID                *SourceBuffer,
+  IN      UINTN                     Length
+  );
+
+/**
+  Set Buffer to Value for Size bytes.
+
+  @param  Buffer   The memory to set.
+  @param  Length   The number of bytes to set.
+  @param  Value    The value of the set operation.
+
+  @return Buffer
+
+**/
+VOID *
+EFIAPI
+InternalMemSetMem (
+  OUT     VOID                      *Buffer,
+  IN      UINTN                     Length,
+  IN      UINT8                     Value
+  );
+
+/**
+  Fills a target buffer with a 16-bit value, and returns the target buffer.
+
+  @param  Buffer  The pointer to the target buffer to fill.
+  @param  Length  The count of 16-bit value to fill.
+  @param  Value   The value with which to fill Length bytes of Buffer.
+
+  @return Buffer
+
+**/
+VOID *
+EFIAPI
+InternalMemSetMem16 (
+  OUT     VOID                      *Buffer,
+  IN      UINTN                     Length,
+  IN      UINT16                    Value
+  );
+
+/**
+  Fills a target buffer with a 32-bit value, and returns the target buffer.
+
+  @param  Buffer  The pointer to the target buffer to fill.
+  @param  Length  The count of 32-bit value to fill.
+  @param  Value   The value with which to fill Length bytes of Buffer.
+
+  @return Buffer
+
+**/
+VOID *
+EFIAPI
+InternalMemSetMem32 (
+  OUT     VOID                      *Buffer,
+  IN      UINTN                     Length,
+  IN      UINT32                    Value
+  );
+
+/**
+  Fills a target buffer with a 64-bit value, and returns the target buffer.
+
+  @param  Buffer  The pointer to the target buffer to fill.
+  @param  Length  The count of 64-bit value to fill.
+  @param  Value   The value with which to fill Length bytes of Buffer.
+
+  @return Buffer
+
+**/
+VOID *
+EFIAPI
+InternalMemSetMem64 (
+  OUT     VOID                      *Buffer,
+  IN      UINTN                     Length,
+  IN      UINT64                    Value
+  );
+
+/**
+  Set Buffer to 0 for Size bytes.
+
+  @param  Buffer Memory to set.
+  @param  Length The number of bytes to set
+
+  @return Buffer
+
+**/
+VOID *
+EFIAPI
+InternalMemZeroMem (
+  OUT     VOID                      *Buffer,
+  IN      UINTN                     Length
+  );
+
+/**
+  Compares two memory buffers of a given length.
+
+  @param  DestinationBuffer The first memory buffer.
+  @param  SourceBuffer      The second memory buffer.
+  @param  Length            The length of DestinationBuffer and SourceBuffer memory
+                            regions to compare. Must be non-zero.
+
+  @return 0                 All Length bytes of the two buffers are identical.
+  @retval Non-zero          The first mismatched byte in SourceBuffer subtracted from the first
+                            mismatched byte in DestinationBuffer.
+
+**/
+INTN
+EFIAPI
+InternalMemCompareMem (
+  IN      CONST VOID                *DestinationBuffer,
+  IN      CONST VOID                *SourceBuffer,
+  IN      UINTN                     Length
+  );
+
+/**
+  Scans a target buffer for an 8-bit value, and returns a pointer to the
+  matching 8-bit value in the target buffer.
+
+  @param  Buffer  The pointer to the target buffer to scan.
+  @param  Length  The count of 8-bit value to scan. Must be non-zero.
+  @param  Value   The value to search for in the target buffer.
+
+  @return The pointer to the first occurrence or NULL if not found.
+
+**/
+CONST VOID *
+EFIAPI
+InternalMemScanMem8 (
+  IN      CONST VOID                *Buffer,
+  IN      UINTN                     Length,
+  IN      UINT8                     Value
+  );
+
+/**
+  Scans a target buffer for a 16-bit value, and returns a pointer to the
+  matching 16-bit value in the target buffer.
+
+  @param  Buffer  The pointer to the target buffer to scan.
+  @param  Length  The count of 16-bit value to scan. Must be non-zero.
+  @param  Value   The value to search for in the target buffer.
+
+  @return The pointer to the first occurrence or NULL if not found.
+
+**/
+CONST VOID *
+EFIAPI
+InternalMemScanMem16 (
+  IN      CONST VOID                *Buffer,
+  IN      UINTN                     Length,
+  IN      UINT16                    Value
+  );
+
+/**
+  Scans a target buffer for a 32-bit value, and returns a pointer to the
+  matching 32-bit value in the target buffer.
+
+  @param  Buffer  The pointer to the target buffer to scan.
+  @param  Length  The count of 32-bit value to scan. Must be non-zero.
+  @param  Value   The value to search for in the target buffer.
+
+  @return The pointer to the first occurrence or NULL if not found.
+
+**/
+CONST VOID *
+EFIAPI
+InternalMemScanMem32 (
+  IN      CONST VOID                *Buffer,
+  IN      UINTN                     Length,
+  IN      UINT32                    Value
+  );
+
+/**
+  Scans a target buffer for a 64-bit value, and returns a pointer to the
+  matching 64-bit value in the target buffer.
+
+  @param  Buffer  The pointer to the target buffer to scan.
+  @param  Length  The count of 64-bit value to scan. Must be non-zero.
+  @param  Value   The value to search for in the target buffer.
+
+  @return A pointer to the first occurrence or NULL if not found.
+
+**/
+CONST VOID *
+EFIAPI
+InternalMemScanMem64 (
+  IN      CONST VOID                *Buffer,
+  IN      UINTN                     Length,
+  IN      UINT64                    Value
+  );
+
+/**
+  Checks whether the contents of a buffer are all zeros.
+
+  @param  Buffer  The pointer to the buffer to be checked.
+  @param  Length  The size of the buffer (in bytes) to be checked.
+
+  @retval TRUE    Contents of the buffer are all zeros.
+  @retval FALSE   Contents of the buffer are not all zeros.
+
+**/
+BOOLEAN
+EFIAPI
+InternalMemIsZeroBuffer (
+  IN CONST VOID  *Buffer,
+  IN UINTN       Length
+  );
+
+#endif

--- a/MdePkg/Library/BaseMemoryLibSse2/ScanMem16Wrapper.c
+++ b/MdePkg/Library/BaseMemoryLibSse2/ScanMem16Wrapper.c
@@ -1,0 +1,61 @@
+/** @file
+  ScanMem16() implementation.
+
+  The following BaseMemoryLib instances contain the same copy of this file:
+
+    BaseMemoryLib
+    BaseMemoryLibMmx
+    BaseMemoryLibSse2
+    BaseMemoryLibRepStr
+    BaseMemoryLibOptDxe
+    BaseMemoryLibOptPei
+    PeiMemoryLib
+    UefiMemoryLib
+
+  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "MemLibInternals.h"
+
+/**
+  Scans a target buffer for a 16-bit value, and returns a pointer to the matching 16-bit value
+  in the target buffer.
+
+  This function searches the target buffer specified by Buffer and Length from the lowest
+  address to the highest address for a 16-bit value that matches Value.  If a match is found,
+  then a pointer to the matching byte in the target buffer is returned.  If no match is found,
+  then NULL is returned.  If Length is 0, then NULL is returned.
+
+  If Length > 0 and Buffer is NULL, then ASSERT().
+  If Buffer is not aligned on a 16-bit boundary, then ASSERT().
+  If Length is not aligned on a 16-bit boundary, then ASSERT().
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+
+  @param  Buffer      The pointer to the target buffer to scan.
+  @param  Length      The number of bytes in Buffer to scan.
+  @param  Value       The value to search for in the target buffer.
+
+  @return A pointer to the matching byte in the target buffer or NULL otherwise.
+
+**/
+VOID *
+EFIAPI
+ScanMem16 (
+  IN CONST VOID  *Buffer,
+  IN UINTN       Length,
+  IN UINT16      Value
+  )
+{
+  if (Length == 0) {
+    return NULL;
+  }
+
+  ASSERT (Buffer != NULL);
+  ASSERT (((UINTN)Buffer & (sizeof (Value) - 1)) == 0);
+  ASSERT ((Length - 1) <= (MAX_ADDRESS - (UINTN)Buffer));
+  ASSERT ((Length & (sizeof (Value) - 1)) == 0);
+
+  return (VOID*)InternalMemScanMem16 (Buffer, Length / sizeof (Value), Value);
+}

--- a/MdePkg/Library/BaseMemoryLibSse2/ScanMem32Wrapper.c
+++ b/MdePkg/Library/BaseMemoryLibSse2/ScanMem32Wrapper.c
@@ -1,0 +1,60 @@
+/** @file
+  ScanMem32() implementation.
+
+  The following BaseMemoryLib instances contain the same copy of this file:
+    BaseMemoryLib
+    BaseMemoryLibMmx
+    BaseMemoryLibSse2
+    BaseMemoryLibRepStr
+    BaseMemoryLibOptDxe
+    BaseMemoryLibOptPei
+    PeiMemoryLib
+    UefiMemoryLib
+
+  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "MemLibInternals.h"
+
+/**
+  Scans a target buffer for a 32-bit value, and returns a pointer to the matching 32-bit value
+  in the target buffer.
+
+  This function searches the target buffer specified by Buffer and Length from the lowest
+  address to the highest address for a 32-bit value that matches Value.  If a match is found,
+  then a pointer to the matching byte in the target buffer is returned.  If no match is found,
+  then NULL is returned.  If Length is 0, then NULL is returned.
+
+  If Length > 0 and Buffer is NULL, then ASSERT().
+  If Buffer is not aligned on a 32-bit boundary, then ASSERT().
+  If Length is not aligned on a 32-bit boundary, then ASSERT().
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+
+  @param  Buffer      The pointer to the target buffer to scan.
+  @param  Length      The number of bytes in Buffer to scan.
+  @param  Value       The value to search for in the target buffer.
+
+  @return A pointer to the matching byte in the target buffer or NULL otherwise.
+
+**/
+VOID *
+EFIAPI
+ScanMem32 (
+  IN CONST VOID  *Buffer,
+  IN UINTN       Length,
+  IN UINT32      Value
+  )
+{
+  if (Length == 0) {
+    return NULL;
+  }
+
+  ASSERT (Buffer != NULL);
+  ASSERT (((UINTN)Buffer & (sizeof (Value) - 1)) == 0);
+  ASSERT ((Length - 1) <= (MAX_ADDRESS - (UINTN)Buffer));
+  ASSERT ((Length & (sizeof (Value) - 1)) == 0);
+
+  return (VOID*)InternalMemScanMem32 (Buffer, Length / sizeof (Value), Value);
+}

--- a/MdePkg/Library/BaseMemoryLibSse2/ScanMem64Wrapper.c
+++ b/MdePkg/Library/BaseMemoryLibSse2/ScanMem64Wrapper.c
@@ -1,0 +1,61 @@
+/** @file
+  ScanMem64() implementation.
+
+  The following BaseMemoryLib instances contain the same copy of this file:
+
+    BaseMemoryLib
+    BaseMemoryLibMmx
+    BaseMemoryLibSse2
+    BaseMemoryLibRepStr
+    BaseMemoryLibOptDxe
+    BaseMemoryLibOptPei
+    PeiMemoryLib
+    UefiMemoryLib
+
+  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "MemLibInternals.h"
+
+/**
+  Scans a target buffer for a 64-bit value, and returns a pointer to the matching 64-bit value
+  in the target buffer.
+
+  This function searches the target buffer specified by Buffer and Length from the lowest
+  address to the highest address for a 64-bit value that matches Value.  If a match is found,
+  then a pointer to the matching byte in the target buffer is returned.  If no match is found,
+  then NULL is returned.  If Length is 0, then NULL is returned.
+
+  If Length > 0 and Buffer is NULL, then ASSERT().
+  If Buffer is not aligned on a 64-bit boundary, then ASSERT().
+  If Length is not aligned on a 64-bit boundary, then ASSERT().
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+
+  @param  Buffer      The pointer to the target buffer to scan.
+  @param  Length      The number of bytes in Buffer to scan.
+  @param  Value       The value to search for in the target buffer.
+
+  @return A pointer to the matching byte in the target buffer or NULL otherwise.
+
+**/
+VOID *
+EFIAPI
+ScanMem64 (
+  IN CONST VOID  *Buffer,
+  IN UINTN       Length,
+  IN UINT64      Value
+  )
+{
+  if (Length == 0) {
+    return NULL;
+  }
+
+  ASSERT (Buffer != NULL);
+  ASSERT (((UINTN)Buffer & (sizeof (Value) - 1)) == 0);
+  ASSERT ((Length - 1) <= (MAX_ADDRESS - (UINTN)Buffer));
+  ASSERT ((Length & (sizeof (Value) - 1)) == 0);
+
+  return (VOID*)InternalMemScanMem64 (Buffer, Length / sizeof (Value), Value);
+}

--- a/MdePkg/Library/BaseMemoryLibSse2/ScanMem8Wrapper.c
+++ b/MdePkg/Library/BaseMemoryLibSse2/ScanMem8Wrapper.c
@@ -1,0 +1,93 @@
+/** @file
+  ScanMem8() and ScanMemN() implementation.
+
+  The following BaseMemoryLib instances contain the same copy of this file:
+
+    BaseMemoryLib
+    BaseMemoryLibMmx
+    BaseMemoryLibSse2
+    BaseMemoryLibRepStr
+    BaseMemoryLibOptDxe
+    BaseMemoryLibOptPei
+    PeiMemoryLib
+    UefiMemoryLib
+
+  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "MemLibInternals.h"
+
+/**
+  Scans a target buffer for an 8-bit value, and returns a pointer to the matching 8-bit value
+  in the target buffer.
+
+  This function searches the target buffer specified by Buffer and Length from the lowest
+  address to the highest address for an 8-bit value that matches Value.  If a match is found,
+  then a pointer to the matching byte in the target buffer is returned.  If no match is found,
+  then NULL is returned.  If Length is 0, then NULL is returned.
+
+  If Length > 0 and Buffer is NULL, then ASSERT().
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+
+  @param  Buffer      The pointer to the target buffer to scan.
+  @param  Length      The number of bytes in Buffer to scan.
+  @param  Value       The value to search for in the target buffer.
+
+  @return A pointer to the matching byte in the target buffer or NULL otherwise.
+
+**/
+VOID *
+EFIAPI
+ScanMem8 (
+  IN CONST VOID  *Buffer,
+  IN UINTN       Length,
+  IN UINT8       Value
+  )
+{
+  if (Length == 0) {
+    return NULL;
+  }
+  ASSERT (Buffer != NULL);
+  ASSERT ((Length - 1) <= (MAX_ADDRESS - (UINTN)Buffer));
+
+  return (VOID*)InternalMemScanMem8 (Buffer, Length, Value);
+}
+
+/**
+  Scans a target buffer for a UINTN sized value, and returns a pointer to the matching
+  UINTN sized value in the target buffer.
+
+  This function searches the target buffer specified by Buffer and Length from the lowest
+  address to the highest address for a UINTN sized value that matches Value.  If a match is found,
+  then a pointer to the matching byte in the target buffer is returned.  If no match is found,
+  then NULL is returned.  If Length is 0, then NULL is returned.
+
+  If Length > 0 and Buffer is NULL, then ASSERT().
+  If Buffer is not aligned on a UINTN boundary, then ASSERT().
+  If Length is not aligned on a UINTN boundary, then ASSERT().
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+
+  @param  Buffer      The pointer to the target buffer to scan.
+  @param  Length      The number of bytes in Buffer to scan.
+  @param  Value       The value to search for in the target buffer.
+
+  @return A pointer to the matching byte in the target buffer or NULL otherwise.
+
+**/
+VOID *
+EFIAPI
+ScanMemN (
+  IN CONST VOID  *Buffer,
+  IN UINTN       Length,
+  IN UINTN       Value
+  )
+{
+  if (sizeof (UINTN) == sizeof (UINT64)) {
+    return ScanMem64 (Buffer, Length, (UINT64)Value);
+  } else {
+    return ScanMem32 (Buffer, Length, (UINT32)Value);
+  }
+}
+

--- a/MdePkg/Library/BaseMemoryLibSse2/SetMem16Wrapper.c
+++ b/MdePkg/Library/BaseMemoryLibSse2/SetMem16Wrapper.c
@@ -1,0 +1,58 @@
+/** @file
+  SetMem16() implementation.
+
+  The following BaseMemoryLib instances contain the same copy of this file:
+    BaseMemoryLib
+    BaseMemoryLibMmx
+    BaseMemoryLibSse2
+    BaseMemoryLibRepStr
+    BaseMemoryLibOptDxe
+    BaseMemoryLibOptPei
+    PeiMemoryLib
+    UefiMemoryLib
+
+  Copyright (c) 2006 - 2010, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "MemLibInternals.h"
+
+/**
+  Fills a target buffer with a 16-bit value, and returns the target buffer.
+
+  This function fills Length bytes of Buffer with the 16-bit value specified by
+  Value, and returns Buffer. Value is repeated every 16-bits in for Length
+  bytes of Buffer.
+
+  If Length > 0 and Buffer is NULL, then ASSERT().
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+  If Buffer is not aligned on a 16-bit boundary, then ASSERT().
+  If Length is not aligned on a 16-bit boundary, then ASSERT().
+
+  @param  Buffer  The pointer to the target buffer to fill.
+  @param  Length  The number of bytes in Buffer to fill.
+  @param  Value   The value with which to fill Length bytes of Buffer.
+
+  @return Buffer.
+
+**/
+VOID *
+EFIAPI
+SetMem16 (
+  OUT VOID   *Buffer,
+  IN UINTN   Length,
+  IN UINT16  Value
+  )
+{
+  if (Length == 0) {
+    return Buffer;
+  }
+
+  ASSERT (Buffer != NULL);
+  ASSERT ((Length - 1) <= (MAX_ADDRESS - (UINTN)Buffer));
+  ASSERT ((((UINTN)Buffer) & (sizeof (Value) - 1)) == 0);
+  ASSERT ((Length & (sizeof (Value) - 1)) == 0);
+
+  return InternalMemSetMem16 (Buffer, Length / sizeof (Value), Value);
+}

--- a/MdePkg/Library/BaseMemoryLibSse2/SetMem32Wrapper.c
+++ b/MdePkg/Library/BaseMemoryLibSse2/SetMem32Wrapper.c
@@ -1,0 +1,58 @@
+/** @file
+  SetMem32() implementation.
+
+  The following BaseMemoryLib instances contain the same copy of this file:
+    BaseMemoryLib
+    BaseMemoryLibMmx
+    BaseMemoryLibSse2
+    BaseMemoryLibRepStr
+    BaseMemoryLibOptDxe
+    BaseMemoryLibOptPei
+    PeiMemoryLib
+    UefiMemoryLib
+
+  Copyright (c) 2006 - 2010, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "MemLibInternals.h"
+
+/**
+  Fills a target buffer with a 32-bit value, and returns the target buffer.
+
+  This function fills Length bytes of Buffer with the 32-bit value specified by
+  Value, and returns Buffer. Value is repeated every 32-bits in for Length
+  bytes of Buffer.
+
+  If Length > 0 and Buffer is NULL, then ASSERT().
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+  If Buffer is not aligned on a 32-bit boundary, then ASSERT().
+  If Length is not aligned on a 32-bit boundary, then ASSERT().
+
+  @param  Buffer  The pointer to the target buffer to fill.
+  @param  Length  The number of bytes in Buffer to fill.
+  @param  Value   The value with which to fill Length bytes of Buffer.
+
+  @return Buffer.
+
+**/
+VOID *
+EFIAPI
+SetMem32 (
+  OUT VOID   *Buffer,
+  IN UINTN   Length,
+  IN UINT32  Value
+  )
+{
+  if (Length == 0) {
+    return Buffer;
+  }
+
+  ASSERT (Buffer != NULL);
+  ASSERT ((Length - 1) <= (MAX_ADDRESS - (UINTN)Buffer));
+  ASSERT ((((UINTN)Buffer) & (sizeof (Value) - 1)) == 0);
+  ASSERT ((Length & (sizeof (Value) - 1)) == 0);
+
+  return InternalMemSetMem32 (Buffer, Length / sizeof (Value), Value);
+}

--- a/MdePkg/Library/BaseMemoryLibSse2/SetMem64Wrapper.c
+++ b/MdePkg/Library/BaseMemoryLibSse2/SetMem64Wrapper.c
@@ -1,0 +1,58 @@
+/** @file
+  SetMem64() implementation.
+
+  The following BaseMemoryLib instances contain the same copy of this file:
+    BaseMemoryLib
+    BaseMemoryLibMmx
+    BaseMemoryLibSse2
+    BaseMemoryLibRepStr
+    BaseMemoryLibOptDxe
+    BaseMemoryLibOptPei
+    PeiMemoryLib
+    UefiMemoryLib
+
+  Copyright (c) 2006 - 2010, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "MemLibInternals.h"
+
+/**
+  Fills a target buffer with a 64-bit value, and returns the target buffer.
+
+  This function fills Length bytes of Buffer with the 64-bit value specified by
+  Value, and returns Buffer. Value is repeated every 64-bits in for Length
+  bytes of Buffer.
+
+  If Length > 0 and Buffer is NULL, then ASSERT().
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+  If Buffer is not aligned on a 64-bit boundary, then ASSERT().
+  If Length is not aligned on a 64-bit boundary, then ASSERT().
+
+  @param  Buffer  The pointer to the target buffer to fill.
+  @param  Length  The number of bytes in Buffer to fill.
+  @param  Value   The value with which to fill Length bytes of Buffer.
+
+  @return Buffer.
+
+**/
+VOID *
+EFIAPI
+SetMem64 (
+  OUT VOID   *Buffer,
+  IN UINTN   Length,
+  IN UINT64  Value
+  )
+{
+  if (Length == 0) {
+    return Buffer;
+  }
+
+  ASSERT (Buffer != NULL);
+  ASSERT ((Length - 1) <= (MAX_ADDRESS - (UINTN)Buffer));
+  ASSERT ((((UINTN)Buffer) & (sizeof (Value) - 1)) == 0);
+  ASSERT ((Length & (sizeof (Value) - 1)) == 0);
+
+  return InternalMemSetMem64 (Buffer, Length / sizeof (Value), Value);
+}

--- a/MdePkg/Library/BaseMemoryLibSse2/SetMemWrapper.c
+++ b/MdePkg/Library/BaseMemoryLibSse2/SetMemWrapper.c
@@ -1,0 +1,85 @@
+/** @file
+  SetMem() and SetMemN() implementation.
+
+  The following BaseMemoryLib instances contain the same copy of this file:
+
+    BaseMemoryLib
+    BaseMemoryLibMmx
+    BaseMemoryLibSse2
+    BaseMemoryLibRepStr
+    BaseMemoryLibOptDxe
+    BaseMemoryLibOptPei
+    PeiMemoryLib
+    UefiMemoryLib
+
+  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "MemLibInternals.h"
+
+/**
+  Fills a target buffer with a byte value, and returns the target buffer.
+
+  This function fills Length bytes of Buffer with Value, and returns Buffer.
+
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+
+  @param  Buffer    The memory to set.
+  @param  Length    The number of bytes to set.
+  @param  Value     The value with which to fill Length bytes of Buffer.
+
+  @return Buffer.
+
+**/
+VOID *
+EFIAPI
+SetMem (
+  OUT VOID  *Buffer,
+  IN UINTN  Length,
+  IN UINT8  Value
+  )
+{
+  if (Length == 0) {
+    return Buffer;
+  }
+
+  ASSERT ((Length - 1) <= (MAX_ADDRESS - (UINTN)Buffer));
+
+  return InternalMemSetMem (Buffer, Length, Value);
+}
+
+/**
+  Fills a target buffer with a value that is size UINTN, and returns the target buffer.
+
+  This function fills Length bytes of Buffer with the UINTN sized value specified by
+  Value, and returns Buffer. Value is repeated every sizeof(UINTN) bytes for Length
+  bytes of Buffer.
+
+  If Length > 0 and Buffer is NULL, then ASSERT().
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+  If Buffer is not aligned on a UINTN boundary, then ASSERT().
+  If Length is not aligned on a UINTN boundary, then ASSERT().
+
+  @param  Buffer  The pointer to the target buffer to fill.
+  @param  Length  The number of bytes in Buffer to fill.
+  @param  Value   The value with which to fill Length bytes of Buffer.
+
+  @return Buffer.
+
+**/
+VOID *
+EFIAPI
+SetMemN (
+  OUT VOID  *Buffer,
+  IN UINTN  Length,
+  IN UINTN  Value
+  )
+{
+  if (sizeof (UINTN) == sizeof (UINT64)) {
+    return SetMem64 (Buffer, Length, (UINT64)Value);
+  } else {
+    return SetMem32 (Buffer, Length, (UINT32)Value);
+  }
+}

--- a/MdePkg/Library/BaseMemoryLibSse2/ZeroMemWrapper.c
+++ b/MdePkg/Library/BaseMemoryLibSse2/ZeroMemWrapper.c
@@ -1,0 +1,50 @@
+/** @file
+  ZeroMem() implementation.
+
+  The following BaseMemoryLib instances contain the same copy of this file:
+
+    BaseMemoryLib
+    BaseMemoryLibMmx
+    BaseMemoryLibSse2
+    BaseMemoryLibRepStr
+    BaseMemoryLibOptDxe
+    BaseMemoryLibOptPei
+    PeiMemoryLib
+    UefiMemoryLib
+
+  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "MemLibInternals.h"
+
+/**
+  Fills a target buffer with zeros, and returns the target buffer.
+
+  This function fills Length bytes of Buffer with zeros, and returns Buffer.
+
+  If Length > 0 and Buffer is NULL, then ASSERT().
+  If Length is greater than (MAX_ADDRESS - Buffer + 1), then ASSERT().
+
+  @param  Buffer      The pointer to the target buffer to fill with zeros.
+  @param  Length      The number of bytes in Buffer to fill with zeros.
+
+  @return Buffer.
+
+**/
+VOID *
+EFIAPI
+ZeroMem (
+  OUT VOID  *Buffer,
+  IN UINTN  Length
+  )
+{
+  if (Length == 0) {
+    return Buffer;
+  }
+
+  ASSERT (Buffer != NULL);
+  ASSERT (Length <= (MAX_ADDRESS - (UINTN)Buffer + 1));
+  return InternalMemZeroMem (Buffer, Length);
+}


### PR DESCRIPTION
Copying the MdePkg BaseMemoryLibSse2 library into
SBL for faster CopyMem and other routines to improve
boot performance during splash screen displaying
and OS Loader payload execution.

The BaseMemoryLibSse2 folder was copied from EDK2
GitHub based on the following commit ID:

9344f0921518309295da89c221d10cbead8531aa

Signed-off-by: James Gutbub <james.gutbub@intel.com>