### PR TITLE
Add support for variable cell width in ConfigEditor

### DIFF
--- a/BootloaderCorePkg/Tools/ConfigEditor.py
+++ b/BootloaderCorePkg/Tools/ConfigEditor.py
@@ -624,7 +624,8 @@ class Application(Frame):
             if NewData[Start:End] != self.OrgCfgDataBin[Start:End] or (
                     Full and Item['name'] and (Item['cname'] != 'Dummy')):
                 if not Item['subreg']:
-                    Text = '%-40s | %s' % (FullName, Item['value'])
+                    ValStr = self.CfgDataObj.FormatDeltaValue (Item)
+                    Text = '%-40s | %s' % (FullName, ValStr)
                     if 'PLATFORMID_CFG_DATA.PlatformId' == FullName:
                         PlatformId = Array2Val(Item['value'])
                     else:
@@ -644,7 +645,8 @@ class Application(Frame):
                                 Offset = len(Item['cname']) + 1
                                 FieldName = '%s.%s' % (
                                     FullName, SubItem['cname'][Offset:])
-                            Text = '%-40s | %s' % (FieldName, SubItem['value'])
+                            ValStr = self.CfgDataObj.FormatDeltaValue (SubItem)
+                            Text = '%-40s | %s' % (FieldName, ValStr)
                             Lines.append(Text)
 
             if Item['embed'].endswith(':END'):

--- a/BootloaderCorePkg/Tools/GenCfgData.py
+++ b/BootloaderCorePkg/Tools/GenCfgData.py
@@ -446,7 +446,10 @@ EndList
         DataList = self.ValueToList(ConfigDict['value'], ConfigDict['length'])
         Unit = int(Struct[4:]) // 8
         if int(ConfigDict['length']) != Unit * len(DataList):
-            raise Exception("Array size is not proper for '%s' !" % ConfigDict['cname'])
+            # Fallback to byte array
+            Unit = 1
+            if int(ConfigDict['length']) != len(DataList):
+                raise Exception("Array size is not proper for '%s' !" % ConfigDict['cname'])
 
         ByteArray = []
         for Value in DataList:

--- a/Platform/QemuBoardPkg/CfgData/CfgDataDef.dsc
+++ b/Platform/QemuBoardPkg/CfgData/CfgDataDef.dsc
@@ -141,10 +141,25 @@
   # !BSF HELP:{Silicon Test 1}
   gCfgData.SiliconTest1           |      * | 0x04 | 0x11223347
 
-  # !BSF NAME:{Silicon Test 9}
-  # !BSF TYPE:{EditNum, HEX, (0x00000000,0xFFFFFFFF)}
-  # !BSF HELP:{Silicon Test 9}
-  gCfgData.SiliconTest2           |      * | 0x04 | 0x11223348
+  # !BSF NAME:{Silicon Test 2}
+  # !BSF TYPE:{Table}
+  # !BSF OPTION:{ 0:1:HEX, 1:1:HEX, 2:1:HEX, 3:1:HEX}
+  # !BSF HELP:{Silicon Test 2 to show BYTE table configuration}
+  gCfgData.SiliconTest2           |      * | 0x04 | 0x04030201
+
+  # !BSF NAME:{Silicon Test 3}
+  # !BSF TYPE:{Table}
+  # !BSF OPTION:{ 0:2:HEX, 1:2:HEX}
+  # !BSF HELP:{Silicon Test 3 to show UINT16 table configuration}
+  # !HDR STRUCT:{UINT16}
+  gCfgData.SiliconTest3           |      * | 0x08 | {0x1111, 0x2222, 0x3333, 0x4444}
+
+  # !BSF NAME:{Silicon Test 4}
+  # !BSF TYPE:{Table}
+  # !BSF OPTION:{ 0:4:HEX, 1:4:HEX}
+  # !BSF HELP:{Silicon Test 4 to show UINT32 table configuration}
+  # !HDR STRUCT:{UINT32}
+  gCfgData.SiliconTest4           |      * | 0x08 | {0x11112222, 0x33334444}
   # !HDR EMBED:{SILICON_CFG_DATA:TAG_200:END}
 
   # ---------------------------------------------------------------------------------------


### PR DESCRIPTION
Current ConfigEditor only supports UINT8 format cell in table.
This patch added support for variable cell width including UINT8,
UINT16, UINT32 in table widget. Test configuration items were
also added in QEMU to test these format.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>