### PR TITLE
Add support for ELF type: Shared object file

### DIFF
--- a/BootloaderCommonPkg/Library/ElfLib/ElfLib.c
+++ b/BootloaderCommonPkg/Library/ElfLib/ElfLib.c
@@ -140,9 +140,9 @@ IsElfImage (
   }
 
   //
-  //  Support executable elf only
+  //  Support ELF types: EXEC (Executable file), DYN (Shared object file)
   //
-  if (ElfHdr->e_type != ET_EXEC) {
+  if ((ElfHdr->e_type != ET_EXEC) && (ElfHdr->e_type != ET_DYN)) {
     return FALSE;
   }
 


### PR DESCRIPTION
SBL only support ELF type: EXEC (Executable file)
This changes also allow loading ELF type: DYN (Shared object file)

This is required to boot recent ACRN Hypervisor.

Signed-off-by: Markus Schuetterle <markus.schuetterle@intel.com>