### PR TITLE
Optimize Stage1A early boot init

### DIFF
--- a/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Ia16/Init16.asm
+++ b/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Ia16/Init16.asm
@@ -31,6 +31,7 @@ EarlyApInitReal16:
 ; @param[out] ESP   Initial value of the EAX register (BIST: Built-in Self Test)
 ;
 EarlyInit16:
+	cli
     ;
     ; ESP -  Initial value of the EAX register (BIST: Built-in Self Test)
     ;

--- a/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Ia16/Init16.asm
+++ b/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Ia16/Init16.asm
@@ -31,7 +31,7 @@ EarlyApInitReal16:
 ; @param[out] ESP   Initial value of the EAX register (BIST: Built-in Self Test)
 ;
 EarlyInit16:
-	cli
+    cli
     ;
     ; ESP -  Initial value of the EAX register (BIST: Built-in Self Test)
     ;

--- a/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Ia16/Real16ToFlat32.asm
+++ b/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Ia16/Real16ToFlat32.asm
@@ -111,5 +111,7 @@ jumpTo32BitAndLandHere:
     mov     fs, ax
     mov     gs, ax
     mov     ss, ax
+    /* Restore the BIST value to EAX register */
+    movd     eax, mm0
     OneTimeCallRet TransitionFromReal16To32BitFlat
 

--- a/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Ia16/Real16ToFlat32.asm
+++ b/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Ia16/Real16ToFlat32.asm
@@ -111,7 +111,5 @@ jumpTo32BitAndLandHere:
     mov     fs, ax
     mov     gs, ax
     mov     ss, ax
-    /* Restore the BIST value to EAX register */
-    movd     eax, mm0
     OneTimeCallRet TransitionFromReal16To32BitFlat
 

--- a/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Ia16/Real16ToFlat32.asm
+++ b/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Ia16/Real16ToFlat32.asm
@@ -92,7 +92,6 @@ GDT_END:
 ; Modified:  EAX, EBX
 ;
 TransitionFromReal16To32BitFlat:
-    cli
     mov     bx, 0xf000
     mov     ds, bx
     mov     bx, ADDR16_OF(gdtr)

--- a/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Main.asm
+++ b/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Main.asm
@@ -36,5 +36,5 @@ BITS    32
     mov     eax, dword [eax]
     mov     esi, dword [eax]               
     ; Restore the BIST value to EAX register
-    movd     eax, mm0   
+    movd    eax, mm0   
     jmp     esi

--- a/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Main.asm
+++ b/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Main.asm
@@ -34,5 +34,7 @@ BITS    32
     ;
     mov     eax, 0FFFFFFFCh    
     mov     eax, dword [eax]
-    mov     esi, dword [eax]                  
+    mov     esi, dword [eax]               
+    ; Restore the BIST value to EAX register
+    movd     eax, mm0   
     jmp     esi


### PR DESCRIPTION
- clear interrupts at EarlyInit16
- Restore BIST value to EAX register

Signed-off-by: Himanshu Sahdev aka CunningLearner <sahdev.himan@gmail.com>


