### PR TITLE
Fix - IFWI built using Stitchloader.py is failing

### DIFF
--- a/Platform/CoffeelakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/CoffeelakeBoardPkg/Script/StitchIfwi.py
@@ -110,7 +110,6 @@ def RunCmd (Cmd, Cwd):
                 CmdArgs[0] = CmdArgs[0][2:]
         else:
             Shell = False
-        #Proc = subprocess.Popen(CmdArgs, shell = Shell, cwd=Cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         Proc = subprocess.Popen(CmdArgs, shell = Shell, cwd=Cwd)
         Out, Err = Proc.communicate()
         Ret = Proc.returncode
@@ -453,8 +452,11 @@ def Stitch (StitchDir, StitchZip, BtgProfile, SpiQuadMode, PlatformData, FullRdu
     os.chdir(StitchDir)
 
     if PlatformData:
+        Fd = open(os.path.join(StitchDir, CfgVar['fitinput'], "SlimBootloader.bin"), "rb")
+        InputData = bytearray(Fd.read())
+        Fd.close()
         print ("\n Adding platform data to Slimbootloader ...")
-        Data = AddPlatformData(os.path.join(StitchDir, CfgVar['fitinput'], "SlimBootloader.bin"), 0, PlatformData)
+        Data = AddPlatformData(InputData, 0, PlatformData)
         Fd = open(os.path.join(StitchDir, CfgVar['fitinput'], "SlimBootloader.bin"), "wb")
         Fd.write(Data)
         Fd.close()

--- a/Platform/CoffeelakeBoardPkg/Script/StitchLoader.py
+++ b/Platform/CoffeelakeBoardPkg/Script/StitchLoader.py
@@ -229,11 +229,7 @@ def LocateComponent(Root, Path):
     else:
         return None
 
-def AddPlatformData (InputFile, RgnLen, PlatformData = None):
-    Fd = open(InputFile, "rb")
-    InputData = bytearray(Fd.read())
-    Fd.close()
-
+def AddPlatformData (InputData, RgnLen, PlatformData = None):
     InputLen = len(InputData)
     if RgnLen is not 0:
         if RgnLen < InputLen:
@@ -256,9 +252,14 @@ def ReplaceRegion (IfwiData, Rgn, InputFile, TailPos, PlatformData = None):
     RgnPos = Rgn[1]
     RgnLen = Rgn[2]
 
-    InputData = AddPlatformData(InputFile, RgnLen, PlatformData)
-    if InputData is None:
-        return
+    Fd = open(InputFile, "rb")
+    InputData = bytearray(Fd.read())
+    Fd.close()
+
+    if PlatformData:
+        InputData = AddPlatformData(InputData, RgnLen, PlatformData)
+        if InputData is None:
+            return
 
     InputLen = len(InputData)
     RgnOff = RgnLen - InputLen


### PR DESCRIPTION
Because of an error in Stitchloader.py, input file
slimbootloader binary data is not patched to the input
Ifwi. This error is now fixed which will produce correct
Ifwi image.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>