### PR TITLE
[PartitionLib] Added ClosePartitions to clean-up partition data

### DIFF
--- a/BootloaderCommonPkg/Include/Library/PartitionLib.h
+++ b/BootloaderCommonPkg/Include/Library/PartitionLib.h
@@ -94,4 +94,18 @@ FindPartitions (
   OUT  EFI_HANDLE          *PartHandle
   );
 
+/**
+  Clean-up allocated memory/etc. used for partitions
+
+  @param[in]  PartHandle      The partition handle to clean-up
+
+  @retval                     none
+
+**/
+VOID
+EFIAPI
+ClosePartitions (
+  IN   EFI_HANDLE             PartHandle
+  );
+
 #endif

--- a/BootloaderCommonPkg/Library/PartitionLib/PartitionLib.c
+++ b/BootloaderCommonPkg/Library/PartitionLib/PartitionLib.c
@@ -596,3 +596,30 @@ FindPartitions (
 
   return Status;
 }
+
+/**
+  Clean-up allocated memory/etc. used for partitions
+
+  @param[in]  PartHandle      The partition handle to clean-up
+
+  @retval                     none
+
+**/
+VOID
+EFIAPI
+ClosePartitions (
+  IN   EFI_HANDLE             PartHandle
+  )
+{
+  PART_BLOCK_DEVICE           *PartBlockDev;
+
+  PartBlockDev = NULL;
+  if (PartHandle != NULL) {
+    PartBlockDev = (PART_BLOCK_DEVICE *)PartHandle;
+    ASSERT (PartBlockDev->Signature == PART_INFO_SIGNATURE);
+  }
+
+  if ((PartBlockDev != NULL) && (PartBlockDev->Signature == PART_INFO_SIGNATURE)) {
+    FreePool (PartBlockDev);
+  }
+}

--- a/PayloadPkg/OsLoader/LoadImage.c
+++ b/PayloadPkg/OsLoader/LoadImage.c
@@ -71,6 +71,7 @@ FindBootPartition (
   Status = FindPartitions (BootOption->HwPart, HwPartHandle);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "Failed to find partition - %r\n", Status));
+    ClosePartitions (*HwPartHandle);
     return Status;
   }
   AddMeasurePoint (0x4060);


### PR DESCRIPTION
The FindPartitions() allocates memory for PART_BLOCK_DEVICE instance.
This allocated memory needs to be de-allocated if no more necessary
to avoid memory leak.

TBD: Current partition info needs to be cleared before going to next
boot option.

Signed-off-by: Aiden Park <aiden.park@intel.com>