### PR TITLE
Add FS (File System) shell command

### DIFF
--- a/BootloaderCommonPkg/Include/Library/Ext23Lib.h
+++ b/BootloaderCommonPkg/Include/Library/Ext23Lib.h
@@ -129,4 +129,22 @@ ExtFsCloseFile (
   IN  EFI_HANDLE                                  FileHandle
   );
 
+/**
+  List directories or files
+
+  @param[in]     FsHandle         file system handle.
+  @param[in]     DirFilePath      directory or file path
+
+  @retval EFI_SUCCESS             list directories of files successfully
+  @retval EFI_UNSUPPORTED         this api is not supported
+  @retval Others                  an error occurs
+
+**/
+EFI_STATUS
+EFIAPI
+ExtFsListDir (
+  IN  EFI_HANDLE                                  FsHandle,
+  IN  CHAR16                                     *DirFilePath
+  );
+
 #endif // _EXT23_LIB_H_

--- a/BootloaderCommonPkg/Include/Library/FatLib.h
+++ b/BootloaderCommonPkg/Include/Library/FatLib.h
@@ -129,4 +129,22 @@ FatFsCloseFile (
   IN  EFI_HANDLE                                  FileHandle
   );
 
+/**
+  List directories or files
+
+  @param[in]     FsHandle         file system handle.
+  @param[in]     DirFilePath      directory or file path
+
+  @retval EFI_SUCCESS             list directories of files successfully
+  @retval EFI_UNSUPPORTED         this api is not supported
+  @retval Others                  an error occurs
+
+**/
+EFI_STATUS
+EFIAPI
+FatFsListDir (
+  IN  EFI_HANDLE                                  FsHandle,
+  IN  CHAR16                                     *DirFilePath
+  );
+
 #endif // _FAT_LIB_H_

