### PR TITLE
Add EXT2F_INCOMPAT_RECOVER to EXT2F_INCOMPAT_SUPP

### DIFF
--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.h
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.h
@@ -248,6 +248,15 @@ typedef struct {
 
 #define EXT2F_INCOMPAT_COMP         0x0001
 #define EXT2F_INCOMPAT_FTYPE        0x0002
+
+//
+// TODO: We need to enable support for
+//       EXT FS recovery handling at some
+//       point to ensure that we don't
+//       encounter a real file error.
+//
+#define EXT2F_INCOMPAT_RECOVER      0x0004
+
 #define EXT2F_INCOMPAT_EXTENTS      0x0040
 #define EXT2F_INCOMPAT_FLEX_BG      0x0200
 
@@ -268,6 +277,7 @@ typedef struct {
 #define EXT2F_ROCOMPAT_SUPP      (EXT2F_ROCOMPAT_SPARSESUPER \
                                  | EXT2F_ROCOMPAT_LARGEFILE)
 #define EXT2F_INCOMPAT_SUPP      (EXT2F_INCOMPAT_FTYPE \
+                                 | EXT2F_INCOMPAT_RECOVER \
                                  | EXT2F_INCOMPAT_EXTENTS \
                                  | EXT2F_INCOMPAT_FLEX_BG)
 


### PR DESCRIPTION
Currently there is some limitation with mounting an
EXT4 partition to retrieve a file for booting when
the partition was not properly umounted during the
previous usage (ex. powering off an OS without
using 'poweroff' command, unplugging power, etc.).

There is recovery support in the Ext23Lib but as
a temporary solution we can ignore the recovery
bit to avoid boot issues when the recovery bit is
flipped due to unexpected power loss.

Signed-off-by: James Gutbub <james.gutbub@intel.com>