### PR TITLE
Enhance build script to support build flexibility

### DIFF
--- a/BootloaderCorePkg/Tools/PrepareBuildComponentBin.py
+++ b/BootloaderCorePkg/Tools/PrepareBuildComponentBin.py
@@ -226,20 +226,21 @@ def BuildFspBins (fsp_dir, sbl_dir, silicon_pkg_name, flag):
     CopyFileList (copy_list, fsp_dir, sbl_dir)
 
 def Main():
-    sbl_dir        = os.environ['PLT_SOURCE']
+
+    if len(sys.argv) < 3:
+        print ('Silicon directory and silicon package name are required!')
+        return -1
+    target = ''
+    if len(sys.argv) > 3:
+        target = sys.argv[3]
+
+    sbl_dir          = sys.argv[1]
+    silicon_pkg_name = sys.argv[2]
+
     workspace_dir  = os.path.join(sbl_dir, '../Download')
     fsp_repo_dir   = os.path.abspath (os.path.join(workspace_dir, 'IntelFsp'))
     qemu_repo_dir  = os.path.abspath (os.path.join(workspace_dir, 'QemuFsp'))
     ucode_repo_dir = os.path.abspath (os.path.join(workspace_dir, 'IntelUcode'))
-
-    if len(sys.argv) < 2:
-        print ('Silicon package name argument is required!')
-        return -1
-    silicon_pkg_name = sys.argv[1]
-
-    target = ''
-    if len(sys.argv) > 2:
-        target = sys.argv[2]
 
     if silicon_pkg_name == 'QemuSocPkg':
         BuildFspBins (qemu_repo_dir, sbl_dir, silicon_pkg_name, target)

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -908,11 +908,15 @@ class Build(object):
 
 		# check if FSP binary exists
 		fsp_dir  = os.path.join(plt_dir, 'Silicon', self._board.SILICON_PKG_NAME, "FspBin", self._board._FSP_PATH_NAME)
+		work_dir = plt_dir
+		if not os.path.exists(fsp_dir):
+			fsp_dir  = os.path.join(sbl_dir, 'Silicon', self._board.SILICON_PKG_NAME, "FspBin", self._board._FSP_PATH_NAME)
+			work_dir = sbl_dir
 		fsp_path = os.path.join(fsp_dir, self._fsp_basename + '.bin')
 
 		check_build_component_bin = os.path.join(tool_dir, 'PrepareBuildComponentBin.py')
 		if os.path.exists(check_build_component_bin):
-			ret = subprocess.call(['python', check_build_component_bin, self._board.SILICON_PKG_NAME, '/d' if self._board.FSPDEBUG_MODE else '/r'])
+			ret = subprocess.call(['python', check_build_component_bin, work_dir, self._board.SILICON_PKG_NAME, '/d' if self._board.FSPDEBUG_MODE else '/r'])
 			if ret:
 				raise Exception  ('Failed to prepare build component binaries !')
 


### PR DESCRIPTION
With this change, customer could copy only board package folder
outside of SBL repo and build it without copying silicon folder.
It could help customer create their own repo and use SBL open
source repo as a submodule.

Signed-off-by: Guo Dong <guo.dong@intel.com>