### PR TITLE
Clean up PCI MM address

### DIFF
--- a/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
+++ b/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -63,6 +63,9 @@ typedef struct {
 
 #define TO_MM_PCI_ADDRESS( Addr ) \
   MM_PCI_ADDRESS ( ((Addr) >> 16) & 0xFF, ((Addr) >> 8) & 0xFF, (Addr) & 0xFF, 0)
+
+#define TO_PCI_LIB_ADDRESS( Addr ) \
+  PCI_LIB_ADDRESS ( ((Addr) >> 16) & 0xFF, ((Addr) >> 8) & 0xFF, (Addr) & 0xFF, 0)
 
 //
 // Enumeration of stages of bootloader execution.

--- a/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -1032,7 +1032,7 @@ UpdateResetReason (
     RstCause = ResetWakeS3;
   }
 
-  Bar     = MmioRead32 (MmPciAddress (0, 0, PCI_DEVICE_NUMBER_PMC, PCI_FUNCTION_NUMBER_PMC, R_PMC_BASE)) & ~0x0F;
+  Bar     = MmioRead32 (MM_PCI_ADDRESS (0, PCI_DEVICE_NUMBER_PMC, PCI_FUNCTION_NUMBER_PMC, R_PMC_BASE)) & ~0x0F;
   PmConf1 = MmioRead32 (Bar + R_PMC_GEN_PMCON_1);
 
   TcoStatus = IoRead32(ACPI_BASE_ADDRESS + R_TCO_STS);
@@ -1458,7 +1458,7 @@ EarlyPcieLinkUp (
     PortIndex = 5;
     ClkReqNum = 0xF;
 
-    Address = MmioRead32 (MmPciAddress (0, 0, PCI_DEVICE_NUMBER_P2SB, PCI_FUNCTION_NUMBER_P2SB, R_P2SB_BASE)) & B_PCH_P2SB_SBREG_RBA;
+    Address = MmioRead32 (MM_PCI_ADDRESS (0, PCI_DEVICE_NUMBER_P2SB, PCI_FUNCTION_NUMBER_P2SB, R_P2SB_BASE)) & B_PCH_P2SB_SBREG_RBA;
     Address |= (0xB0 << 16);                                        // PID_FIA: 0xB0
     Address |= (0x100 + (SC_PCIE_ROOT_PORT_FUNC (PortIndex) / 2)); // R_SC_PCR_FIA_DRCRM1: 0x100
     Data8   = MmioRead8 (Address);
@@ -1467,7 +1467,7 @@ EarlyPcieLinkUp (
     MmioWrite8 (Address, Data8);
     DEBUG ((DEBUG_INFO, "Address = 0x%08X Value = 0x%X\n", Address, Data8));
 
-    Address = MmPciAddress (0, 0, SC_PCIE_ROOT_PORT_BUS (PortIndex), SC_PCIE_ROOT_PORT_FUNC (PortIndex), 0);
+    Address = MM_PCI_ADDRESS (0, SC_PCIE_ROOT_PORT_BUS (PortIndex), SC_PCIE_ROOT_PORT_FUNC (PortIndex), 0);
     DEBUG ((DEBUG_INFO, "RpBase = 0x%08X\n", Address));
     MmioOr16 (Address + R_PCH_PCIE_XCAP, B_PCIE_XCAP_SI);
   }
@@ -1675,7 +1675,7 @@ RtcInit (
   UINT8   PmConf1;
   UINT8   Data8;
 
-  Bar     = MmioRead32 (MmPciAddress (0, 0, PCI_DEVICE_NUMBER_PMC, PCI_FUNCTION_NUMBER_PMC, R_PMC_BASE)) & ~0x0F;
+  Bar     = MmioRead32 (MM_PCI_ADDRESS (0, PCI_DEVICE_NUMBER_PMC, PCI_FUNCTION_NUMBER_PMC, R_PMC_BASE)) & ~0x0F;
   PmConf1 = MmioRead8 (Bar + R_PMC_GEN_PMCON_1);
 
   if ((PmConf1 & B_PMC_GEN_PMCON_RTC_PWR_STS) != 0) {

--- a/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
+++ b/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
 #  which accompanies this distribution.  The full text of the license may be found at
@@ -68,6 +68,7 @@
   gPlatformModuleTokenSpaceGuid.PcdCfgDatabaseSize
   gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootEnabled
+  gPlatformModuleTokenSpaceGuid.PcdAcpiEnabled
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
   gPlatformModuleTokenSpaceGuid.PcdCfgDataSize
   gPlatformModuleTokenSpaceGuid.PcdStage1BLoadBase

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -393,12 +393,12 @@ AssignPciIrqs (
   // Need to program interrupt register for add-in cards
   Shift = 0;
   for (Function = PCI_FUNCTION_NUMBER_PCIE_ROOT_PORT_5; Function <= PCI_FUNCTION_NUMBER_PCIE_ROOT_PORT_6; Function++) {
-    PciBase = MmPciBase (DEFAULT_PCI_BUS_NUMBER_SC, PCI_DEVICE_NUMBER_SC_PCIE_DEVICE_2, Function);
+    PciBase = MM_PCI_ADDRESS (DEFAULT_PCI_BUS_NUMBER_SC, PCI_DEVICE_NUMBER_SC_PCIE_DEVICE_2, Function, 0); 
     if (MmioRead32(PciBase) == 0xFFFFFFFF) {
       continue;
     }
     Bus = MmioRead8(PciBase + PCI_BRIDGE_SECONDARY_BUS_REGISTER_OFFSET);
-    PciBase = MmPciBase (Bus, 0, 0);
+    PciBase = MM_PCI_ADDRESS (Bus, 0, 0, 0);
     if (MmioRead32(PciBase) == 0xFFFFFFFF) {
       continue;
     } else {

--- a/Silicon/ApollolakePkg/Include/RegAccess.h
+++ b/Silicon/ApollolakePkg/Include/RegAccess.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -20,15 +20,5 @@
 #include <PcieRegs.h>
 #include <SocRegs.h>
 #include <PlatformBase.h>
-
-#define MmPciAddress( Segment, Bus, Device, Function, Register ) \
-  ( (UINTN)PcdGet64(PcdPciExpressBaseAddress) + \
-    (UINTN)(Bus << 20) + \
-    (UINTN)(Device << 15) + \
-    (UINTN)(Function << 12) + \
-    (UINTN)(Register) \
-  )
-
-#define MmPciBase(Bus, Device, Function)   MmPciAddress(0, Bus, Device, Function, 0)
 
 #endif

--- a/Silicon/ApollolakePkg/Library/GpioLib/GpioLib.c
+++ b/Silicon/ApollolakePkg/Library/GpioLib/GpioLib.c
@@ -1,7 +1,7 @@
 /** @file
   The platform GPIO library.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -18,6 +18,7 @@
 #include <RegAccess.h>
 #include <GpioDefines.h>
 #include <Library/ScSbiAccessLib.h>
+#include <Library/BootloaderCommonLib.h>
 
 //
 // Structure for storing information about registers offset, community,
@@ -118,11 +119,7 @@ GetBxtSeries (
   UINT16  VenId;
   UINT16  DevId;
 
-  McD0Base = MmPciBase (
-               SA_MC_BUS,
-               SA_MC_DEV,
-               SA_MC_FUN
-               );
+  McD0Base = MM_PCI_ADDRESS (SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, 0);
 
   VenId = MmioRead16 (McD0Base + PCI_VENDOR_ID_OFFSET);
   DevId = MmioRead16 (McD0Base + PCI_DEVICE_ID_OFFSET);
@@ -182,7 +179,7 @@ GetSideBandMmioAddress(
   IN UINT16 TargetRegister
   )
 {
-  UINT32 Temp = MmioRead32(MmPciAddress(0, 0, PCI_DEVICE_NUMBER_P2SB, PCI_FUNCTION_NUMBER_P2SB, 0) + R_P2SB_BASE) & 0xff000000;
+  UINT32 Temp = MmioRead32(MM_PCI_ADDRESS(0, PCI_DEVICE_NUMBER_P2SB, PCI_FUNCTION_NUMBER_P2SB, 0) + R_P2SB_BASE) & 0xff000000;
   Temp |= TargetPortId << 16;
   Temp |= TargetRegister;
 

--- a/Silicon/ApollolakePkg/Library/GpioLib/GpioLib.inf
+++ b/Silicon/ApollolakePkg/Library/GpioLib/GpioLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
 #  which accompanies this distribution.  The full text of the license may be found at
@@ -31,6 +31,7 @@
 [Packages]
   MdePkg/MdePkg.dec
   BootloaderCorePkg/BootloaderCorePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
   Silicon/ApollolakePkg/ApollolakePkg.dec
   
 [LibraryClasses]

--- a/Silicon/ApollolakePkg/Library/PlatformHookLib/PlatformHookLib.c
+++ b/Silicon/ApollolakePkg/Library/PlatformHookLib/PlatformHookLib.c
@@ -1,7 +1,7 @@
 /** @file
   The platform hook library.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -18,7 +18,7 @@
 #include <Library/BaseLib.h>
 #include <Library/IoLib.h>
 #include <Library/BootloaderCoreLib.h>
-
+#include <Library/BootloaderCommonLib.h>
 #include <RegAccess.h>
 #include <PlatformHookSupport.h>
 
@@ -44,13 +44,7 @@ UartPortInitialize (
   //
   // Program the UART PCI resource
   //
-  PciUartMmBase = MmPciAddress (
-                    0,
-                    DEFAULT_PCI_BUS_NUMBER_SC,
-                    PCI_DEVICE_NUMBER_LPSS_HSUART,
-                    (PCI_FUNCTION_NUMBER_LPSS_HSUART0 + Port),
-                    0
-                    );
+  PciUartMmBase = MM_PCI_ADDRESS (0, PCI_DEVICE_NUMBER_LPSS_HSUART, PCI_FUNCTION_NUMBER_LPSS_HSUART0 + Port, 0);
   if (MmioRead8 (PciUartMmBase + R_LPSS_IO_STSCMD) & 0x02) {
     PciBar = MmioRead32 (PciUartMmBase + R_LPSS_IO_BAR) & 0xFFFFFFF0;
   } else {

--- a/Silicon/ApollolakePkg/Library/PlatformHookLib/PlatformHookSupport.c
+++ b/Silicon/ApollolakePkg/Library/PlatformHookLib/PlatformHookSupport.c
@@ -1,7 +1,7 @@
 /** @file
   The platform hook library.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -19,6 +19,7 @@
 #include <Library/IoLib.h>
 #include <RegAccess.h>
 #include <PlatformHookSupport.h>
+#include <Library/BootloaderCommonLib.h>
 
 typedef struct {
   UINT16  Community   : 4;
@@ -68,11 +69,7 @@ GetUartBaseAddress (
 {
   UINTN                 PciUartMmBase;
 
-  PciUartMmBase = MmPciAddress (0,\
-    DEFAULT_PCI_BUS_NUMBER_SC, \
-    PCI_DEVICE_NUMBER_LPSS_HSUART, \
-    (PCI_FUNCTION_NUMBER_LPSS_HSUART0 + Port), \
-    0);
+  PciUartMmBase = MM_PCI_ADDRESS (0, PCI_DEVICE_NUMBER_LPSS_HSUART, PCI_FUNCTION_NUMBER_LPSS_HSUART0 + Port, 0);
 
   if ((MmioRead8 (PciUartMmBase + R_LPSS_IO_STSCMD) & 0x02) != 0x02) {
     DEBUG ((DEBUG_ERROR, "UART%d was not configured properly!", Port));

--- a/Silicon/ApollolakePkg/Library/ScSbiAccessLib/ScSbiAccessLib.c
+++ b/Silicon/ApollolakePkg/Library/ScSbiAccessLib/ScSbiAccessLib.c
@@ -1,7 +1,7 @@
 /** @file
   Program SC SBI register.
 
-  Copyright (c) 2013 - 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2013 - 2019, Intel Corporation. All rights reserved.<BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -17,6 +17,7 @@
 #include <Library/DebugLib.h>
 #include <RegAccess.h>
 #include <Library/ScSbiAccessLib.h>
+#include <Library/BootloaderCommonLib.h>
 
 EFI_STATUS
 EFIAPI
@@ -136,11 +137,7 @@ PchSbiExecutionEx (
   }
 
   P2sbOrgStatus = FALSE;
-  P2sbBase      = MmPciBase (
-                    DEFAULT_PCI_BUS_NUMBER_SC,
-                    PCI_DEVICE_NUMBER_P2SB,
-                    PCI_FUNCTION_NUMBER_P2SB
-                    );
+  P2sbBase      = MM_PCI_ADDRESS (0, PCI_DEVICE_NUMBER_P2SB, PCI_FUNCTION_NUMBER_P2SB, 0);
   PchRevealP2sb (P2sbBase, &P2sbOrgStatus);
 
   Timeout = 0xFFFFFFF;
@@ -255,11 +252,7 @@ PchSbiRegisterSave (
   UINTN                                 Timeout;
   UINT16                                SbiStat;
 
-  P2sbBase      = MmPciBase (
-                    DEFAULT_PCI_BUS_NUMBER_SC,
-                    PCI_DEVICE_NUMBER_P2SB,
-                    PCI_FUNCTION_NUMBER_P2SB
-                    );
+  P2sbBase = MM_PCI_ADDRESS (0, PCI_DEVICE_NUMBER_P2SB, PCI_FUNCTION_NUMBER_P2SB, 0);
   if (MmioRead16 (P2sbBase + PCI_VENDOR_ID_OFFSET) == 0xFFFF) {
     return EFI_DEVICE_ERROR;
   }
@@ -312,11 +305,7 @@ PchSbiRegisterRestore (
   UINTN                                 Timeout;
   UINT16                                SbiStat;
 
-  P2sbBase      = MmPciBase (
-                    DEFAULT_PCI_BUS_NUMBER_SC,
-                    PCI_DEVICE_NUMBER_P2SB,
-                    PCI_FUNCTION_NUMBER_P2SB
-                    );
+  P2sbBase = MM_PCI_ADDRESS (0, PCI_DEVICE_NUMBER_P2SB, PCI_FUNCTION_NUMBER_P2SB, 0);
   if (MmioRead16 (P2sbBase + PCI_VENDOR_ID_OFFSET) == 0xFFFF) {
     return EFI_DEVICE_ERROR;
   }

--- a/Silicon/ApollolakePkg/Library/ScSbiAccessLib/ScSbiAccessLib.inf
+++ b/Silicon/ApollolakePkg/Library/ScSbiAccessLib/ScSbiAccessLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
 #  which accompanies this distribution.  The full text of the license may be found at
@@ -31,6 +31,7 @@
 [Packages]
   MdePkg/MdePkg.dec
   BootloaderCorePkg/BootloaderCorePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
   Silicon/ApollolakePkg/ApollolakePkg.dec
  
 [LibraryClasses]

--- a/Silicon/ApollolakePkg/Library/SerialPortLib/SerialPortLib.c
+++ b/Silicon/ApollolakePkg/Library/SerialPortLib/SerialPortLib.c
@@ -1,7 +1,7 @@
 /** @file
   Serial I/O Port library functions with no library constructor/destructor
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -79,8 +79,7 @@ GetPciUartBase (
   UINT32  PciUartMmBase;
   UINT16  Cmd16;
 
-  PciUartMmBase = MmPciAddress (
-                    0,
+  PciUartMmBase = MM_PCI_ADDRESS (
                     DEFAULT_PCI_BUS_NUMBER_SC,
                     PCI_DEVICE_NUMBER_LPSS_HSUART,
                     (PCI_FUNCTION_NUMBER_LPSS_HSUART0 + GetDebugPort()),


### PR DESCRIPTION
Common MM_PCI_ADDRESS() provided PCI device BDF to PCIE MMIO base address.
So remove MmPciAddress() and MmPciBase () defined in platform and update
code to use MM_PCI_ADDRESS().
Add TO_PCI_LIB_ADDRESS() in common library.

Signed-off-by: Guo Dong <guo.dong@intel.com>