### PR TITLE
[ShellLib] Add ShellCommandRegister API

### DIFF
--- a/BootloaderCommonPkg/Include/Library/ShellLib.h
+++ b/BootloaderCommonPkg/Include/Library/ShellLib.h
@@ -1,7 +1,7 @@
 /** @file
   A minimal command-line shell.
 
-  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -25,7 +25,6 @@ typedef struct {
 
 struct _SHELL {
   BOOLEAN               ShouldExit;
-  CONST SHELL_COMMAND **Commands;
 };
 
 /**
@@ -63,53 +62,18 @@ ShellPrint (
   ...
   );
 
-// Basic Commands
-extern CONST SHELL_COMMAND ShellCommandExit;
-extern CONST SHELL_COMMAND ShellCommandHelp;
-#define SHELL_COMMANDS_BASIC \
-  &ShellCommandExit, \
-  &ShellCommandHelp, \
+/**
+  Register a Shell Command
 
-// Standard Commands
-extern CONST SHELL_COMMAND ShellCommandHob;
-extern CONST SHELL_COMMAND ShellCommandMem;
-extern CONST SHELL_COMMAND ShellCommandMmap;
-extern CONST SHELL_COMMAND ShellCommandPerf;
-extern CONST SHELL_COMMAND ShellCommandBoot;
-extern CONST SHELL_COMMAND ShellCommandMmcDll;
-extern CONST SHELL_COMMAND ShellCommandCdata;
-extern CONST SHELL_COMMAND ShellCommandDmesg;
+  @param[in]  ShellCommand A Shell Command to be registered
 
-#define SHELL_COMMANDS_STANDARD \
-  &ShellCommandHob, \
-  &ShellCommandMem, \
-  &ShellCommandMmap, \
-  &ShellCommandPerf, \
-  &ShellCommandBoot, \
-  &ShellCommandMmcDll, \
-  &ShellCommandCdata, \
-  &ShellCommandDmesg, \
-
-// x86 Architectural Commands
-extern CONST SHELL_COMMAND ShellCommandCpuid;
-extern CONST SHELL_COMMAND ShellCommandIo;
-extern CONST SHELL_COMMAND ShellCommandMsr;
-extern CONST SHELL_COMMAND ShellCommandMtrr;
-extern CONST SHELL_COMMAND ShellCommandPci;
-extern CONST SHELL_COMMAND ShellCommandReset;
-extern CONST SHELL_COMMAND ShellCommandUcode;
-#define SHELL_COMMANDS_X86 \
-  &ShellCommandCpuid, \
-  &ShellCommandIo, \
-  &ShellCommandMsr, \
-  &ShellCommandMtrr, \
-  &ShellCommandPci, \
-  &ShellCommandReset, \
-  &ShellCommandUcode, \
-
-#define SHELL_COMMANDS_DEFAULT \
-  SHELL_COMMANDS_BASIC \
-  SHELL_COMMANDS_STANDARD \
-  SHELL_COMMANDS_X86 \
+  @retval EFI_SUCCESS
+  @retval EFI_OUT_OF_RESOURCES
+**/
+EFI_STATUS
+EFIAPI
+ShellCommandRegister (
+  IN  CONST SHELL_COMMAND   *ShellCommand
+  );
 
 #endif

--- a/BootloaderCommonPkg/Library/ShellLib/CmdHelp.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdHelp.c
@@ -1,14 +1,14 @@
 /** @file
   Shell command `help` to display the list of supported shell commands.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
 #include <Library/ShellLib.h>
-
-extern CONST SHELL_COMMAND *mShellDefaultCommands[];
+#include <Library/DebugLib.h>
+#include "Shell.h"
 
 /**
   Display list of supported shell commands.
@@ -54,16 +54,15 @@ ShellCommandHelpFunc (
   IN CHAR16 *Argv[]
   )
 {
-  CONST SHELL_COMMAND **Iter;
+  LIST_ENTRY                *EntryList;
+  LIST_ENTRY                *Link;
+  SHELL_COMMAND_LIST_ENTRY  *Entry;
 
-  for (Iter = mShellDefaultCommands; *Iter != NULL; Iter++) {
-    ShellPrint (L"%-8s - %s\n", (*Iter)->Name,
-                (*Iter)->Desc);
-  }
+  EntryList = GetShellCommandEntryList ();
+  for (Link = EntryList->ForwardLink; Link != EntryList; Link = Link->ForwardLink) {
+    Entry = CR (Link, SHELL_COMMAND_LIST_ENTRY, Link, SHELL_COMMAND_LIST_ENTRY_SIGNATURE);
 
-  for (Iter = Shell->Commands; *Iter != NULL; Iter++) {
-    ShellPrint (L"%-8s - %s\n", (*Iter)->Name,
-                (*Iter)->Desc);
+    ShellPrint (L"%-8s - %s\n", Entry->ShellCommand->Name, Entry->ShellCommand->Desc);
   }
 
   return EFI_SUCCESS;

--- a/BootloaderCommonPkg/Library/ShellLib/Shell.h
+++ b/BootloaderCommonPkg/Library/ShellLib/Shell.h
@@ -1,13 +1,21 @@
 /** @file
   A minimal command-line shell.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
 #ifndef _SHELL_H_
 #define _SHELL_H_
+
+#define SHELL_COMMAND_LIST_ENTRY_SIGNATURE  SIGNATURE_32('S','C','L','E')
+
+typedef struct {
+  UINT32                    Signature;
+  CONST SHELL_COMMAND      *ShellCommand;
+  LIST_ENTRY                Link;
+} SHELL_COMMAND_LIST_ENTRY;
 
 /**
   Read a line of input from the serial port.
@@ -47,6 +55,17 @@ ShellReadUintn (
   OUT       CHAR16  *Buffer,
   IN  CONST UINTN    BufferSize,
   OUT       BOOLEAN *IsHex
+  );
+
+/**
+  Return a Shell Command Entry List Pointer
+
+  @retval LIST_ENTRY Pointer
+**/
+LIST_ENTRY *
+EFIAPI
+GetShellCommandEntryList (
+  VOID
   );
 
 #endif

