### PR TITLE
Add hash type param to bootloader build and signing tools

### DIFF
--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -314,7 +314,7 @@ def gen_flash_map_bin (flash_map_file, comp_list):
 def copy_expanded_file (src, dst):
 	gen_cfg_data ("GENDLT", src, dst)
 
-def gen_config_file (fv_dir, brd_name, platform_id, pri_key, cfg_db_size, cfg_size, cfg_int, cfg_ext):
+def gen_config_file (fv_dir, brd_name, platform_id, pri_key, cfg_db_size, cfg_size, cfg_int, cfg_ext, hash_type):
 	# Remove previous generated files
 	for file in glob.glob(os.path.join(fv_dir, "CfgData*.*")):
 			os.remove(file)
@@ -400,7 +400,7 @@ def gen_config_file (fv_dir, brd_name, platform_id, pri_key, cfg_db_size, cfg_si
 
 	cfg_final_file = os.path.join(fv_dir, "CFGDATA.bin")
 	if pri_key:
-		cfg_data_tool ('sign', ['-k', pri_key, cfg_merged_bin_file], cfg_final_file)
+		cfg_data_tool ('sign', ['-k', pri_key, '-auth', hash_type, cfg_merged_bin_file], cfg_final_file)
 	else:
 		shutil.copy(cfg_merged_bin_file, cfg_final_file)
 
@@ -470,7 +470,7 @@ def gen_payload_bin (fv_dir, pld_list, pld_bin, priv_key, brd_name = None):
 	gen_container_bin ([pld_list], fv_dir, fv_dir, key_dir, '')
 
 
-def gen_hash_file (src_path, hash_path = '', is_key = False):
+def gen_hash_file (src_path, hash_type, hash_path = '', is_key = False):
 	if not hash_path:
 		hash_path = os.path.splitext(src_path)[0] + '.hash'
 	with open(src_path,'rb') as fi:
@@ -480,7 +480,10 @@ def gen_hash_file (src_path, hash_path = '', is_key = False):
 			raise Exception ("Invalid public key binary!")
 		di = di[4:]
 		di = di[:0x100][::-1] + di[0x100:][::-1]
-	ho = hashlib.sha256(di)
+	if hash_type == 'SHA2_256':
+		ho = hashlib.sha256(di)
+	else:
+		raise Exception ("Unsupported hash type provided!")
 	with open(hash_path,'wb') as fo:
 		fo.write(ho.digest())
 

--- a/BootloaderCorePkg/Tools/CfgDataTool.py
+++ b/BootloaderCorePkg/Tools/CfgDataTool.py
@@ -9,6 +9,7 @@ import collections
 
 sys.dont_write_bytecode = True
 from   IfwiUtility import *
+from   CommonUtility import *
 
 
 class CDATA_BLOB_HEADER(Structure):
@@ -114,7 +115,6 @@ class CRsaSign:
             Bins.extend(PubKey)
 
         open(OutFile, 'wb').write(Bins)
-
 
 class CCfgData:
 
@@ -785,6 +785,7 @@ def Main():
                             help='Configuration binary file')
     SignParser.add_argument('-o', dest='cfg_out_file', type=str, help='Signed configuration output binary file name to be generated', required=True)
     SignParser.add_argument('-k', dest='cfg_pri_key', type=str, help='Private key file (PEM format) used to sign configuration data', required=True)
+    SignParser.add_argument('-auth', dest='auth_type', type=str, help='Auth Type with RSA signing', required=True)
     SignParser.set_defaults(func=CmdSign)
 
     ExtractParser = SubParser.add_parser('extract', help='extract a single config data to a file')

--- a/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
+++ b/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
@@ -427,7 +427,7 @@ def SignImage(RawData, OutFile, PrivKey):
     fwupdate_bin_file = 'fwupdate_unsigned.bin'
     open(fwupdate_bin_file, 'wb').write(unsigned_image + RawData)
 
-    rsa_sign_file(PrivKey, pubkey_file, fwupdate_bin_file, OutFile, True, True)
+    rsa_sign_file(PrivKey, pubkey_file, self.SIGN_HASH_TYPE, fwupdate_bin_file, OutFile, True, True )
 
     os.remove(pubkey_file)
     os.remove(fwupdate_bin_file)

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -25,7 +25,6 @@ import multiprocessing
 from   ctypes import *
 from   BuildUtility import *
 
