### PR TITLE
[TOOLS] Add python3 build support

### DIFF
--- a/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Build.py
+++ b/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Build.py
@@ -20,35 +20,34 @@ def FixupForRawSection(sectionFile):
     if c > len(d):
         c -= len(d)
         f = open(sectionFile, 'wb')
-        f.write('\x90' * c)
+        f.write(b'\x90' * c)
         f.write(d)
         f.close()
 
 for filename in glob.glob(os.path.join('Bin', '*.raw')):
     os.remove(filename)
 
-if 1:
-    if 1:
-        arch = 'ia32'
-        debugType = None
-        output = os.path.join('Bin', 'ResetVector')
-        output += '.' + arch
-        if debugType is not None:
-            output += '.' + debugType
-        output += '.raw'
-        nasmpath = os.path.join(os.environ.get ('NASM_PREFIX', ''), 'nasm')
-        commandLine = (
-            nasmpath,
-            '-D', 'ARCH_%s' % arch.upper(),
-            '-D', 'DEBUG_%s' % str(debugType).upper(),
-            '-o', output,
-            'Vtf0.nasmb',
-            )
-        ret = RunCommand(commandLine)
-        print '\tASM\t' + output
-        if ret != 0: sys.exit(ret)
 
-        FixupForRawSection(output)
-        print '\tFIXUP\t' + output
+arch = 'ia32'
+debugType = None
+output = os.path.join('Bin', 'ResetVector')
+output += '.' + arch
+if debugType is not None:
+    output += '.' + debugType
+output += '.raw'
+nasmpath = os.path.join(os.environ.get ('NASM_PREFIX', ''), 'nasm')
+commandLine = (
+    nasmpath,
+    '-D', 'ARCH_%s' % arch.upper(),
+    '-D', 'DEBUG_%s' % str(debugType).upper(),
+    '-o', output,
+    'Vtf0.nasmb',
+    )
+ret = RunCommand(commandLine)
+print ('\tASM\t' + output)
+if ret != 0: sys.exit(ret)
+
+FixupForRawSection(output)
+print ('\tFIXUP\t' + output)
 
 

--- a/BootloaderCorePkg/Tools/CommonUtility.py
+++ b/BootloaderCorePkg/Tools/CommonUtility.py
@@ -17,6 +17,7 @@ import shutil
 import subprocess
 import struct
 import hashlib
+from   functools import reduce
 from   ctypes import *
 
 class LZ_HEADER(Structure):
@@ -56,7 +57,7 @@ def gen_file_from_object (file, object):
 	open (file, 'wb').write(object)
 
 def gen_file_with_size (file, size):
-	open (file, 'wb').write('\xFF' * size);
+	open (file, 'wb').write(b'\xFF' * size);
 
 def get_openssl_path ():
 	if os.name == 'nt':
@@ -79,7 +80,7 @@ def run_process (arg_list, print_cmd = False, capture_out = False):
 	output = ''
 	try:
 		if capture_out:
-			output = subprocess.check_output(arg_list)
+			output = subprocess.check_output(arg_list).decode()
 		else:
 			result = subprocess.call (arg_list)
 	except Exception as exc:
@@ -138,7 +139,7 @@ def gen_pub_key (priv_key, pub_key = None):
 		modulus = modulus[2:]
 	mod = bytearray.fromhex(modulus)
 	exp = bytearray.fromhex('{:08x}'.format(exponent))
-	key = "$IPP" + mod + exp
+	key = b"$IPP" + mod + exp
 	if pub_key:
 		gen_file_from_object (pub_key, key)
 
@@ -211,7 +212,7 @@ def compress (in_file, alg, out_path = '', tool_dir = ''):
 
 	compress_data = get_file_data(out_file)
 	lz_hdr = LZ_HEADER ()
-	lz_hdr.signature = sig
+	lz_hdr.signature = sig.encode()
 	lz_hdr.compressed_len = len(compress_data)
 	lz_hdr.length = os.path.getsize(in_file)
 	data = bytearray ()

--- a/BootloaderCorePkg/Tools/ConfigEditor.py
+++ b/BootloaderCorePkg/Tools/ConfigEditor.py
@@ -9,10 +9,19 @@ import os
 import re
 import sys
 import marshal
-from Tkinter import *
-import ttk
-import tkMessageBox
-import tkFileDialog
+
+if sys.hexversion >= 0x3000000:
+    # for Python3
+    from tkinter import *   ## notice lowercase 't' in tkinter here
+    import tkinter.ttk as ttk
+    import tkinter.messagebox as messagebox
+    import tkinter.filedialog as filedialog
+else:
+    # for Python2
+    from Tkinter import *   ## notice capitalized T in Tkinter
+    import ttk
+    import tkMessageBox as messagebox
+    import tkFileDialog as filedialog
 
 from GenCfgData import CGenCfgData, Bytes2Str, Bytes2Val, Array2Val
 
@@ -430,7 +439,7 @@ class Application(Frame):
         Text = []
         for Line in Lines:
             Text.append(Line.center(Width, ' '))
-        tkMessageBox.showinfo('Config Editor', '\n'.join(Text))
+        messagebox.showinfo('Config Editor', '\n'.join(Text))
 
     def GetOpenFileName(self, Type):
         if self.IsConfigDataLoaded():
@@ -442,7 +451,7 @@ class Application(Frame):
                 Question = 'All configuration will be reloaded from DSC file, continue ?'
             else:
                 raise Exception('Unsupported file type !')
-            Reply = tkMessageBox.askquestion('', Question, icon='warning')
+            Reply = messagebox.askquestion('', Question, icon='warning')
             if Reply == 'no':
                 return None
 
@@ -453,7 +462,7 @@ class Application(Frame):
             FileType = Type.upper()
             FileExt  = Type
 
