### PR TITLE
Fix boot performance issue for BP1

### DIFF
--- a/BootloaderCommonPkg/Library/BootloaderCommonLib/BootloaderCommonLib.c
+++ b/BootloaderCommonPkg/Library/BootloaderCommonLib/BootloaderCommonLib.c
@@ -357,7 +357,7 @@ GetComponentInfoByPartition (
       // Check if need to get back up copy
       // Back up copies can be identified with back up flag
       //
-      if ( ((EntryDesc.Flags & FLASH_MAP_FLAGS_NON_REDUNDANT_REGION) != 0) ||
+      if ( ((EntryDesc.Flags & (FLASH_MAP_FLAGS_NON_REDUNDANT_REGION | FLASH_MAP_FLAGS_NON_VOLATILE_REGION)) != 0) ||
            (((IsBackupPartition ? FLASH_MAP_FLAGS_BACKUP : 0) ^ (EntryDesc.Flags & FLASH_MAP_FLAGS_BACKUP)) == 0) ) {
         PcdBase = (UINT32) (RomBase + EntryDesc.Offset);
         PcdSize = EntryDesc.Size;
@@ -458,7 +458,7 @@ GetRegionOffsetSize (
 /**
   This function retrieves a GUIDed HOB data and size.
 
-  This function will search the HobListPtr to find the first GUIDed HOB that 
+  This function will search the HobListPtr to find the first GUIDed HOB that
   its GUID matches Guid, and return the GUID size in Length if Lengh is no NULL.
   If HobListPtr is NULL, it will use the loader HOB list.
 

--- a/Platform/CoffeelakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.inf
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.inf
@@ -43,8 +43,11 @@
 
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
+  gPlatformModuleTokenSpaceGuid.PcdFlashSize
 
 [FixedPcd]
+  gPlatformModuleTokenSpaceGuid.PcdStage1ABase
+  gPlatformModuleTokenSpaceGuid.PcdStage1ASize
   gPlatformModuleTokenSpaceGuid.PcdUcodeBase
   gPlatformModuleTokenSpaceGuid.PcdUcodeSize
   gPlatformModuleTokenSpaceGuid.PcdPayloadBase

--- a/Silicon/CoffeelakePkg/Include/Register/CpuRegs.h
+++ b/Silicon/CoffeelakePkg/Include/Register/CpuRegs.h
@@ -9,6 +9,16 @@
 #ifndef _CPU_REGS_H_
 #define _CPU_REGS_H_
 
+#define EFI_CACHE_UNCACHEABLE                  0
+#define EFI_CACHE_WRITECOMBINING               1
+#define EFI_CACHE_WRITETHROUGH                 4
+#define EFI_CACHE_WRITEPROTECTED               5
+#define EFI_CACHE_WRITEBACK                    6
+
+#define MSR_CACHE_VARIABLE_MTRR_BASE                                  0x200
+#define B_CACHE_MTRR_VALID                                            BIT11
+#define B_CACHE_FIXED_MTRR_VALID                                      BIT10
+
 #define MSR_BOOT_GUARD_SACM_INFO                                      0x13A
 #define V_TPM_PRESENT_MASK                                            0x06
 #define B_BOOT_GUARD_SACM_INFO_NEM_ENABLED                            BIT0


### PR DESCRIPTION
On WHL, if using Boot Guard profile 0, booting from BP1 will be
significantly slower than BP0. It is because some code region in BP1
is not covered by MTRR cache settings. This patch adjusted MTRR
settings during PostTempRamInit notification to cover full flash
code region if Boot Guard profile 0 is used.

It fixed #188.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>