### PR TITLE
Enable PatchCheck in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ services:
   - docker
 
 before_install:
+  - PATCHCHECK=$(python BaseTools/Scripts/PatchCheck.py $TRAVIS_COMMIT_RANGE); ERRORS=$(echo $PATCHCHECK | grep -c 'is not valid'); echo "$PATCHCHECK"; if [[ $ERRORS -gt 0 ]]; then travis_terminate 1; fi
   - docker build -t sbl .
   - chmod -R a+w .
 


### PR DESCRIPTION
This will run PatchCheck.py in travis before building a target.
If the format is invalid, travis will exit immediately.

Signed-off-by: Aiden Park <aiden.park@intel.com>