### PR TITLE
Redefine CR macro to address Klocwork scanning issue

### DIFF
--- a/MdePkg/Include/Library/DebugLib.h
+++ b/MdePkg/Include/Library/DebugLib.h
@@ -571,14 +571,18 @@ DebugPrintLevelEnabled (
   @param  TestSignature  The 32-bit signature value to match.
 
 **/
-#if !defined(MDEPKG_NDEBUG)
-  #define CR(Record, TYPE, Field, TestSignature)                                              \
-    (DebugAssertEnabled () && (BASE_CR (Record, TYPE, Field)->Signature != TestSignature)) ?  \
-    (TYPE *) (_ASSERT (CR has Bad Signature), Record) :                                       \
-    BASE_CR (Record, TYPE, Field)
+#ifdef __KLOCWORK__
+  #define CR(Record, TYPE, Field, TestSignature)  BASE_CR(Record, TYPE, Field)
 #else
-  #define CR(Record, TYPE, Field, TestSignature)                                              \
-    BASE_CR (Record, TYPE, Field)
+  #if !defined(MDEPKG_NDEBUG)
+    #define CR(Record, TYPE, Field, TestSignature)                                              \
+      (DebugAssertEnabled () && (BASE_CR (Record, TYPE, Field)->Signature != TestSignature)) ?  \
+      (TYPE *) (_ASSERT (CR has Bad Signature), Record) :                                       \
+      BASE_CR(Record, TYPE, Field)
+  #else
+    #define CR(Record, TYPE, Field, TestSignature)                                              \
+      BASE_CR(Record, TYPE, Field)
+  #endif
 #endif
 
 #endif


### PR DESCRIPTION
Klocwork has issue to handle the CR macro in SBL code and it reported
false positives such as unused variables, uninitialized variables, etc.
This patch added special handling to resolve the issues reported by
Klocwork scanning.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>