### PR TITLE
Publickey and Signature data structure updates

### DIFF
--- a/BootloaderCommonPkg/Include/Library/IasImageLib.h
+++ b/BootloaderCommonPkg/Include/Library/IasImageLib.h
@@ -69,12 +69,11 @@ typedef struct {        /* a file (sub-image) inside a boot image */
 } IMAGE_DATA;
 
 //
-// IAS Pub Key format for use with IPP CryptoLib
+// IAS Pub Key format for use
 //
 typedef struct {
-  UINT32  Signature;
-  UINT8 PubKeyMod[RSA_MOD_SIZE];
-  UINT8 PubKeyExp[RSA_E_SIZE];
+  UINT8 Modulus[RSA_MOD_SIZE];
+  UINT8 PubExp[RSA_E_SIZE];
 } IAS_PUB_KEY;
 
 /**

--- a/BootloaderCommonPkg/Include/Library/SecureBootLib.h
+++ b/BootloaderCommonPkg/Include/Library/SecureBootLib.h
@@ -9,6 +9,7 @@
 #define __VERIFIED_BOOT_LIB_H__
 
 #include <Guid/KeyHashGuid.h>
+#include <Library/CryptoLib.h>
 
 #define  SIG_TYPE_RSA2048_SHA256       0
 #define  SIG_TYPE_RSA3072_SHA384       1
@@ -47,8 +48,8 @@ DoHashVerify (
   @param[in]  Data            Data buffer pointer.
   @param[in]  Length          Data buffer size.
   @param[in]  ComponentType   Component type.
-  @param[in]  Signature       Signature for the data buffer.
-  @param[in]  PubKey          Public key data pointer.
+  @param[in]  SignatureHdr    Signature header for singanture data.
+  @param[in]  PubKeyHdr       Public key header for key data
   @param[in]  PubKeyHash      Public key hash value when ComponentType is not used.
   @param[out] OutHash         Calculated data hash value.
 
@@ -64,8 +65,8 @@ DoRsaVerify (
   IN CONST UINT8           *Data,
   IN       UINT32           Length,
   IN       UINT8            ComponentType,
-  IN CONST UINT8           *Signature,
-  IN       UINT8           *PubKey,
+  IN CONST SIGNATURE_HDR   *SignatureHdr,
+  IN       PUB_KEY_HDR     *PubKeyHdr,
   IN       UINT8           *PubKeyHash      OPTIONAL,
   OUT      UINT8           *OutHash         OPTIONAL
   );

--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
@@ -257,6 +257,9 @@ AuthenticateComponent (
   )
 {
   EFI_STATUS  Status;
+  UINT8                    *SigPtr;
+  UINT8                    *KeyPtr;
+  SIGNATURE_HDR            *SignHdr;
 
   if (!FeaturePcdGet (PcdVerifiedBootEnabled)) {
     Status = EFI_SUCCESS;
@@ -264,8 +267,12 @@ AuthenticateComponent (
     if (AuthType == AUTH_TYPE_SHA2_256) {
       Status = DoHashVerify (Data, Length, HASH_TYPE_SHA256, CompType, HashData);
     } else if (AuthType == AUTH_TYPE_SIG_RSA2048_SHA256) {
-      Status = DoRsaVerify (Data, Length, CompType, AuthData,
-                            AuthData + RSA2048NUMBYTES, HashData, NULL);
+
+      SigPtr   = (UINT8 *) AuthData;
+      SignHdr  = (SIGNATURE_HDR *) SigPtr;
+      KeyPtr   = (UINT8 *)SignHdr + sizeof(SIGNATURE_HDR) + SignHdr->SigSize ;
+      Status   = DoRsaVerify (Data, Length, CompType, SignHdr,
+                            (PUB_KEY_HDR *) KeyPtr, HashData, NULL);
     } else if (AuthType == AUTH_TYPE_NONE) {
       Status = EFI_SUCCESS;
     } else {

--- a/BootloaderCommonPkg/Library/IppCryptoLib/rsa_verify.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/rsa_verify.c
@@ -103,16 +103,16 @@ int VerifyRsaSignature (const void *hash, const void *rsa_n,  const void *rsa_e,
  * Returns RETURN_SUCCESS on success, others on failure.
  */
 RETURN_STATUS
