### PR TITLE
PatchCheck: Skip TAB check in .py files

### DIFF
--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -374,7 +374,8 @@ class GitDiffCheck:
         if self.force_crlf and eol != '\r\n':
             self.added_line_error('Line ending (%s) is not CRLF' % repr(eol),
                                   line)
-        if '\t' in line:
+        # TBD: Skip python file for now
+        if '\t' in line and not self.filename.endswith('.py'):
             self.added_line_error('Tab character used', line)
         if len(stripped) < len(line):
             self.added_line_error('Trailing whitespace found', line)


### PR DESCRIPTION
This patch will skip TAB check in all python files for now.
THis change will be reverted after cleanup all TABs.

Signed-off-by: Aiden Park <aiden.park@intel.com>