### PR TITLE
Adjust USB KB polling rate

### DIFF
--- a/BootloaderCommonPkg/Library/UsbKbLib/UsbKbLibInternal.h
+++ b/BootloaderCommonPkg/Library/UsbKbLib/UsbKbLibInternal.h
@@ -54,6 +54,8 @@ typedef struct {
   UINT8                               RepeatKey;
   CHAR8                               RepeatChar;
   UINT8                               LastKeyCodeArray[8];
+  UINT32                              TimeStampFreqKhz;
+  UINT64                              LastTransferTimeStamp;
 } USB_KB_DEV;
 
 #endif


### PR DESCRIPTION
When USB keybaord input console is enabled, current code will keep
sending interrupt transfers to poll the USB keyboard state. However,
according to USB spec, it needs to be polled at certain interval
returned by the device. If the polling rate is too high, sometime,
host will fail to schedule the SPLIT transfer. This patch adjusted
the polling rate to the required interval.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>