### PR TITLE
Replace ASSERT macro in DebugLib for klocwork scanning

### DIFF
--- a/MdePkg/Include/Library/DebugLib.h
+++ b/MdePkg/Include/Library/DebugLib.h
@@ -289,10 +289,14 @@ DebugPrintLevelEnabled (
   @param  Expression  Boolean expression that evaluated to FALSE
 
 **/
-#ifdef LITE_PRINT
-#define _ASSERT(Expression)  DebugAssert (gEfiCallerBaseName, __LINE__, "")
+#ifdef __KLOCWORK__
+  #define _ASSERT(Expression)    do { if (!(Expression)) abort(); } while (0)
 #else
-#define _ASSERT(Expression)  DebugAssert (__FILE__, __LINE__, #Expression)
+  #ifdef LITE_PRINT
+    #define _ASSERT(Expression)  DebugAssert (gEfiCallerBaseName, __LINE__, "")
+  #else
+    #define _ASSERT(Expression)  DebugAssert (__FILE__, __LINE__, #Expression)
+  #endif
 #endif
 
 /**
@@ -332,18 +336,22 @@ DebugPrintLevelEnabled (
   @param  Expression  Boolean expression.
 
 **/
-#if !defined(MDEPKG_NDEBUG)
-  #define ASSERT(Expression)        \
-    do {                            \
-      if (DebugAssertEnabled ()) {  \
-        if (!(Expression)) {        \
-          _ASSERT (Expression);     \
-          ANALYZER_UNREACHABLE ();  \
-        }                           \
-      }                             \
-    } while (FALSE)
+#ifdef __KLOCWORK__
+  #define ASSERT(Expression)    _ASSERT (Expression)
 #else
-  #define ASSERT(Expression)
+  #if !defined(MDEPKG_NDEBUG)
+    #define ASSERT(Expression)        \
+      do {                            \
+        if (DebugAssertEnabled ()) {  \
+          if (!(Expression)) {        \
+            _ASSERT (Expression);     \
+            ANALYZER_UNREACHABLE ();  \
+          }                           \
+        }                             \
+      } while (FALSE)
+  #else
+    #define ASSERT(Expression)
+  #endif
 #endif
 
 /**


### PR DESCRIPTION
This patch replace the standard ASSERT macro with klocwork specific
implementation as indicated on:
  https://docs.roguewave.com/en/klocwork/current/tuningccanalysis
This can provide hints to klocwork scanning on the ASSERT() statement
so as to avoid false positives.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>