### PR TITLE
Fix AHCI memory de-allocation issue

### DIFF
--- a/BootloaderCommonPkg/Library/AhciLib/AhciBlkIo.c
+++ b/BootloaderCommonPkg/Library/AhciLib/AhciBlkIo.c
@@ -297,14 +297,14 @@ AhciDeinitialize (
       );
   }
 
-  if (AhciRegisters->AhciCommandTable != NULL) {
+  if (AhciRegisters->AhciCmdList != NULL) {
     FreePages (
       AhciRegisters->AhciCmdList,
       EFI_SIZE_TO_PAGES ((UINTN) AhciRegisters->MaxCommandListSize)
       );
   }
 
-  if (AhciRegisters->AhciCommandTable != NULL) {
+  if (AhciRegisters->AhciRFis != NULL) {
     FreePages (
       AhciRegisters->AhciRFis,
       EFI_SIZE_TO_PAGES ((UINTN) AhciRegisters->MaxReceiveFisSize)


### PR DESCRIPTION
This patch fixed the pointer check before de-allocating memory
previously allocated for AHCI controller.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>