### PR TITLE
[APL] Update mBxtSocRevInfo table to support APL F1 stepping

### DIFF
--- a/Silicon/ApollolakePkg/Library/SocInfoLib/SocInfoLib.c
+++ b/Silicon/ApollolakePkg/Library/SocInfoLib/SocInfoLib.c
@@ -27,6 +27,7 @@ CONST SOC_REV_INFO mBxtSocRevInfo[] = { // new      old
   { 0xa,  0,  "APL",   "B0" },        // APL-B0   BXTP-B1
   { 0xb,  0,  "APL",   "B1" },        // APL-B1   BXTP-B2
   { 0xb,  1,  "APL",   "D0" },        // APL-D0  (BXTP-B2)
+  { 0xd,  1,  "APL",   "F1" },        // APL-F1
   { 0x0,  0,  "INVD",  "XX" }         // Invalid
 };
 


### PR DESCRIPTION
Updated the mBxtSocRevInfo table to support APL F1 stepping by adding it's 'RevId' and 'PlatformId'.

Signed-off-by: Vegnish Rao <vegnish.rao.paramesura.rao@intel.com>