### PR TITLE
Support for SHA384 and SM3 in SBL measured boot

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -85,6 +85,38 @@
 
   gPlatformCommonLibTokenSpaceGuid.PcdLowestSupportedFwVer		  | 0x00000000 | UINT32 | 0x20000601
 
+
+  ## This PCD indicates the signing algorithm to be enabled by bootloader
+  #  Based on the value set, bootloader would use cipher for verified boot
+  #     0x00    - RSA2048.<BR>
+  #     0x01    - RSA3072.<BR>
+  #     0x02    - SM2.<BR>
+  gPlatformCommonLibTokenSpaceGuid.PcdRsaSignType             |         0x0| UINT8  | 0x20000701
+
+  ## This PCD indicates hash algorithm to be enabled by bootloader
+  #  Based on the value set, bootloader would use alg for verified boot
+  #     0x00    - SHA2_256.<BR>
+  #     0x01    - SHA2_384.<BR>
+  #     0x02    - SHA2_512.<BR>
+  #     0x03    - SM3_256.<BR>
+  gPlatformCommonLibTokenSpaceGuid.PcdSignHashType            |         0x0| UINT8  | 0x20000702
+
+  ## This PCD indicates the HASH algorithm to be included by IPP Crypto library
+  #  Based on the value set, the required algorithm hash API would be enabled 
+  #     0x0001    - SHA2_256.<BR>
+  #     0x0002    - SHA2_384.<BR>
+  #     0x0004    - SHA2_512.<BR>
+  #     0x0008    - SM3_256.<BR>
+  gPlatformCommonLibTokenSpaceGuid.PcdIppHashLibSupported     |        0x01| UINT16 | 0x20000704
+
+  ## This PCD indicates the Signing crypto algorithm to be included by IPP Crypto library
+  #  Based on the value set, the required algorithm hash API would be enabled 
+  #     0x0001    - RSA2048.<BR>
+  #     0x0002    - RSA3072.<BR>
+  #     0x0004    - SM2.<BR>
+  gPlatformCommonLibTokenSpaceGuid.PcdIppSignLibSupported     |        0x01| UINT16 | 0x20000705
+
+
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   # For patchable PCDs, try to set the default as none-zero
   # It is to prevent it from being put into BSS section, thus cause patching issue
@@ -197,6 +229,14 @@
   # @Prompt Minimum length(in bytes) of the system preboot TCG event log area(LAML).
   gPlatformCommonLibTokenSpaceGuid.PcdTcgLogAreaMinLen|0x10000|UINT32|0x00010081
 
+[PcdsDynamic]
+  ## This PCD indicates the hash algorithm to be enabled by bootloader for measured boot
+  #  Based on the value set, PCR bank world be enabled and extended
+  #     0x00    - SHA2_256.<BR>
+  #     0x01    - SHA2_384.<BR>
+  #     0x02    - SHA2_512.<BR>
+  #     0x03    - SM3_256.<BR>
+  gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashType    |         0x0| UINT8  | 0x20000703
 
 
 [PcdsFeatureFlag]

--- a/BootloaderCommonPkg/Include/Library/CryptoLib.h
+++ b/BootloaderCommonPkg/Include/Library/CryptoLib.h
@@ -17,8 +17,21 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define SIG_TYPE_RSA2048SHA256   0
 
+
+#define  HASH_TYPE_SHA256              0
+#define  HASH_TYPE_SHA384              1
+#define  HASH_TYPE_SHA512              2
+#define  HASH_TYPE_SM3                 3
+
 #define SHA256_DIGEST_SIZE       32
+#define SHA384_DIGEST_SIZE       48
+#define SM3_DIGEST_SIZE          32
+#define SHA512_DIGEST_SIZE       64
+#define HASH_DIGEST_MAX          SHA384_DIGEST_SIZE
+
 #define RSA2048NUMBYTES          256
+#define RSA3072NUMBYTES          384
+
 
 #define RSA_MOD_SIZE 256 //hardcode n size to be 256
 #define RSA_E_SIZE   4   //hardcode e size to be 4
