### PR TITLE
Allocate page aligned memory for component loading in container

### DIFF
--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
@@ -529,7 +529,7 @@ LoadComponentWithCallback (
   if (!EFI_ERROR (Status)) {
     CompressHdr = (LOADER_COMPRESSED_HEADER *)CompBuf;
     if (ReqCompBase == NULL) {
-      CompBase = AllocatePool (DecompressedLen);
+      CompBase = AllocatePages (EFI_SIZE_TO_PAGES ((UINTN) DecompressedLen));
     } else {
       CompBase = ReqCompBase;
     }
@@ -541,7 +541,7 @@ LoadComponentWithCallback (
       }
       if (EFI_ERROR (Status)) {
         if (ReqCompBase == NULL) {
-          FreePool (CompBase);
+          FreePages (CompBase, EFI_SIZE_TO_PAGES ((UINTN) DecompressedLen));
         }
       }
     } else {


### PR DESCRIPTION
To assist source level debug, it is better to always load PE/TE images
at page aligned memory address so that the script can locate the image
much easier. This patch changed the AllocatePool to AllocatePages for
component loading inside a container.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>