### PR TITLE
Fix FAT file path matching issue

### DIFF
--- a/BootloaderCommonPkg/Library/FatLib/FatLib.c
+++ b/BootloaderCommonPkg/Library/FatLib/FatLib.c
@@ -137,10 +137,17 @@ FindFile (
           //
           // Compare whether the file name is recovery file name.
           //
-          if (EngStrniColl (NodeCurr, File->FileName, NodeLen) ||
-              EngStrniColl (NodeCurr, File->LongFileName, NodeLen)) {
-            break;
+          if (EngStrniColl (NodeCurr, File->FileName, NodeLen)) {
+            if (File->FileName[NodeLen] == 0) {
+              break;
+            }
           }
+
+          if (EngStrniColl (NodeCurr, File->LongFileName, NodeLen)) {
+            if (File->LongFileName[NodeLen] == 0) {
+              break;
+            }
+           }
         }
       } while (Status == EFI_SUCCESS);
       if (EFI_ERROR (Status)) {

--- a/PayloadPkg/OsLoader/BootConfig.c
+++ b/PayloadPkg/OsLoader/BootConfig.c
@@ -260,7 +260,7 @@ ParseLinuxBootConfig (
       CurrLine = TrimLeft (CurrLine);
       MenuEntry[EntryNum].Command.Pos = CurrLine - CfgBuffer;
       EndLine  = TrimRight (EndLine);
-      MenuEntry[EntryNum].Command.Len = EndLine - CfgBuffer - MenuEntry[EntryNum].Command.Pos;
+      MenuEntry[EntryNum].Command.Len = EndLine - CfgBuffer - MenuEntry[EntryNum].Command.Pos + 1;
     } else if (MatchKeyWord (CurrLine, "initrd") > 0) {
       CurrLine += 6;
 
@@ -268,7 +268,7 @@ ParseLinuxBootConfig (
       CurrLine = TrimLeft (CurrLine);
       MenuEntry[EntryNum].InitRd.Pos = CurrLine - CfgBuffer;
       EndLine  = TrimRight (EndLine);
-      MenuEntry[EntryNum].InitRd.Len = EndLine - CfgBuffer - MenuEntry[EntryNum].InitRd.Pos;
+      MenuEntry[EntryNum].InitRd.Len = EndLine - CfgBuffer - MenuEntry[EntryNum].InitRd.Pos + 1;
     }
 
     CurrLine = NextLine;


### PR DESCRIPTION
In current FAT lib, the file path matching code will just compare
the 1st N chars and ignored the remaining. The end of the string
should be checked to ensure exact matching. As part of this fix,
the GRUB config parsing library needs to be updated since the file
name length field is one less than expected.

It fixed #183.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>