### PR TITLE
Set auth type to default in CfgDataTool

### DIFF
--- a/BootloaderCorePkg/Tools/CfgDataTool.py
+++ b/BootloaderCorePkg/Tools/CfgDataTool.py
@@ -785,7 +785,7 @@ def Main():
                             help='Configuration binary file')
     SignParser.add_argument('-o', dest='cfg_out_file', type=str, help='Signed configuration output binary file name to be generated', required=True)
     SignParser.add_argument('-k', dest='cfg_pri_key', type=str, help='Private key file (PEM format) used to sign configuration data', required=True)
-    SignParser.add_argument('-auth', dest='auth_type', type=str, help='Auth Type with RSA signing', required=True)
+    SignParser.add_argument('-auth', dest='auth_type', type=str, help='Auth Type with RSA signing',  default = 'RSA2048SHA256')
     SignParser.set_defaults(func=CmdSign)
 
     ExtractParser = SubParser.add_parser('extract', help='extract a single config data to a file')


### PR DESCRIPTION
Auth_type param is set to RSA2048SHA256 for default cases.

Signed-off-by: Subash Lakkimsetti <subashx.lakkimsetti@intel.com>