### PR TITLE
Fix KW issue

### DIFF
--- a/PayloadPkg/Library/SblParameterLib/SblParameterLib.c
+++ b/PayloadPkg/Library/SblParameterLib/SblParameterLib.c
@@ -313,7 +313,7 @@ AddSblCommandLine (
   //
   if ((OsConfigData != NULL) && (OsConfigData->EnableCrashMode != 0)) {
     Data8 = (UINT8)~(ResetCold | ResetPowerOn | ResetGlobal | ResetWakeS3);
-    if ((OsBootOptionList->ResetReason & Data8) != 0) {
+    if ((ResetReason & Data8) != 0) {
       AsciiStrCatS (CommandLine, MaxCmdSize, " boot_target=CRASHMODE");
     }
   }


### PR DESCRIPTION
It should use local variable ResetReason instead of OsBootOptionList
in case of OS boot option is not available.

Signed-off-by: Guo Dong <guo.dong@intel.com>