### PR TITLE
Store GPT entry info for later usage

### DIFF
--- a/BootloaderCommonPkg/Include/Library/PartitionLib.h
+++ b/BootloaderCommonPkg/Include/Library/PartitionLib.h
@@ -11,6 +11,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define _PARTITION_LIB_H_
 
 #include <BlockDevice.h>
+#include <Uefi/UefiGpt.h>
 
 #define  PART_INFO_SIGNATURE      SIGNATURE_32 ('P', 'A', 'R', 'T')
 
@@ -100,6 +101,21 @@ VOID
 EFIAPI
 ClosePartitions (
   IN   EFI_HANDLE             PartHandle
+  );
+
+/**
+  Get the GPT entries array from the last GPT block
+  device read.
+
+  @param  None
+
+  @retval                   Pointer to the GPT entry data
+
+**/
+EFI_PARTITION_ENTRY *
+EFIAPI
+GetGptEntryData (
+  VOID
   );
 
 #endif


### PR DESCRIPTION
It may be useful to store the GPT entry
data when it is read from the GPT partitioned
block device during the partition location
routines. The partition GUIDs may be needed
for other purposes during the boot setup.

Signed-off-by: James Gutbub <james.gutbub@intel.com>