### PR TITLE
[CFL] Restore regsiters on S3 resume

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -126,6 +126,7 @@
   DebugAgentLib|BootloaderCommonPkg/Library/DebugAgentLib/DebugAgentLibNull.inf
 !endif
   ElfLib|BootloaderCommonPkg/Library/ElfLib/ElfLib.inf
+  S3SaveRestoreLib|BootloaderCorePkg/Library/S3SaveRestoreLib/S3SaveRestoreLib.inf
 
 [LibraryClasses.IA32]
   PagingLib|$(PLATFORM_PACKAGE)/Library/PagingLib/PagingLib.inf

--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -120,22 +120,6 @@ typedef struct {
   UINT8         BootPartition;
 } S3_DATA;
 
-typedef struct {
-  UINT32  ApicId;
-  UINT32  SmmBase;
-} CPU_SMMBASE;
-
-typedef struct {
-  UINT32       Signature;
-  UINT8        CpuEntry;
-  UINT8        Unused;
-  UINT8        SmiCtrlRegType;
-  UINT8        SmiCtrlRegWidth;
-  UINT32       SmiCtrlRegAddr;
-  UINT32       SmiCtrlRegVal;
-  CPU_SMMBASE  SmmBase[];
-} SMMBASE_INFO;
-
 #pragma pack()
 
 //

--- a/BootloaderCorePkg/Include/Library/MpInitLib.h
+++ b/BootloaderCorePkg/Include/Library/MpInitLib.h
@@ -6,6 +6,7 @@
 **/
 
 #ifndef _MP_INIT_LIB_H_
