### PR TITLE
[Ext23Lib] Fix EXT filesystem booting failure

### DIFF
--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.c
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.c
@@ -230,7 +230,7 @@ BDevStrategy (
 
   Startblockno = BlockNum + PrivateData->StartBlock;
   if (ReadWrite == F_READ) {
-    Res = MediaReadBlocks (0, (UINT32)Startblockno, Size, Buf);
+    Res = MediaReadBlocks (PrivateData->PhysicalDevNo, (UINT32)Startblockno, Size, Buf);
     if (Res != 0) {
       return Res;
     }


### PR DESCRIPTION
Currently, Ext23Lib accesses device index 0 only.
It must access proper hardware partition when reading blocks.
- Reproducible with QEMU which has SATA port 5

Signed-off-by: Aiden Park <aiden.park@intel.com>