### PR TITLE
OsLoader: Free all allocated memory at failing on a boot option

### DIFF
--- a/BootloaderCommonPkg/Include/Library/IasImageLib.h
+++ b/BootloaderCommonPkg/Include/Library/IasImageLib.h
@@ -55,9 +55,17 @@ typedef struct {               // an IAS image generic header:
   UINT32    HeaderCrc;       // CRC-32C over entire header
 } IAS_HEADER;
 
+typedef enum {
+  ImageAllocateTypePool = 0,      // Allocate memory in Pool
+  ImageAllocateTypePage,          // Allocate memory in Page
+  ImageAllocateTypePointer,       // No allocate memory, but pointer to the existing memory
+  ImageAllocateTypeMax
+} IMAGE_ALLOCATE_TYPE;
+
 typedef struct {        /* a file (sub-image) inside a boot image */
-  VOID      *Addr;
-  UINT32    Size;
+  VOID                 *Addr;
+  UINT32                Size;
+  IMAGE_ALLOCATE_TYPE   AllocType;
 } IMAGE_DATA;
 
 //

--- a/BootloaderCommonPkg/Include/Library/MultibootLib.h
+++ b/BootloaderCommonPkg/Include/Library/MultibootLib.h
@@ -212,6 +212,27 @@ typedef struct {
   UINT32  Reserved;
 } MULTIBOOT_MODULE;
 
