### PR TITLE
Break Load Linux BzImage into more functions

### DIFF
--- a/BootloaderCommonPkg/Include/Library/LinuxLib.h
+++ b/BootloaderCommonPkg/Include/Library/LinuxLib.h
@@ -218,6 +218,17 @@ LoadBzImage (
   );
 
 /**
+  Update linux kernel boot parameters.
+
+  @retval EFI_SUCCESS        Linux boot parameters were updated successfully.
+**/
+VOID
+EFIAPI
+UpdateLinuxBootParams (
+  VOID
+  );
+
+/**
   Load linux kernel image to specified address and setup boot parameters.
 
   @param[in]  HobList    HOB list pointer. Not used for now.

--- a/BootloaderCommonPkg/Library/LinuxLib/LinuxLib.c
+++ b/BootloaderCommonPkg/Library/LinuxLib/LinuxLib.c
@@ -193,13 +193,6 @@ LoadBzImage (
   UINT32                      BootParamSize;
   UINTN                       KernelSize;
   VOID CONST                 *ImageBase;
-  EFI_HOB_GUID_TYPE          *GuidHob;
-  EFI_PEI_GRAPHICS_INFO_HOB  *GfxInfoHob;
-  UINTN                       MemoryMapSize;
-  E820_ENTRY                 *E820Entry;
-  MEMORY_MAP_INFO            *MapInfo;
-  UINTN                      Index;
-  EFI_GRAPHICS_OUTPUT_MODE_INFORMATION *GfxMode;
 
   ImageBase = KernelBase;
   if (ImageBase == NULL) {
@@ -233,6 +226,31 @@ LoadBzImage (
   Bp->Hdr.CmdlineSize  = CmdLineLen;
   Bp->Hdr.RamDiskStart = (UINT32)InitRdBase;
   Bp->Hdr.RamDisklen   = InitRdLen;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Update linux kernel boot parameters.
+
+  @retval EFI_SUCCESS        Linux boot parameters were updated successfully.
+**/
+VOID
+EFIAPI
+UpdateLinuxBootParams (
+  VOID
+  )
+{
+  BOOT_PARAMS                *Bp;
+  EFI_HOB_GUID_TYPE          *GuidHob;
+  EFI_PEI_GRAPHICS_INFO_HOB  *GfxInfoHob;
+  UINTN                       MemoryMapSize;
+  E820_ENTRY                 *E820Entry;
+  MEMORY_MAP_INFO            *MapInfo;
+  UINTN                       Index;
+  EFI_GRAPHICS_OUTPUT_MODE_INFORMATION *GfxMode;
+
+  Bp = GetLinuxBootParams ();
 
   //
   // Get graphics data
@@ -281,7 +299,6 @@ LoadBzImage (
   }
   Bp->E820Entries = (UINT8)MapInfo->Count;
 
-  return EFI_SUCCESS;
 }
 
 /**
@@ -298,6 +315,8 @@ LinuxBoot (
   )
 {
   BOOT_PARAMS   *Bp;
+
+  UpdateLinuxBootParams ();
   Bp = GetLinuxBootParams ();
   JumpToKernel ((VOID *)Bp->Hdr.Code32Start, Bp);
 }

--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -250,6 +250,7 @@ SetupBootImage (
       DEBUG ((DEBUG_ERROR, "Setup BzImage error, %r\n", Status));
       return Status;
     }
+    UpdateLinuxBootParams ();
     LinuxImage->BootParams = GetLinuxBootParams ();
     LoadedImage->Flags  = (LoadedImage->Flags  & ~LOADED_IMAGE_MULTIBOOT) | LOADED_IMAGE_LINUX;
   }


### PR DESCRIPTION
This patch splitted LoadBzImage() into two functions.  One is just
for kernel loading.  The other one UpdateLinuxBootParams() is for
Linux boot parameter updates. It is required to do so because when
kernel loading in Stage2 is enabled the loading occurs before all
HOBs are finalized. The Linux boot parameters depend on HOBs to fill
correct information, such as frame buffer. With this patch, the boot
parameters can be updated at the very end.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>