### PR TITLE
[WHL] Remove _L6F GPE handler in ASL code

### DIFF
--- a/Platform/CoffeelakeBoardPkg/AcpiTables/Dsdt/Gpe.asl
+++ b/Platform/CoffeelakeBoardPkg/AcpiTables/Dsdt/Gpe.asl
@@ -741,19 +741,25 @@
     Notify(\_SB.PCI0.RP21, 0x02)   // device wake, Slot 1 is using Pcie Root Port #21 to #24
   }
   Name(PRES, 1) // keep last PCH PwrBtn status, 0=press, 1=release
-  Method(_L6F) // 2-tier GPE event handler
-  {
-    //
-    // handle events from RTD3 support
-    //
-    If(LEqual(RTD3,1)) // if RTD3 enabled
-    {
-      If (CondRefOf(\_GPE.AL6F))
-      {
-        \_GPE.AL6F()        // call handler from RTD3 table
-      }
-    }
-  }
+
+  //
+  // Handle 2-tier GPE event
+  // Since RTD3 table is not added yet, comment it out for _L6F block to avoid SCI interrupt storm.
+  // When RTD3 is implemented, the below ASL code can be uncommented to handle the event.
+  //
+  // Method(_L6F) // 2-tier GPE event handler
+  // {
+  //   //
+  //   // handle events from RTD3 support
+  //   //
+  //   If(LEqual(RTD3,1)) // if RTD3 enabled
+  //   {
+  //     If (CondRefOf(\_GPE.AL6F))
+  //     {
+  //       \_GPE.AL6F()        // call handler from RTD3 table
+  //     }
+  //   }
+  // }
 
   Method (_L26){
     If(LAnd(LNotEqual(WLGP, 0x00), LEqual(WLRP, 0x03))){


### PR DESCRIPTION
On WHL after booting to Windows, SCI interrupt storm was seen due
to GPE event 111 (2-tier GPE event). This event needs to be handled
when RTD3 table is implemented. However, current code has _L6F
ASL code without RTD3 table. This causes the SCI event to be enabled
in Windows. Since there is no real handler to clear the SCI event,
SCI interrupt storm will occur. This patch commented out the _L6F ASL
method.

Tested this on WHL. The CPU utilization drop down from original 10%
to close to 0% for system interrupts.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>