### PR TITLE
[WHL][CFL] Fix invalid config in default GFX CFGDATA

### DIFF
--- a/Platform/CoffeelakeBoardPkg/CfgData/CfgData_GpuConfig.dsc
+++ b/Platform/CoffeelakeBoardPkg/CfgData/CfgData_GpuConfig.dsc
@@ -5,8 +5,7 @@
 #
 ##
 
-  # !BSF PAGES:{GPU:SIL:"GPU"}
-  # !BSF PAGES:{GPU_CFG:GPU:"GPU Config"}
+  # !BSF PAGES:{GPU_CFG:SIL:"Graphic & Display"}
 
   # !BSF PAGE:{GPU_CFG}
 
@@ -26,8 +25,9 @@
   gCfgData.ApertureSize                |    * | 0x01 | 0x01
 
   # !BSF NAME:{Internal Graphics} TYPE:{Combo} OPTION:{$EN_DIS}
+  # !BSF OPTION:{1:Enable, 0:Disable}
   # !BSF HELP:{Enable/disable internal graphics.}
-  gCfgData.InternalGfx                 |    * | 0x01 | 0x02
+  gCfgData.InternalGfx                 |    * | 0x01 | 0x01
 
   # !BSF NAME:{Selection of the primary display device} TYPE:{Combo}
   # !BSF OPTION:{0:iGFX, 1:PEG, 2:PCIe Graphics on PCH, 3:AUTO, 4:Switchable Graphics}


### PR DESCRIPTION
ConfigEditor returns a warning in GPU Config page.
  WARNING: Value '2' is an invalid option for 'InternalGfx' !
  Update InternalGfx from 0x02 to 0x01 !

The InternalGfx does not provide proper options and its default value
must be '1' or '0' instead of '2'.

Additionally, renamed 'GPU Config' page name to 'Graphic and Display'
and also removed unnecessary sub-page 'GPU'.

Signed-off-by: Aiden Park <aiden.park@intel.com>