### PR TITLE
Resolve Klocwork issue in FWU code

### DIFF
--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -984,7 +984,7 @@ ProcessCapsule (
   // If capsule header is NULL or no payloads found in the capsule
   // return EFI_NOT_FOUND;
   //
-  if ((CapHeader != NULL) && (CapHeader->PayloadItemCount == 0)) {
+  if ((CapHeader == NULL) || (CapHeader->PayloadItemCount == 0)) {
     ImgHeader = NULL;
     return EFI_NOT_FOUND;
   }


### PR DESCRIPTION
If capsule header is NULL or no payloads
found in the capsule return EFI_NOT_FOUND.

Signed-off-by: James Gutbub <james.gutbub@intel.com>