### PR TITLE
Signing hash type in GenCapsuleFirmware tool

### DIFF
--- a/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
+++ b/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
@@ -397,7 +397,7 @@ class Firmware_Update_Header(Structure):
   ]
 
 
-def SignImage(RawData, OutFile, PrivKey):
+def SignImage(RawData, OutFile, HashType, PrivKey):
 
     #
     # Generate the new image layout
@@ -427,7 +427,7 @@ def SignImage(RawData, OutFile, PrivKey):
     fwupdate_bin_file = 'fwupdate_unsigned.bin'
     open(fwupdate_bin_file, 'wb').write(unsigned_image + RawData)
 
-    rsa_sign_file(PrivKey, pubkey_file, self.SIGN_HASH_TYPE, fwupdate_bin_file, OutFile, True, True )
+    rsa_sign_file(PrivKey, pubkey_file, HashType, fwupdate_bin_file, OutFile, True, True )
 
     os.remove(pubkey_file)
     os.remove(fwupdate_bin_file)
@@ -471,6 +471,7 @@ def main():
 
     parser.add_argument('-p',  '--payload', nargs=2, action='append', type=str, required=True, help='Specify payload information including GUID, FileName')
     parser.add_argument('-k',  '--priv_key', dest='PrivKey', type=str, required=True, help='Private RSA 2048 key in PEM format to sign image')
+    parser.add_argument('-a',  '--alg_hash', dest='HashType', type=str, required=True, help='Hash type for signing')
     parser.add_argument('-o',  '--output', dest='NewImage', type=str, required=True, help='Output file for signed image')
     parser.add_argument("-v",  "--verbose", dest='Verbose', action="store_true", help= "Turn on verbose output with informational messages printed, including capsule headers and warning messages.")
 
@@ -504,7 +505,7 @@ def main():
     #
     # Create final capsule
     #
-    SignImage(Result, args.NewImage, args.PrivKey)
+    SignImage(Result, args.NewImage, args.HashType, args.PrivKey)
 
     print('Success')
 


### PR DESCRIPTION
Added hash type to be used in signing process for
GenCapsuleFirmware.

Parameter added: -a alg_hash

Signed-off-by: Subash Lakkimsetti <subashx.lakkimsetti@intel.com>