### PR TITLE
[APL] Fix firmware update failure

### DIFF
--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -438,14 +438,20 @@ GetStateMachineFlag (
   IN OUT UINT8    *StateMachine
 )
 {
-  FIRMWARE_UPDATE_STATUS  *FwUpdStatus;
+  EFI_STATUS              Status;
+  UINT32                  FwUpdStatusOffset;
+  FIRMWARE_UPDATE_STATUS  FwUpdStatus;
 
   //
   // Read from the reserved region and return state machine
   //
-  FwUpdStatus = (FIRMWARE_UPDATE_STATUS *)(PcdGet32(PcdRsvdRegionBase));
-
-  *StateMachine = FwUpdStatus->StateMachine;
+  FwUpdStatusOffset = PcdGet32(PcdFwUpdStatusBase);
+  Status = BootMediaRead (FwUpdStatusOffset, sizeof(FIRMWARE_UPDATE_STATUS), (UINT8 *)&FwUpdStatus);
+  if (EFI_ERROR (Status)) {
+    *StateMachine = FW_UPDATE_SM_INIT;
+  } else {
+    *StateMachine = FwUpdStatus.StateMachine;
+  }
 }
 
 /**
@@ -468,7 +474,7 @@ SetStateMachineFlag (
   UINT32                  FwUpdStatusOffset;
   FIRMWARE_UPDATE_STATUS  FwUpdStatus;
 
-  DEBUG((DEBUG_INIT, "Set next FWU state to 0x%02X\n", StateMachine));
+  DEBUG((DEBUG_INIT, "Set next FWU state: 0x%02X\n", StateMachine));
 
   //
   // Any value less than 0xFC is invalid

--- a/Silicon/ApollolakePkg/Library/HeciLib/HeciLib.c
+++ b/Silicon/ApollolakePkg/Library/HeciLib/HeciLib.c
@@ -1009,11 +1009,11 @@ PrepareCseForFirmwareUpdate (
   HECI_RES_IFWI_PREPARE_FOR_UPDATE *Response;
 
   ZeroMem(DataBuffer, sizeof(DataBuffer));
+  Response = (HECI_RES_IFWI_PREPARE_FOR_UPDATE*)DataBuffer;
 
   Request = (HECI_REQ_IFWI_PREPARE_FOR_UPDATE*)DataBuffer;
-  Request->MkhiHeader.Fields.GroupId = 0x20;
-  Request->MkhiHeader.Fields.Command = 0x01;
-
+  Request->MkhiHeader.Fields.GroupId = MKHI_IFWI_UPDATE_GROUP_ID;
+  Request->MkhiHeader.Fields.Command = IFWI_PREPARE_FOR_UPDATE_CMD_ID;
   Request->ResetType = 1;
 
   HeciSendLength = sizeof (HECI_REQ_IFWI_PREPARE_FOR_UPDATE) - 3;
@@ -1031,20 +1031,18 @@ PrepareCseForFirmwareUpdate (
     return Status;
   }
 
-  Response = (HECI_RES_IFWI_PREPARE_FOR_UPDATE*)DataBuffer;
-
   if (Response->MkhiHeader.Fields.Result != 0x0) {
     DEBUG ((EFI_D_ERROR, "Rejected request IFWI prepare update \n"));
     return EFI_ACCESS_DENIED;
   }
-
+  
   if (Response->Flag == 0x02) {
-    DEBUG ((EFI_D_ERROR, "HECI/CSE prepare for update failed \n"));
+    return EFI_SUCCESS;
+  } else {
+    DEBUG ((EFI_D_ERROR, "HECI/CSE prepare for update not ready yet \n"));
     return EFI_DEVICE_ERROR;
   }
 
-  DEBUG ((EFI_D_ERROR, "HECI/CSE ready for update \n"));
-  return EFI_SUCCESS;
 }
 
 /**

--- a/Silicon/ApollolakePkg/Library/HeciLib/MkhiMsgs.h
+++ b/Silicon/ApollolakePkg/Library/HeciLib/MkhiMsgs.h
@@ -91,4 +91,7 @@ typedef struct {
 #define COMMON_GROUP_ID          0xF0
 #define DRAM_INIT_DONE_CMD       0x01
 
+#define MKHI_IFWI_UPDATE_GROUP_ID       0x20
+#define IFWI_PREPARE_FOR_UPDATE_CMD_ID  0x01
+
 #endif // _MKHI_MSGS_H


### PR DESCRIPTION
Firmware update with latest code broke on APL platform.
This patch fixed #162 by:
- Corrected the HECI command response flag check
- Always read FWU state machine using SPI command instead memory map

Signed-off-by: Maurice Ma <maurice.ma@intel.com>