-        Path = tkFileDialog.askopenfilename(
+        Path = filedialog.askopenfilename(
             initialdir=self.LastDir,
             title="Load file",
             filetypes=(("%s files" % FileType, "*.%s" % FileExt), (
@@ -476,7 +485,7 @@ class Application(Frame):
             self.CfgDataObj.OverrideDefaultValue(Path)
             self.CfgDataObj.UpdateDefaultValue()
         except Exception as e:
-            tkMessageBox.showerror('LOADING ERROR', str(e))
+            messagebox.showerror('LOADING ERROR', str(e))
             return
 
         self.RefreshConfigDataPage()
@@ -493,7 +502,7 @@ class Application(Frame):
         try:
             self.ReloadConfigDataFromBin(BinData)
         except Exception as e:
-            tkMessageBox.showerror('LOADING ERROR', str(e))
+            messagebox.showerror('LOADING ERROR', str(e))
             return
 
     def LoadDscFile(self, Path):
@@ -504,7 +513,7 @@ class Application(Frame):
         try:
             self.CfgDataObj = self.LoadConfigData(Path)
         except Exception as e:
-            tkMessageBox.showerror('LOADING ERROR', str(e))
+            messagebox.showerror('LOADING ERROR', str(e))
             return -1
 
         self.OrgCfgDataBin = self.CfgDataObj.GenerateBinaryArray()
@@ -524,7 +533,7 @@ class Application(Frame):
         self.LoadDscFile(Path)
 
     def GetSaveFileName (self, Extension):
-        Path = tkFileDialog.asksaveasfilename(
+        Path = filedialog.asksaveasfilename(
                   initialdir=self.LastDir,
                   title="Save file",
                   defaultextension=Extension)

--- a/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
+++ b/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
@@ -398,7 +398,7 @@ class Firmware_Update_Header(Structure):
 
 
 def SignImage(RawData, OutFile, PrivKey):
-    
+
     #
     # Generate the new image layout
     # 1. write firmware update header
@@ -408,7 +408,7 @@ def SignImage(RawData, OutFile, PrivKey):
 
     file_size = len(RawData)
 
-    header.FileGuid         = (c_ubyte *16).from_buffer_copy(FIRMWARE_UPDATE_IMAGE_FILE_GUID.get_bytes_le())
+    header.FileGuid         = (c_ubyte *16).from_buffer_copy(FIRMWARE_UPDATE_IMAGE_FILE_GUID.bytes_le)
     header.HeaderSize       = sizeof(Firmware_Update_Header)
     header.FirmwreVersion   = 1
     header.CapsuleFlags     = 0
@@ -424,9 +424,8 @@ def SignImage(RawData, OutFile, PrivKey):
 
     header.PubKeySize = os.path.getsize(pubkey_file)
 
-    unsigned_image.extend(RawData)
     fwupdate_bin_file = 'fwupdate_unsigned.bin'
-    open(fwupdate_bin_file, 'wb').write(unsigned_image)
+    open(fwupdate_bin_file, 'wb').write(unsigned_image + RawData)
 
     rsa_sign_file(PrivKey, pubkey_file, fwupdate_bin_file, OutFile, True, True)
 
@@ -482,7 +481,7 @@ def main():
 
     FmpCapsuleHeader = FmpCapsuleHeaderClass()
     for PldUuid, PldFile in args.payload:
-        
+
         FmpPayloadHeader = FmpPayloadHeaderClass()
         Buffer = open(PldFile, 'rb').read()
         Result = Buffer

--- a/BootloaderCorePkg/Tools/GenCfgData.py
+++ b/BootloaderCorePkg/Tools/GenCfgData.py
@@ -34,9 +34,9 @@ def Bytes2Str (Bytes):
     return '{ %s }' % (', '.join('0x%02X' % i for i in Bytes))
 
 def Str2Bytes (Value, Blen):
-    Result = bytearray(Value[1:-1], 'utf8')  # Excluding quotes
+    Result = bytearray(Value[1:-1], 'utf-8')  # Excluding quotes
     if len(Result) < Blen:
-        Result.extend('\x00' * (Blen - len(Result)))
+        Result.extend(b'\x00' * (Blen - len(Result)))
     return Result
 
 def Val2Bytes (Value, Blen):
@@ -391,7 +391,7 @@ EndList
             except ValueError as e:
                 raise Exception ("Bytes in '%s' must be in range 0~255 !" % ValueStr)
         if len(Result) < Length:
-            Result.extend('\x00' * (Length - len(Result)))
+            Result.extend(b'\x00' * (Length - len(Result)))
         elif len(Result) > Length:
             raise Exception ("Value '%s' is too big to fit into %d bytes !" % (ValueStr, Length))
 
@@ -412,7 +412,7 @@ EndList
                     pass
                 else:
                     if Each[0] in ['"', "'"]:
-                        Result.extend(list(bytearray(Each[1:-1])))
+                        Result.extend(list(bytearray(Each[1:-1], 'utf-8')))
                     elif ':' in Each:
                         Match    = re.match("(.+):(\d+)b", Each)
                         if Match is None:
@@ -444,7 +444,7 @@ EndList
             return
 
         DataList = self.ValueToList(ConfigDict['value'], ConfigDict['length'])
-        Unit = int(Struct[4:]) / 8
+        Unit = int(Struct[4:]) // 8
         if int(ConfigDict['length']) != Unit * len(DataList):
             raise Exception("Array size is not proper for '%s' !" % ConfigDict['cname'])
 
@@ -1140,7 +1140,7 @@ EndList
             Type = Struct
             if Struct in ['UINT8','UINT16','UINT32','UINT64']:
                 IsArray = True
-                Unit = int(Type[4:]) / 8
+                Unit = int(Type[4:]) // 8
                 Length = Length / Unit
             else:
                 IsArray = False
@@ -1515,7 +1515,7 @@ EndList
         for Item in self._CfgItemList:
             if Item['offset'] > Offset:
                 Gap = Item['offset'] - Offset
-                BinDat.extend('\x00' * Gap)
+                BinDat.extend(b'\x00' * Gap)
             BinDat.extend(self.ValueToByteArray(Item['value'], Item['length']))
             Offset = Item['offset'] + Item['length']
         return BinDat
@@ -1768,7 +1768,7 @@ EndList
                         if BitsRemain:
                             BsfFd.write("        Skip %d bits\n" % BitsRemain)
                             BitsGap -= BitsRemain
-                        BytesRemain = BitsGap / 8
+                        BytesRemain = BitsGap // 8
                         if BytesRemain:
                             BsfFd.write("        Skip %d bytes\n" % BytesRemain)
                     NextOffset = Item['offset'] + Item['length']

--- a/BootloaderCorePkg/Tools/IfwiUtility.py
+++ b/BootloaderCorePkg/Tools/IfwiUtility.py
@@ -283,7 +283,7 @@ class IFWI_PARSER:
             print ("Not a valid ifwi image!")
             return -2
 
-        ifwi_comps = ifwi_parser.locate_components (ifwi, path)
+        ifwi_comps = self.locate_components (ifwi, path)
         if len(ifwi_comps) == 0:
             print ("Cannot find path '%s' in ifwi image!" % path)
             return -4

--- a/BootloaderCorePkg/Tools/PatchFv.py
+++ b/BootloaderCorePkg/Tools/PatchFv.py
@@ -1,6 +1,6 @@
 ## @ PatchFv.py
 #
-# Copyright (c) 2014 - 2016, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2014 - 2019, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -25,7 +25,10 @@ def readDataFromFile (binfile, offset, len=1):
     if (offval & 0x80000000):
         offval = fsize - (0xFFFFFFFF - offval + 1)
     fd.seek(offval)
-    bytearray = [ord(b) for b in fd.read(len)]
+    if sys.version_info[0] < 3:
+        bytearray = [ord(b) for b in fd.read(len)]
+    else:
+        bytearray = [b for b in fd.read(len)]
     value = 0
     idx   = len - 1
     while  idx >= 0:
@@ -45,7 +48,7 @@ def IsFspHeaderValid (binfile):
     fd     = open (binfile, "rb")
     bindat = fd.read(0x200) # only read first 0x200 bytes
     fd.close()
-    HeaderList = ['FSPH' , 'FSPP' , 'FSPE']       # Check 'FSPH', 'FSPP', and 'FSPE' in the FSP header
+    HeaderList = [b'FSPH' , b'FSPP' , b'FSPE']       # Check 'FSPH', 'FSPP', and 'FSPE' in the FSP header
     OffsetList = []
     for each in HeaderList:
         if each in bindat:
@@ -55,7 +58,10 @@ def IsFspHeaderValid (binfile):
         OffsetList.append(idx)
     if not OffsetList[0] or not OffsetList[1]:    # If 'FSPH' or 'FSPP' is missing, it will return false
         return False
-    Revision = ord(bindat[OffsetList[0] + 0x0B])
+    if sys.version_info[0] < 3:
+        Revision = ord(bindat[OffsetList[0] + 0x0B])
+    else:
+        Revision = bindat[OffsetList[0] + 0x0B]
     #
     # if revision is bigger than 1, it means it is FSP v1.1 or greater revision, which must contain 'FSPE'.
     #
@@ -86,7 +92,10 @@ def patchDataInFile (binfile, offset, value, len=1):
         value          = value >> 8
         idx            = idx + 1
     fd.seek(offval)
-    fd.write("".join(chr(b) for b in bytearray))
+    if sys.version_info[0] < 3:
+        fd.write("".join(chr(b) for b in bytearray))
+    else:
+        fd.write(bytes(bytearray))
     fd.close()
     return len
 
@@ -151,7 +160,7 @@ class Symbols:
     #
     def createDicts (self, fvDir, fvNames):
         #
-        # If the fvDir is not a dirctory, then raise an exception
+        # If the fvDir is not a directory, then raise an exception
         #
         if not os.path.isdir(fvDir):
             raise Exception ("'%s' is not a valid directory!" % FvDir)
@@ -794,7 +803,7 @@ class Symbols:
     #  retval      ret
     #
     def getSymbols(self, value):
-        if self.dictSymbolAddress.has_key(value):
+        if value in self.dictSymbolAddress:
             # Module:Function
             ret = int (self.dictSymbolAddress[value], 16)
         else:
@@ -831,7 +840,8 @@ class Symbols:
 #  Print out the usage
 #
 def Usage():
-    print "Usage: \n\tPatchFv FvBuildDir [FvFileBaseNames:]FdFileBaseNameToPatch \"Offset, Value\""
+    print ("PatchFv Version 0.50")
+    print ("Usage: \n\tPatchFv FvBuildDir [FvFileBaseNames:]FdFileBaseNameToPatch \"Offset, Value\"")
 
 def main():
     #
@@ -850,7 +860,7 @@ def main():
     # If it fails to create dictionaries, then return an error.
     #
     if symTables.createDicts(sys.argv[1], sys.argv[2]) != 0:
-        print "ERROR: Failed to create symbol dictionary!!"
+        print ("ERROR: Failed to create symbol dictionary!!")
         return 2
 
     #
@@ -911,7 +921,7 @@ def main():
                 if ret:
                     raise Exception ("Patch failed for offset 0x%08X" % offset)
                 else:
-                    print  "Patched offset 0x%08X:[%08X] with value 0x%08X  # %s" % (offset, oldvalue, value, comment)
+                    print ("Patched offset 0x%08X:[%08X] with value 0x%08X  # %s" % (offset, oldvalue, value, comment))
 
             elif command == "COPY":
                 #
@@ -932,13 +942,13 @@ def main():
                 if ret:
                     raise Exception ("Copy failed from offset 0x%08X to offset 0x%08X!" % (src, dest))
                 else :
-                    print  "Copied %d bytes from offset 0x%08X ~ offset 0x%08X  # %s" % (clen, src, dest, comment)
+                    print ("Copied %d bytes from offset 0x%08X ~ offset 0x%08X  # %s" % (clen, src, dest, comment))
             else:
                 raise Exception ("Unknown command %s!" % command)
         return 0
 
-    except Exception as (ex):
-        print "ERROR: %s" % ex
+    except Exception as ex:
+        print ("ERROR: %s" % ex)
         return 1
 
 if __name__ == '__main__':

--- a/BootloaderCorePkg/Tools/PrepareBuildComponentBin.py
+++ b/BootloaderCorePkg/Tools/PrepareBuildComponentBin.py
@@ -167,7 +167,7 @@ def BuildFspBins (fsp_dir, sbl_dir, silicon_pkg_name, flag):
             Fatal ('Failed to clone FSP repo to directory %s !' % fsp_dir)
         print ('Done\n')
     else:
-        output = subprocess.check_output(['git', 'tag', '-l'], cwd=fsp_dir)
+        output = subprocess.check_output(['git', 'tag', '-l'], cwd=fsp_dir).decode()
         if edk2_base_tag not in output:
             ret = subprocess.call(['git', 'fetch', '--all'], cwd=fsp_dir)
             if ret:
@@ -208,7 +208,7 @@ def BuildFspBins (fsp_dir, sbl_dir, silicon_pkg_name, flag):
     else:
         flags = [flag]
 
-    print flags
+    print(flags)
     for flag in flags:
         os.environ['WORKSPACE'] = ''
         os.environ['EDK_TOOLS_PATH'] = ''

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -42,16 +42,16 @@ def rebuild_basetools ():
 		genffs_exe_path = os.path.join(sblsource, 'BaseTools', 'Bin', 'Win32', 'GenFfs.exe')
 		genffs_exist = os.path.exists(genffs_exe_path)
 		if not genffs_exist:
-			print "Could not find pre-built BaseTools binaries, try to rebuild BaseTools ..."
+			print ("Could not find pre-built BaseTools binaries, try to rebuild BaseTools ...")
 			ret = run_process (['BaseTools\\toolsetup.bat', 'forcerebuild'])
 
 	if ret:
-		print "Build BaseTools failed, please check required build environment and utilities !"
+		print ("Build BaseTools failed, please check required build environment and utilities !")
 		sys.exit(1)
 
 		genffs_exist = os.path.exists(genffs_exe_path)
 		if not genffs_exist:
-				print "Build python executables failed !"
+				print("Build python executables failed !")
 				sys.exit(1)
 
 
@@ -86,7 +86,7 @@ def prep_env ():
 				os.environ[toolchainprefix] = os.path.join(os.environ[vs_tool], '..//..//')
 				break
 		if not toolchain:
-			print "Could not find supported Visual Studio version !"
+			print("Could not find supported Visual Studio version !")
 			sys.exit(1)
 		if 'NASM_PREFIX' not in os.environ:
 			os.environ['NASM_PREFIX'] = "C:\\Nasm\\"
@@ -95,7 +95,7 @@ def prep_env ():
 		if 'IASL_PREFIX' not in os.environ:
 			os.environ['IASL_PREFIX'] = "C:\\ASL\\"
 	else:
-		print "Unsupported operating system !"
+		print("Unsupported operating system !")
 		sys.exit(1)
 
 	check_for_openssl()
@@ -219,7 +219,7 @@ class BaseBoard(object):
 
 		# OS Loader FD/FV sizes
 		self.OS_LOADER_FD_SIZE     = 0x00040000
-		self.OS_LOADER_FD_NUMBLK   = self.OS_LOADER_FD_SIZE / self.FLASH_BLOCK_SIZE
+		self.OS_LOADER_FD_NUMBLK   = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
 		self.PLD_HEAP_SIZE         = 0x02000000
 		self.PLD_STACK_SIZE        = 0x00010000
@@ -248,7 +248,7 @@ class BaseBoard(object):
 		self._CFGDATA_INT_FILE     = []
 		self._CFGDATA_EXT_FILE     = []
 
-		for key, value in kwargs.items():
+		for key, value in list(kwargs.items()):
 			setattr(self, '%s' % key, value)
 
 
@@ -330,9 +330,9 @@ class Build(object):
 				if len(u_code_images) > 0:
 					offset, size = u_code_images.pop(0)
 					fit_entry.set_values(base + offset, 0, 0x100, 0x1, 0)
-					print('  Patching entry %d with 0x%08X - uCode' % (i, fit_entry.address))
+					print ('  Patching entry %d with 0x%08X - uCode' % (i, fit_entry.address))
 				else:
-					print('  Nullifying unused uCode patch entry %d' % i)
+					print ('  Nullifying unused uCode patch entry %d' % i)
 					fit_entry.type      = 0x7f
 
 			if len(u_code_images) > 0:
@@ -342,7 +342,7 @@ class Build(object):
 			# ACM
 			fit_entry = FitEntry.from_buffer(rom, fit_offset + (num_fit_entries+1)*16)
 			fit_entry.set_values(self._board.ACM_BASE, 0, 0x100, 0x2, 0)
-			print('  Patching entry %d with 0x%08X:0x%08X - ACM' % (num_fit_entries, fit_entry.address, fit_entry.size))
+			print ('  Patching entry %d with 0x%08X:0x%08X - ACM' % (num_fit_entries, fit_entry.address, fit_entry.size))
 			num_fit_entries     += 1
 
 			# BIOS Module (IBB segment 0): from FIT table end to 4GB
@@ -355,7 +355,7 @@ class Build(object):
 			module_size =  (fit_address.value - addr) >> 4
 			fit_entry = FitEntry.from_buffer(rom, fit_offset + (num_fit_entries+1)*16)
 			fit_entry.set_values(addr, module_size, 0x100, 0x7, 0)
-			print('  Patching entry %d with 0x%08X:0x%08X - BIOS Module(Stage1A base to FIT table start)' % (num_fit_entries, fit_entry.address, fit_entry.size))
+			print ('  Patching entry %d with 0x%08X:0x%08X - BIOS Module(Stage1A base to FIT table start)' % (num_fit_entries, fit_entry.address, fit_entry.size))
 			num_fit_entries     += 1
 
 			# BIOS Module (IBB segment 2): full Stage1B
@@ -363,21 +363,21 @@ class Build(object):
 			module_size = self._board.STAGE1B_SIZE >> 4
 			fit_entry = FitEntry.from_buffer(rom, fit_offset + (num_fit_entries+1)*16)
 			fit_entry.set_values(addr, module_size, 0x100, 0x7, 0)
-			print('  Patching entry %d with 0x%08X:0x%08X - BIOS Module(Stage1B)' % (num_fit_entries, fit_entry.address, fit_entry.size))
+			print ('  Patching entry %d with 0x%08X:0x%08X - BIOS Module(Stage1B)' % (num_fit_entries, fit_entry.address, fit_entry.size))
 			num_fit_entries     += 1
 
 			# KM
 			addr = self._board.ACM_BASE + self._board.ACM_SIZE - (self._board.KM_SIZE + self._board.BPM_SIZE)
 			fit_entry = FitEntry.from_buffer(rom, fit_offset + (num_fit_entries+1)*16)
 			fit_entry.set_values(addr, self._board.KM_SIZE, 0x100, 0xb, 0)
-			print('  Patching entry %d with 0x%08X:0x%08X - KM' % (num_fit_entries, fit_entry.address, fit_entry.size))
+			print ('  Patching entry %d with 0x%08X:0x%08X - KM' % (num_fit_entries, fit_entry.address, fit_entry.size))
 			num_fit_entries     += 1
 
 			# BPM
 			addr = self._board.ACM_BASE + self._board.ACM_SIZE - self._board.BPM_SIZE
 			fit_entry = FitEntry.from_buffer(rom, fit_offset + (num_fit_entries+1)*16)
 			fit_entry.set_values(addr, self._board.BPM_SIZE, 0x100, 0xc, 0)
-			print('  Patching entry %d with 0x%08X:0x%08X - BPM' % (num_fit_entries, fit_entry.address, fit_entry.size))
+			print ('  Patching entry %d with 0x%08X:0x%08X - BPM' % (num_fit_entries, fit_entry.address, fit_entry.size))
 			num_fit_entries     += 1
 
 			# Patch the entry 'FIT table end to 4GB' since FIT table size is known now
@@ -388,7 +388,7 @@ class Build(object):
 			module_size = (0x100000000 - addr) >> 4
 			fit_entry = FitEntry.from_buffer(rom, fit_offset + (patch_entry+1)*16)
 			fit_entry.set_values(addr, module_size, 0x100, 0x7, 0)
-			print('  Patching entry %d with 0x%08X:0x%08X - BIOS Module(FIT table end to 4GB)' % (patch_entry, fit_entry.address, fit_entry.size))
+			print ('  Patching entry %d with 0x%08X:0x%08X - BIOS Module(FIT table end to 4GB)' % (patch_entry, fit_entry.address, fit_entry.size))
 
 		else :
 			addr = fit_address.value + (num_fit_entries + 1) * 16
@@ -398,7 +398,7 @@ class Build(object):
 		if spaceleft > 0:
 				raise Exception('  Insufficient FIT entries in FIT table, need %d more entries !' %  ((spaceleft + 15) // 16))
 
-		print('  FIT %d entries added' % num_fit_entries)
+		print ('  FIT %d entries added' % num_fit_entries)
 
 		# Update FIT checksum
 		print('  Updating Checksum')
@@ -444,7 +444,7 @@ class Build(object):
 		if not self._board.HAVE_VERIFIED_BOOT:
 			return
 
-		print 'Updating HashStore %s' % os.path.basename (img_file)
+		print('Updating HashStore %s' % os.path.basename (img_file))
 
 		fi = open(img_file,'rb')
 		stage1_bins = bytearray(fi.read())
@@ -470,7 +470,7 @@ class Build(object):
 				continue
 
 			if hash_file == 'PLDDYN':
-				hash_data = bytearray('\x00' * hash_len)
+				hash_data = bytearray(b'\x00' * hash_len)
 			else:
 				src_path = os.path.join(self._fv_dir, hash_file)
 				if not os.path.exists(src_path):
@@ -488,7 +488,7 @@ class Build(object):
 			# update valid bit
 			hash_store.Valid |= 1 << hash_idx
 
-			print ' Update HashStore entry %d at offset 0x%08X:0x%X with file %s' % (hash_idx, start, hash_len, hash_file)
+			print(' Update HashStore entry %d at offset 0x%08X:0x%X with file %s' % (hash_idx, start, hash_len, hash_file))
 
 		fo = open(img_file,'r+b')
 		fo.seek(hs_offset)
@@ -564,7 +564,7 @@ class Build(object):
 				rgn['base'] = image_base + rgn['offset']
 
 		except ValueError:
-			print "Warning: No '%s' component in image list !" % master_name
+			print("Warning: No '%s' component in image list !" % master_name)
 
 		#print_component_list (comp_list)
 
@@ -640,31 +640,41 @@ class Build(object):
 
 
 	def create_dsc_inc_file (self, file):
+		lines = []
 
-		with open(file, 'w') as fh:
-			fh.write('%s\n' % AUTO_GEN_DSC_HDR)
-			fh.write('# Platform specific macro definitions\n')
-			fh.write('[Defines]\n')
+		lines.append('%s\n' % AUTO_GEN_DSC_HDR)
+		lines.append('# Platform specific macro definitions\n')
+		lines.append('[Defines]\n')
 
-			for attr in sorted(vars(self._board)):
-				if attr.startswith('_'):
-					continue
-				value = getattr(self._board, attr)
-				if type(value) is not str:
-					if value == 0 or value == 1:
-						value = '0x%x' % value
-					else:
-						value = '0x%08X' % value
-				fh.write('  DEFINE %-24s = %s\n'   % (attr, value))
+		for attr in sorted(vars(self._board)):
+			if attr.startswith('_'):
+				continue
+			value = getattr(self._board, attr)
+			if type(value) is not str:
+				if value == 0 or value == 1:
+					value = '0x%x' % value
+				else:
+					value = '0x%08X' % value
+			lines.append('  DEFINE %-24s = %s\n'   % (attr, value))
 
-			if getattr(self._board, "GetDscLibrarys", None):
-				libsdict = self._board.GetDscLibrarys()
-				for arch in libsdict:
-					fh.write('\n# Platform specific libraries\n')
-					fh.write('[LibraryClasses.%s]\n' % arch)
-					for lib in libsdict[arch]:
-						fh.write('  %s\n' % lib)
-					fh.write('\n')
+		if getattr(self._board, "GetDscLibrarys", None):
+			libsdict = self._board.GetDscLibrarys()
+			for arch in libsdict:
+				lines.append('\n# Platform specific libraries\n')
+				lines.append('[LibraryClasses.%s]\n' % arch)
+				for lib in libsdict[arch]:
+					lines.append('  %s\n' % lib)
+				lines.append('\n')
+
+		update = True
+		text = ''.join(lines)
+		if os.path.exists(file):
+				old_text = get_file_data (file, 'r')
+				if text == old_text:
+						update = False
+
+		if update:
+				open (file, 'w').write(text)
 
 
 	def create_platform_vars (self):
@@ -738,7 +748,7 @@ class Build(object):
 		if self._board.REDUNDANT_SIZE == 0:
 			return
 
-		print "Generating redundant components"
+		print("Generating redundant components")
 
 		shutil.copy(
 			os.path.join(self._fv_dir, 'STAGE1A.fd'),
@@ -770,7 +780,7 @@ class Build(object):
 
 		if self._board.STAGE1B_XIP:
 			# Rebase stage1b.fd
-			print "Rebasing STAGE1B_B"
+			print("Rebasing STAGE1B_B")
 			rebase_stage (stage1b_path, stage1b_b_path, -self._board.REDUNDANT_SIZE)
 
 			# rebase FSPM in Stage1B and update stage1B hash in key store
@@ -798,7 +808,7 @@ class Build(object):
 
 		for idx, (comp_name, file_list)  in enumerate(self._img_list):
 			if (self._board.ENABLE_FWU == 0) and (comp_name == 'Stitch_FWU.bin') :
-				print "No firmware update payload specified, skip firmware update."
+				print("No firmware update payload specified, skip firmware update.")
 				continue
 			out_file = comp_name
 			out_path = os.path.join(self._fv_dir, out_file)
@@ -837,7 +847,7 @@ class Build(object):
 				fi.close()
 
 			if comp_name == self._image:
-				bins = '\xff' * (self._board.SLIMBOOTLOADER_SIZE - len(bins)) + bins
+				bins = b'\xff' * (self._board.SLIMBOOTLOADER_SIZE - len(bins)) + bins
 
 			fo = open(out_path,'wb')
 			fo.write(bins)
@@ -884,7 +894,7 @@ class Build(object):
 
 	def pre_build(self):
 		# Check if BaseTools has been compiled
-                rebuild_basetools ()
+		rebuild_basetools ()
 
 		# Update search path
 		sbl_dir = os.environ['SBL_SOURCE']
@@ -1003,7 +1013,6 @@ class Build(object):
 		platform_dsc_path = os.path.join(sbl_dir, 'BootloaderCorePkg', 'Platform.dsc')
 		self.create_dsc_inc_file (platform_dsc_path)
 
-
 		# rebase FSP accordingly
 		if self._board.HAVE_FSP_BIN:
 			rebase_fsp(fsp_path, self._fv_dir, self._board.FSP_T_BASE, self._board.FSP_M_BASE, self._board.FSP_S_BASE)
@@ -1031,7 +1040,7 @@ class Build(object):
 		if x: raise Exception ('Failed to build reset vector !')
 
 	def build(self):
-		print "Build [%s] ..." % self._board.BOARD_NAME
+		print("Build [%s] ..." % self._board.BOARD_NAME)
 
 		# Run pre-build
 		self.pre_build()
@@ -1053,7 +1062,7 @@ class Build(object):
 		# Run post-build
 		self.post_build()
 
-		print "Done [%s] !" % self._board.BOARD_NAME
+		print("Done [%s] !" % self._board.BOARD_NAME)
 
 
 	def post_build(self):
@@ -1077,13 +1086,13 @@ class Build(object):
 
 		# create variable binary
 		if self._board.VARIABLE_SIZE:
-			varhdr = VariableRegionHeader.from_buffer(bytearray('\xFF' * sizeof(VariableRegionHeader)))
-			varhdr.Signature = 'VARS'
+			varhdr = VariableRegionHeader.from_buffer(bytearray(b'\xFF' * sizeof(VariableRegionHeader)))
+			varhdr.Signature = b'VARS'
 			varhdr.Size      = self._board.VARIABLE_SIZE >> 1
 			varhdr.State     = 0xFE
 			varfile = open (os.path.join(self._fv_dir, "VARIABLE.bin"), "wb")
 			varfile.write(varhdr)
-			varfile.write('\xFF' * (self._board.VARIABLE_SIZE - sizeof(varhdr)));
+			varfile.write(b'\xFF' * (self._board.VARIABLE_SIZE - sizeof(varhdr)));
 			varfile.close()
 
 
@@ -1119,7 +1128,7 @@ class Build(object):
 
 		# create SPI IAS image if required
 		if self._board.SPI_IAS1_SIZE > 0 or self._board.SPI_IAS2_SIZE > 0:
-			for idx in xrange (1, 3):
+			for idx in range (1, 3):
 				file_path  = os.path.join('Platform', self._board.BOARD_PKG_NAME, 'SpiIasBin', 'iasimage%d.bin' % idx)
 				file_space = getattr(self._board, 'SPI_IAS%d_SIZE' % idx)
 				gen_ias_file (file_path, file_space, os.path.join(self._fv_dir, "SPI_IAS%d.bin" % idx))
@@ -1145,7 +1154,7 @@ class Build(object):
 		if self._board.HAVE_FLASH_MAP and len(self._comp_list) > 0:
 			print_addr = False if getattr(self._board, "GetFlashMapList", None) else True
 			flash_map_text = decode_flash_map (os.path.join(self._fv_dir, 'FlashMap.bin'), print_addr)
-			print '%s' % flash_map_text
+			print('%s' % flash_map_text)
 			fd = open (os.path.join(self._fv_dir, 'FlashMap.txt'), 'w')
 			fd.write (flash_map_text)
 			fd.close ()
@@ -1216,12 +1225,12 @@ def main():
 
 		for dir in dirs:
 			dirpath = os.path.join (workspace, dir)
-			print 'Removing %s' % dirpath
+			print('Removing %s' % dirpath)
 			shutil.rmtree(dirpath, ignore_errors=True)
 
 		for file in files:
 			if os.path.exists(file):
-				print 'Removing %s' % file
+				print('Removing %s' % file)
 				os.remove(file)
 
 		if os.path.exists(os.path.join (sbl_dir, '.git')):

--- a/Platform/CoffeelakeBoardPkg/Script/StitchLoader.py
+++ b/Platform/CoffeelakeBoardPkg/Script/StitchLoader.py
@@ -5,10 +5,20 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
-
+import os
 import sys
 import argparse
-from ctypes import *
+from   ctypes import *
+from   functools import reduce
+
+sys.dont_write_bytecode = True
+sys.path.append (os.path.join(os.getenv('SBL_SOURCE', ''), 'BootloaderCorePkg' , 'Tools'))
+try:
+    from   IfwiUtility import *
+except ImportError:
+    ErrMsg  = "Cannot find IfwiUtility module!\n"
+    ErrMsg += "Please make sure 'SBL_SOURCE' environment variable is set to open source SBL root folder."
+    raise  ImportError(ErrMsg)
 
 ExtraUsageTxt = """
 This script creates a new Whiskeylake/Coffeelake Slim Bootloader IFWI image basing
@@ -32,286 +42,71 @@ Please follow steps below:
       python StitchLoader.py -i IFWI.bin
 """
 
-
-class BIOS_ENTRY(Structure):
-    _pack_ = 1
-    _fields_ = [
-        ('Name', ARRAY(c_char, 4)),
-        ('Offset', c_uint32),
-        ('Length', c_uint32),
-        ('Reserved', c_uint32),
-    ]
-
-
-class COMPONENT:
-    TYPE_BIOS = 0
-    TYPE_IFWI = 1
-    TYPE_BP   = 2
-    TYPE_BPDT = 3
-    TYPE_PART = 4
-    TYPE_FILE = 5
-
-    def __init__(self, Name, Type, Offset, Length):
-        self.Name = Name
-        self.Type = Type
-        self.Offset = Offset
-        self.Length = Length
-        self.Child = []
-
-    def AddChild(self, Child):
-        self.Child.append(Child)
-        self.Child.sort (key=lambda x: x.Offset)
-
-
-class FlashMapDesc(Structure):
-    _pack_ = 1
-    _fields_ = [
-        ('Sig',     ARRAY(c_char, 4)),
-        ('Flags',   c_uint32),
-        ('Offset',  c_uint32),
-        ('Size',    c_uint32),
-        ]
-
-class FlashMap(Structure):
-    FLASH_MAP_DESC_SIGNATURE = 'FLMP'
-
-    FLASH_MAP_ATTRIBUTES = {
-        "PRIMARY_REGION"  : 0x00000000,
-        "BACKUP_REGION"   : 0x00000001,
-    }
-
-    FLASH_MAP_DESC_FLAGS = {
-        "TOP_SWAP"      : 0x00000001,
-        "REDUNDANT"     : 0x00000002,
-        "NON_REDUNDANT" : 0x00000004,
-        "NON_VOLATILE"  : 0x00000008,
-        "COMPRESSED"    : 0x00000010,
-        "BACKUP"        : 0x00000040,
-    }
-
-    _pack_ = 1
-    _fields_ = [
-        ('Sig',              ARRAY(c_char, 4)),
-        ('Version',          c_uint16),
-        ('Length',           c_uint16),
-        ('Attributes',       c_uint8),
-        ('Reserved',         ARRAY(c_char, 3)),
-        ('Romsize',          c_uint32),
-        ]
-
-
-def Bytes2Val (bytes):
-    return reduce(lambda x,y: (x<<8)|y,  bytes[::-1] )
-
-def Val2Bytes (value, length):
-    return [(value>>(i*8) & 0xff) for i in range(length)]
-
-class SPI_DESCRIPTOR(Structure):
-    DESC_SIGNATURE = 0x0FF0A55A
-    FLASH_REGIONS = {
-        "descriptor"    : 0x0,
-        "bios"          : 0x4
-    }
-    _pack_ = 1
-    _fields_ = [
-        ('Reserved',  ARRAY(c_char, 16)),
-        ('FlValSig',  c_uint32),
-        ('FlMap0',    c_uint32),
-        ('Remaining', ARRAY(c_char, 0x1000 - 0x28)),
-    ]
-
-def FindSpiRegion (SpiDescriptor, RgnName):
-    Frba = ((SpiDescriptor.FlMap0 >> 16) & 0xFF) << 4
-    FlReg = SpiDescriptor.FLASH_REGIONS[RgnName] + Frba
-    RgnOff = c_uint32.from_buffer(SpiDescriptor, FlReg)
-    RgnBase = (RgnOff.value & 0x7FFF) << 12
-    RgnLimit = ((RgnOff.value & 0x7FFF0000) >> 4) | 0xFFF
-    if RgnLimit <= RgnBase:
-        return (None, None)
-    else:
-        return (RgnBase, RgnLimit)
-
-def ParseIfwiLayout (IfwiImgData):
-    SpiDescriptor = SPI_DESCRIPTOR.from_buffer(IfwiImgData, 0)
-    if SpiDescriptor.FlValSig != SpiDescriptor.DESC_SIGNATURE:
-        return None
-
-    RgnList = []
-    Regions = [("descriptor", "DESC"), ("bios" , "BIOS")]
-    for Rgn in Regions:
-        Start, Limit = FindSpiRegion (SpiDescriptor, Rgn[0])
-        if Start is None:
-            continue
-        RgnList.append((Rgn[1], Start, Limit - Start + 1))
-
-    RgnList.sort (key = lambda Rgn : Rgn[1])
-    return RgnList
-
-def GetRegion (RgnList, RegionName):
-    if RgnList == None:
-        Fatal("Invalid Region List !")
-
-    for Rgn in RgnList:
-        if Rgn[0] == RegionName:
-            return Rgn
-
-    return None
-
-
-def ParseFlashMap (ImgData, BaseOff = 0):
-
-    PartDict = {
-        0x01:  "TS0",
-        0x41:  "TS1",
-        0x02:  "RD0",
-        0x42:  "RD1",
-        0x04:  "NRD",
-        0x08:  "NVS",
-    }
-
-    #
-    # No SPI descriptor, try to check the flash map
-    #
-    Offset = Bytes2Val(ImgData[-8:-4]) - (0x100000000 - len(ImgData))
-    if Offset <0 or Offset >= len(ImgData) - 0x10:
-        return None
-
-    FlaMapOff = Offset
-    if Bytes2Val(ImgData[FlaMapOff:FlaMapOff+4]) != 0x504d4c46:
-        return None
-
-    IfwiComp  = COMPONENT('IFWI', COMPONENT.TYPE_IFWI, 0, len(ImgData))
-    BiosComp  = COMPONENT('BIOS', COMPONENT.TYPE_BIOS, BaseOff, len(ImgData) - BaseOff)
-    CurrPart  = -1
-    FlaMapStr = FlashMap.from_buffer (ImgData, FlaMapOff)
-    EntryNum  = (FlaMapStr.Length - sizeof(FlashMap)) // sizeof(FlashMapDesc)
-    for Idx in range (EntryNum):
-        Idx   = EntryNum - 1 - Idx
-        Desc  = FlashMapDesc.from_buffer (ImgData, FlaMapOff + sizeof(FlashMap) + Idx * sizeof(FlashMapDesc))
-        FileComp = COMPONENT(Desc.Sig, COMPONENT.TYPE_FILE, Desc.Offset + BaseOff, Desc.Size)
-        if CurrPart != Desc.Flags & 0x4F:
-            CurrPart = Desc.Flags & 0x4F
-            PartComp = COMPONENT('%s' % (PartDict[CurrPart]), COMPONENT.TYPE_BIOS, Desc.Offset + BaseOff, Desc.Size)
-            BiosComp.AddChild (PartComp)
-        else:
-            PartComp.Length += Desc.Size
-
-        PartComp.AddChild(FileComp)
-    IfwiComp.AddChild(BiosComp)
-    return IfwiComp
-
-
-def PrintTree(Root, Level=0):
-    print "%-24s [O:0x%06X  L:0x%06X]" % ('  ' * Level + Root.Name,
-                                          Root.Offset, Root.Length)
-    for Comp in Root.Child:
-        Level += 1
-        PrintTree(Comp, Level)
-        Level -= 1
-
-def LocateComponents(Root, Path):
-    Result = []
-    Nodes  = Path.split('/')
-    if len(Nodes) < 1 or Root.Name != Nodes[0]:
-        return []
-    if len(Nodes) == 1:
-        return [Root]
-    for Comp in Root.Child:
-        Return = LocateComponents(Comp, '/'.join(Nodes[1:]))
-        if len(Return) > 0:
-            Result.extend(Return)
-    return Result
-
-def LocateComponent(Root, Path):
-    result = LocateComponents(Root, Path)
-    if len(result) > 0:
-        return result[0]
-    else:
-        return None
-
-def AddPlatformData (InputData, RgnLen, PlatformData = None):
-    InputLen = len(InputData)
-    if RgnLen is not 0:
-        if RgnLen < InputLen:
-            Fatal("Input binary size(0x%08x) cannot exceed %s region size(0x%08x) !" % (InputLen, Rgn[0], RgnLen))
+def AddPlatformData (BiosData, PlatformData = None):
+    if PlatformData:
+        # Parse BIOS image
+        IfwiParser = IFWI_PARSER ()
+        Bios = IfwiParser.parse_ifwi_binary (BiosData)
+        if not Bios:
             return None
 
-    if PlatformData:
-      # Parse Flash Map
-      Ifwi = ParseFlashMap (InputData)
-      for Part in range(2):
-        Path = 'IFWI/BIOS/TS%d/SG1A' %Part
-        Stage1A = LocateComponent (Ifwi, Path)
-        if Stage1A:
-          PlatDataOffset = Stage1A.Offset + Stage1A.Length - 12
-          c_uint32.from_buffer (InputData, PlatDataOffset).value = PlatformData
-        print "Platform data was patched for %s" % Path
-      return InputData
+        for Part in range(2):
+          Path = 'IFWI/BIOS/TS%d/SG1A' % Part
+          Stage1A = IfwiParser.locate_component (Bios, Path)
+          if Stage1A:
+              PlatDataOffset = Stage1A.offset + Stage1A.length - 12
+              c_uint32.from_buffer (BiosData, PlatDataOffset).value = PlatformData
+          print("Platform data was patched for %s" % Path)
 
-def ReplaceRegion (IfwiData, Rgn, InputFile, TailPos, PlatformData = None):
-    RgnPos = Rgn[1]
-    RgnLen = Rgn[2]
+    return BiosData
 
-    Fd = open(InputFile, "rb")
-    InputData = bytearray(Fd.read())
-    Fd.close()
-
-    if PlatformData:
-        InputData = AddPlatformData(InputData, RgnLen, PlatformData)
-        if InputData is None:
-            return
-
-    InputLen = len(InputData)
-    RgnOff = RgnLen - InputLen
-    if TailPos == 1:
-        if RgnLen != InputLen:
-            IfwiData[RgnPos:RgnPos+RgnOff] = '\xff' * RgnOff
-        IfwiData[RgnPos+RgnOff:RgnPos+RgnLen] = InputData
-    else:
-        IfwiData[RgnPos:RgnPos+InputLen] = InputData
-        if RgnLen != InputLen:
-            IfwiData[RgnPos+InputLen:RgnPos+RgnLen] = '\xff' * RgnOff
 
 def CreateIfwiImage (IfwiIn, IfwiOut, SblIn, PlatformData):
-    Fd = open(IfwiIn, "rb")
-    IfwiData = bytearray(Fd.read())
-    Fd.close()
-
-    RgnList = ParseIfwiLayout(IfwiData)
+    IfwiData   = bytearray (get_file_data (IfwiIn))
+    IfwiParser = IFWI_PARSER ()
+    Ifwi = IfwiParser.parse_ifwi_binary (IfwiData)
+    if not Ifwi:
+        print ("Invalid IFWI input image!")
+        return -1
 
     # update bios region
-    print "Update BIOS region ..."
-    Rgn = GetRegion(RgnList, "BIOS")
-    if Rgn == None:
-        Fatal("Failed to find BIOS region!")
+    Bios = IfwiParser.locate_component (Ifwi, 'IFWI/BIOS')
+    if not Bios:
+        print ("Cound not find BIOS region!")
+        return -2
 
-    ReplaceRegion(IfwiData, Rgn, SblIn, 1, PlatformData)
-    print "Done"
+    BiosData = bytearray (get_file_data (SblIn))
+    BiosData = AddPlatformData (BiosData, PlatformData)
+    if not BiosData:
+        print ("Failed to parse BIOS image!")
+        return -3
+
+    Padding  = Bios.length - len(BiosData)
+    if Padding < 0:
+        print ("BIOS image is too big to fit into BIOS region!")
+        return -4
+
+    BiosData = b'\xff' * Padding + BiosData
+    Ret = IfwiParser.replace_component (IfwiData, BiosData, 'IFWI/BIOS')
+    if Ret != 0:
+        print ("Failed to replace BIOS region!")
+        return -5
 
     # create new ifwi
-    print "Creating IFWI image ..."
+    print("Creating IFWI image ...")
     if IfwiOut == '':
         IfwiOut = IfwiIn
-    Fd = open (IfwiOut, 'wb')
-    Fd.write(IfwiData)
-    Fd.close()
+    gen_file_from_object (IfwiOut, IfwiData)
+
     print ('Done!')
 
 
 def PrintIfwiLayout (IfwiFile):
-    Fd = open(IfwiFile, "rb")
-    IfwiData = bytearray(Fd.read())
-    Fd.close()
-
-    RgnList = ParseIfwiLayout (IfwiData)
-    for Rgn in RgnList:
-        print "%04s: 0x%08x - 0x%08x" % (Rgn[0], Rgn[1], Rgn[1] + Rgn[2])
-
-    print ''
-    for Rgn in RgnList:
-        if Rgn[0] == 'BIOS':
-            Bios = ParseFlashMap (IfwiData, Rgn[1])
-            PrintTree (Bios)
+    IfwiData   = bytearray (get_file_data (IfwiFile))
+    IfwiParser = IFWI_PARSER ()
+    Ifwi = IfwiParser.parse_ifwi_binary (IfwiData)
+    if Ifwi:
+        IfwiParser.print_tree (Ifwi)
 
 
 def main():


### PR DESCRIPTION
EDK II build has enabled python3 support. Since SBL has its own scripts,
it is required to port them accordingly to support python3. This patch
added python3 build support for SBL.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>