-RsaVerify(const RSA_PUB_KEY *key, const Ipp8u *sig, const Ipp32u sig_len, const Ipp8u  sig_type, const Ipp8u *hash)
+RsaVerify_Pkcs_1_5 (CONST PUB_KEY_HDR *PubKeyHdr, CONST SIGNATURE_HDR *SignatureHdr,  CONST UINT8  *Hash)
 {
   Ipp8u  *rsa_n;
   Ipp8u  *rsa_e;
 
-  if ((key->Signature != RSA_KEY_IPP_SIGNATURE) || (sig_type != SIG_TYPE_RSA2048SHA256) || (sig_len != RSA_MOD_SIZE)) {
+  if ((SignatureHdr->SigType != SIGNING_TYPE_RSA_PKCS_1_5) || (SignatureHdr->SigSize != RSA_MOD_SIZE)) {
     return RETURN_INVALID_PARAMETER;
   } else {
-    rsa_n = (Ipp8u *)key->PubKeyData;
-    rsa_e = rsa_n + RSA_MOD_SIZE;
-    return VerifyRsaSignature (hash, rsa_n, rsa_e, sig) ? RETURN_SECURITY_VIOLATION : RETURN_SUCCESS ;
+    rsa_n = (Ipp8u *) PubKeyHdr->KeyData;
+    rsa_e = (Ipp8u *) PubKeyHdr->KeyData + PubKeyHdr->KeySize - RSA_E_SIZE;
+    return VerifyRsaSignature (Hash, rsa_n, rsa_e, SignatureHdr->Signature) ? RETURN_SECURITY_VIOLATION : RETURN_SUCCESS ;
   }
 }

--- a/BootloaderCommonPkg/Library/SecureBootLib/SecureBootRsa.c
+++ b/BootloaderCommonPkg/Library/SecureBootLib/SecureBootRsa.c
@@ -20,8 +20,8 @@
   @param[in]  Data            Data buffer pointer.
   @param[in]  Length          Data buffer size.
   @param[in]  ComponentType   Component type.
-  @param[in]  Signature       Signature for the data buffer.
-  @param[in]  PubKey          Public key data pointer.
+  @param[in]  Signature       Signature header for singanture data.
+  @param[in]  PubKeyHdr       Public key header for key data
   @param[in]  PubKeyHash      Public key hash value when ComponentType is not used.
   @param[out] OutHash         Calculated data hash value.
 
@@ -37,31 +37,23 @@ DoRsaVerify (
   IN CONST UINT8           *Data,
   IN       UINT32           Length,
   IN       UINT8            ComponentType,
-  IN CONST UINT8           *Signature,
-  IN       UINT8           *PubKey,
+  IN CONST SIGNATURE_HDR   *SignatureHdr,
+  IN       PUB_KEY_HDR     *PubKeyHdr,
   IN       UINT8           *PubKeyHash      OPTIONAL,
   OUT      UINT8           *OutHash         OPTIONAL
   )
 {
-  UINTN            Index;
   RETURN_STATUS    Status;
-  UINT8           *TmpPubKey;
-  RSA_PUB_KEY     *InpPubKey;
+  PUB_KEY_HDR     *PublicKey;
   UINT8            Digest[SHA256_DIGEST_SIZE];
-  UINT8            PubKeyBuf[RSA_MOD_SIZE + RSA_E_SIZE];
+
+  PublicKey = PubKeyHdr;
+  if ((PublicKey->Identifier != PUBKEY_IDENTIFIER) || (SignatureHdr->Identifier != SIGNATURE_IDENTIFIER)){
+    return RETURN_INVALID_PARAMETER;
+  }
 
   // Verify public key first
-  // Hash caculation for key uses different endian
-  InpPubKey = (RSA_PUB_KEY *)PubKey;
-  TmpPubKey = PubKeyBuf;
-  for (Index = 0; Index < RSA_MOD_SIZE; Index++) {
-    TmpPubKey[Index] = InpPubKey->PubKeyData[RSA_MOD_SIZE - 1 - Index];
-  }
-  for (Index = 0; Index < RSA_E_SIZE; Index++) {
-    TmpPubKey[RSA_MOD_SIZE + Index] = InpPubKey->PubKeyData[RSA_MOD_SIZE + RSA_E_SIZE - 1 - Index];
-  }
-
-  Status = DoHashVerify ((CONST UINT8 *)PubKeyBuf, RSA_MOD_SIZE + RSA_E_SIZE, HASH_TYPE_SHA256, ComponentType, PubKeyHash);
+  Status = DoHashVerify (PublicKey->KeyData, RSA_MOD_SIZE + RSA_E_SIZE, HASH_TYPE_SHA256, ComponentType, PubKeyHash);
   if (RETURN_ERROR (Status)) {
     return Status;
   }
@@ -73,31 +65,36 @@ DoRsaVerify (
     CopyMem (OutHash, Digest, sizeof (Digest));
   }
 
-  Status = RsaVerify ((RSA_PUB_KEY *)PubKey, Signature, RSA2048NUMBYTES, SIG_TYPE_RSA2048SHA256, Digest);
-  if (RETURN_ERROR (Status)) {
-    DEBUG_CODE_BEGIN();
+  if(SignatureHdr->SigType == SIGNING_TYPE_RSA_PKCS_1_5) {
 
-    DEBUG ((DEBUG_INFO, "RSA Verification Failed!\n"));
+    Status = RsaVerify_Pkcs_1_5 (PublicKey, SignatureHdr, Digest);
+    if (RETURN_ERROR (Status)) {
+      DEBUG_CODE_BEGIN();
 
-    DEBUG ((DEBUG_INFO, "First 32Bytes Input Data\n"));
-    DumpHex (2, 0, SHA256_DIGEST_SIZE, (VOID *)Data);
+      DEBUG ((DEBUG_INFO, "RSA Verification Failed!\n"));
 
-    DEBUG ((DEBUG_INFO, "Last 32Bytes Input Data\n"));
-    DumpHex (2, 0, SHA256_DIGEST_SIZE, (VOID *) (Data + Length - 32));
+      DEBUG ((DEBUG_INFO, "First 32Bytes Input Data\n"));
+      DumpHex (2, 0, SHA256_DIGEST_SIZE, (VOID *)Data);
 
-    DEBUG ((DEBUG_INFO, "Image Digest\n"));
-    DumpHex (2, 0, SHA256_DIGEST_SIZE, (VOID *)Digest);
+      DEBUG ((DEBUG_INFO, "Last 32Bytes Input Data\n"));
+      DumpHex (2, 0, SHA256_DIGEST_SIZE, (VOID *) (Data + Length - 32));
 
-    DEBUG ((DEBUG_INFO, "Signature\n"));
-    DumpHex (2, 0, RSA2048NUMBYTES, (VOID *)Signature);
+      DEBUG ((DEBUG_INFO, "Image Digest\n"));
+      DumpHex (2, 0, SHA256_DIGEST_SIZE, (VOID *)Digest);
 
-    DEBUG ((DEBUG_INFO, "Public Key\n"));
-    DumpHex (2, 0, RSA_MOD_SIZE + RSA_E_SIZE + sizeof (UINT32), PubKey);
+      DEBUG ((DEBUG_INFO, "Signature\n"));
+      DumpHex (2, 0, RSA2048_NUMBYTES, (VOID *)(SignatureHdr->Signature));
 
-    DEBUG_CODE_END();
+      DEBUG ((DEBUG_INFO, "Public Key\n"));
+      DumpHex (2, 0, RSA_MOD_SIZE + RSA_E_SIZE + sizeof (UINT32), PubKeyHdr->KeyData);
 
+      DEBUG_CODE_END();
+
+    } else {
+      DEBUG ((DEBUG_INFO, "RSA Verification Success!\n"));
+    }
   } else {
-    DEBUG ((DEBUG_INFO, "RSA Verification Success!\n"));
+    return RETURN_UNSUPPORTED;
   }
 
   return Status;

--- a/BootloaderCorePkg/Stage1B/Stage1B.h
+++ b/BootloaderCorePkg/Stage1B/Stage1B.h
@@ -28,6 +28,7 @@
 #include <Library/FspApiLib.h>
 #include <Library/BlMemoryAllocationLib.h>
 #include <Library/SecureBootLib.h>
+#include <Library/CryptoLib.h>
 #include <Library/CpuExceptionLib.h>
 #include <Library/DebugDataLib.h>
 #include <Library/DebugLogBufferLib.h>

--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -65,15 +65,6 @@ class FLASH_REGION_TYPE:
     ALL          = 0x6
     MAX          = 0x7
 
-class RsaSignature (Structure):
-    _pack_ = 1
-    _fields_ = [
-        ('Signature',  ARRAY(c_uint8, 256)),
-        ('Identifier', c_uint32),
-        ('PubKeyMod',  ARRAY(c_uint8, 256)),
-        ('PubKeyExp',  ARRAY(c_uint8, 4)),
-        ('Padding',    ARRAY(c_uint8, 8)),
-        ]
 
 class UcodeHeader(Structure):
     _pack_ = 1
@@ -506,17 +497,16 @@ def gen_hash_file (src_path, hash_type, hash_path = '', is_key = False):
     with open(src_path,'rb') as fi:
         di = bytearray(fi.read())
     if is_key:
-        if len(di) != 0x108:
+        if len(di) != (0x104 + sizeof(PUB_KEY_HDR)):
             raise Exception ("Invalid public key binary!")
-        di = di[4:]
-        di = di[:0x100][::-1] + di[0x100:][::-1]
+        di = di[sizeof(PUB_KEY_HDR):]
+        di = di[:0x100] + di[0x100:]
     if hash_type == 'SHA2_256':
         ho = hashlib.sha256(di)
     else:
         raise Exception ("Unsupported hash type provided!")
     with open(hash_path,'wb') as fo:
         fo.write(ho.digest())
-
 
 def align_pad_file (src, dst, val, mode = STITCH_OPS.MODE_FILE_ALIGN, pos = STITCH_OPS.MODE_POS_TAIL):
     fi = open(src, 'rb')
@@ -885,4 +875,3 @@ def find_component_in_image_list (comp_name, img_list):
 def print_component_list (comp_list):
     for comp in comp_list:
         print('%-20s BASE=0x%08X' % (comp['name'], comp['base']))
-

--- a/BootloaderCorePkg/Tools/CfgDataTool.py
+++ b/BootloaderCorePkg/Tools/CfgDataTool.py
@@ -86,7 +86,7 @@ class CRsaSign:
         if (len(Mod) != 256):
             raise Exception('Unsupported modulus length!')
 
-        Key = b"$IPP" + Mod + Exp
+        Key = Mod + Exp
 
         return Key
 
@@ -109,11 +109,20 @@ class CRsaSign:
         else:
             Bins = bytearray()
 
-        Sign = open(OutFile, 'rb').read()
-        Bins.extend(Sign)
+        signature = open(OutFile, 'rb').read()
+
+        sign = SIGNATURE_HDR()
+        sign.SigSize = len(signature)
+        sign.SigType = SIGN_TYPE_SCHEME['RSA_PCKS_1_5']
+        sign.HashAlg = HASH_TYPE_VALUE['SHA2_256']
+        Bins.extend(bytearray(sign) + signature)
 
         if IncKey:
-            Bins.extend(PubKey)
+            publickey = PUB_KEY_HDR()
+            publickey.KeySize    = len(PubKey)
+            KeyType    = PUB_KEY_TYPE['RSA']
+
+            Bins.extend(bytearray(publickey) + PubKey)
 
         open(OutFile, 'wb').write(Bins)
 

--- a/BootloaderCorePkg/Tools/CommonUtility.py
+++ b/BootloaderCorePkg/Tools/CommonUtility.py
@@ -34,6 +34,39 @@ class LZ_HEADER(Structure):
         'LZMA' : 'Lzma',
     }
 
+# Reference header for Public key
+class PUB_KEY (Structure):
+    _fields_ = [
+        ('Modulus', ARRAY(c_uint8, 0)),      #RSA2K/RSA3K in bytes
+        ('PubExp',  ARRAY(c_uint8, 4)),
+        ]
+
+class PUB_KEY_HDR (Structure):
+    _pack_ = 1
+    _fields_ = [
+        ('Identifier', ARRAY(c_char, 4)),      #signature ('P', 'U', 'B', 'K')
+        ('KeySize',    c_uint16),              #Length of Public Key
+        ('KeyType',    c_uint8),               #RSA or ECC
+        ('Reserved',   ARRAY(c_uint8, 1)),
+        ('KeyData',    ARRAY(c_uint8, 0)),   #Pubic key data with KeySize bytes for RSA_KEY() format
+        ]
+
+    def __init__(self):
+        self.Identifier = b'PUBK'
+
+class SIGNATURE_HDR (Structure):
+    _pack_ = 1
+    _fields_ = [
+        ('Identifier', ARRAY(c_char, 4)),      #signature Identifier('S', 'I', 'G', 'N')
+        ('SigSize',    c_uint16),              #Length of signature 2K and 3K in bytes
+        ('SigType',    c_uint8),               #PKCSv1.5 or RSA-PSS or ECC
+        ('HashAlg',    c_uint8),               #Hash Alg for signingh SHA256, 384
+        ('Signature',  ARRAY(c_uint8, 0)),     #Signature length defined by SigSize bytes
+        ]
+
+    def __init__(self):
+        self.Identifier = b'SIGN'
+
 # Hash values defined should match with cryptolib.h
 HASH_TYPE_VALUE = {
 # {   Hash_string:        Hash_Value}
@@ -80,6 +113,24 @@ def set_bits_to_bytes (bytes, start, length, bvalue):
     update = fmt2.format(bvalue)[-length:][::-1]
     newval = oldval[:start] + update + oldval[start + length:]
     bytes[:] = value_to_bytes (int(newval[::-1], 2), len(bytes))
+
+# Key types  defined should match with cryptolib.h
+PUB_KEY_TYPE = {
+# {   key_type:   key_val}
+            "RSA"       : 1,
+            "ECC"       : 2,
+            "DSA"       : 3,
+    }
+
+# Signing type schemes  defined should match with cryptolib.h
+SIGN_TYPE_SCHEME = {
+# {   key_type:   key_val}
+            "RSA_PCKS_1_5"        : 1,
+            "RSA_PSS"             : 2,
+            "ECC"                 : 3,
+            "DSA"                 : 4,
+    }
+
 
 def bytes_to_value (bytes):
     return reduce(lambda x,y: (x<<8)|y,  bytes[::-1] )
@@ -153,9 +204,9 @@ def run_process (arg_list, print_cmd = False, capture_out = False):
 def rsa_sign_file (priv_key, pub_key, hash_type, in_file, out_file, inc_dat = False, inc_key = False):
 
     _hash_type_string = {
-            "SHA2_256"    : '-sha256',
-            "SHA2_384"    : '-sha384',
-            "SHA2_512"    : '-sha512',
+        "SHA2_256"    : '-sha256',
+        "SHA2_384"    : '-sha384',
+        "SHA2_512"    : '-sha512',
     }
 
     cmdargs = [get_openssl_path(), 'dgst' , '%s' % _hash_type_string[hash_type], '-sign', '%s' % priv_key,
@@ -166,10 +217,17 @@ def rsa_sign_file (priv_key, pub_key, hash_type, in_file, out_file, inc_dat = Fa
     if inc_dat:
         bins.extend(get_file_data(in_file))
     out_data = get_file_data(out_file)
-    bins.extend(out_data)
+
+    sign = SIGNATURE_HDR()
+    sign.SigSize = len(out_data)
+    sign.SigType = SIGN_TYPE_SCHEME['RSA_PCKS_1_5']
+    sign.HashAlg = HASH_TYPE_VALUE['SHA2_256']
+
+    bins.extend(bytearray(sign) + out_data)
     if inc_key:
         key = gen_pub_key (priv_key, pub_key)
         bins.extend(key)
+
     if len(bins) != len(out_data):
         gen_file_from_object (out_file, bins)
 
@@ -184,23 +242,31 @@ def gen_pub_key (priv_key, pub_key = None):
     output = run_process (cmdline, capture_out = capture)
     if not capture:
         output = get_file_data(pub_key, 'r')
-    data   = output.replace('\r', '')
-    data   = data.replace('\n', '')
-    data   = data.replace('  ', '')
+    data     = output.replace('\r', '')
+    data     = data.replace('\n', '')
+    data     = data.replace('  ', '')
 
     # Extract the modulus
     match = re.search('modulus(.*)publicExponent:\s+(\d+)\s+', data)
     if not match:
         raise Exception('Public key not found!')
-    modulus = match.group(1).replace(':', '')
+    modulus  = match.group(1).replace(':', '')
     exponent = int(match.group(2))
 
     # Remove the '00' from the front if the MSB is 1
     if (len(modulus) != 512):
         modulus = modulus[2:]
+
     mod = bytearray.fromhex(modulus)
     exp = bytearray.fromhex('{:08x}'.format(exponent))
-    key = b"$IPP" + mod + exp
+
+    keydata   = mod + exp
+    publickey = PUB_KEY_HDR()
+    publickey.KeySize  = len(keydata)
+    publickey.KeyType  = PUB_KEY_TYPE['RSA']
+
+    key =  bytearray(publickey) +  keydata
+
     if pub_key:
         gen_file_from_object (pub_key, key)
 
@@ -283,9 +349,9 @@ def compress (in_file, alg, out_path = '', tool_dir = ''):
 
     return out_file
 
-def get_priv_key_type (priv_key, openssl_path):
+def get_rsa_priv_key_type (priv_key, openssl_path):
 
-    print ("get_priv_key_type")
+    print ("get_rsa_priv_key_type info..")
     Output = subprocess.check_output(
             [openssl_path, 'rsa', '-pubout', '-text', '-noout', '-in',
              '%s' % priv_key],
@@ -295,6 +361,8 @@ def get_priv_key_type (priv_key, openssl_path):
     temp = re.findall(r'\d+', Match.group(1))
     key_type = list(map(int, temp))
 
-    print ("Key Type: RSA%s" % key_type[0])
 
-    return key_type
+    priv_key_str = 'RSA' + str(key_type[0])
+    print ("Key Type: %s" % priv_key_str)
+
+    return priv_key_str

--- a/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
+++ b/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
@@ -16,7 +16,7 @@ from ctypes import *
 
 sys.dont_write_bytecode = True
 from BuildUtility import rsa_sign_file, gen_pub_key
-
+from CommonUtility import *
 
 class FmpCapsuleImageHeaderClass(object):
     # typedef struct {
@@ -408,6 +408,12 @@ def SignImage(RawData, OutFile, HashType, PrivKey):
 
     file_size = len(RawData)
 
+    key_type = get_rsa_priv_key_type(PrivKey, get_openssl_path())
+    if key_type ==  'RSA2048':
+        key_size = 256
+    elif key_type ==  'RSA3072':
+        key_size = 384
+
     header.FileGuid         = (c_ubyte *16).from_buffer_copy(FIRMWARE_UPDATE_IMAGE_FILE_GUID.bytes_le)
     header.HeaderSize       = sizeof(Firmware_Update_Header)
     header.FirmwreVersion   = 1
@@ -415,7 +421,7 @@ def SignImage(RawData, OutFile, HashType, PrivKey):
     header.ImageOffset      = header.HeaderSize
     header.ImageSize        = file_size
     header.SignatureOffset  = header.ImageOffset + header.ImageSize
-    header.SignatureSize    = 256
+    header.SignatureSize    = sizeof(SIGNATURE_HDR) + key_size
     header.PubKeyOffset     = header.SignatureOffset + header.SignatureSize
 
     pubkey_file = 'fwu_public_key.bin'

--- a/BootloaderCorePkg/Tools/GenContainer.py
+++ b/BootloaderCorePkg/Tools/GenContainer.py
@@ -148,14 +148,12 @@ class CONTAINER ():
             auth_type_str = CONTAINER.get_auth_type_str (auth_type)
         else:
             auth_type_str = auth_type
-        lib_id_len   = 4
-        key_exp_len  = 4
         if  auth_type_str == 'NONE':
             auth_len = 0
         elif auth_type_str.startswith ('RSA'):
             auth_len = int(auth_type_str[3:]) >> 3
             if signed:
-                auth_len = auth_len * 2 + lib_id_len + key_exp_len
+                auth_len = auth_len * 2 + sizeof(PUB_KEY_HDR) + sizeof(SIGNATURE_HDR) +  4
         elif auth_type_str.startswith ('SHA2_'):
             auth_len = int(auth_type_str[5:]) >> 3
             if signed:
@@ -219,8 +217,8 @@ class CONTAINER ():
     def get_pub_key_hash (key, hash_type):
         # calculate publish key hash
         if hash_type == 'SHA2_256':
-            dh = bytearray (key)[4:]
-            dh = dh[:0x100][::-1] + dh[0x100:][::-1]
+            dh = bytearray (key)[sizeof(PUB_KEY_HDR):]
+            dh = dh[:0x100] + dh[0x100:]
             return bytearray(hashlib.sha256(dh).digest())
         else:
             raise Exception ("Unsupported hash type in get_pub_key_hash!")
@@ -245,7 +243,7 @@ class CONTAINER ():
             rsa_sign_file (priv_key, pub_key, hash_type, file, out_file, False, True)
             auth_data.extend (get_file_data(out_file))
         else:
-            raise Exception ("Unsupport AuthTupe '%s' !" % auth_type)
+            raise Exception ("Unsupport AuthType '%s' !" % auth_type)
         return hash_data, auth_data
 
 
@@ -299,7 +297,7 @@ class CONTAINER ():
                     key_hash = self.get_pub_key_hash (file_data[offset:])
                     hash_data.extend (key_hash)
                 else:
-                    raise Exception ("Unsupport AuthTupe '%s' !" % auth_type)
+                    raise Exception ("Unsupport AuthType '%s' !" % auth_type)
         return data, hash_data, auth_data
 
     def adjust_header (self):

--- a/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
+++ b/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
@@ -171,7 +171,7 @@ GetCapsuleFromRawPartition (
     return EFI_NOT_FOUND;
   }
 
-  if (FwUpdHeader->SignatureSize != RSA2048NUMBYTES) {
+  if (FwUpdHeader->SignatureSize != RSA2048_NUMBYTES) {
     DEBUG ((DEBUG_INFO, "Invalid Capsule image found, Signature size mismatch\n"));
     return EFI_NOT_FOUND;
   }


### PR DESCRIPTION
Added pubKey and signature updates to storage and implementation of these changes to secure boot and crypto libs. This patch set adapted changes for only RSA2048 & SHA256 in signing tools and secure boot/crypto libs.

Data reversal is removed while computing Hash of the data.

Adapted updated structures in Stage1B and ContainerLib where RSA_Verify() gets used.
For IAS image, data is transformed from IAS header to Cryptolib structures.

FwCapsuleupdate component and corresponding tool are be updated 

