### PR TITLE
Fix invalid PatchCheck commit ranges in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 before_install:
-  - PATCHCHECK=$(python BaseTools/Scripts/PatchCheck.py $TRAVIS_COMMIT_RANGE); ERRORS=$(echo $PATCHCHECK | grep -c 'is not valid'); echo "$PATCHCHECK"; if [[ $ERRORS -gt 0 ]]; then travis_terminate 1; fi
+  - HEAD_COMMIT=$(git rev-list --no-merges HEAD | head -1); PATCHCHECK=$(python BaseTools/Scripts/PatchCheck.py master..$HEAD_COMMIT); ERRORS=$(echo $PATCHCHECK | grep -c 'is not valid'); echo "$PATCHCHECK"; if [[ $ERRORS -gt 0 ]]; then travis_terminate 1; fi
   - docker build -t sbl .
   - chmod -R a+w .
 


### PR DESCRIPTION
PatchCheck was using 'TRAVIS_COMMIT_RANGE' travis variable to get commit
range, but it lost tracks when doing force push or rebase. There are many
issue reports about this variable.
To avoid potential issue, let's get the range from git command directly
instead of TRAVIS_COMMIT_RANGE variable.

Signed-off-by: Aiden Park <aiden.park@intel.com>