### PR TITLE
Enable optional extra platform DSC

### DIFF
--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -667,6 +667,10 @@ class Build(object):
 					lines.append('  %s\n' % lib)
 				lines.append('\n')
 
+		if os.path.exists(os.path.join(os.environ['PLT_SOURCE'], 'Platform', self._board.BOARD_PKG_NAME, 'ExtraPlatform.dsc')):
+			lines.append('\n# Extra Platform specific DSC file\n')
+			lines.append('!include Platform/$(BOARD_PKG_NAME)/ExtraPlatform.dsc\n')
+
 		update = True
 		text = ''.join(lines)
 		if os.path.exists(file):


### PR DESCRIPTION
For additional DSC file settings that are
platform specific we may want to be able
to add an extra DSC file that can use the
same $(VAR) logic that BootloaderCore DSC
file can use based on BoardConfig.py vars.

Signed-off-by: James Gutbub <james.gutbub@intel.com>