### PR TITLE
Add normal region parsing support for IfwiUtility

### DIFF
--- a/BootloaderCorePkg/Tools/IfwiUtility.py
+++ b/BootloaderCorePkg/Tools/IfwiUtility.py
@@ -240,6 +240,7 @@ class FLASH_MAP(Structure):
     }
 
     FLASH_MAP_REGION = {
+        0x00:  "RGN",
         0x01:  "TS0",
         0x41:  "TS1",
         0x02:  "RD0",


### PR DESCRIPTION
Current IfwiUtility does not support the old non-redundant image
layout format. This patch added support for non-redundant image by
defining a new FLASH_MAP_REGION key.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>