### PR TITLE
[CFL] Enable UPX SIO debug UART for COM1 and COM2

### DIFF
--- a/Platform/CoffeelakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.inf
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.inf
@@ -32,6 +32,7 @@
   BootloaderCommonPkg/BootloaderCommonPkg.dec
   Silicon/CoffeelakePkg/CoffeelakePkg.dec
   Platform/CoffeelakeBoardPkg/CoffeelakeBoardPkg.dec
+  Platform/CommonBoardPkg/CommonBoardPkg.dec
 
 [LibraryClasses]
   BaseLib

--- a/Silicon/CoffeelakePkg/Include/Register/PchRegsLpc.h
+++ b/Silicon/CoffeelakePkg/Include/Register/PchRegsLpc.h
@@ -24,13 +24,14 @@
 #define PCH_PCR_BASE_ADDRESS                      0xFD000000
 #define PCH_PCR_ADDRESS(Pid, Offset)              (PCH_PCR_BASE_ADDRESS | ((UINT8)(Pid) << 16) | (UINT16)(Offset))
 
+#define B_LPC_CFG_IOE_SIO                         BIT12
 #define B_LPC_CFG_IOE_ME1                         BIT11
 #define B_LPC_CFG_IOE_CBE                         BIT1
 #define B_LPC_CFG_IOE_CAE                         BIT0
 
 #define R_PCH_LPC_IOD                             0x80
 #define N_PCH_LPC_IOD_COMB                        4
-#define V_PCH_LPC_IOD_COMB_3E8                    7
+#define V_PCH_LPC_IOD_COMB_2F8                    1
 #define N_PCH_LPC_IOD_COMA                        0
 #define V_PCH_LPC_IOD_COMA_3F8                    0
 

--- a/Silicon/CoffeelakePkg/Library/PlatformHookLib/PlatformHookLib.c
+++ b/Silicon/CoffeelakePkg/Library/PlatformHookLib/PlatformHookLib.c
@@ -51,7 +51,7 @@ LegacySerialPortInitialize (
     0);
 
   Data16 = PciRead16 (LpcBaseAddr + R_PCH_LPC_IOD);
-  Data16 |= (V_PCH_LPC_IOD_COMB_3E8 << N_PCH_LPC_IOD_COMB);
+  Data16 |= (V_PCH_LPC_IOD_COMB_2F8 << N_PCH_LPC_IOD_COMB);
   Data16 |= (V_PCH_LPC_IOD_COMA_3F8 << N_PCH_LPC_IOD_COMA);
   MmioWrite16 (PCH_PCR_ADDRESS (PID_DMI, R_PCH_PCR_DMI_LPCIOD), Data16);
   PciWrite16 (LpcBaseAddr + R_PCH_LPC_IOD, Data16);

--- a/Silicon/CoffeelakePkg/Library/SerialPortLib/SerialPortLib.c
+++ b/Silicon/CoffeelakePkg/Library/SerialPortLib/SerialPortLib.c
@@ -96,7 +96,11 @@ GetPciUartBase (
 
   DebugPort = GetDebugPort ();
   if (DebugPort >=  PCH_MAX_SERIALIO_UART_CONTROLLERS) {
-    return 0x3F8;
+    if (DebugPort == 0xFE) {
+      return 0x2F8;
+    } else {
+      return 0x3F8;
+    }
   }
 
   PciAddress = gUartMmPciOffset[DebugPort] + (UINTN)PcdGet64(PcdPciExpressBaseAddress);


### PR DESCRIPTION
On UP Xtreme board current code only supports PCH UART debug port.
But this board has two extra UART ports behind SIO chip F81801.
This patch added required initialization for the SIO chip to enable
UART on SIO. It can be enabled through platform data during stitching.
For exmaple,
  "-p 0xAA000210" parameter in stitching will select PCH UART2.
  "-p 0xAA00FF10" parameter will select SIO COM1 as debug device.
  "-p 0xAA00FE10" parameter will select SIO COM2 as debug device.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>