### PR TITLE
[WHL][CFL] Use fixed Tseg size (4MB)

### DIFF
--- a/Platform/CoffeelakeBoardPkg/CfgData/CfgData_Memory.dsc
+++ b/Platform/CoffeelakeBoardPkg/CfgData/CfgData_Memory.dsc
@@ -77,11 +77,6 @@
   # !BSF HELP:{Indicates DqPinsInterleaved setting: board-dependent}
   gCfgData.DqPinsInterleaved                |      * | 0x01 | 0x1
 
-  # !BSF NAME:{Tseg Size} TYPE:{Combo}
-  # !BSF OPTION:{0x0400000:4MB, 0x01000000:16MB}
-  # !BSF HELP:{Size of SMRAM memory reserved. 0x400000 for Release build and 0x1000000 for Debug build}
-  gCfgData.TsegSize                         |      * | 0x04 | 0x00800000
-
   # !BSF NAME:{MMIO Size}
   # !BSF TYPE:{EditNum, HEX, (0,0xC00)}
   # !BSF HELP:{Size of MMIO space reserved for devices. non-Zero=size in MB }

--- a/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -120,7 +120,10 @@ UpdateFspConfig (
   CopyMem (&Fspmcfg->DqsMapCpu2DramCh0, MemCfgData->DqsMapCpu2DramCh0, sizeof(MemCfgData->DqsMapCpu2DramCh0));
   CopyMem (&Fspmcfg->DqsMapCpu2DramCh1, MemCfgData->DqsMapCpu2DramCh1, sizeof(MemCfgData->DqsMapCpu2DramCh1));
   Fspmcfg->DqPinsInterleaved      = MemCfgData->DqPinsInterleaved;
-  Fspmcfg->TsegSize               = MemCfgData->TsegSize;
+  //
+  // Tseg 4MB is enough for both debug/release build with SBL
+  //
+  Fspmcfg->TsegSize               = 0x00400000;
   Fspmcfg->MmioSize               = MemCfgData->MmioSize;
   Fspmcfg->RMT                    = MemCfgData->RMT;
   FspmcfgTest->BdatEnable         = MemCfgData->BdatEnable;


### PR DESCRIPTION
There is a invalid value(8MB) in CfgData_Memory.dsc which causes
an WARNING when opening memory setting in ConfigEditor.
WARNING: Value "8388608" is an invalid option for "TsegSize" !
Update TsegSize from 0x00800000 to 0x01000000 !

In FspmUpd.h description, Tseg Size is "0x400000 for Release build
and 0x1000000 for Debug build".

Tseg size 4MB(0x400000) is enough with SBL regardless of build type.
Therefore, let's remove config option and use fixed size(4MB) simply.
It fixed #205.

Signed-off-by: Aiden Park <aiden.park@intel.com>