### PR TITLE
[WHL][CFL] Fix S3 resume with OsLoader payload

### DIFF
--- a/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -666,6 +666,7 @@ DEBUG_CODE_END();
     CopyMem (PltDeviceTable->Device, mPlatformDevices, sizeof (mPlatformDevices));
     SetDeviceTable (PltDeviceTable);
     SpiControllerInitialize ();
+    SetBootMode (IsFirmwareUpdate() ? BOOT_ON_FLASH_UPDATE : GetPlatformPowerState());
     break;
   case PostConfigInit:
     PlatformIdInitialize ();
@@ -680,7 +681,6 @@ DEBUG_CODE_END();
   case PreTempRamExit:
     break;
   case PostTempRamExit:
-    SetBootMode (IsFirmwareUpdate() ? BOOT_ON_FLASH_UPDATE : GetPlatformPowerState());
     if (FeaturePcdGet (PcdMeasuredBootEnabled)) {
       TpmInitialize();
     }

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -963,9 +963,6 @@ BoardInit (
     }
     break;
   case PrePciEnumeration:
-    if (GetBootMode() == BOOT_ON_S3_RESUME) {
-      EnableSmi ();
-    }
     break;
   case PostPciEnumeration:
     break;
@@ -1045,6 +1042,9 @@ BoardInit (
 
     break;
   case EndOfFirmware:
+    if ((GetBootMode() == BOOT_ON_S3_RESUME) && (GetPayloadId () == UEFI_PAYLOAD_ID_SIGNATURE)) {
+      EnableSmi ();
+    }
     break;
   default:
     break;


### PR DESCRIPTION
- Revert 'Determine Firmware Update boot mode at post tempram exit #210'
- Enable SMI on S3 resume path ONLY with UEFI payload
- Move EnableSmi from PrePciEnumeration to EndOfFirmware

Signed-off-by: Aiden Park <aiden.park@intel.com>