### PR TITLE
Fix no SBL serial output after restart Windows

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -217,3 +217,5 @@
   gPlatformCommonLibTokenSpaceGuid.PcdEmmcHs400SupportEnabled | TRUE       | BOOLEAN | 0x20000214
   # Determine if the Pre-OS checker should be executed or not.
   gPlatformCommonLibTokenSpaceGuid.PcdPreOsCheckerEnabled     | FALSE      | BOOLEAN | 0x20000215
+  # This PCD will force to initialize SerialPort regardless of its initialized state
+  gPlatformCommonLibTokenSpaceGuid.PcdForceToInitSerialPort   | FALSE      | BOOLEAN | 0x20000216

--- a/BootloaderCommonPkg/Library/SerialPortLib/SerialPortLib.c
+++ b/BootloaderCommonPkg/Library/SerialPortLib/SerialPortLib.c
@@ -122,7 +122,8 @@ SerialPortInitialize (
   UINTN  Divisor;
   UINT8  OutputData;
 
-  if (SerialPortReadRegister (SCR_OFFSET) != UART_MAGIC) {
+  if (FeaturePcdGet (PcdForceToInitSerialPort) || \
+    (SerialPortReadRegister (SCR_OFFSET) != UART_MAGIC)) {
     //
     // Calculate divisor for baud generator
     //

--- a/BootloaderCommonPkg/Library/SerialPortLib/SerialPortLib.inf
+++ b/BootloaderCommonPkg/Library/SerialPortLib/SerialPortLib.inf
@@ -33,4 +33,4 @@
   PlatformHookLib
 
 [Pcd]
-
+  gPlatformCommonLibTokenSpaceGuid.PcdForceToInitSerialPort

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -336,6 +336,7 @@
   $(PLATFORM_PACKAGE)/Stage1A/Stage1A.inf {
     <PcdsFeatureFlag>
       gPlatformCommonLibTokenSpaceGuid.PcdMinDecompression | TRUE
+      gPlatformCommonLibTokenSpaceGuid.PcdForceToInitSerialPort | TRUE
     <LibraryClasses>
       BaseMemoryLib| MdePkg/Library/BaseMemoryLibRepStr/BaseMemoryLibRepStr.inf
       SocInitLib   | Silicon/$(SILICON_PKG_NAME)/Library/Stage1ASocInitLib/Stage1ASocInitLib.inf

--- a/Silicon/ApollolakePkg/Library/SerialPortLib/SerialPortLib.c
+++ b/Silicon/ApollolakePkg/Library/SerialPortLib/SerialPortLib.c
@@ -111,7 +111,8 @@ SerialPortInitialize (
   UINTN  Divisor;
   UINT8  OutputData;
 
-  if ((SerialPortReadRegister (SCR_OFFSET) & UART_MAGIC_MASK) != UART_MAGIC_VAL) {
+  if (FeaturePcdGet (PcdForceToInitSerialPort) || \
+    ((SerialPortReadRegister (SCR_OFFSET) & UART_MAGIC_MASK) != UART_MAGIC_VAL)) {
     //
     // Calculate divisor for baud generator
     //

--- a/Silicon/ApollolakePkg/Library/SerialPortLib/SerialPortLib.inf
+++ b/Silicon/ApollolakePkg/Library/SerialPortLib/SerialPortLib.inf
@@ -33,3 +33,4 @@
   PlatformHookLib
 
 [Pcd]
+  gPlatformCommonLibTokenSpaceGuid.PcdForceToInitSerialPort


### PR DESCRIPTION
SerialPortLib sets UART Scratch Register to a known value at the first
initialization to avoid unnecessary re-initialization afterward. But,
one of Windows driver(SIO) re-configures UART Registers while the Scratch
Register is preserved. As a result, SBL skips serial port initialization
after restarting from Windows.
Therefore, force to initialize Serial Port at Stage1A all the time simply.

Signed-off-by: Aiden Park <aiden.park@intel.com>