--- a/BootloaderCommonPkg/Include/Library/FileSystemLib.h
+++ b/BootloaderCommonPkg/Include/Library/FileSystemLib.h
@@ -128,6 +128,55 @@ VOID
   );
 
 /**
+  List directories or files
+
+  @param[in]     FsHandle         file system handle.
+  @param[in]     DirFilePath      directory or file path
+
+  @retval EFI_SUCCESS             list directories of files successfully
+  @retval EFI_UNSUPPORTED         this api is not supported
+  @retval Others                  an error occurs
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *FS_LIST_DIR) (
+  IN  EFI_HANDLE                                  FsHandle,
+  IN  CHAR16                                     *DirFilePath
+  );
+
+/**
+  Get SW partition no. of detected file system
+
+  @param[in]     FsHandle               file system handle.
+  @param[out]    SwPartNo               sw part no.
+
+  @retval        EFI_SUCCESS            found sw part no.
+  @retval        EFI_INVALID_PARAMETER  Invalid FsHandle
+
+**/
+EFI_STATUS
+EFIAPI
+GetFileSystemCurrentPartNo (
+  IN  EFI_HANDLE                                    FsHandle,
+  OUT UINT32                                       *SwPartNo
+  );
+
+/**
+  Get detected file system type
+
+  @param[in]     FsHandle             file system handle.
+
+  @retval        OS_FILE_SYSTEM_TYPE  file system type enum
+
+**/
+OS_FILE_SYSTEM_TYPE
+EFIAPI
+GetFileSystemType (
+  IN  EFI_HANDLE                                    FsHandle
+  );
+
+/**
   Initialize file systems.
 
   @param[in]     SwPart           Software partition index.
@@ -240,6 +289,24 @@ CloseFile (
   IN  EFI_HANDLE                                  FileHandle
   );
 
+/**
+  List directories or files
+
+  @param[in]     FsHandle         file system handle.
+  @param[in]     DirFilePath      directory or file path
+
+  @retval EFI_SUCCESS             list directories of files successfully
+  @retval EFI_UNSUPPORTED         this api is not supported
+  @retval Others                  an error occurs
+
+**/
+EFI_STATUS
+EFIAPI
+ListDir (
+  IN  EFI_HANDLE                                  FsHandle,
+  IN  CHAR16                                     *DirFilePath
+  );
+
 typedef struct {
   FS_INIT_FILE_SYSTEM                 InitFileSystem;
   FS_CLOSE_FILE_SYSTEM                CloseFileSystem;
@@ -247,6 +314,7 @@ typedef struct {
   FS_GET_FILE_SIZE                    GetFileSize;
   FS_READ_FILE                        ReadFile;
   FS_CLOSE_FILE                       CloseFile;
+  FS_LIST_DIR                         ListDir;
 } FILE_SYSTEM_FUNC;
 
 #endif // _FAT_PEIM_H_

--- a/BootloaderCommonPkg/Include/Library/PartitionLib.h
+++ b/BootloaderCommonPkg/Include/Library/PartitionLib.h
@@ -19,12 +19,12 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define  GPT_MAX_NUM_PARTITIONS   128
 
-enum {
+typedef enum {
   EnumPartTypeUnknown = 0,
   EnumPartTypeMbr,
   EnumPartTypeGpt,
   EnumPartTypeMax
-};
+} PARTITION_TYPE;
 
 //
 // The block device
@@ -100,6 +100,37 @@ VOID
 EFIAPI
 ClosePartitions (
   IN   EFI_HANDLE             PartHandle
+  );
+
+/**
+  Get detected partition type
+
+  @param[in]  PartHandle      The partition handle to clean-up
+
+  @retval                     Partition type enum
+
+**/
+PARTITION_TYPE
+EFIAPI
+GetPartitionType (
+  IN   EFI_HANDLE             PartHandle
+  );
+
+/**
+  Get HW part no of the detected partition
+
+  @param[in]  PartHandle              The partition handle to clean-up
+  @param[in]  HwPartNo                HW part no.
+
+  @retval     EFI_SUCCESS             Found SW part no.
+  @retval     EFI_INVALID_PARAMETER   Invalid PartHandle
+
+**/
+EFI_STATUS
+EFIAPI
+GetPartitionCurrentPartNo (
+  IN  EFI_HANDLE            PartHandle,
+  OUT UINT32               *HwPartNo
   );
 
 #endif

--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext23Lib.inf
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext23Lib.inf
@@ -24,6 +24,7 @@
 [Sources]
   ExtLib.c
   Ext2Fs.c
+  Ext2FsLs.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.c
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.c
@@ -97,19 +97,6 @@
 #endif
 
 /**
- Read a new inode into a FILE structure.
- @param [in] INumber inode number
- @param [in] File pointer to open file struct.
- @retval
-**/
-STATIC
-INT32
-ReadInode (
-  IN    INODE32      INumber,
-  IN    OPEN_FILE   *File
-  );
-
-/**
   Given an offset in a FILE, find the disk block number that
   contains that block.
   @param File           pointer to an Open file.
@@ -124,21 +111,6 @@ BlockMap (
   OPEN_FILE     *File,
   INDPTR         FileBlock,
   INDPTR        *DiskBlockPtr
-  );
-
-/**
-  Read a portion of a FILE into an internal buffer.
-  Return the location in the buffer and the amount in the buffer.
-  @param File       Pointer to the open file.
-  @param BufferPtr  buffer corresponding to offset
-  @param SizePtr    Size of remainder of buffer.
-**/
-STATIC
-INT32
-BufReadFile (
-  OPEN_FILE     *File,
-  CHAR8        **BufferPtr,
-  UINT32        *SizePtr
   );
 
 /**
@@ -212,7 +184,6 @@ BDevStrategy (
  @param [in] File pointer to open file struct.
  @retval
 **/
-STATIC
 INT32
 ReadInode (
   IN    INODE32      INumber,
@@ -456,7 +427,6 @@ BlockMap (
   @param BufferPtr  buffer corresponding to offset
   @param SizePtr    Size of remainder of buffer.
 **/
-STATIC
 INT32
 BufReadFile (
   OPEN_FILE     *File,
@@ -576,6 +546,7 @@ SearchDirectory (
         // found entry
         //
         *INumPtr = Dp->Ext2DirectInodeNumber;
+        File->FileNamePtr = Name;
         return 0;
       }
     }

--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.c
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.c
@@ -99,58 +99,64 @@
 /**
   Given an offset in a FILE, find the disk block number that
   contains that block.
-  @param File           pointer to an Open file.
-  @param FileBlock      Block to find the file.
-  @param DiskBlockPtr   Pointer to the disk which contains block.
+
+  @param[in]  File            pointer to an Open file.
+  @param[in]  FileBlock       Block to find the file.
+  @param[out] DiskBlockPtr    Pointer to the disk which contains block.
+
   @retval 0 if success
   @retval other if error.
 **/
 STATIC
 INT32
 BlockMap (
-  OPEN_FILE     *File,
-  INDPTR         FileBlock,
-  INDPTR        *DiskBlockPtr
+  IN  OPEN_FILE     *File,
+  IN  INDPTR         FileBlock,
+  OUT INDPTR        *DiskBlockPtr
   );
 
 /**
-  Search a directory for a Name and return its
-  inode number.
-  @param Name       Name to compare with
-  @param Length     Length of the dir name
-  @param File       Pointer to file private data
-  @param INumPtr    pointer to Inode number.
+  Search a directory for a Name and return its inode number.
+
+  @param[in]      Name        Name to compare with
+  @param[in]      Length      Length of the dir name
+  @param[in/out]  File        Pointer to file private data
+  @param[out]     INumPtr     pointer to Inode number.
+
+  @retval 0 if success
+  @retval other if error.
 **/
 STATIC
 INT32
 SearchDirectory (
-  CHAR8         *Name,
-  INT32          Length,
-  OPEN_FILE     *File,
-  INODE32       *INumPtr
+  IN      CHAR8         *Name,
+  IN      INT32          Length,
+  IN OUT  OPEN_FILE     *File,
+  OUT     INODE32       *INumPtr
   );
 
 /**
-Gives the info of device block config.
+  Gives the info of device block config.
 
-@param  DevData     Device privete data.
-@param  ReadWrite   Read write
-@param  BlockNum    Block number to start
-@param  Size        Size to read block.
-@param  Buf         Buffer to read the block data.
-@param  RSize
+  @param[in]    DevData     Device privete data.
+  @param[in]    ReadWrite   Read or Write
+  @param[in]    BlockNum    Block number to start
+  @param[in]    Size        Size to read block.
+  @param[out]   Buf         Buffer to read the block data.
+  @param[out]   RSize       Actual read size
 
-@retval EFI_SUCCESS       The function completed successfully.
-@retval !EFI_SUCCESS      Something error while read FILE.
+  @retval 0 if success
+  @retval other if error.
 **/
 INT32
+EFIAPI
 BDevStrategy (
-  VOID     *DevData,
-  INT32     ReadWrite,
-  DADDRESS  BlockNum,
-  UINT32    Size,
-  VOID     *Buf,
-  UINT32   *RSize
+  IN  VOID       *DevData,
+  IN  INT32       ReadWrite,
+  IN  DADDRESS    BlockNum,
+  IN  UINT32      Size,
+  OUT VOID       *Buf,
+  OUT UINT32     *RSize
   )
 {
   INT32                    Res;
@@ -179,12 +185,16 @@ BDevStrategy (
 }
 
 /**
- Read a new inode into a FILE structure.
- @param [in] INumber inode number
- @param [in] File pointer to open file struct.
- @retval
+  Read a new inode into a FILE structure.
+
+  @param[in]      INumber     inode number
+  @param[in/out]  File        pointer to open file struct.
+
+  @retval         0 if success
+  @retval         other if error.
 **/
 INT32
+EFIAPI
 ReadInode (
   IN    INODE32      INumber,
   IN    OPEN_FILE   *File
@@ -242,18 +252,20 @@ ReadInode (
 /**
   Given an offset in a FILE, find the disk block number that
   contains that block.
-  @param File           pointer to an Open file.
-  @param FileBlock      Block to find the file.
-  @param DiskBlockPtr   Pointer to the disk which contains block.
+
+  @param[in]  File            pointer to an Open file.
+  @param[in]  FileBlock       Block to find the file.
+  @param[out] DiskBlockPtr    Pointer to the disk which contains block.
+
   @retval 0 if success
   @retval other if error.
 **/
 STATIC
 INT32
 BlockMap (
-  OPEN_FILE     *File,
-  INDPTR         FileBlock,
-  INDPTR        *DiskBlockPtr
+  IN  OPEN_FILE     *File,
+  IN  INDPTR         FileBlock,
+  OUT INDPTR        *DiskBlockPtr
   )
 {
   FILE     *Fp;
@@ -422,16 +434,22 @@ BlockMap (
 
 /**
   Read a portion of a FILE into an internal buffer.
+
   Return the location in the buffer and the amount in the buffer.
-  @param File       Pointer to the open file.
-  @param BufferPtr  buffer corresponding to offset
-  @param SizePtr    Size of remainder of buffer.
+
+  @param[in]  File        Pointer to the open file.
+  @param[out] BufferPtr   buffer corresponding to offset
+  @param[out] SizePtr     Size of remainder of buffer.
+
+  @retval     0 if success
+  @retval     other if error.
 **/
 INT32
+EFIAPI
 BufReadFile (
-  OPEN_FILE     *File,
-  CHAR8        **BufferPtr,
-  UINT32        *SizePtr
+  IN  OPEN_FILE     *File,
+  OUT CHAR8        **BufferPtr,
+  OUT UINT32        *SizePtr
   )
 {
   FILE *Fp;
@@ -493,20 +511,23 @@ BufReadFile (
 }
 
 /**
-  Search a directory for a Name and return its
-  inode number.
-  @param Name       Name to compare with
-  @param Length     Length of the dir name
-  @param File       Pointer to file private data
-  @param INumPtr    pointer to Inode number.
+  Search a directory for a Name and return its inode number.
+
+  @param[in]      Name        Name to compare with
+  @param[in]      Length      Length of the dir name
+  @param[in/out]  File        Pointer to file private data
+  @param[out]     INumPtr     pointer to Inode number.
+
+  @retval 0 if success
+  @retval other if error.
 **/
 STATIC
 INT32
 SearchDirectory (
-  CHAR8         *Name,
-  INT32          Length,
-  OPEN_FILE     *File,
-  INODE32       *INumPtr
+  IN      CHAR8         *Name,
+  IN      INT32          Length,
+  IN OUT  OPEN_FILE     *File,
+  OUT     INODE32       *INumPtr
   )
 {
   FILE *Fp;
@@ -557,16 +578,18 @@ SearchDirectory (
 
 /**
   Read Superblock of the file.
-  @param File       File for which super block needs to be read.
-  @param FileSystem Fs on which super block is computed.
+
+  @param[in]      File          File for which super block needs to be read.
+  @param[in/out]  FileSystem    Fs on which super block is computed.
 
   @retval 0 if superblock compute is success
   @retval other if error.
 **/
 INT32
+EFIAPI
 ReadSBlock (
-  OPEN_FILE     *File,
-  M_EXT2FS      *FileSystem
+  IN      OPEN_FILE     *File,
+  IN OUT  M_EXT2FS      *FileSystem
   )
 {
   PEI_EXT_PRIVATE_DATA *PrivateData;
@@ -638,16 +661,18 @@ Exit:
 
 /**
   Read group descriptor of the file.
-  @param File       File for which group descriptor needs to be read.
-  @param FileSystem Fs on which super block is computed.
+
+  @param[in/out]  File          File for which group descriptor needs to be read.
+  @param[in]      FileSystem    Fs on which super block is computed.
 
   @retval 0 if Group descriptor read is success
   @retval other if error.
 **/
 INT32
+EFIAPI
 ReadGDBlock (
-  OPEN_FILE     *File,
-  M_EXT2FS      *FileSystem
+  IN OUT  OPEN_FILE     *File,
+  IN      M_EXT2FS      *FileSystem
   )
 {
   FILE *Fp;
@@ -681,20 +706,20 @@ ReadGDBlock (
   return 0;
 }
 
-
 /**
   Open struct file.
 
-  @param  Path          path to locate the file
-  @param  File          The struct having the device and file info
+  @param[in]      Path          Path to locate the file
+  @param[in/out]  File          The struct having the device and file info
 
-  @retval 0 if Group descriptor read is success
+  @retval 0 if file open is success
   @retval other if error.
 **/
 INT32
+EFIAPI
 Ext2fsOpen (
-  CHAR8         *Path,
-  OPEN_FILE     *File
+  IN      CHAR8         *Path,
+  IN OUT  OPEN_FILE     *File
   )
 {
 #ifndef LIBSA_FS_SINGLECOMPONENT
@@ -926,14 +951,16 @@ out:
 }
 
 /**
-  Close the file.
-  @param File  File to be closed.
+  Close the opened file.
 
-  @retval 0 if Group descriptor read is success
+  @param[in/out]    File        File to be closed.
+
+  @retval 0 regardless of success/fail condition
 **/
 INT32
+EFIAPI
 Ext2fsClose (
-  OPEN_FILE     *File
+  IN OUT  OPEN_FILE     *File
   )
 {
   FILE *Fp;
@@ -959,12 +986,14 @@ Ext2fsClose (
 /**
   Gets the size of the file from descriptor.
 
-  @param File  File to be closed.
+  @param[in]    File      File to be closed.
+
   @retval size of the file from descriptor.
 **/
 UINT32
+EFIAPI
 Ext2fsFileSize (
-  OPEN_FILE     *File
+  IN  OPEN_FILE     *File
   )
 {
   FILE *Fp;
@@ -973,19 +1002,24 @@ Ext2fsFileSize (
 }
 
 /**
-  Copy a portion of a FILE into kernel memory.
+  Copy a portion of a FILE into a memory.
   Cross block boundaries when necessary
-  @param File
-  @param Start
-  @param Size
-  @param ResId
+
+  @param[in/out]    File      File handle to be read
+  @param[in]        Start     Start address of read buffer
+  @param[in]        Size      Size to be read
+  @param[out]       ResId     Actual read size
+
+  @retval 0 if file read is success
+  @retval other if error.
 **/
 INT32
+EFIAPI
 Ext2fsRead (
-  OPEN_FILE     *File,
-  VOID          *Start,
-  UINT32         Size,
-  UINT32        *ResId
+  IN OUT  OPEN_FILE     *File,
+  IN      VOID          *Start,
+  IN      UINT32         Size,
+  OUT     UINT32        *ResId
   )
 {
   FILE *Fp;
@@ -1029,79 +1063,18 @@ Ext2fsRead (
   return Rc;
 }
 
-/**
-  Updates the seek ptr of file based on seek point.
-  @param File       pointer to an Open file.
-  @param Offset     Offset to update the seekptr.
-  @param Where      Seek point where it needs to be update.
-
-**/
-OFFSET
-Ext2fsSeek (
-  OPEN_FILE    *File,
-  OFFSET        Offset,
-  INT32         Where
-  )
-{
-  FILE *Fp;
-  Fp = (FILE *)File->FileSystemSpecificData;
-
-  switch (Where) {
-  case SEEK_SET:
-    Fp->SeekPtr = Offset;
-    break;
-  case SEEK_CUR:
-    Fp->SeekPtr += Offset;
-    break;
-  case SEEK_END:
-    //
-    // XXX should handle LARGEFILE
-    //
-    Fp->SeekPtr = Fp->DiskInode.Ext2DInodeSize - Offset;
-    break;
-  default:
-    return -1;
-  }
-  return Fp->SeekPtr;
-}
-
-/**
-  Update the mode and size from descriptor to stat Block.
-  contains that block.
-  @param File       pointer to an file private data.
-  @param StatBlock  pointer to File information (stats).
-  @retval 0 if success
-**/
-INT32
-Ext2fsStat (
-  OPEN_FILE     *File,
-  STAT          *StatBlock
-  )
-{
-  FILE *Fp;
-
-  Fp = (FILE *)File->FileSystemSpecificData;
-  //
-  // only important stuff
-  //
-  SetMem32 (StatBlock, sizeof * StatBlock, 0);
-  StatBlock->StatMode = Fp->DiskInode.Ext2DInodeMode;
-  //
-  // XXX should handle LARGEFILE
-  //
-  StatBlock->StatSize = Fp->DiskInode.Ext2DInodeSize;
-  return 0;
-}
-
 #ifdef EXT2FS_DEBUG
 /**
   Dump the file system super block info.
 
-  @param FileSystem     pointer to filesystem.
+  @param[in]  FileSystem     pointer to filesystem.
+
+  @retval     none
 **/
 VOID
+EFIAPI
 DumpSBlock (
-  M_EXT2FS  *FileSystem
+  IN  M_EXT2FS  *FileSystem
   )
 {
 
@@ -1140,11 +1113,14 @@ DumpSBlock (
 /**
   Dump the file group descriptor block info.
 
-  @param FileSystem     pointer to filesystem.
+  @param[in]  FileSystem     pointer to filesystem.
+
+  @retval     none
 **/
 VOID
+EFIAPI
 DumpGroupDesBlock (
-  M_EXT2FS  *FileSystem
+  IN  M_EXT2FS  *FileSystem
   )
 {
   INT32     Index;
@@ -1165,139 +1141,3 @@ DumpGroupDesBlock (
   }
 }
 #endif
-
-/**
-
-  Determine the disk block(s) that contains data for FILE <File>,
-  starting at Offset <FilePosition> and extending for up to <Len> bytes.
-  @param File           Pointer to an file private data.
-  @param FilePosition   offset address of the file position.
-  @param Len            Number of bytes
-  @param NBlocks        Number of consecutive blocks
-
-  @retval  First disk block, number of consecutive blocks thru *<nblock>.
-**/
-INT32
-Ext2fsDiskBlocks (
-  OPEN_FILE    *File,
-  UINT32        FilePosition,
-  UINT32        Len,
-  UINT32       *NBlocks
-  )
-{
-  FILE      *Fp;
-  M_EXT2FS  *FileSystem;
-  UINT32    BlockSize;
-  UINT32    First;
-  UINT32    Num;
-  INDPTR    FileBlock;
-  INDPTR    DiskBlock;
-  INT32     Rc;
-
-  First = 0;
-  Num   = 0;
-
-  Fp         = (FILE *) File->FileSystemSpecificData;
-  FileSystem = Fp->SuperBlockPtr;
-  BlockSize  = FileSystem->Ext2FsBlockSize;
-
-  *NBlocks = 0;
-  while (Len >= BlockSize) {
-    FileBlock = LBLKNO (FileSystem, FilePosition);
-    DiskBlock = 0;
-
-    Rc = BlockMap (File, FileBlock, &DiskBlock);
-    if (Rc != 0) {
-      if (Num == 0) {
-        return 0;
-      } else {
-        break;
-      }
-    }
-
-    if (Num == 0) {
-      First = DiskBlock;
-      Num  += 1;
-    } else if (First + Num == (UINT32)DiskBlock) {
-      Num += 1;
-    } else {
-      break;
-    }
-
-    FilePosition += BlockSize;
-    Len -= BlockSize;
-  }
-
-  *NBlocks = Num;
-  return FSBTODB (FileSystem, First);
-}
-
-/**
-  Given an offset in a FILE, find the disk block number that
-  contains that block.
-  @param OpenFile       pointer to an Open file.
-  @param Stat           Block to find the file.
-  @param Name           Pointer to the disk which contains block.
-  @param NamLen
-  @retval 0 if success
-  @retval other if error.
-**/
-INT32
-Ext2fsLookUpFile (
-  OPEN_FILE     *OpenFile,
-  STAT          *Stat,
-  CHAR8         *Name,
-  UINT32         NamLen
-  )
-{
-  FILE      *Fp;
-  EXT2FS_DIRECT *Dp;
-  CHAR8  *Buf;
-  UINT32 BufSize;
-  UINT32 Ext2DirectInodeNumber;
-  INT32      Ext2DirectRecLen;
-  UINT32 Ext2DirectNameLen;
-  INT32 Rc;
-
-  Fp = OpenFile->FileSystemSpecificData;
-
-  do {
-    if ((UINT32)Fp->SeekPtr >= Fp->DiskInode.Ext2DInodeSize) {
-      return 0;
-    }
-
-    if ((Rc = BufReadFile (OpenFile, &Buf, &BufSize)) != 0) {
-      return (Rc < 0) ? Rc : -Rc;
-    }
-
-    if (BufSize < sizeof (EXT2FS_DIRECT) - EXT2FS_MAXNAMLEN + 1) {
-      return -1;  // XXX: corrupt entry.
-    }
-    Dp = (EXT2FS_DIRECT *) Buf;
-
-    Ext2DirectInodeNumber   =   Dp->Ext2DirectInodeNumber;
-    Ext2DirectRecLen        =   Dp->Ext2DirectRecLen;
-    Ext2DirectNameLen       =   Dp->Ext2DirectNameLen;
-
-    Dp->Ext2DirectName[Ext2DirectNameLen] = '\0';
-
-    if (Ext2DirectRecLen <= 0) {
-      return 0;
-    }
-
-    Fp->SeekPtr += Ext2DirectRecLen;
-  } while (Ext2DirectInodeNumber == 0 || Ext2DirectNameLen == 0);
-
-  CopyMem (Name, Dp->Ext2DirectName, MIN (NamLen, Ext2DirectNameLen));
-
-  _FILE Tf;
-  SetMem32 (&Tf, sizeof (Tf), 0);
-  if ((Rc = Ext2fsOpen (Dp->Ext2DirectName, &Tf.Openfile)) != 0) {
-    return (Rc < 0) ? Rc : -Rc;
-  }
-
-  Ext2fsStat (&Tf.Openfile, Stat);
-  Ext2fsClose (&Tf.Openfile);
-
-  return Ext2DirectNameLen;
-}

--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.h
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.h
@@ -421,185 +421,141 @@ typedef struct {
   UINT8                PhysicalDevNo;
 } PEI_EXT_PRIVATE_DATA;
 
-
 /**
-Gives the info of device block config.
+  Gives the info of device block config.
 
-@param  DevData     Device privete data.
-@param  ReadWrite   Read write
-@param  BlockNum    Block number to start
-@param  Size        Size to read block.
-@param  Buf         Buffer to read the block data.
-@param  RSize
+  @param[in]    DevData     Device privete data.
+  @param[in]    ReadWrite   Read or Write
+  @param[in]    BlockNum    Block number to start
+  @param[in]    Size        Size to read block.
+  @param[out]   Buf         Buffer to read the block data.
+  @param[out]   RSize       Actual read size
 
-@retval EFI_SUCCESS       The function completed successfully.
-@retval !EFI_SUCCESS      Something error while read FILE.
+  @retval 0 if success
+  @retval other if error.
 **/
 INT32
+EFIAPI
 BDevStrategy (
-  VOID     *DevData,
-  INT32     ReadWrite,
-  DADDRESS  BlockNum,
-  UINT32    Size,
-  VOID     *Buf,
-  UINT32   *RSize
+  IN  VOID       *DevData,
+  IN  INT32       ReadWrite,
+  IN  DADDRESS    BlockNum,
+  IN  UINT32      Size,
+  OUT VOID       *Buf,
+  OUT UINT32     *RSize
   );
 #define    DEV_STRATEGY(d)    BDevStrategy
 
 /**
   Open struct file.
 
-  @param  Path          path to locate the file
-  @param  File          The struct having the device and file info
+  @param[in]      Path          Path to locate the file
+  @param[in/out]  File          The struct having the device and file info
 
-  @retval 0 if Group descriptor read is success
+  @retval 0 if file open is success
   @retval other if error.
 **/
 INT32
+EFIAPI
 Ext2fsOpen (
-  CHAR8         *Path,
-  OPEN_FILE     *File
+  IN      CHAR8         *Path,
+  IN OUT  OPEN_FILE     *File
   );
 
 /**
-  Close the file.
-  @param File  File to be closed.
+  Close the opened file.
 
-  @retval 0 if Group descriptor read is success
+  @param[in/out]    File        File to be closed.
+
+  @retval 0 regardless of success/fail condition
 **/
 INT32
+EFIAPI
 Ext2fsClose (
-  OPEN_FILE     *File
+  IN OUT  OPEN_FILE     *File
   );
 
-
 /**
-  Copy a portion of a FILE into kernel memory.
+  Copy a portion of a FILE into a memory.
   Cross block boundaries when necessary
-  @param File
-  @param Start
-  @param Size
-  @param ResId
+
+  @param[in/out]    File      File handle to be read
+  @param[in]        Start     Start address of read buffer
+  @param[in]        Size      Size to be read
+  @param[out]       ResId     Actual read size
+
+  @retval 0 if file read is success
+  @retval other if error.
 **/
 INT32
+EFIAPI
 Ext2fsRead (
-  OPEN_FILE     *File,
-  VOID          *Start,
-  UINT32         Size,
-  UINT32        *ResId
+  IN OUT  OPEN_FILE     *File,
+  IN      VOID          *Start,
+  IN      UINT32         Size,
+  OUT     UINT32        *ResId
   );
 
 /**
-  Update the mode and size from descriptor to stat Block.
-  contains that block.
-  @param File       pointer to an file private data.
-  @param StatBlock  pointer to File information (stats).
-  @retval 0 if success
-**/
-INT32
-Ext2fsStat (
-  OPEN_FILE     *File,
-  STAT          *StatBlock
-  );
+  List directories or files and print them
 
-/**
-  Update the mode and size from descriptor to stat Block.
-  contains that block.
-  @param File       pointer to an file private data
-  @param Pattern    pointer to Pattern
+  @param[in] File           pointer to an file private data
+  @param[in] Pattern        not used for now
+
+  @retval EFI_SUCCESS       list directories or files successfully
+  @retval EFI_NOT_FOUND     not found specified dir or file
+  @retval EFI_DEVICE_ERROR  an error while accessing filesystem
 **/
 EFI_STATUS
+EFIAPI
 Ext2fsLs (
-  OPEN_FILE *File,
-  const CHAR8 *Pattern
-  );
-
-/**
-
-  Determine the disk block(s) that contains data for FILE <File>,
-  starting at Offset <FilePosition> and extending for up to <Len> bytes.
-  @param File           Pointer to an file private data.
-  @param FilePosition   offset address of the file position.
-  @param Len            Number of bytes
-  @param NBlocks        Number of consecutive blocks
-
-  @retval  First disk block, number of consecutive blocks thru *<nblock>.
-**/
-INT32
-Ext2fsDiskBlocks (
-  OPEN_FILE    *File,
-  UINT32        FilePosition,
-  UINT32        Len,
-  UINT32       *NBlocks
-  );
-
-/**
-  Given an offset in a FILE, find the disk block number that
-  contains that block.
-  @param OpenFile       pointer to an Open file.
-  @param Stat           Block to find the file.
-  @param Name           Pointer to the disk which contains block.
-  @param NamLen
-  @retval 0 if success
-  @retval other if error.
-**/
-INT32
-Ext2fsLookUpFile (
-  OPEN_FILE     *OpenFile,
-  STAT          *Stat,
-  CHAR8         *Name,
-  UINT32         NamLen
-  );
-
-/**
-  Updates the seek ptr of file based on seek point.
-  @param File       pointer to an Open file.
-  @param Offset     Offset to update the seekptr.
-  @param Where      Seek point where it needs to be update.
-
-**/
-OFFSET
-Ext2fsSeek (
-  OPEN_FILE    *File,
-  OFFSET        Offset,
-  INT32         Where
+  IN  OPEN_FILE     *File,
+  IN  CONST CHAR8   *Pattern
   );
 
 /**
   Read Superblock of the file.
-  @param File       File for which super block needs to be read.
-  @param FileSystem Fs on which super block is computed.
+
+  @param[in]      File          File for which super block needs to be read.
+  @param[in/out]  FileSystem    Fs on which super block is computed.
 
   @retval 0 if superblock compute is success
   @retval other if error.
 **/
 INT32
+EFIAPI
 ReadSBlock (
-  OPEN_FILE     *File,
-  M_EXT2FS      *FileSystem
+  IN      OPEN_FILE     *File,
+  IN OUT  M_EXT2FS      *FileSystem
   );
 
 /**
   Read group descriptor of the file.
-  @param File       File for which group descriptor needs to be read.
-  @param FileSystem Fs on which super block is computed.
+
+  @param[in/out]  File          File for which group descriptor needs to be read.
+  @param[in]      FileSystem    Fs on which super block is computed.
 
   @retval 0 if Group descriptor read is success
   @retval other if error.
 **/
 INT32
+EFIAPI
 ReadGDBlock (
-  OPEN_FILE     *File,
-  M_EXT2FS      *FileSystem
+  IN OUT  OPEN_FILE     *File,
+  IN      M_EXT2FS      *FileSystem
   );
 
 /**
- Read a new inode into a FILE structure.
- @param [in] INumber inode number
- @param [in] File pointer to open file struct.
- @retval
+  Read a new inode into a FILE structure.
+
+  @param[in]      INumber     inode number
+  @param[in/out]  File        pointer to open file struct.
+
+  @retval         0 if success
+  @retval         other if error.
 **/
 INT32
+EFIAPI
 ReadInode (
   IN    INODE32      INumber,
   IN    OPEN_FILE   *File
@@ -607,48 +563,62 @@ ReadInode (
 
 /**
   Read a portion of a FILE into an internal buffer.
+
   Return the location in the buffer and the amount in the buffer.
-  @param File       Pointer to the open file.
-  @param BufferPtr  buffer corresponding to offset
-  @param SizePtr    Size of remainder of buffer.
+
+  @param[in]  File        Pointer to the open file.
+  @param[out] BufferPtr   buffer corresponding to offset
+  @param[out] SizePtr     Size of remainder of buffer.
+
+  @retval     0 if success
+  @retval     other if error.
 **/
 INT32
+EFIAPI
 BufReadFile (
-  OPEN_FILE     *File,
-  CHAR8        **BufferPtr,
-  UINT32        *SizePtr
+  IN  OPEN_FILE     *File,
+  OUT CHAR8        **BufferPtr,
+  OUT UINT32        *SizePtr
   );
 
 /**
   Gets the size of the file from descriptor.
 
-  @param File  File to be closed.
+  @param[in]    File      File to be closed.
+
   @retval size of the file from descriptor.
 **/
 UINT32
+EFIAPI
 Ext2fsFileSize (
-  OPEN_FILE     *File
+  IN  OPEN_FILE     *File
   );
 
 #ifdef EXT2FS_DEBUG
 /**
   Dump the file system super block info.
 
-  @param FileSystem     pointer to filesystem.
+  @param[in]  FileSystem     pointer to filesystem.
+
+  @retval     none
 **/
 VOID
+EFIAPI
 DumpSBlock (
-  M_EXT2FS  *FileSystem
+  IN  M_EXT2FS  *FileSystem
   );
 
 /**
-  Dump the file system group descriptor block info.
+  Dump the file group descriptor block info.
 
-  @param FileSystem     pointer to filesystem.
+  @param[in]  FileSystem     pointer to filesystem.
+
+  @retval     none
 **/
 VOID
+EFIAPI
 DumpGroupDesBlock (
-  M_EXT2FS  *FileSystem
+  IN  M_EXT2FS  *FileSystem
   );
 #endif
 

--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.h
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.h
@@ -503,6 +503,18 @@ Ext2fsStat (
   );
 
 /**
+  Update the mode and size from descriptor to stat Block.
+  contains that block.
+  @param File       pointer to an file private data
+  @param Pattern    pointer to Pattern
+**/
+EFI_STATUS
+Ext2fsLs (
+  OPEN_FILE *File,
+  const CHAR8 *Pattern
+  );
+
+/**
 
   Determine the disk block(s) that contains data for FILE <File>,
   starting at Offset <FilePosition> and extending for up to <Len> bytes.
@@ -579,6 +591,32 @@ INT32
 ReadGDBlock (
   OPEN_FILE     *File,
   M_EXT2FS      *FileSystem
+  );
+
+/**
+ Read a new inode into a FILE structure.
+ @param [in] INumber inode number
+ @param [in] File pointer to open file struct.
+ @retval
+**/
+INT32
+ReadInode (
+  IN    INODE32      INumber,
+  IN    OPEN_FILE   *File
+  );
+
+/**
+  Read a portion of a FILE into an internal buffer.
+  Return the location in the buffer and the amount in the buffer.
+  @param File       Pointer to the open file.
+  @param BufferPtr  buffer corresponding to offset
+  @param SizePtr    Size of remainder of buffer.
+**/
+INT32
+BufReadFile (
+  OPEN_FILE     *File,
+  CHAR8        **BufferPtr,
+  UINT32        *SizePtr
   );
 
 /**

--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext2FsLs.c
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext2FsLs.c
@@ -90,8 +90,6 @@
 #include "Ext2Fs.h"
 #include "LibsaFsStand.h"
 
-#define NELEM(x) (sizeof (x) / sizeof(*x))
-
 typedef struct ENTRY ENTRY;
 struct ENTRY {
   ENTRY    *EntryNext;
@@ -105,15 +103,18 @@ STATIC CONST CHAR8 *CONST mTypeStr[] = { "unknown", "REG",  "DIR",  "CHR",  "BLK
 /**
   List directories or files and print them
 
-  @param File       pointer to an file private data
-  @param Pattern    not used for now
+  @param[in] File           pointer to an file private data
+  @param[in] Pattern        not used for now
 
+  @retval EFI_SUCCESS       list directories or files successfully
+  @retval EFI_NOT_FOUND     not found specified dir or file
+  @retval EFI_DEVICE_ERROR  an error while accessing filesystem
 **/
 EFI_STATUS
 EFIAPI
 Ext2fsLs (
-  OPEN_FILE     *File,
-  CONST CHAR8   *Pattern
+  IN  OPEN_FILE     *File,
+  IN  CONST CHAR8   *Pattern
   )
 {
   EFI_STATUS      Status;
@@ -168,7 +169,7 @@ Ext2fsLs (
         continue;
       }
 
-      if (Dp->Ext2DirectType >= NELEM (mTypeStr)) {
+      if (Dp->Ext2DirectType >= ARRAY_SIZE (mTypeStr)) {
         //
         //  This does not handle "Old"
         //  filesystems properly. On little

--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext2FsLs.c
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext2FsLs.c
@@ -136,7 +136,7 @@ Ext2fsLs (
   Fp = (FILE *)File->FileSystemSpecificData;
 
   if ((Fp->DiskInode.Ext2DInodeMode & EXT2_IFMT) == EXT2_IFREG) {
-    DEBUG ((DEBUG_INFO, "  %a\t%d\n", File->FileNamePtr, Fp->DiskInode.Ext2DInodeSize));
+    DEBUG ((DEBUG_INFO, "  %-16a %d\n", File->FileNamePtr, Fp->DiskInode.Ext2DInodeSize));
     return EFI_SUCCESS;
   } else if ((Fp->DiskInode.Ext2DInodeMode & EXT2_IFMT) != EXT2_IFDIR) {
     return EFI_NOT_FOUND;
@@ -222,7 +222,7 @@ Ext2fsLs (
           Fp = (FILE *)File->FileSystemSpecificData;
           FileSize = Fp->DiskInode.Ext2DInodeSize;
         }
-        DEBUG ((DEBUG_INFO, "  %a\t%d\n", New->EntryName, FileSize));
+        DEBUG ((DEBUG_INFO, "  %-16a %d\n", New->EntryName, FileSize));
       }
       PNames = New->EntryNext;
     } while (PNames != NULL);

--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext2FsLs.c
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext2FsLs.c
@@ -1,0 +1,239 @@
+/** @file
+
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  Copyright (c) 1997 Manuel Bouyer.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ -
+  Copyright (c) 1993
+    The Regents of the University of California.  All rights reserved.
+
+  This code is derived from software contributed to Berkeley by
+  The Mach Operating System project at Carnegie-Mellon University.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  3. Neither the Name of the University nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+  SUCH DAMAGE.
+
+
+  Copyright (c) 1990, 1991 Carnegie Mellon University
+  All Rights Reserved.
+
+  Author: David Golub
+
+  Permission to use, copy, modify and distribute this software and its
+  documentation is hereby granted, provided that both the copyright
+  notice and this permission notice appear in all copies of the
+  software, derivative works or modified versions, and any portions
+  thereof, and that both notices appear in supporting documentation.
+
+  CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS"
+  CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
+  ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+
+  Carnegie Mellon requests users of this software to return to
+
+   Software Distribution Coordinator  or  Software.Distribution@CS.CMU.EDU
+   School of Computer Science
+   Carnegie Mellon University
+   Pittsburgh PA 15213-3890
+
+  any improvements or extensions that they make and grant Carnegie the
+  rights to redistribute these changes.
+
+    Stand-alone FILE reading package for Ext2 FILE system.
+**/
+
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/MediaAccessLib.h>
+#include "Ext2Fs.h"
+#include "LibsaFsStand.h"
+
+#define NELEM(x) (sizeof (x) / sizeof(*x))
+
+typedef struct ENTRY ENTRY;
+struct ENTRY {
+  ENTRY    *EntryNext;
+  INODE32  EntryInode;
+  UINT8    EntryType;
+  CHAR8    EntryName[EXT2FS_MAXNAMLEN];
+};
+
+STATIC CONST CHAR8 *CONST mTypeStr[] = { "unknown", "REG",  "DIR",  "CHR",  "BLK",  "FIFO",  "SOCK",  "LNK" };
+
+/**
+  List directories or files and print them
+
+  @param File       pointer to an file private data
+  @param Pattern    not used for now
+
+**/
+EFI_STATUS
+EFIAPI
+Ext2fsLs (
+  OPEN_FILE     *File,
+  CONST CHAR8   *Pattern
+  )
+{
+  EFI_STATUS      Status;
+  FILE           *Fp;
+  UINT32          BlockSize;
+  CHAR8          *Buf;
+  UINT32          BufSize;
+  ENTRY          *Names;
+  ENTRY          *New;
+  ENTRY         **NextPtr;
+  EXT2FS_DIRECT  *Dp;
+  EXT2FS_DIRECT  *EdPtr;
+  INT32           Rc;
+  UINT32          FileSize;
+  ENTRY          *PNames;
+  CONST CHAR8    *Type;
+
+  Status = EFI_SUCCESS;
+  Fp = (FILE *)File->FileSystemSpecificData;
+
+  if ((Fp->DiskInode.Ext2DInodeMode & EXT2_IFMT) == EXT2_IFREG) {
+    DEBUG ((DEBUG_INFO, "  %a\t%d\n", File->FileNamePtr, Fp->DiskInode.Ext2DInodeSize));
+    return EFI_SUCCESS;
+  } else if ((Fp->DiskInode.Ext2DInodeMode & EXT2_IFMT) != EXT2_IFDIR) {
+    return EFI_NOT_FOUND;
+  }
+
+  BlockSize = Fp->SuperBlockPtr->Ext2FsBlockSize;
+  Names = NULL;
+  Fp->SeekPtr = 0;
+  while (Fp->SeekPtr < (OFFSET)Fp->DiskInode.Ext2DInodeSize) {
+    Rc = BufReadFile (File, &Buf, &BufSize);
+    if (Rc != 0) {
+      Status = EFI_DEVICE_ERROR;
+      goto out;
+    }
+    if ((BufSize != BlockSize) || (BufSize == 0)) {
+      Status = EFI_DEVICE_ERROR;
+      goto out;
+    }
+
+    Dp = (EXT2FS_DIRECT *)Buf;
+    EdPtr = (EXT2FS_DIRECT *)(Buf + BufSize);
+
+    for (; Dp < EdPtr;  Dp = (VOID *) ((CHAR8 *)Dp + Dp->Ext2DirectRecLen)) {
+      if (Dp->Ext2DirectRecLen <= 0) {
+        Status = EFI_DEVICE_ERROR;
+        goto out;
+      }
+
+      if (Dp->Ext2DirectInodeNumber == 0) {
+        continue;
+      }
+
+      if (Dp->Ext2DirectType >= NELEM (mTypeStr)) {
+        //
+        //  This does not handle "Old"
+        //  filesystems properly. On little
+        //  endian machines, we get a bogus
+        //  type Name if the NameLen matches a
+        //  valid type identifier. We could
+        //  check if we read NameLen "0" and
+        //  handle this case specially, if
+        //  there were a pressing need...
+        //
+        DEBUG ((DEBUG_INFO, "bad dir entry - %d\n", Dp->Ext2DirectType));
+        Status = EFI_DEVICE_ERROR;
+        goto out;
+      }
+      Type = mTypeStr[Dp->Ext2DirectType];
+
+      New = AllocateZeroPool (sizeof * New + AsciiStrLen (Dp->Ext2DirectName));
+      if (New == NULL) {
+        DEBUG ((DEBUG_INFO, "%d: %s (%s)\n",
+                Dp->Ext2DirectInodeNumber, Dp->Ext2DirectName, Type));
+        continue;
+      }
+
+      New->EntryInode = Dp->Ext2DirectInodeNumber;
+      New->EntryType  = Dp->Ext2DirectType;
+      AsciiStrCpyS (New->EntryName, EXT2FS_MAXNAMLEN, Dp->Ext2DirectName);
+      New->EntryName[Dp->Ext2DirectNameLen] = '\0';
+      for (NextPtr = &Names; *NextPtr != NULL; NextPtr = & (*NextPtr)->EntryNext) {
+          if (AsciiStrCmp (New->EntryName, (*NextPtr)->EntryName) < 0) {
+          break;
+        }
+      }
+      New->EntryNext = *NextPtr;
+      *NextPtr = New;
+    }
+    Fp->SeekPtr += BufSize;
+  }
+
+  if (Names != NULL) {
+    PNames = Names;
+
+    do {
+      New = PNames;
+      if (New->EntryType == 2) {
+        DEBUG ((DEBUG_INFO, "  %a/\n", New->EntryName));
+      } else if (New->EntryType == 1) {
+        FileSize = 0;
+        Rc = ReadInode (New->EntryInode, File);
+        if (!Rc) {
+          Fp = (FILE *)File->FileSystemSpecificData;
+          FileSize = Fp->DiskInode.Ext2DInodeSize;
+        }
+        DEBUG ((DEBUG_INFO, "  %a\t%d\n", New->EntryName, FileSize));
+      }
+      PNames = New->EntryNext;
+    } while (PNames != NULL);
+  }
+out:
+  if (Names != NULL) {
+    do {
+      New   = Names;
+      Names = New->EntryNext;
+      FreePool (New);
+    } while (Names != NULL);
+  }
+
+  return Status;
+}

--- a/BootloaderCommonPkg/Library/Ext23Lib/ExtLib.c
+++ b/BootloaderCommonPkg/Library/Ext23Lib/ExtLib.c
@@ -130,7 +130,7 @@ ExtFsOpenFile (
     return Status;
   }
 
-  OpenFile = (OPEN_FILE *)AllocatePool (sizeof (OPEN_FILE));
+  OpenFile = (OPEN_FILE *)AllocateZeroPool (sizeof (OPEN_FILE));
   if (OpenFile == NULL) {
     Status = EFI_OUT_OF_RESOURCES;
     goto Error;
@@ -269,4 +269,41 @@ ExtFsCloseFile (
   }
   Ext2fsClose (OpenFile);
   FreePool (OpenFile);
+}
+
+/**
+  List directories or files
+
+  @param[in]     FsHandle         file system handle.
+  @param[in]     DirFilePath      directory or file path
+
+  @retval EFI_SUCCESS             list directories of files successfully
+  @retval EFI_UNSUPPORTED         this api is not supported
+  @retval Others                  an error occurs
+
+**/
+EFI_STATUS
+EFIAPI
+ExtFsListDir (
+  IN  EFI_HANDLE                                  FsHandle,
+  IN  CHAR16                                     *DirFilePath
+  )
+{
+  EFI_STATUS              Status;
+  EFI_HANDLE              FileHandle;
+
+  Status = EFI_UNSUPPORTED;
+
+DEBUG_CODE_BEGIN ();
+  FileHandle = NULL;
+  Status = ExtFsOpenFile (FsHandle, DirFilePath, &FileHandle);
+  if (!EFI_ERROR (Status)) {
+    Status = Ext2fsLs ((OPEN_FILE *)FileHandle, NULL);
+  }
+  if (FileHandle != NULL) {
+    ExtFsCloseFile (FileHandle);
+  }
+DEBUG_CODE_END ();
+
+  return Status;
 }

--- a/BootloaderCommonPkg/Library/Ext23Lib/LibsaFsStand.h
+++ b/BootloaderCommonPkg/Library/Ext23Lib/LibsaFsStand.h
@@ -99,6 +99,7 @@ typedef struct {
 #if !defined(LIBSA_NO_RAW_ACCESS)
   OFFSET      FileOffset;                     // current file offset (F_RAW)
 #endif
+  CHAR8       *FileNamePtr;
 } OPEN_FILE;
 
 #if ! defined(LIBSA_SINGLE_DEVICE)

--- a/BootloaderCommonPkg/Library/FatLib/FatLib.c
+++ b/BootloaderCommonPkg/Library/FatLib/FatLib.c
@@ -40,7 +40,7 @@ PrintFileName (
   if (File->Attributes & FAT_ATTR_DIRECTORY) {
     DEBUG ((DEBUG_INFO, "  %s/\n", FileName));
   } else {
-    DEBUG ((DEBUG_INFO, "  %s\t%d\n", FileName, File->FileSize));
+    DEBUG ((DEBUG_INFO, "  %-16s %d\n", FileName, File->FileSize));
   }
 }
 

--- a/BootloaderCommonPkg/Library/PartitionLib/PartitionLib.c
+++ b/BootloaderCommonPkg/Library/PartitionLib/PartitionLib.c
@@ -617,3 +617,57 @@ ClosePartitions (
     FreePool (PartBlockDev);
   }
 }
+
+/**
+  Get detected partition type
+
+  @param[in]  PartHandle      The partition handle to clean-up
+
+  @retval                     Partition type enum
+
+**/
+PARTITION_TYPE
+EFIAPI
+GetPartitionType (
+  IN   EFI_HANDLE             PartHandle
+  )
+{
+  PART_BLOCK_DEVICE           *PartBlockDev;
+  PARTITION_TYPE               PartType;
+
+  PartType = EnumPartTypeMax;
+  PartBlockDev = (PART_BLOCK_DEVICE *)PartHandle;
+  if ((PartBlockDev != NULL) && (PartBlockDev->Signature == PART_INFO_SIGNATURE)) {
+    PartType = PartBlockDev->PartitionType;
+  }
+
+  return PartType;
+}
+
+/**
+  Get HW part no of the detected partition
+
+  @param[in]  PartHandle              The partition handle to clean-up
+  @param[in]  HwPartNo                HW part no.
+
+  @retval     EFI_SUCCESS             Found SW part no.
+  @retval     EFI_INVALID_PARAMETER   Invalid PartHandle
+
+**/
+EFI_STATUS
+EFIAPI
+GetPartitionCurrentPartNo (
+  IN  EFI_HANDLE            PartHandle,
+  OUT UINT32               *HwPartNo
+  )
+{
+  PART_BLOCK_DEVICE          *PartBlockDev;
+
+  PartBlockDev = (PART_BLOCK_DEVICE *)PartHandle;
+  if ((PartBlockDev == NULL) || (PartBlockDev->Signature != PART_INFO_SIGNATURE)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *HwPartNo = PartBlockDev->HarewareDevice;
+  return EFI_SUCCESS;
+}

--- a/BootloaderCommonPkg/Library/ShellLib/CmdFs.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdFs.c
@@ -1,0 +1,316 @@
+/** @file
+  Shell command `fs` to view partition information
+
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BootloaderCommonLib.h>
+#include <Library/ShellLib.h>
+#include <Library/PartitionLib.h>
+#include <Library/FileSystemLib.h>
+#include <Library/MediaAccessLib.h>
+#include <Guid/OsBootOptionGuid.h>
+#include <Library/BootOptionLib.h>
+#include <Guid/DeviceTableHobGuid.h>
+
+STATIC  OS_BOOT_MEDIUM_TYPE mDeviceType   = OsBootDeviceMax;
+STATIC  EFI_HANDLE          mHwPartHandle = NULL;
+STATIC  EFI_HANDLE          mFsHandle     = NULL;
+
+/**
+  Show media information
+
+  @param[in]  Shell        shell instance
+  @param[in]  Argc         number of command line arguments
+  @param[in]  Argv         command line arguments
+
+  @retval EFI_SUCCESS
+
+**/
+STATIC
+EFI_STATUS
+ShellCommandFsFunc (
+  IN SHELL  *Shell,
+  IN UINTN   Argc,
+  IN CHAR16 *Argv[]
+  );
+
+CONST SHELL_COMMAND ShellCommandFs = {
+  L"fs",
+  L"filesystem access command",
+  &ShellCommandFsFunc
+};
+
+/**
+  Print available platform devices
+
+  @retval     none
+
+**/
+STATIC
+VOID
+PrintPlatformDevices (
+  IN  VOID
+  )
+{
+  PLT_DEVICE_TABLE   *DeviceTable;
+  UINT16              Count;
+  UINT16              Index;
+  OS_BOOT_MEDIUM_TYPE DeviceType;
+
+  Count = 0;
+  DeviceTable = (PLT_DEVICE_TABLE *)GetDeviceTable ();
+  if (DeviceTable != NULL) {
+    Count = DeviceTable->DeviceNumber;
+    for (Index = 0; Index < Count; Index++) {
+      DeviceType = (OS_BOOT_MEDIUM_TYPE)DeviceTable->Device[Index].Type;
+      if (DeviceType >= OsBootDeviceMax)
+        continue;
+
+      ShellPrint (L"%d:%a ", DeviceType, GetBootDeviceNameString (DeviceType));
+    }
+  }
+  ShellPrint (L"\n");
+}
+
+/**
+  Close file system
+
+  @retval     EFI_SUCCESS
+
+**/
+STATIC
+EFI_STATUS
+CmdFsClose (
+  IN  VOID
+  )
+{
+  if (mFsHandle != NULL) {
+    CloseFileSystem (mFsHandle);
+    mFsHandle = NULL;
+  }
+  if (mHwPartHandle != NULL) {
+    ClosePartitions (mHwPartHandle);
+    mHwPartHandle = NULL;
+  }
+
+  if (mDeviceType != OsBootDeviceMax) {
+    mDeviceType = OsBootDeviceMax;
+  }
+  return EFI_SUCCESS;
+}
+
+/**
+  Initialize file system
+
+  @param[in]  DeviceType      Platform Device Index
+  @param[in]  HwPartNo        HW Partition Number
+  @param[in]  SwPartNo        SW Partition Number
+
+  @retval     EFI_SUCCESS     FS init success
+  @retval     Others          Error
+
+**/
+STATIC
+EFI_STATUS
+CmdFsInit (
+  IN  OS_BOOT_MEDIUM_TYPE   DeviceType,
+  IN  UINT32                HwPartNo,
+  IN  UINT32                SwPartNo
+  )
+{
+  EFI_STATUS          Status;
+  OS_FILE_SYSTEM_TYPE FsType;
+  UINTN               BaseAddress;
+
+  // Get device bar
+  BaseAddress = GetDeviceAddr (DeviceType, 0);
+  if (BaseAddress == 0) {
+    ShellPrint (L"Device no. %d (%a) is not in platform devices. <device no.> - ",
+      DeviceType, GetBootDeviceNameString (DeviceType));
+    PrintPlatformDevices ();
+    return EFI_ABORTED;
+  } else if (!(BaseAddress & 0xFF000000)) {
+    BaseAddress = TO_MM_PCI_ADDRESS (BaseAddress);
+  }
+
+  if (mDeviceType != OsBootDeviceMax) {
+    CmdFsClose ();
+  }
+
+  // Set media interface
+  Status = MediaSetInterfaceType (DeviceType);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = MediaInitialize (BaseAddress, DevInitAll);
+  ShellPrint (L"Media(%a) Init ", GetBootDeviceNameString (DeviceType));
+  if (!EFI_ERROR (Status)) {
+    ShellPrint (L"Success!\n");
+    mDeviceType = DeviceType;
+  } else {
+    ShellPrint (L"Fail!\n");
+    return EFI_ABORTED;
+  }
+
+  // Find a partition
+  ShellPrint (L"Find a Partition\n");
+  Status = FindPartitions (HwPartNo, &mHwPartHandle);
+  ShellPrint (L"Partition Detect (device:%d, hwpart:%d) ", mDeviceType, HwPartNo);
+  if (!EFI_ERROR (Status)) {
+    ShellPrint (L"Success!\n");
+  } else {
+    ShellPrint (L"Fail!\n");
+    goto Error;
+  }
+
+  ShellPrint (L"Init FileSystem\n");
+  Status = InitFileSystem (SwPartNo, EnumFileSystemTypeAuto, mHwPartHandle, &mFsHandle);
+  ShellPrint (L"FileSystem Detect (device:%d, hwpart:%d, swpart:%d) ",
+    mDeviceType, HwPartNo, SwPartNo);
+  if (!EFI_ERROR (Status)) {
+    FsType = GetFileSystemType (mFsHandle);
+    ShellPrint (L"Success! (%a)\n", GetFsTypeString (FsType));
+  } else {
+    ShellPrint (L"Fail!\n");
+    goto Error;
+  }
+
+  return EFI_SUCCESS;
+
+Error:
+  CmdFsClose ();
+  return Status;
+}
+
+/**
+  Print directory or file list
+
+  @retval EFI_SUCCESS
+  @retval EFI_ABORTED
+
+**/
+STATIC
+EFI_STATUS
+CmdFsFsListDir (
+  IN  CHAR16      *DirFilePath
+  )
+{
+  EFI_STATUS      Status;
+
+  if (mFsHandle == NULL) {
+    ShellPrint (L"FileSystem is not initialized!\n");
+    return EFI_ABORTED;
+  }
+
+  Status = ListDir (mFsHandle, DirFilePath);
+  if (Status == EFI_NOT_FOUND) {
+    ShellPrint (L"Not found!\n");
+  } else if (Status == EFI_UNSUPPORTED) {
+    ShellPrint (L"This command has been disabled.\n");
+  }
+  return EFI_SUCCESS;
+}
+
+/**
+  Display current filesystem info
+
+  @retval EFI_SUCCESS
+
+**/
+STATIC
+EFI_STATUS
+CmdFsInfo (
+  IN  VOID
+  )
+{
+  EFI_STATUS            Status;
+  UINT32                HwPartNo;
+  UINT32                SwPartNo;
+  OS_FILE_SYSTEM_TYPE   FsType;
+
+  ShellPrint (L"Current Device: %a\n", (mDeviceType != OsBootDeviceMax) ?
+    GetBootDeviceNameString (mDeviceType) : "Not Initialized");
+
+  Status = GetPartitionCurrentPartNo (mHwPartHandle, &HwPartNo);
+  if (!EFI_ERROR (Status)) {
+    ShellPrint (L"Current HwPart: %d\n", HwPartNo);
+  } else {
+    ShellPrint (L"Current HwPart: Not Initialized\n");
+  }
+
+  Status = GetFileSystemCurrentPartNo (mFsHandle, &SwPartNo);
+  if (!EFI_ERROR (Status)) {
+    ShellPrint (L"Current SwPart: %d\n", SwPartNo);
+  } else {
+    ShellPrint (L"Current SwPart: Not Initialized\n");
+  }
+
+  FsType = GetFileSystemType (mFsHandle);
+  ShellPrint (L"Current FileSystem: %a\n", (FsType != EnumFileSystemMax) ?
+    GetFsTypeString (FsType) : "Not Detected");
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Basic file system test commands
+
+  @param[in]  Shell        shell instance
+  @param[in]  Argc         number of command line arguments
+  @param[in]  Argv         command line arguments
+
+  @retval EFI_SUCCESS
+
+**/
+STATIC
+EFI_STATUS
+ShellCommandFsFunc (
+  IN SHELL  *Shell,
+  IN UINTN   Argc,
+  IN CHAR16 *Argv[]
+  )
+{
+  EFI_STATUS          Status;
+  OS_BOOT_MEDIUM_TYPE DeviceType;
+  UINT32              HwPartNo;
+  UINT32              SwPartNo;
+  CHAR16             *SubCmd;
+
+  if (Argc < 2) {
+    goto Usage;
+  }
+
+  SubCmd = Argv[1];
+  if (StrCmp (SubCmd, L"init") == 0) {
+    DeviceType = (Argc < 3) ? 0 : (OS_BOOT_MEDIUM_TYPE)StrHexToUintn (Argv[2]);
+    HwPartNo = (Argc < 4) ? 0 : StrHexToUintn (Argv[3]);
+    SwPartNo = (Argc < 5) ? 0 : StrHexToUintn (Argv[4]);
+    Status = CmdFsInit (DeviceType, HwPartNo, SwPartNo);
+  } else if (StrCmp (SubCmd, L"close") == 0) {
+    Status = CmdFsClose ();
+  } else if (StrCmp (SubCmd, L"ls") == 0) {
+    Status = CmdFsFsListDir ((Argc < 3) ? L"/" : Argv[2]);
+  } else if (StrCmp (SubCmd, L"info") == 0) {
+    Status = CmdFsInfo ();
+  } else {
+    goto Usage;
+  }
+  return Status;
+
+Usage:
+  ShellPrint (L"Usage: %s init [device no.] [hwpart no.] [swpart no.]\n", Argv[0]);
+  ShellPrint (L"       %s close\n", Argv[0]);
+  ShellPrint (L"       %s info\n", Argv[0]);
+  ShellPrint (L"       %s ls [dir or file path]\n", Argv[0]);
+
+  ShellPrint (L"\n  - [device no.] ");
+  PrintPlatformDevices ();
+  ShellPrint (L"  - [hwpart no.] hw partition or port number\n");
+  ShellPrint (L"  - [swpart no.] logical partition index from mbr or gpt\n");
+
+  return EFI_ABORTED;
+}

--- a/BootloaderCommonPkg/Library/ShellLib/ShellCmds.c
+++ b/BootloaderCommonPkg/Library/ShellLib/ShellCmds.c
@@ -6,6 +6,7 @@
 **/
 
 #include "ShellCmds.h"
+#include <Library/DebugLib.h>
 
 EFI_STATUS
 LoadShellCommands (
@@ -29,5 +30,7 @@ LoadShellCommands (
   ShellCommandRegister (&ShellCommandReset);
   ShellCommandRegister (&ShellCommandUcode);
   ShellCommandRegister (&ShellCommandCls);
+  ShellCommandRegister (&ShellCommandFs);
+
   return EFI_SUCCESS;
 }

--- a/BootloaderCommonPkg/Library/ShellLib/ShellCmds.h
+++ b/BootloaderCommonPkg/Library/ShellLib/ShellCmds.h
@@ -27,6 +27,7 @@ extern CONST SHELL_COMMAND ShellCommandPci;
 extern CONST SHELL_COMMAND ShellCommandReset;
 extern CONST SHELL_COMMAND ShellCommandUcode;
 extern CONST SHELL_COMMAND ShellCommandCls;
+extern CONST SHELL_COMMAND ShellCommandFs;
 
 EFI_STATUS
 LoadShellCommands (

--- a/BootloaderCommonPkg/Library/ShellLib/ShellLib.inf
+++ b/BootloaderCommonPkg/Library/ShellLib/ShellLib.inf
@@ -38,6 +38,7 @@
   CmdUcode.c
   CmdCdata.c
   CmdCls.c
+  CmdFs.c
   ShellCmds.c
   Parsing.c
   Printing.c


### PR DESCRIPTION
This 'fs' shell command can be used for basic file system check.

Usage: fs init [device no.] [hwpart no.] [swpart no.]
       fs close
       fs info
       fs ls [dir or file path]

- 'device no.' is from Platform Device Table.
- all 0s by default if 'fs init' has no parameters
- root dir by default if 'fs ls' has no dir or file path

Signed-off-by: Aiden Park <aiden.park@intel.com>