### PR TITLE
Exclude board notifications for built-in payloads

### DIFF
--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -225,6 +225,7 @@ NormalBootPath (
   LOADER_GLOBAL_DATA             *LdrGlobal;
   EFI_STATUS                      Status;
   BOOLEAN                         CallBoardNotify;
+  UINT32                          PayloadId;
 
   LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer();
 
@@ -270,12 +271,19 @@ NormalBootPath (
 
   BoardInit (EndOfStages);
 
-  CallBoardNotify = TRUE;
-  if ((GetPayloadId () == UEFI_PAYLOAD_ID_SIGNATURE) && (Dst[0] != 0)) {
+  PayloadId = GetPayloadId ();
+  if (PayloadId == 0) {
+    // For built-in payload including OsLoader and FirmwareUpdate, it will handle
+    // notification through SBL platform services, so do not call notifications
+    // here.
+    CallBoardNotify = FALSE;
+  } else if ((PayloadId == UEFI_PAYLOAD_ID_SIGNATURE) && (Dst[0] != 0)) {
     // Current open sourced UEFI payload does not call any FSP notifications,
     // but some customized UEFI payload will. The 1st DWORD in UEFI payload image
     // will be used to indicate if it will handle FSP notifications.
     CallBoardNotify = FALSE;
+  } else {
+    CallBoardNotify = TRUE;
   }
 
   if (CallBoardNotify) {


### PR DESCRIPTION
Previous commit 4061d47f3041e95a23c9307d38ea07c4dd62b9cd missed one
condition while handling the board notification calls. For built-in
payload such as OsLoader and FwUpdate, it will issue notifications
from payload through SBL platform services. So for these payloads,
board notification should not be called in SBL Stage2. This patch
fixed this.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>