### PR TITLE
Add SHA384 and SM3 wrapper library support for IPP crypto

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -85,6 +85,15 @@
 
   gPlatformCommonLibTokenSpaceGuid.PcdLowestSupportedFwVer		  | 0x00000000 | UINT32 | 0x20000601
 
+  ## This PCD indicates the HASH algorithm to be included by IPP Crypto library
+  #  Based on the value set, the required algorithm hash API would be enabled
+  #     0x0001    - SHA1.<BR>
+  #     0x0002    - SHA2_256.<BR>
+  #     0x0004    - SHA2_384.<BR>
+  #     0x0008    - SHA2_512.<BR>
+  #     0x0010    - SM3_256.<BR>
+  gPlatformCommonLibTokenSpaceGuid.PcdIppHashLibSupportedMask     |        0x02| UINT16 | 0x20000701
+
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   # For patchable PCDs, try to set the default as none-zero
   # It is to prevent it from being put into BSS section, thus cause patching issue

--- a/BootloaderCommonPkg/Include/Library/CryptoLib.h
+++ b/BootloaderCommonPkg/Include/Library/CryptoLib.h
@@ -17,8 +17,21 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define SIG_TYPE_RSA2048SHA256   0
 
+
+#define  HASH_TYPE_SHA256              0
+#define  HASH_TYPE_SHA384              1
+#define  HASH_TYPE_SHA512              2
+#define  HASH_TYPE_SM3                 3
+
 #define SHA256_DIGEST_SIZE       32
+#define SHA384_DIGEST_SIZE       48
+#define SM3_DIGEST_SIZE          32
+#define SHA512_DIGEST_SIZE       64
+#define HASH_DIGEST_MAX          SHA384_DIGEST_SIZE
+
 #define RSA2048NUMBYTES          256
+#define RSA3072NUMBYTES          384
+
 
 #define RSA_MOD_SIZE 256 //hardcode n size to be 256
 #define RSA_E_SIZE   4   //hardcode e size to be 4
@@ -26,6 +39,12 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define RSA_SIGNATURE_AND_KEY_SIZE  (RSA2048NUMBYTES + RSA_MOD_SIZE + RSA_E_SIZE + sizeof(UINT32))
 
 #define IPP_HASH_CTX_SIZE  256   //IPP Hash context size
+
+#define IPP_HASHLIB_SHA1         0x0001
+#define IPP_HASHLIB_SHA2_256     0x0002
+#define IPP_HASHLIB_SHA2_384     0x0004
+#define IPP_HASHLIB_SHA2_512     0x0008
+#define IPP_HASHLIB_SM3_256      0x0010
 
 typedef UINT8 HASH_CTX[IPP_HASH_CTX_SIZE];   //IPP Hash context buffer
 
