### PR TITLE
[CFL] Fix S3/S4 resume

### DIFF
--- a/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -570,13 +570,18 @@ GetPlatformPowerState (
     }
   }
 
+  ///
+  /// Clear Wake Status
+  /// Also clear the PWRBTN_EN, it causes SMI# otherwise (SCI_EN is 0)
+  ///
+  IoWrite32 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_STS, ((UINT32)~B_ACPI_IO_PM1_EN_PWRBTN_EN & R_ACPI_IO_PM1_EN_MASK) | B_ACPI_IO_PM1_STS_WAK );
+
   if ((MmioRead8 (PCH_PWRM_BASE_ADDRESS + R_PMC_PWRM_GEN_PMCON_B) & B_PMC_PWRM_GEN_PMCON_B_RTC_PWR_STS) != 0) {
     BootMode = BOOT_WITH_FULL_CONFIGURATION;
 
     ///
-    /// Clear Wake Status and Sleep Type
+    /// Clear Sleep Type
     ///
-    IoWrite16 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_STS, B_ACPI_IO_PM1_STS_WAK);
     IoAndThenOr16 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_CNT, (UINT16) ~B_ACPI_IO_PM1_CNT_SLP_TYP, V_ACPI_IO_PM1_CNT_S0);
   }
 

--- a/Silicon/CoffeelakePkg/Include/Register/PchRegsPmc.h
+++ b/Silicon/CoffeelakePkg/Include/Register/PchRegsPmc.h
@@ -19,6 +19,8 @@
 
 #define R_ACPI_IO_PM1_STS                        0x00
 #define B_ACPI_IO_PM1_STS_WAK                    BIT15
+#define R_ACPI_IO_PM1_EN_MASK                    0xFFFF0000
+#define B_ACPI_IO_PM1_EN_PWRBTN_EN               BIT24
 
 #define R_ACPI_IO_PM1_CNT                        0x04
 #define B_ACPI_IO_PM1_CNT_SLP_TYP                (BIT12 | BIT11 | BIT10)


### PR DESCRIPTION
S4 resume sets PWRBTN_EN. And since SCI_EN is set to 0,
this situation will generate spurious SMI# once GblSmi
is enabled.

Also moving RestoreS3regs before ProcessAllLocks, as SMI_LOCK
setting will prevent enabling GblSmi on S3 resume path.

Signed-off-by: Sai Talamudupula <sai.kiran.talamudupula@intel.com>