### PR TITLE
Add ContainerLib to support sub-region

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -50,6 +50,8 @@
   gPlatformCommonLibTokenSpaceGuid.PcdHeciLibId              |          5 |  UINT8 | 0x20000106
   gPlatformCommonLibTokenSpaceGuid.PcdMmcTuningLibId         |          6 |  UINT8 | 0x20000107
 
+  gPlatformCommonLibTokenSpaceGuid.PcdContainerMaxNumber     |          8 | UINT32 | 0x20000120
+
   gPlatformCommonLibTokenSpaceGuid.PcdCpuLocalApicBaseAddress| 0xFEE00000 | UINT32  | 0x20000186
   gPlatformCommonLibTokenSpaceGuid.PcdSupportedMediaTypeMask | 0xFFFFFFFF | UINT32  | 0x20000187
   gPlatformCommonLibTokenSpaceGuid.PcdMmcTuningLba           | 0x00000040 | UINT32  | 0x20000188

--- a/BootloaderCommonPkg/Include/Guid/LoaderPlatformDataGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/LoaderPlatformDataGuid.h
@@ -35,6 +35,7 @@ typedef struct {
   UINT8                     Reserved0[3];
   DEBUG_LOG_BUFFER_HEADER  *DebugLogBuffer;
   VOID                     *ConfigDataPtr;
+  VOID                     *ContainerList;
 } LOADER_PLATFORM_DATA;
 
 #endif

--- a/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
+++ b/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
@@ -36,6 +36,14 @@ typedef struct {
   UINT32        BufSize;
 } LIBRARY_DATA;
 
+typedef struct {
+  UINT32        Signature;
+  UINT32        CompressedSize;
+  UINT32        Size;
+  UINT32        Reserved;
+  UINT8         Data[];
+} LOADER_COMPRESSED_HEADER;
+
 #pragma pack()
 
 //
@@ -533,6 +541,19 @@ EFIAPI
 GetDeviceAddr (
   IN  UINT8          DeviceType,
   IN  UINT8          DeviceInstance
+  );
+
+
+/**
+  This function retrieves container list pointer.
+
+  @retval    The container list pointer.
+
+**/
+VOID *
+EFIAPI
+GetContainerListPtr (
+  VOID
   );
 
 #endif

--- a/BootloaderCommonPkg/Include/Library/ContainerLib.h
+++ b/BootloaderCommonPkg/Include/Library/ContainerLib.h
@@ -1,0 +1,128 @@
+/** @file
+  Header file for container library implementation.
+
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#ifndef _CONTAINER_LIB_H_
+#define _CONTAINER_LIB_H_
+
+#include <Library/PcdLib.h>
+
+#define CONTAINER_LIST_SIGNATURE SIGNATURE_32('C','T','N', 'L')
+
+#define AUTH_TYPE_NONE                0
+#define AUTH_TYPE_SHA2_256            1
+#define AUTH_TYPE_SHA2_384            2
+#define AUTH_TYPE_SIG_RSA2048_SHA256  3
+#define AUTH_TYPE_SIG_RSA3072_SHA384  4
+
+typedef struct {
+  UINT32           Signature;
+  UINT32           HeaderCache;
+  UINT32           Base;
+  UINT32           Reserved;
+} CONTAINER_ENTRY;
+
+typedef struct {
+  UINT32           Signature;
+  UINT32           Reserved;
+  UINT32           TotalLength;
+  UINT32           Count;
+  CONTAINER_ENTRY  Entry[0];
+} CONTAINER_LIST;
+
+typedef struct {
+  UINT32           Signature;
+  UINT16           Version;
+  UINT16           DataOffset;
+  UINT32           DataSize;
+  UINT8            AuthType;
+  UINT8            ImageType;
+  UINT8            Flags;
+  UINT8            Count;
+} CONTAINER_HDR;
+
+typedef struct {
+  UINT32           Name;
+  UINT32           Offset;
+  UINT32           Size;
+  UINT8            Rserved;
+  UINT8            Alignment;
+  UINT8            AuthType;
+  UINT8            HashSize;
+  UINT8            HashData[0];
+} COMPONENT_ENTRY;
+
+
+/**
+  Load a component region information from a container.
+
+  @param[in] ContainerSig    Container signature.
+  @param[in] ComponentName   component name.
+  @param[in] Buffer          Pointer to receive component base.
+  @param[in] Length          Pointer to receive component size.
+
+  @retval EFI_UNSUPPORTED          Unsupported AuthType.
+  @retval EFI_NOT_FOUND            Cannot locate component.
+  @retval EFI_SECURITY_VIOLATION   Authentication failed.
+  @retval EFI_SUCCESS              Authentication succeeded.
+
+**/
+EFI_STATUS
+EFIAPI
+LocateComponentRegion (
+  IN     UINT32    ContainerSig,
+  IN     UINT32    ComponentName,
+  OUT    UINT32   *RegionBase,
+  OUT    UINT32   *RegionLength
+  );
+
+/**
+  Locate a component from a container.
+
+  @param[in]     ContainerSig       Container signature.
+  @param[in]     ComponentName      Component name.
+  @param[in,out] ContainerEntryPtr  Pointer to receive container entry info.
+  @param[in,out] ComponentEntryPtr  Pointer to receive component entry info.
+
+  @retval EFI_UNSUPPORTED          Unsupported AuthType.
+  @retval EFI_NOT_FOUND            Cannot locate component.
+  @retval EFI_SECURITY_VIOLATION   Authentication failed.
+  @retval EFI_SUCCESS              component region is located successfully.
+
+**/
+EFI_STATUS
+LocateComponent (
+  IN      UINT32                  ContainerSig,
+  IN      UINT32                  ComponentName,
+  IN OUT  CONTAINER_ENTRY       **ContainerEntryPtr,
+  IN OUT  COMPONENT_ENTRY       **ComponentEntryPtr
+  );
+
+/**
+  Load a component from a container to memory.
+
+  @param[in]     ContainerSig    Container signature or component type.
+  @param[in]     ComponentName   Component name.
+  @param[in,out] Buffer          Pointer to receive component base.
+  @param[in,out] Length          Pointer to receive component size.
+
+  @retval EFI_UNSUPPORTED          Unsupported AuthType.
+  @retval EFI_NOT_FOUND            Cannot locate component.
+  @retval EFI_BUFFER_TOO_SMALL     Specified buffer size is too small.
+  @retval EFI_SECURITY_VIOLATION   Authentication failed.
+  @retval EFI_SUCCESS              Authentication succeeded.
+
+**/
+EFI_STATUS
+EFIAPI
+LoadComponent (
+  IN     UINT32    ContainerSig,
+  IN     UINT32    ComponentName,
+  IN OUT VOID    **Buffer,
+  IN OUT UINT32   *Length
+  );
+
+#endif

