### PR TITLE
[AcpiInitLib] Fix build failure on Windows

### DIFF
--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
@@ -394,8 +394,11 @@ UpdateMadt (
   for (Index = 0; Index < SysCpuInfo->CpuCount; Index++) {
     LocalApic[Index].Type             = EFI_ACPI_5_0_PROCESSOR_LOCAL_APIC;
     LocalApic[Index].Length           = sizeof (EFI_ACPI_5_0_PROCESSOR_LOCAL_APIC_STRUCTURE);
-    LocalApic[Index].AcpiProcessorId  = Index + 1;
-    LocalApic[Index].ApicId           = SysCpuInfo->CpuInfo[Index].ApicId;
+    //
+    // ProcessorId and ApicId has sizeof (UINT8).
+    //
+    LocalApic[Index].AcpiProcessorId  = (UINT8)Index + 1;
+    LocalApic[Index].ApicId           = (UINT8)SysCpuInfo->CpuInfo[Index].ApicId;
     LocalApic[Index].Flags            = 1;
   }
   Length = sizeof (EFI_ACPI_5_0_PROCESSOR_LOCAL_APIC_STRUCTURE) * SysCpuInfo->CpuCount;


### PR DESCRIPTION
Error: conversion from 'UINT32' to 'UINT8', possible loss of data

MADT ProcessorId and ApicId has the size of UINT8. Cast the size from UINT32 to UINT8.

Change-Id: I3f46b2015b0d21c2b3e2f9389ecb8d5364ed5a5e
Signed-off-by: Aiden Park <aiden.park@intel.com>