### PR TITLE
[APL]Increase payload size to fix build error.

### DIFF
--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -113,7 +113,7 @@ class Board(BaseBoard):
 		self.STAGE1B_FD_SIZE      = 0x0006B000
 		if self.RELEASE_MODE == 0:
 			self.STAGE1B_FD_SIZE += 0x00002000
-			self.PAYLOAD_SIZE    += 0x00003000
+			self.PAYLOAD_SIZE    += 0x00004000
 		# For Stage2, it is always compressed.
 		# if STAGE2_LOAD_HIGH is 1, STAGE2_FD_BASE will be ignored
 		self.STAGE2_FD_BASE       = 0x01000000


### PR DESCRIPTION
APL build hit into exception: File 'PAYLOAD.lz' size 0x224B5 is greater than padding size 0x22000 !
This patch to increase the payload size to fix the build issue. 
Test and booted on JuniperHill board to SBL Shell and Uefi Shell

Signed-off-by: Teo Boon Tiong <boon.tiong.teo@intel.com>