### PR TITLE
Add device deinit support

### DIFF
--- a/BootloaderCommonPkg/Include/BlockDevice.h
+++ b/BootloaderCommonPkg/Include/BlockDevice.h
@@ -19,7 +19,8 @@ typedef struct {
 typedef enum {
   DevInitAll,
   DevInitOnlyPhase1,
-  DevInitOnlyPhase2
+  DevInitOnlyPhase2,
+  DevDeinit
 } DEVICE_INIT_PHASE;
 
 /**

--- a/BootloaderCommonPkg/Library/MemoryDeviceBlockIoLib/MemoryDeviceBlockIoLib.c
+++ b/BootloaderCommonPkg/Library/MemoryDeviceBlockIoLib/MemoryDeviceBlockIoLib.c
@@ -28,6 +28,11 @@ InitializeMemoryDevice (
   IN  DEVICE_INIT_PHASE   DevInitPhase
   )
 {
+  if (DevInitPhase == DevDeinit) {
+    // Handle Deinit if required.
+    return EFI_SUCCESS;
+  }
+
   return EFI_SUCCESS;
 }
 

--- a/BootloaderCommonPkg/Library/MmcAccessLib/MmcAccessLib.c
+++ b/BootloaderCommonPkg/Library/MmcAccessLib/MmcAccessLib.c
@@ -452,6 +452,10 @@ MmcInitialize (
   IN  DEVICE_INIT_PHASE   MmcInitMode
   )
 {
+  if (MmcInitMode == DevDeinit) {
+    // Handle Deinit if required.
+    return EFI_SUCCESS;
+  }
   return SdMmcInitialize (MmcHcPciBase, EmmcCardType, MmcInitMode);
 }
 
@@ -479,6 +483,9 @@ SdInitialize (
   IN  DEVICE_INIT_PHASE   SdInitMode
   )
 {
-
+  if (SdInitMode == DevDeinit) {
+    // Handle Deinit if required.
+    return EFI_SUCCESS;
+  }
   return SdMmcInitialize (SdHcPciBase, SdCardType, SdInitMode);
 }

--- a/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpress.c
+++ b/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpress.c
@@ -262,6 +262,18 @@ NvmeInitialize (
   NVME_CONTROLLER_PRIVATE_DATA        *Private;
   EFI_PHYSICAL_ADDRESS                PhysicalAddress;
 
+  if (NvmeInitMode == DevDeinit) {
+    Private = mNvmeCtrlPrivate;
+    if ((Private != NULL) && (Private->ControllerData != NULL)) {
+      FreePool (Private->ControllerData);
+    }
+    if (Private != NULL) {
+      FreePool (Private);
+    }
+    mNvmeCtrlPrivate = NULL;
+    return EFI_SUCCESS;
+  }
+
   DEBUG ((EFI_D_INFO, "NvmExpressDriverBindingStart: start\n"));
 
   Private          = NULL;

--- a/BootloaderCommonPkg/Library/SpiBlockIoLib/SpiBlockIoLib.c
+++ b/BootloaderCommonPkg/Library/SpiBlockIoLib/SpiBlockIoLib.c
@@ -32,6 +32,11 @@ InitializeSpi (
 {
   EFI_STATUS Status;
 
+  if (DevInitPhase == DevDeinit) {
+    // Handle Deinit if required.
+    return EFI_SUCCESS;
+  }
+
   mSpiService = (SPI_FLASH_SERVICE *) GetServiceBySignature (SPI_FLASH_SERVICE_SIGNATURE);
   if (mSpiService == NULL) {
     return EFI_UNSUPPORTED;

--- a/BootloaderCommonPkg/Library/UfsBlockIoLib/UfsBlockIoLib.c
+++ b/BootloaderCommonPkg/Library/UfsBlockIoLib/UfsBlockIoLib.c
@@ -1287,6 +1287,14 @@ InitializeUfs (
   UINT8                         Controller;
   UFS_HC_PEI_PRIVATE_DATA      *UfsPrivateHcData;
 
+  if (DevInitPhase == DevDeinit) {
+    if (gPrivate != NULL) {
+      FreePool (gPrivate);
+      gPrivate = NULL;
+    }
+    return EFI_SUCCESS;
+  }
+
   gPrivate = (UFS_PEIM_HC_PRIVATE_DATA *)AllocatePool (sizeof (UFS_PEIM_HC_PRIVATE_DATA));
   if (gPrivate == NULL) {
     DEBUG ((EFI_D_ERROR, "Failed to allocate memory for UFS_PEIM_HC_PRIVATE_DATA! \n"));

--- a/BootloaderCommonPkg/Library/UsbBlockIoLib/UsbBlockIoLib.c
+++ b/BootloaderCommonPkg/Library/UsbBlockIoLib/UsbBlockIoLib.c
@@ -72,6 +72,12 @@ InitializeUsb (
   UINT32            UsbIoCount;
   PEI_USB_IO_PPI  **UsbIoArray;
 
+  if (DevInitPhase == DevDeinit) {
+    DeinitUsbDevices ();
+    mUsbBlkCount = 0;
+    return EFI_SUCCESS;
+  }
+
   mUsbBlkCount = 0;
   Status = InitUsbDevices (UsbHcPciBase);
   if (!EFI_ERROR(Status)) {

--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -519,6 +519,23 @@ PrintStackHeapInfo (
   }
 }
 
+/**
+  The function will de-initialize boot device.
+
+**/
+VOID
+DeinitBootDevices (
+  VOID
+  )
+{
+  // Deinit boot media
+  MediaInitialize (0, DevDeinit);
+
+  if ((PcdGet32 (PcdConsoleInDeviceMask) & ConsoleInUsbKeyboard) != 0) {
+    // Deinit USB devices if USB keyboard console is active
+    DeinitUsbDevices ();
+  }
+}
 
 /**
   This function will send FSP notification, indicate ReadyToBoot event to TPM and print
@@ -552,8 +569,8 @@ BeforeOSJump (
   }
   AddMeasurePoint (0x4100);
 
-  // De-init USB before OS boot.
-  DeinitUsbDevices ();
+  // De-init boot devices before OS boot.
+  DeinitBootDevices ();
 
   // Print performance data
   PrintLinuxMeasurePoint ();
@@ -899,8 +916,8 @@ PayloadMain (
       break;
     }
 
-    // De-init USB to prevent issues while restarting payload.
-    DeinitUsbDevices ();
+    // De-init boot devices while restarting payload.
+    DeinitBootDevices ();
 
     //
     // Use switch stack to ensure stack will be rolled back to original point.


### PR DESCRIPTION
This patch added basic deinit support in the media DevInit() interface.
It uses a special DevDeinit phase to inform the media driver to do
device de-initialization. This de-initialization flow will be called
before OsLoader restarting and OS booting.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>