### PR TITLE
Fix invalid string in Configuration data

### DIFF
--- a/Platform/CoffeelakeBoardPkg/CfgData/CfgData_Silicon.dsc
+++ b/Platform/CoffeelakeBoardPkg/CfgData/CfgData_Silicon.dsc
@@ -20,9 +20,9 @@
   # !BSF HELP:{Enable or Disable processor debug features; <b>0: Disable</b>; 1: Enable.}
   gCfgData.DebugInterfaceEnable   |      * | 0x01 | 0x00
 
-  # !BSF NAME:{Enable or Disable processor debug features} TYPE:{Combo}
+  # !BSF NAME:{Enable or Disable legacy serial port expose to OS} TYPE:{Combo}
   # !BSF TYPE:{Combo} OPTION:{$EN_DIS}
-  # !BSF HELP:{Enable or Disable processor debug features; <b>0: Disable</b>; 1: Enable.}
+  # !BSF HELP:{Enable or Disable legacy serial port expose to OS; <b>0: Disable</b>; 1: Enable.}
   gCfgData.EnableLegacySerial     |      * | 0x01 | 0x00
 
   # !BSF PAGES:{PSEL:SIL:"Payload Selection GPIO"}


### PR DESCRIPTION
This patch will fix an invalid string in the
configuration data for CFL/WHL platforms.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>