### PR TITLE
Replace HASH_INDEX_* with COMP_TYPE_*

### DIFF
--- a/BootloaderCommonPkg/Include/Library/SecureBootLib.h
+++ b/BootloaderCommonPkg/Include/Library/SecureBootLib.h
@@ -30,7 +30,7 @@
 
   @param[in]  Data           Data buffer pointer.
   @param[in]  Length         Data buffer size.
-  @param[in]  HashAlg        Specify hash algrothsm.
+  @param[in]  HashAlg        Specify hash algorithm.
   @param[in]  ComponentType  Component type.
   @param[in,out]  Hash       On input,  expected hash value when ComponentType is not used.
                              On output, calculated hash value when verification succeeds.
@@ -88,7 +88,7 @@ DoRsaVerify (
   @param[in] Size                    Size of the array to be generated.
 
   @retval EFI_SUCCESS                Random number generation successful.
-  @retval EFI_UNSUPPORTED            Couldnt generate a random number.
+  @retval EFI_UNSUPPORTED            Couldn't generate a random number.
 **/
 RETURN_STATUS
 EFIAPI

--- a/BootloaderCorePkg/Include/HashStore.h
+++ b/BootloaderCorePkg/Include/HashStore.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2016 - 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -11,16 +11,7 @@
 #define  HASH_STORE_SIGNATURE                SIGNATURE_32('_', 'H', 'S', '_')
 #define  HASH_STORE_DIGEST_LENGTH            32
 
-#define  HASH_INDEX_STAGE_1B               0
-#define  HASH_INDEX_STAGE_2                1
-#define  HASH_INDEX_PAYLOAD                2
-#define  HASH_INDEX_FIRMWARE_UPDATE        3
-#define  HASH_INDEX_CFG_PUBKEY             4
-#define  HASH_INDEX_FWU_PUBKEY             5
-#define  HASH_INDEX_OS_PUBKEY              6
-#define  HASH_INDEX_PAYLOAD_DYNAMIC        7
-#define  HASH_INDEX_MAX_NUM                8
-
+#define  HASH_INDEX_MAX_NUM                  8
 
 #pragma pack(1)
 typedef struct {

--- a/BootloaderCorePkg/Library/BootloaderLib/BootloaderLib.c
+++ b/BootloaderCorePkg/Library/BootloaderLib/BootloaderLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -10,6 +10,7 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLogBufferLib.h>
 #include <Library/BootloaderCoreLib.h>
+#include <Library/SecureBootLib.h>
 #include <Library/HobLib.h>
 #include <Library/PcdLib.h>
 #include <HashStore.h>
@@ -86,7 +87,7 @@ SetComponentHash (
   HashIndex = ComponentType;
   LdrGlobal = GetLoaderGlobalDataPointer ();
   HashStorePtr = (HASH_STORE_TABLE *)LdrGlobal->HashStorePtr;
-  if ((HashStorePtr == NULL) || (HashIndex != HASH_INDEX_PAYLOAD_DYNAMIC)) {
+  if ((HashStorePtr == NULL) || (HashIndex != COMP_TYPE_PAYLOAD_DYNAMIC)) {
     return RETURN_UNSUPPORTED;
   }
 


### PR DESCRIPTION
Since HASH_INDEX_* is a 1:1 mapping with
COMP_TYPE_* we can remove HASH_INDEX_* and
replace with COMP_TYPE_*.

Also fix some misspellings.

Signed-off-by: James Gutbub <james.gutbub@intel.com>