@@ -52,6 +65,47 @@ typedef struct {
 **/
 UINT8 *
 Sha256 (
+  IN  CONST UINT8          *Data,
+  IN        UINT32          Length,
+  OUT       UINT8          *Digest
+  );
+
+
+/**
+  Computes the SHA-384 message digest of a input data buffer.
+
+  This function performs the SHA-384 message digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  @param[in]   Data        Pointer to the buffer containing the data to be hashed.
+  @param[in]   Length      Length of Data buffer in bytes.
+  @param[out]  Digest      Pointer to a buffer that receives the SHA-256 digest
+                           value (48 bytes).
+
+  @retval                  A pointer to SHA-384 digest value
+**/
+UINT8 *
+Sha384 (
+  IN  CONST UINT8          *Data,
+  IN        UINT32          Length,
+  OUT       UINT8          *Digest
+  );
+
+/**
+  Computes the SHA-384 message digest of a input data buffer.
+
+  This function performs the SM3 message digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  @param[in]   Data        Pointer to the buffer containing the data to be hashed.
+  @param[in]   Length      Length of Data buffer in bytes.
+  @param[out]  Digest      Pointer to a buffer that receives the SHA-256 digest
+                           value (32 bytes).
+
+  @retval                  A pointer to SM3 digest value
+**/
+UINT8 *
+Sm3 (
   IN  CONST UINT8          *Data,
   IN        UINT32          Length,
   OUT       UINT8          *Digest
@@ -182,6 +236,105 @@ Sha256Update (
 **/
 RETURN_STATUS
 Sha256Final (
+  IN       HASH_CTX   *HashCtx,
+  OUT      UINT8      *Hash
+  );
+
+
+/**
+  Initializes the hash context for SHA384 hashing.
+
+  @param[in]   HashCtx       Pointer to the hash context buffer.
+  @param[in]   HashCtxSize   Length of the hash context.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_BUFFER_TOO_SMALL    Hash context buffer size is not large enough.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+Sha384Init (
+  IN      HASH_CTX   *HashCtx,
+  IN      UINT32      HashCtxSize
+  );
+
+/**
+  Consumes the data for SHA384 hashing.
+  This method can be called multiple times to hash separate pieces of data.
+
+  @param[in]   HashCtx     Pointer to the hash context buffer.
+  @param[in]   Msg         Data to be hashed.
+  @param[in]   MsgLen      Length of data to be hashed.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+Sha384Update (
+  IN        HASH_CTX   *HashCtx,
+  IN CONST  UINT8      *Msg,
+  IN        UINT32      MsgLen
+  );
+
+/**
+  Finalizes the SHA384 hashing and returns the hash.
+
+  @param[in]   HashCtx     Pointer to the hash context buffer.
+  @param[out]  Hash        Sha384 hash of the data.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+Sha384Final (
+  IN       HASH_CTX   *HashCtx,
+  OUT      UINT8      *Hash
+  );
+
+/**
+  Initializes the hash context for SM3 hashing.
+
+  @param[in]   HashCtx       Pointer to the hash context buffer.
+  @param[in]   HashCtxSize   Length of the hash context.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_BUFFER_TOO_SMALL    Hash context buffer size is not large enough.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+Sm3Init (
+  IN      HASH_CTX   *HashCtx,
+  IN      UINT32      HashCtxSize
+  );
+
+/**
+  Consumes the data for SM3 hashing.
+  This method can be called multiple times to hash separate pieces of data.
+
+  @param[in]   HashCtx     Pointer to the hash context buffer.
+  @param[in]   Msg         Data to be hashed.
+  @param[in]   MsgLen      Length of data to be hashed.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+Sm3Update (
+  IN        HASH_CTX   *HashCtx,
+  IN CONST  UINT8      *Msg,
+  IN        UINT32      MsgLen
+  );
+
+/**
+  Finalizes the SM3 hashing and returns the hash.
+
+  @param[in]   HashCtx     Pointer to the hash context buffer.
+  @param[out]  Hash        Sm3 hash of the data.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+Sm3Final (
   IN       HASH_CTX   *HashCtx,
   OUT      UINT8      *Hash
   );

--- a/BootloaderCommonPkg/Include/Library/SecureBootLib.h
+++ b/BootloaderCommonPkg/Include/Library/SecureBootLib.h
@@ -8,10 +8,6 @@
 #ifndef __VERIFIED_BOOT_LIB_H__
 #define __VERIFIED_BOOT_LIB_H__
 
-#define  HASH_TYPE_SHA256              0
-#define  HASH_TYPE_SHA384              1
-#define  HASH_TYPE_SHA512              2
-
 #define  SIG_TYPE_RSA2048_SHA256       0
 #define  SIG_TYPE_RSA3072_SHA384       1
 
@@ -54,13 +50,15 @@ DoHashVerify (
 /**
   Verifies the RSA signature with PKCS1-v1_5 encoding scheme defined in RSA PKCS#1.
   Also(optional), return the hash of the message to the caller.
-
+ 
   @param[in]  Data            Data buffer pointer.
   @param[in]  Length          Data buffer size.
   @param[in]  ComponentType   Component type.
   @param[in]  Signature       Signature for the data buffer.
   @param[in]  PubKey          Public key data pointer.
   @param[in]  PubKeyHash      Public key hash value when ComponentType is not used.
+  @param[in]  SignKeyType     Type of Public key Sign .
+  @param[in]  SignHashAlg     Hash type used for signing.
   @param[out] OutHash         Calculated data hash value.
 
 
@@ -78,6 +76,8 @@ DoRsaVerify (
   IN CONST UINT8           *Signature,
   IN       UINT8           *PubKey,
   IN       UINT8           *PubKeyHash      OPTIONAL,
+  IN       UINT8            SignKeyType     OPTIONAL,
+  IN       UINT8            SignHashAlg     OPTIONAL,
   OUT      UINT8           *OutHash         OPTIONAL
   );
 
@@ -95,5 +95,29 @@ EFIAPI
 GenerateRandomNumbers(
   OUT   CHAR8   *Data,
   IN    UINTN   Size
+  );
+
+
+/**
+  Calculate hash API.
+
+  @param[in]  Data           Data buffer pointer.
+  @param[in]  Length         Data buffer size.
+  @param[in]  HashAlg        Specify hash algrothsm.
+  @param[in,out]  OutHash    On input,  expected hash value when ComponentType is not used.
+                             On output, calculated hash value.
+
+  @retval RETURN_SUCCESS             Hash verification succeeded.
+  @retval RETRUN_INVALID_PARAMETER   Hash parameter is not valid.
+  @retval RETURN_UNSUPPORTED         Hash component type is not supported.
+
+**/
+
+RETURN_STATUS
+DoHashCalc (
+  IN      UINT8          *Data,
+  IN      UINT32          Length,
+  IN      UINT8           HashAlg,
+  IN OUT  UINT8          *OutHash
   );
 #endif /* __VERIFIED_BOOT_LIB_H__ */

--- a/BootloaderCommonPkg/Include/Library/TpmLib.h
+++ b/BootloaderCommonPkg/Include/Library/TpmLib.h
@@ -107,13 +107,17 @@ TpmExtendPcrAndLogEvent (
   in PCR 0 with EV_POST_CODE event type.
 
   @param[in] ComponentType    Stage whose measurement need to be extended.
+  @param[in] Signature        Signature of the component
+  @param[in] CalculateHash    Flag to indicate hash calculation is needed
 
   @retval RETURN_SUCCESS      Operation completed successfully.
   @retval Others              Unable to extend stage hash.
 **/
 RETURN_STATUS
 TpmExtendStageHash (
-  IN       UINT8            ComponentType
+  IN       UINT8            ComponentType,
+  IN       UINT32           Signature,
+  IN       BOOLEAN          CalculateHash
   );
 
 /**
@@ -143,6 +147,11 @@ TpmLogEvent (
 **/
 RETURN_STATUS
 TpmIndicateReadyToBoot (
+  VOID
+  );
+
+UINT32
+GetTpmHashAlgEnabled(
   VOID
   );
 #endif  // _TPM_LIB_H

--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
@@ -257,15 +257,21 @@ AuthenticateComponent (
   )
 {
   EFI_STATUS  Status;
+  UINT8 RsaSignType, SignHashType;
+
+  //TO-DO: RsaSignType & SignHashType hash info has to be retrivied from container header
+  RsaSignType = FixedPcdGet8(PcdRsaSignType);
+  SignHashType = FixedPcdGet8(PcdSignHashType);
 
   if (!FeaturePcdGet (PcdVerifiedBootEnabled)) {
     Status = EFI_SUCCESS;
   } else {
     if (AuthType == AUTH_TYPE_SHA2_256) {
-      Status = DoHashVerify (Data, Length, HASH_TYPE_SHA256, CompType, HashData);
+      Status = DoHashVerify (Data, Length, SignHashType, CompType, HashData);
     } else if (AuthType == AUTH_TYPE_SIG_RSA2048_SHA256) {
+      
       Status = DoRsaVerify (Data, Length, CompType, AuthData,
-                            AuthData + RSA2048NUMBYTES, HashData, NULL);
+                            AuthData + RSA2048NUMBYTES, HashData, RsaSignType, SignHashType, NULL);
     } else if (AuthType == AUTH_TYPE_NONE) {
       Status = EFI_SUCCESS;
     } else {

--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.inf
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.inf
@@ -30,3 +30,6 @@
 [Pcd]
   gPlatformCommonLibTokenSpaceGuid.PcdContainerMaxNumber
   gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdRsaSignType               ## CONSUMES
+  gPlatformCommonLibTokenSpaceGuid.PcdSignHashType              ## CONSUMES
+  gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashType      ## CONSUMES

--- a/BootloaderCommonPkg/Library/IasImageLib/IasImage.c
+++ b/BootloaderCommonPkg/Library/IasImageLib/IasImage.c
@@ -42,6 +42,7 @@ IsIasImageValid (
   UINT32                     CrcOut;
   UINT32                     Index;
   UINT32                     KeyIdx;
+  UINT8 RsaSignType, SignHashType;
 
   Hdr = (IAS_HEADER *) ImageAddr;
 
@@ -84,8 +85,15 @@ IsIasImageValid (
   }
 
   Signature = (UINT8 *) IAS_SIGNATURE (Hdr);
+
+  //TO-DO: RsaSignType & SignHashType hash info to be retrivied from IasImage header pr 
+  // any other process
+  RsaSignType = FixedPcdGet8(PcdRsaSignType);
+  SignHashType = FixedPcdGet8(PcdSignHashType);
+
   Status = DoRsaVerify ((CONST UINT8 *)Hdr, ((UINT32)IAS_PAYLOAD_END (Hdr)) - ((UINT32)Hdr), COMP_TYPE_PUBKEY_OS,
-                        Signature, (UINT8 *)&Key, NULL, ImageHash);
+                        Signature, (UINT8 *)&Key, NULL, RsaSignType, 
+                        SignHashType, ImageHash);
   if (EFI_ERROR (Status) != EFI_SUCCESS) {
     DEBUG ((DEBUG_ERROR, "IAS image verification failed!\n"));
     return NULL;

--- a/BootloaderCommonPkg/Library/IasImageLib/IasImageLib.inf
+++ b/BootloaderCommonPkg/Library/IasImageLib/IasImageLib.inf
@@ -36,7 +36,12 @@
   CryptoLib
   SecureBootLib
 
+
 [Guids]
 
 [Pcd]
   gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdRsaSignType               ## CONSUMES
+  gPlatformCommonLibTokenSpaceGuid.PcdSignHashType              ## CONSUMES
+  gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashType      ## CONSUMES
+  

--- a/BootloaderCommonPkg/Library/IppCryptoLib/IppCryptoLib.inf
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/IppCryptoLib.inf
@@ -39,10 +39,14 @@
   $(IPP_PATH)/pcpngrsamontstuff.c
   $(IPP_PATH)/pcpngrsassapkcsv15ca_rmf.c
   $(IPP_PATH)/pcpsha256ca.c
+  $(IPP_PATH)/pcpsha512ca.c
+  $(IPP_PATH)/pcpsm3ca.c
   $(IPP_PATH)/pcphmacca_rmf.c
   hmac.c
   rsa_verify.c
   sha256.c
+  sha384.c
+  sm3.c
 
 [Sources.IA32]
   $(IPP_PATH)/Ia32/pcpsha256v8as.nasm
@@ -58,6 +62,7 @@
 
 [FixedPcd]
   gPlatformCommonLibTokenSpaceGuid.PcdCryptoShaNiEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdIppHashLibSupported
 
 [BuildOptions]
   MSFT:*_*_*_CC_FLAGS = -D_SLIMBOOT_OPT -D_ARCH_IA32 -D_IPP_LE

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/ippcp.h
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/ippcp.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -62,6 +62,7 @@ IPPAPI( const IppLibraryVersion*, ippcpGetLibVersion, (void) )
 
 /* method based generalized (reduced memory footprint) Hash Primitives */
 IPPAPI( const IppsHashMethod*, ippsHashMethod_MD5, (void) )
+IPPAPI( const IppsHashMethod*, ippsHashMethod_SM3, (void) )
 IPPAPI( const IppsHashMethod*, ippsHashMethod_SHA1, (void) )
 IPPAPI( const IppsHashMethod*, ippsHashMethod_SHA1_NI, (void) )
 IPPAPI( const IppsHashMethod*, ippsHashMethod_SHA1_TT, (void) )

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/owncp.h
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/owncp.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -72,12 +72,12 @@ typedef int cpSize;
 #define BITS2WORD64_SIZE(x) (((x)+63)>>6)
 
 /* WORD and DWORD manipulators */
-#define LODWORD(x)    ((Ipp32u)(x))
-#define HIDWORD(x)    ((Ipp32u)(((Ipp64u)(x) >>32) & 0xFFFFFFFF))
+#define IPP_LODWORD(x)    ((Ipp32u)(x))
+#define IPP_HIDWORD(x)    ((Ipp32u)(((Ipp64u)(x) >>32) & 0xFFFFFFFF))
 
-#define MAKEHWORD(bLo,bHi) ((Ipp16u)(((Ipp8u)(bLo))  | ((Ipp16u)((Ipp8u)(bHi))) << 8))
-#define MAKEWORD(hLo,hHi)  ((Ipp32u)(((Ipp16u)(hLo)) | ((Ipp32u)((Ipp16u)(hHi))) << 16))
-#define MAKEDWORD(wLo,wHi) ((Ipp64u)(((Ipp32u)(wLo)) | ((Ipp64u)((Ipp32u)(wHi))) << 32))
+#define IPP_MAKEHWORD(bLo,bHi) ((Ipp16u)(((Ipp8u)(bLo))  | ((Ipp16u)((Ipp8u)(bHi))) << 8))
+#define IPP_MAKEWORD(hLo,hHi)  ((Ipp32u)(((Ipp16u)(hLo)) | ((Ipp32u)((Ipp16u)(hHi))) << 16))
+#define IPP_MAKEDWORD(wLo,wHi) ((Ipp64u)(((Ipp32u)(wLo)) | ((Ipp64u)((Ipp32u)(wHi))) << 32))
 
 /* extract byte */
 #define EBYTE(w,n) ((Ipp8u)((w) >> (8 * (n))))
@@ -150,7 +150,7 @@ typedef int cpSize;
   #else
   #  define ENDIANNESS(x) ((ROR32((x), 24) & 0x00ff00ff) | (ROR32((x), 8) & 0xff00ff00))
   #  define ENDIANNESS32(x) ENDIANNESS((x))
-  #  define ENDIANNESS64(x) MAKEDWORD(ENDIANNESS(HIDWORD((x))), ENDIANNESS(LODWORD((x))))
+  #  define ENDIANNESS64(x) MAKEDWORD(ENDIANNESS(IPP_HIDWORD((x))), ENDIANNESS(IPP_LODWORD((x))))
   #endif
 #endif
 

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/owndefs.h
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/owndefs.h
@@ -737,7 +737,7 @@ void __CDECL ownUnregisterLib( IppDomain );
 #endif
 #endif
 
-#define UNREFERENCED_PARAMETER(p) (p)=(p)
+#define IPP_UNREFERENCED_PARAMETER(p) (void)(p)
 
 #if defined( _IPP_MARK_LIBRARY )
 static char G[] = {73, 80, 80, 71, 101, 110, 117, 105, 110, 101, 243, 193, 210, 207, 215};

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpbnu32arith.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpbnu32arith.c
@@ -37,8 +37,8 @@ Ipp32u cpAdd_BNU32(Ipp32u* pR, const Ipp32u* pA, const Ipp32u* pB, cpSize ns)
    cpSize i;
    for(i=0; i<ns; i++) {
       Ipp64u t = (Ipp64u)carry +pA[i] + pB[i];
-      pR[i] = LODWORD(t);
-      carry = HIDWORD(t);
+      pR[i] = IPP_LODWORD(t);
+      carry = IPP_HIDWORD(t);
    }
    return carry;
 }
@@ -52,8 +52,8 @@ Ipp32u cpSub_BNU32(Ipp32u* pR, const Ipp32u* pA, const Ipp32u* pB, cpSize ns)
    cpSize i;
    for(i=0; i<ns; i++) {
       Ipp64u t = (Ipp64u)(pA[i]) - pB[i] - borrow;
-      pR[i] = LODWORD(t);
-      borrow = 0-HIDWORD(t);
+      pR[i] = IPP_LODWORD(t);
+      borrow = 0-IPP_HIDWORD(t);
    }
    return borrow;
 }
@@ -67,8 +67,8 @@ Ipp32u cpInc_BNU32(Ipp32u* pR, const Ipp32u* pA, cpSize ns, Ipp32u v)
    cpSize i;
    for(i=0; i<ns && carry; i++) {
       Ipp64u t = (Ipp64u)carry +pA[i];
-      pR[i] = LODWORD(t);
-      carry = HIDWORD(t);
+      pR[i] = IPP_LODWORD(t);
+      carry = IPP_HIDWORD(t);
    }
    return carry;
 }
@@ -82,8 +82,8 @@ Ipp32u cpDec_BNU32(Ipp32u* pR, const Ipp32u* pA, cpSize ns, Ipp32u v)
    int n;
    for(n=0; n<ns; n++) {
       Ipp64u t = (Ipp64u)(pA[n]) - (Ipp64u)borrow;
-      pR[n] = LODWORD(t);
-      borrow = HIDWORD(t)>>(32-1);
+      pR[n] = IPP_LODWORD(t);
+      borrow = IPP_HIDWORD(t)>>(32-1);
    }
    return borrow;
 }
@@ -101,8 +101,8 @@ Ipp32u cpMulDgt_BNU32(Ipp32u* pR, const Ipp32u* pA, cpSize nsA, Ipp32u val)
 #else
       Ipp64u t = (Ipp64u)val * (Ipp64u)pA[i] + carry;
 #endif
-      pR[i] = LODWORD(t);
-      carry = HIDWORD(t);
+      pR[i] = IPP_LODWORD(t);
+      carry = IPP_HIDWORD(t);
     }
     return carry;
 }
@@ -124,8 +124,8 @@ Ipp32u cpSubMulDgt_BNU32(Ipp32u* pR, const Ipp32u* pA, cpSize nsA, Ipp32u val)
 #else
       Ipp64u r = (Ipp64u)*pR - (Ipp64u)(*pA++) * val - carry;
 #endif
-      *pR++  = LODWORD(r);
-      carry  = 0-HIDWORD(r);
+      *pR++  = IPP_LODWORD(r);
+      carry  = 0-IPP_HIDWORD(r);
    }
    return carry;
 }