@@ -52,6 +71,47 @@ typedef struct {
 **/
 UINT8 *
 Sha256 (
+  IN  CONST UINT8          *Data,
+  IN        UINT32          Length,
+  OUT       UINT8          *Digest
+  );
+
+
+/**
+  Computes the SHA-384 message digest of a input data buffer.
+
+  This function performs the SHA-384 message digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  @param[in]   Data        Pointer to the buffer containing the data to be hashed.
+  @param[in]   Length      Length of Data buffer in bytes.
+  @param[out]  Digest      Pointer to a buffer that receives the SHA-384 digest
+                           value (48 bytes).
+
+  @retval                  A pointer to SHA-384 digest value
+**/
+UINT8 *
+Sha384 (
+  IN  CONST UINT8          *Data,
+  IN        UINT32          Length,
+  OUT       UINT8          *Digest
+  );
+
+/**
+  Computes the SM3 message digest of a input data buffer.
+
+  This function performs the SM3 message digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  @param[in]   Data        Pointer to the buffer containing the data to be hashed.
+  @param[in]   Length      Length of Data buffer in bytes.
+  @param[out]  Digest      Pointer to a buffer that receives the SM3 digest
+                           value (32 bytes).
+
+  @retval                  A pointer to SM3 digest value
+**/
+UINT8 *
+Sm3 (
   IN  CONST UINT8          *Data,
   IN        UINT32          Length,
   OUT       UINT8          *Digest
@@ -182,6 +242,105 @@ Sha256Update (
 **/
 RETURN_STATUS
 Sha256Final (
+  IN       HASH_CTX   *HashCtx,
+  OUT      UINT8      *Hash
+  );
+
+
+/**
+  Initializes the hash context for SHA384 hashing.
+
+  @param[in]   HashCtx       Pointer to the hash context buffer.
+  @param[in]   HashCtxSize   Length of the hash context.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_BUFFER_TOO_SMALL    Hash context buffer size is not large enough.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+Sha384Init (
+  IN      HASH_CTX   *HashCtx,
+  IN      UINT32      HashCtxSize
+  );
+
+/**
+  Consumes the data for SHA384 hashing.
+  This method can be called multiple times to hash separate pieces of data.
+
+  @param[in]   HashCtx     Pointer to the hash context buffer.
+  @param[in]   Msg         Data to be hashed.
+  @param[in]   MsgLen      Length of data to be hashed.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+Sha384Update (
+  IN        HASH_CTX   *HashCtx,
+  IN CONST  UINT8      *Msg,
+  IN        UINT32      MsgLen
+  );
+
+/**
+  Finalizes the SHA384 hashing and returns the hash.
+
+  @param[in]   HashCtx     Pointer to the hash context buffer.
+  @param[out]  Hash        Sha384 hash of the data.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+Sha384Final (
+  IN       HASH_CTX   *HashCtx,
+  OUT      UINT8      *Hash
+  );
+
+/**
+  Initializes the hash context for SM3 hashing.
+
+  @param[in]   HashCtx       Pointer to the hash context buffer.
+  @param[in]   HashCtxSize   Length of the hash context.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_BUFFER_TOO_SMALL    Hash context buffer size is not large enough.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+Sm3Init (
+  IN      HASH_CTX   *HashCtx,
+  IN      UINT32      HashCtxSize
+  );
+
+/**
+  Consumes the data for SM3 hashing.
+  This method can be called multiple times to hash separate pieces of data.
+
+  @param[in]   HashCtx     Pointer to the hash context buffer.
+  @param[in]   Msg         Data to be hashed.
+  @param[in]   MsgLen      Length of data to be hashed.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+Sm3Update (
+  IN        HASH_CTX   *HashCtx,
+  IN CONST  UINT8      *Msg,
+  IN        UINT32      MsgLen
+  );
+
+/**
+  Finalizes the SM3 hashing and returns the hash.
+
+  @param[in]   HashCtx     Pointer to the hash context buffer.
+  @param[out]  Hash        Sm3 hash of the data.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+Sm3Final (
   IN       HASH_CTX   *HashCtx,
   OUT      UINT8      *Hash
   );

--- a/BootloaderCommonPkg/Library/IppCryptoLib/IppCryptoLib.inf
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/IppCryptoLib.inf
@@ -45,6 +45,8 @@
   hmac.c
   rsa_verify.c
   sha256.c
+  sha384.c
+  sm3.c
 
 [Sources.IA32]
   $(IPP_PATH)/Ia32/pcpsha256v8as.nasm
@@ -60,6 +62,7 @@
 
 [FixedPcd]
   gPlatformCommonLibTokenSpaceGuid.PcdCryptoShaNiEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdIppHashLibSupportedMask
 
 [BuildOptions]
   MSFT:*_*_*_CC_FLAGS = -D_SLIMBOOT_OPT -D_ARCH_IA32 -D_IPP_LE

--- a/BootloaderCommonPkg/Library/IppCryptoLib/sha384.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/sha384.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -15,24 +15,24 @@
 #include <Library/CryptoLib.h>
 
 
-/**
-  Computes the SHA-256 message digest of a input data buffer.
 
-  This function performs the SHA-256 message digest of a given data buffer, and places
+/**
+  Computes the SHA-384 message digest of a input data buffer.
+
+  This function performs the SHA-384 message digest of a given data buffer, and places
   the digest value into the specified memory.
 
   @param[in]   pMsg        Pointer to the buffer containing the data to be hashed.
   @param[in]   msgLen      Length of Data buffer in bytes.
-  @param[out]  pMD         Pointer to a buffer that receives the SHA-256 digest
-                           value (32 bytes).
+  @param[out]  pMD         Pointer to a buffer that receives the SHA-384 digest
+                           value (48 bytes).
 
-  @retval                  A pointer to SHA-256 digest value
+  @retval                  A pointer to SHA-384 digest value
 **/
-Ipp8u* Sha256 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
+Ipp8u* Sha384 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
 {
-  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_256) {
-
-    ippsHashMessage_rmf(pMsg, msgLen, pMD, ippsHashMethod_SHA256 ());
+  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_384) {
+    ippsHashMessage_rmf(pMsg, msgLen, pMD, ippsHashMethod_SHA384 ());
     return pMD;
 
   } else {
@@ -42,7 +42,7 @@ Ipp8u* Sha256 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
 }
 
 /**
-  Initializes the hash context for SHA256 hashing.
+  Initializes the hash context for SHA384 hashing.
 
   @param[in]   HashCtx       Pointer to the hash context buffer.
   @param[in]   HashCtxSize   Length of the hash context.
@@ -52,17 +52,17 @@ Ipp8u* Sha256 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
-Sha256Init (
+Sha384Init (
   IN      HASH_CTX   *HashCtx,
   IN      Ipp32u      HashCtxSize
   )
 {
-  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_256) {
+  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_384) {
     if (HashCtxSize < sizeof(IppsHashState_rmf)) {
       return RETURN_BUFFER_TOO_SMALL;
     }
 
-    if (ippsHashInit_rmf((IppsHashState_rmf*)HashCtx, ippsHashMethod_SHA256 ()) == ippStsNoErr) {
+    if (ippsHashInit_rmf((IppsHashState_rmf*)HashCtx, ippsHashMethod_SHA384 ()) == ippStsNoErr) {
       return RETURN_SUCCESS;
     }
 
@@ -74,7 +74,7 @@ Sha256Init (
 }
 
 /**
-  Consumes the data for SHA256 hashing.
+  Consumes the data for SHA384 hashing.
   This method can be called multiple times to hash separate pieces of data.
 
   @param[in]   HashCtx     Pointer to the hash context buffer.
@@ -85,41 +85,41 @@ Sha256Init (
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
-Sha256Update (
+Sha384Update (
   IN        HASH_CTX   *HashCtx,
   IN CONST  Ipp8u      *Msg,
   IN        Ipp32u      MsgLen
   )
 {
-  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_256) {
+  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_384) {
     if (ippsHashUpdate_rmf(Msg, MsgLen, (IppsHashState_rmf*)HashCtx) == ippStsNoErr) {
       return RETURN_SUCCESS;
     }
 
     return RETURN_SECURITY_VIOLATION;
 
-  }  else {
-    return RETURN_UNSUPPORTED;
+  } else {
+      return RETURN_UNSUPPORTED;
   }
 }
 
 
 /**
-  Finalizes the SHA256 hashing and returns the hash.
+  Finalizes the SHA384 hashing and returns the hash.
 
   @param[in]   HashCtx     Pointer to the hash context buffer.
-  @param[out]  Hash        Sha256 hash of the data.
+  @param[out]  Hash        Sha384 hash of the data.
 
   @retval  RETURN_SUCCESS             Success.
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
-Sha256Final (
+Sha384Final (
   IN       HASH_CTX   *HashCtx,
   OUT      Ipp8u      *Hash
   )
 {
-  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_256) {
+  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_384) {
     if (ippsHashFinal_rmf(Hash, (IppsHashState_rmf*)HashCtx) == ippStsNoErr) {
       return RETURN_SUCCESS;
     }

--- a/BootloaderCommonPkg/Library/IppCryptoLib/sm3.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/sm3.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -14,35 +14,34 @@
 
 #include <Library/CryptoLib.h>
 
-
 /**
-  Computes the SHA-256 message digest of a input data buffer.
+  Computes the SM3 message digest of a input data buffer.
 
-  This function performs the SHA-256 message digest of a given data buffer, and places
+  This function performs the SM3 message digest of a given data buffer, and places
   the digest value into the specified memory.
 
   @param[in]   pMsg        Pointer to the buffer containing the data to be hashed.
   @param[in]   msgLen      Length of Data buffer in bytes.
-  @param[out]  pMD         Pointer to a buffer that receives the SHA-256 digest
+  @param[out]  pMD         Pointer to a buffer that receives the SM3 digest
                            value (32 bytes).
 
-  @retval                  A pointer to SHA-256 digest value
+  @retval                  A pointer to SM3 digest value
 **/
-Ipp8u* Sha256 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
+Ipp8u* Sm3 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
 {
-  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_256) {
-
-    ippsHashMessage_rmf(pMsg, msgLen, pMD, ippsHashMethod_SHA256 ());
+  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SM3_256) {
+    ippsHashMessage_rmf(pMsg, msgLen, pMD, ippsHashMethod_SM3 ());
     return pMD;
 
   } else {
     pMD = NULL;
     return pMD;
   }
+
 }
 
 /**
-  Initializes the hash context for SHA256 hashing.
+  Initializes the hash context for Sm3 hashing.
 
   @param[in]   HashCtx       Pointer to the hash context buffer.
   @param[in]   HashCtxSize   Length of the hash context.
@@ -52,17 +51,17 @@ Ipp8u* Sha256 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
-Sha256Init (
+Sm3Init (
   IN      HASH_CTX   *HashCtx,
   IN      Ipp32u      HashCtxSize
   )
 {
-  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_256) {
+  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SM3_256) {
     if (HashCtxSize < sizeof(IppsHashState_rmf)) {
       return RETURN_BUFFER_TOO_SMALL;
     }
 
-    if (ippsHashInit_rmf((IppsHashState_rmf*)HashCtx, ippsHashMethod_SHA256 ()) == ippStsNoErr) {
+    if (ippsHashInit_rmf((IppsHashState_rmf*)HashCtx, ippsHashMethod_SM3 ()) == ippStsNoErr) {
       return RETURN_SUCCESS;
     }
 
@@ -74,7 +73,7 @@ Sha256Init (
 }
 
 /**
-  Consumes the data for SHA256 hashing.
+  Consumes the data for Sm3 hashing.
   This method can be called multiple times to hash separate pieces of data.
 
   @param[in]   HashCtx     Pointer to the hash context buffer.
@@ -85,47 +84,46 @@ Sha256Init (
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
-Sha256Update (
+Sm3Update (
   IN        HASH_CTX   *HashCtx,
   IN CONST  Ipp8u      *Msg,
   IN        Ipp32u      MsgLen
   )
 {
-  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_256) {
+
+  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SM3_256) {
     if (ippsHashUpdate_rmf(Msg, MsgLen, (IppsHashState_rmf*)HashCtx) == ippStsNoErr) {
       return RETURN_SUCCESS;
     }
 
     return RETURN_SECURITY_VIOLATION;
-
-  }  else {
+  } else {
     return RETURN_UNSUPPORTED;
   }
 }
 
 
 /**
-  Finalizes the SHA256 hashing and returns the hash.
+  Finalizes the Sm3 hashing and returns the hash.
 
   @param[in]   HashCtx     Pointer to the hash context buffer.
-  @param[out]  Hash        Sha256 hash of the data.
+  @param[out]  Hash        Sm3 hash of the data.
 
   @retval  RETURN_SUCCESS             Success.
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
-Sha256Final (
+Sm3Final (
   IN       HASH_CTX   *HashCtx,
   OUT      Ipp8u      *Hash
   )
 {
-  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_256) {
+  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SM3_256) {
     if (ippsHashFinal_rmf(Hash, (IppsHashState_rmf*)HashCtx) == ippStsNoErr) {
       return RETURN_SUCCESS;
     }
 
     return RETURN_SECURITY_VIOLATION;
-
   } else {
     return RETURN_UNSUPPORTED;
   }

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -247,6 +247,8 @@
   gPlatformCommonLibTokenSpaceGuid.PcdUsbKeyboardPollingTimeout | $(USB_KB_POLLING_TIMEOUT)
   gPlatformCommonLibTokenSpaceGuid.PcdLowestSupportedFwVer		| $(LOWEST_SUPPORTED_FW_VER)
 
+  gPlatformCommonLibTokenSpaceGuid.PcdIppHashLibSupportedMask    | $(IPP_HASH_LIB_SUPPORTED_MASK)
+
 [PcdsPatchableInModule]
   gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel   | 0x8000004F
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress  | $(PCI_EXPRESS_BASE)

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -258,6 +258,8 @@ class BaseBoard(object):
 		self._CFGDATA_INT_FILE     = []
 		self._CFGDATA_EXT_FILE     = []
 
+		self.IPP_HASH_LIB_SUPPORTED_MASK   = 0x0002 #SHA256 for default
+
 		for key, value in list(kwargs.items()):
 			setattr(self, '%s' % key, value)
 


### PR DESCRIPTION
Functionality to Crypto Hash function is guarded with an
PcdIppHashLibSupported.

PcdIppHashLibSupported indicates IPP crypto algo supported

Signed-off-by: Subash Lakkimsetti <subashx.lakkimsetti@intel.com>