### PR TITLE
Fix double debug message output on serial port

### DIFF
--- a/BootloaderCommonPkg/Library/BootloaderDebugLib/BootloaderDebugLib.inf
+++ b/BootloaderCommonPkg/Library/BootloaderDebugLib/BootloaderDebugLib.inf
@@ -43,3 +43,4 @@
   gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask              ## CONSUMES
   gEfiMdePkgTokenSpaceGuid.PcdFixedDebugPrintErrorLevel      ## CONSUMES
   gPlatformCommonLibTokenSpaceGuid.PcdDebugOutputDeviceMask  ## CONSUMES
+  gPlatformCommonLibTokenSpaceGuid.PcdConsoleOutDeviceMask   ## CONSUMES


### PR DESCRIPTION
SBL allows debug message to be redirected to output console besides
the serial port. However, serial port itself could be part of the
output console device as well. In this case the debug message will
be printed twice. This patch added check to this condition and skip
the redundant print.

It fixed #349.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>