### PR TITLE
[QEMU] Support -smp option

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -221,6 +221,8 @@
   gPlatformModuleTokenSpaceGuid.PcdCfgDataLoadSource      | $(CFGDATA_REGION_TYPE)
   gPlatformModuleTokenSpaceGuid.PcdCfgDatabaseSize        | $(CFG_DATABASE_SIZE)
 
+  gPlatformModuleTokenSpaceGuid.PcdCpuMaxLogicalProcessorNumber | $(CPU_MAX_LOGICAL_PROCESSOR_NUMBER)
+
   gPlatformCommonLibTokenSpaceGuid.PcdDebugOutputDeviceMask  | $(DEBUG_OUTPUT_DEVICE_MASK)
 
   gPlatformCommonLibTokenSpaceGuid.PcdConsoleInDeviceMask  | $(CONSOLE_IN_DEVICE_MASK)

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -191,6 +191,8 @@ class BaseBoard(object):
 		self.ENABLE_SMBIOS         = 0
 		self.ENABLE_LINUX_PAYLOAD  = 0
 
+		self.CPU_MAX_LOGICAL_PROCESSOR_NUMBER = 16
+
 		self.ACM_SIZE              = 0
 		self.ACM3_SIZE             = 0
 		self.UCODE_SIZE            = 0

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -48,6 +48,8 @@ class Board(BaseBoard):
 		self.ENABLE_GRUB_CONFIG       = 1
 		self.ENABLE_LINUX_PAYLOAD     = 1
 
+		self.CPU_MAX_LOGICAL_PROCESSOR_NUMBER = 255
+
 		# To enable source debug, set 1 to self.ENABLE_SOURCE_DEBUG
 		# self.ENABLE_SOURCE_DEBUG  = 1
 


### PR DESCRIPTION
QEMU supports '-smp' option to emulate up-to maximum 255 CPUs, but failed
to do MpInit with '-smp' option. Currently, there are only fixed size(4)
Processor Local APIC entries in QEMU MADT and its ApicId does not match
with detected CPU info.
- Append ProcessorLocalApic entries into MADT in runtime with MpInfo
- Make PcdCpuMaxLogicalProcessorNumber configurable in each BoardConfig
- Set PcdCpuMaxLogicalProcessorNumber to 255 in QEMU BoardConfig.py

Test>
qemu-system-x86_64 -machine q35 -nographic -serial mon:stdio
                   -pflash Outputs/qemu/SlimBootloader.bin
                   -smp 8

Signed-off-by: Aiden Park aiden.park@intel.com