### PR TITLE
Remove using FitHelp.py in StitchIfwi

### DIFF
--- a/BootloaderCorePkg/Tools/IfwiUtility.py
+++ b/BootloaderCorePkg/Tools/IfwiUtility.py
@@ -376,7 +376,7 @@ class IFWI_PARSER:
             elif gap < 0:
                 gap = -gap
                 print ("Padding 0x%x bytes at the end to fill the region '%s'" % (gap, ifwi_comp.name))
-                comp_bin.extend ('\xff' * gap)
+                comp_bin.extend (b'\xff' * gap)
 
             ifwi_bin[ifwi_comp.offset:ifwi_comp.offset + ifwi_comp.length] = \
                 comp_bin[0:ifwi_comp.length]


### PR DESCRIPTION
This patch will remove FitHelp.py dependency from StitchIfwi
and reuses code from IfwiUtility to patch ACM binary.

This patch also fixed some case dependency required for python
in xml file patching. without this fix, fit does not work as
expected.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>