### PR TITLE
Enhance build support for binary downloading

### DIFF
--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -912,7 +912,7 @@ class Build(object):
 
 		check_build_component_bin = os.path.join(tool_dir, 'PrepareBuildComponentBin.py')
 		if os.path.exists(check_build_component_bin):
-			ret = subprocess.call(['python', check_build_component_bin, plt_dir, self._board.BOARD_NAME, '/d' if self._board.FSPDEBUG_MODE else '/r'])
+			ret = subprocess.call(['python', check_build_component_bin, self._board.SILICON_PKG_NAME, '/d' if self._board.FSPDEBUG_MODE else '/r'])
 			if ret:
 				raise Exception  ('Failed to prepare build component binaries !')
 

--- a/Silicon/ApollolakePkg/FspBin/FspBin.inf
+++ b/Silicon/ApollolakePkg/FspBin/FspBin.inf
@@ -8,10 +8,11 @@
 #
 ##
 
-[Defines]
-  FSP_COMMIT_ID  = 7431e4f3399a5081c956753b5fa3bcd764196723
+[UserExtensions.SBL."CloneRepo"]
+  REPO    = https://github.com/IntelFsp/FSP.git
+  COMMIT  = 7431e4f3399a5081c956753b5fa3bcd764196723
 
-[CopyList]
+[UserExtensions.SBL."CopyList"]
   ApolloLakeFspBinPkg/FspBin/Fsp.fd     : Silicon/ApollolakePkg/FspBin/FspDbg.bin
   ApolloLakeFspBinPkg/FspBin/Fsp.fd     : Silicon/ApollolakePkg/FspBin/FspRel.bin
   ApolloLakeFspBinPkg/FspBin/Fsp.bsf    : Silicon/ApollolakePkg/FspBin/Fsp.bsf

--- a/Silicon/CoffeelakePkg/FspBin/FspBin.inf
+++ b/Silicon/CoffeelakePkg/FspBin/FspBin.inf
@@ -8,10 +8,12 @@
 #
 ##
 
-[Defines]
-  FSP_COMMIT_ID  = 59964173e18950debcc6b8856c5c928935ce0b4f
 
-[CopyList]
+[UserExtensions.SBL."CloneRepo"]
+  REPO    = https://github.com/IntelFsp/FSP.git
+  COMMIT  = 59964173e18950debcc6b8856c5c928935ce0b4f
+
+[UserExtensions.SBL."CopyList"]
   CoffeeLakeFspBinPkg/FSP.fd                 : Silicon/CoffeelakePkg/FspBin/FspDbg.bin
   CoffeeLakeFspBinPkg/FSP.fd                 : Silicon/CoffeelakePkg/FspBin/FspRel.bin
   CoffeeLakeFspBinPkg/Fsp.bsf                : Silicon/CoffeelakePkg/FspBin/Fsp.bsf

--- a/Silicon/CoffeelakePkg/Microcode/Microcode.inf
+++ b/Silicon/CoffeelakePkg/Microcode/Microcode.inf
@@ -12,7 +12,6 @@
   FILE_GUID            = 197DB236-F856-4924-90F8-CDF12FB875F3
   MODULE_TYPE          = USER_DEFINED
   VERSION_STRING       = 1.0
-  MICROCODE_TAG        = microcode-20190514a
 
 [Sources]
   06-8e-0c.mcb
@@ -20,3 +19,14 @@
   06-9e-0d.mcb
   06-9e-0c.mcb
   06-9e-0a.mcb
+
+[UserExtensions.SBL."CloneRepo"]
+  REPO  = https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files.git
+  TAG   = microcode-20190514a
+
+[UserExtensions.SBL."CopyList"]
+  intel-ucode/06-8e-0c  : Silicon/CoffeelakePkg/Microcode/06-8e-0c.mcb
+  intel-ucode/06-8e-0b  : Silicon/CoffeelakePkg/Microcode/06-8e-0b.mcb
+  intel-ucode/06-9e-0d  : Silicon/CoffeelakePkg/Microcode/06-9e-0d.mcb
+  intel-ucode/06-9e-0c  : Silicon/CoffeelakePkg/Microcode/06-9e-0c.mcb
+  intel-ucode/06-9e-0a  : Silicon/CoffeelakePkg/Microcode/06-9e-0a.mcb


### PR DESCRIPTION
Removing hard code in PrepareBuildComponentBin.py, so it could
support other platforms. And enhance its logic to support to
run in different places.
Moving repo and commit information to driver INF so this script
could reuse code to support different drivers.

Signed-off-by: Guo Dong <guo.dong@intel.com>