### PR TITLE
CmdFs: Support display console print in 'fs ls'

### DIFF
--- a/BootloaderCommonPkg/Include/Library/Ext23Lib.h
+++ b/BootloaderCommonPkg/Include/Library/Ext23Lib.h
@@ -14,6 +14,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
 #include <Library/MemoryAllocationLib.h>
+#include <Library/FileSystemLib.h>
 
 #define FS_EXT_SIGNATURE    SIGNATURE_32 ('p', 'e', 'x', 't')
 
@@ -134,6 +135,7 @@ ExtFsCloseFile (
 
   @param[in]     FsHandle         file system handle.
   @param[in]     DirFilePath      directory or file path
+  @param[in]     ConsoleOutFunc   redirect output message to a console
 
   @retval EFI_SUCCESS             list directories of files successfully
   @retval EFI_UNSUPPORTED         this api is not supported
@@ -144,7 +146,8 @@ EFI_STATUS
 EFIAPI
 ExtFsListDir (
   IN  EFI_HANDLE                                  FsHandle,
-  IN  CHAR16                                     *DirFilePath
+  IN  CHAR16                                     *DirFilePath,
+  IN  CONSOLE_OUT_FUNC                            ConsoleOutFunc
   );
 
 #endif // _EXT23_LIB_H_

--- a/BootloaderCommonPkg/Include/Library/FatLib.h
+++ b/BootloaderCommonPkg/Include/Library/FatLib.h
@@ -14,6 +14,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
 #include <Library/PartitionLib.h>
+#include <Library/FileSystemLib.h>
 
 #define FS_FAT_SIGNATURE    SIGNATURE_32 ('p', 'f', 'a', 't')
 
@@ -134,6 +135,7 @@ FatFsCloseFile (
 
   @param[in]     FsHandle         file system handle.
   @param[in]     DirFilePath      directory or file path
+  @param[in]     ConsoleOutFunc   redirect output message to a console
 
   @retval EFI_SUCCESS             list directories of files successfully
   @retval EFI_UNSUPPORTED         this api is not supported
@@ -144,7 +146,8 @@ EFI_STATUS
 EFIAPI
 FatFsListDir (
   IN  EFI_HANDLE                                  FsHandle,
-  IN  CHAR16                                     *DirFilePath
+  IN  CHAR16                                     *DirFilePath,
+  IN  CONSOLE_OUT_FUNC                            ConsoleOutFunc
   );
 
 #endif // _FAT_LIB_H_

--- a/BootloaderCommonPkg/Include/Library/FileSystemLib.h
+++ b/BootloaderCommonPkg/Include/Library/FileSystemLib.h
@@ -13,6 +13,11 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PartitionLib.h>
 #include <Guid/OsBootOptionGuid.h>
 
+//
+// To redirect output message to consoles (serial, graphic console and etc.)
+//
+typedef UINTN (* CONSOLE_OUT_FUNC) (CONST CHAR16 *Format, ...);
+
 /**
   Initialize file systems.
 
@@ -132,6 +137,7 @@ VOID
 
   @param[in]     FsHandle         file system handle.
   @param[in]     DirFilePath      directory or file path
+  @param[in]     ConsoleOutFunc   redirect output message to a console
 
   @retval EFI_SUCCESS             list directories of files successfully
   @retval EFI_UNSUPPORTED         this api is not supported
@@ -142,7 +148,8 @@ typedef
 EFI_STATUS
 (EFIAPI *FS_LIST_DIR) (
   IN  EFI_HANDLE                                  FsHandle,
-  IN  CHAR16                                     *DirFilePath
+  IN  CHAR16                                     *DirFilePath,
+  IN  CONSOLE_OUT_FUNC                            ConsoleOutFunc
   );
 
 /**
@@ -294,6 +301,7 @@ CloseFile (
 
   @param[in]     FsHandle         file system handle.
   @param[in]     DirFilePath      directory or file path
+  @param[in]     ConsoleOutFunc   redirect output message to a console
 
   @retval EFI_SUCCESS             list directories of files successfully
   @retval EFI_UNSUPPORTED         this api is not supported
@@ -304,7 +312,8 @@ EFI_STATUS
 EFIAPI
 ListDir (
   IN  EFI_HANDLE                                  FsHandle,
-  IN  CHAR16                                     *DirFilePath
+  IN  CHAR16                                     *DirFilePath,
+  IN  CONSOLE_OUT_FUNC                            ConsoleOutFunc
   );
 
 typedef struct {

--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.h
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.h
@@ -67,6 +67,7 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/BaseLib.h>
 #include <Library/PartitionLib.h>
+#include <Library/FileSystemLib.h>
 #include "Ext2FsDiNode.h"
 #include "Ext2FsDir.h"
 #include "LibsaFsStand.h"
@@ -501,6 +502,7 @@ Ext2fsRead (
 
   @param[in] File           pointer to an file private data
   @param[in] Pattern        not used for now
+  @param[in] ConsoleOutFunc redirect output message to a console
 
   @retval EFI_SUCCESS       list directories or files successfully
   @retval EFI_NOT_FOUND     not found specified dir or file
@@ -509,8 +511,9 @@ Ext2fsRead (
 EFI_STATUS
 EFIAPI
 Ext2fsLs (
-  IN  OPEN_FILE     *File,
-  IN  CONST CHAR8   *Pattern
+  IN  OPEN_FILE         *File,
+  IN  CONST CHAR8       *Pattern,
+  IN  CONSOLE_OUT_FUNC   ConsoleOutFunc
   );
 
 /**

--- a/BootloaderCommonPkg/Library/Ext23Lib/ExtLib.c
+++ b/BootloaderCommonPkg/Library/Ext23Lib/ExtLib.c
@@ -276,6 +276,7 @@ ExtFsCloseFile (
 
   @param[in]     FsHandle         file system handle.
   @param[in]     DirFilePath      directory or file path
+  @param[in]     ConsoleOutFunc   redirect output message to a console
 
   @retval EFI_SUCCESS             list directories of files successfully
   @retval EFI_UNSUPPORTED         this api is not supported
@@ -286,7 +287,8 @@ EFI_STATUS
 EFIAPI
 ExtFsListDir (
   IN  EFI_HANDLE                                  FsHandle,
-  IN  CHAR16                                     *DirFilePath
+  IN  CHAR16                                     *DirFilePath,
+  IN  CONSOLE_OUT_FUNC                            ConsoleOutFunc
   )
 {
   EFI_STATUS              Status;
@@ -295,10 +297,14 @@ ExtFsListDir (
   Status = EFI_UNSUPPORTED;
 
 DEBUG_CODE_BEGIN ();
+  if (ConsoleOutFunc == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
   FileHandle = NULL;
   Status = ExtFsOpenFile (FsHandle, DirFilePath, &FileHandle);
   if (!EFI_ERROR (Status)) {
-    Status = Ext2fsLs ((OPEN_FILE *)FileHandle, NULL);
+    Status = Ext2fsLs ((OPEN_FILE *)FileHandle, NULL, ConsoleOutFunc);
   }
   if (FileHandle != NULL) {
     ExtFsCloseFile (FileHandle);

--- a/BootloaderCommonPkg/Library/FileSystemLib/FileSystemLib.c
+++ b/BootloaderCommonPkg/Library/FileSystemLib/FileSystemLib.c
@@ -468,6 +468,7 @@ CloseFile (
 
   @param[in]     FsHandle         file system handle.
   @param[in]     DirFilePath      directory or file path
+  @param[in]     ConsoleOutFunc   redirect output message to a console
 
   @retval EFI_SUCCESS             list directories of files successfully
   @retval EFI_UNSUPPORTED         this api is not supported
@@ -478,12 +479,17 @@ EFI_STATUS
 EFIAPI
 ListDir (
   IN  EFI_HANDLE                                  FsHandle,
-  IN  CHAR16                                     *DirFilePath
+  IN  CHAR16                                     *DirFilePath,
+  IN  CONSOLE_OUT_FUNC                            ConsoleOutFunc
   )
 {
 DEBUG_CODE_BEGIN ();
   OS_FILE_SYSTEM_TYPE         FsType;
   FILE_SYSTEM_CONTROL_BLOCK  *FileSystemControlBlock;
+
+  if (ConsoleOutFunc == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
 
   FileSystemControlBlock = (FILE_SYSTEM_CONTROL_BLOCK *)FsHandle;
   ASSERT (FileSystemControlBlock != NULL);
@@ -497,7 +503,7 @@ DEBUG_CODE_BEGIN ();
   }
 
   if (mFileSystemFuncs[FsType].ListDir != NULL) {
-    return mFileSystemFuncs[FsType].ListDir (FileSystemControlBlock->FsHandle, DirFilePath);
+    return mFileSystemFuncs[FsType].ListDir (FileSystemControlBlock->FsHandle, DirFilePath, ConsoleOutFunc);
   }
 DEBUG_CODE_END ();
 

--- a/BootloaderCommonPkg/Library/ShellLib/CmdFs.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdFs.c
@@ -206,7 +206,7 @@ CmdFsFsListDir (
     return EFI_ABORTED;
   }
 
-  Status = ListDir (mFsHandle, DirFilePath);
+  Status = ListDir (mFsHandle, DirFilePath, ShellPrint);
   if (Status == EFI_NOT_FOUND) {
     ShellPrint (L"Not found!\n");
   } else if (Status == EFI_UNSUPPORTED) {


### PR DESCRIPTION
This allows 'fs ls' command to print directory or file lists to both serial
and display console according to CONSOLE_OUT_DEVICE_MASK.

Signed-off-by: Aiden Park <aiden.park@intel.com>