### PR TITLE
Fix cfgdata dword parsing issue

### DIFF
--- a/BootloaderCorePkg/Tools/GenCfgData.py
+++ b/BootloaderCorePkg/Tools/GenCfgData.py
@@ -449,7 +449,7 @@ EndList
             raise Exception("Array size is not proper for '%s' !" % ConfigDict['cname'])
 
         ByteArray = []
-        for Value in ByteArray:
+        for Value in DataList:
             for Loop in range(Unit):
                 ByteArray.append("0x%02X" % (Value & 0xFF))
                 Value = Value >> 8


### PR DESCRIPTION
This patch to fix the GenCfgData tool that wrongly parsing the dword data from an array.
For exmaple: 
CfgData1 |  *| 0x8 {0x5fff, 0x7fff, ...}, but generate result for CfgData1[0] = 0 and so on.

