### PR TITLE
Add ACPI_ENABLED()

### DIFF
--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
   which accompanies this distribution.  The full text of the license may be found at
@@ -144,8 +144,12 @@ typedef struct {
 
 #pragma pack()
 
-#define ACPI_FEATURE_ENABLED()    (GetFeatureCfg() & FEATURE_ACPI)
-#define MEASURED_BOOT_ENABLED()   (ACPI_FEATURE_ENABLED() && FeaturePcdGet (PcdMeasuredBootEnabled) && (GetFeatureCfg() & FEATURE_MEASURED_BOOT))
+//
+// These MACRO definations should be used only after feature config data is set in stage1b.
+//
+#define ACPI_FEATURE_ENABLED()   (GetFeatureCfg() & FEATURE_ACPI)
+#define ACPI_ENABLED()           (FeaturePcdGet (PcdAcpiEnabled) && ACPI_FEATURE_ENABLED())
+#define MEASURED_BOOT_ENABLED()  (FeaturePcdGet (PcdMeasuredBootEnabled) && (GetFeatureCfg() & FEATURE_MEASURED_BOOT) && ACPI_FEATURE_ENABLED())
 
 /*
           Reserved MEM

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -491,7 +491,7 @@ SecStartup (
   }
 
   // ACPI Initialization
-  if ( FixedPcdGetBool (PcdAcpiEnabled) && ACPI_FEATURE_ENABLED() ) {
+  if (ACPI_ENABLED()) {
     if (PcdGet32 (PcdLoaderAcpiNvsSize) < GetAcpiGnvsSize()) {
       AcpiGnvs = 0;
       AcpiTop  = 0;
@@ -549,7 +549,7 @@ SecStartup (
   AddMeasurePoint (0x30E0);
 
   // Continue boot flow
-  if (FixedPcdGetBool (PcdAcpiEnabled) && (BootMode == BOOT_ON_S3_RESUME) && ACPI_FEATURE_ENABLED() ) {
+  if (ACPI_ENABLED() && (BootMode == BOOT_ON_S3_RESUME)) {
     S3ResumePath (Stage2Hob);
   } else {
     NormalBootPath (Stage2Hob);

--- a/Silicon/ApollolakePkg/Include/PlatformData.h
+++ b/Silicon/ApollolakePkg/Include/PlatformData.h
@@ -142,7 +142,7 @@ typedef struct {
 
 #define PLAT_DATA                         ((PLATFORM_DATA *)GetPlatformDataPtr ())
 #define PLAT_FEAT                         (PLAT_DATA->PlatformFeatures)
-#define VT_ENABLED()                      (ACPI_FEATURE_ENABLED() && FeaturePcdGet (PcdVtdEnabled) && PLAT_FEAT.Vt)
+#define VT_ENABLED()                      (FeaturePcdGet (PcdVtdEnabled) && ACPI_FEATURE_ENABLED() && PLAT_FEAT.Vt)
 #define EMMC_TUNE_FEATURE_ENABLED()       (PLAT_FEAT.eMMCTuning)
 #define DCI_DBG_FEATURE_ENABLED()         (PLAT_FEAT.DciDebug)
 


### PR DESCRIPTION
Add ACPI_ENABLED() to align with MEASURED_BOOT_ENABLED().
Update MEASURED_BOOT_ENABLED() by checking PcdMeasuredBootEnabled
firstly.
Update PlatformFeaturesInit () in stage1b to fix potential
inconsistent.
Update other code for changes above.

Signed-off-by: Guo Dong <guo.dong@intel.com>