### PR TITLE
[APL] Fix inconsistent file name on IFWI stitch

### DIFF
--- a/Platform/ApollolakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/ApollolakeBoardPkg/Script/StitchIfwi.py
@@ -260,7 +260,7 @@ def PaddingIasImage (IbblImage):
         Desc  = FlashMapDesc.from_buffer (IbblImgData, FlaMapOff + sizeof(FlashMap) + Idx * sizeof(FlashMapDesc))
         if Desc.Sig != 'IAS1' :
             continue
-        Ias1Name  = os.path.join(os.path.dirname (IbblImage), 'Stitch_PROV.bin')
+        Ias1Name  = os.path.join(os.path.dirname (IbblImage), 'Stitch_FB.bin')
         if not os.path.exists(Ias1Name):
             Ias1Size = 0
             Mode     = 'wb'
@@ -437,7 +437,7 @@ def GenMeuSblXml (MeuDir, Src, Dst):
     Node = Tree.find('./ObbSubPartition/Modules')
     ModList = [
       ("OPAD",  "OPAD"),
-      ("PROV",  "PROV"),
+      ("FB",  "FB"),
       ("EPLD",  "EPLD"),
       ("UVAR",  "UVAR")
       ]

--- a/Platform/ApollolakeBoardPkg/Script/StitchLoader.py
+++ b/Platform/ApollolakeBoardPkg/Script/StitchLoader.py
@@ -369,7 +369,7 @@ def LocateComponent(Root, Path):
 def PatchFlashMap (ImageData, PlatformData = 0xffffffff):
     CompBpdtDict = {
       'RSVD' : 'ROOT/IFWI/BP1/SBPDT/BpdtObb/RSVD',
-      'IAS1' : 'ROOT/IFWI/BP1/SBPDT/BpdtObb/PROV',
+      'IAS1' : 'ROOT/IFWI/BP1/SBPDT/BpdtObb/FB',
       'EPLD' : 'ROOT/IFWI/BP1/SBPDT/BpdtObb/EPLD',
       'UVAR' : 'ROOT/IFWI/BP1/SBPDT/BpdtObb/UVAR',
       'PYLD' : 'ROOT/IFWI/BP0/BPDT/BpdtIbb/PLD',
@@ -441,7 +441,7 @@ def PatchFlashMap (ImageData, PlatformData = 0xffffffff):
                 Desc.Size = Comp.Length
                 Desc.Offset = Comp.Offset - Bp0.Offset
                 continue
-            if Desc.Size != Comp.Length and Comp.Name != 'PROV':
+            if Desc.Size != Comp.Length and Comp.Name != 'FB':
                 raise Exception("Mismatch component '%s' length in FlashMap and BPDT !" % CompBpdtDict[Desc.Sig])
             if Desc.Sig not in ['_BPM', 'OEMK'] and (Comp.Offset & 0xFFF > 0):
                 raise Exception("Component '%s' %x is not aligned at 4KB boundary, " \
@@ -829,7 +829,7 @@ def CreateIfwiImage (IfwiIn, IfwiOut, BiosOut, PlatformData, NonRedundant, Stitc
         ]
 
         ObbList = [
-          ('PROV' , 'FB'),
+          ('FB' , 'FB'),
           ('EPLD' , 'EPLD'),
           ('UVAR' , 'UVAR'),
           ('PLD'  , 'PLD'),


### PR DESCRIPTION
Issue:
The Bios.xml generated from StitchIfwi.py is referring to Stitch_PROV.bin.
But the SBL Output Stitch_Components.zip contain instead Stitch_FB.bin.

Fix for issue #224:
Consistently use input file names for IFWI stitching, by chosen for 'FB'
instead of 'PROV'.

Signed-off-by: Markus Schuetterle <markus.schuetterle@intel.com>