### PR TITLE
Modify kernel size loading check

### DIFF
--- a/PayloadPkg/OsLoader/Linux.c
+++ b/PayloadPkg/OsLoader/Linux.c
@@ -220,7 +220,7 @@ SetupBzImage (
   KernelBuf  = (VOID *) (UINTN)LINUX_KERNEL_BASE;
   KernelSize = Bp->Hdr.SysSize * 16;
   DEBUG ((DEBUG_INFO, "Src=0x%p Dest=0x%p KernelSize=%d\n", Buffer + BootParamSize, KernelBuf, KernelSize));
-  if (KernelSize > IMAGE_MAX_SIZE) {
+  if ((LINUX_KERNEL_BASE + KernelSize) > (((UINT32) _ModuleEntryPoint) & ~(SIZE_4KB - 1))) {
     DEBUG ((DEBUG_ERROR, "Linux kernel too big!\n"));
     Status = EFI_LOAD_ERROR;
     return Status;

--- a/PayloadPkg/OsLoader/OsLoader.h
+++ b/PayloadPkg/OsLoader/OsLoader.h
@@ -63,7 +63,6 @@
 
 #define BOOT_PARAMS_BASE         0x00090000
 #define LINUX_KERNEL_BASE        0x00100000
-#define IMAGE_MAX_SIZE           0x00F00000
 #define CMDLINE_OFFSET           0xF000
 #define CMDLINE_LENGTH_MAX       0x800
 #define EOF                      "<eof>"
@@ -137,6 +136,16 @@ typedef struct {
 } LOADED_IMAGE;
 
 typedef  VOID   (*PRE_OS_CHECKER_ENTRY) (VOID *Params);
+
+/**
+OS Loader module entry point. Can also be used to get the
+base address of the OS Loader's location in memory.
+
+**/
+VOID
+_ModuleEntryPoint (
+  VOID
+  );
 
 /**
 Print out the Multiboot information block.


### PR DESCRIPTION
When loading a Linux kernel we should not
limit the size of the kernel being loaded
to 15MB but we should verify that the kernel
will not overwrite the payload which can
some times be located in low memory where
the kernel is being loaded.

Signed-off-by: James Gutbub <james.gutbub@intel.com>