### PR TITLE
Fix CfgDataTool issue on some platforms

### DIFF
--- a/BootloaderCorePkg/Tools/CfgDataStitch.py
+++ b/BootloaderCorePkg/Tools/CfgDataStitch.py
@@ -21,7 +21,7 @@ def get_tool_dir():
 
 def run_cmd(cmd_list):
     sys.stdout.flush()
-    print ' '.join(cmd_list)
+    print (' '.join(cmd_list))
     ret = subprocess.call(cmd_list)
     if ret:
         sys.exit(1)
@@ -107,7 +107,7 @@ def cfgdata_stitch(ifwi_file, ifwi_out_file, cfg_dir, key_dir, tool_dir, pid):
     # replace the CFGDATA in IFWI
     cmd_list = [sys.executable, os.path.join(tool_dir, 'CfgDataTool.py'), 'replace',
                 '-i', ifwi_file, os.path.join(out_dir, 'CfgData.bin')]
-    cmd_list.extend(['-o', os.path.join(out_dir, os.path.basename(ifwi_file))])
+    cmd_list.extend(['-o', os.path.join(out_dir, os.path.basename(ifwi_out_file))])
     run_cmd(cmd_list)
 
     # clean intermediate files

--- a/BootloaderCorePkg/Tools/CfgDataTool.py
+++ b/BootloaderCorePkg/Tools/CfgDataTool.py
@@ -703,20 +703,21 @@ def CmdReplace(Args):
     CompList = []
     StartOff = 0
     EndOff   = 0
-    CfgName  = 'CNFG'
     if IfwiParser.is_ifwi_image(BiosBins):
         #Check if it has BPDT
         SpiDesc = SPI_DESCRIPTOR.from_buffer(BiosBins, 0)
         Comp = IfwiParser.find_ifwi_region(SpiDesc, RegionName)
         if len(Comp) < 1:
             raise Exception("Cannot not find CFGDATA in SPI flash region '%s' !" % RegionName)
-        CfgName = 'CFGD'
 
     if not CompList:
         if RegionName == 'bios':
             Ifwi = IfwiParser.parse_ifwi_binary (BiosBins)
-            cfgs = IfwiParser.find_components(Ifwi, CfgName)
+            cfgs = IfwiParser.find_components(Ifwi, 'CNFG')
+            if not cfgs:
+                cfgs = IfwiParser.find_components(Ifwi, 'CFGD')
             for cfgd in cfgs:
+                print (IfwiParser.get_component_path (cfgd))
                 CompList.append((cfgd.offset, cfgd.length))
         else:
             # For PDR region, always assume CFGDATA starts from offset 0

--- a/BootloaderCorePkg/Tools/IfwiUtility.py
+++ b/BootloaderCorePkg/Tools/IfwiUtility.py
@@ -317,6 +317,14 @@ class IFWI_PARSER:
         return result
 
     @staticmethod
+    def get_component_path (comp):
+        path = []
+        while comp:
+            path.append (comp.name)
+            comp = comp.parent
+        return '/'.join(path[::-1])
+
+    @staticmethod
     def print_tree(root, level=0):
         if root is None:
             return


### PR DESCRIPTION
CfgDataTool was originally developed for APL. On APL, the CFGDATA
region name is 'CFGD'.  However, on all other platform, the name
is 'CNFG'. This patch modified the script to handle both. And it
fixed #293.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>