### PR TITLE
Handle empty and NULL strings in Smbios types

### DIFF
--- a/BootloaderCommonPkg/Library/SmbiosInitLib/SmbiosInitLib.c
+++ b/BootloaderCommonPkg/Library/SmbiosInitLib/SmbiosInitLib.c
@@ -244,7 +244,10 @@ GetSmbiosString (
 
   for (Index = 0; Index < PcdGet16 (PcdSmbiosStringsCnt); ++Index) {
     if (Type == SmbiosStrings[Index].Type && StringId == SmbiosStrings[Index].Idx) {
-      return SmbiosStrings[Index].String;
+      if (SmbiosStrings[Index].String != NULL && AsciiStrLen (SmbiosStrings[Index].String) != 0) {
+        return SmbiosStrings[Index].String;
+      }
+      break;
     }
   }
 


### PR DESCRIPTION
If the platform provides an empty or a NULL string,
Smbios type might end abruptly and the Types are
reported incorrectly.

Signed-off-by: Sai Talamudupula <sai.kiran.talamudupula@intel.com>