### PR TITLE
[CFL] Drop undefined and unused shell command

### DIFF
--- a/Platform/CoffeelakeBoardPkg/Library/ShellExtensionLib/ShellExtension.c
+++ b/Platform/CoffeelakeBoardPkg/Library/ShellExtensionLib/ShellExtension.c
@@ -9,7 +9,6 @@
 #include <Library/ShellLib.h>
 
 extern CONST SHELL_COMMAND mShellCommandFwUpdate;
-extern CONST SHELL_COMMAND mShellCommandCse;
 
 CONST SHELL_COMMAND *mShellExtensionCommands[] = {
   &mShellCommandFwUpdate,


### PR DESCRIPTION
{CoffeelakeBoardPkg}ShellExtension.c: Drop undefined and unused shell command

mShellCommandCse is not defined in CoffeelakeBoardPkg so can't extern.  
It is not either used in current context.

