### PR TITLE
:[WHL] Enable payload selection using GPIO

### DIFF
--- a/Platform/CoffeelakeBoardPkg/CfgData/CfgDataInt_Whl.dlt
+++ b/Platform/CoffeelakeBoardPkg/CfgData/CfgDataInt_Whl.dlt
@@ -31,6 +31,8 @@ MEMORY_CFG_DATA.SpdAddressTable          | {0xA0, 0xA2, 0xA4, 0xA6}
 GPU_CFG_DATA.DdiPortDHpd                 | 0x0
 GPU_CFG_DATA.DdiPortFHpd                 | 0x0
 
+GEN_CFG_DATA.PayloadId                   | 'AUTO'
+
 SILICON_CFG_DATA.PayloadSelGpio          | 0x80A5
 
 GPIO_CFG_DATA.GpioPinOffset_GPP_A00 | 0x04000000


### PR DESCRIPTION
This patch allows payload ID selection toggling using GPIO. When
the payload ID is set to "AUTO" in CFGDATA, the actual payload ID
will be updated according to current GPIO level. If the GPIO is low,
the payload ID will be set to 0 to boot OsLoader/FwUpdate payload.
If the GPIO is high, the payload ID will be set to 'UEFI' to boot
UEFI payload.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>