+#define _MP_INIT_LIB_H_
 
 typedef enum {
   EnumMpInitNull   = 0x00,

--- a/BootloaderCorePkg/Include/Library/S3SaveRestoreLib.h
+++ b/BootloaderCorePkg/Include/Library/S3SaveRestoreLib.h
@@ -1,0 +1,150 @@
+/** @file
+
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _S3_SAVE_RESTORE_LIB_H_
+#define _S3_SAVE_RESTORE_LIB_H_
+
+
+#define BL_PLD_COMM_SIG       SIGNATURE_32('B', 'P', 'C', 'O')
+
+#define SMMBASE_INFO_COMM_ID  1
+#define S3_SAVE_REG_COMM_ID   2
+
+//
+// Format to share info between bootloader and payload.
+// Structures can be present in any order within the 4KB
+// communication area starting from TSEG. They are
+// identified by their Id.
+//
+
+      //  -------------------------- <----TSEG_BASE------
+      //  |     BL_PLD_COMM_HDR    |
+      //  |         (Id:1)         |
+      //  --------------------------
+      //  |       SMMBASE_INFO     |
+      //  --------------------------
+      //  --------------------------
+      //  |     BL_PLD_COMM_HDR    |
+      //  |         (Id:*)         |
+      //  --------------------------
+      //  |      COMM_STRUCT_2     |
+      //  --------------------------
+      //  --------------------------
+      //  |     BL_PLD_COMM_HDR    |
+      //  |         (Id:*)         |
+      //  --------------------------
+      //  |      COMM_STRUCT_3     |
+      //  --------------------------
+      //  --------------------------
+      //  |     BL_PLD_COMM_HDR    |
+      //  |         (Id:2)         |
+      //  --------------------------
+      //  |      S3_SAVE_REG       |
+      //  --------------------------
+      //  --------------------------
+      //  |     BL_PLD_COMM_HDR    |
+      //  |         (Id:*)         |
+      //  --------------------------
+      //  |      COMM_STRUCT_5     |
+      //  --------------------------
+      //  --------------------------
+      //            .....
+      //            .....
+      //            .....
+
+
+#pragma pack(1)
+
+typedef struct {
+  UINT32  Signature;
+  UINT8   Id;
+  UINT8   Count;
+  UINT16  TotalSize;
+} BL_PLD_COMM_HDR;
+
+typedef struct {
+  UINT8         Type;
+  UINT8         Width;
+  UINT8         Rsvd[2];
+  UINT32        Addr;
+  UINT32        Val;
+} REG_INFO;
+
+typedef struct {
+  BL_PLD_COMM_HDR S3SaveHdr;
+  REG_INFO        RegInfo[];
+} S3_SAVE_REG;
+
+typedef struct {
+  UINT32  ApicId;
+  UINT32  SmmBase;
+} CPU_SMMBASE;
+
+typedef struct {
+  BL_PLD_COMM_HDR SmmBaseHdr;
+  CPU_SMMBASE     SmmBase[];
+} SMMBASE_INFO;
+
+#pragma pack()
+
+/**
+  This function appends information in TSEG area
+  designated for S3 save/restore purpose.
+
+  @param    DataPtr               Address of the structure to be copied to TSEG
+
+  @retval   EFI_OUT_OF_RESOURCES  If SmmSize is exceeding 4KiB
+  @retval   EFI_OUT_OF_RESOURCES  If appeding new struct exceeds SmmSize
+  @retval   EFI_SUCCESS           Append is successful
+
+**/
+EFI_STATUS
+EFIAPI
+AppendS3Info (
+  IN  VOID    *DataPtr
+  );
+
+
+/**
+  Get pointer to a specific struct area in TSEG
+
+  @param      Id                Id of the struct to be retreived
+
+  @retval     NULL              Struct with signature not found
+  @retval     Ptr               Pointer to struct with signature
+
+**/
+VOID *
+EFIAPI
+FindS3Info (
+  IN  UINT8   Id
+  );
+
+
+/**
+  This function restores the states of the registers that were
+  set to be saved by the bootloader in the normal boot path.
+  After the payload has updated the 'Val' field of the reg info
+  in the normal boot path, we simply OR the updated 'Val'
+  with the existing vale of the register in the S3 resume boot path.
+  This function is only called in the S3 resume path.
+
+  @param    S3SaveReg               S3_SAVE_REG info offset
+
+  @retval   EFI_INVALID_PARAMETER   Invalid pointer to S3_SAVE_REG in Communicaton region
+  @retval   EFI_INVALID_PARAMETER   Invalid Type and Width
+  @retval   EFI_SUCCESS             Restore successful
+
+**/
+EFI_STATUS
+EFIAPI
+RestoreS3RegInfo (
+  IN  S3_SAVE_REG   *S3SaveReg
+  );
+
+
+#endif

--- a/BootloaderCorePkg/Library/MpInitLib/Ia32/MpInitLibInternal.h
+++ b/BootloaderCorePkg/Library/MpInitLib/Ia32/MpInitLibInternal.h
@@ -28,11 +28,10 @@
 #define   AP_TASK_TIMEOUT_UNIT     15
 #define   AP_TASK_TIMEOUT_CNT      1000
 
-#define   SMM_BASE_GAP             0x1000
-#define   SMM_BASE_MIN_SIZE        0x10000
-
-#define   PLD_TO_LDR_SMM_SIG       SIGNATURE_32('S', 'C', 'O', 'M')
 #define   RSM_SIG                  0x9090AA0F  /// Opcode for 'rsm'
+
+#define SMM_BASE_GAP               0x1000
+#define SMM_BASE_MIN_SIZE          0x10000
 
 #pragma pack(1)
 typedef struct {

--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
@@ -33,6 +33,7 @@
 [LibraryClasses]
   BaseLib
   DebugLib
+  S3SaveRestoreLib
 
 [LibraryClasses.IA32]
   LocalApicLib

--- a/BootloaderCorePkg/Library/S3SaveRestoreLib/S3SaveRestore.c
+++ b/BootloaderCorePkg/Library/S3SaveRestoreLib/S3SaveRestore.c
@@ -1,0 +1,185 @@
+/** @file
+
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+#include <Library/DebugLib.h>
+#include <Library/HobLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/S3SaveRestoreLib.h>
+#include <Library/IoLib.h>
+#include <Guid/SmmInformationGuid.h>
+#include <Library/BoardInitLib.h>
+#include <Guid/SmmInformationGuid.h>
+#include <Base.h>
+
+typedef UINT32 (*REG_READ)  (UINTN);
+typedef VOID   (*REG_WRITE) (UINTN, UINT32);
+
+#define NUM_TYPE    2
+#define NUM_WIDTH   3
+
+const REG_WRITE  mRegWrite[NUM_TYPE][NUM_WIDTH] = {
+  { (REG_WRITE) MmioWrite8, (REG_WRITE) MmioWrite16, (REG_WRITE) MmioWrite32 },
+  { (REG_WRITE) IoWrite8, (REG_WRITE) IoWrite16, (REG_WRITE) IoWrite32 }
+};
+
+const REG_READ mRegRead[NUM_TYPE][NUM_WIDTH] = {
+  { (REG_READ) MmioRead8, (REG_READ) MmioRead16, (REG_READ) MmioRead32 },
+  { (REG_READ) IoRead8, (REG_READ) IoRead16, (REG_READ) IoRead32 }
+};
+
+const UINT8 mWidthToIdx[NUM_WIDTH][2] = {
+  { 0, WIDE8  },
+  { 1, WIDE16 },
+  { 2, WIDE32 }
+};
+
+/**
+  This function appends information in TSEG area
+  designated for S3 save/restore purpose.
+
+  @param    DataPtr               Address of the structure to be copied to TSEG
+
+  @retval   EFI_OUT_OF_RESOURCES  If SmmSize is exceeding 4KiB
+  @retval   EFI_OUT_OF_RESOURCES  If appeding new struct exceeds SmmSize
+  @retval   EFI_SUCCESS           Append is successful
+
+**/
+EFI_STATUS
+EFIAPI
+AppendS3Info (
+  IN  VOID    *DataPtr
+  )
+{
+  LDR_SMM_INFO      LdrSmmInfo;
+  UINT8             *SmmBase;
+  UINT32            SmmSize;
+  BL_PLD_COMM_HDR   *CommHdr;
+
+  PlatformUpdateHobInfo (&gSmmInformationGuid, &LdrSmmInfo);
+  SmmBase = (UINT8 *) LdrSmmInfo.SmmBase;
+  if (LdrSmmInfo.Flags & SMM_FLAGS_4KB_COMMUNICATION) {
+    SmmSize = SIZE_4KB;
+  } else {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CommHdr = (BL_PLD_COMM_HDR *) SmmBase;
+  while ( ((UINT8 *)CommHdr < SmmBase + SmmSize) &&
+          CommHdr->Signature == BL_PLD_COMM_SIG) {
+    CommHdr = (BL_PLD_COMM_HDR *) ((UINT8 *)CommHdr + CommHdr->TotalSize);
+  }
+
+  if ( (UINT8 *)CommHdr + ((BL_PLD_COMM_HDR*)DataPtr)->TotalSize > SmmBase + SmmSize ) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+  CopyMem ((VOID *)CommHdr, DataPtr, ((BL_PLD_COMM_HDR*)DataPtr)->TotalSize);
+
+  return EFI_SUCCESS;
+}
+
+
+/**
+  Get pointer to a specific struct area in TSEG
+
+  @param      Id                Id of the struct to be retreived
+
+  @retval     NULL              Struct with signature not found
+  @retval     Ptr               Pointer to struct with signature
+
+**/
+VOID *
+EFIAPI
+FindS3Info (
+  IN  UINT8   Id
+  )
+{
+  LDR_SMM_INFO      LdrSmmInfo;
+  UINT8             *SmmBase;
+  UINT32            SmmSize;
+  BOOLEAN           FoundInfo = FALSE;
+  BL_PLD_COMM_HDR   *CommHdr;
+
+  PlatformUpdateHobInfo (&gSmmInformationGuid, &LdrSmmInfo);
+  SmmBase = (UINT8 *) LdrSmmInfo.SmmBase;
+  if (LdrSmmInfo.Flags & SMM_FLAGS_4KB_COMMUNICATION) {
+    SmmSize = SIZE_4KB;
+  } else {
+    DEBUG((DEBUG_INFO, "Invalid Communication area size\n"));
+    return NULL;
+  }
+
+  CommHdr = (BL_PLD_COMM_HDR *) SmmBase;
+  while ( ((UINT8 *)CommHdr < SmmBase + SmmSize) &&
+          CommHdr->Signature == BL_PLD_COMM_SIG) {
+    if (CommHdr->Id == Id) {
+      FoundInfo = TRUE;
+      break;
+    }
+    CommHdr = (BL_PLD_COMM_HDR *) ((UINT8 *)CommHdr + CommHdr->TotalSize);
+  }
+
+  if (!FoundInfo) {
+    return NULL;
+  }
+
+  return (VOID *) CommHdr;
+}
+
+
+/**
+  This function restores the states of the registers that were
+  set to be saved by the bootloader in the normal boot path.
+  After the payload has updated the 'Val' field of the reg info
+  in the normal boot path, we simply OR the updated 'Val'
+  with the existing vale of the register in the S3 resume boot path.
+  This function is only called in the S3 resume path.
+
+  @param    S3SaveReg               S3_SAVE_REG info offset
+    
+  @retval   EFI_INVALID_PARAMETER   Invalid pointer to S3_SAVE_REG in Communicaton region
+  @retval   EFI_INVALID_PARAMETER   Invalid Type and Width
+  @retval   EFI_SUCCESS             Restore successful
+
+**/
+EFI_STATUS
+EFIAPI
+RestoreS3RegInfo (
+  IN  S3_SAVE_REG   *S3SaveReg
+  )
+{
+  UINT8     Index;
+  UINT32    Data32;
+  UINT8     Type;
+  UINT8     Width;
+  UINT8     Idx;
+
+  if (S3SaveReg == NULL || S3SaveReg->S3SaveHdr.Id != S3_SAVE_REG_COMM_ID) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  for (Index = 0; Index < S3SaveReg->S3SaveHdr.Count; Index++) {
+    if (S3SaveReg->RegInfo[Index].Addr != 0x00) {
+      Type = S3SaveReg->RegInfo[Index].Type;
+      Width = S3SaveReg->RegInfo[Index].Width;
+      for (Idx = 0; Idx < NUM_WIDTH; Idx++) {
+        if (mWidthToIdx[Idx][1] == Width) {
+          Width = Idx;
+          break;
+        }
+      }
+      if (Type >= NUM_TYPE || Width >= NUM_WIDTH) {
+        return EFI_INVALID_PARAMETER;
+      }
+      mRegWrite[Type][Width] (S3SaveReg->RegInfo[Index].Addr, S3SaveReg->RegInfo[Index].Val);
+      Data32 = mRegRead[Type][Width] (S3SaveReg->RegInfo[Index].Addr);
+      DEBUG ((DEBUG_INFO, "Value after restore reg @ 0x%08X=0x%08X\n", S3SaveReg->RegInfo[Index].Addr, Data32));
+    }
+  }
+
+  return EFI_SUCCESS;
+}

--- a/BootloaderCorePkg/Library/S3SaveRestoreLib/S3SaveRestoreLib.inf
+++ b/BootloaderCorePkg/Library/S3SaveRestoreLib/S3SaveRestoreLib.inf
@@ -1,0 +1,39 @@
+## @file
+#
+#  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = S3SaveRestoreLib
+  FILE_GUID                      = 6DBF359B-DC7D-4009-9827-D8C736157706
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = S3SaveRestoreLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  S3SaveRestore.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCorePkg/BootloaderCorePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  HobLib
+  BootloaderCoreLib
+
+[Guids]
+  gSmmInformationGuid
+
+[Pcd]

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -50,6 +50,7 @@
   SgxLib
   GpioLib
   PsdLib
+  S3SaveRestoreLib
 
 [Guids]
   gSmmInformationGuid


### PR DESCRIPTION
Restore the register information saved during the
normal boot, on S3 resume path for UEFI payload only.

Signed-off-by: Sai Talamudupula <sai.kiran.talamudupula@intel.com>