### PR TITLE
[WHL] Fix firmware update failure

### DIFF
--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -629,6 +629,10 @@ UpdatePayloadId (
   UINT32              PayloadId;
   UINT32              GpioLevel;
 
+  if (GetBootMode() == BOOT_ON_FLASH_UPDATE) {
+    return;
+  }
+
   PayloadId = 0;
   GenericCfgData = (GEN_CFG_DATA *)FindConfigDataByTag (CDATA_GEN_TAG);
   if (GenericCfgData != NULL) {


### PR DESCRIPTION
Current code set payload id depending on the gpio settings
and user selection from configuration data. When UEFI payload is
selected using GPIO or config data, payload id is being set to
UEFI irrespective of boot mode, which cause notification function
to get called, this locks the spi which inturn fails firmware update

Modified code to set payload id only in non-firmware update boot mode.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>