### PR TITLE
Add common functions on PlatformName and external config data

### DIFF
--- a/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
+++ b/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
@@ -50,6 +50,7 @@
   RleCompressLib
   BootGuardLib
   HeciLib
+  BoardSupportLib
 
 [Guids]
   gEfiHeciMbpDataHobGuid

--- a/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
@@ -43,6 +43,7 @@
   BootGuardLib
   SgxLib
   MmcAccessLib
+  BoardSupportLib
 
 [Guids]
 

--- a/Platform/CommonBoardPkg/Include/Library/BoardSupportLib.h
+++ b/Platform/CommonBoardPkg/Include/Library/BoardSupportLib.h
@@ -21,4 +21,38 @@ FillBootOptionListFromCfgData (
   IN OUT   OS_BOOT_OPTION_LIST   *OsBootOptionList
 );
 
+
+/**
+  Set the platform name with CFGDATA info
+
+ **/
+VOID
+EFIAPI
+PlatformNameInit (
+  VOID
+);
+
+/**
+  Load the configuration data blob from SPI flash into destination buffer.
+  It supports the sources: PDR, BIOS for external Cfgdata.
+
+  @param[in]    Dst        Destination address to load configuration data blob.
+  @param[in]    Src        Source address to load configuration data blob.
+  @param[in]    Len        The destination address buffer size.
+
+  @retval  EFI_SUCCESS             Configuration data blob was loaded successfully.
+  @retval  EFI_NOT_FOUND           Configuration data blob cannot be found.
+  @retval  EFI_OUT_OF_RESOURCES    Destination buffer is too small to hold the
+                                   configuration data blob.
+  @retval  Others                  Failed to load configuration data blob.
+
+**/
+EFI_STATUS
+EFIAPI
+SpiLoadExternalConfigData (
+  IN UINT32  Dst,
+  IN UINT32  Src,
+  IN UINT32  Len
+  );
+
 #endif

--- a/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.inf
+++ b/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.inf
@@ -27,3 +27,6 @@
 
 [Pcd]
   gPlatformModuleTokenSpaceGuid.PcdOsBootOptionNumber
+  gPlatformModuleTokenSpaceGuid.PcdCfgDataLoadSource
+  gPlatformModuleTokenSpaceGuid.PcdCfgDatabaseSize
+  gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled

--- a/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -22,6 +22,7 @@
 #include <Library/SpiFlashLib.h>
 #include <Library/VariableLib.h>
 #include <Library/BootloaderCoreLib.h>
+#include <Library/BoardSupportLib.h>
 #include <ConfigDataBlob.h>
 #include <FspmUpd.h>
 #include <BlCommon.h>
@@ -169,21 +170,6 @@ VOID BoardDetection (
   SetPlatformId (BoardId);
 }
 
-/**
-    Read the Platform Name from the config data
-**/
-VOID
-PlatformNameInit (
-  VOID
-  )
-{
-  PLAT_NAME_CFG_DATA          *PlatNameConfigData;
-
-  PlatNameConfigData = (PLAT_NAME_CFG_DATA *) FindConfigDataByTag(CDATA_PLAT_NAME_TAG);
-  if (PlatNameConfigData != NULL) {
-    SetPlatformName ((VOID *)&PlatNameConfigData->PlatformName);
-  }
-}
 
 /**
   Board specific hook points.
@@ -275,27 +261,8 @@ LoadExternalConfigData (
   IN UINT32  Len
   )
 {
-  EFI_STATUS   Status;
-  CDATA_BLOB  *CfgBlob;
-  UINT32       SignedLen;
 
-  Status = EFI_SUCCESS;
-  CfgBlob = (CDATA_BLOB  *)Src;
-  if ((CfgBlob != NULL) && (CfgBlob->Signature == CFG_DATA_SIGNATURE)) {
-    SignedLen = CfgBlob->UsedLength;
-    if (FeaturePcdGet (PcdVerifiedBootEnabled)) {
-      SignedLen += RSA_SIGNATURE_AND_KEY_SIZE;
-    }
-    if ((SignedLen <= Len) && (SignedLen > sizeof(CDATA_BLOB))) {
-      CopyMem ((VOID *)Dst, (VOID *)Src, SignedLen);
-    } else {
-      Status = EFI_OUT_OF_RESOURCES;
-    }
-  } else {
-    Status = EFI_NOT_FOUND;
-  }
-
-  return Status;
+  return SpiLoadExternalConfigData (Dst, Src, Len);
 }
 
 /**

--- a/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
+++ b/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
@@ -39,6 +39,7 @@
   ConfigDataLib
   SpiFlashLib
   VariableLib
+  BoardSupportLib
 
 [Guids]
 


### PR DESCRIPTION
Getting platform name from config data and set platform name is
common almost for all the platforms. So move it to common library.
Loading external configuration data from SPI is also common, so
add it into common library. Platform could still use its own method
to load config data if the common one doesn't work.

Signed-off-by: Guo Dong <guo.dong@intel.com>