### PR TITLE
Update FPDT length

### DIFF
--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiFpdt.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiFpdt.c
@@ -219,7 +219,7 @@ UpdateFpdt (
     UpdateFpdtBootTable (BootPerfTable);
 
     // Fixup FPDT table length
-    Fpdt->Header.Length = sizeof (FIRMWARE_PERFORMANCE_TABLE);
+    Fpdt->Header.Length = sizeof (INTERNAL_FIRMWARE_PERFORMANCE_TABLE);
   }
 
   return  EFI_SUCCESS;


### PR DESCRIPTION
If FPDT->Length is just the size of FIRMWARE_PERFORMANCE_TABLE,
BOOT_PERFORMANCE_TABLE and S3_PERFORMANCE_TABLE are overwritten
by the next Table in ACPI init. Therefore, make the size in the
header as sizeof(INTERNAL_FIRMWARE_PERFORMANCE_TABLE) so that
the next table starts after INTERNAL_FIRMWARE_PERFORMANCE_TABLE.
Otherwise, S3 Perf Table can't be located on S3 resume path.

Signed-off-by: Sai Talamudupula <sai.kiran.talamudupula@intel.com>