### PR TITLE
Change DEBUG_ERROR to DEBUG_INFO for update fail

### DIFF
--- a/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -169,7 +169,7 @@ UpdateFspConfig (
   }
 
   if (!(UpdateFspmSgxConfig (FspmUpd))) {
-    DEBUG ((DEBUG_ERROR, "UpdateFspmSgxConfig failed.\n"));
+    DEBUG ((DEBUG_INFO, "FSP-M variables for Intel(R) SGX were NOT updated.\n"));
   }
 
   Fspmcfg->PlatformDebugConsent = MemCfgData->PlatformDebugConsent;

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1581,7 +1581,7 @@ UpdateFspConfig (
   }
 
   if (!(UpdateFspsSgxConfig (FspsUpd))) {
-    DEBUG ((DEBUG_ERROR, "UpdateFspsSgxConfig failed.\n"));
+    DEBUG ((DEBUG_INFO, "FSP-S variables for Intel(R) SGX were NOT updated.\n"));
   }
 }
 


### PR DESCRIPTION
Change DEBUG_ERROR to DEBUG_INFO for reporting UpdateFspmSgxConfig() and
UpdateFspsSgxConfig() return statuses since failing to update FSP
variables for Intel(R) SGX is not necessarily due to an error.

Signed-off-by: Iyer, Naveen <naveen.iyer@intel.com>