### PR TITLE
Clean up EXT library

### DIFF
--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.h
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.h
@@ -340,70 +340,15 @@ typedef struct {
 } FILE;
 
 
-/**
-  EXT2FS metadatas are stored in little-endian byte order. These macros
-  helps reading theses metadatas
-**/
+//
+// EXT2FS meta data is stored in little-endian byte order. These macros
+// help with reading the meta data.
+//
 
-#if BYTE_ORDER == LITTLE_ENDIAN
-#define H2FS16(x) (x)
-#define H2FS32(x) (x)
-#define H2FS64(x) (x)
-#define FS2H16(x) (x)
-#define FS2H32(x) (x)
-#define FS2H64(x) (x)
 #define E2FS_SBLOAD(old, new) CopyMem((new), (old), SBSIZE);
 #define E2FS_CGLOAD(old, new, size) CopyMem((new), (old), (size));
 #define E2FS_SBSAVE(old, new) CopyMem((new), (old), SBSIZE);
 #define E2FS_CGSAVE(old, new, size) CopyMem((new), (old), (size));
-#else
-/**
-  Byte swap functions for big endian machines.
-  (Ext2Fs is always little endian)
-
-  XXX: We should use src/sys/ufs/Ext2Fs/ext2fs_bswap.c
-
- These functions are only needed if native byte order is not big endian
-
- @param Old pointer to old filesystem field
- @param New pointer to new filesystem field
-**/
-VOID
-E2fsSBByteSwap (
-  EXT2FS *Old,
-  EXT2FS *New
-  );
-
-/**
-  Byte swap functions for big endian machines.
-  (Ext2Fs is always little endian)
-
-  XXX: We should use src/sys/ufs/Ext2Fs/ext2fs_bswap.c
-
- These functions are only needed if native byte order is not big endian
-
- @param Old     pointer to old filesystem field
- @param New     pointer to new filesystem field
- @param Size    Size to swap
-**/
-VOID
-E2fsCGByteSwap (
-  EXT2GD *Old,
-  EXT2GD *New,
-  INT32 Size
-  );
-
-#define H2FS16(x) bswap16(x)
-#define H2FS32(x) bswap32(x)
-#define H2FS64(x) bswap64(x)
-#define FS2H16(x) bswap16(x)
-#define FS2H32(x) bswap32(x)
-#define FS2H64(x) bswap64(x)
-#define E2FS_SBLOAD(old, new) E2fsSBByteSwap((old), (new))
-#define E2FS_CGLOAD(old, new, size) E2fsCGByteSwap((old), (new), (size));
-#define E2FS_SBSAVE(old, new) E2fsSBByteSwap((old), (new))
-#define E2FS_CGSAVE(old, new, size) E2fsCGByteSwap((old), (new), (size));
-#endif
 
 /**
   Turn file system block numbers into disk block addresses.
@@ -557,20 +502,6 @@ Ext2fsStat (
   STAT          *StatBlock
   );
 
-#if defined(LIBSA_ENABLE_LS_OP)
-/**
-  Update the mode and size from descriptor to stat Block.
-  contains that block.
-  @param File       pointer to an file private data
-  @param Pattern    pointer to Pattern
-**/
-VOID
-Ext2fsLs (
-  OPEN_FILE *File,
-  const CHAR8 *Pattern
-  );
-#endif
-
 /**
 
   Determine the disk block(s) that contains data for FILE <File>,
@@ -669,6 +600,16 @@ Ext2fsFileSize (
 **/
 VOID
 DumpSBlock (
+  M_EXT2FS  *FileSystem
+  );
+
+/**
+  Dump the file system group descriptor block info.
+
+  @param FileSystem     pointer to filesystem.
+**/
+VOID
+DumpGroupDesBlock (
   M_EXT2FS  *FileSystem
   );
 #endif

--- a/BootloaderCommonPkg/Library/Ext23Lib/LibsaFsStand.h
+++ b/BootloaderCommonPkg/Library/Ext23Lib/LibsaFsStand.h
@@ -95,15 +95,11 @@ typedef struct {
   DEVSW       *DevPtr;                        // pointer to device operations
 #endif
   VOID        *FileDevData;                   // device specific data
-#if !defined(LIBSA_SINGLE_FILESYSTEM)
-  const struct fs_ops *FileOperations;        // pointer to file system operations
-#endif
   VOID        *FileSystemSpecificData;        // file system specific data
 #if !defined(LIBSA_NO_RAW_ACCESS)
   OFFSET      FileOffset;                     // current file offset (F_RAW)
 #endif
 } OPEN_FILE;
-
 
 #if ! defined(LIBSA_SINGLE_DEVICE)
 
@@ -144,19 +140,6 @@ BDevStrategy (
   );
 
 #endif
-
-struct fs_ops {
-  INT32   (*open) (CHAR8 *, OPEN_FILE *);
-  INT32   (*close) (OPEN_FILE *);
-  INT32   (*read) (OPEN_FILE *, VOID *, UINT32, UINT32 *);
-  INT32   (*write) (OPEN_FILE *, VOID *, UINT32 size, UINT32 *);
-  OFFSET  (*seek) (OPEN_FILE *, OFFSET, INT32);
-  INT32   (*stat) (OPEN_FILE *, STAT *);
-  VOID    (*ls) (OPEN_FILE *, const CHAR8 *);
-  INT32   (*disk_blocks) (OPEN_FILE *, UINT32, UINT32, UINT32 *);
-  INT32   (*lookup_file) (OPEN_FILE *, STAT *, CHAR8 *, UINT32);
-};
-
 
 //
 // f_flags values


### PR DESCRIPTION
The EXT library has some unused code that
we can remove to help reduce the size and
to clean things up some more. Also add a
routine for dumping the group descriptor
table which can be helpful for debugging
issues.

Signed-off-by: James Gutbub <james.gutbub@intel.com>