### PR TITLE
Fix S3 resume issue with OsLoader payload

### DIFF
--- a/BootloaderCorePkg/Library/MpInitLib/Ia32/MpInitLib.c
+++ b/BootloaderCorePkg/Library/MpInitLib/Ia32/MpInitLib.c
@@ -76,13 +76,15 @@ CpuInit (
   if (PcdGet8 (PcdSmmRebaseMode) == SMM_REBASE_ENABLE_ON_S3_RESUME_ONLY) {
     if (GetBootMode() == BOOT_ON_S3_RESUME) {
       SmmBaseInfo = (SMMBASE_INFO *) FindS3Info (SMMBASE_INFO_COMM_ID);
-      for (CpuIdx = 0; CpuIdx < SmmBaseInfo->SmmBaseHdr.Count; CpuIdx++) {
-        if (ApicId == SmmBaseInfo->SmmBase[CpuIdx].ApicId) {
-          SmmRebase (Index, ApicId, SmmBaseInfo->SmmBase[CpuIdx].SmmBase);
-          break;
+      if (SmmBaseInfo != NULL) {
+        for (CpuIdx = 0; CpuIdx < SmmBaseInfo->SmmBaseHdr.Count; CpuIdx++) {
+          if (ApicId == SmmBaseInfo->SmmBase[CpuIdx].ApicId) {
+            SmmRebase (Index, ApicId, SmmBaseInfo->SmmBase[CpuIdx].SmmBase);
+            break;
+          }
         }
+        ASSERT (CpuIdx < SmmBaseInfo->SmmBaseHdr.Count);
       }
-      ASSERT (CpuIdx < SmmBaseInfo->SmmBaseHdr.Count);
     }
   } else if (PcdGet8 (PcdSmmRebaseMode) == SMM_REBASE_ENABLE) {
     SmmRebase (Index, ApicId, 0);


### PR DESCRIPTION
SmmRebase should not be done while using OsLoader
payload. Added PayloadId check to make sure we do
it only for UEFI payload for now.

Signed-off-by: Sai Talamudupula <sai.kiran.talamudupula@intel.com>