@@ -162,13 +162,13 @@ int cpDiv_BNU32(Ipp32u* pQ, cpSize* sizeQ,
       int i;
       Ipp32u r = 0;
       for(i=(int)sizeX-1; i>=0; i--) {
-         Ipp64u tmp = MAKEDWORD(pX[i],r);
+         Ipp64u tmp = IPP_MAKEDWORD(pX[i],r);
 #ifdef _SLIMBOOT_OPT
-         Ipp32u q = LODWORD(DivU64x32 (tmp , pY[0]));
-         r = LODWORD(tmp - MultU64x32(pY[0], q));
+         Ipp32u q = IPP_LODWORD(DivU64x32 (tmp , pY[0]));
+         r = IPP_LODWORD(tmp - MultU64x32(pY[0], q));
 #else
-         Ipp32u q = LODWORD(tmp / pY[0]);
-         r = LODWORD(tmp - q*pY[0]);
+         Ipp32u q = IPP_LODWORD(tmp / pY[0]);
+         r = IPP_LODWORD(tmp - q*pY[0]);
 #endif
          if(pQ) pQ[i] = q;
       }
@@ -216,7 +216,7 @@ int cpDiv_BNU32(Ipp32u* pQ, cpSize* sizeQ,
             Ipp32u extend;
 
             /* estimate digit of quotient */
-            Ipp64u tmp = MAKEDWORD(pX[i+sizeY-1], pX[i+sizeY]);
+            Ipp64u tmp = IPP_MAKEDWORD(pX[i+sizeY-1], pX[i+sizeY]);
 #ifdef _SLIMBOOT_OPT
             Ipp64u q = DivU64x32 (tmp, yHi);
             Ipp64u r = tmp - MultU64x32 (q , yHi);
@@ -229,13 +229,13 @@ int cpDiv_BNU32(Ipp32u* pQ, cpSize* sizeQ,
             /* tune estimation above */
             //for(; (q>=CONST_64(0x100000000)) || (Ipp64u)q*pY[sizeY-2] > MAKEDWORD(pX[i+sizeY-2],r); ) {
 #ifdef _SLIMBOOT_OPT
-            for(; HIDWORD(q) || (Ipp64u)MultU64x32 (q, pY[sizeY-2]) > MAKEDWORD(pX[i+sizeY-2],r); ) {
+            for(; IPP_HIDWORD(q) || (Ipp64u)MultU64x32 (q, pY[sizeY-2]) > IPP_MAKEDWORD(pX[i+sizeY-2],r); ) {
 #else
-            for(; HIDWORD(q) || (Ipp64u)q*pY[sizeY-2] > MAKEDWORD(pX[i+sizeY-2],r); ) {
+            for(; IPP_HIDWORD(q) || (Ipp64u)q*pY[sizeY-2] > IPP_MAKEDWORD(pX[i+sizeY-2],r); ) {
 #endif
                q -= 1;
                r += yHi;
-               if( HIDWORD(r) )
+               if( IPP_HIDWORD(r) )
                   break;
             }
 
@@ -250,7 +250,7 @@ int cpDiv_BNU32(Ipp32u* pQ, cpSize* sizeQ,
             }
 
             /* store quotation digit */
-            if(pQ) pQ[i] = LODWORD(q);
+            if(pQ) pQ[i] = IPP_LODWORD(q);
          }
       }
 
@@ -286,8 +286,8 @@ int cpDiv_BNU32(Ipp32u* pQ, cpSize* sizeQ,
       Ipp32u c = 0; \
       for(aidx=0; aidx<(LEN); aidx++) { \
          Ipp64u t = (R)[bidx+aidx] + (A)[aidx] * b + c; \
-         (R)[bidx+aidx] = LODWORD(t); \
-         c = HIDWORD(t); \
+         (R)[bidx+aidx] = IPP_LODWORD(t); \
+         c = IPP_HIDWORD(t); \
       } \
       (R)[bidx+aidx] = c; \
    } \

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpbnuarith.h
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpbnuarith.h
@@ -98,7 +98,7 @@ int cpModInv_BNU(BNU_CHUNK_T* pInv,
 __INLINE cpSize cpMul_BNU_BufferSize(cpSize opLen)
 {
 #if !defined (_USE_KARATSUBA_)
-   UNREFERENCED_PARAMETER(opLen);
+   IPP_UNREFERENCED_PARAMETER(opLen);
    return 0;
 #else
    return cpKaratsubaBufferSize(opLen);
@@ -110,7 +110,7 @@ __INLINE BNU_CHUNK_T cpMul_BNU(BNU_CHUNK_T* pR,
                                BNU_CHUNK_T* pBuffer)
 {
 #if !defined(_USE_KARATSUBA_)
-   UNREFERENCED_PARAMETER(pBuffer);
+   IPP_UNREFERENCED_PARAMETER(pBuffer);
    return cpMul_BNU_school(pR, pA,nsA, pB,nsB);
 #else
    if(nsA!=nsB || nsA<CP_KARATSUBA_MUL_THRESHOLD || !pBuffer)
@@ -124,7 +124,7 @@ __INLINE BNU_CHUNK_T cpSqr_BNU(BNU_CHUNK_T * pR,
                                BNU_CHUNK_T* pBuffer)
 {
 #if !defined(_USE_KARATSUBA_)
-   UNREFERENCED_PARAMETER(pBuffer);
+   IPP_UNREFERENCED_PARAMETER(pBuffer);
    return cpSqr_BNU_school(pR, pA,nsA);
 #else
    if(nsA<CP_KARATSUBA_SQR_THRESHOLD || !pBuffer)

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpngrsamontstuff.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpngrsamontstuff.c
@@ -31,7 +31,7 @@ void gsMontGetSize(IppsExpMethod method, int maxLen32, int* pSize)
    int maxBitSize = maxLen32 << 5;
    gsModEngineGetSize(maxBitSize, MOD_ENGINE_RSA_POOL_SIZE, &size);
 
-   UNREFERENCED_PARAMETER(method);
+   IPP_UNREFERENCED_PARAMETER(method);
 
    *pSize = size + MONT_ALIGNMENT;
 }

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpngrsamontstuff.h
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpngrsamontstuff.h
@@ -34,8 +34,8 @@
 __INLINE int gsIsKaratsubaApplicable(cpSize ns, cpSize threshold)
 {
    #if !defined(_USE_KARATSUBA_)
-   UNREFERENCED_PARAMETER(ns);
-   UNREFERENCED_PARAMETER(threshold);
+   IPP_UNREFERENCED_PARAMETER(ns);
+   IPP_UNREFERENCED_PARAMETER(threshold);
    return 0;
    #else
    return ns>=threshold;
@@ -48,7 +48,7 @@ __INLINE int gsIsKaratsubaApplicable(cpSize ns, cpSize threshold)
 __INLINE cpSize gsKaratsubaBufferLen(cpSize ns)
 {
    #if !defined(_USE_KARATSUBA_)
-   UNREFERENCED_PARAMETER(ns);
+   IPP_UNREFERENCED_PARAMETER(ns);
    return 0;
    #else
    cpSize len= 0;
@@ -82,7 +82,7 @@ __INLINE cpSize gsMontExp_WinSize(cpSize bitsize)
          bitsize>  178? 3 :    /*  178 - 716  */
          bitsize>   41? 2 : 1; /*   41 - 177  */
    #else
-   UNREFERENCED_PARAMETER(bitsize);
+   IPP_UNREFERENCED_PARAMETER(bitsize);
    return 1;
    #endif
 }

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpsha256ca.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpsha256ca.c
@@ -220,7 +220,7 @@ void sha224_hashOctString(Ipp8u* pMD, void* pHashVal)
 
 void sha256_msgRep(Ipp8u* pDst, Ipp64u lenLo, Ipp64u lenHi)
 {
-   UNREFERENCED_PARAMETER(lenHi);
+   IPP_UNREFERENCED_PARAMETER(lenHi);
    lenLo = ENDIANNESS64(lenLo<<3);
    ((Ipp64u*)(pDst))[0] = lenLo;
 }

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpsha512ca.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpsha512ca.c
@@ -1,0 +1,589 @@
+/** @file
+
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+/* 
+// 
+//  Purpose:
+//     Cryptography Primitive.
+//     SHA512 message digest
+// 
+//  Contents:
+//     SHA512 stuff
+// 
+// 
+*/
+
+#include "owndefs.h"
+#include "owncp.h"
+#include "pcphash.h"
+#include "pcphash_rmf.h"
+#include "pcptool.h"
+
+//#if !defined(_PCP_SHA512_STUFF_H)
+//#define _PCP_SHA512_STUFF_H
+
+/* SHA-512, SHA-384, SHA512-224, SHA512 constants */
+static const Ipp64u sha512_iv[] = {
+   CONST_64(0x6A09E667F3BCC908), CONST_64(0xBB67AE8584CAA73B),
+   CONST_64(0x3C6EF372FE94F82B), CONST_64(0xA54FF53A5F1D36F1),
+   CONST_64(0x510E527FADE682D1), CONST_64(0x9B05688C2B3E6C1F),
+   CONST_64(0x1F83D9ABFB41BD6B), CONST_64(0x5BE0CD19137E2179)};
+static const Ipp64u sha512_384_iv[] = {
+   CONST_64(0xCBBB9D5DC1059ED8), CONST_64(0x629A292A367CD507),
+   CONST_64(0x9159015A3070DD17), CONST_64(0x152FECD8F70E5939),
+   CONST_64(0x67332667FFC00B31), CONST_64(0x8EB44A8768581511),
+   CONST_64(0xDB0C2E0D64F98FA7), CONST_64(0x47B5481DBEFA4FA4)};
+static const Ipp64u sha512_256_iv[] = {
+   CONST_64(0x22312194FC2BF72C), CONST_64(0x9F555FA3C84C64C2),
+   CONST_64(0x2393B86B6F53B151), CONST_64(0x963877195940EABD),
+   CONST_64(0x96283EE2A88EFFE3), CONST_64(0xBE5E1E2553863992),
+   CONST_64(0x2B0199FC2C85B8AA), CONST_64(0x0EB72DDC81C52CA2)};
+static const Ipp64u sha512_224_iv[] = {
+   CONST_64(0x8C3D37C819544DA2), CONST_64(0x73E1996689DCD4D6),
+   CONST_64(0x1DFAB7AE32FF9C82), CONST_64(0x679DD514582F9FCF),
+   CONST_64(0x0F6D2B697BD44DA8), CONST_64(0x77E36F7304C48942),
+   CONST_64(0x3F9D85A86A1D36C8), CONST_64(0x1112E6AD91D692A1)};
+
+static __ALIGN16 const Ipp64u sha512_cnt[] = {
+   CONST_64(0x428A2F98D728AE22), CONST_64(0x7137449123EF65CD), CONST_64(0xB5C0FBCFEC4D3B2F), CONST_64(0xE9B5DBA58189DBBC),
+   CONST_64(0x3956C25BF348B538), CONST_64(0x59F111F1B605D019), CONST_64(0x923F82A4AF194F9B), CONST_64(0xAB1C5ED5DA6D8118),
+   CONST_64(0xD807AA98A3030242), CONST_64(0x12835B0145706FBE), CONST_64(0x243185BE4EE4B28C), CONST_64(0x550C7DC3D5FFB4E2),
+   CONST_64(0x72BE5D74F27B896F), CONST_64(0x80DEB1FE3B1696B1), CONST_64(0x9BDC06A725C71235), CONST_64(0xC19BF174CF692694),
+   CONST_64(0xE49B69C19EF14AD2), CONST_64(0xEFBE4786384F25E3), CONST_64(0x0FC19DC68B8CD5B5), CONST_64(0x240CA1CC77AC9C65),
+   CONST_64(0x2DE92C6F592B0275), CONST_64(0x4A7484AA6EA6E483), CONST_64(0x5CB0A9DCBD41FBD4), CONST_64(0x76F988DA831153B5),
+   CONST_64(0x983E5152EE66DFAB), CONST_64(0xA831C66D2DB43210), CONST_64(0xB00327C898FB213F), CONST_64(0xBF597FC7BEEF0EE4),
+   CONST_64(0xC6E00BF33DA88FC2), CONST_64(0xD5A79147930AA725), CONST_64(0x06CA6351E003826F), CONST_64(0x142929670A0E6E70),
+   CONST_64(0x27B70A8546D22FFC), CONST_64(0x2E1B21385C26C926), CONST_64(0x4D2C6DFC5AC42AED), CONST_64(0x53380D139D95B3DF),
+   CONST_64(0x650A73548BAF63DE), CONST_64(0x766A0ABB3C77B2A8), CONST_64(0x81C2C92E47EDAEE6), CONST_64(0x92722C851482353B),
+   CONST_64(0xA2BFE8A14CF10364), CONST_64(0xA81A664BBC423001), CONST_64(0xC24B8B70D0F89791), CONST_64(0xC76C51A30654BE30),
+   CONST_64(0xD192E819D6EF5218), CONST_64(0xD69906245565A910), CONST_64(0xF40E35855771202A), CONST_64(0x106AA07032BBD1B8),
+   CONST_64(0x19A4C116B8D2D0C8), CONST_64(0x1E376C085141AB53), CONST_64(0x2748774CDF8EEB99), CONST_64(0x34B0BCB5E19B48A8),
+   CONST_64(0x391C0CB3C5C95A63), CONST_64(0x4ED8AA4AE3418ACB), CONST_64(0x5B9CCA4F7763E373), CONST_64(0x682E6FF3D6B2B8A3),
+   CONST_64(0x748F82EE5DEFB2FC), CONST_64(0x78A5636F43172F60), CONST_64(0x84C87814A1F0AB72), CONST_64(0x8CC702081A6439EC),
+   CONST_64(0x90BEFFFA23631E28), CONST_64(0xA4506CEBDE82BDE9), CONST_64(0xBEF9A3F7B2C67915), CONST_64(0xC67178F2E372532B),
+   CONST_64(0xCA273ECEEA26619C), CONST_64(0xD186B8C721C0C207), CONST_64(0xEADA7DD6CDE0EB1E), CONST_64(0xF57D4F7FEE6ED178),
+   CONST_64(0x06F067AA72176FBA), CONST_64(0x0A637DC5A2C898A6), CONST_64(0x113F9804BEF90DAE), CONST_64(0x1B710B35131C471B),
+   CONST_64(0x28DB77F523047D84), CONST_64(0x32CAAB7B40C72493), CONST_64(0x3C9EBE0A15C9BEBC), CONST_64(0x431D67C49C100D4C),
+   CONST_64(0x4CC5D4BECB3E42B6), CONST_64(0x597F299CFC657E2A), CONST_64(0x5FCB6FAB3AD6FAEC), CONST_64(0x6C44198C4A475817)
+};
+
+/* setup init hash value */
+__INLINE void hashInit(Ipp64u* pHash, const Ipp64u* iv)
+{
+   pHash[0] = iv[0];
+   pHash[1] = iv[1];
+   pHash[2] = iv[2];
+   pHash[3] = iv[3];
+   pHash[4] = iv[4];
+   pHash[5] = iv[5];
+   pHash[6] = iv[6];
+   pHash[7] = iv[7];
+}
+static void sha512_hashInit(void* pHash)
+{
+   hashInit((Ipp64u*)pHash, sha512_iv);
+}
+static void sha512_384_hashInit(void* pHash)
+{
+   hashInit((Ipp64u*)pHash, sha512_384_iv);
+}
+static void sha512_256_hashInit(void* pHash)
+{
+   hashInit((Ipp64u*)pHash, sha512_256_iv);
+}
+static void sha512_224_hashInit(void* pHash)
+{
+   hashInit((Ipp64u*)pHash, sha512_224_iv);
+}
+
+static void sha512_hashUpdate(void* pHash, const Ipp8u* pMsg, int msgLen)
+{
+   UpdateSHA512(pHash, pMsg, msgLen, sha512_cnt);
+}
+
+/* convert hash into big endian */
+static void sha512_hashOctString(Ipp8u* pMD, void* pHashVal)
+{
+   ((Ipp64u*)pMD)[0] = ENDIANNESS64(((Ipp64u*)pHashVal)[0]);
+   ((Ipp64u*)pMD)[1] = ENDIANNESS64(((Ipp64u*)pHashVal)[1]);
+   ((Ipp64u*)pMD)[2] = ENDIANNESS64(((Ipp64u*)pHashVal)[2]);
+   ((Ipp64u*)pMD)[3] = ENDIANNESS64(((Ipp64u*)pHashVal)[3]);
+   ((Ipp64u*)pMD)[4] = ENDIANNESS64(((Ipp64u*)pHashVal)[4]);
+   ((Ipp64u*)pMD)[5] = ENDIANNESS64(((Ipp64u*)pHashVal)[5]);
+   ((Ipp64u*)pMD)[6] = ENDIANNESS64(((Ipp64u*)pHashVal)[6]);
+   ((Ipp64u*)pMD)[7] = ENDIANNESS64(((Ipp64u*)pHashVal)[7]);
+}
+static void sha512_384_hashOctString(Ipp8u* pMD, void* pHashVal)
+{
+   ((Ipp64u*)pMD)[0] = ENDIANNESS64(((Ipp64u*)pHashVal)[0]);
+   ((Ipp64u*)pMD)[1] = ENDIANNESS64(((Ipp64u*)pHashVal)[1]);
+   ((Ipp64u*)pMD)[2] = ENDIANNESS64(((Ipp64u*)pHashVal)[2]);
+   ((Ipp64u*)pMD)[3] = ENDIANNESS64(((Ipp64u*)pHashVal)[3]);
+   ((Ipp64u*)pMD)[4] = ENDIANNESS64(((Ipp64u*)pHashVal)[4]);
+   ((Ipp64u*)pMD)[5] = ENDIANNESS64(((Ipp64u*)pHashVal)[5]);
+}
+static void sha512_256_hashOctString(Ipp8u* pMD, void* pHashVal)
+{
+   ((Ipp64u*)pMD)[0] = ENDIANNESS64(((Ipp64u*)pHashVal)[0]);
+   ((Ipp64u*)pMD)[1] = ENDIANNESS64(((Ipp64u*)pHashVal)[1]);
+   ((Ipp64u*)pMD)[2] = ENDIANNESS64(((Ipp64u*)pHashVal)[2]);
+   ((Ipp64u*)pMD)[3] = ENDIANNESS64(((Ipp64u*)pHashVal)[3]);
+}
+static void sha512_224_hashOctString(Ipp8u* pMD, void* pHashVal)
+{
+   ((Ipp64u*)pMD)[0] = ENDIANNESS64(((Ipp64u*)pHashVal)[0]);
+   ((Ipp64u*)pMD)[1] = ENDIANNESS64(((Ipp64u*)pHashVal)[1]);
+   ((Ipp64u*)pMD)[2] = ENDIANNESS64(((Ipp64u*)pHashVal)[2]);
+   ((Ipp32u*)pMD)[6] = ENDIANNESS32(((Ipp32u*)pHashVal)[7]);
+}
+
+static void sha512_msgRep(Ipp8u* pDst, Ipp64u lenLo, Ipp64u lenHi)
+{
+   lenHi = LSL64(lenHi,3) | LSR64(lenLo,63-3);
+   lenLo = LSL64(lenLo,3);
+   ((Ipp64u*)(pDst))[0] = ENDIANNESS64(lenHi);
+   ((Ipp64u*)(pDst))[1] = ENDIANNESS64(lenLo);
+}
+
+static IppStatus GetSizeSHA512(int* pSize)
+{
+   /* test pointer */
+   IPP_BAD_PTR1_RET(pSize);
+   *pSize = sizeof(IppsSHA512State) +(SHA512_ALIGNMENT-1);
+   return ippStsNoErr;
+}
+
+//#define   cpFinalizeSHA512       OWNAPI(cpFinalizeSHA512)
+//void      cpFinalizeSHA512(DigestSHA512 pHash, const Ipp8u* inpBuffer, int inpLen, Ipp64u lenLo, Ipp64u lenHi);
+#define   cpSHA512MessageDigest  OWNAPI(cpSHA512MessageDigest)
+IppStatus cpSHA512MessageDigest(DigestSHA512 hash, const Ipp8u* pMsg, int msgLen, const DigestSHA512 IV);
+#define   InitSHA512             OWNAPI(InitSHA512)
+IppStatus InitSHA512(IppsSHA512State* pState, const DigestSHA512 IV);
+
+static void cpFinalizeSHA512(DigestSHA512 pHash,
+                       const Ipp8u* inpBuffer, int inpLen,
+                             Ipp64u lenLo, Ipp64u lenHi)
+{
+   /* local buffer and it length */
+   Ipp8u buffer[MBS_SHA512*2];
+   int bufferLen = inpLen < (MBS_SHA512-(int)MLR_SHA512)? MBS_SHA512 : MBS_SHA512*2; 
+
+   /* copy rest of message into internal buffer */
+   CopyBlock(inpBuffer, buffer, inpLen);
+
+   /* padd message */
+   buffer[inpLen++] = 0x80;
+   PaddBlock(0, buffer+inpLen, bufferLen-inpLen-MLR_SHA512);
+
+   /* message length representation */
+   lenHi = LSL64(lenHi,3) | LSR64(lenLo,63-3);
+   lenLo = LSL64(lenLo,3);
+   ((Ipp64u*)(buffer+bufferLen))[-2] = ENDIANNESS64(lenHi);
+   ((Ipp64u*)(buffer+bufferLen))[-1] = ENDIANNESS64(lenLo);
+
+   /* copmplete hash computation */
+   UpdateSHA512(pHash, buffer, bufferLen, sha512_cnt);
+}
+
+// #endif /* #if !defined(_PCP_SHA512_STUFF_H) */
+
+
+
+IppStatus InitSHA512(IppsSHA512State* pState, const DigestSHA512 IV)
+{
+   /* test state pointer */
+   IPP_BAD_PTR1_RET(pState);
+   pState = (IppsSHA512State*)( IPP_ALIGNED_PTR(pState, SHA512_ALIGNMENT) );
+
+   /* set state ID */
+   HASH_CTX_ID(pState) = idCtxSHA512;
+   /* zeros message length */
+   HASH_LENLO(pState) = 0;
+   HASH_LENHI(pState) = 0;
+   /* message buffer is free */
+   HAHS_BUFFIDX(pState) = 0;
+   /* setup initial digest */
+   hashInit(HASH_VALUE(pState), IV);
+
+   return ippStsNoErr;
+}
+
+
+/*F*
+//    Name: ippsSHA384Final
+//
+// Purpose: Stop message digesting and return digest.
+//
+// Returns:                Reason:
+//    ippStsNullPtrErr        pMD == NULL
+//                            pState == NULL
+//    ippStsContextMatchErr   pState->idCtx != idCtxSHA512
+//    ippStsNoErr             no errors
+//
+// Parameters:
+//    pMD         address of the output digest
+//    pState      pointer to the SHA384 state
+//
+*F*/
+
+IPPFUN(IppStatus, ippsSHA384Final,(Ipp8u* pMD, IppsSHA384State* pState))
+{
+   /* test state pointer and ID */
+   IPP_BAD_PTR1_RET(pState);
+   pState = (IppsSHA512State*)( IPP_ALIGNED_PTR(pState, SHA512_ALIGNMENT) );
+   IPP_BADARG_RET(idCtxSHA512 !=HASH_CTX_ID(pState), ippStsContextMatchErr);
+
+   /* test digest pointer */
+   IPP_BAD_PTR1_RET(pMD);
+
+   cpFinalizeSHA512(HASH_VALUE(pState),
+                    HASH_BUFF(pState), HAHS_BUFFIDX(pState),
+                    HASH_LENLO(pState), HASH_LENHI(pState));
+   /* convert hash into big endian */
+   ((Ipp64u*)pMD)[0] = ENDIANNESS64(HASH_VALUE(pState)[0]);
+   ((Ipp64u*)pMD)[1] = ENDIANNESS64(HASH_VALUE(pState)[1]);
+   ((Ipp64u*)pMD)[2] = ENDIANNESS64(HASH_VALUE(pState)[2]);
+   ((Ipp64u*)pMD)[3] = ENDIANNESS64(HASH_VALUE(pState)[3]);
+   ((Ipp64u*)pMD)[4] = ENDIANNESS64(HASH_VALUE(pState)[4]);
+   ((Ipp64u*)pMD)[5] = ENDIANNESS64(HASH_VALUE(pState)[5]);
+
+   /* re-init hash value */
+   HAHS_BUFFIDX(pState) = 0;
+   HASH_LENLO(pState) = 0;
+   HASH_LENHI(pState) = 0;
+   sha512_384_hashInit(HASH_VALUE(pState));
+
+   return ippStsNoErr;
+}
+
+
+/*F*
+//    Name: ippsSHA512Update
+//
+// Purpose: Updates intermadiate digest based on input stream.
+//
+// Returns:                Reason:
+//    ippStsNullPtrErr        pSrc == NULL
+//                            pState == NULL
+//    ippStsContextMatchErr   pState->idCtx != idCtxSHA512
+//    ippStsLengthErr         len <0
+//    ippStsNoErr             no errors
+//
+// Parameters:
+//    pSrc        pointer to the input stream
+//    len         input stream length
+//    pState      pointer to the SHA512 state
+//
+*F*/
+IPPFUN(IppStatus, ippsSHA512Update,(const Ipp8u* pSrc, int len, IppsSHA512State* pState))
+{
+   /* test state pointer and ID */
+   IPP_BAD_PTR1_RET(pState);
+   /* use aligned context */
+   pState = (IppsSHA512State*)( IPP_ALIGNED_PTR(pState, SHA512_ALIGNMENT) );
+   IPP_BADARG_RET(idCtxSHA512 !=HASH_CTX_ID(pState), ippStsContextMatchErr);
+
+   /* test input length */
+   IPP_BADARG_RET((len<0), ippStsLengthErr);
+   /* test source pointer */
+   IPP_BADARG_RET((len && !pSrc), ippStsNullPtrErr);
+
+   /*
+   // handle non empty message
+   */
+   if(len) {
+      int procLen;
+
+      int idx = HAHS_BUFFIDX(pState);
+      Ipp8u* pBuffer = HASH_BUFF(pState);
+      Ipp64u lenLo = HASH_LENLO(pState) +len;
+      Ipp64u lenHi = HASH_LENHI(pState);
+      if(lenLo < HASH_LENLO(pState)) lenHi++;
+
+      /* if non empty internal buffer filling */
+      if(idx) {
+         /* copy from input stream to the internal buffer as match as possible */
+         procLen = IPP_MIN(len, (MBS_SHA512-idx));
+         CopyBlock(pSrc, pBuffer+idx, procLen);
+
+         /* update message pointer and length */
+         pSrc += procLen;
+         len  -= procLen;
+         idx  += procLen;
+
+         /* update digest if buffer full */
+         if(MBS_SHA512 == idx) {
+            UpdateSHA512(HASH_VALUE(pState), pBuffer, MBS_SHA512, sha512_cnt);
+            idx = 0;
+         }
+      }
+
+      /* main message part processing */
+      procLen = len & ~(MBS_SHA512-1);
+      if(procLen) {
+         UpdateSHA512(HASH_VALUE(pState), pSrc, procLen, sha512_cnt);
+         pSrc += procLen;
+         len  -= procLen;
+      }
+
+      /* store rest of message into the internal buffer */
+      if(len) {
+         CopyBlock(pSrc, pBuffer, len);
+         idx += len;
+      }
+
+      /* update length of processed message */
+      HASH_LENLO(pState) = lenLo;
+      HASH_LENHI(pState) = lenHi;
+      HAHS_BUFFIDX(pState) = idx;
+   }
+
+   return ippStsNoErr;
+}
+
+/*F*
+//    Name: ippsSHA384Init
+//
+// Purpose: Init SHA384
+//
+// Returns:                Reason:
+//    ippStsNullPtrErr        pState == NULL
+//    ippStsNoErr             no errors
+//
+// Parameters:
+//    pState      pointer to the SHA384 state
+//
+*F*/
+
+IPPFUN(IppStatus, ippsSHA384Init,(IppsSHA384State* pState))
+{
+   return InitSHA512(pState, sha512_384_iv);
+}
+
+/*F*
+//    Name: ippsSHA384Update
+//
+// Purpose: Updates intermadiate digest based on input stream.
+//
+// Returns:                Reason:
+//    ippStsNullPtrErr        pSrc == NULL
+//                            pState == NULL
+//    ippStsContextMatchErr   pState->idCtx != idCtxSHA512
+//    ippStsLengthErr         len <0
+//    ippStsNoErr             no errors
+//
+// Parameters:
+//    pSrc        pointer to the input stream
+//    len         input stream length
+//    pState      pointer to the SHA384 state
+//
+*F*/
+
+IPPFUN(IppStatus, ippsSHA384Update,(const Ipp8u* pSrc, int len, IppsSHA384State* pState))
+{
+   return ippsSHA512Update(pSrc, len, pState);
+}
+
+
+/*
+// available SHA384 methods
+*/
+IPPFUN( const IppsHashMethod*, ippsHashMethod_SHA384, (void) )
+{
+   static IppsHashMethod method = {
+      ippHashAlg_SHA384,
+      IPP_SHA384_DIGEST_BITSIZE/8,
+      MBS_SHA384,
+      MLR_SHA384,
+      sha512_384_hashInit,
+      sha512_hashUpdate,
+      sha512_384_hashOctString,
+      sha512_msgRep
+   };
+   return &method;
+}
+
+#pragma message("IPP_ALG_HASH_SHA512 enabled")
+
+#if !((_IPP==_IPP_W7) || (_IPP==_IPP_T7) || \
+      (_IPP==_IPP_V8) || (_IPP==_IPP_P8) || \
+      (_IPP==_IPP_S8) || (_IPP>=_IPP_G9) || \
+      (_IPP32E==_IPP32E_M7) || \
+      (_IPP32E==_IPP32E_U8) || (_IPP32E==_IPP32E_Y8) || \
+      (_IPP32E==_IPP32E_N8) || (_IPP32E>=_IPP32E_E9))
+/*
+// SHA512 Specific Macros (reference proposal 256-384-512)
+//
+// Note: All operations act on DWORDs (64-bits)
+*/
+#define CH(x,y,z)    (((x) & (y)) ^ (~(x) & (z)))
+#define MAJ(x,y,z)   (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
+
+#define SUM0(x)   (ROR64((x),28) ^ ROR64((x),34) ^ ROR64((x),39))
+#define SUM1(x)   (ROR64((x),14) ^ ROR64((x),18) ^ ROR64((x),41))
+
+#define SIG0(x)   (ROR64((x), 1) ^ ROR64((x), 8) ^ LSR64((x), 7))
+#define SIG1(x)   (ROR64((x),19) ^ ROR64((x),61) ^ LSR64((x), 6))
+
+#define SHA512_UPDATE(i) \
+   wdat[i&15] += SIG1(wdat[(i+14)&15]) + wdat[(i+9)&15] + SIG0(wdat[(i+1)&15])
+
+#define SHA512_STEP(i,j)  \
+    v[(7-i)&7] += (j ? SHA512_UPDATE(i) : wdat[i&15])    \
+               + SHA512_cnt_loc[i+j]                         \
+               + SUM1(v[(4-i)&7])                        \
+               + CH(v[(4-i)&7], v[(5-i)&7], v[(6-i)&7]); \
+    v[(3-i)&7] += v[(7-i)&7];                            \
+    v[(7-i)&7] += SUM0(v[(0-i)&7]) + MAJ(v[(0-i)&7], v[(1-i)&7], v[(2-i)&7])
+
+#define COMPACT_SHA512_STEP(A,B,C,D,E,F,G,H, W,K, r) { \
+   Ipp64u _T1 = (H) + SUM1((E)) + CH((E),(F),(G)) + (W)[(r)] + (K)[(r)]; \
+   Ipp64u _T2 = SUM0((A)) + MAJ((A),(B),(C)); \
+   (H) = (G); \
+   (G) = (F); \
+   (F) = (E); \
+   (E) = (D)+_T1; \
+   (D) = (C); \
+   (C) = (B); \
+   (B) = (A); \
+   (A) = _T1+_T2; \
+}
+
+/*F*
+//    Name: UpdateSHA512
+//
+// Purpose: Update internal hash according to input message stream.
+//
+// Parameters:
+//    uniHash  pointer to in/out hash
+//    mblk     pointer to message stream
+//    mlen     message stream length (multiple by message block size)
+//    uniParam pointer to the optional parameter
+//
+*F*/
+#if defined(_ALG_SHA512_COMPACT_)
+#pragma message("SHA512 compact")
+
+void UpdateSHA512(void* uniHash, const Ipp8u* mblk, int mlen, const void* uniPraram)
+{
+   Ipp32u* data = (Ipp32u*)mblk;
+
+   Ipp64u* digest = (Ipp64u*)uniHash;
+   Ipp64u* SHA512_cnt_loc = (Ipp64u*)uniPraram;
+
+
+   for(; mlen>=MBS_SHA512; data += MBS_SHA512/sizeof(Ipp32u), mlen -= MBS_SHA512) {
+      int t;
+      Ipp64u W[80];
+
+      /*
+      // expand message block
+      */
+      /* initialize the first 16 words in the array W (remember about endian) */
+      for(t=0; t<16; t++) {
+         Ipp32u hiX = data[2*t];
+         Ipp32u loX = data[2*t+1];
+         #if (IPP_ENDIAN == IPP_BIG_ENDIAN)
+         W[t] = IPP_MAKEDWORD(loX, hiX);
+         #else
+         W[t] = IPP_MAKEDWORD( ENDIANNESS(loX), ENDIANNESS(hiX) );
+         #endif
+      }
+      for(; t<80; t++)
+         W[t] = SIG1(W[t-2]) + W[t-7] + SIG0(W[t-15]) + W[t-16];
+
+      /*
+      // update hash
+      */
+      {
+         /* init A, B, C, D, E, F, G, H by the input hash */
+         Ipp64u A = digest[0];
+         Ipp64u B = digest[1];
+         Ipp64u C = digest[2];
+         Ipp64u D = digest[3];
+         Ipp64u E = digest[4];
+         Ipp64u F = digest[5];
+         Ipp64u G = digest[6];
+         Ipp64u H = digest[7];
+
+         for(t=0; t<80; t++)
+            COMPACT_SHA512_STEP(A,B,C,D,E,F,G,H, W,SHA512_cnt_loc, t);
+
+         /* update hash*/
+         digest[0] += A;
+         digest[1] += B;
+         digest[2] += C;
+         digest[3] += D;
+         digest[4] += E;
+         digest[5] += F;
+         digest[6] += G;
+         digest[7] += H;
+      }
+   }
+}
+
+#else
+void UpdateSHA512(void* uniHash, const Ipp8u* mblk, int mlen, const void* uniPraram)
+{
+   Ipp32u* data = (Ipp32u*)mblk;
+
+   Ipp64u* digest = (Ipp64u*)uniHash;
+   Ipp64u* SHA512_cnt_loc = (Ipp64u*)uniPraram;
+
+   for(; mlen>=MBS_SHA512; data += MBS_SHA512/sizeof(Ipp32u), mlen -= MBS_SHA512) {
+      Ipp64u wdat[16];
+      int j;
+
+      Ipp64u v[8];
+
+      /* initialize the first 16 words in the array W (remember about endian) */
+      for(j=0; j<16; j++) {
+         Ipp32u hiX = data[2*j];
+         Ipp32u loX = data[2*j+1];
+         #if (IPP_ENDIAN == IPP_BIG_ENDIAN)
+         wdat[j] = IPP_MAKEDWORD(loX, hiX);
+         #else
+         wdat[j] = IPP_MAKEDWORD( ENDIANNESS(loX), ENDIANNESS(hiX) );
+         #endif
+      }
+
+      /* copy digest */
+      CopyBlock(digest, v, IPP_SHA512_DIGEST_BITSIZE/BYTESIZE);
+
+      for(j=0; j<80; j+=16) {
+         SHA512_STEP( 0, j);
+         SHA512_STEP( 1, j);
+         SHA512_STEP( 2, j);
+         SHA512_STEP( 3, j);
+         SHA512_STEP( 4, j);
+         SHA512_STEP( 5, j);
+         SHA512_STEP( 6, j);
+         SHA512_STEP( 7, j);
+         SHA512_STEP( 8, j);
+         SHA512_STEP( 9, j);
+         SHA512_STEP(10, j);
+         SHA512_STEP(11, j);
+         SHA512_STEP(12, j);
+         SHA512_STEP(13, j);
+         SHA512_STEP(14, j);
+         SHA512_STEP(15, j);
+      }
+
+      /* update digest */
+      digest[0] += v[0];
+      digest[1] += v[1];
+      digest[2] += v[2];
+      digest[3] += v[3];
+      digest[4] += v[4];
+      digest[5] += v[5];
+      digest[6] += v[6];
+      digest[7] += v[7];
+   }
+}
+#endif
+
+#endif

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpsm3ca.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpsm3ca.c
@@ -1,0 +1,588 @@
+/** @file
+
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+/*
+//
+//  Purpose:
+//     Cryptography Primitive.
+//     Digesting message according to SM3
+//
+//  Contents:
+//     ippsSM3Init()
+//     ippsSM3Update()
+//     ippsSM3Final()
+//
+//
+*/
+
+#include "owndefs.h"
+#include "owncp.h"
+#include "pcphash.h"
+#include "pcphash_rmf.h"
+#include "pcptool.h"
+
+
+//#if !defined _PCP_SM3_STUFF_H
+//#define _PCP_SM3_STUFF_H
+
+/* SM3 constants */
+static const Ipp32u sm3_iv[] = {
+   0x7380166F, 0x4914B2B9, 0x172442D7, 0xDA8A0600,
+   0xA96F30BC, 0x163138AA, 0xE38DEE4D, 0xB0FB0E4E};
+
+static __ALIGN16 const Ipp32u sm3_cnt[] = {
+   0x79CC4519,0xF3988A32,0xE7311465,0xCE6228CB,0x9CC45197,0x3988A32F,0x7311465E,0xE6228CBC,
+   0xCC451979,0x988A32F3,0x311465E7,0x6228CBCE,0xC451979C,0x88A32F39,0x11465E73,0x228CBCE6,
+   0x9D8A7A87,0x3B14F50F,0x7629EA1E,0xEC53D43C,0xD8A7A879,0xB14F50F3,0x629EA1E7,0xC53D43CE,
+   0x8A7A879D,0x14F50F3B,0x29EA1E76,0x53D43CEC,0xA7A879D8,0x4F50F3B1,0x9EA1E762,0x3D43CEC5,
+   0x7A879D8A,0xF50F3B14,0xEA1E7629,0xD43CEC53,0xA879D8A7,0x50F3B14F,0xA1E7629E,0x43CEC53D,
+   0x879D8A7A,0x0F3B14F5,0x1E7629EA,0x3CEC53D4,0x79D8A7A8,0xF3B14F50,0xE7629EA1,0xCEC53D43,
+   0x9D8A7A87,0x3B14F50F,0x7629EA1E,0xEC53D43C,0xD8A7A879,0xB14F50F3,0x629EA1E7,0xC53D43CE,
+   0x8A7A879D,0x14F50F3B,0x29EA1E76,0x53D43CEC,0xA7A879D8,0x4F50F3B1,0x9EA1E762,0x3D43CEC5
+};
+
+static void sm3_hashInit(void* pHash)
+{
+   /* setup initial digest */
+   ((Ipp32u*)pHash)[0] = sm3_iv[0];
+   ((Ipp32u*)pHash)[1] = sm3_iv[1];
+   ((Ipp32u*)pHash)[2] = sm3_iv[2];
+   ((Ipp32u*)pHash)[3] = sm3_iv[3];
+   ((Ipp32u*)pHash)[4] = sm3_iv[4];
+   ((Ipp32u*)pHash)[5] = sm3_iv[5];
+   ((Ipp32u*)pHash)[6] = sm3_iv[6];
+   ((Ipp32u*)pHash)[7] = sm3_iv[7];
+}
+
+static void sm3_hashUpdate(void* pHash, const Ipp8u* pMsg, int msgLen)
+{
+   UpdateSM3(pHash, pMsg, msgLen, sm3_cnt);
+}
+
+static void sm3_hashOctString(Ipp8u* pMD, void* pHashVal)
+{
+   /* convert hash into big endian */
+   ((Ipp32u*)pMD)[0] = ENDIANNESS32(((Ipp32u*)pHashVal)[0]);
+   ((Ipp32u*)pMD)[1] = ENDIANNESS32(((Ipp32u*)pHashVal)[1]);
+   ((Ipp32u*)pMD)[2] = ENDIANNESS32(((Ipp32u*)pHashVal)[2]);
+   ((Ipp32u*)pMD)[3] = ENDIANNESS32(((Ipp32u*)pHashVal)[3]);
+   ((Ipp32u*)pMD)[4] = ENDIANNESS32(((Ipp32u*)pHashVal)[4]);
+   ((Ipp32u*)pMD)[5] = ENDIANNESS32(((Ipp32u*)pHashVal)[5]);
+   ((Ipp32u*)pMD)[6] = ENDIANNESS32(((Ipp32u*)pHashVal)[6]);
+   ((Ipp32u*)pMD)[7] = ENDIANNESS32(((Ipp32u*)pHashVal)[7]);
+}
+
+static void sm3_msgRep(Ipp8u* pDst, Ipp64u lenLo, Ipp64u lenHi)
+{
+   IPP_UNREFERENCED_PARAMETER(lenHi);
+   lenLo = ENDIANNESS64(lenLo<<3);
+   ((Ipp64u*)(pDst))[0] = lenLo;
+}
+
+#define cpFinalizeSM3 OWNAPI(cpFinalizeSM3)
+void cpFinalizeSM3(DigestSHA1 pHash, const Ipp8u* inpBuffer, int inpLen, Ipp64u processedMsgLen);
+
+//#endif /* #if !defined _PCP_SM3_STUFF_H */
+
+
+
+void cpFinalizeSM3(DigestSHA1 pHash, const Ipp8u* inpBuffer, int inpLen, Ipp64u processedMsgLen)
+{
+   /* local buffer and it length */
+   Ipp8u buffer[MBS_SM3*2];
+   int bufferLen = inpLen < (MBS_SM3-(int)MLR_SM3)? MBS_SM3 : MBS_SM3*2; 
+
+   /* copy rest of message into internal buffer */
+   CopyBlock(inpBuffer, buffer, inpLen);
+
+   /* padd message */
+   buffer[inpLen++] = 0x80;
+   PaddBlock(0, buffer+inpLen, bufferLen-inpLen-MLR_SM3);
+
+   /* put processed message length in bits */
+   processedMsgLen = ENDIANNESS64(processedMsgLen<<3);
+   ((Ipp64u*)(buffer+bufferLen))[-1] = processedMsgLen;
+
+   /* copmplete hash computation */
+   UpdateSM3(pHash, buffer, bufferLen, sm3_cnt);
+}
+
+
+/*F*
+//    Name: ippsSM3Init
+//
+// Purpose: Init SM3
+//
+// Returns:                Reason:
+//    ippStsNullPtrErr        pState == NULL
+//    ippStsNoErr             no errors
+//
+// Parameters:
+//    pState      pointer to the SHA512 state
+//
+*F*/
+IPPFUN(IppStatus, ippsSM3Init,(IppsSM3State* pState))
+{
+   /* test state pointer */
+   IPP_BAD_PTR1_RET(pState);
+   pState = (IppsSM3State*)( IPP_ALIGNED_PTR(pState, SM3_ALIGNMENT) );
+
+   PaddBlock(0, pState, sizeof(IppsSM3State));
+   HASH_CTX_ID(pState) = idCtxSM3;
+   sm3_hashInit(HASH_VALUE(pState));
+   return ippStsNoErr;
+}
+
+/*F*
+//    Name: ippsSM3Update
+//
+// Purpose: Updates intermediate digest based on input stream.
+//
+// Returns:                Reason:
+//    ippStsNullPtrErr        pSrc == NULL
+//                            pState == NULL
+//    ippStsContextMatchErr   pState->idCtx != idCtxSM3
+//    ippStsLengthErr         len <0
+//    ippStsNoErr             no errors
+//
+// Parameters:
+//    pSrc        pointer to the input stream
+//    len         input stream length
+//    pState      pointer to the SM3 state
+//
+*F*/
+IPPFUN(IppStatus, ippsSM3Update,(const Ipp8u* pSrc, int len, IppsSM3State* pState))
+{
+   /* test state pointer and ID */
+   IPP_BAD_PTR1_RET(pState);
+   pState = (IppsSM3State*)( IPP_ALIGNED_PTR(pState, SM3_ALIGNMENT) );
+   IPP_BADARG_RET(idCtxSM3 !=HASH_CTX_ID(pState), ippStsContextMatchErr);
+
+   /* test input length */
+   IPP_BADARG_RET((len<0), ippStsLengthErr);
+   /* test source pointer */
+   IPP_BADARG_RET((len && !pSrc), ippStsNullPtrErr);
+
+   /*
+   // handle non empty message
+   */
+   if(len) {
+      int procLen;
+
+      int idx = HAHS_BUFFIDX(pState);
+      Ipp8u* pBuffer = HASH_BUFF(pState);
+      Ipp64u lenLo = HASH_LENLO(pState) +len;
+
+      /* if non empty internal buffer filling */
+      if(idx) {
+         /* copy from input stream to the internal buffer as match as possible */
+         procLen = IPP_MIN(len, (MBS_SM3-idx));
+         CopyBlock(pSrc, pBuffer+idx, procLen);
+
+         /* update message pointer and length */
+         idx  += procLen;
+         pSrc += procLen;
+         len  -= procLen;
+
+         /* update digest if buffer full */
+         if( MBS_SM3 == idx) {
+            UpdateSM3(HASH_VALUE(pState), pBuffer, MBS_SM3, sm3_cnt);
+            idx = 0;
+         }
+      }
+
+      /* main message part processing */
+      procLen = len & ~(MBS_SM3-1);
+      if(procLen) {
+         UpdateSM3(HASH_VALUE(pState), pSrc, procLen, sm3_cnt);
+         pSrc += procLen;
+         len  -= procLen;
+      }
+
+      /* store rest of message into the internal buffer */
+      if(len) {
+         CopyBlock(pSrc, pBuffer, len);
+         idx += len;
+      }
+
+      /* update length of processed message */
+      HASH_LENLO(pState) = lenLo;
+      HAHS_BUFFIDX(pState) = idx;
+   }
+
+   return ippStsNoErr;
+}
+
+/*F*
+//    Name: ippsSM3Final
+//
+// Purpose: Stop message digesting and return digest.
+//
+// Returns:                Reason:
+//    ippStsNullPtrErr        pState == NULL
+//                            pMD == NULL
+//    ippStsContextMatchErr   pState->idCtx != idCtxSM3
+//    ippStsNoErr             no errors
+//
+// Parameters:
+//    pMD         address of the output digest
+//    pState      pointer to the SM3 state
+//
+*F*/
+IPPFUN(IppStatus, ippsSM3Final,(Ipp8u* pMD, IppsSM3State* pState))
+{
+   /* test state pointer and ID */
+   IPP_BAD_PTR1_RET(pState);
+   pState = (IppsSM3State*)( IPP_ALIGNED_PTR(pState, SM3_ALIGNMENT) );
+   IPP_BADARG_RET(idCtxSM3 !=HASH_CTX_ID(pState), ippStsContextMatchErr);
+
+   /* test digest pointer */
+   IPP_BAD_PTR1_RET(pMD);
+
+   cpFinalizeSM3(HASH_VALUE(pState), HASH_BUFF(pState), HAHS_BUFFIDX(pState), HASH_LENLO(pState));
+   /* convert hash into big endian */
+   ((Ipp32u*)pMD)[0] = ENDIANNESS32(HASH_VALUE(pState)[0]);
+   ((Ipp32u*)pMD)[1] = ENDIANNESS32(HASH_VALUE(pState)[1]);
+   ((Ipp32u*)pMD)[2] = ENDIANNESS32(HASH_VALUE(pState)[2]);
+   ((Ipp32u*)pMD)[3] = ENDIANNESS32(HASH_VALUE(pState)[3]);
+   ((Ipp32u*)pMD)[4] = ENDIANNESS32(HASH_VALUE(pState)[4]);
+   ((Ipp32u*)pMD)[5] = ENDIANNESS32(HASH_VALUE(pState)[5]);
+   ((Ipp32u*)pMD)[6] = ENDIANNESS32(HASH_VALUE(pState)[6]);
+   ((Ipp32u*)pMD)[7] = ENDIANNESS32(HASH_VALUE(pState)[7]);
+
+   /* re-init hash value */
+   HAHS_BUFFIDX(pState) = 0;
+   HASH_LENLO(pState) = 0;
+   sm3_hashInit(HASH_VALUE(pState));
+
+   return ippStsNoErr;
+}
+
+/*
+// available SM3 methods
+*/
+IPPFUN( const IppsHashMethod*, ippsHashMethod_SM3, (void) )
+{
+   static IppsHashMethod method = {
+      ippHashAlg_SM3,
+      IPP_SM3_DIGEST_BITSIZE/8,
+      MBS_SM3,
+      MLR_SM3,
+      sm3_hashInit,
+      sm3_hashUpdate,
+      sm3_hashOctString,
+      sm3_msgRep
+   };
+   return &method;
+}
+
+
+
+#pragma message("IPP_ALG_HASH_SM3 enabled")
+
+#if !((_IPP32E>=_IPP32E_U8) || (_IPP32E==_IPP32E_N8) )
+
+/*
+// SM3 Specific Macros
+// (reference SM3 Cryptographic Hash Algorithm,
+//  Chinese Commercial Cryptography Administration Office, 2010.12)
+*/
+
+/* T1 and T2 are base for additive const generation */
+#define T1  (0x79CC4519)
+#define T2  (0x7A879D8A)
+
+// boolean functions (0<=nr<16)
+#define FF1(x,y,z) ((x)^(y)^(z))
+#define GG1(x,y,z) ((x)^(y)^(z))
+// boolean functions (16<=nr<64)
+#define FF2(x,y,z) (((x)&(y)) | ((x)&(z)) | ((y)&(z)))
+#define GG2(x,y,z) (((x)&(y)) | (~(x)&(z)))
+
+// P0 permutation:
+#define P0(x)  ((x) ^ ROL32((x),9) ^ ROL32((x),17))
+// P1 permutation:
+#define P1(x)  ((x) ^ ROL32((x),15) ^ ROL32((x),23))
+
+// update W
+#define WUPDATE(nr, W) (P1(W[((nr)-16)&15] ^ W[((nr)-9)&15] ^ ROL32(W[((nr)-3)&15],15)) ^ ROL32(W[((nr)-13)&15],7) ^ W[((nr)-6)&15])
+
+// SM3 steps
+#define SM3_STEP1(nr, A,B,C,D,E,F,G,H, Tj, W)  { \
+   TT1 = FF1(A,B,C) + D + (W[nr&15] ^ W[(nr+4)&15]); \
+   TT2 = GG1(E,F,G) + H + W[nr&15]; \
+   H = ROL32(A,12); \
+   D = ROL32(H + E +Tj, 7); \
+   H ^= D; \
+   D += TT2; \
+   H += TT1; \
+   B = ROL32(B, 9); \
+   D = P0(D); \
+   F = ROL32(F, 19); \
+   /*Tj = ROL32(Tj, 1);*/ \
+   W[(nr)&15] = WUPDATE(nr, W); \
+}
+
+#define SM3_STEP2(nr, A,B,C,D,E,F,G,H, Tj, W)  { \
+   TT1 = FF2(A,B,C) + D + (W[nr&15] ^ W[(nr+4)&15]); \
+   TT2 = GG2(E,F,G) + H + W[nr&15]; \
+   H = ROL32(A,12); \
+   D = ROL32(H + E +Tj, 7); \
+   H ^= D; \
+   D += TT2; \
+   H += TT1; \
+   B = ROL32(B, 9); \
+   D = P0(D); \
+   F = ROL32(F, 19); \
+   /*Tj = ROL32(Tj, 1);*/ \
+   W[(nr)&15] = WUPDATE(nr, W); \
+}
+
+#define SM3_STEP3(nr, A,B,C,D,E,F,G,H, Tj, W)  { \
+   TT1 = FF2(A,B,C) + D + (W[nr&15] ^ W[(nr+4)&15]); \
+   TT2 = GG2(E,F,G) + H + W[nr&15]; \
+   H = ROL32(A,12); \
+   D = ROL32(H + E +Tj, 7); \
+   H ^= D; \
+   D += TT2; \
+   H += TT1; \
+   B = ROL32(B, 9); \
+   D = P0(D); \
+   F = ROL32(F, 19); \
+   /*Tj = ROL32(Tj, 1);*/ \
+}
+
+#define COMPACT_SM3_STEP(A,B,C,D,E,F,G,H, FF, GG, W,Tj, r)  { \
+   TT1 = FF((r)&0x30, A,B,C) + D + (W[(r)] ^ W[(r)+4]); \
+   TT2 = GG((r)&0x30, E,F,G) + H + W[(r)]; \
+   \
+   _H = ROL32(A,12); \
+   _D = ROL32(_H + E +Tj[(r)], 7); \
+   _H ^= _D;   \
+   _D += TT2;  \
+   _H += TT1;  \
+   _D = P0(_D);\
+   \
+   H = G; \
+   G = ROL32(F,19); \
+   F = E; \
+   E =_D; \
+   D = C; \
+   C = ROL32(B, 9); \
+   B = A; \
+   A =_H; \
+}
+
+
+/*F*
+//    Name: UpdateSM3
+//
+// Purpose: Update internal hash according to input message stream.
+//
+// Parameters:
+//    uniHash  pointer to in/out hash
+//    mblk     pointer to message stream
+//    mlen     message stream length (multiple by message block size)
+//    uniParam pointer to the optional parameter
+//
+*F*/
+#if defined(_ALG_SM3_COMPACT_)
+#pragma message("SM3 compact")
+
+__INLINE Ipp32u MagicFF(int s, Ipp32u a, Ipp32u b, Ipp32u c)
+{
+   switch(s) {
+      case 0: return FF1(a,b,c);
+      default:return FF2(a,b,c);
+   }
+}
+__INLINE Ipp32u MagicGG(int s, Ipp32u e, Ipp32u f, Ipp32u g)
+{
+   switch(s) {
+      case 0: return GG1(e,f,g);
+      default:return GG2(e,f,g);
+   }
+}
+
+void UpdateSM3(void* uniHash, const Ipp8u* mblk, int mlen, const void* uniParam)
+{
+   Ipp32u* data = (Ipp32u*)mblk;
+
+   Ipp32u* hash = (Ipp32u*)uniHash;
+   Ipp32u* SM3_cnt_loc = (Ipp32u*)uniParam;
+
+   for(; mlen>=MBS_SM3; data += MBS_SM3/sizeof(Ipp32u), mlen -= MBS_SM3) {
+      int r;
+
+      /*
+      // expand message block
+      */
+      Ipp32u W[68];
+      /* initialize the first 16 words in the array W (remember about endian) */
+      for(r=0; r<16; r++) {
+         #if (IPP_ENDIAN == IPP_BIG_ENDIAN)
+         W[r] = data[r];
+         #else
+         W[r] = ENDIANNESS( data[r] );
+         #endif
+      }
+      for(; r<68; r++)
+         W[r] = P1(W[r-16] ^ W[r-9] ^ ROL32(W[r-3],15)) ^ ROL32(W[r-13],7) ^ W[r-6];
+
+      /*
+      // update hash
+      */
+      {
+         /* init A, B, C, D, E, F, G, H by the input hash */
+         Ipp32u A = hash[0];
+         Ipp32u B = hash[1];
+         Ipp32u C = hash[2];
+         Ipp32u D = hash[3];
+         Ipp32u E = hash[4];
+         Ipp32u F = hash[5];
+         Ipp32u G = hash[6];
+         Ipp32u H = hash[7];
+
+         Ipp32u TT1, TT2, _H, _D;
+         for(r=0; r<64; r++)
+            COMPACT_SM3_STEP(A,B,C,D,E,F,G,H, MagicFF,MagicGG, W, SM3_cnt_loc, r);
+
+         /* update hash */
+         hash[0] ^= A;
+         hash[1] ^= B;
+         hash[2] ^= C;
+         hash[3] ^= D;
+         hash[4] ^= E;
+         hash[5] ^= F;
+         hash[6] ^= G;
+         hash[7] ^= H;
+      }
+   }
+}
+
+#else
+void UpdateSM3(void* uniHash, const Ipp8u* mblk, int mlen, const void* uniParam)
+{
+   Ipp32u* data = (Ipp32u*)mblk;
+
+   Ipp32u* hash = (Ipp32u*)uniHash;
+   Ipp32u* SM3_cnt_loc = (Ipp32u*)uniParam;
+
+   for(; mlen>=MBS_SM3; data += MBS_SM3/sizeof(Ipp32u), mlen -= MBS_SM3) {
+
+      /* copy input hash */
+      Ipp32u A = hash[0];
+      Ipp32u B = hash[1];
+      Ipp32u C = hash[2];
+      Ipp32u D = hash[3];
+      Ipp32u E = hash[4];
+      Ipp32u F = hash[5];
+      Ipp32u G = hash[6];
+      Ipp32u H = hash[7];
+
+      Ipp32u W[16];
+      int j;
+
+
+      /* initialize the first 16 words in the array W (remember about endian) */
+      for(j=0; j<16; j++) {
+         #if (IPP_ENDIAN == IPP_BIG_ENDIAN)
+         W[j] = data[j];
+         #else
+         W[j] = ENDIANNESS( data[j] );
+         #endif
+      }
+
+      /* apply compression function */
+      {
+         Ipp32u TT1, TT2;
+         SM3_STEP1( 0,  A,B,C,D,E,F,G,H, SM3_cnt_loc[0], W);
+         SM3_STEP1( 1,  H,A,B,C,D,E,F,G, SM3_cnt_loc[1], W);
+         SM3_STEP1( 2,  G,H,A,B,C,D,E,F, SM3_cnt_loc[2], W);
+         SM3_STEP1( 3,  F,G,H,A,B,C,D,E, SM3_cnt_loc[3], W);
+         SM3_STEP1( 4,  E,F,G,H,A,B,C,D, SM3_cnt_loc[4], W);
+         SM3_STEP1( 5,  D,E,F,G,H,A,B,C, SM3_cnt_loc[5], W);
+         SM3_STEP1( 6,  C,D,E,F,G,H,A,B, SM3_cnt_loc[6], W);
+         SM3_STEP1( 7,  B,C,D,E,F,G,H,A, SM3_cnt_loc[7], W);
+
+         SM3_STEP1( 8,  A,B,C,D,E,F,G,H, SM3_cnt_loc[ 8], W);
+         SM3_STEP1( 9,  H,A,B,C,D,E,F,G, SM3_cnt_loc[ 9], W);
+         SM3_STEP1(10,  G,H,A,B,C,D,E,F, SM3_cnt_loc[10], W);
+         SM3_STEP1(11,  F,G,H,A,B,C,D,E, SM3_cnt_loc[11], W);
+         SM3_STEP1(12,  E,F,G,H,A,B,C,D, SM3_cnt_loc[12], W);
+         SM3_STEP1(13,  D,E,F,G,H,A,B,C, SM3_cnt_loc[13], W);
+         SM3_STEP1(14,  C,D,E,F,G,H,A,B, SM3_cnt_loc[14], W);
+         SM3_STEP1(15,  B,C,D,E,F,G,H,A, SM3_cnt_loc[15], W);
+
+         SM3_STEP2(16,  A,B,C,D,E,F,G,H, SM3_cnt_loc[16], W);
+         SM3_STEP2(17,  H,A,B,C,D,E,F,G, SM3_cnt_loc[17], W);
+         SM3_STEP2(18,  G,H,A,B,C,D,E,F, SM3_cnt_loc[18], W);
+         SM3_STEP2(19,  F,G,H,A,B,C,D,E, SM3_cnt_loc[19], W);
+         SM3_STEP2(20,  E,F,G,H,A,B,C,D, SM3_cnt_loc[20], W);
+         SM3_STEP2(21,  D,E,F,G,H,A,B,C, SM3_cnt_loc[21], W);
+         SM3_STEP2(22,  C,D,E,F,G,H,A,B, SM3_cnt_loc[22], W);
+         SM3_STEP2(23,  B,C,D,E,F,G,H,A, SM3_cnt_loc[23], W);
+
+         SM3_STEP2(24,  A,B,C,D,E,F,G,H, SM3_cnt_loc[24], W);
+         SM3_STEP2(25,  H,A,B,C,D,E,F,G, SM3_cnt_loc[25], W);
+         SM3_STEP2(26,  G,H,A,B,C,D,E,F, SM3_cnt_loc[26], W);
+         SM3_STEP2(27,  F,G,H,A,B,C,D,E, SM3_cnt_loc[27], W);
+         SM3_STEP2(28,  E,F,G,H,A,B,C,D, SM3_cnt_loc[28], W);
+         SM3_STEP2(29,  D,E,F,G,H,A,B,C, SM3_cnt_loc[29], W);
+         SM3_STEP2(30,  C,D,E,F,G,H,A,B, SM3_cnt_loc[30], W);
+         SM3_STEP2(31,  B,C,D,E,F,G,H,A, SM3_cnt_loc[31], W);
+
+         SM3_STEP2(32,  A,B,C,D,E,F,G,H, SM3_cnt_loc[32], W);
+         SM3_STEP2(33,  H,A,B,C,D,E,F,G, SM3_cnt_loc[33], W);
+         SM3_STEP2(34,  G,H,A,B,C,D,E,F, SM3_cnt_loc[34], W);
+         SM3_STEP2(35,  F,G,H,A,B,C,D,E, SM3_cnt_loc[35], W);
+         SM3_STEP2(36,  E,F,G,H,A,B,C,D, SM3_cnt_loc[36], W);
+         SM3_STEP2(37,  D,E,F,G,H,A,B,C, SM3_cnt_loc[37], W);
+         SM3_STEP2(38,  C,D,E,F,G,H,A,B, SM3_cnt_loc[38], W);
+         SM3_STEP2(39,  B,C,D,E,F,G,H,A, SM3_cnt_loc[39], W);
+
+         SM3_STEP2(40,  A,B,C,D,E,F,G,H, SM3_cnt_loc[40], W);
+         SM3_STEP2(41,  H,A,B,C,D,E,F,G, SM3_cnt_loc[41], W);
+         SM3_STEP2(42,  G,H,A,B,C,D,E,F, SM3_cnt_loc[42], W);
+         SM3_STEP2(43,  F,G,H,A,B,C,D,E, SM3_cnt_loc[43], W);
+         SM3_STEP2(44,  E,F,G,H,A,B,C,D, SM3_cnt_loc[44], W);
+         SM3_STEP2(45,  D,E,F,G,H,A,B,C, SM3_cnt_loc[45], W);
+         SM3_STEP2(46,  C,D,E,F,G,H,A,B, SM3_cnt_loc[46], W);
+         SM3_STEP2(47,  B,C,D,E,F,G,H,A, SM3_cnt_loc[47], W);
+
+         SM3_STEP2(48,  A,B,C,D,E,F,G,H, SM3_cnt_loc[48], W);
+         SM3_STEP2(49,  H,A,B,C,D,E,F,G, SM3_cnt_loc[49], W);
+         SM3_STEP2(50,  G,H,A,B,C,D,E,F, SM3_cnt_loc[50], W);
+         SM3_STEP2(51,  F,G,H,A,B,C,D,E, SM3_cnt_loc[51], W);
+         SM3_STEP3(52,  E,F,G,H,A,B,C,D, SM3_cnt_loc[52], W);
+         SM3_STEP3(53,  D,E,F,G,H,A,B,C, SM3_cnt_loc[53], W);
+         SM3_STEP3(54,  C,D,E,F,G,H,A,B, SM3_cnt_loc[54], W);
+         SM3_STEP3(55,  B,C,D,E,F,G,H,A, SM3_cnt_loc[55], W);
+
+         SM3_STEP3(56,  A,B,C,D,E,F,G,H, SM3_cnt_loc[56], W);
+         SM3_STEP3(57,  H,A,B,C,D,E,F,G, SM3_cnt_loc[57], W);
+         SM3_STEP3(58,  G,H,A,B,C,D,E,F, SM3_cnt_loc[58], W);
+         SM3_STEP3(59,  F,G,H,A,B,C,D,E, SM3_cnt_loc[59], W);
+         SM3_STEP3(60,  E,F,G,H,A,B,C,D, SM3_cnt_loc[60], W);
+         SM3_STEP3(61,  D,E,F,G,H,A,B,C, SM3_cnt_loc[61], W);
+         SM3_STEP3(62,  C,D,E,F,G,H,A,B, SM3_cnt_loc[62], W);
+         SM3_STEP3(63,  B,C,D,E,F,G,H,A, SM3_cnt_loc[63], W);
+      }
+      /* update hash */
+      hash[0] ^= A;
+      hash[1] ^= B;
+      hash[2] ^= C;
+      hash[3] ^= D;
+      hash[4] ^= E;
+      hash[5] ^= F;
+      hash[6] ^= G;
+      hash[7] ^= H;
+   }
+}
+#endif
+
+#endif /* _PX/_W7/_T7, _MX/_M7 versions */

--- a/BootloaderCommonPkg/Library/IppCryptoLib/sha384.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/sha384.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -14,12 +14,11 @@
 
 #include <Library/CryptoLib.h>
 
-Ipp8u* Sha256 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
+Ipp8u* Sha384 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
 {
   #if (FixedPcdGet8(PcdIppHashLibSupported) & 0x2)
   {
-
-    ippsHashMessage_rmf(pMsg, msgLen, pMD, ippsHashMethod_SHA256 ());
+    ippsHashMessage_rmf(pMsg, msgLen, pMD, ippsHashMethod_SHA384 ());
     return pMD;
   }
   #else
@@ -31,7 +30,7 @@ Ipp8u* Sha256 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
 }
 
 /**
-  Initializes the hash context for SHA256 hashing.
+  Initializes the hash context for SHA384 hashing.
 
   @param[in]   HashCtx       Pointer to the hash context buffer.
   @param[in]   HashCtxSize   Length of the hash context.
@@ -41,7 +40,7 @@ Ipp8u* Sha256 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
-Sha256Init (
+Sha384Init (
   IN      HASH_CTX   *HashCtx,
   IN      Ipp32u      HashCtxSize
   )
@@ -52,7 +51,7 @@ Sha256Init (
       return RETURN_BUFFER_TOO_SMALL;
     }
 
-    if (ippsHashInit_rmf((IppsHashState_rmf*)HashCtx, ippsHashMethod_SHA256 ()) == ippStsNoErr) {
+    if (ippsHashInit_rmf((IppsHashState_rmf*)HashCtx, ippsHashMethod_SHA384 ()) == ippStsNoErr) {
       return RETURN_SUCCESS;
     }
 
@@ -66,7 +65,7 @@ Sha256Init (
 }
 
 /**
-  Consumes the data for SHA256 hashing.
+  Consumes the data for SHA384 hashing.
   This method can be called multiple times to hash separate pieces of data.
 
   @param[in]   HashCtx     Pointer to the hash context buffer.
@@ -77,7 +76,7 @@ Sha256Init (
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
-Sha256Update (
+Sha384Update (
   IN        HASH_CTX   *HashCtx,
   IN CONST  Ipp8u      *Msg,
   IN        Ipp32u      MsgLen
@@ -93,23 +92,23 @@ Sha256Update (
   }
   #else
   {
-    return RETURN_UNSUPPORTED;
+      return RETURN_UNSUPPORTED;
   }
   #endif
 }
 
 
 /**
-  Finalizes the SHA256 hashing and returns the hash.
+  Finalizes the SHA384 hashing and returns the hash.
 
   @param[in]   HashCtx     Pointer to the hash context buffer.
-  @param[out]  Hash        Sha256 hash of the data.
+  @param[out]  Hash        Sha384 hash of the data.
 
   @retval  RETURN_SUCCESS             Success.
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
-Sha256Final (
+Sha384Final (
   IN       HASH_CTX   *HashCtx,
   OUT      Ipp8u      *Hash
   )

--- a/BootloaderCommonPkg/Library/IppCryptoLib/sm3.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/sm3.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -14,12 +14,11 @@
 
 #include <Library/CryptoLib.h>
 
-Ipp8u* Sha256 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
+Ipp8u* Sm3 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
 {
-  #if (FixedPcdGet8(PcdIppHashLibSupported) & 0x2)
+  #if (FixedPcdGet8(PcdIppHashLibSupported) & 0x8)
   {
-
-    ippsHashMessage_rmf(pMsg, msgLen, pMD, ippsHashMethod_SHA256 ());
+    ippsHashMessage_rmf(pMsg, msgLen, pMD, ippsHashMethod_SM3 ());
     return pMD;
   }
   #else
@@ -31,7 +30,7 @@ Ipp8u* Sha256 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
 }
 
 /**
-  Initializes the hash context for SHA256 hashing.
+  Initializes the hash context for Sm3 hashing.
 
   @param[in]   HashCtx       Pointer to the hash context buffer.
   @param[in]   HashCtxSize   Length of the hash context.
@@ -41,18 +40,18 @@ Ipp8u* Sha256 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
-Sha256Init (
+Sm3Init (
   IN      HASH_CTX   *HashCtx,
   IN      Ipp32u      HashCtxSize
   )
 {
-  #if (FixedPcdGet8(PcdIppHashLibSupported) & 0x2)
+  #if (FixedPcdGet8(PcdIppHashLibSupported) & 0x8)
   {
     if (HashCtxSize < sizeof(IppsHashState_rmf)) {
       return RETURN_BUFFER_TOO_SMALL;
     }
 
-    if (ippsHashInit_rmf((IppsHashState_rmf*)HashCtx, ippsHashMethod_SHA256 ()) == ippStsNoErr) {
+    if (ippsHashInit_rmf((IppsHashState_rmf*)HashCtx, ippsHashMethod_SM3 ()) == ippStsNoErr) {
       return RETURN_SUCCESS;
     }
 
@@ -66,7 +65,7 @@ Sha256Init (
 }
 
 /**
-  Consumes the data for SHA256 hashing.
+  Consumes the data for Sm3 hashing.
   This method can be called multiple times to hash separate pieces of data.
 
   @param[in]   HashCtx     Pointer to the hash context buffer.
@@ -77,13 +76,14 @@ Sha256Init (
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
-Sha256Update (
+Sm3Update (
   IN        HASH_CTX   *HashCtx,
   IN CONST  Ipp8u      *Msg,
   IN        Ipp32u      MsgLen
   )
 {
-  #if (FixedPcdGet8(PcdIppHashLibSupported) & 0x2)
+
+  #if (FixedPcdGet8(PcdIppHashLibSupported) & 0x8)
   {
     if (ippsHashUpdate_rmf(Msg, MsgLen, (IppsHashState_rmf*)HashCtx) == ippStsNoErr) {
       return RETURN_SUCCESS;
@@ -100,21 +100,21 @@ Sha256Update (
 
 
 /**
-  Finalizes the SHA256 hashing and returns the hash.
+  Finalizes the Sm3 hashing and returns the hash.
 
   @param[in]   HashCtx     Pointer to the hash context buffer.
-  @param[out]  Hash        Sha256 hash of the data.
+  @param[out]  Hash        Sm3 hash of the data.
 
   @retval  RETURN_SUCCESS             Success.
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
-Sha256Final (
+Sm3Final (
   IN       HASH_CTX   *HashCtx,
   OUT      Ipp8u      *Hash
   )
 {
-  #if (FixedPcdGet8(PcdIppHashLibSupported) & 0x2)
+  #if (FixedPcdGet8(PcdIppHashLibSupported) & 0x8)
   {
     if (ippsHashFinal_rmf(Hash, (IppsHashState_rmf*)HashCtx) == ippStsNoErr) {
       return RETURN_SUCCESS;

--- a/BootloaderCommonPkg/Library/TpmLib/Tpm2Help.c
+++ b/BootloaderCommonPkg/Library/TpmLib/Tpm2Help.c
@@ -12,6 +12,7 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
+#include <Library/CryptoLib.h>
 
 typedef struct {
   TPMI_ALG_HASH              HashAlgo;

--- a/BootloaderCommonPkg/Library/TpmLib/TpmLib.inf
+++ b/BootloaderCommonPkg/Library/TpmLib/TpmLib.inf
@@ -41,6 +41,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdTcgLogAreaMinLen          ## CONSUMES
   gPlatformCommonLibTokenSpaceGuid.PcdTpmLibId                  ## CONSUMES
   gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled       ## CONSUMES
+  gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashType      ## CONSUMES
 
 [LibraryClasses]
   BaseLib

--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -112,6 +112,7 @@
 
   gPlatformModuleTokenSpaceGuid.PcdSmbiosTablesSize       |     0x1000 | UINT16 | 0x200000E3
 
+
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   #
   # For module patchable PCDs, if it is required to do static patching during the build

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -247,6 +247,24 @@
   gPlatformCommonLibTokenSpaceGuid.PcdUsbKeyboardPollingTimeout | $(USB_KB_POLLING_TIMEOUT)
   gPlatformCommonLibTokenSpaceGuid.PcdLowestSupportedFwVer		| $(LOWEST_SUPPORTED_FW_VER)
 
+  !if $(RSA_SIGN_TYPE) == RSA2048
+    gPlatformCommonLibTokenSpaceGuid.PcdRsaSignType | 0x0
+  !elseif $(RSA_SIGN_TYPE) == RSA3072
+    gPlatformCommonLibTokenSpaceGuid.PcdRsaSignType | 0x1
+  !endif
+
+  !if $(SIGN_HASH_TYPE) == SHA2_256
+    gPlatformCommonLibTokenSpaceGuid.PcdSignHashType | 0x0
+  !elseif $(SIGN_HASH_TYPE) == SHA2_384
+    gPlatformCommonLibTokenSpaceGuid.PcdSignHashType | 0x1
+  !elseif $(SIGN_HASH_TYPE) == SHA2_512
+    gPlatformCommonLibTokenSpaceGuid.PcdSignHashType | 0x2
+  !elseif $(SIGN_HASH_TYPE) == SM3_256
+    gPlatformCommonLibTokenSpaceGuid.PcdSignHashType | 0x3
+  !endif
+
+  gPlatformCommonLibTokenSpaceGuid.PcdIppHashLibSupported    | 0xB
+
 [PcdsPatchableInModule]
   gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel   | 0x8000004F
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress  | $(PCI_EXPRESS_BASE)
@@ -309,6 +327,17 @@
 
 [PcdsDynamicDefault]
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut         | 2
+
+  !if $(MEASURED_BOOT_HASH_TYPE) == SHA2_256
+    gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashType | 0x0
+  !elseif $(MEASURED_BOOT_HASH_TYPE) == SHA2_384
+    gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashType | 0x1
+  !elseif $(MEASURED_BOOT_HASH_TYPE) == SHA2_512
+    gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashType | 0x2
+  !elseif $(MEASURED_BOOT_HASH_TYPE) == SM3_256
+    gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashType | 0x3
+  !endif
+  
 
 ###############################################################################
 ##

--- a/BootloaderCorePkg/Include/HashStore.h
+++ b/BootloaderCorePkg/Include/HashStore.h
@@ -9,7 +9,12 @@
 #define __HASH_STORE_H__
 
 #define  HASH_STORE_SIGNATURE                SIGNATURE_32('_', 'H', 'S', '_')
-#define  HASH_STORE_DIGEST_LENGTH            32
+
+#if (FixedPcdGet8(PcdSignHashType) != 0x0)  //0x0 SHA265
+	#define  HASH_STORE_DIGEST_LENGTH            48
+#else
+	#define  HASH_STORE_DIGEST_LENGTH            32
+#endif
 
 #define  HASH_INDEX_MAX_NUM                  8
 

--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -66,7 +66,7 @@ typedef struct {
   UINT32        CarTop;
   UINT32        PayloadBase;
   UINT8         ConfigDataHashValid;
-  UINT8         ConfigDataHash[32];
+  UINT8         ConfigDataHash[48];  //Set size for max supported size - SHA384 length
 } STAGE1B_HOB;
 
 typedef struct {

--- a/BootloaderCorePkg/Library/BootloaderLib/BootloaderLib.c
+++ b/BootloaderCorePkg/Library/BootloaderLib/BootloaderLib.c
@@ -37,6 +37,8 @@ GetComponentHash (
   HASH_STORE_TABLE    *HashStorePtr;
   UINT8                HashIndex;
 
+  DEBUG ((DEBUG_INFO, "++Bootloaderlib: GetComponentHash %d\n",ComponentType));
+
   if (HashData == NULL) {
     return RETURN_INVALID_PARAMETER;
   }
@@ -83,6 +85,9 @@ SetComponentHash (
   if (HashData == NULL) {
     return RETURN_INVALID_PARAMETER;
   }
+
+  DEBUG ((DEBUG_INFO, "++Bootloaderlib: SetComponentHash %d\n",ComponentType));
+
 
   HashIndex = ComponentType;
   LdrGlobal = GetLoaderGlobalDataPointer ();

--- a/BootloaderCorePkg/Stage1A/Stage1A.h
+++ b/BootloaderCorePkg/Stage1A/Stage1A.h
@@ -16,6 +16,7 @@
 #include <Library/BootloaderCoreLib.h>
 #include <Library/LoaderLib.h>
 #include <Library/SecureBootLib.h>
+#include <Library/CryptoLib.h>
 #include <Library/DecompressLib.h>
 #include <Library/TimeStampLib.h>
 #include <Library/ConfigDataLib.h>

--- a/BootloaderCorePkg/Stage1B/Stage1B.inf
+++ b/BootloaderCorePkg/Stage1B/Stage1B.inf
@@ -97,6 +97,9 @@
   gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootEnabled
   gPlatformModuleTokenSpaceGuid.PcdEarlyLogBufferSize
   gPlatformModuleTokenSpaceGuid.PcdLogBufferSize
+  gPlatformCommonLibTokenSpaceGuid.PcdRsaSignType
+  gPlatformCommonLibTokenSpaceGuid.PcdSignHashType
+  gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashType
 
 [Depex]
   TRUE

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -60,6 +60,8 @@ PreparePayload (
   UINT8                          BootMode;
   UINT8                          HashIdx;
   COMPONENT_ENTRY               *ComponentEntry;
+  BOOLEAN                        MbHashCalcReq;
+
 
   // Load payload to PcdPayloadLoadBase.
   PayloadId   = GetPayloadId ();
@@ -111,7 +113,10 @@ PreparePayload (
         }
       }
     }
-    TpmExtendStageHash (HashIdx);
+
+    //TO-DO: PcdSignHashType has to be retrived from Hash Store
+    MbHashCalcReq = (FixedPcdGet8(PcdSignHashType) != PcdGet8(PcdMeasuredBootHashType)) ? TRUE : FALSE;
+    TpmExtendStageHash (HashIdx, ComponentName, MbHashCalcReq);
     AddMeasurePoint (0x3150);
   }
 

--- a/BootloaderCorePkg/Stage2/Stage2.inf
+++ b/BootloaderCorePkg/Stage2/Stage2.inf
@@ -131,6 +131,9 @@
   gPlatformModuleTokenSpaceGuid.PcdSmbiosTablesSize
   gPlatformModuleTokenSpaceGuid.PcdSmbiosEnabled
   gPlatformModuleTokenSpaceGuid.PcdLinuxPayloadEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdSignHashType
+  gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashType
+
 
 [Depex]
   TRUE

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -137,6 +137,10 @@ class BaseBoard(object):
 		self._IAS_PRIVATE_KEY       = os.path.join(key_dir, 'TestSigningPrivateKey.pem')
 		self.LOGO_FILE              = 'Platform/CommonBoardPkg/Logo/Logo.bmp'
 
+		self.RSA_SIGN_TYPE						= 'RSA2048'
+		self.SIGN_HASH_TYPE						= 'SHA2_256'
+		self.MEASURED_BOOT_HASH_TYPE	= 'SHA2_256'
+
 		self.VERINFO_IMAGE_ID       = 'SB_???? '
 		self.VERINFO_PROJ_ID        = 1
 		self.VERINFO_CORE_MAJOR_VER = 0

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -853,6 +853,8 @@ AuthenticateCapsule (
   UINT8                     *Signature;
   FW_UPDATE_STATUS          FwUpdStatus;
   UINT32                    FwUpdStatusOffset;
+  UINT8 RsaSignType, SignHashType;
+
 
   FwUpdStatusOffset = PcdGet32(PcdFwUpdStatusBase);
 
@@ -900,7 +902,11 @@ AuthenticateCapsule (
     }
   }
 
-  Status    = DoRsaVerify (FwImage, Header->SignatureOffset, COMP_TYPE_PUBKEY_FWU, Signature, Key, NULL, NULL);
+  //TO-DO: RsaSignType & SignHashType hash info has to be retrivied from container header
+  RsaSignType = FixedPcdGet8(PcdRsaSignType);
+  SignHashType = FixedPcdGet8(PcdSignHashType);
+
+  Status    = DoRsaVerify (FwImage, Header->SignatureOffset, COMP_TYPE_PUBKEY_FWU, Signature, Key, NULL, RsaSignType, SignHashType, NULL);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "Image verification failed, %r!\n", Status));
     return EFI_SECURITY_VIOLATION;

--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -427,8 +427,12 @@ LoadAndSetupImage (
     }
     if (FeaturePcdGet (PcdMeasuredBootEnabled) && (LoaderPlatformInfo->LdrFeatures & FEATURE_MEASURED_BOOT)) {
       // Extend hash of the image into TPM.
-      TpmExtendPcrAndLogEvent ( 8, TPM_ALG_SHA256, LoadedImage->ImageHash,
-        EV_COMPACT_HASH, sizeof("LinuxLoaderPkg: OS Image"), (UINT8 *)"LinuxLoaderPkg: OS Image");
+      TpmExtendPcrAndLogEvent ( 8, 
+        (TPMI_ALG_HASH) GetTpmHashAlgEnabled(),  //To-Do: Hash alogrithm should be retrived from IasImage header?
+        LoadedImage->ImageHash,
+        EV_COMPACT_HASH,
+        sizeof("LinuxLoaderPkg: OS Image"),
+        (UINT8 *)"LinuxLoaderPkg: OS Image");
     }
   }
   return Status;

--- a/PayloadPkg/OsLoader/OsLoader.inf
+++ b/PayloadPkg/OsLoader/OsLoader.inf
@@ -104,6 +104,7 @@
   gPayloadTokenSpaceGuid.PcdGrubBootCfgEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdContainerBootEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdPreOsCheckerEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashType
 
 [Depex]
   TRUE


### PR DESCRIPTION
Ported IPP SHA384 and SM3 algorithms to IPP Crytop Lib.

Added dynamic PcdMeasuredBootHashType and it would be 
updated based on Config data hash. 

Hooks added for PcdRsaSignType, PcdSignHashType.

Secureboot lib: Updated interfaces for hash and signing mechanism
TpmLib: Interfaces to support measured boot based on selected TPM hash