### PR TITLE
Remove boot option reset from boot cmd

### DIFF
--- a/BootloaderCommonPkg/Library/ShellLib/CmdBoot.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdBoot.c
@@ -1,7 +1,7 @@
 /** @file
   Shell command `boot` to print or modify the OS boot option list.
 
-  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -544,9 +544,6 @@ ShellCommandBootFunc (
 ExitBootCmd:
   if (EFI_ERROR (Status)) {
     ShellPrint (L"ERROR, exiting command unsuccessfully\n");
-  } else {
-    BootOptionList->BootOptionReset = 1;
-    BootOptionList->CurrentBoot     = 0;
   }
   return Status;
 }


### PR DESCRIPTION
The 'boot' command is resetting the current
boot option to be option zero any time the
command is invoked which conflicts with the
'c' command which allows a user to select the
next boot option that should be tried. Remove
the resetting to resolve the issue when doing
'c' sub-command in the 'boot' command.

Signed-off-by: James Gutbub <james.gutbub@intel.com>