+typedef struct {
+  IMAGE_DATA  CmdFile;
+  IMAGE_DATA  ImgFile;
+} MULTIBOOT_MODULE_DATA;
+
+typedef struct {
+  IMAGE_DATA              VmmBootParams;
+  IMAGE_DATA              VmmHeapAddr;
+  IMAGE_DATA              VmmRuntimeAddr;
+} VMM_IMAGE_DATA;
+
+typedef struct {
+  IMAGE_DATA              Base;
+  IMAGE_DATA              SeedList;
+  IMAGE_DATA              PlatformInfo;
+} BOOTPARAMS_IMAGE_DATA;
+
+typedef struct {
+  VMM_IMAGE_DATA          VmmImageData;
+  BOOTPARAMS_IMAGE_DATA   BootParamsData;
+} TRUSTY_IMAGE_DATA;
 
 #define MAX_MULTIBOOT_MODULE_NUMBER  16
 typedef struct {
@@ -222,8 +243,9 @@ typedef struct {
   UINT16                  CmdBufferSize;
   UINT16                  MbModuleNumber;
   MULTIBOOT_MODULE        MbModule[MAX_MULTIBOOT_MODULE_NUMBER];
+  MULTIBOOT_MODULE_DATA   MbModuleData[MAX_MULTIBOOT_MODULE_NUMBER];
+  TRUSTY_IMAGE_DATA       TrustyImageData;
 } MULTIBOOT_IMAGE;
-
 
 /**
   Check if it is Multiboot image

--- a/BootloaderCommonPkg/Library/IasImageLib/IasImage.c
+++ b/BootloaderCommonPkg/Library/IasImageLib/IasImage.c
@@ -129,11 +129,13 @@ IasGetFiles (
     // Return Addr single entry (namely the entire payload) for plain images.
     Img[0].Addr = Addr = (UINT32 *) IAS_PAYLOAD (IasImage);
     Img[0].Size = Size = IasImage->DataLength;
+    Img[0].AllocType = ImageAllocateTypePointer;
 
     // If there are sub-images (Index.e NumFile > 0) return their addresses and sizes.
     for (Index = 0 ; Index < NumImg && Index < NumFile ; Index += 1) {
       Img[Index].Addr = Addr;
       Img[Index].Size = Size = ImgSize[Index];
+      Img[Index].AllocType = ImageAllocateTypePointer;
       Addr = (UINT32 *) ((UINT8 *)Addr + ROUNDED_UP (Size, 4));
     }
   }

--- a/PayloadPkg/Include/Library/SblParameterLib.h
+++ b/PayloadPkg/Include/Library/SblParameterLib.h
@@ -8,28 +8,37 @@
 
 #include <PiPei.h>
 #include <Guid/OsBootOptionGuid.h>
+#include <Library/IasImageLib.h>
 
 #ifndef __SBL_PARAMETER_LIB_H__
 #define __SBL_PARAMETER_LIB_H__
+
+typedef struct {
+  IMAGE_DATA            BootDevicesData;    // allocated for bootdevices cmdline
+  IMAGE_DATA            OsPerfData;         // allocated for timestamps cmdline
+  IMAGE_DATA            OsCrashMemoryData;  // allocated for ramoops.mem_address cmdline
+} RESERVED_CMDLINE_DATA;
 
 /**
   Add Sbl specific command line parameters
 
   Some Os requires SBL specific command line parameters.
 
-  @param[in]     BootOption        Current boot option
-  @param[out]    CommandLine       Command line for adding new parameters
-  @param[in,out] CommandLineSize   The max size of buffer CommandLine when input.
-                                   and the actual Command line string size, including NULL
-                                   terminator when return.
+  @param[in]     BootOption           Current boot option
+  @param[out]    CommandLine          Command line for adding new parameters
+  @param[in,out] CommandLineSize      The max size of buffer CommandLine when input.
+                                      and the actual Command line string size, including NULL
+                                      terminator when return.
+  @param[in,out] ReservedCmdlineData  Reserved memory info about kernel command line for OS
 
 **/
 EFI_STATUS
 EFIAPI
 AddSblCommandLine (
-  IN     OS_BOOT_OPTION     *BootOption,
-  OUT    CHAR8              *CommandLine,
-  IN OUT UINT32             *CommandLineSize
+  IN     OS_BOOT_OPTION         *BootOption,
+  OUT    CHAR8                  *CommandLine,
+  IN OUT UINT32                 *CommandLineSize,
+  IN OUT RESERVED_CMDLINE_DATA  *ReservedCmdlineData
   );
 
 #endif

--- a/PayloadPkg/Library/TrustyBootLib/TrustyBootLib.c
+++ b/PayloadPkg/Library/TrustyBootLib/TrustyBootLib.c
@@ -58,101 +58,66 @@ ReserveMemUnder1Mb (
 }
 
 /**
-  Get the Platform info parameters.
-
-  Pass this as a cmd line pointer to all OSes.
-
-  @retval  PlatformInfo           The platform info data was successfully setup.
-  @retval  NULL                   The platform info data could not be allocated.
-
-**/
-LOADER_PLATFORM_INFO *
-GetPlatformInfo (
-  VOID
-  )
-{
-  LOADER_PLATFORM_INFO    *LoaderPlatformInfo;
-  LOADER_PLATFORM_INFO    *PlatformInfo;
-
-  LoaderPlatformInfo = (LOADER_PLATFORM_INFO *)GetLoaderPlatformInfoPtr();
-  if (LoaderPlatformInfo == NULL) {
-    return NULL;
-  }
-
-  PlatformInfo = (LOADER_PLATFORM_INFO *) AllocateReservedPool (sizeof (LOADER_PLATFORM_INFO));
-  if (PlatformInfo == NULL) {
-    return NULL;
-  }
-  ZeroMem (PlatformInfo, sizeof (LOADER_PLATFORM_INFO));
-  CopyMem (PlatformInfo, LoaderPlatformInfo, sizeof(LOADER_PLATFORM_INFO));
-
-  return PlatformInfo;
-}
-
-/**
-  Get SeedList info.
-
-  Pass this as a cmd line pointer.
-
-  @retval  SeedList           SeedList data was successfully setup.
-  @retval  NULL               SeedList data could not be allocated.
-
-**/
-SEED_LIST_INFO_HOB *
-GetSeedListInfo (
-  VOID
-  )
-{
-  SEED_LIST_INFO_HOB      *SeedList;
-  SEED_LIST_INFO_HOB      *SeedListInfoHob;
-  UINT32                  SeedListLen;
-
-  SeedList = NULL;
-  if (PcdGetBool (PcdSeedListEnabled)) {
-    // Get Seed List HOB from Stage2
-    SeedListInfoHob = GetSeedListInfoHOB(&SeedListLen);
-    if ((SeedListInfoHob == NULL) || (SeedListLen == 0)) {
-      return NULL;
-    }
-
-    // Allocate reserved memory for SeedList to pass to Trusty
-    SeedList = AllocateReservedPool (SeedListLen);
-    if (SeedList == NULL) {
-      return NULL;
-    }
-    ZeroMem (SeedList, SeedListLen);
-    CopyMem (SeedList, SeedListInfoHob, SeedListLen);
-  }
-  return SeedList;
-}
-
-
-/**
   Get the VMM boot parameters information
 
   When performing Trusty boot there are memory map requirements
   to allocate some memory for the vmm to use during its execution.
 
+  @param[in,out]  VmmImageData    The VMM image data pointer which manages reserved memories for VMM
   @param[in,out]  TrustyMbi       The primary Multiboot module's information.
   @param[in,out]  BootOsMbi       The secondary Multiboot module's information.
 
-  @retval  VmmBootParam           The VMM boot parameters were successfully setup.
-  @retval  NULL                   The VMM boot parameters could not be allocated.
+  @retval         EFI_SUCCESS     The VMM boot parameters were successfully setup.
+  @retval         Others          The VMM boot parameters could not be allocated.
 **/
-VMM_BOOT_PARAM *
+EFI_STATUS
 GetVmmBootParam (
+  IN OUT  VMM_IMAGE_DATA    *VmmImageData,
   IN OUT  MULTIBOOT_INFO    *TrustyMbi,
   IN OUT  MULTIBOOT_INFO    *BootOsMbi
   )
 {
   VMM_BOOT_PARAM *VmmBootParam;
+  UINT32          Size;
 
-  VmmBootParam = (VMM_BOOT_PARAM *) AllocateReservedPool (sizeof (VMM_BOOT_PARAM));
-  if (VmmBootParam == NULL) {
-    return NULL;
+  ZeroMem (VmmImageData, sizeof (VMM_IMAGE_DATA));
+
+  //
+  // Reserve Memory for Vmm Boot Params
+  //
+  Size = sizeof (VMM_BOOT_PARAM);
+  VmmImageData->VmmBootParams.Addr = AllocateReservedPool (Size);
+  if (VmmImageData->VmmBootParams.Addr == NULL) {
+    return EFI_OUT_OF_RESOURCES;
   }
-  ZeroMem (VmmBootParam, sizeof (VMM_BOOT_PARAM));
+  VmmImageData->VmmBootParams.Size = Size;
 
+  //
+  // Reserve Memory for Vmm Heap Memory
+  //
+  Size = EFI_SIZE_TO_PAGES (VMM_OS_HEAP_SIZE);
+  VmmImageData->VmmHeapAddr.Addr = AllocateReservedPages (Size);
+  if (VmmImageData->VmmHeapAddr.Addr == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+  VmmImageData->VmmHeapAddr.Size = VMM_OS_HEAP_SIZE;
+  VmmImageData->VmmHeapAddr.AllocType = ImageAllocateTypePage;
+
+  //
+  // Reserve Memory for Vmm Runtime Memory
+  //
+  Size = EFI_SIZE_TO_PAGES (VMM_OS_RUNTIME_MEM_SIZE);
+  VmmImageData->VmmRuntimeAddr.Addr = AllocateReservedPages (Size);
+  if (VmmImageData->VmmRuntimeAddr.Addr == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+  VmmImageData->VmmRuntimeAddr.Size = VMM_OS_RUNTIME_MEM_SIZE;
+  VmmImageData->VmmRuntimeAddr.AllocType = ImageAllocateTypePage;
+
+  //
+  // Update VmmBootParam Info
+  //
+  VmmBootParam = (VMM_BOOT_PARAM *)VmmImageData->VmmBootParams.Addr;
   VmmBootParam->SizeOfThisStruct = sizeof (VMM_BOOT_PARAM);
 
   // 4KB under 1M reserved in e820.
@@ -165,14 +130,11 @@ GetVmmBootParam (
   ReserveMemUnder1Mb (BootOsMbi, KB_ (8));
 
   // 64KB, SBL should reserve it in e820
-  VmmBootParam->HeapAddr = (UINT32) AllocateReservedPages (EFI_SIZE_TO_PAGES (VMM_OS_HEAP_SIZE));
+  VmmBootParam->HeapAddr = (UINT32) VmmImageData->VmmHeapAddr.Addr;
   // 4MB, SBL should reserve it in e820
-  VmmBootParam->VmmRuntimeAddr = (UINT32) AllocateReservedPages (EFI_SIZE_TO_PAGES (VMM_OS_RUNTIME_MEM_SIZE));
+  VmmBootParam->VmmRuntimeAddr = (UINT32) VmmImageData->VmmRuntimeAddr.Addr;
 
-  if ((VmmBootParam->HeapAddr == 0) || (VmmBootParam->VmmRuntimeAddr == 0)) {
-    return NULL;
-  }
-  return VmmBootParam;
+  return EFI_SUCCESS;
 }
 
 /**
@@ -254,33 +216,65 @@ UpdateCmdLine (
 
   Pass this as a cmd line pointer.
 
-  @retval  BootParams        Boot Parameter structure was successfully returned.
-  @retval  NULL              Boot Parameter structure could not be allocated.
+  @param[in,out]  BootParamsData    The Boot Parameter data pointer which manages reserved memories for Boot Parameter
+
+  @retval         EFI_SUCCESS       Boot Parameter structure was successfully built.
+  @retval         Others            Boot Parameter structure could not be allocated.
 **/
-IMAGE_BOOT_PARAM *
+EFI_STATUS
 GetImageBootParamInfo (
-  VOID
+  IN OUT  BOOTPARAMS_IMAGE_DATA   *BootParamsData
   )
 {
   IMAGE_BOOT_PARAM          *BootParams;
+  LOADER_PLATFORM_INFO      *LoaderPlatformInfo;
+  SEED_LIST_INFO_HOB        *SeedListInfoHob;
+  UINT32                     Length;
 
-  BootParams = (IMAGE_BOOT_PARAM *) AllocateReservedPool (sizeof (IMAGE_BOOT_PARAM));
-  if (BootParams == NULL) {
-    return NULL;
+  if (BootParamsData == NULL) {
+    return EFI_INVALID_PARAMETER;
   }
+  ZeroMem (BootParamsData, sizeof (BOOTPARAMS_IMAGE_DATA));
+  BootParamsData->Base.Addr = AllocateReservedPool (sizeof (IMAGE_BOOT_PARAM));
+  if (BootParamsData->Base.Addr == NULL) {
+    return RETURN_OUT_OF_RESOURCES;
+  }
+  BootParamsData->Base.Size = sizeof (IMAGE_BOOT_PARAM);
+
+  BootParams = (IMAGE_BOOT_PARAM *)BootParamsData->Base.Addr;
   BootParams->SizeOfThisStruct = sizeof (IMAGE_BOOT_PARAM);
   BootParams->Version = 0;
 
+  // Update SEED List
   if (PcdGetBool (PcdSeedListEnabled)) {
-    BootParams->SeedListInfoAddr = (UINT64) (UINTN)GetSeedListInfo ();
+    SeedListInfoHob = GetSeedListInfoHOB (&Length);
+    if ((SeedListInfoHob == NULL) || (Length == 0)) {
+      return EFI_NOT_FOUND;
+    }
+    // Allocate reserved memory for SeedList to pass to Trusty
+    BootParamsData->SeedList.Addr = AllocateReservedPool (Length);
+    if (BootParamsData->SeedList.Addr == NULL) {
+      return RETURN_OUT_OF_RESOURCES;
+    }
+    BootParamsData->SeedList.Size = Length;
+
+    ZeroMem (BootParamsData->SeedList.Addr, Length);
+    CopyMem (BootParamsData->SeedList.Addr, SeedListInfoHob, Length);
   }
-  BootParams->PlatformInfoAddr  = (UINT64) (UINTN)GetPlatformInfo ();
 
-  // VmmBootParams is only applicable for Trusty. Set it to zero by default
-  // and update this in TrustyBoot function
-  BootParams->VmmBootParamAddr = 0;
+  // Update Platform Info
+  LoaderPlatformInfo = (LOADER_PLATFORM_INFO *)GetLoaderPlatformInfoPtr();
+  if (LoaderPlatformInfo != NULL) {
+    Length = sizeof (LOADER_PLATFORM_INFO);
+    BootParamsData->PlatformInfo.Addr = (LOADER_PLATFORM_INFO *) AllocateReservedPool (Length);
+    if (BootParamsData->PlatformInfo.Addr != NULL) {
+      BootParamsData->PlatformInfo.Size = Length;
+      ZeroMem (BootParamsData->PlatformInfo.Addr, Length);
+      CopyMem (BootParamsData->PlatformInfo.Addr, LoaderPlatformInfo, Length);
+    }
+  }
 
-  return BootParams;
+  return EFI_SUCCESS;
 }
 
 /**
@@ -299,24 +293,36 @@ SetupTrustyBoot (
   IN OUT  MULTIBOOT_IMAGE    *BootOsImage
   )
 {
+  RETURN_STATUS              Status;
   IMAGE_BOOT_PARAM          *BootParams;
   VMM_BOOT_PARAM            *VmmBootParams;
-  RETURN_STATUS             Status;
+  BOOTPARAMS_IMAGE_DATA     *TrustyBootParamsData;
+  BOOTPARAMS_IMAGE_DATA     *NormalBootParamsData;
+  VMM_IMAGE_DATA            *VmmImageData;
 
   //
   // Update Trusty OS command line parameter
   //
-  BootParams = GetImageBootParamInfo();
-  if (BootParams == NULL) {
-    return RETURN_OUT_OF_RESOURCES;
+  TrustyBootParamsData = &TrustyImage->TrustyImageData.BootParamsData;
+  Status = GetImageBootParamInfo (TrustyBootParamsData);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+  BootParams = (IMAGE_BOOT_PARAM *) TrustyBootParamsData->Base.Addr;
+
+  //
+  // Get VmmBootParams is required for trusty OS
+  //
+  VmmImageData = &TrustyImage->TrustyImageData.VmmImageData;
+  Status = GetVmmBootParam (VmmImageData, &TrustyImage->MbInfo, &BootOsImage->MbInfo);
+  if (!EFI_ERROR (Status)) {
+    VmmBootParams = (VMM_BOOT_PARAM *)VmmImageData->VmmBootParams.Addr;
+    SetCpuState (&VmmBootParams->CpuState, &BootOsImage->BootState);
+    BootParams->VmmBootParamAddr = (UINT64) (UINTN)VmmBootParams;
+  } else {
+    return Status;
   }
 
-  // Get VmmBootParams is required for trusty OS
-  VmmBootParams = GetVmmBootParam (&TrustyImage->MbInfo, &BootOsImage->MbInfo);
-  if (VmmBootParams != NULL) {
-    SetCpuState (& (VmmBootParams->CpuState), &BootOsImage->BootState);
-    BootParams->VmmBootParamAddr  = (UINT64) (UINTN)VmmBootParams;
-  }
   Status = UpdateCmdLine (&TrustyImage->CmdFile, BootParams, TrustyImage->CmdBufferSize);
   if (EFI_ERROR (Status)) {
     return Status;
@@ -327,10 +333,12 @@ SetupTrustyBoot (
   //
   // Update normal OS command line parameter
   //
-  BootParams = GetImageBootParamInfo();
-  if (BootParams == NULL) {
-    return RETURN_OUT_OF_RESOURCES;
+  NormalBootParamsData = &BootOsImage->TrustyImageData.BootParamsData;
+  Status = GetImageBootParamInfo (NormalBootParamsData);
+  if (EFI_ERROR (Status)) {
+    return Status;
   }
+  BootParams = (IMAGE_BOOT_PARAM *) NormalBootParamsData->Base.Addr;
 
   Status = UpdateCmdLine (&BootOsImage->CmdFile, BootParams, BootOsImage->CmdBufferSize);
   if (EFI_ERROR (Status)) {
@@ -339,4 +347,3 @@ SetupTrustyBoot (
 
   return Status;
 }
-

--- a/PayloadPkg/OsLoader/BootParameters.c
+++ b/PayloadPkg/OsLoader/BootParameters.c
@@ -195,12 +195,14 @@ DisplayInfo (
   IN     LOADED_IMAGE        *LoadedImage
   )
 {
+DEBUG_CODE_BEGIN ();
   if ((LoadedImage->Flags & LOADED_IMAGE_MULTIBOOT) != 0) {
     DumpMbInfo (&LoadedImage->Image.MultiBoot.MbInfo);
     DumpMbBootState (&LoadedImage->Image.MultiBoot.BootState);
   } else if ((LoadedImage->Flags & LOADED_IMAGE_LINUX) != 0) {
     DumpLinuxBootParams (LoadedImage->Image.Linux.BootParams);
   }
+DEBUG_CODE_END ();
 }
 
 /**
@@ -273,7 +275,7 @@ UpdateOsParameters (
   }
 
   CmdFile->Size = CMDLINE_LENGTH_MAX;
-  Status = AddSblCommandLine (CurrentBootOption, (CHAR8 *)CmdFile->Addr, &CmdFile->Size);
+  Status = AddSblCommandLine (CurrentBootOption, (CHAR8 *)CmdFile->Addr, &CmdFile->Size, &LoadedImage->ReservedCmdlineData);
   if (EFI_ERROR (Status)) {
     return Status;
   }

--- a/PayloadPkg/OsLoader/OsLoader.h
+++ b/PayloadPkg/OsLoader/OsLoader.h
@@ -123,7 +123,6 @@ typedef struct {
   IMAGE_DATA              CmdFile;
 } COMMON_IMAGE;
 
-
 typedef union {
   COMMON_IMAGE            Common;
   MULTIBOOT_IMAGE         MultiBoot;
@@ -138,6 +137,7 @@ typedef struct {
   EFI_HANDLE              HwPartHandle;
   LOADED_IMAGE_TYPE       Image;
   UINT8                   ImageHash[SHA256_DIGEST_SIZE];
+  RESERVED_CMDLINE_DATA   ReservedCmdlineData;
 } LOADED_IMAGE;
 
 /**
@@ -225,12 +225,38 @@ GetLoadedImageByType (
 
   @param[in]  LoadedImageHandle Loaded Image handle
 
-  @retval     none
 **/
 VOID
 EFIAPI
 UnloadBootImages (
   IN  EFI_HANDLE       LoadedImageHandle
+  );
+
+/**
+  Free all allocated memory in a loaded image
+
+  This function will clean up all temporary resources used to load a single image.
+
+  @param[in]  LoadedImage     A load image pointer which has a boot image info
+
+**/
+VOID
+UnloadLoadedImage (
+  IN  LOADED_IMAGE  *LoadedImage
+  );
+
+/**
+  Free the allocated memory in an image data
+
+  This function free a memory allocated in IMAGE_DATA according to Allocation Type.
+
+  @param[in]  ImageData       An image data pointer which has allocated memory address,
+                              its size, and allocation type.
+
+**/
+VOID
+FreeImageData (
+  IN  IMAGE_DATA    *ImageData
   );
 
 /**


### PR DESCRIPTION
While trying to boot all boot options, some allocated memory are not
de-allocated properly. To avoid memory leak while booting next boot
options, OsLoader will track all image data and free the unnecessary
memory at failing to boot current boot option.

Tested and verified with
- Traditional linux image on debug build
- IAS type image
- Container type image
- MultiBoot image
- BootSlot (A/B Boot)
- Trusty image

Signed-off-by: Aiden Park <aiden.park@intel.com>