### PR TITLE
Enable more build options in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,11 @@ before_install:
   - chmod -R a+w .
 
 env:
-  - BUILD_TARGET=qemu
-  - BUILD_TARGET=apl
-  - BUILD_TARGET=cfl
+  - BUILD_TARGET=qemu  PYTHON_VER=2
+  - BUILD_TARGET=apl   PYTHON_VER=2  BUILD_REL=-r
+  - BUILD_TARGET=apl   PYTHON_VER=3
+  - BUILD_TARGET=cfl   PYTHON_VER=2
+  - BUILD_TARGET=cfl   PYTHON_VER=3  BUILD_REL=-r
 
 script:
-  - docker run --rm -v ${PWD}:/tmp/sbl -w /tmp/sbl --network=host sbl ./BuildLoader.py build $BUILD_TARGET
-
+  - docker run --rm -v ${PWD}:/tmp/sbl -w /tmp/sbl --network=host sbl python${PYTHON_VER} ./BuildLoader.py build ${BUILD_REL} ${BUILD_TARGET}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
 FROM ubuntu:18.04
 
 # Install build dependencies
-RUN apt-get update && apt-get -y install sudo build-essential python \
+RUN apt-get update && apt-get -y install sudo build-essential python python3 \
 	uuid-dev nasm openssl gcc-multilib git m4 bison flex
 
 # Install ACPICA Utilities
-ADD https://acpica.org/sites/acpica/files/acpica-unix-20160422.tar.gz /tmp
+ADD http://ftp.br.debian.org/debian/pool/main/a/acpica-unix/acpica-tools_20160831-1+b1_amd64.deb /tmp
 RUN cd /tmp && \
-    tar -xvf acpica-unix-20160422.tar.gz && \
-    cd acpica-unix-20160422 && \
-    make && make install && \
-    cd /tmp && rm -rf acpica-unix-20160422 acpica-unix-20160422.tar.gz
+    dpkg -i acpica-tools_20160831-1+b1_amd64.deb && \
+    apt-get install -f && \
+    apt-get -y install python3-distutils
 
 # Add a user account, give sudo access
 RUN useradd -m docker && echo "docker:docker" | chpasswd && adduser docker sudo


### PR DESCRIPTION
Current travis build only performs debug build with python 2.
This patch allows to test debug and release build, python2 and
python3 build.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>