### PR TITLE
Switch to use container for EPAYLOAD

### DIFF
--- a/BootloaderCommonPkg/Include/Library/ContainerLib.h
+++ b/BootloaderCommonPkg/Include/Library/ContainerLib.h
@@ -12,11 +12,18 @@
 
 #define CONTAINER_LIST_SIGNATURE SIGNATURE_32('C','T','N', 'L')
 
+#define PROGESS_ID_LOCATE             1
+#define PROGESS_ID_COPY               2
+#define PROGESS_ID_AUTHENTICATE       3
+#define PROGESS_ID_DECOMPRESS         4
+
 #define AUTH_TYPE_NONE                0
 #define AUTH_TYPE_SHA2_256            1
 #define AUTH_TYPE_SHA2_384            2
 #define AUTH_TYPE_SIG_RSA2048_SHA256  3
 #define AUTH_TYPE_SIG_RSA3072_SHA384  4
+
+typedef VOID (*LOAD_COMPONENT_CALLBACK) (UINT32 ProgressId);
 
 typedef struct {
   UINT32           Signature;
@@ -57,30 +64,7 @@ typedef struct {
 
 
 /**
-  Load a component region information from a container.
-
-  @param[in] ContainerSig    Container signature.
-  @param[in] ComponentName   component name.
-  @param[in] Buffer          Pointer to receive component base.
-  @param[in] Length          Pointer to receive component size.
-
-  @retval EFI_UNSUPPORTED          Unsupported AuthType.
-  @retval EFI_NOT_FOUND            Cannot locate component.
-  @retval EFI_SECURITY_VIOLATION   Authentication failed.
-  @retval EFI_SUCCESS              Authentication succeeded.
-
-**/
-EFI_STATUS
-EFIAPI
-LocateComponentRegion (
-  IN     UINT32    ContainerSig,
-  IN     UINT32    ComponentName,
-  OUT    UINT32   *RegionBase,
-  OUT    UINT32   *RegionLength
-  );
-
-/**
-  Locate a component from a container.
+  Locate a component information from a container.
 
   @param[in]     ContainerSig       Container signature.
   @param[in]     ComponentName      Component name.
@@ -94,18 +78,69 @@ LocateComponentRegion (
 
 **/
 EFI_STATUS
-LocateComponent (
+LocateComponentEntry (
   IN      UINT32                  ContainerSig,
   IN      UINT32                  ComponentName,
   IN OUT  CONTAINER_ENTRY       **ContainerEntryPtr,
   IN OUT  COMPONENT_ENTRY       **ComponentEntryPtr
   );
 
+
 /**
-  Load a component from a container to memory.
+  Load a component from a container or flahs map to memory and call callback
+  function at predefined point.
 
   @param[in]     ContainerSig    Container signature or component type.
   @param[in]     ComponentName   Component name.
+  @param[in,out] Buffer          Pointer to receive component base.
+  @param[in,out] Length          Pointer to receive component size.
+  @param[in]     CallbackFunc    Callback function pointer.
+
+  @retval EFI_UNSUPPORTED          Unsupported AuthType.
+  @retval EFI_NOT_FOUND            Cannot locate component.
+  @retval EFI_BUFFER_TOO_SMALL     Specified buffer size is too small.
+  @retval EFI_SECURITY_VIOLATION   Authentication failed.
+  @retval EFI_SUCCESS              Authentication succeeded.
+
+**/
+EFI_STATUS
+EFIAPI
+LoadComponentWithCallback (
+  IN     UINT32                   ContainerSig,
+  IN     UINT32                   ComponentName,
+  IN OUT VOID                   **Buffer,
+  IN OUT UINT32                  *Length,
+  IN     LOAD_COMPONENT_CALLBACK  LoadComponentCallback
+  );
+
+/**
+  Locate a component region information from a container or flash map.
+
+  @param[in]      ContainerSig    Container signature or component type.
+  @param[in]      ComponentName   component name.
+  @param[in, out] Buffer          Pointer to receive component base.
+  @param[in, out] Length          Pointer to receive component size.
+
+  @retval EFI_UNSUPPORTED          Unsupported AuthType.
+  @retval EFI_NOT_FOUND            Cannot locate component.
+  @retval EFI_SECURITY_VIOLATION   Authentication failed.
+  @retval EFI_SUCCESS              Authentication succeeded.
+
+**/
+EFI_STATUS
+EFIAPI
+LocateComponent (
+  IN     UINT32    ContainerSig,
+  IN     UINT32    ComponentName,
+  IN OUT VOID    **Buffer,
+  IN OUT UINT32   *Length
+  );
+
+/**
+  Load a component from a container or flash map to memory.
+
+  @param[in] ContainerSig    Container signature or component type.
+  @param[in] ComponentName   Component name.
   @param[in,out] Buffer          Pointer to receive component base.
   @param[in,out] Length          Pointer to receive component size.
 

--- a/BootloaderCommonPkg/Library/LoaderPerformanceLib/LoaderPerformancePrintLib.c
+++ b/BootloaderCommonPkg/Library/LoaderPerformanceLib/LoaderPerformancePrintLib.c
@@ -80,6 +80,8 @@ DefPerfIdToStr (
   case 0x20B0:
     return "Decompress Stage2";
   case 0x20C0:
+    return "Extend Stage2 hash";
+  case 0x20D0:
     return "Rebase Stage2";
   case 0x3000:
     return "Stage2 entry point";
@@ -112,11 +114,15 @@ DefPerfIdToStr (
   case 0x3100:
     return "Load payload";
   case 0x3110:
-    return "Copy payload to memory";
+    return "Locate payload";
   case 0x3120:
-    return "Verify payload";
+    return "Copy payload to memory";
   case 0x3130:
+    return "Verify payload";
+  case 0x3140:
     return "Decompress payload";
+  case 0x3150:
+    return "Extend payload hash";
   case 0x31A0:
     return "Board PostPayloadLoading hook";
   case 0x31B0:

--- a/BootloaderCorePkg/Stage1B/Stage1B.inf
+++ b/BootloaderCorePkg/Stage1B/Stage1B.inf
@@ -60,6 +60,7 @@
   TpmLib
   ResetSystemLib
   DebugAgentLib
+  ContainerLib
 
 [Guids]
   gPlatformModuleTokenSpaceGuid

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -71,6 +71,7 @@ class Board(BaseBoard):
 		self.STAGE1B_SIZE         = 0x00012000
 		self.STAGE2_SIZE          = 0x00018000
 
+		self.SIIPFW_SIZE          = 0x00010000
 		self.EPAYLOAD_SIZE        = 0x0010D000
 		self.PAYLOAD_SIZE         = 0x00020000
 		self.CFGDATA_SIZE         = 0x00001000
@@ -145,6 +146,21 @@ class Board(BaseBoard):
 		]
 		return dsc_libs
 
+	def GetContainerList (self):
+		container_list = []
+		container_list.append ([
+		  # Name       | Image File |    CompressAlg  | AuthType   | Key File                     | Region Size
+		  # =====================================================================================================================
+		  ('IPFW',      'SIIPFW.bin',    '',           'RSA2048',   'TestSigningPrivateKey.pem',    0     ),   # Container Header
+		  ('TST1',      '',              'Dummy',      '',          '',                             0x2000),   # Component 1
+		  ('TST2',      '',              'Lz4',        '',          '',                             0x3000),   # Component 2
+		  ('TST3',      '',              'Lz4',        'RSA2048',   'TestSigningPrivateKey.pem',    0x3000),   # Component 3
+		  ('TST4',      '',              'Lzma',       'SHA2_256',  '',                             0x3000),   # Component 4
+		  ('TST5',      '',              'Dummy',      'RSA2048',   'TestSigningPrivateKey.pem',    0x3000),   # Component 5
+		  ('TST6',      '',              '',           '',          '',                             0x1000),   # Component 6
+		])
+		return container_list
+
 	def GetImageLayout (self):
 
 		compress = '' if self.STAGE1B_XIP else 'Lz4'
@@ -178,6 +194,7 @@ class Board(BaseBoard):
 					('VARIABLE.bin' ,  ''        , self.VARIABLE_SIZE, STITCH_OPS.MODE_FILE_NOP, STITCH_OPS.MODE_POS_TAIL),
 					('PAYLOAD.bin'  ,  'Lzma'    , self.PAYLOAD_SIZE,  STITCH_OPS.MODE_FILE_PAD, STITCH_OPS.MODE_POS_TAIL),
 					('EPAYLOAD.bin' ,  ''        , self.EPAYLOAD_SIZE, STITCH_OPS.MODE_FILE_PAD, STITCH_OPS.MODE_POS_TAIL),
+					('SIIPFW.bin'   ,  ''        , self.SIIPFW_SIZE,   STITCH_OPS.MODE_FILE_PAD, STITCH_OPS.MODE_POS_TAIL),
 					]
 				),
 				('REDUNDANT_A.bin', [

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -22,6 +22,7 @@
 #include <Library/BootloaderCoreLib.h>
 #include <Library/BlMemoryAllocationLib.h>
 #include <Library/FspSupportLib.h>
+#include <Library/ContainerLib.h>
 #include <Guid/GraphicsInfoHob.h>
 #include <Guid/SystemTableInfoGuid.h>
 #include <Guid/SerialPortInfoGuid.h>
@@ -239,6 +240,8 @@ BoardInit (
   UINT64               TsegSize;
   UINT32               VbtAddress;
   UINT8                BootDev;
+  VOID                *Buffer;      
+  UINT32               Length;
 
   switch (InitPhase) {
   case PreSiliconInit:
@@ -268,7 +271,13 @@ BoardInit (
         Status = PcdSet32S (PcdGraphicsVbtAddress,  VbtAddress);
       }
     }
+    // Load IP firmware from container
+    Buffer = NULL;
+    Length = 0;
+    Status = LoadComponent (SIGNATURE_32('I', 'P', 'F', 'W'), SIGNATURE_32('T', 'S', 'T', '3'), &Buffer,  &Length);
+    DEBUG ((EFI_D_INFO, "Load IP firmware @ %p:0x%X - %r\n", Buffer, Length, Status));
     break;
+
   case PostPciEnumeration:
     GenericCfgData = (GEN_CFG_DATA *)FindConfigDataByTag (CDATA_GEN_TAG);
     if (GenericCfgData != NULL) {
@@ -290,6 +299,7 @@ BoardInit (
       }
     }
     break;
+
   default:
     break;
   }


### PR DESCRIPTION
This patch enabled container use case for EPAYLOAD loading.
It also switched to use LoadComponent() API for Stage2 and
payload loading. An example in QEMU was added to demonstrate
on how to add a container in build and load it in stage2 code.

To define a container layout, it is required to provide
GetContainerList() in BoardConfig.py. Then in stage or payload
code, LoadComponent() can be used to load a component from the
container.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>