### PR TITLE
Fix firmware capsule loading assertion issue

### DIFF
--- a/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
+++ b/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
@@ -318,7 +318,7 @@ Done:
   }
 
   if (EFI_ERROR (Status)) {
-    if (*CapsuleImage == NULL) {
+    if (*CapsuleImage != NULL) {
       FreePool (*CapsuleImage);
       *CapsuleImage = NULL;
     }


### PR DESCRIPTION
This patch fixed a logic bug in firmware update library when
de-allocating memory in error handling flow. It fixed #275.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>