-
 def rebuild_basetools ():
 	exe_list = 'GenFfs  GenFv  GenFw  GenSec  Lz4Compress  LzmaCompress'.split()
 	ret = 0
@@ -137,6 +136,8 @@ class BaseBoard(object):
 		self._IAS_PRIVATE_KEY       = os.path.join(key_dir, 'TestSigningPrivateKey.pem')
 		self.LOGO_FILE              = 'Platform/CommonBoardPkg/Logo/Logo.bmp'
 
+		self.RSA_SIGN_TYPE						= 'RSA2048'
+		self.SIGN_HASH_TYPE						= 'SHA2_256'
 		self.VERINFO_IMAGE_ID       = 'SB_???? '
 		self.VERINFO_PROJ_ID        = 1
 		self.VERINFO_CORE_MAJOR_VER = 0
@@ -860,7 +861,7 @@ class Build(object):
 					if src == 'STAGE2.fd':
 						raise Exception ("STAGE2.fd must be compressed, please change BoardConfig.py file !")
 				if src not in rgn_name_list:
-					gen_hash_file (src_path)
+					gen_hash_file (src_path, self._board.SIGN_HASH_TYPE, '', False)
 
 				if mode != STITCH_OPS.MODE_FILE_NOP:
 					dst_path = bas_path + '.pad'
@@ -1059,13 +1060,13 @@ class Build(object):
 				cfg_priv_key     = self._board._CFG_PRIVATE_KEY
 				cfg_pub_key_file = os.path.join(self._fv_dir, "CFGKEY.bin")
 				gen_pub_key (cfg_priv_key, cfg_pub_key_file)
-				gen_hash_file (cfg_pub_key_file, '', True)
+				gen_hash_file (cfg_pub_key_file, self._board.SIGN_HASH_TYPE, '', True)
 			else:
 				cfg_priv_key = None
 			# create config data files
 			gen_config_file (self._fv_dir, self._board.BOARD_PKG_NAME, self._board._PLATFORM_ID,
 											 cfg_priv_key, self._board.CFG_DATABASE_SIZE, self._board.CFGDATA_SIZE,
-											 self._board._CFGDATA_INT_FILE, self._board._CFGDATA_EXT_FILE)
+											 self._board._CFGDATA_INT_FILE, self._board._CFGDATA_EXT_FILE, self._board.SIGN_HASH_TYPE)
 
 		# rebuild reset vector
 		vtf_dir = os.path.join('BootloaderCorePkg', 'Stage1A', 'Ia32', 'Vtf0')
@@ -1143,7 +1144,7 @@ class Build(object):
 		if self._board.HAVE_VERIFIED_BOOT:
 			ias_pub_key_file = os.path.join(self._fv_dir, "OSKEY.bin")
 			gen_pub_key (self._board._IAS_PRIVATE_KEY, ias_pub_key_file)
-			gen_hash_file (ias_pub_key_file, '', True)
+			gen_hash_file (ias_pub_key_file, self._board.SIGN_HASH_TYPE, '', True)
 
 
 		# generate payload
@@ -1159,7 +1160,7 @@ class Build(object):
 				os.path.join(self._fv_dir, "FWUPDATE.bin"))
 			fwup_key_file = os.path.join(self._fv_dir, "FWUKEY.bin")
 			gen_pub_key (self._board._FWU_PRIVATE_KEY, fwup_key_file)
-			gen_hash_file (fwup_key_file, '', True)
+			gen_hash_file (fwup_key_file, self._board.SIGN_HASH_TYPE, '', True)
 
 
 		# create SPI IAS image if required
@@ -1173,7 +1174,7 @@ class Build(object):
 		if getattr(self._board, "GetContainerList", None):
 		  container_list = self._board.GetContainerList ()
 		  component_dir = os.path.join(os.environ['PLT_SOURCE'], 'Platform', self._board.BOARD_PKG_NAME, 'Binaries')
-		  gen_container_bin (container_list, self._fv_dir, component_dir, self._key_dir, '')
+		  gen_container_bin (container_list, self._fv_dir, component_dir, self._key_dir, '', self._board.SIGN_HASH_TYPE)
 
 		# patch stages
 		self.patch_stages ()


### PR DESCRIPTION
hash_type parameter added to build tool API's as required and
current supported hash in tools is for SHA2_256.

Added functionality for retriving RSA private key type.

Signed-off-by: Subash Lakkimsetti <subashx.lakkimsetti@intel.com>