### PR TITLE
[APL] Fix boot option settings for ACRN

### DIFF
--- a/Platform/ApollolakeBoardPkg/CfgData/CfgData_BootOption.dsc
+++ b/Platform/ApollolakeBoardPkg/CfgData/CfgData_BootOption.dsc
@@ -8,16 +8,16 @@
   # !BSF PAGE:{OS}
   # !HDR HEADER:{OFF}
 
-  #                             # |ImgType|flag|DevType|DevNum|HwPart|SwPart|FsType|  image0 name
+  #                               |ImgType|flag|DevType|DevNum|HwPart|SwPart|FsType|ImageName or LBA#
   # eMMC boot P1
   # !BSF SUBT:{BOOT_OPTION_TMPL:0 :  0    :  0 :   2   :  0   :   0  :    0 :    0 :'iasimage.bin'}
   # eMMC boot P2
-  # !BSF SUBT:{BOOT_OPTION_TMPL:1 :  0    :  0 :   2   :  0   :   0  :    0 :    3 :      ''      }
+  # !BSF SUBT:{BOOT_OPTION_TMPL:1 :  0    :  0 :   2   :  0   :   0  :    1 :    3 :'#0'          }
   # SATA boot
   # !BSF SUBT:{BOOT_OPTION_TMPL:2 :  0    :  0 :   0   :  0   :   0  :    0 :    0 :'iasimage.bin'}
   # USB boot
   # !BSF SUBT:{BOOT_OPTION_TMPL:3 :  0    :  0 :   5   :  0   :   0  :    0 :    0 :'iasimage.bin'}
   # SPI boot (for fastboot recovery)
-  # !BSF SUBT:{BOOT_OPTION_TMPL:4 :  4    :  0 :   7   :  0   :   0  :    0 :    3 :      ''      }
+  # !BSF SUBT:{BOOT_OPTION_TMPL:4 :  4    :  0 :   7   :  0   :   0  :    0 :    3 :'#0'          }
 
   # !HDR HEADER:{ON}


### PR DESCRIPTION
In order to make ACRN to boot, it is required to set boot from eMMC
RAW partition 1. However, current boot option is set to 0, which
caused the boot failure. This patch updated the SwPart to 1 and filled
the LBA with expected format. It fixed #317.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>