--- a/BootloaderCommonPkg/Include/Library/SecureBootLib.h
+++ b/BootloaderCommonPkg/Include/Library/SecureBootLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -8,34 +8,34 @@
 #ifndef __VERIFIED_BOOT_LIB_H__
 #define __VERIFIED_BOOT_LIB_H__
 
-#define    COMP_TYPE_STAGE_1B            0
-#define    COMP_TYPE_STAGE_2             1
-#define    COMP_TYPE_PAYLOAD             2
-#define    COMP_TYPE_FIRMWARE_UPDATE     3
-#define    COMP_TYPE_PUBKEY_CFG_DATA     4
-#define    COMP_TYPE_PUBKEY_FWU          5
-#define    COMP_TYPE_PUBKEY_OS           6
-#define    COMP_TYPE_INVALID             7
+#define  HASH_TYPE_SHA256              0
+#define  HASH_TYPE_SHA384              1
+#define  HASH_TYPE_SHA512              2
 
-/**
-  Halt CPU from execution.
+#define  SIG_TYPE_RSA2048_SHA256       0
+#define  SIG_TYPE_RSA3072_SHA384       1
 
-  @param[in]  Message      Message to display before halt.
-
-**/
-VOID
-CpuHalt (
-  IN CHAR8  *Message
-  );
+#define  COMP_TYPE_STAGE_1B            0
+#define  COMP_TYPE_STAGE_2             1
+#define  COMP_TYPE_PAYLOAD             2
+#define  COMP_TYPE_FIRMWARE_UPDATE     3
+#define  COMP_TYPE_PUBKEY_CFG_DATA     4
+#define  COMP_TYPE_PUBKEY_FWU          5
+#define  COMP_TYPE_PUBKEY_OS           6
+#define  COMP_TYPE_INVALID             7
 
 /**
   Verify data block hash with the built-in one.
 
-  @param[in]  Data            Data buffer pointer.
-  @param[in]  Length          Data buffer size.
-  @param[in]  ComponentType   Component type.
+  @param[in]  Data           Data buffer pointer.
+  @param[in]  Length         Data buffer size.
+  @param[in]  HashAlg        Specify hash algrothsm.
+  @param[in]  ComponentType  Component type.
+  @param[in,out]  Hash       On input,  expected hash value when ComponentType is not used.
+                             On output, calculated hash value when verification succeeds.
 
   @retval RETURN_SUCCESS             Hash verification succeeded.
+  @retval RETRUN_INVALID_PARAMETER   Hash parameter is not valid.
   @retval RETURN_NOT_FOUND           Hash data for ComponentType is not found.
   @retval RETURN_UNSUPPORTED         Hash component type is not supported.
   @retval RETURN_SECURITY_VIOLATION  Hash verification failed.
@@ -45,7 +45,9 @@ RETURN_STATUS
 DoHashVerify (
   IN CONST UINT8           *Data,
   IN       UINT32           Length,
-  IN       UINT8            ComponentType
+  IN       UINT8            HashAlg,
+  IN       UINT8            ComponentType,
+  IN OUT   UINT8           *Hash
   );
 
 /**
@@ -56,8 +58,10 @@ DoHashVerify (
   @param[in]  Length          Data buffer size.
   @param[in]  ComponentType   Component type.
   @param[in]  Signature       Signature for the data buffer.
-  @param[in]  PubKey          Public Key data pointer.
-  @param[out] OutHash         OutHash buffer pointer.
+  @param[in]  PubKey          Public key data pointer.
+  @param[in]  PubKeyHash      Public key hash value when ComponentType is not used.
+  @param[out] OutHash         Calculated data hash value.
+
 
   @retval RETURN_SUCCESS             RSA verification succeeded.
   @retval RETURN_NOT_FOUND           Hash data for ComponentType is not found.
@@ -72,16 +76,8 @@ DoRsaVerify (
   IN       UINT8            ComponentType,
   IN CONST UINT8           *Signature,
   IN       UINT8           *PubKey,
-  OUT      UINT8           *OutHash
-  );
-
-typedef RETURN_STATUS (*RSA_VERIFY) (
-  IN CONST UINT8           *Data,
-  IN       UINT32           Length,
-  IN       UINT8            ComponentType,
-  IN CONST UINT8           *Signature,
-  IN       UINT8           *PubKey,
-  OUT      UINT8           *OutHash
+  IN       UINT8           *PubKeyHash      OPTIONAL,
+  OUT      UINT8           *OutHash         OPTIONAL
   );
 
 /**

--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
@@ -1,0 +1,523 @@
+/** @file
+  Container library implementation.
+
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PcdLib.h>
+#include <Library/BootloaderCommonLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/BlMemoryAllocationLib.h>
+#include <Library/ContainerLib.h>
+#include <Library/CryptoLib.h>
+#include <Library/SecureBootLib.h>
+#include <Library/DecompressLib.h>
+
+#define  TEMP_BUF_ALIGN    0x10
+#define  AUTH_DATA_ALIGN   0x04
+
+/**
+  This function registers a container.
+
+  @param[in]  ContainerBase      Container base address to register.
+
+  @retval EFI_NOT_READY          Not ready for register yet.
+  @retval EFI_BUFFER_TOO_SMALL   Insufficant max container entry number.
+  @retval EFI_OUT_OF_RESOURCES   No space to add new container.
+  @retval EFI_SUCCESS            The container has been registered successfully.
+
+**/
+STATIC
+EFI_STATUS
+RegisterContainer (
+  IN UINT32    ContainerBase
+  )
+{
+  CONTAINER_LIST       *ContainerList;
+  CONTAINER_HDR        *ContainerHdr;
+  UINT32                Index;
+  VOID                 *Buffer;
+
+  ContainerList = (CONTAINER_LIST *)GetContainerListPtr ();
+  if (ContainerList == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  Index = ContainerList->Count;
+  if (Index >= PcdGet32 (PcdContainerMaxNumber)) {
+    return EFI_BUFFER_TOO_SMALL;
+  }
+
+  ContainerHdr = (CONTAINER_HDR *)ContainerBase;
+  Buffer = AllocatePool (ContainerHdr->DataOffset);
+  if (Buffer == NULL) {
+    return  EFI_OUT_OF_RESOURCES;
+  }
+
+  ContainerList->Entry[Index].Signature   = ContainerHdr->Signature;
+  ContainerList->Entry[Index].HeaderCache = (UINT32)Buffer;
+  ContainerList->Entry[Index].Base        = ContainerBase;
+  CopyMem (Buffer, (VOID *)ContainerBase, ContainerHdr->DataOffset);
+  ContainerList->Count++;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This function unregisters a container in the last entry.
+
+  @retval EFI_NOT_READY          Not ready for unregister yet.
+  @retval EFI_NOT_FOUND          Not container available for unregisteration.
+  @retval EFI_SUCCESS            The container has been unregistered successfully.
+
+**/
+STATIC
+EFI_STATUS
+UnregisterLastContainer (
+  VOID
+  )
+{
+  EFI_STATUS            Status;
+  CONTAINER_LIST       *ContainerList;
+  UINT32                Index;
+
+  ContainerList = (CONTAINER_LIST *)GetContainerListPtr ();
+  if (ContainerList == NULL) {
+    return EFI_NOT_READY;
+  }
+
+  Index = ContainerList->Count;
+  if (Index > 0) {
+    Index--;
+    FreePool ((VOID *)ContainerList->Entry[Index].HeaderCache);
+    ContainerList->Count = Index;
+    Status = EFI_SUCCESS;
+  } else {
+    Status = EFI_NOT_FOUND;
+  }
+
+  return Status;
+}
+
+/**
+  Get the container pointer by the container signature
+
+  @param[in] Signature            The signature for the container to get.
+
+  @retval NULL                    The service is not available.
+  @retval Others                  The pointer of container entry.
+
+**/
+STATIC
+CONTAINER_ENTRY *
+GetContainerBySignature (
+  IN UINT32       Signature
+  )
+{
+  UINT32                Index;
+  CONTAINER_LIST       *ContainerList;
+  CONTAINER_ENTRY      *ContainerEntry;
+
+  ContainerList = (CONTAINER_LIST *)GetContainerListPtr ();
+  if (ContainerList != NULL) {
+    for (Index = 0; Index < ContainerList->Count; Index++) {
+      ContainerEntry = (CONTAINER_ENTRY *)&ContainerList->Entry[Index];
+      if (ContainerEntry->Signature == Signature) {
+        return ContainerEntry;
+      }
+    }
+  }
+
+  return NULL;
+}
+
+/**
+  This function returns the container header size.
+
+  @param[in] ContainerEntry    Container entry pointer.
+
+  @retval         Container header size.
+
+**/
+STATIC
+UINT32
+GetContainerHeaderSize (
+  IN  CONTAINER_HDR  *ContainerHdr
+  )
+{
+  INT32                 Offset;
+  UINT32                Index;
+  COMPONENT_ENTRY      *CompEntry;
+
+  Offset = 0;
+  if (ContainerHdr != NULL) {
+    CompEntry   = (COMPONENT_ENTRY *)&ContainerHdr[1];
+    for (Index = 0; Index < ContainerHdr->Count; Index++) {
+      CompEntry = (COMPONENT_ENTRY *)((UINT8 *)(CompEntry + 1) + CompEntry->HashSize);
+      Offset = (UINT8 *)CompEntry - (UINT8 *)ContainerHdr;
+      if ((Offset < 0) || (Offset >= ContainerHdr->DataOffset)) {
+        Offset = 0;
+        break;
+      }
+    }
+  }
+
+  return (UINT32)Offset;
+}
+
+/**
+  This function returns the container header size.
+
+  @param[in] ContainerEntry    Container entry pointer.
+  @param[in] ComponentName     Component name in container.
+
+  @retval         Container header size.
+
+**/
+STATIC
+COMPONENT_ENTRY  *
+LocateComponentEntry (
+  IN  CONTAINER_HDR  *ContainerHdr,
+  IN  UINT32          ComponentName
+  )
+{
+  UINT32                Index;
+  COMPONENT_ENTRY      *CompEntry;
+  COMPONENT_ENTRY      *CurrEntry;
+
+  CompEntry = NULL;
+  CurrEntry = (COMPONENT_ENTRY *)&ContainerHdr[1];
+  for (Index = 0; Index < ContainerHdr->Count; Index++) {
+    if (CurrEntry->Name == ComponentName) {
+      CompEntry = CurrEntry;
+      break;
+    }
+    CurrEntry = (COMPONENT_ENTRY *)((UINT8 *)(CurrEntry + 1) + CurrEntry->HashSize);
+  }
+
+  return CompEntry;
+}
+
+/**
+  Authenticate a container header or component.
+
+  @param[in] Data         Data buffer to be authenticated.
+  @param[in] Length       Data length to be authenticated.
+  @param[in] AuthType     Authentication type.
+  @param[in] AuthData     Authentication data buffer.
+  @param[in] HashData     Hash data buffer.
+  @param[in] CompType     Component type.
+
+  @retval EFI_UNSUPPORTED          Unsupported AuthType.
+  @retval EFI_SECURITY_VIOLATION   Authentication failed.
+  @retval EFI_SUCCESS              Authentication succeeded.
+
+**/
+STATIC
+EFI_STATUS
+AuthenticateComponent (
+  IN  UINT8    *Data,
+  IN  UINT32    Length,
+  IN  UINT8     AuthType,
+  IN  UINT8    *AuthData,
+  IN  UINT8    *HashData,
+  IN  UINT8     CompType
+  )
+{
+  EFI_STATUS  Status;
+
+  if (AuthType == AUTH_TYPE_SHA2_256) {
+    Status = DoHashVerify (Data, Length, HASH_TYPE_SHA256, CompType, HashData);
+  } else if (AuthType == AUTH_TYPE_SIG_RSA2048_SHA256) {
+    Status = DoRsaVerify (Data, Length, CompType, AuthData,
+                          AuthData + RSA2048NUMBYTES, HashData, NULL);
+  } else if (AuthType == AUTH_TYPE_NONE) {
+    Status = EFI_SUCCESS;
+  } else {
+    Status = EFI_UNSUPPORTED;
+  }
+  return Status;
+}
+
+/**
+  Locate a component from a container.
+
+  @param[in]     ContainerSig       Container signature.
+  @param[in]     ComponentName      Component name.
+  @param[in,out] ContainerEntryPtr  Pointer to receive container entry info.
+  @param[in,out] ComponentEntryPtr  Pointer to receive component entry info.
+
+  @retval EFI_UNSUPPORTED          Unsupported AuthType.
+  @retval EFI_NOT_FOUND            Cannot locate component.
+  @retval EFI_SECURITY_VIOLATION   Authentication failed.
+  @retval EFI_SUCCESS              component region is located successfully.
+
+**/
+EFI_STATUS
+LocateComponent (
+  IN      UINT32                  ContainerSig,
+  IN      UINT32                  ComponentName,
+  IN OUT  CONTAINER_ENTRY       **ContainerEntryPtr,
+  IN OUT  COMPONENT_ENTRY       **ComponentEntryPtr
+  )
+{
+  EFI_STATUS                Status;
+  CONTAINER_HDR            *ContainerHdr;
+  CONTAINER_ENTRY          *ContainerEntry;
+  COMPONENT_ENTRY          *CompEntry;
+  UINT8                    *AuthData;
+  UINT32                    ContainerBase;
+  UINT32                    ContainerSize;
+  UINT32                    ContainerHdrSize;
+  UINT8                     AuthType;
+
+  // Search container header from cache
+  ContainerEntry = GetContainerBySignature (ContainerSig);
+  if (ContainerEntry == NULL) {
+    // Location container from Flash Map
+    Status = GetComponentInfo (ContainerSig, &ContainerBase, &ContainerSize);
+    if (EFI_ERROR (Status)) {
+      return EFI_NOT_FOUND;
+    }
+
+    // Register container temporarily
+    DEBUG ((EFI_D_INFO, "Register container 0x%08X\n", ContainerSig));
+    Status = RegisterContainer (ContainerBase);
+    if (EFI_ERROR (Status)) {
+      return EFI_UNSUPPORTED;
+    }
+
+    // Find authentication data offset and authenticate the container header
+    ContainerEntry   = GetContainerBySignature (ContainerSig);
+    ContainerHdr     = (CONTAINER_HDR *)ContainerEntry->HeaderCache;
+    ContainerHdrSize = GetContainerHeaderSize (ContainerHdr);
+    if (ContainerHdrSize > 0) {
+      AuthType = ContainerHdr->AuthType;
+      AuthData = (UINT8 *)ContainerHdr + ALIGN_UP(ContainerHdrSize, AUTH_DATA_ALIGN);
+      if ((AuthType == AUTH_TYPE_NONE) && FeaturePcdGet (PcdVerifiedBootEnabled)) {
+        Status = EFI_SECURITY_VIOLATION;
+      } else {
+        Status = AuthenticateComponent ((UINT8 *)ContainerHdr, ContainerHdrSize,
+                                             AuthType, AuthData, NULL, COMP_TYPE_PUBKEY_FWU);
+      }
+    } else {
+      Status   = EFI_UNSUPPORTED;
+    }
+
+    if (EFI_ERROR (Status)) {
+      // Unregister the container since authentication failed
+      UnregisterLastContainer ();
+      return EFI_SECURITY_VIOLATION;
+    }
+  }
+
+  // Locate the component from the container header
+  ContainerHdr = (CONTAINER_HDR *)ContainerEntry->HeaderCache;
+  CompEntry = LocateComponentEntry (ContainerHdr, ComponentName);
+  if (CompEntry == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  if (ContainerEntryPtr != NULL) {
+    *ContainerEntryPtr = ContainerEntry;
+  }
+
+  if (ComponentEntryPtr != NULL) {
+    *ComponentEntryPtr   = CompEntry;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Load a component region information from a container.
+
+  @param[in] ContainerSig    Container signature.
+  @param[in] ComponentName   component name.
+  @param[in] Buffer          Pointer to receive component base.
+  @param[in] Length          Pointer to receive component size.
+
+  @retval EFI_UNSUPPORTED          Unsupported AuthType.
+  @retval EFI_NOT_FOUND            Cannot locate component.
+  @retval EFI_SECURITY_VIOLATION   Authentication failed.
+  @retval EFI_SUCCESS              Authentication succeeded.
+
+**/
+EFI_STATUS
+EFIAPI
+LocateComponentRegion (
+  IN     UINT32    ContainerSig,
+  IN     UINT32    ComponentName,
+  OUT    UINT32   *RegionBase,
+  OUT    UINT32   *RegionLength
+  )
+{
+  EFI_STATUS                Status;
+  CONTAINER_HDR            *ContainerHdr;
+  CONTAINER_ENTRY          *ContainerEntry;
+  COMPONENT_ENTRY          *CompEntry;
+
+  Status = LocateComponent (ContainerSig, ComponentName, &ContainerEntry, &CompEntry);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  ContainerHdr = (CONTAINER_HDR *)ContainerEntry->HeaderCache;
+  if (RegionBase != NULL) {
+    *RegionBase = ContainerEntry->Base + ContainerHdr->DataOffset + CompEntry->Offset;
+  }
+  if (RegionLength != NULL) {
+    *RegionLength = CompEntry->Size;
+  }
+
+  return Status;
+}
+
+/**
+  Load a component from a container to memory.
+
+  @param[in]     ContainerSig    Container signature or component type.
+  @param[in]     ComponentName   Component name.
+  @param[in,out] Buffer          Pointer to receive component base.
+  @param[in,out] Length          Pointer to receive component size.
+
+  @retval EFI_UNSUPPORTED          Unsupported AuthType.
+  @retval EFI_NOT_FOUND            Cannot locate component.
+  @retval EFI_BUFFER_TOO_SMALL     Specified buffer size is too small.
+  @retval EFI_SECURITY_VIOLATION   Authentication failed.
+  @retval EFI_SUCCESS              Authentication succeeded.
+
+**/
+EFI_STATUS
+EFIAPI
+LoadComponent (
+  IN     UINT32    ContainerSig,
+  IN     UINT32    ComponentName,
+  IN OUT VOID    **Buffer,
+  IN OUT UINT32   *Length
+  )
+{
+  EFI_STATUS                Status;
+  LOADER_COMPRESSED_HEADER *CompressHdr;
+  CONTAINER_HDR            *ContainerHdr;
+  CONTAINER_ENTRY          *ContainerEntry;
+  COMPONENT_ENTRY          *CompEntry;
+  UINT8                    *CompData;
+  UINT8                    *CompBuf;
+  UINT8                    *HashData;
+  VOID                     *CompBase;
+  VOID                     *ReqCompBase;
+  UINT8                     CompType;
+  UINT8                     AuthType;
+  UINT32                    DecompressedLen;
+  UINT32                    CompLen;
+  UINT32                    SignedDataLen;
+  UINT32                    DstLen;
+  UINT32                    ScrLen;
+
+  if (ContainerSig < COMP_TYPE_INVALID) {
+    // Check if it is container signature or component type
+    CompType     = (UINT8)ContainerSig;
+    ContainerSig = 0;
+
+    Status = GetComponentInfo (ComponentName, (UINT32 *)&CompData,  &CompLen);
+    if (EFI_ERROR (Status)) {
+      return EFI_NOT_FOUND;
+    }
+
+    if (FeaturePcdGet (PcdVerifiedBootEnabled)) {
+      AuthType = AUTH_TYPE_SHA2_256;
+    } else {
+      AuthType = AUTH_TYPE_NONE;
+    }
+    HashData = NULL;
+  } else {
+    // Find the component info
+    Status = LocateComponent (ContainerSig, ComponentName, &ContainerEntry, &CompEntry);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    // Collect component info
+    ContainerHdr = (CONTAINER_HDR *)ContainerEntry->HeaderCache;
+    CompData  = (UINT8 *)(ContainerEntry->Base + ContainerHdr->DataOffset + CompEntry->Offset);
+    CompLen   = CompEntry->Size;
+    AuthType  = CompEntry->AuthType;
+    HashData  = CompEntry->HashData;
+    CompType  = COMP_TYPE_INVALID;
+  }
+
+  // Component must have LOADER_COMPRESSED_HEADER
+  Status = EFI_UNSUPPORTED;
+  CompressHdr  = (LOADER_COMPRESSED_HEADER *)CompData;
+  if (IS_COMPRESSED (CompressHdr)) {
+    SignedDataLen = sizeof (LOADER_COMPRESSED_HEADER) + CompressHdr->CompressedSize;
+    if (SignedDataLen <= CompLen) {
+      Status = DecompressGetInfo (CompressHdr->Signature, CompressHdr->Data,
+                                  CompressHdr->CompressedSize, &DstLen, &ScrLen);
+    }
+  }
+  if (EFI_ERROR (Status)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  // If it is required to use an existing buffer, verify the size
+  ReqCompBase = NULL;
+  DecompressedLen = CompressHdr->Size;
+  if ((Buffer != NULL) && (*Buffer != NULL)) {
+    ReqCompBase = *Buffer;
+    if ((Length != NULL) && (*Length != 0) && (*Length < DecompressedLen)) {
+      return EFI_BUFFER_TOO_SMALL;
+    }
+  }
+
+  // Allocate temporary buffer since decompression is required.
+  CompBuf = AllocateTemporaryMemory (SignedDataLen + ScrLen + TEMP_BUF_ALIGN * 2);
+  if (CompBuf == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // Authenticate component and decompress it if required
+  CopyMem (CompBuf, CompData, SignedDataLen);
+  Status = AuthenticateComponent (CompBuf, SignedDataLen, AuthType,
+             CompData + ALIGN_UP(SignedDataLen, AUTH_DATA_ALIGN),  HashData, CompType);
+  if (!EFI_ERROR (Status)) {
+    CompressHdr = (LOADER_COMPRESSED_HEADER *)CompBuf;
+    if (ReqCompBase == NULL) {
+      CompBase = AllocatePool (DecompressedLen);
+    } else {
+      CompBase = ReqCompBase;
+    }
+    if (CompBase != NULL) {
+      Status = Decompress (CompressHdr->Signature, CompressHdr->Data, CompressHdr->CompressedSize,
+                           CompBase, (VOID *)(CompBuf + ALIGN_UP (SignedDataLen, TEMP_BUF_ALIGN)));
+      if (EFI_ERROR (Status)) {
+        if (ReqCompBase == NULL) {
+          FreePool (CompBase);
+        }
+      }
+    } else {
+      Status = EFI_OUT_OF_RESOURCES;
+    }
+
+  } else {
+    Status = EFI_SECURITY_VIOLATION;
+  }
+  FreeTemporaryMemory (CompBuf);
+
+  if (!EFI_ERROR (Status)) {
+    if (Buffer != NULL) {
+      *Buffer = CompBase;
+    }
+    if (Length != NULL) {
+      *Length = DecompressedLen;
+    }
+  }
+
+  return Status;
+}

--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.inf
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.inf
@@ -1,0 +1,32 @@
+## @file
+#  Container Library Instance.
+#
+#  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = ContainerLib
+  FILE_GUID                      = F7EAF992-7473-4232-B1D2-4A798E92722A
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = ContainerLib
+
+[Sources]
+  ContainerLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  SecureBootLib
+  DecompressLib
+
+[Pcd]
+  gPlatformCommonLibTokenSpaceGuid.PcdContainerMaxNumber
+  gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled

--- a/BootloaderCommonPkg/Library/IasImageLib/IasImage.c
+++ b/BootloaderCommonPkg/Library/IasImageLib/IasImage.c
@@ -81,7 +81,7 @@ IsIasImageValid (
 
   Signature = (UINT8 *) IAS_SIGNATURE (Hdr);
   Status = DoRsaVerify ((CONST UINT8 *)Hdr, ((UINT32)IAS_PAYLOAD_END (Hdr)) - ((UINT32)Hdr), COMP_TYPE_PUBKEY_OS,
-                        Signature, (UINT8 *)&Key, ImageHash);
+                        Signature, (UINT8 *)&Key, NULL, ImageHash);
   if (EFI_ERROR (Status) != EFI_SUCCESS) {
     DEBUG ((DEBUG_ERROR, "IAS image verification failed!\n"));
     return NULL;

--- a/BootloaderCommonPkg/Library/SecureBootLib/SecureBootRsa.c
+++ b/BootloaderCommonPkg/Library/SecureBootLib/SecureBootRsa.c
@@ -15,13 +15,16 @@
 
 /**
   Verifies the RSA signature with PKCS1-v1_5 encoding scheme defined in RSA PKCS#1.
+  Also(optional), return the hash of the message to the caller.
 
   @param[in]  Data            Data buffer pointer.
   @param[in]  Length          Data buffer size.
   @param[in]  ComponentType   Component type.
   @param[in]  Signature       Signature for the data buffer.
-  @param[in]  PubKey          Public Key data pointer.
-  @param[out] OutHash         OutHash buffer pointer.
+  @param[in]  PubKey          Public key data pointer.
+  @param[in]  PubKeyHash      Public key hash value when ComponentType is not used.
+  @param[out] OutHash         Calculated data hash value.
+
 
   @retval RETURN_SUCCESS             RSA verification succeeded.
   @retval RETURN_NOT_FOUND           Hash data for ComponentType is not found.
@@ -36,7 +39,8 @@ DoRsaVerify (
   IN       UINT8            ComponentType,
   IN CONST UINT8           *Signature,
   IN       UINT8           *PubKey,
-  OUT      UINT8           *OutHash
+  IN       UINT8           *PubKeyHash      OPTIONAL,
+  OUT      UINT8           *OutHash         OPTIONAL
   )
 {
   UINTN            Index;
@@ -56,7 +60,8 @@ DoRsaVerify (
   for (Index = 0; Index < RSA_E_SIZE; Index++) {
     TmpPubKey[RSA_MOD_SIZE + Index] = InpPubKey->PubKeyData[RSA_MOD_SIZE + RSA_E_SIZE - 1 - Index];
   }
-  Status = DoHashVerify ((CONST UINT8 *)PubKeyBuf, RSA_MOD_SIZE + RSA_E_SIZE, ComponentType);
+
+  Status = DoHashVerify ((CONST UINT8 *)PubKeyBuf, RSA_MOD_SIZE + RSA_E_SIZE, HASH_TYPE_SHA256, ComponentType, PubKeyHash);
   if (RETURN_ERROR (Status)) {
     return Status;
   }

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -117,6 +117,7 @@
   DebugLib|BootloaderCommonPkg/Library/BootloaderDebugLib/BootloaderDebugLib.inf
   ConsoleInLib|BootloaderCommonPkg/Library/ConsoleInLib/ConsoleInLib.inf
   ConsoleOutLib|BootloaderCommonPkg/Library/ConsoleOutLib/ConsoleOutLib.inf
+  ContainerLib|BootloaderCommonPkg/Library/ContainerLib/ContainerLib.inf
 !if $(HAVE_FSP_BIN)
   FspApiLib|$(PLATFORM_PACKAGE)/Library/FspApiLib/FspApiLib.inf
 !endif

--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -79,14 +79,6 @@ typedef struct {
 
 typedef struct {
   UINT32        Signature;
-  UINT32        CompressedSize;
-  UINT32        Size;
-  UINT32        Reserved;
-  UINT8         Data[];
-} LOADER_COMPRESSED_HEADER;
-
-typedef struct {
-  UINT32        Signature;
   UINT32        EntryNum;
   UINT32        EntrySize;
   UINT32        Reserved;
@@ -196,6 +188,7 @@ typedef struct {
   VOID             *PcdDataPtr;
   VOID             *LogBufPtr;
   VOID             *DeviceTable;
+  VOID             *ContainerList;
   UINT8             PlatformName[PLATFORM_NAME_SIZE];
   UINT32            LdrFeatures;
   BL_PERF_DATA      PerfData;

--- a/BootloaderCorePkg/Library/BootloaderLib/BootloaderLib.c
+++ b/BootloaderCorePkg/Library/BootloaderLib/BootloaderLib.c
@@ -286,6 +286,21 @@ GetPlatformDataPtr (
 }
 
 /**
+  This function retrieves container list pointer.
+
+  @retval    The container list pointer.
+
+**/
+VOID *
+EFIAPI
+GetContainerListPtr  (
+  VOID
+  )
+{
+  return GetLoaderGlobalDataPointer()->ContainerList;
+}
+
+/**
   Gets component information from the flash map.
 
   This function will look for the component based on the input signature

--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -59,7 +59,7 @@ PrepareStage1B (
     if (IS_COMPRESSED (Src)) {
       Length = sizeof (LOADER_COMPRESSED_HEADER) + Hdr->CompressedSize;
     }
-    Status = DoHashVerify ((CONST UINT8 *)Src, Length, COMP_TYPE_STAGE_1B);
+    Status = DoHashVerify ((CONST UINT8 *)Src, Length, HASH_TYPE_SHA256, COMP_TYPE_STAGE_1B, NULL);
     AddMeasurePoint (0x10A0);
     if (EFI_ERROR (Status)) {
       if (Status != RETURN_NOT_FOUND) {

--- a/BootloaderCorePkg/Stage1B/Stage1B.h
+++ b/BootloaderCorePkg/Stage1B/Stage1B.h
@@ -34,6 +34,7 @@
 #include <Library/LocalApicLib.h>
 #include <Library/DebugAgentLib.h>
 #include <Library/TpmLib.h>
+#include <Library/ContainerLib.h>
 #include <Guid/PcdDataBaseSignatureGuid.h>
 #include <Guid/LoaderPlatformDataGuid.h>
 #include <VerInfo.h>

--- a/BootloaderCorePkg/Stage1B/Stage1B.inf
+++ b/BootloaderCorePkg/Stage1B/Stage1B.inf
@@ -68,6 +68,7 @@
 [Pcd]
   gPlatformCommonLibTokenSpaceGuid.PcdMaxLibraryDataEntry
   gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdContainerMaxNumber
   gPlatformModuleTokenSpaceGuid.PcdStage1StackSize
   gPlatformModuleTokenSpaceGuid.PcdStage1DataSize
   gPlatformModuleTokenSpaceGuid.PcdFSPTBase

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -118,7 +118,7 @@ PreparePayload (
 
     if (IsNormalPld || (Stage2Hob->PayloadId != 0)) {
       // For standard payload or components inside multi-payload, do hash verififcation
-      Status = DoHashVerify ((CONST UINT8 *)Src, Length, HashIdx);
+      Status = DoHashVerify ((CONST UINT8 *)Src, Length, HASH_TYPE_SHA256, HashIdx, NULL);
     } else {
       // For multi-payload header, do signature verififcation
       PldHdr    = (MULTI_PAYLOAD_HEADER *)&Hdr[1];
@@ -132,7 +132,7 @@ PreparePayload (
         Length = (UINT32)((UINT8 *)PldEntry - (UINT8 *)Hdr);
         PubKey = (UINT8 *)PldEntry + RSA2048NUMBYTES;
         Status = DoRsaVerify ((CONST UINT8 *)Src,  Length, COMP_TYPE_PUBKEY_CFG_DATA,
-                              (CONST UINT8 *)PldEntry, PubKey, NULL);
+                              (CONST UINT8 *)PldEntry, PubKey, NULL, NULL);
       }
     }
     AddMeasurePoint (0x3120);
@@ -231,7 +231,9 @@ NormalBootPath (
 
   // Load payload
   Dst = (UINT32 *)PreparePayload (Stage2Hob);
-  ASSERT (Dst != NULL);
+  if (Dst == NULL) {
+    CpuHalt ("Failed to load payload!");
+  }
 
   BoardInit (PostPayloadLoading);
   AddMeasurePoint (0x31A0);

--- a/BootloaderCorePkg/Stage2/Stage2.h
+++ b/BootloaderCorePkg/Stage2/Stage2.h
@@ -35,6 +35,7 @@
 #include <Library/TpmLib.h>
 #include <Library/DebugLogBufferLib.h>
 #include <Library/LiteFvLib.h>
+#include <Library/ContainerLib.h>
 #include <Guid/BootLoaderServiceGuid.h>
 #include <Guid/BootLoaderVersionGuid.h>
 #include <Guid/LoaderPlatformInfoGuid.h>

--- a/BootloaderCorePkg/Stage2/Stage2.inf
+++ b/BootloaderCorePkg/Stage2/Stage2.inf
@@ -67,7 +67,7 @@
   DebugAgentLib
   LiteFvLib
   ElfLib
-
+  ContainerLib
   SmbiosInitLib
 
 [Guids]

--- a/BootloaderCorePkg/Stage2/Stage2Support.c
+++ b/BootloaderCorePkg/Stage2/Stage2Support.c
@@ -556,6 +556,7 @@ BuildExtraInfoHob (
     LoaderPlatformData->Revision = 1;
     LoaderPlatformData->DebugLogBuffer = (DEBUG_LOG_BUFFER_HEADER *) GetDebugLogBufferPtr ();
     LoaderPlatformData->ConfigDataPtr  = GetConfigDataPtr ();
+    LoaderPlatformData->ContainerList  = GetContainerListPtr ();
   }
 
   // Build flash map info hob

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -343,7 +343,7 @@ GetVersionfromFv (
   Verify the firmware version to make sure it is no less than current firmware version.
 
   @param[in] ImageHdr     Pointer to the fw mgmt capsule image header
-  @param[in] FwPolicy     Firmware update policy. 
+  @param[in] FwPolicy     Firmware update policy.
 
   @retval  EFI_SUCCESS    The operation completed successfully.
   @retval  others         There is error happening.
@@ -457,8 +457,8 @@ GetStateMachineFlag (
   Set state machine flag in flash.
 
   This function will set state machine flag in the bootloader reserved region
-  First byte in the booloader reserved region is state machine flag 
-  
+  First byte in the booloader reserved region is state machine flag
+
   ----------------------------------------------------------------------------------------
   |  SM                            |             Operation                               |
   ----------------------------------------------------------------------------------------
@@ -486,7 +486,7 @@ SetStateMachineFlag (
   FW_UPDATE_COMP_STATUS   FwUpdCompStatus[MAX_FW_COMPONENTS];
 
   DEBUG((DEBUG_INIT, "Set next FWU state: 0x%02X\n", StateMachine));
-  
+
   FwUpdStatusOffset = PcdGet32(PcdFwUpdStatusBase);
 
   //
@@ -499,9 +499,9 @@ SetStateMachineFlag (
   }
 
   //
-  // If we are to clear state machine, Wipe the whole region and preserve 
+  // If we are to clear state machine, Wipe the whole region and preserve
   // the last update status and version for all firmwares
-  // 
+  //
   // If we are to set the capsule to processing, then this is start of the firmware update
   // in this case, clear the whole region.
   //
@@ -535,7 +535,7 @@ SetStateMachineFlag (
     UpdateSize = sizeof(UINT64);
 
     //
-    // Write back the firware update status 
+    // Write back the firware update status
     //
     Status = BootMediaWrite((FwUpdStatusOffset + sizeof(FW_UPDATE_STATUS)),\
                             MAX_FW_COMPONENTS * sizeof(FW_UPDATE_COMP_STATUS), (UINT8 *)&FwUpdCompStatus);
@@ -761,7 +761,7 @@ UpdateStatus (
   //
   for (Count = 0; Count < MAX_FW_COMPONENTS; Count ++) {
     if (CompareGuid(&(FwUpdCompStatus[Count].FirmwareId), ImageId) == TRUE) {
-      DEBUG((DEBUG_VERBOSE, "FOund the component to update status\n")); 
+      DEBUG((DEBUG_VERBOSE, "FOund the component to update status\n"));
       break;
     }
   }
@@ -801,21 +801,21 @@ UpdateStatus (
   // Update a field at a time, if we loose power in between, we can still have control
   //
   ByteOffset = COMP_STATUS_OFFSET(FwUpdStatusOffset, Count) + OFFSET_OF(FW_UPDATE_COMP_STATUS, LastAttemptVersion);
-  Status = BootMediaWrite(ByteOffset, sizeof(UINT32), (UINT8 *)&(FwUpdCompStatus[Count].LastAttemptVersion)); 
+  Status = BootMediaWrite(ByteOffset, sizeof(UINT32), (UINT8 *)&(FwUpdCompStatus[Count].LastAttemptVersion));
   if (EFI_ERROR (Status)) {
     DEBUG((DEBUG_ERROR, "Updating last attempt version failed with status: %r\n", Status));
     return Status;
   }
 
   ByteOffset = COMP_STATUS_OFFSET(FwUpdStatusOffset, Count) + OFFSET_OF(FW_UPDATE_COMP_STATUS, LastAttemptStatus);
-  Status = BootMediaWrite(ByteOffset, sizeof(UINT32), (UINT8 *)&(FwUpdCompStatus[Count].LastAttemptStatus)); 
+  Status = BootMediaWrite(ByteOffset, sizeof(UINT32), (UINT8 *)&(FwUpdCompStatus[Count].LastAttemptStatus));
   if (EFI_ERROR (Status)) {
     DEBUG((DEBUG_ERROR, "Updating last attempt status failed with status: %r\n", Status));
     return Status;
   }
 
   ByteOffset = COMP_STATUS_OFFSET(FwUpdStatusOffset, Count) + OFFSET_OF(FW_UPDATE_COMP_STATUS, UpdatePending);
-  Status = BootMediaWrite(ByteOffset, sizeof(UINT8), (UINT8 *)&(FwUpdCompStatus[Count].UpdatePending)); 
+  Status = BootMediaWrite(ByteOffset, sizeof(UINT8), (UINT8 *)&(FwUpdCompStatus[Count].UpdatePending));
   if (EFI_ERROR (Status)) {
     DEBUG((DEBUG_ERROR, "Updating updatepending failed with status: %r\n", Status));
     return Status;
@@ -900,7 +900,7 @@ AuthenticateCapsule (
     }
   }
 
-  Status    = DoRsaVerify (FwImage, Header->SignatureOffset, COMP_TYPE_PUBKEY_FWU, Signature, Key, NULL);
+  Status    = DoRsaVerify (FwImage, Header->SignatureOffset, COMP_TYPE_PUBKEY_FWU, Signature, Key, NULL, NULL);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "Image verification failed, %r!\n", Status));
     return EFI_SECURITY_VIOLATION;
@@ -924,7 +924,7 @@ AuthenticateCapsule (
 }
 
 /**
-  Process capsule image. 
+  Process capsule image.
 
   This function will abstract firmware images from the capsule image. for each
   of the firmware image found, FW_UPDATE_COMP_STATUS structure will be created
@@ -968,7 +968,7 @@ ProcessCapsule (
 
   //
   // If state machine is 0xFF, Capsule is not processed yet
-  // set SM to capsule processing stage, this will reset back to 
+  // set SM to capsule processing stage, this will reset back to
   // init at the end of firmware update
   //
   if (FwUpdStatus.StateMachine == FW_UPDATE_SM_INIT) {
@@ -1044,10 +1044,10 @@ ProcessCapsule (
 /**
   Find payload in the capsule image.
 
-  This function will parse through the capsule image to find the payload 
-  matching the input guid. 
+  This function will parse through the capsule image to find the payload
+  matching the input guid.
 
-  This function if provided with an empty guid will return the first payload 
+  This function if provided with an empty guid will return the first payload
   found
 
   @param[in] ImageId        Guid to identify payload in the capsule image
@@ -1190,9 +1190,9 @@ UpdateSystemFirmware (
 /**
   Perform Firmware update.
 
-  This function based on the image type id guid from the image header will 
+  This function based on the image type id guid from the image header will
   call the respective functions to perform capsule update.
-*  
+*
   @param[in] CapImage       Pointer to the capsule Image
   @param[in] CapImageSize   Size of the capsule image in bytes
 * @param[in] ImageHdr       Pointer to fw mgmt capsule Image header
@@ -1311,7 +1311,7 @@ InitFirmwareUpdate (
         // Update component state in the reserved region
         //
         ByteOffset = COMP_STATUS_OFFSET(FwUpdStatusOffset, Count) + OFFSET_OF(FW_UPDATE_COMP_STATUS, UpdatePending);
-        Status = BootMediaWrite(ByteOffset, sizeof(UINT8), (UINT8 *)&(FwUpdCompStatus[Count].UpdatePending)); 
+        Status = BootMediaWrite(ByteOffset, sizeof(UINT8), (UINT8 *)&(FwUpdCompStatus[Count].UpdatePending));
         if (EFI_ERROR (Status)) {
           DEBUG((DEBUG_ERROR, "BootMediaWrite. offset: 0x%llx, Status = 0x%x\n", (FwUpdStatusOffset + sizeof(FW_UPDATE_STATUS)), Status));
           return Status;
@@ -1338,7 +1338,7 @@ InitFirmwareUpdate (
       //
       // Update firmware update status of the component in reserved region
       //
-      Status = UpdateStatus(&(ImgHdr->UpdateImageTypeId), (UINT16)ImgHdr->Version, Status); 
+      Status = UpdateStatus(&(ImgHdr->UpdateImageTypeId), (UINT16)ImgHdr->Version, Status);
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR, "UpdateStatus failed! Status = %r\n", Status));
         DEBUG((DEBUG_ERROR, "Reset required to proceed with the firmware update.\n"));

--- a/PayloadPkg/Include/Library/PayloadLib.h
+++ b/PayloadPkg/Include/Library/PayloadLib.h
@@ -28,6 +28,7 @@ typedef struct {
   VOID             *LogBufPtr;
   VOID             *CfgDataPtr;
   VOID             *DeviceTable;
+  VOID             *ContainerList;
   UINT32           LdrFeatures;
   BL_PERF_DATA     PerfData;
 } PAYLOAD_GLOBAL_DATA;

--- a/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
+++ b/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
@@ -19,6 +19,7 @@
 #include <Library/SerialPortLib.h>
 #include <Library/DebugLogBufferLib.h>
 #include <Library/DebugPrintErrorLevelLib.h>
+#include <Library/ContainerLib.h>
 #include <Guid/BootLoaderServiceGuid.h>
 #include <Guid/BootLoaderVersionGuid.h>
 #include <Guid/LoaderPlatformDataGuid.h>
@@ -56,6 +57,7 @@ PayloadInit (
   LOADER_PLATFORM_DATA      *LoaderPlatformData;
   EFI_STATUS                PcdStatus1;
   EFI_STATUS                PcdStatus2;
+  CONTAINER_LIST            *ContainerList;
 
   PcdStatus1 = PcdSet32S (PcdPayloadHobList, (UINT32)HobList);
 
@@ -104,6 +106,14 @@ PayloadInit (
       CopyMem (BufPtr, DebugLogBufferHdr, DebugLogBufferHdr->UsedLength);
       GlobalDataPtr->LogBufPtr = BufPtr;
     }
+
+    ContainerList = LoaderPlatformData->ContainerList;
+    if (ContainerList != NULL) {
+      BufPtr = AllocatePool (ContainerList->TotalLength);
+      CopyMem (BufPtr, ContainerList, ContainerList->TotalLength);
+      GlobalDataPtr->ContainerList = ContainerList;
+    }
+
   }
 
   SerialPortInitialize ();

--- a/PayloadPkg/Library/PayloadLib/PayloadLib.c
+++ b/PayloadPkg/Library/PayloadLib/PayloadLib.c
@@ -394,3 +394,21 @@ GetDeviceTable (
   return PayloadGlobalDataPtr->DeviceTable;
 }
 
+/**
+  This function retrieves container list pointer.
+
+  @retval    The container list pointer.
+
+**/
+VOID *
+EFIAPI
+GetContainerListPtr (
+  VOID
+  )
+{
+  PAYLOAD_GLOBAL_DATA     *PayloadGlobalDataPtr;
+
+  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *)PcdGet32 (PcdGlobalDataAddress);
+
+  return PayloadGlobalDataPtr->ContainerList;
+}


### PR DESCRIPTION
This patch added a ContainerLib to support load and location a
component from a specified container. It copies the component
from flash to memory, authenticate it, and then decompress it if
required. It can also be used to support load component from flash
map in SBL stage2 or payload, such as payload or e-payload.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>