### PR TITLE
Switch to use container for pre-OS checker/payload

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.fdf
+++ b/BootloaderCorePkg/BootloaderCorePkg.fdf
@@ -223,12 +223,6 @@ FV = OsLoader
 
   INF PayloadPkg/OsLoader/OsLoader.inf
 
-!if $(ENABLE_PRE_OS_CHECKER)
-  FILE FREEFORM = 01C46D7E-00A2-48E8-A50F-17467D1CA0C5 {
-    SECTION RAW = Platform/$(BOARD_PKG_NAME)/Binaries/PreOsChecker.bin
-  }
-!endif
-
 #------------------------------------------------------------------------------
 # FwUpdate FV to make FirmwareUpdate.efi visible to modules
 #------------------------------------------------------------------------------

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -170,9 +170,6 @@ NormalBootPath (
     // It is a FV format
     DEBUG ((DEBUG_INFO, "FV Format Payload\n"));
     Status = LoadFvImage (Dst, Stage2Hob->PayloadActualLength, (VOID **)&PldEntry);
-    if ((FixedPcdGetBool (PcdPreOsCheckerEnabled))) {
-      PldBase = (UINT32) Dst;
-    }
   } else if (IsElfImage (Dst)) {
     Status = LoadElfImage (Dst, (VOID *)&PldEntry);
   } else {

--- a/BootloaderCorePkg/Stage2/Stage2.inf
+++ b/BootloaderCorePkg/Stage2/Stage2.inf
@@ -118,7 +118,6 @@
   gPlatformModuleTokenSpaceGuid.PcdFlashSize
   gPlatformModuleTokenSpaceGuid.PcdSplashEnabled
   gPlatformModuleTokenSpaceGuid.PcdSplashLogoAddress
-  gPlatformModuleTokenSpaceGuid.PcdPreOsCheckerEnabled
   gPlatformModuleTokenSpaceGuid.PcdOsBootOptionNumber
   gPlatformModuleTokenSpaceGuid.PcdServiceNumber
   gPlatformModuleTokenSpaceGuid.PcdFlashMapEnabled

--- a/PayloadPkg/OsLoader/OsLoader.h
+++ b/PayloadPkg/OsLoader/OsLoader.h
@@ -43,6 +43,7 @@
 #include <Library/UsbKbLib.h>
 #include <Library/ElfLib.h>
 #include <Library/LinuxLib.h>
+#include <Library/ContainerLib.h>
 #include <Guid/SeedInfoHobGuid.h>
 #include <Guid/OsConfigDataHobGuid.h>
 #include <Guid/OsBootOptionGuid.h>

--- a/PayloadPkg/OsLoader/OsLoader.inf
+++ b/PayloadPkg/OsLoader/OsLoader.inf
@@ -75,6 +75,7 @@
   ElfLib
   LiteFvLib
   LinuxLib
+  ContainerLib
 
 [Guids]
   gOsConfigDataGuid


### PR DESCRIPTION
Since we may want to perform FW update on
pre-OS checker/payload binaries separately
from the OS Loader payload we will search
for pre-OS checker/payload in the container
entries instead of adding it into the OS
Loader FD.

Signed-off-by: James Gutbub <james.gutbub@intel.com>