### PR TITLE
[APL] Update FSP to MR6 (#392)

### DIFF
--- a/Silicon/ApollolakePkg/FspBin/FspBin.inf
+++ b/Silicon/ApollolakePkg/FspBin/FspBin.inf
@@ -10,7 +10,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/IntelFsp/FSP.git
-  COMMIT  = 7431e4f3399a5081c956753b5fa3bcd764196723
+  COMMIT  = 7222054e9b7fc2d021fc404f87b4719d99b4c8ec
 
 [UserExtensions.SBL."CopyList"]
   ApolloLakeFspBinPkg/FspBin/Fsp.fd     : Silicon/ApollolakePkg/FspBin/FspDbg.bin


### PR DESCRIPTION
There is an issue with Vbt.bin in MR5; MR6 has this fixed.

Test: compiles OK, boots Linux OK.

Signed-off-by: Ursula Maplehurst <ursula@kangatronix.co.uk>