### PR TITLE
Enhance USB keyboard input experience

### DIFF
--- a/BootloaderCommonPkg/Library/UsbKbLib/UsbKbLibInternal.h
+++ b/BootloaderCommonPkg/Library/UsbKbLib/UsbKbLibInternal.h
@@ -24,6 +24,9 @@
 #define USB_KB_DEVICE_SIG      SIGNATURE_32 ('U', 'S', 'K', 'B')
 
 #define QUEUE_MAX_COUNT        32
+#define KEY_REPEAT_DELAY       10
+
+#define USBKBD_VALID_KEYCODE(Key) ((UINT8) (Key) > 3)
 
 typedef struct {
   UINTN                                      Front;
@@ -47,8 +50,10 @@ typedef struct {
   BOOLEAN                             CapsOn;
   BOOLEAN                             ScrollOn;
   SIMPLE_QUEUE                        Queue;
-  UINT8                               KeyRepeat;
-  CHAR8                               LastChar;
+  UINT32                              RepeatCounter;
+  UINT8                               RepeatKey;
+  CHAR8                               RepeatChar;
+  UINT8                               LastKeyCodeArray[8];
 } USB_KB_DEV;
 
 #endif


### PR DESCRIPTION
Current SBL USB keyboard driver cannot handle the key input nicely.
If typing is too fast, some chars will be missing. On the other side,
sometimes singe key press will generate multiple repeated chars.
This patch reimplemented the logic to detect key press/release using
similar flow as EDK2 UsbDxe driver. With this logic, USB keyboard
worked pretty well. It has been tested on APL platform.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>