### PR TITLE
Add SortLib support in BootloaderCommonPkg

### DIFF
--- a/BootloaderCommonPkg/Include/Library/SortLib.h
+++ b/BootloaderCommonPkg/Include/Library/SortLib.h
@@ -1,0 +1,60 @@
+/** @file
+  Library used for sorting and comparison routines.
+
+  Copyright (c) 2009 - 2019, Intel Corporation. All rights reserved. <BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#ifndef __SORT_LIB_H__
+#define __SORT_LIB_H__
+
+/**
+  Prototype for comparison function for any two element types.
+
+  @param[in] Buffer1                  The pointer to first buffer.
+  @param[in] Buffer2                  The pointer to second buffer.
+
+  @retval 0                           Buffer1 equal to Buffer2.
+  @return <0                          Buffer1 is less than Buffer2.
+  @return >0                          Buffer1 is greater than Buffer2.
+**/
+typedef
+INTN
+(EFIAPI *SORT_COMPARE)(
+  IN CONST VOID                 *Buffer1,
+  IN CONST VOID                 *Buffer2
+  );
+
+/**
+  Worker function for QuickSorting.  This function is identical to PerformQuickSort,
+  except that is uses the pre-allocated buffer so the in place sorting does not need to
+  allocate and free buffers constantly.
+
+  Each element must be equal sized.
+
+  if BufferToSort is NULL, then ASSERT.
+  if CompareFunction is NULL, then ASSERT.
+  if Buffer is NULL, then ASSERT.
+
+  if Count is < 2 then perform no action.
+  if Size is < 1 then perform no action.
+
+  @param[in, out] BufferToSort   on call a Buffer of (possibly sorted) elements
+                                 on return a buffer of sorted elements
+  @param[in] Count               the number of elements in the buffer to sort
+  @param[in] ElementSize         Size of an element in bytes
+  @param[in] CompareFunction     The function to call to perform the comparison
+                                 of any 2 elements
+  @param[in] Buffer              Buffer of size ElementSize for use in swapping
+**/
+VOID
+EFIAPI
+PerformQuickSort (
+  IN OUT VOID                           *BufferToSort,
+  IN CONST UINTN                        Count,
+  IN CONST UINTN                        ElementSize,
+  IN       SORT_COMPARE                 CompareFunction,
+  IN VOID                               *Buffer
+  );
+
+#endif //__SORT_LIB_H__

