### PR TITLE
BootloaderCore: Handle BIST failure in SecEntry

### DIFF
--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -48,6 +48,7 @@ typedef struct {
   UINT32        CarBase;
   UINT32        CarTop;
   UINT64        TimeStamp;
+  UINT32        BistVal;
 } STAGE1A_ASM_HOB;
 
 typedef struct {

--- a/BootloaderCorePkg/Stage1A/Ia32/SecEntry.nasm
+++ b/BootloaderCorePkg/Stage1A/Ia32/SecEntry.nasm
@@ -61,13 +61,12 @@ FspApiSuccess:
         ;
         mov     esp, ecx
         add     esp, dword [ASM_PFX(PcdGet32(PcdStage1StackSize))]
-        mov     eax, esp
 
-        movd    ebx, mm0
+        movd    eax, mm0
         emms                         ; Exit MMX Instruction
 
         ; Setup HOB
-        push    ebx                  ; BistVal
+        push    eax                  ; BistVal
         push    edi                  ; TimeStamp[0] [63:32]
         push    esi                  ; TimeStamp[0] [31:0]
         push    edx                  ; CarTop

--- a/BootloaderCorePkg/Stage1A/Ia32/SecEntry.nasm
+++ b/BootloaderCorePkg/Stage1A/Ia32/SecEntry.nasm
@@ -64,6 +64,7 @@ FspApiSuccess:
         mov     eax, esp
 
         movd    ebx, mm0
+        emms                         ; Exit MMX Instruction
 
         ; Setup HOB
         push    ebx                  ; BistVal

--- a/BootloaderCorePkg/Stage1A/Ia32/SecEntry.nasm
+++ b/BootloaderCorePkg/Stage1A/Ia32/SecEntry.nasm
@@ -24,8 +24,8 @@ extern  ASM_PFX(FspTempRamInit)
 
 global  ASM_PFX(_ModuleEntryPoint)
 ASM_PFX(_ModuleEntryPoint):
-        mov     ebx, eax
-        
+        movd    mm0, eax
+
         ;
         ; Read time stamp
         ;
@@ -62,6 +62,8 @@ FspApiSuccess:
         mov     esp, ecx
         add     esp, dword [ASM_PFX(PcdGet32(PcdStage1StackSize))]
         mov     eax, esp
+
+        movd    ebx, mm0
 
         ; Setup HOB
         push    ebx                  ; BistVal

--- a/BootloaderCorePkg/Stage1A/Ia32/SecEntry.nasm
+++ b/BootloaderCorePkg/Stage1A/Ia32/SecEntry.nasm
@@ -24,6 +24,8 @@ extern  ASM_PFX(FspTempRamInit)
 
 global  ASM_PFX(_ModuleEntryPoint)
 ASM_PFX(_ModuleEntryPoint):
+        mov     ebx, eax
+        
         ;
         ; Read time stamp
         ;
@@ -62,6 +64,7 @@ FspApiSuccess:
         mov     eax, esp
 
         ; Setup HOB
+        push    ebx                  ; BistVal
         push    edi                  ; TimeStamp[0] [63:32]
         push    esi                  ; TimeStamp[0] [31:0]
         push    edx                  ; CarTop

--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -240,8 +240,9 @@ SecStartup2 (
     DEBUG ((DEBUG_INIT, "\n%a\n", mBootloaderName));
   }
 
-  if (Stage1aAsmHob->BistVal != 0)
+  if (Stage1aAsmHob->BistVal != 0) {
     CpuHalt ("CPU BIST failure!\n");
+  }
 
   if ( (BufPtr == NULL) ||
        ((Stage1aHob.AllocDataBase + Stage1aHob.AllocDataLen) < (UINT32)(UINTN)BufPtr) ) {

--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -240,6 +240,9 @@ SecStartup2 (
     DEBUG ((DEBUG_INIT, "\n%a\n", mBootloaderName));
   }
 
+  if(Stage1aAsmHob->BistVal != 0)
+    CpuHalt ("BIST failure!\n");
+
   if ( (BufPtr == NULL) ||
        ((Stage1aHob.AllocDataBase + Stage1aHob.AllocDataLen) < (UINT32)(UINTN)BufPtr) ) {
     CpuHalt ("Insufficant memory pool!\n");

--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -240,8 +240,8 @@ SecStartup2 (
     DEBUG ((DEBUG_INIT, "\n%a\n", mBootloaderName));
   }
 
-  if(Stage1aAsmHob->BistVal != 0)
-    CpuHalt ("BIST failure!\n");
+  if (Stage1aAsmHob->BistVal != 0)
+    CpuHalt ("CPU BIST failure!\n");
 
   if ( (BufPtr == NULL) ||
        ((Stage1aHob.AllocDataBase + Stage1aHob.AllocDataLen) < (UINT32)(UINTN)BufPtr) ) {


### PR DESCRIPTION
- add BistVal in STAGE1A_ASM_HOB structure
- use MM0 register to preserve the BIST value
- push BistVal while setup HOB in stack
- add check for CPU BIST failure and halt the system when failed

Signed-off-by: Himanshu Sahdev aka CunningLearner <sahdev.himan@gmail.com>