### PR TITLE
Add image type param for GenContainer.py

### DIFF
--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -205,13 +205,15 @@ ParseContainerImage (
           } else {
             File[Index].Addr = (UINT8 *)LzHdr + sizeof(LOADER_COMPRESSED_HEADER);
             File[Index].Size = LzHdr->Size;
-            Index++;
           }
         }
       } else {
         // Use Load to decompress to a new buffer
         Status = LoadComponent (ContainerHdr->Signature, (UINT32) ComponentName, (VOID **)&File[Index].Addr, &File[Index].Size);
       }
+    }
+    if (Status == EFI_SUCCESS) {
+      Index++;
     }
   }
 


### PR DESCRIPTION
Container type can be input from command line
from a list of [NORMAL, CLASSIC, MULTIBOOT] while
generating a container using GenContainer.py.
Setting default as NORMAL.

Signed-off-by: Sai Talamudupula <sai.kiran.talamudupula@intel.com>