### PR TITLE
Enable NOOPT target for debugging purpose

### DIFF
--- a/BootloaderCommonPkg/Library/Ext23Lib/ExtLib.c
+++ b/BootloaderCommonPkg/Library/Ext23Lib/ExtLib.c
@@ -126,7 +126,8 @@ ExtFsOpenFile (
   NameBuffer = AllocatePool (NameSize);
   Status = UnicodeStrToAsciiStrS (FileName, NameBuffer, NameSize);
   if (EFI_ERROR(Status)) {
-    goto Error;
+    FreePool (NameBuffer);
+    return Status;
   }
 
   OpenFile = (OPEN_FILE *)AllocatePool (sizeof (OPEN_FILE));

--- a/BootloaderCommonPkg/Library/FatLib/FatLib.c
+++ b/BootloaderCommonPkg/Library/FatLib/FatLib.c
@@ -147,7 +147,7 @@ FindFile (
       if (EFI_ERROR (Status)) {
         return EFI_NOT_FOUND;
       } else {
-        Parent = *File;
+        CopyMem (&Parent, File, sizeof (PEI_FAT_FILE));
       }
     }
     NodeCurr = NodeNext;

--- a/BootloaderCommonPkg/Library/ShellLib/CmdMem.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdMem.c
@@ -57,6 +57,7 @@ ShellCommandMemFunc (
   Width = 4;
   Write = FALSE;
   Value = 0;
+  Count = 0;
 
   if ((Argc == 2) || (Argc == 3)) {
     // Read 1 element

--- a/BootloaderCommonPkg/Library/TpmLib/TpmEventLog.c
+++ b/BootloaderCommonPkg/Library/TpmLib/TpmEventLog.c
@@ -44,6 +44,9 @@ GetTCGLasa (
   if (TpmLibData != NULL) {
     *Lasa = (UINT32) (TpmLibData->LogAreaStartAddress);
     *Laml = TpmLibData->LogAreaMinLength;
+  } else {
+    *Lasa = 0;
+    *Laml = 0;
   }
 }
 

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -18,7 +18,7 @@
   DSC_SPECIFICATION                   = 0x00010005
   OUTPUT_DIRECTORY                    = Build/$(PLATFORM_NAME)
   SUPPORTED_ARCHITECTURES             = IA32|X64|ARC
-  BUILD_TARGETS                       = DEBUG|RELEASE
+  BUILD_TARGETS                       = DEBUG|RELEASE|NOOPT
   SKUID_IDENTIFIER                    = DEFAULT
   FLASH_DEFINITION                    = $(PLATFORM_NAME)/$(PLATFORM_NAME).fdf
 
@@ -396,4 +396,11 @@
   *_*_*_CC_FLAGS = -DLITE_PRINT
 !endif
 
-
+!if $(TARGET) == NOOPT
+  # GCC: -O0 results in too big size. Override it to -O1 with lto
+  *_GCC49_*_CC_FLAGS = -O1
+  *_GCC49_*_DLINK_FLAGS = -O1
+  *_GCC5_*_CC_FLAGS = -flto -O1
+  *_GCC5_*_DLINK_FLAGS = -flto -O1
+  # VS: Use default /Od for now
+!endif

--- a/BootloaderCorePkg/Stage2/Stage2Support.c
+++ b/BootloaderCorePkg/Stage2/Stage2Support.c
@@ -293,6 +293,10 @@ SplitMemroyMap (
           // Payload reserved memory
           Adjust = PcdGet32 (PcdPayloadReservedMemSize);
           Flag   = MEM_MAP_FLAG_PAYLOAD;
+          break;
+        default:
+          Adjust = 0;
+          break;
         }
         if (Adjust == 0) {
           continue;

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -237,6 +237,7 @@ class BaseBoard(object):
 		self.CFGDATA_REGION_TYPE   = FLASH_REGION_TYPE.BIOS
 
 		self.RELEASE_MODE          = 0
+		self.NO_OPT_MODE           = 0
 		self.FSPDEBUG_MODE         = 0
 		self.MIN_FSP_REVISION      = 0
 		self.FSP_IMAGE_ID          = ''
@@ -263,7 +264,7 @@ class Build(object):
 		self._workspace                    = os.environ['WORKSPACE']
 		self._board                        = board
 		self._image                        = "SlimBootloader.bin"
-		self._target                       = 'RELEASE' if board.RELEASE_MODE  else 'DEBUG'
+		self._target                       = 'RELEASE' if board.RELEASE_MODE  else 'NOOPT' if board.NO_OPT_MODE else 'DEBUG'
 		self._fsp_basename                 = 'FspDbg'  if board.FSPDEBUG_MODE else 'FspRel'
 		self._fv_dir                       = os.path.join(self._workspace, 'Build', 'BootloaderCorePkg', '%s_%s' % (self._target, self._toolchain), 'FV')
 		self._key_dir                      = os.path.join('BootloaderCorePkg', 'Tools', 'Keys')
@@ -1214,6 +1215,7 @@ def main():
 				brdcfg = imp.load_source('BoardConfig', board_cfgs[index])
 				board  = brdcfg.Board(
 										RELEASE_MODE      = args.release,     \
+										NO_OPT_MODE       = args.noopt,       \
 										FSPDEBUG_MODE     = args.fspdebug,    \
 										USE_VERSION       = args.usever,      \
 										_PAYLOAD_NAME     = args.payload,     \
@@ -1228,6 +1230,7 @@ def main():
 	buildp.add_argument('-v',  '--usever',  action='store_true', help='Use board version file')
 	buildp.add_argument('-fp', dest='fsppath', type=str, help='FSP binary path relative to FspBin in Silicon folder', default='')
 	buildp.add_argument('-fd', '--fspdebug', action='store_true', help='Use debug FSP binary')
+	buildp.add_argument('-no', '--noopt', action='store_true', help='No compile/link optimization for debugging purpose. Not enabled in Release build.')
 	buildp.add_argument('-p',  '--payload' , dest='payload', type=str, help='Payload file name', default ='OsLoader.efi')
 	buildp.add_argument('board', metavar='board', choices=board_names, help='Board Name (%s)' % ', '.join(board_names))
 	buildp.set_defaults(func=cmd_build)

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -110,12 +110,18 @@ class Board(BaseBoard):
 			# For Stage1B, it can be compressed if STAGE1B_XIP is 0
 			# If so, 	STAGE1B_FD_BASE/STAGE1B_FD_SIZE need to be defined
 			self.STAGE1B_FD_SIZE    = 0x30000
+			if self.NO_OPT_MODE:
+				self.STAGE1B_FD_SIZE += 0x2000
 			self.STAGE1B_FD_BASE    = FREE_TEMP_RAM_TOP - self.STAGE1B_FD_SIZE
 
 		# For Stage2, it is always compressed.
 		# if STAGE2_LOAD_HIGH is 1, STAGE2_FD_BASE will be ignored
 		self.STAGE2_FD_BASE       = 0x01000000
 		self.STAGE2_FD_SIZE       = 0x00060000
+
+		if self.NO_OPT_MODE:
+			self.OS_LOADER_FD_SIZE   += 0x00010000
+			self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
 		self.STAGE1_STACK_SIZE    = 0x00002000
 		self.STAGE1_DATA_SIZE     = 0x00006000


### PR DESCRIPTION
Compile optimization sometimes needs to be disabled for debugging.
EDKII BaseTools provide NOOPT target, so leverage it.
The default GCC '-O0' and VS '/Od' option results in huge size image,
so the optimization level is adjusted with approximately level.

Add a new build option '-no' or '--noopt' for NOOPT target
- Release build option '-r' will ignore '--noopt' option
ex) python BuildLoader.py build qemu --noopt