### PR TITLE
Allow to use platform specific logo file

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.fdf
+++ b/BootloaderCorePkg/BootloaderCorePkg.fdf
@@ -195,7 +195,7 @@ FV = OsLoader
 
 !if $(ENABLE_SPLASH)
   FILE FREEFORM = 5E2D3BE9-AD72-4D1D-AAD5-6B08AF921590 {
-    SECTION RAW = Platform/CommonBoardPkg/Logo/Logo.bmp
+    SECTION RAW = $(LOGO_FILE)
   }
 !endif
 

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -134,6 +134,7 @@ class BaseBoard(object):
 		self._CFG_PRIVATE_KEY       = os.path.join(key_dir, 'TestSigningPrivateKey.pem')
 		self._FWU_PRIVATE_KEY       = os.path.join(key_dir, 'TestSigningPrivateKey.pem')
 		self._IAS_PRIVATE_KEY       = os.path.join(key_dir, 'TestSigningPrivateKey.pem')
+		self.LOGO_FILE              = 'Platform/CommonBoardPkg/Logo/Logo.bmp'
 
 		self.VERINFO_IMAGE_ID       = 'SB_???? '
 		self.VERINFO_PROJ_ID        = 1


### PR DESCRIPTION
This patch allows platform to use BoardConfig.py to override the
LOGO_FILE path so that customized logo file can be used instead of
the common one.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>