### PR TITLE
[WHL] Fix power button overrride smi storm issue

### DIFF
--- a/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -501,6 +501,13 @@ GetPlatformPowerState (
   PmconA = MmioRead32 (PCH_PWRM_BASE_ADDRESS + R_PMC_PWRM_GEN_PMCON_A);
 
   //
+  // Clear PWRBTNOR_STS
+  //
+  if (IoRead16 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_STS) & B_ACPI_IO_PM1_STS_PRBTNOR) {
+    IoWrite16 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_STS, B_ACPI_IO_PM1_STS_PRBTNOR);
+  }
+
+  //
   // If Global Reset Status, Power Failure. Host Reset Status bits are set, return S5 State
   //
   if ((PmconA & (B_PMC_PWRM_GEN_PMCON_A_GBL_RST_STS | B_PMC_PWRM_GEN_PMCON_A_PWR_FLR | B_PMC_PWRM_GEN_PMCON_A_HOST_RST_STS)) != 0) {

--- a/Silicon/CoffeelakePkg/Include/Register/PchRegsPmc.h
+++ b/Silicon/CoffeelakePkg/Include/Register/PchRegsPmc.h
@@ -19,6 +19,7 @@
 
 #define R_ACPI_IO_PM1_STS                        0x00
 #define B_ACPI_IO_PM1_STS_WAK                    BIT15
+#define B_ACPI_IO_PM1_STS_PRBTNOR                BIT11
 #define R_ACPI_IO_PM1_EN_MASK                    0xFFFF0000
 #define B_ACPI_IO_PM1_EN_PWRBTN_EN               BIT24
 


### PR DESCRIPTION
power button 4 second press will cause power button override
bit to set in PM1 status register, this bit is not cleared on
reset and is causing SMI storm during booting to OS.

Power button override bit if set is cleared now in stage1b and
this fixed the SMI storm issue.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>