### PR TITLE
Filter out include DSC files in ConfigEditor open dialog

### DIFF
--- a/BootloaderCorePkg/Tools/ConfigEditor.py
+++ b/BootloaderCorePkg/Tools/ConfigEditor.py
@@ -448,7 +448,7 @@ class Application(Frame):
 
         if Type == 'dsc':
             FileType = 'DSC or PKL'
-            FileExt  = 'dsc *.pkl'
+            FileExt  = 'pkl *Def.dsc'
         else:
             FileType = Type.upper()
             FileExt  = Type


### PR DESCRIPTION
In ConfigEditor, when open DSC files, many files will show up. It
is expected to only open the CfgDataDef.dsc. This patch changed
the file match pattern to only list *Def.dsc file.  In this way,
user will not make mistake to open some include DSC file.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>