### PR TITLE
Reinitialize Shell command list

### DIFF
--- a/BootloaderCommonPkg/Library/ShellLib/Shell.c
+++ b/BootloaderCommonPkg/Library/ShellLib/Shell.c
@@ -113,6 +113,8 @@ Shell (
   SHELL   Shell;
   CONST SHELL_COMMAND **Iter;
 
+  InitializeListHead (&mShellCommandEntryList);
+
   LoadShellCommands ();
   for (Iter = Commands; *Iter != NULL; Iter++) {
     ShellCommandRegister (*Iter);


### PR DESCRIPTION
Since OsLoader will restart from beginning and all memory will be
reclaimed, it is required for Shell library to re-initialize the
global varaibles, for example, command list. Otherwise, the old
memory pointer will be used and cause issues. This patch added the
link list re-initialization in Shell lib.  It fixed #253.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>