### PR TITLE
Update TPM Type to Loader Platform info HOB

### DIFF
--- a/BootloaderCommonPkg/Include/Guid/LoaderPlatformInfoGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/LoaderPlatformInfoGuid.h
@@ -45,6 +45,12 @@ extern EFI_GUID gLoaderPlatformInfoGuid;
 //Secure debug (0 - disabled, 1 - enabled)
 #define        HWSTATE_SECURE_DEBUG              BIT3
 
+//Tpm Type dTPM 2.0 (0 - Not Availble, 1 - detected)
+#define        HWSTATE_DTPM_20                   BIT4
+
+//Tpm Type TPM 2.0 PTT (0 - Not Availble, 1 - detected)
+#define        HWSTATE_TPM_PTT                   BIT5
+
 //Definition for LOADER_PLATFORM_INFO.Flags
 
 //

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1787,9 +1787,14 @@ UpdateLoaderPlatformInfo (
   if(PlatformData != NULL) {
     LoaderPlatformInfo->HwState = PlatformData->BtGuardInfo.VerifiedBoot | (PlatformData->BtGuardInfo.MeasuredBoot << 1);
     LoaderPlatformInfo->Flags   = FLAGS_SPI_DISABLE_SMM_WRITE_PROTECT;
+
+    if (PlatformData->BtGuardInfo.TpmType == dTpm20)
+      LoaderPlatformInfo->HwState |= HWSTATE_DTPM_20;
+    else if (PlatformData->BtGuardInfo.TpmType == Ptt)
+      LoaderPlatformInfo->HwState |= HWSTATE_TPM_PTT;
+
     DEBUG ((EFI_D_INFO, "Stage2: HwState 0x%x\n", LoaderPlatformInfo->HwState));
   }
-
 }
 
 /**


### PR DESCRIPTION
TPM type as dTPM and fTPM is utilized in UEFI payload to
update TPM instance

Signed-off-by: Subash Lakkimsetti <subashx.lakkimsetti@intel.com>