### PR TITLE
Add HobListPtr to pre-OS payload param struct

### DIFF
--- a/PayloadPkg/Include/Library/PayloadLib.h
+++ b/PayloadPkg/Include/Library/PayloadLib.h
@@ -57,6 +57,7 @@ typedef struct {
   UINT32        HeapSize;
   UINT32        HeapAddr;
   OS_BOOT_STATE OsBootState;
+  UINT32        HobListPtr;
 } PRE_OS_PAYLOAD_PARAM;
 
 #pragma pack ()

--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -500,6 +500,7 @@ StartBooting (
       PreOsParams.Version  = 0x1;
       PreOsParams.HeapSize = EFI_SIZE_TO_PAGES (0);
       PreOsParams.HeapAddr = (UINT32) AllocatePages (PreOsParams.HeapSize);
+      PreOsParams.HobListPtr = PcdGet32 (PcdPayloadHobList);
 
       PreOsParams.OsBootState.Esi = (UINT32) BootParams;
       PreOsParams.OsBootState.Eip = BootParams->Hdr.Code32Start;


### PR DESCRIPTION
It might be useful for the pre-OS payload/checker
to have a handle to the HOB list data for additional
support or data checking that the HOB list contains.

Signed-off-by: James Gutbub <james.gutbub@intel.com>