### PR TITLE
Remove platform specific GetBuiltInConfigData()

### DIFF
--- a/BootloaderCommonPkg/Include/Library/ConfigDataLib.h
+++ b/BootloaderCommonPkg/Include/Library/ConfigDataLib.h
@@ -98,15 +98,6 @@ LoadExternalConfigData (
   IN UINT32  Len
   );
 
-/**
-  Get the pointer to the Built-In Config Data.
-
-  @retval UINT8*    Pointer to the Built-In Config Data
-**/
-UINT8 *
-GetBuiltInConfigData (
-  IN  VOID
-  );
 
 /**
   Find configuration data header by its tag and platform ID.

--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -129,6 +129,7 @@
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegBase          | 0xFF000000 | UINT32 | 0x20000120
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegSize          | 0x00000000 | UINT32 | 0x20000121
   gPlatformModuleTokenSpaceGuid.PcdHashStoreBase          | 0xFF000000 | UINT32 | 0x20000181
+  gPlatformModuleTokenSpaceGuid.PcdCfgDataIntBase         | 0xFF000000 | UINT32 | 0x20000182
   gPlatformModuleTokenSpaceGuid.PcdDeviceTreeBase         | 0xFF000000 | UINT32 | 0x20000183
   gPlatformModuleTokenSpaceGuid.PcdSplashLogoAddress      | 0xFF000000 | UINT32 | 0x20000184
   gPlatformModuleTokenSpaceGuid.PcdFileDataBase           | 0xFF000000 | UINT32 | 0x20000185

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -259,11 +259,12 @@
   gPlatformModuleTokenSpaceGuid.PcdGraphicsVbtAddress| 0xFF000000
   gPlatformModuleTokenSpaceGuid.PcdDeviceTreeBase    | 0xFF000000
   gPlatformCommonLibTokenSpaceGuid.PcdAcpiPmTimerBase   | $(ACPI_PM_TIMER_BASE)
+  gPlatformModuleTokenSpaceGuid.PcdFSPSBase          | $(FSP_S_BASE)
   gPlatformModuleTokenSpaceGuid.PcdHashStoreBase     | 0xFF000000
   gPlatformModuleTokenSpaceGuid.PcdVerInfoBase       | 0xFF000000
   gPlatformModuleTokenSpaceGuid.PcdFileDataBase      | 0xFF000000
-  gPlatformModuleTokenSpaceGuid.PcdFSPSBase          | $(FSP_S_BASE)
   gPlatformModuleTokenSpaceGuid.PcdSplashLogoAddress | 0xFF000000
+  gPlatformModuleTokenSpaceGuid.PcdCfgDataIntBase    | 0xFF000000
   gPlatformCommonLibTokenSpaceGuid.PcdEmmcMaxRwBlockNumber     | 0xFFFF
   gPlatformModuleTokenSpaceGuid.PcdPayloadReservedMemSize | $(PLD_RSVD_MEM_SIZE)
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegBase     | 0xFF000000

--- a/BootloaderCorePkg/BootloaderCorePkg.fdf
+++ b/BootloaderCorePkg/BootloaderCorePkg.fdf
@@ -157,6 +157,10 @@ FV = OsLoader
 
   INF $(PLATFORM_PACKAGE)/Stage1B/Stage1B.inf
 
+  FILE FREEFORM = 016E6CD0-4834-4C7E-BCFE-41DFB88A6A6D {
+    SECTION RAW = $(FV_DIR)/CfgDataInt.bin
+  }
+
 #------------------------------------------------------------------------------
 # STAGE2 FV
 #------------------------------------------------------------------------------

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -171,7 +171,8 @@ CreateConfigDatabase (
       }
     }
 
-    IntCfgAddPtr = (UINT8 *)GetBuiltInConfigData ();
+    // Add internal CFGDATA at the end
+    IntCfgAddPtr = (UINT8 *)PCD_GET32_WITH_ADJUST (PcdCfgDataIntBase);
     if (IntCfgAddPtr != NULL) {
       Status = AddConfigData (IntCfgAddPtr);
       if (!EFI_ERROR (Status)) {

--- a/BootloaderCorePkg/Stage1B/Stage1B.inf
+++ b/BootloaderCorePkg/Stage1B/Stage1B.inf
@@ -97,6 +97,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootEnabled
   gPlatformModuleTokenSpaceGuid.PcdEarlyLogBufferSize
   gPlatformModuleTokenSpaceGuid.PcdLogBufferSize
+  gPlatformModuleTokenSpaceGuid.PcdCfgDataIntBase
 
 [Depex]
   TRUE

--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -392,9 +392,6 @@ def gen_config_file (fv_dir, brd_name, platform_id, pri_key, cfg_db_size, cfg_si
 			if bin_file_size >= cfg_rgn_size:
 				raise Exception ('CFGDATA_SIZE is too small, requested 0x%X for %s CFGDATA !' % (bin_file_size, cfg_rgn_name))
 
-			if cfg_file_list is cfg_int:
-				gen_cfg_data ("GENINC", cfg_merged_bin_file, cfg_inc_file)
-
 	if not os.path.exists(cfg_merged_bin_file):
 		cfg_merged_bin_file = cfg_bin_int_file
 

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -643,6 +643,7 @@ class Build(object):
 				"STAGE1B:STAGE1B",
 				"_OFFS_STAGE1B_,        Stage1B:__ModuleEntryPoint,        @Patch Stage1B Entry",
 				"_OFFS_STAGE1B_+4,      Stage1B:BASE,                      @Patch Stage1B Base",
+				"<Stage1B:__gPcd_BinaryPatch_PcdCfgDataIntBase>, {016E6CD0-4834-4C7E-BCFE-41DFB88A6A6D:0x1C}, @Patch Internal CfgDataBase"
 				)
 
 		print('Patching STAGE2')

--- a/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -34,11 +34,8 @@
 #include <Library/HeciLib.h>
 #include <Library/BootloaderCommonLib.h>
 #include <Library/BoardSupportLib.h>
-
 #include <FspmUpd.h>
 #include <GpioDefines.h>
-#include <ConfigDataBlob.h>
-
 #include <PlatformBase.h>
 #include "ScRegs/RegsPmc.h"
 #include <Pi/PiBootMode.h>
@@ -930,24 +927,6 @@ LoadExternalConfigData (
   return SpiLoadExternalConfigData (Dst, Src, Len);
 
 }
-
-/**
-  Get the pointer to the Built-In Config Data.
-
-  @retval UINT8*    Pointer to the Built-In Config Data
-**/
-UINT8 *
-GetBuiltInConfigData (
-  IN  VOID
-  )
-{
-  if (PcdGet32 (PcdCfgDatabaseSize) > 0) {
-    return (UINT8 *) &mConfigDataBlob[16];
-  } else {
-    return NULL;
-  }
-}
-
 
 /**
   Get the reset reason from the PMC registers.

--- a/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -29,7 +29,6 @@
 #include <Library/BoardSupportLib.h>
 #include <RegAccess.h>
 #include <Library/CryptoLib.h>
-#include <ConfigDataBlob.h>
 #include <Library/PchInfoLib.h>
 #include <Library/SocInitLib.h>
 #include <Library/TpmLib.h>
@@ -708,22 +707,4 @@ LoadExternalConfigData (
 {
 
   return SpiLoadExternalConfigData (Dst, Src, Len);
-}
-
-
-/**
-  Get the pointer to the Built-In Config Data
-
-  @retval UINT8*    Pointer to the Built-In Config Data
-**/
-UINT8 *
-GetBuiltInConfigData(
-  IN  VOID
-)
-{
-  if (PcdGet32 (PcdCfgDatabaseSize) > 0) {
-    return (UINT8 *) &mConfigDataBlob[16];
-  } else {
-    return NULL;
-  }
 }

--- a/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -23,7 +23,6 @@
 #include <Library/VariableLib.h>
 #include <Library/BootloaderCoreLib.h>
 #include <Library/BoardSupportLib.h>
-#include <ConfigDataBlob.h>
 #include <FspmUpd.h>
 #include <BlCommon.h>
 #include <ConfigDataDefs.h>
@@ -265,21 +264,4 @@ LoadExternalConfigData (
 {
 
   return SpiLoadExternalConfigData (Dst, Src, Len);
-}
-
-/**
-  Get the pointer to the Built-In Config Data
-
-  @retval UINT8*    Pointer to the Built-In Config Data
-**/
-UINT8 *
-GetBuiltInConfigData(
-  IN  VOID
-)
-{
-  if (PcdGet32 (PcdCfgDatabaseSize) > 0) {
-    return (UINT8 *) &mConfigDataBlob[16];
-  } else {
-    return NULL;
-  }
 }


### PR DESCRIPTION
Current SBL has platform specific GetBuiltInConfigData() implementation
because the internal CFGDATA blob is embedded into Stage1B data section.
Instead, it can be put into Stage1B FV FFS file, and then use a PCD to
get the base. In this way, it can be handled directly in core code and
remove platform specific implementation.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>