### PR TITLE
Display multiline help string in ConfigEditor

### DIFF
--- a/BootloaderCorePkg/Tools/ConfigEditor.py
+++ b/BootloaderCorePkg/Tools/ConfigEditor.py
@@ -54,7 +54,7 @@ class CreateToolTip(object):
         # Leaves only the label and removes the app window
         self.TopWin.wm_overrideredirect(True)
         self.TopWin.wm_geometry("+%d+%d" % (x, y))
-        label = Label(self.TopWin,
+        label = Message(self.TopWin,
                       text=self.Text,
                       justify='left',
                       background='bisque',


### PR DESCRIPTION
Current SBL display long help string in single line in ConfigEditor.
If the line is too long, only part of the line is visible on screen.
By change widget from Label to Message, it allows multiple lines
help string display.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>