### PR TITLE
Fix build failure in PreOsChecker on Windows

### DIFF
--- a/PayloadPkg/OsLoader/PreOsChecker.c
+++ b/PayloadPkg/OsLoader/PreOsChecker.c
@@ -140,7 +140,7 @@ StartPreOsChecker (
   PreOsParams.OsBootState.Eip     = OsBootParam->Hdr.Code32Start;
   PreOsParams.OsBootState.Eflags  = 0;
 
-  EntryPoint = (PRE_OS_CHECKER_ENTRY)mPreOsCheckerEntry;
+  EntryPoint = (PRE_OS_CHECKER_ENTRY)(UINTN)mPreOsCheckerEntry;
   EntryPoint (&PreOsParams);
 
   //


### PR DESCRIPTION
Fix type cast error from pointer to function pointer

Signed-off-by: Aiden Park <aiden.park@intel.com>