--- a/BootloaderCommonPkg/Library/ShellLib/ShellCmds.c
+++ b/BootloaderCommonPkg/Library/ShellLib/ShellCmds.c
@@ -1,0 +1,34 @@
+/** @file
+
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "ShellCmds.h"
+
+EFI_STATUS
+LoadShellCommands (
+  VOID
+  )
+{
+  ShellCommandRegister (&ShellCommandExit);
+  ShellCommandRegister (&ShellCommandHelp);
+  ShellCommandRegister (&ShellCommandHob);
+  ShellCommandRegister (&ShellCommandMem);
+  ShellCommandRegister (&ShellCommandMmap);
+  ShellCommandRegister (&ShellCommandPerf);
+  ShellCommandRegister (&ShellCommandBoot);
+  ShellCommandRegister (&ShellCommandMmcDll);
+  ShellCommandRegister (&ShellCommandCdata);
+  ShellCommandRegister (&ShellCommandDmesg);
+  ShellCommandRegister (&ShellCommandCpuid);
+  ShellCommandRegister (&ShellCommandIo);
+  ShellCommandRegister (&ShellCommandMsr);
+  ShellCommandRegister (&ShellCommandMtrr);
+  ShellCommandRegister (&ShellCommandPci);
+  ShellCommandRegister (&ShellCommandReset);
+  ShellCommandRegister (&ShellCommandUcode);
+
+  return EFI_SUCCESS;
+}

--- a/BootloaderCommonPkg/Library/ShellLib/ShellCmds.h
+++ b/BootloaderCommonPkg/Library/ShellLib/ShellCmds.h
@@ -1,0 +1,36 @@
+/** @file
+
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __SHELL_CMDS_H__
+#define __SHELL_CMDS_H__
+
+#include <Library/ShellLib.h>
+
+extern CONST SHELL_COMMAND ShellCommandExit;
+extern CONST SHELL_COMMAND ShellCommandHelp;
+extern CONST SHELL_COMMAND ShellCommandHob;
+extern CONST SHELL_COMMAND ShellCommandMem;
+extern CONST SHELL_COMMAND ShellCommandMmap;
+extern CONST SHELL_COMMAND ShellCommandPerf;
+extern CONST SHELL_COMMAND ShellCommandBoot;
+extern CONST SHELL_COMMAND ShellCommandMmcDll;
+extern CONST SHELL_COMMAND ShellCommandCdata;
+extern CONST SHELL_COMMAND ShellCommandDmesg;
+extern CONST SHELL_COMMAND ShellCommandCpuid;
+extern CONST SHELL_COMMAND ShellCommandIo;
+extern CONST SHELL_COMMAND ShellCommandMsr;
+extern CONST SHELL_COMMAND ShellCommandMtrr;
+extern CONST SHELL_COMMAND ShellCommandPci;
+extern CONST SHELL_COMMAND ShellCommandReset;
+extern CONST SHELL_COMMAND ShellCommandUcode;
+
+EFI_STATUS
+LoadShellCommands (
+  VOID
+  );
+
+#endif /* __SHELL_CMDS_H__ */

--- a/BootloaderCommonPkg/Library/ShellLib/ShellLib.inf
+++ b/BootloaderCommonPkg/Library/ShellLib/ShellLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -37,10 +37,11 @@
   CmdPerf.c
   CmdReset.c
   CmdUcode.c
+  CmdCdata.c
+  ShellCmds.c
   Parsing.c
   Printing.c
   Shell.c
-  CmdCdata.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -62,6 +63,7 @@
   BootOptionLib
   ResetSystemLib
   BootloaderCommonLib
+  MemoryAllocationLib
 
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress


### PR DESCRIPTION
Currently, all shell commands are statically defined in header file.
Add shell command registration API to allow include/exclude shell
commands dynamically.
Later, some debug shell commands will be added according to build
mode or debug mask.
- TBD: Sorting shell commands by name

Signed-off-by: Aiden Park <aiden.park@intel.com>