### PR TITLE
Fix ContainerLib flash bug

### DIFF
--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
@@ -500,7 +500,7 @@ LoadComponentWithCallback (
   // before authentication for security concern.
   IsInFlash = IS_FLASH_ADDRESS (CompData);
   AllocLen  = ScrLen + TEMP_BUF_ALIGN * 2;
-  if (!IsInFlash) {
+  if (IsInFlash) {
     AllocLen += SignedDataLen;
   }
   AllocBuf = AllocateTemporaryMemory (AllocLen);


### PR DESCRIPTION
There is a small bug in the ContainerLib
where the check for whether the data is
stored in the flash needs to be adjusted.

Signed-off-by: James Gutbub <james.gutbub@intel.com>