--- a/BootloaderCommonPkg/Library/SortLib/SortLib.c
+++ b/BootloaderCommonPkg/Library/SortLib/SortLib.c
@@ -1,0 +1,117 @@
+/** @file
+  Library used for sorting routines.
+
+  Copyright (c) 2009 - 2019, Intel Corporation. All rights reserved. <BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <PiPei.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/SortLib.h>
+
+/**
+  Worker function for QuickSorting.  This function is identical to PerformQuickSort,
+  except that is uses the pre-allocated buffer so the in place sorting does not need to
+  allocate and free buffers constantly.
+
+  Each element must be equal sized.
+
+  if BufferToSort is NULL, then ASSERT.
+  if CompareFunction is NULL, then ASSERT.
+  if Buffer is NULL, then ASSERT.
+
+  if Count is < 2 then perform no action.
+  if Size is < 1 then perform no action.
+
+  @param[in, out] BufferToSort   on call a Buffer of (possibly sorted) elements
+                                 on return a buffer of sorted elements
+  @param[in] Count               the number of elements in the buffer to sort
+  @param[in] ElementSize         Size of an element in bytes
+  @param[in] CompareFunction     The function to call to perform the comparison
+                                 of any 2 elements
+  @param[in] Buffer              Buffer of size ElementSize for use in swapping
+**/
+VOID
+EFIAPI
+PerformQuickSort (
+  IN OUT VOID                           *BufferToSort,
+  IN CONST UINTN                        Count,
+  IN CONST UINTN                        ElementSize,
+  IN       SORT_COMPARE                 CompareFunction,
+  IN VOID                               *Buffer
+  )
+{
+  VOID        *Pivot;
+  UINTN       LoopCount;
+  UINTN       NextSwapLocation;
+
+  ASSERT ((BufferToSort != NULL) && (CompareFunction != NULL) && (Buffer != NULL));
+
+  if ((Count < 2)  || (ElementSize < 1)) {
+    return;
+  }
+
+  NextSwapLocation = 0;
+
+  //
+  // pick a pivot (we choose last element)
+  //
+  Pivot = ((UINT8 *)BufferToSort + ((Count - 1) * ElementSize));
+
+  //
+  // Now get the pivot such that all on "left" are below it
+  // and everything "right" are above it
+  //
+  for ( LoopCount = 0; LoopCount < Count - 1; LoopCount++) {
+    //
+    // if the element is less than the pivot
+    //
+    if (CompareFunction ((VOID *)((UINT8 *)BufferToSort + ((LoopCount)*ElementSize)), Pivot) <= 0) {
+      //
+      // swap
+      //
+      CopyMem (Buffer, (UINT8 *)BufferToSort + (NextSwapLocation * ElementSize), ElementSize);
+      CopyMem ((UINT8 *)BufferToSort + (NextSwapLocation * ElementSize), (UINT8 *)BufferToSort + ((LoopCount)*ElementSize),
+               ElementSize);
+      CopyMem ((UINT8 *)BufferToSort + ((LoopCount)*ElementSize), Buffer, ElementSize);
+
+      //
+      // increment NextSwapLocation
+      //
+      NextSwapLocation++;
+    }
+  }
+  //
+  // swap pivot to it's final position (NextSwapLocaiton)
+  //
+  CopyMem (Buffer, Pivot, ElementSize);
+  CopyMem (Pivot, (UINT8 *)BufferToSort + (NextSwapLocation * ElementSize), ElementSize);
+  CopyMem ((UINT8 *)BufferToSort + (NextSwapLocation * ElementSize), Buffer, ElementSize);
+
+  //
+  // Now recurse on 2 paritial lists.  neither of these will have the 'pivot' element
+  // IE list is sorted left half, pivot element, sorted right half...
+  //
+  if (NextSwapLocation >= 2) {
+    PerformQuickSort (
+      BufferToSort,
+      NextSwapLocation,
+      ElementSize,
+      CompareFunction,
+      Buffer);
+  }
+
+  if ((Count - NextSwapLocation - 1) >= 2) {
+    PerformQuickSort (
+      (UINT8 *)BufferToSort + (NextSwapLocation + 1) * ElementSize,
+      Count - NextSwapLocation - 1,
+      ElementSize,
+      CompareFunction,
+      Buffer);
+  }
+
+  return;
+}

--- a/BootloaderCommonPkg/Library/SortLib/SortLib.inf
+++ b/BootloaderCommonPkg/Library/SortLib/SortLib.inf
@@ -1,0 +1,33 @@
+##  @file
+#   Library used for sorting routines.
+#
+#  Copyright (c) 2009 - 2019, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010006
+  BASE_NAME                      = SortLib
+  FILE_GUID                      = 03F3331B-F12D-494f-BF37-E55A657F2497
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = SortLib
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 EBC
+#
+
+[Sources.common]
+  SortLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -121,6 +121,7 @@
   LinuxLib|BootloaderCommonPkg/Library/LinuxLib/LinuxLib.inf
   UefiVariableLib|BootloaderCommonPkg/Library/UefiVariableLib/UefiVariableLib.inf
   SerialPortLib|BootloaderCommonPkg/Library/SerialPortLib/SerialPortLib.inf
+  SortLib|BootloaderCommonPkg/Library/SortLib/SortLib.inf
 
 !if $(HAVE_FSP_BIN)
   FspApiLib|$(PLATFORM_PACKAGE)/Library/FspApiLib/FspApiLib.inf

--- a/BootloaderCorePkg/Library/MpInitLib/Ia32/MpInitLib.c
+++ b/BootloaderCorePkg/Library/MpInitLib/Ia32/MpInitLib.c
@@ -16,6 +16,31 @@ volatile MP_DATA_EXCHANGE_STRUCT   mMpDataStruct;
 UINT8                             *mBackupBuffer;
 UINT32                             mMpInitPhase = EnumMpInitNull;
 
