### PR TITLE
[APL] Fix IFWI stitiching issue for SPI QUAD mode

### DIFF
--- a/Platform/ApollolakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/ApollolakeBoardPkg/Script/StitchIfwi.py
@@ -361,9 +361,9 @@ def gen_fit_xml (fit_dir, src, dst, btg_profile, spi_quad):
 
     # Change SPI mode settings
     if spi_quad:
-        value = 'yes'
+        value = 'Yes'
     else:
-        value = 'no'
+        value = 'No'
     print("Set SPI QUAD mode: %s" % value)
     node = tree.find('./FlashSettings/FlashConfiguration/QuadIoReadEnable')
     node.attrib['value'] = value


### PR DESCRIPTION
StitchIfwi.py supports '-q' parameter to enable SPI QUAD mode.
However, it does not work as expected. When the script tries to
modify the XML file, it used 'yes' and 'no' as option values.
But it is case sensitive, and should use 'Yes' and 'No' instead.
This patch fixed this issue.

Test was done on LeafHill board and it enabled SPI QUAD mode
in IFWI after the fix. It fixed #370.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>