### PR TITLE
Add initial support for Mender boot

### DIFF
--- a/BootloaderCommonPkg/Include/Guid/OsBootOptionGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/OsBootOptionGuid.h
@@ -1,7 +1,7 @@
 /** @file
   This file defines the hob structure for the OS boot configuration.
 
-  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -19,6 +19,7 @@
 #define BOOT_FLAGS_CRASH_OS        BIT1
 #define BOOT_FLAGS_TRUSTY          BIT2
 #define BOOT_FLAGS_EXTRA           BIT3
+#define BOOT_FLAGS_MENDER          BIT4
 
 // This bit is used dynamically.
 #define LOAD_IMAGE_FROM_BACKUP     BIT7

--- a/PayloadPkg/Library/AbSupportLib/AbSupportLib.c
+++ b/PayloadPkg/Library/AbSupportLib/AbSupportLib.c
@@ -1,7 +1,7 @@
 /** @file
-  Payload implements one instance of Paltform Hook Library.
+  Payload implements one instance of Platform Hook Library.
 
-  Copyright (c) 2015 - 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2015 - 2019, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -168,19 +168,25 @@ GetBootSlot (
   INT32                      BootSlot;
 
   BootSlot = 0;
-  if ((BootOption->BootFlags & BOOT_FLAGS_MISC) == 0) {
-    return BootSlot;
-  }
 
-  Status   = LoadMisc (BootOption, HwPartHandle, &AbBootInfo);
-  if (!EFI_ERROR (Status)) {
-    BootSlot = ParseBootSlot (&AbBootInfo);
-    if (BootSlot < 0) {
-      DEBUG ((DEBUG_ERROR, "ERROR: boot slot error (%d)\n", BootSlot));
-      BootSlot = 0;
+  if ((BootOption->BootFlags & BOOT_FLAGS_MISC) != 0) {
+    Status   = LoadMisc (BootOption, HwPartHandle, &AbBootInfo);
+    if (!EFI_ERROR (Status)) {
+      BootSlot = ParseBootSlot (&AbBootInfo);
+      if (BootSlot < 0) {
+        DEBUG ((DEBUG_ERROR, "ERROR: boot slot error (%d)\n", BootSlot));
+        BootSlot = 0;
+      }
+    } else {
+      DEBUG ((DEBUG_ERROR, "LoadMisc Status = %r\n", Status));
     }
-  } else {
-    DEBUG ((DEBUG_ERROR, "LoadMisc Status = %r\n", Status));
+  } else if ((BootOption->BootFlags & BOOT_FLAGS_MENDER) != 0) {
+    //
+    // TODO: Need to support env file parsing to determine which
+    //       boot slot we should really be using for Mender boot
+    //       support. For now, just return primary (e.g. 0)
+    //
+    BootSlot = 0;
   }
 
   return BootSlot;

--- a/PayloadPkg/Library/SblParameterLib/SblParameterLib.c
+++ b/PayloadPkg/Library/SblParameterLib/SblParameterLib.c
@@ -1,7 +1,7 @@
 /** @file
   SBL parameters for specific OS.
 
-  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -254,6 +254,19 @@ AddSblCommandLine (
   UINT32                    DiskBus;
   UINT32                    MaxCmdSize;
 
+  MaxCmdSize = *CommandLineSize;
+
+  //
+  // Add OS Mender boot info parameter
+  //
+  if ((BootOption->BootFlags & BOOT_FLAGS_MENDER) != 0) {
+    if ((BootOption->BootFlags & LOAD_IMAGE_FROM_BACKUP) == 0) {
+      AsciiStrCatS (CommandLine, MaxCmdSize, " root=PARTLABEL=primary");
+    } else {
+      AsciiStrCatS (CommandLine, MaxCmdSize, " root=PARTLABEL=secondary");
+    }
+  }
+
   if (BootOption->ImageType != EnumImageTypeAdroid) {
     // currently these command line parameters are tested only with Android OS.
     return EFI_SUCCESS;
@@ -262,7 +275,6 @@ AddSblCommandLine (
   //
   // Allocate the reserved memory and update command line parameters
   //
-  MaxCmdSize = *CommandLineSize;
   OsConfigData = (OS_CONFIG_DATA_HOB *) GetGuidHobData (NULL, NULL, &gOsConfigDataGuid);
   if ((OsConfigData != NULL) && (OsConfigData->OsCrashMemorySize != 0)) {
     Buffer = AllocateReservedPages (EFI_SIZE_TO_PAGES (OsConfigData->OsCrashMemorySize));

--- a/PayloadPkg/OsLoader/BootParameters.c
+++ b/PayloadPkg/OsLoader/BootParameters.c
@@ -150,7 +150,7 @@ UpdateOsMemMap (
 
   //
   // Linux E820 Mmap is very similar with multiboot MMAP
-  // Here find the diffenerce to share same update logic below
+  // Here find the difference to share same update logic below
   //
   if ((LoadedImage->Flags & LOADED_IMAGE_MULTIBOOT) != 0) {
     MultiBoot = &LoadedImage->Image.MultiBoot;
@@ -203,7 +203,7 @@ DisplayInfo (
 /**
   Update OS boot parameters
 
-  This function will append reqired command line parameters,
+  This function will append required command line parameters,
   and update mem map info.
 
   @param[in]     CurrentBootOption Current boot option

--- a/Platform/CommonBoardPkg/CfgData/Template_BootOption.dsc
+++ b/Platform/CommonBoardPkg/CfgData/Template_BootOption.dsc
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -21,7 +21,7 @@
 
     # !BSF NAME:{Boot Flags}
     # !BSF TYPE:{Combo}
-    # !BSF OPTION:{0:Normal, 1:A/B support, 2:Crash OS, 4:Trusty support, 5:Trusty and A/B support}
+    # !BSF OPTION:{0:Normal, 1:A/B support, 2:Crash OS, 4:Trusty support, 5:Trusty and A/B support, 16:Mender support}
     # !BSF HELP:{Specify boot flags (options)}
     gCfgData.BootFlags_$(1)                 |      * | 0x01 | $(3)
 
@@ -36,7 +36,7 @@
     # !BSF NAME:{Boot Device instance}
     # !BSF TYPE:{Combo}
     # !BSF OPTION:{0:Device 0, 1:Device 1, 2:Device 2, 3:Device 3}
-    # !BSF HELP:{Specify boot device instance when then are multple instances}
+    # !BSF HELP:{Specify boot device instance when then are multiple instances}
     # !BSF ORDER:{0000.0000}
     gCfgData.BootDeviceInstance_$(1)        |      * | 0x01 | $(5)
 
@@ -78,7 +78,7 @@
     # !BSF NAME:{LBA address for normal OS Image)}
     # !BSF CONDITION:{$FsType_$(1) == 3}
     # !BSF TYPE:{EditNum, INT, (0,0xFFFFFFFF)}
-    # !BSF HELP:{pecify LBA address where to find normal OS image}
+    # !BSF HELP:{Specify LBA address where to find normal OS image}
     gCfgData.LbaAddr_0_$(1)                 |      * | 0x04 | $(11)
 
     # ---------------------------- IMAGE[1] -------------------------
@@ -115,7 +115,7 @@
 
     gCfgData.Valid_2_$(1)                   |      * | 0x01 | 1
 
-    # !BSF NAME:{Sofware partition for misc Image}
+    # !BSF NAME:{Software partition for misc Image}
     # !BSF CONDITION:{($BootFlags_$(1) & 0x1 == 0x1) and ($FsType_$(1) == 3)}
     # !BSF TYPE:{EditNum, INT, (0,127)}
     # !BSF HELP:{Specify software partition number for OS A/B support}


### PR DESCRIPTION
Mender is a A/B partitioning scheme
for Linux OSes. Adding initial support
for specifying the root partition label
that should be tried. Later on the root
partition label should be acquired based
on the value of the env files stored in
the EFI/FAT32 partition of the boot media.

Signed-off-by: James Gutbub <james.gutbub@intel.com>