### PR TITLE
Add MP hook point for platform CPU init

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -146,6 +146,7 @@
   gPlatformModuleTokenSpaceGuid.PcdSmbiosTablesBase       | 0x00000000 | UINT32 | 0x20000197
   gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsPtr       | 0x00000000 | UINT32 | 0x20000198
   gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsCnt       |     0x0000 | UINT16 | 0x20000199
+  gPlatformModuleTokenSpaceGuid.PcdFuncCpuInitHook        | 0x00000000 | UINT32 | 0x2000019A
 
 
 [PcdsFeatureFlag]

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -270,6 +270,7 @@
   gPlatformModuleTokenSpaceGuid.PcdSmbiosTablesBase  | 0x00000000
   gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsPtr  | 0x00000000
   gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsCnt  | 0x0000
+  gPlatformModuleTokenSpaceGuid.PcdFuncCpuInitHook   | 0x00000000
 
 [PcdsFeatureFlag]
   gPlatformCommonLibTokenSpaceGuid.PcdMinDecompression    | FALSE

--- a/BootloaderCorePkg/Include/Library/MpInitLib.h
+++ b/BootloaderCorePkg/Include/Library/MpInitLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2016 - 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -49,7 +49,8 @@ typedef struct {
   CPU_TASK         CpuTask[0];
 } SYS_CPU_TASK;
 
-typedef UINT32 (*CPU_TASK_PROC) (UINT32 Arg);
+typedef UINT32 (*CPU_TASK_PROC)          (UINT32 Arg);
+typedef VOID   (*PLATFORM_CPU_INIT_HOOK) (UINT32 CpuIndex);
 
 /**
   Run a task function for a specific processor.

--- a/BootloaderCorePkg/Library/MpInitLib/Ia32/MpInitLib.c
+++ b/BootloaderCorePkg/Library/MpInitLib/Ia32/MpInitLib.c
@@ -1,7 +1,7 @@
 /** @file
   MP init library implementation.
 
-  Copyright (c) 2015 - 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015 - 2019, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -65,12 +65,13 @@ SmmRebase (
 EFI_STATUS
 EFIAPI
 CpuInit (
-  IN UINT32     Index
+  IN UINT32               Index
   )
 {
-  SMMBASE_INFO  *SmmBaseInfo;
-  UINT32         ApicId;
-  UINT32         CpuIdx;
+  SMMBASE_INFO            *SmmBaseInfo;
+  UINT32                  ApicId;
+  UINT32                  CpuIdx;
+  PLATFORM_CPU_INIT_HOOK  PlatformCpuInitHook;
 
   ApicId = GetApicId();
   if (Index < PcdGet32 (PcdCpuMaxLogicalProcessorNumber)) {
@@ -94,6 +95,11 @@ CpuInit (
     }
   } else if (PcdGet8 (PcdSmmRebaseMode) == SMM_REBASE_ENABLE) {
     SmmRebase (Index, ApicId, 0);
+  }
+
+  PlatformCpuInitHook = (PLATFORM_CPU_INIT_HOOK)(UINTN)PcdGet32 (PcdFuncCpuInitHook);
+  if (PlatformCpuInitHook != NULL) {
+    PlatformCpuInitHook (Index);
   }
 
   return EFI_SUCCESS;

--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
 #  which accompanies this distribution.  The full text of the license may be found at
@@ -54,3 +54,4 @@
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegBase
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegSize
   gPlatformModuleTokenSpaceGuid.PcdSmmRebaseMode
+  gPlatformModuleTokenSpaceGuid.PcdFuncCpuInitHook

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -101,3 +101,4 @@
   gPlatformModuleTokenSpaceGuid.PcdSmmRebaseMode
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegBase
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegSize
+  gPlatformModuleTokenSpaceGuid.PcdFuncCpuInitHook


### PR DESCRIPTION
Some platform might need do some platform specific init
on all the threads. So add a MP hook using a PCD.
Np impact for the platform that doesn't need this hook.
This patch also enable InSMM bit for APL.

Signed-off-by: Guo Dong <guo.dong@intel.com>