+
+/**
+  The function is called by PerformQuickSort to sort CPU_INFO by ApicId.
+
+  @param[in] Buffer1         The pointer to first buffer.
+  @param[in] Buffer2         The pointer to second buffer.
+
+  @retval 0                  Buffer1 ApicId is less than Buffer2 ApicId.
+  @retval 1                  Buffer1 ApicId is greater than or equal to Buffer2 ApicId.
+
+**/
+STATIC
+INTN
+CompareCpuApicId (
+  IN CONST VOID                 *Buffer1,
+  IN CONST VOID                 *Buffer2
+  )
+{
+  if (((CPU_INFO *)Buffer1)->ApicId < ((CPU_INFO *)Buffer2)->ApicId) {
+    return  0;
+  } else {
+    return  1;
+  }
+}
+
 /**
   Sort the CPU entry according to their thread distances
 
@@ -42,15 +67,7 @@ SortSysCpu (
   }
 
   // Sort by APIC ID first
-  for (Idx1 = 0; Idx1 < SysCpuInfo->CpuCount - 1; Idx1++) {
-    for (Idx2 = Idx1; Idx2 < SysCpuInfo->CpuCount; Idx2++) {
-      if (SysCpuInfo->CpuInfo[Idx1].ApicId > SysCpuInfo->CpuInfo[Idx2].ApicId) {
-        CopyMem (&Temp, &SysCpuInfo->CpuInfo[Idx1], sizeof(CPU_INFO));
-        CopyMem (&SysCpuInfo->CpuInfo[Idx1], &SysCpuInfo->CpuInfo[Idx2], sizeof(CPU_INFO));
-        CopyMem (&SysCpuInfo->CpuInfo[Idx2], &Temp, sizeof(CPU_INFO));
-      }
-    }
-  }
+  PerformQuickSort (SysCpuInfo->CpuInfo, SysCpuInfo->CpuCount, sizeof (CPU_INFO), CompareCpuApicId, &Temp);
 
   // Keep a backup copy
   CopyMem (&OldSysCpuInfo,  SysCpuInfo, sizeof (ALL_CPU_INFO));

--- a/BootloaderCorePkg/Library/MpInitLib/Ia32/MpInitLibInternal.h
+++ b/BootloaderCorePkg/Library/MpInitLib/Ia32/MpInitLibInternal.h
@@ -16,6 +16,7 @@
 #include <Library/TimerLib.h>
 #include <Library/SynchronizationLib.h>
 #include <Library/LocalApicLib.h>
+#include <Library/SortLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/BootloaderCommonLib.h>
 #include <Library/MpInitLib.h>

--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
@@ -38,6 +38,7 @@
 [LibraryClasses.IA32]
   LocalApicLib
   SynchronizationLib
+  SortLib
 
 [Guids]
 

--- a/BootloaderCorePkg/Stage2/Stage2.h
+++ b/BootloaderCorePkg/Stage2/Stage2.h
@@ -36,6 +36,7 @@
 #include <Library/LinuxLib.h>
 #include <Library/DebugLogBufferLib.h>
 #include <Library/LiteFvLib.h>
+#include <Library/SortLib.h>
 #include <Library/ContainerLib.h>
 #include <Guid/BootLoaderServiceGuid.h>
 #include <Guid/BootLoaderVersionGuid.h>

--- a/BootloaderCorePkg/Stage2/Stage2.inf
+++ b/BootloaderCorePkg/Stage2/Stage2.inf
@@ -70,6 +70,7 @@
   ContainerLib
   SmbiosInitLib
   LinuxLib
+  SortLib
 
 [Guids]
   gFspReservedMemoryResourceHobGuid


### PR DESCRIPTION
There are multiple instances of sorting use case in SBL. For example,
memory map sorting and CPU APIC ID sorting. This patch added a generic
quick sort library to provide common sort API. As part of the change,
the quick sort API will be used for memory map and CPU APIC ID sorting.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>