### PR TITLE
Add COMP_TYPE_PAYLOAD_DYNAMIC for DoHashVerify

### DIFF
--- a/BootloaderCommonPkg/Include/Library/SecureBootLib.h
+++ b/BootloaderCommonPkg/Include/Library/SecureBootLib.h
@@ -22,7 +22,8 @@
 #define  COMP_TYPE_PUBKEY_CFG_DATA     4
 #define  COMP_TYPE_PUBKEY_FWU          5
 #define  COMP_TYPE_PUBKEY_OS           6
-#define  COMP_TYPE_INVALID             7
+#define  COMP_TYPE_PAYLOAD_DYNAMIC     7
+#define  COMP_TYPE_INVALID             8
 
 /**
   Verify data block hash with the built-in one.


### PR DESCRIPTION
Recent update to DoHashVerify routine is no longer
working for HASH_INDEX_PAYLOAD_DYNAMIC (ex. UEFI
Payload). Need to add COMP_TYPE_PAYLOAD_DYNAMIC
and increase COMP_TYPE_INVALID to resolve the
issue.

Signed-off-by: James Gutbub <james.gutbub@intel.com>