### PR TITLE
Fix config file buffer overflow issue

### DIFF
--- a/PayloadPkg/OsLoader/LoadImage.c
+++ b/PayloadPkg/OsLoader/LoadImage.c
@@ -415,7 +415,8 @@ GetTraditionalLinux (
       continue;
     }
 
-    ConfigFile = AllocatePool (ConfigFileSize);
+    // Allocate one more space to append NULL char
+    ConfigFile = AllocatePool (ConfigFileSize + 1);
     if (ConfigFile == NULL) {
       CloseFile (FileHandle);
       return EFI_OUT_OF_RESOURCES;


### PR DESCRIPTION
Current code will try to append a NULL char at the end of the
config file buffer to ensure the tring is terminated properly.
However, it did that without considering the buffer size. The
current config buffer could have been fully used and no more
space is available to append an extra NULL char. If this happens,
during the pool de-allocation, the assertion will be seen due to
buffer overflow. This patch increased the config buffer buffer
size by 1 to ensure it will have space to append string terminator.

It fixed #319.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>