### PR TITLE
[QEMU] Fix QEMU build and boot issue

### DIFF
--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -71,11 +71,11 @@ class Board(BaseBoard):
 		self.STAGE1B_XIP          = 0
 
 		self.STAGE1A_SIZE         = 0x00010000
-		self.STAGE1B_SIZE         = 0x00012000
+		self.STAGE1B_SIZE         = 0x00030000
 		self.STAGE2_SIZE          = 0x00018000
 
 		self.SIIPFW_SIZE          = 0x00010000
-		self.EPAYLOAD_SIZE        = 0x0030D000
+		self.EPAYLOAD_SIZE        = 0x0020D000
 		self.PAYLOAD_SIZE         = 0x00020000
 		self.CFGDATA_SIZE         = 0x00001000
 		self.VARIABLE_SIZE        = 0x00002000
@@ -90,9 +90,9 @@ class Board(BaseBoard):
 			self.NON_REDUNDANT_SIZE = 0x400000
 		else:
 			self.TOP_SWAP_SIZE      = 0x010000
-			self.REDUNDANT_SIZE     = 0x050000
+			self.REDUNDANT_SIZE     = 0x080000
 			self.NON_VOLATILE_SIZE  = 0x001000
-			self.NON_REDUNDANT_SIZE = 0x33F000
+			self.NON_REDUNDANT_SIZE = 0x2DF000
 
 
 		self.SLIMBOOTLOADER_SIZE = (self.TOP_SWAP_SIZE + self.REDUNDANT_SIZE) * 2 + \

--- a/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -195,10 +195,12 @@ BoardInit (
     SetDeviceTable (PltDeviceTable);
     BoardDetection ();
     UpdateBootMode ();
-    SpiConstructor ();
-    VariableConstructor (PcdGet32 (PcdVariableRegionBase), PcdGet32 (PcdVariableRegionSize));
-    Status = TestVariableService ();
-    ASSERT_EFI_ERROR (Status);
+    if (!FeaturePcdGet (PcdStage1BXip)) {
+      SpiConstructor ();
+      VariableConstructor (PcdGet32 (PcdVariableRegionBase), PcdGet32 (PcdVariableRegionSize));
+      Status = TestVariableService ();
+      ASSERT_EFI_ERROR (Status);
+    }
     break;
   case PostConfigInit:
     PlatformNameInit ();

--- a/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
+++ b/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
@@ -50,3 +50,4 @@
   gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled
   gPlatformModuleTokenSpaceGuid.PcdVariableRegionBase
   gPlatformModuleTokenSpaceGuid.PcdVariableRegionSize
+  gPlatformModuleTokenSpaceGuid.PcdStage1BXip

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -250,8 +250,10 @@ BoardInit (
     SpiConstructor ();
     EnableLegacyRegions ();
     VariableConstructor (PcdGet32 (PcdVariableRegionBase), PcdGet32 (PcdVariableRegionSize));
-    Status = TestVariableService ();
-    ASSERT_EFI_ERROR (Status);
+    if (!FeaturePcdGet (PcdStage1BXip)) {
+      Status = TestVariableService ();
+      ASSERT_EFI_ERROR (Status);
+    }
     // Get TSEG info from FSP HOB
     // It will be consumed in MpInit if SMM rebase is enabled
     LdrGlobal  = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -60,5 +60,5 @@
   gPlatformModuleTokenSpaceGuid.PcdSmmRebaseMode
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegBase
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegSize
-
+  gPlatformModuleTokenSpaceGuid.PcdStage1BXip
 


### PR DESCRIPTION
QEMU compiling will fail when EXECUTE_IN_PLACE is set to 1 due to
size issue.  Even after fixing size issue, the execution will still
fail. It is because the variable services will try to put SPI into
command mode while code fetching will fail if it is executed from flash.
This patch added necessary code to skip variable tests in Stage1B and
Stage2 when XIP is enabled. It fixed #324.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>