### PR TITLE
Implement common API to get CPU TSC frequency

### DIFF
--- a/BootloaderCommonPkg/Include/Library/TimeStampLib.h
+++ b/BootloaderCommonPkg/Include/Library/TimeStampLib.h
@@ -20,4 +20,16 @@ ReadTimeStamp (
   VOID
   );
 
+/**
+  Get timestamp frequency in KHZ.
+
+  @return   Timestamp frequency in KHZ.
+
+**/
+UINT32
+EFIAPI
+GetTimeStampFrequency (
+  VOID
+  );
+
 #endif

--- a/BootloaderCommonPkg/Library/TimeStampLib/Ia32/TimeStampLib.c
+++ b/BootloaderCommonPkg/Library/TimeStampLib/Ia32/TimeStampLib.c
@@ -21,3 +21,26 @@ ReadTimeStamp (
 {
   return AsmReadTsc();
 }
+
+/**
+  Get timestamp frequency in KHZ.
+
+  @return   Timestamp frequency in KHZ.
+
+**/
+UINT32
+EFIAPI
+GetTimeStampFrequency (
+  VOID
+  )
+{
+  UINT8  Ratio;
+
+  Ratio = (UINT8)(AsmReadMsr64 (0xCE) >> 8);
+  if (Ratio == 0) {
+    // This might be QEMU case
+    Ratio = 8;
+  }
+  // Ratio * 100000
+  return (UINT32)(Ratio * 100000);
+}

--- a/BootloaderCorePkg/Include/Library/SocInitLib.h
+++ b/BootloaderCorePkg/Include/Library/SocInitLib.h
@@ -49,17 +49,6 @@ SocUpdateAcpiGnvs (
   );
 
 /**
-  Get cpu tsc frequency.
-
-  @retval   cpu TSC frequency
-**/
-UINT32
-EFIAPI
-GetCpuTscFreqency (
-  VOID
-  );
-
-/**
   Update reset reason.
 **/
 VOID

--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -315,7 +315,7 @@ SecStartup (
   LdrGlobal->MemPoolCurrBottom     = LdrGlobal->MemPoolStart;
   LdrGlobal->DebugPrintErrorLevel  = PcdGet32 (PcdDebugPrintErrorLevel);
   LdrGlobal->PerfData.PerfIndex    = 2;
-  LdrGlobal->PerfData.FreqKhz      = GetCpuTscFreqency ();
+  LdrGlobal->PerfData.FreqKhz      = GetTimeStampFrequency ();
   LdrGlobal->PerfData.TimeStamp[0] = Stage1aAsmHob->TimeStamp | 0x1000000000000000ULL;
   LdrGlobal->PerfData.TimeStamp[1] = TimeStamp  | 0x1010000000000000ULL;
   // Set the Loader features to default here.

--- a/Silicon/ApollolakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
+++ b/Silicon/ApollolakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
@@ -34,17 +34,3 @@ EnableCodeExecution (
 {
   AsmWriteMsr32 (0x120, 0x100);
 }
-
-/**
-  Get cpu tsc frequency.
-
-  @retval   cpu TSC frequency
-**/
-UINT32
-EFIAPI
-GetCpuTscFreqency (
-  VOID
-  )
-{
-  return ((AsmReadMsr64(0xCE) >> 8) & 0xFF) * 100000;
-}

--- a/Silicon/CoffeelakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
+++ b/Silicon/CoffeelakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
@@ -30,13 +30,3 @@ DisableWatchDogTimer (
   ///
   IoWrite16 (TCO_BASE_ADDRESS + R_TCO_IO_TCO1_CNT, B_TCO_IO_TCO1_CNT_TMR_HLT);
 }
-
-
-UINT32
-EFIAPI
-GetCpuTscFreqency (
-  VOID
-)
-{
-  return ((AsmReadMsr64(0xCE) >> 8) & 0xFF) * 100000;
-}

--- a/Silicon/QemuSocPkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
+++ b/Silicon/QemuSocPkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
@@ -27,18 +27,3 @@ EnableCodeExecution (
 )
 {
 }
-
-
-/**
-  Get cpu tsc frequency.
-
-  @retval   cpu TSC frequency
-**/
-UINT32
-EFIAPI
-GetCpuTscFreqency (
-  VOID
-)
-{
-  return 8 * 100000;
-}


### PR DESCRIPTION
 This patch implemented the common API to get CPU frequency and 
 used the common API GetTimeStampFrequency() to get CPU
 TSC frequency instead of the original GetCpuTscFreqency(). As part
 of it, all SOC specific instances for GetCpuTscFreqency() were
 removed.
