### PR TITLE
Silicon init with eMMC HS400 mode config

### DIFF
--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1019,6 +1019,9 @@ UpdateFspConfig (
   FspsConfig->SdioEnabled                 = (UINT8)DevEnCfgData->DevEnControl1.SdioEnable;
   FspsConfig->SmbusEnable                 = (UINT8)DevEnCfgData->DevEnControl1.SmbusEnable;
 
+  // Set HS200 if HS400 is disabled. No DDR50 in scope.
+  FspsConfig->eMMCHostMaxSpeed            = (UINT8)((FeaturePcdGet (PcdEmmcHs400SupportEnabled) != 0) ? 0 : 1);
+
   FspsConfig->PortUsb20Enable[0]          = (UINT8)DevEnCfgData->DevEnControl2.Usb20Port0Enable;
   FspsConfig->PortUsb20Enable[1]          = (UINT8)DevEnCfgData->DevEnControl2.Usb20Port1Enable;
   FspsConfig->PortUsb20Enable[2]          = (UINT8)DevEnCfgData->DevEnControl2.Usb20Port2Enable;

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -98,3 +98,4 @@
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegBase
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegSize
   gPlatformModuleTokenSpaceGuid.PcdFuncCpuInitHook
+  gPlatformCommonLibTokenSpaceGuid.PcdEmmcHs400SupportEnabled

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1327,7 +1327,7 @@ UpdateFspConfig (
   FspsUpd->FspsConfig.Enable8254ClockGatingOnS3 = 0;
 
   FspsUpd->FspsConfig.ScsEmmcEnabled      = 1;
-  FspsUpd->FspsConfig.ScsEmmcHs400Enabled = 1;
+  FspsUpd->FspsConfig.ScsEmmcHs400Enabled = (UINT8)((FeaturePcdGet (PcdEmmcHs400SupportEnabled) != 0) ? 1 : 0);
   FspsUpd->FspsConfig.ScsSdCardEnabled    = 0;
   FspsUpd->FspsConfig.ScsUfsEnabled       = 0;
 

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -81,3 +81,4 @@
   gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsCnt
   gPlatformModuleTokenSpaceGuid.PcdSmbiosTablesBase
   gPlatformModuleTokenSpaceGuid.PcdSmbiosEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdEmmcHs400SupportEnabled


### PR DESCRIPTION
This patch is a follow-up patch of #380. If a platform disables HS400 mode,
silicon init code will configure eMMC in HS200. Other modes not in scope.

This will also fix #406.

Signed-off-by: Aiden Park <aiden.park@intel.com>