### PR TITLE
Add InsertionSort for Linked List

### DIFF
--- a/BootloaderCommonPkg/Include/Library/SortLib.h
+++ b/BootloaderCommonPkg/Include/Library/SortLib.h
@@ -57,4 +57,24 @@ PerformQuickSort (
   IN VOID                               *Buffer
   );
 
+/**
+  Insertion Sort for doubly-linked list
+
+  This function is to insert a new list entry to a sorted doubly-linked list head.
+
+  @param[in, out] ListHead          A pointer to the head node of doubly-linked list
+  @param[in, out] Entry             A pointer to the new entry node to be inserted
+                                    to the sorted list head
+  @param[in]      CompareFunction   The function to call to perform the comparison
+                                    of any 2 elements
+
+**/
+VOID
+EFIAPI
+PerformInsertionSortList (
+  IN OUT  LIST_ENTRY                *ListHead,
+  IN OUT  LIST_ENTRY                *Entry,
+  IN      SORT_COMPARE               CompareFunction
+  );
+
 #endif //__SORT_LIB_H__

--- a/BootloaderCommonPkg/Library/ShellLib/ShellLib.inf
+++ b/BootloaderCommonPkg/Library/ShellLib/ShellLib.inf
@@ -66,6 +66,7 @@
   ResetSystemLib
   BootloaderCommonLib
   MemoryAllocationLib
+  SortLib
 
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress

--- a/BootloaderCommonPkg/Library/SortLib/InsertionSort.c
+++ b/BootloaderCommonPkg/Library/SortLib/InsertionSort.c
@@ -1,0 +1,51 @@
+/** @file
+  Library used for sorting routines.
+
+  Copyright (c) 2019, Intel Corporation. All rights reserved. <BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <PiPei.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/SortLib.h>
+
+/**
+  Insertion Sort for doubly-linked list
+
+  This function is to insert a new list entry to a sorted doubly-linked list head.
+
+  @param[in, out] ListHead          A pointer to the head node of doubly-linked list
+  @param[in, out] Entry             A pointer to the new entry node to be inserted
+                                    to the sorted list head
+  @param[in]      CompareFunction   The function to call to perform the comparison
+                                    of any 2 elements
+
+**/
+VOID
+EFIAPI
+PerformInsertionSortList (
+  IN OUT  LIST_ENTRY                *ListHead,
+  IN OUT  LIST_ENTRY                *Entry,
+  IN      SORT_COMPARE               CompareFunction
+  )
+{
+  LIST_ENTRY            *Curr;
+
+  ASSERT ((ListHead != NULL) && (Entry != NULL) && (CompareFunction != NULL));
+
+  Curr = ListHead->BackLink;
+  while (Curr != ListHead) {
+    if (CompareFunction ((VOID *)Entry, (VOID *)Curr) > 0) {
+      break;
+    }
+    Curr = Curr->BackLink;
+  }
+
+  Curr->ForwardLink->BackLink = Entry;
+  Entry->BackLink = Curr;
+  Entry->ForwardLink = Curr->ForwardLink;
+  Curr->ForwardLink = Entry;
+}

--- a/BootloaderCommonPkg/Library/SortLib/SortLib.inf
+++ b/BootloaderCommonPkg/Library/SortLib/SortLib.inf
@@ -22,6 +22,7 @@
 
 [Sources.common]
   SortLib.c
+  InsertionSort.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.inf
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.inf
@@ -19,23 +19,25 @@
 #  VALID_ARCHITECTURES           = IA32 X64 IPF
 #
 
-[Sources]  
+[Sources]
   InternalPciEnumerationLib.h
   PciEnumerationLib.c
 
 [Packages]
-  MdePkg/MdePkg.dec  
+  MdePkg/MdePkg.dec
   IntelFsp2Pkg/IntelFsp2Pkg.dec
   BootloaderCorePkg/BootloaderCorePkg.dec
-  
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+
 [LibraryClasses]
   BaseLib
   DebugLib
   PciExpressLib
+  SortLib
 
 [Guids]
   gFspNonVolatileStorageHobGuid
-  
+
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress  ## CONSUMES
   gPlatformModuleTokenSpaceGuid.PcdPciResourceIoBase


### PR DESCRIPTION
This provides basic insertion sort API for Linked List. As part of change,
this insertion sort is used for PCI BAR calculation by its alignment
and for shell commands list by its name.

Signed-off-by: Aiden Park <aiden.park@intel.com>