### PR TITLE
Fix debug message output issue

### DIFF
--- a/BootloaderCommonPkg/Library/BootloaderDebugLib/DebugLib.c
+++ b/BootloaderCommonPkg/Library/BootloaderDebugLib/DebugLib.c
@@ -63,14 +63,14 @@ DebugPrint (
     return;
   }
 
-  Length = AsciiStrLen (Buffer);
-
   //
   // Convert the DEBUG() message to an ASCII String
   //
   VA_START (Marker, Format);
   AsciiVSPrint (Buffer, sizeof (Buffer), Format, Marker);
   VA_END (Marker);
+
+  Length = AsciiStrLen (Buffer);
 
   //
   // Send the print string to debug output handler


### PR DESCRIPTION
The latest code has debug message output issue. It is caused by
the following CommitId: 56867c3bc674097b5982fed19d3ee1b022112e39.
This patch provided proper fixes for this issue. The root cause
is due to incorrect string length.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>