### PR TITLE
Change default behavior for GPIO payload ID selection

### DIFF
--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -654,7 +654,7 @@ UpdatePayloadId (
   if ((PlatCfgData != NULL) && (PlatCfgData->PayloadSelGpio.Enable != 0)) {
     // The default GPIOSet to Pull Up 20K
     GpioGetInputValue (PlatCfgData->PayloadSelGpio.PadInfo, 0x0C, &GpioLevel);
-    if (GpioLevel == 0) {
+    if (GpioLevel != 0) {
       PayloadId = 0;
     } else {
       if ((GenericCfgData != NULL) && (GenericCfgData->PayloadId == AUTO_PAYLOAD_ID_SIGNATURE)) {


### PR DESCRIPTION
Current default GPIO payload ID selection is UEFI on APL platform
since the GPIO pin is high without any jumper set. This patch
changed the default paylod ID to OsLoader when the GPIO is set to
high.

It fixed #208.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>