### PR TITLE
Add call to board notifications by default

### DIFF
--- a/BootloaderCommonPkg/Library/LoaderPerformanceLib/LoaderPerformancePrintLib.c
+++ b/BootloaderCommonPkg/Library/LoaderPerformanceLib/LoaderPerformancePrintLib.c
@@ -128,7 +128,7 @@ DefPerfIdToStr (
   case 0x31E0:
     return "FSP EndOfFirmware notify";
   case 0x31F0:
-    return "Board ReadyToBoot hook";
+    return "End of stage2";
   }
   return NULL;
 }


### PR DESCRIPTION
Current SBL does not call board ReadyToBoot & EndOfFirmware phases
in Stage on normal boot flow. Current open source UEFI payload does not
do it either. It caused some security concerns. The patch enforced
these notification calls on normal boot flow in SBL for all payloads
except for those that can handle board and FSP notification on its own.

It fixed #191.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>