### PR TITLE
[OsLoader] OsLoader lifecycle change

### DIFF
--- a/BootloaderCommonPkg/Include/Guid/OsBootOptionGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/OsBootOptionGuid.h
@@ -24,13 +24,16 @@
 // This bit is used dynamically.
 #define LOAD_IMAGE_FROM_BACKUP     BIT7
 
-#define LOAD_IMAGE_NORMAL          0
-#define LOAD_IMAGE_TRUSTY          1
-#define LOAD_IMAGE_MISC            2
-#define LOAD_IMAGE_EXTRA0          3
-#define LOAD_IMAGE_EXTRA1          4
-#define LOAD_IMAGE_EXTRA2          5
-#define LOAD_IMAGE_EXTRA3          6
+typedef enum {
+  LoadImageTypeNormal              = 0x0,
+  LoadImageTypeTrusty,
+  LoadImageTypeMisc,
+  LoadImageTypeExtra0,
+  LoadImageTypeExtra1,
+  LoadImageTypeExtra2,
+  LoadImageTypeExtra3,
+  LoadImageTypeMax
+} LOAD_IMAGE_TYPE;
 
 ///
 /// OS Boot Option GUID
@@ -155,7 +158,7 @@ typedef struct {
   // Image[1] is for trusty OS
   // Image[2] is for misc image
   // Image[3-6] is for extra Images
-  BOOT_IMAGE           Image[7];
+  BOOT_IMAGE           Image[LoadImageTypeMax];
 } OS_BOOT_OPTION;
 
 

--- a/PayloadPkg/Library/AbSupportLib/AbSupportLib.c
+++ b/PayloadPkg/Library/AbSupportLib/AbSupportLib.c
@@ -102,7 +102,7 @@ LoadMisc (
   UINT32                     BlockSize;
   LBA_IMAGE_LOCATION         *LbaImage;
 
-  LbaImage = &BootOption->Image[LOAD_IMAGE_MISC].LbaImage;
+  LbaImage = &BootOption->Image[LoadImageTypeMisc].LbaImage;
   Status = GetLogicalPartitionInfo (LbaImage->SwPart, HwPartHandle, &LogicBlkDev);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_INFO, "Get logical partition error, Status = %r\n", Status));
@@ -137,11 +137,17 @@ LoadMisc (
              );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_INFO, "Read Mics error, Status = %r\n", Status));
-    return Status;
+  } else {
+    MiscPartitionData = (MISC_PARTITION_DATA *)Buffer;
+    CopyMem (AbBootInfo, &MiscPartitionData->AbBootInfo, sizeof (AB_BOOT_INFO));
   }
 
-  MiscPartitionData = (MISC_PARTITION_DATA *)Buffer;
-  CopyMem (AbBootInfo, &MiscPartitionData->AbBootInfo, sizeof (AB_BOOT_INFO));
+  //
+  // Free temporary memory
+  //
+  if (Buffer != NULL) {
+    FreePages (Buffer, EFI_SIZE_TO_PAGES (ReadSize));
+  }
 
   return Status;
 }

--- a/PayloadPkg/OsLoader/OsLoader.h
+++ b/PayloadPkg/OsLoader/OsLoader.h
@@ -196,39 +196,64 @@ PrintBootOptions (
   );
 
 /**
+  Get a pointer of Loaded Image which has specific LoadImageType
+
+  This function will return the pointer address of a Loaded Image with given
+  LoadImageType.
+
+  @param[in]  LoadedImageHandle       Loaded Image handle
+  @param[in]  LoadImageType           Load Image Type Index
+  @param[out] LoadedImage             Loaded Image
+
+  @retval     EFI_SUCCESS             Found a Loaded Image from the handle successfully
+  @retval     EFI_INVALID_PARAMETER   If Loaded Image handle is invalid
+  @retval     EFI_NOT_FOUND           Not found a Loaded Image from the handle
+
+**/
+EFI_STATUS
+EFIAPI
+GetLoadedImageByType (
+  IN   EFI_HANDLE         LoadedImageHandle,
+  IN   LOAD_IMAGE_TYPE    LoadImageType,
+  OUT  LOADED_IMAGE     **LoadedImage
+  );
+
+/**
+  Free all temporary resources used for Boot Image
+
+  This function will clean up all temporary resources used to load Boot Image.
+
+  @param[in]  LoadedImageHandle Loaded Image handle
+
+  @retval     none
+**/
+VOID
+EFIAPI
+UnloadBootImages (
+  IN  EFI_HANDLE       LoadedImageHandle
+  );
+
+/**
   Load Image from boot media.
 
   This function will initialize OS boot device, and load image based on
   boot option, the loaded image info will be saved in  LoadedImage.
 
-  @param[in]  BootOption     Current boot option
-  @param[out] LoadedImage    Loaded Image information.
+  @param[in]  BootOption        Current boot option
+  @param[in]  HwPartHandle      Hardware partition handle
+  @param[in]  FsHandle          FileSystem handle
+  @param[out] LoadedImageHandle Loaded Image handle
 
-  @retval  RETURN_SUCCESS    If image was loaded successfully
-  @retval  Others            If image was not loaded.
+  @retval     RETURN_SUCCESS    If image was loaded successfully
+  @retval     Others            If image was not loaded.
 **/
 EFI_STATUS
-GetImageFromMedia (
-  IN  OS_BOOT_OPTION         *BootOption,
-  OUT LOADED_IMAGE           *LoadedImage
-  );
-
-/**
-  Get hardware partition handle from boot option info
-
-  This function will initialize boot device, and get hardware partition
-  handle based on boot option.
-
-  @param[in]  BootOption      Current boot option
-  @param[out] HwPartHandle    Hardware partition handle for boot image
-
-  @retval  RETURN_SUCCESS     If partition was found successfully
-  @retval  Others             If partition was not found
-**/
-EFI_STATUS
-FindBootPartition (
-  IN  OS_BOOT_OPTION         *BootOption,
-  OUT EFI_HANDLE             *HwPartHandle
+EFIAPI
+LoadBootImages (
+  IN  OS_BOOT_OPTION  *OsBootOption,
+  IN  EFI_HANDLE       HwPartHandle,
+  IN  EFI_HANDLE       FsHandle,
+  OUT EFI_HANDLE      *LoadedImageHandle
   );
 
 /**


### PR DESCRIPTION
This patch allows OsLoader to handle all Boot Options without restarting.

Currently, OsLoader restarts to handle next Boot Option from the beginning.
This behavior does not preserve allocated memories from Payload heap,
so it makes hardware/software state hard to maintain.

Signed-off-by: Aiden Park <aiden.park@intel.com>