### PR TITLE
[CFL] Change default payload sel based on GPIO

### DIFF
--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1038,7 +1038,7 @@ UpdatePayloadId (
     }
     Status = GpioGetInputValue (PayloadSelGpioPad, &PayloadSelGpioData);
     if (!EFI_ERROR (Status)) {
-      if (PayloadSelGpioData == 0) {
+      if (PayloadSelGpioData == 1) {
         PayloadId = 0;
       } else {
         if ((GenericCfgData != NULL) && (GenericCfgData->PayloadId == AUTO_PAYLOAD_ID_SIGNATURE)) {


### PR DESCRIPTION
This patch changes the default behavior of gpio pin for payload
selection, currently user configured GPIO pin being high boots
to uefi payload, modified code will boot to OS loader when GPIO pin
is high.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>