### PR TITLE
Enable Linux as payload support

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -291,6 +291,7 @@
   gPlatformModuleTokenSpaceGuid.PcdPsdBiosEnabled         | $(HAVE_PSD_TABLE)
   gPayloadTokenSpaceGuid.PcdGrubBootCfgEnabled            | $(ENABLE_GRUB_CONFIG)
   gPlatformModuleTokenSpaceGuid.PcdSmbiosEnabled          | $(ENABLE_SMBIOS)
+  gPlatformModuleTokenSpaceGuid.PcdLinuxPayloadEnabled    | $(ENABLE_LINUX_PAYLOAD)
 
 !ifdef $(S3_DEBUG)
   gPlatformModuleTokenSpaceGuid.PcdS3DebugEnabled         | $(S3_DEBUG)

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -188,6 +188,7 @@ class BaseBoard(object):
 		self.ENABLE_SMM_REBASE     = 0
 		self.ENABLE_GRUB_CONFIG    = 0
 		self.ENABLE_SMBIOS         = 0
+		self.ENABLE_LINUX_PAYLOAD  = 0
 
 		self.ACM_SIZE              = 0
 		self.UCODE_SIZE            = 0

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -46,6 +46,7 @@ class Board(BaseBoard):
 		self.ENABLE_FRAMEBUFFER_INIT  = 1
 		self.ENABLE_FWU               = 1
 		self.ENABLE_GRUB_CONFIG       = 1
+		self.ENABLE_LINUX_PAYLOAD     = 1
 
 		# To enable source debug, set 1 to self.ENABLE_SOURCE_DEBUG
 		# self.ENABLE_SOURCE_DEBUG  = 1
@@ -72,7 +73,7 @@ class Board(BaseBoard):
 		self.STAGE2_SIZE          = 0x00018000
 
 		self.SIIPFW_SIZE          = 0x00010000
-		self.EPAYLOAD_SIZE        = 0x0010D000
+		self.EPAYLOAD_SIZE        = 0x0030D000
 		self.PAYLOAD_SIZE         = 0x00020000
 		self.CFGDATA_SIZE         = 0x00001000
 		self.VARIABLE_SIZE        = 0x00002000
@@ -84,12 +85,12 @@ class Board(BaseBoard):
 			self.TOP_SWAP_SIZE      = 0x000000
 			self.REDUNDANT_SIZE     = 0x000000
 			self.NON_VOLATILE_SIZE  = 0x000000
-			self.NON_REDUNDANT_SIZE = 0x200000
+			self.NON_REDUNDANT_SIZE = 0x400000
 		else:
 			self.TOP_SWAP_SIZE      = 0x010000
 			self.REDUNDANT_SIZE     = 0x050000
 			self.NON_VOLATILE_SIZE  = 0x001000
-			self.NON_REDUNDANT_SIZE = 0x13F000
+			self.NON_REDUNDANT_SIZE = 0x33F000
 
 
 		self.SLIMBOOTLOADER_SIZE = (self.TOP_SWAP_SIZE + self.REDUNDANT_SIZE) * 2 + \

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -283,14 +283,20 @@ BoardInit (
     GenericCfgData = (GEN_CFG_DATA *)FindConfigDataByTag (CDATA_GEN_TAG);
     if (GenericCfgData != NULL) {
       if (GenericCfgData->PayloadId == AUTO_PAYLOAD_ID_SIGNATURE) {
-        // Use QEMU bootorder to select the payload
-        // Add QEMU command line parameter '-boot order=??a' to enable EFI payload
-        // Here ?? is the normal boot device.
+        // Use QEMU 3rd bootorder to select the payload
+        // Add QEMU command line parameter:
+        //   default           : enable OsLoader
+        //   '-boot order=??a' : enable EFI payload
+        //   '-boot order=??c' : enable LINUX payload
+        // Here ?? is the normal boot devices.
         IoWrite8 (0x70, 0x38);
         BootDev = IoRead8 (0x71) >> 4;
         if (BootDev == 1) {
           // Boot UEFI payload
           SetPayloadId (UEFI_PAYLOAD_ID_SIGNATURE);
+        } else if (BootDev == 2) {
+          // Boot LINUX payload
+          SetPayloadId (LINX_PAYLOAD_ID_SIGNATURE);
         } else {
           // Boot OsLoader
           SetPayloadId (0);


### PR DESCRIPTION
This patch enabled Linux as payload support on QEMU platform. To build
Linux as payload, please follow instructions mentioned in commit:
  4a5af4f8b0824f298b9f91bdd874c8cb60f46fb6
In addtion, to boot Linux payload on QEMU, please append following
into QEMU command line to set Payload ID to 'LINX' dynamically.
  -boot order=abc

Signed-off-by: Maurice Ma <maurice.ma@intel.com>