### PR TITLE
Allow platform to degrade eMMC from HS400 to HS200

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -200,8 +200,9 @@
 
 
 [PcdsFeatureFlag]
-  gPlatformCommonLibTokenSpaceGuid.PcdMinDecompression       | FALSE      | BOOLEAN | 0x20000201
-  gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled    | FALSE      | BOOLEAN | 0x20000210
-  gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootEnabled    | FALSE      | BOOLEAN | 0x20000211
-  gPlatformCommonLibTokenSpaceGuid.PcdSourceDebugEnabled     | FALSE      | BOOLEAN | 0x20000212
-  gPlatformCommonLibTokenSpaceGuid.PcdContainerBootEnabled   | FALSE      | BOOLEAN | 0x20000213
+  gPlatformCommonLibTokenSpaceGuid.PcdMinDecompression        | FALSE      | BOOLEAN | 0x20000201
+  gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled     | FALSE      | BOOLEAN | 0x20000210
+  gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootEnabled     | FALSE      | BOOLEAN | 0x20000211
+  gPlatformCommonLibTokenSpaceGuid.PcdSourceDebugEnabled      | FALSE      | BOOLEAN | 0x20000212
+  gPlatformCommonLibTokenSpaceGuid.PcdContainerBootEnabled    | FALSE      | BOOLEAN | 0x20000213
+  gPlatformCommonLibTokenSpaceGuid.PcdEmmcHs400SupportEnabled | TRUE       | BOOLEAN | 0x20000214

--- a/BootloaderCommonPkg/Library/MmcAccessLib/MmcAccessLib.inf
+++ b/BootloaderCommonPkg/Library/MmcAccessLib/MmcAccessLib.inf
@@ -38,3 +38,4 @@
 [Pcd]
   gPlatformCommonLibTokenSpaceGuid.PcdEmmcBlockDeviceLibId
   gPlatformCommonLibTokenSpaceGuid.PcdEmmcMaxRwBlockNumber
+  gPlatformCommonLibTokenSpaceGuid.PcdEmmcHs400SupportEnabled

--- a/BootloaderCommonPkg/Library/MmcAccessLib/MmcAccessLibGeneric.c
+++ b/BootloaderCommonPkg/Library/MmcAccessLib/MmcAccessLibGeneric.c
@@ -1112,8 +1112,15 @@ MmcSetBusMode (
     // The host controller supports 8bits bus.
     //
     ASSERT (BusWidth == 8);
-    HsTiming  = 3;
-    IsDdr     = TRUE;
+    if (FeaturePcdGet (PcdEmmcHs400SupportEnabled)) {
+      HsTiming  = 3;
+      IsDdr     = TRUE;
+    } else {
+      // Fallback to HS200 if HS400 needs to be disabled
+      HsTiming  = 2;
+      IsDdr     = FALSE;
+      DEBUG ((DEBUG_INFO, "Degrade HS400 to HS200 per request\n"));
+    }
     ClockFreq = 200;
   }
 

--- a/BootloaderCommonPkg/Library/MmcTuningLib/MmcTuningLib.inf
+++ b/BootloaderCommonPkg/Library/MmcTuningLib/MmcTuningLib.inf
@@ -40,3 +40,5 @@
 [Pcd]
   gPlatformCommonLibTokenSpaceGuid.PcdMmcTuningLibId
   gPlatformCommonLibTokenSpaceGuid.PcdMmcTuningLba
+  gPlatformCommonLibTokenSpaceGuid.PcdEmmcHs400SupportEnabled
+

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -298,6 +298,7 @@
   gPlatformModuleTokenSpaceGuid.PcdLinuxPayloadEnabled    | $(ENABLE_LINUX_PAYLOAD)
   gPlatformCommonLibTokenSpaceGuid.PcdContainerBootEnabled| $(ENABLE_CONTAINER_BOOT)
   gPayloadTokenSpaceGuid.PcdCsmeUpdateEnabled             | $(ENABLE_CSME_UPDATE)
+  gPlatformCommonLibTokenSpaceGuid.PcdEmmcHs400SupportEnabled | $(ENABLE_EMMC_HS400)
 
 !ifdef $(S3_DEBUG)
   gPlatformModuleTokenSpaceGuid.PcdS3DebugEnabled         | $(S3_DEBUG)

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -192,6 +192,7 @@ class BaseBoard(object):
 		self.ENABLE_LINUX_PAYLOAD  = 0
 		self.ENABLE_CONTAINER_BOOT = 1
 		self.ENABLE_CSME_UPDATE    = 0
+		self.ENABLE_EMMC_HS400     = 1
 
 		self.BUILD_CSME_UPDATE_DRIVER    = 0
 


### PR DESCRIPTION
This patch allows platform to degrade eMMC HS400 to HS200 using
static configuration. To do this, please add the following into
BoardConfig.py:
  self.ENABLE_EMMC_HS400 = 0
This is useful when platform has hardware issue to run at eMMC
HS400 mode.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>