### PR TITLE
Skip IAS image verification if VERIFIED_BOOT is disabled

### DIFF
--- a/BootloaderCommonPkg/Library/IasImageLib/IasImage.c
+++ b/BootloaderCommonPkg/Library/IasImageLib/IasImage.c
@@ -63,6 +63,10 @@ IsIasImageValid (
     return NULL;
   }
 
+  if (!FeaturePcdGet (PcdVerifiedBootEnabled)) {
+    DEBUG ((DEBUG_INFO, "IAS image verification is skipped!\n"));
+    return Hdr;
+  }
 
   if (!IAS_IMAGE_IS_SIGNED (Hdr->ImageType)) {
     DEBUG ((DEBUG_ERROR, "IAS image is not signed!\n"));

--- a/BootloaderCommonPkg/Library/IasImageLib/IasImageLib.inf
+++ b/BootloaderCommonPkg/Library/IasImageLib/IasImageLib.inf
@@ -39,3 +39,4 @@
 [Guids]
 
 [Pcd]
+  gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled


### PR DESCRIPTION
Current SBL code will assert if HAVE_VERIFIED_BOOT is 0. This patch
added check for PcdVerifiedBootEnabled to decide if IAS verification
is required.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>