### PR TITLE
Move clear HOB to the very end of the boot flow

### DIFF
--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -588,8 +588,6 @@ ProgramSecuritySetting (
 
   // Set the BIOS Lock Enable and EISS bits
   MmioOr8 (SpiBaseAddress + R_SPI_BCR, (UINT8) (B_SPI_BCR_BLE | B_SPI_BCR_EISS));
-
-  ClearFspHob ();
 }
 
 
@@ -755,6 +753,7 @@ BoardInit (
     IoWrite32 (ACPI_BASE_ADDRESS + R_TCO1_CNT, TcoCnt | B_TCO1_CNT_LOCK);
     break;
   case EndOfFirmware:
+    ClearFspHob ();
     // Clear known MCA logged in BANK4 and enable this MCA again
     AsmWriteMsr64 (IA32_MC4_STATUS, 0);
     AsmMsrOr32    (IA32_MC4_CTL,    (UINT32)BIT4);

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1172,8 +1172,6 @@ BoardInit (
     if ((GetBootMode() != BOOT_ON_FLASH_UPDATE) && (GetPayloadId() != 0)) {
       // Set the BIOS Lock Enable and EISS bits
       MmioOr8 (SpiBaseAddress + R_SPI_BCR, (UINT8) (B_SPI_BCR_BLE | B_SPI_BCR_EISS));
-
-      ClearFspHob ();
     }
     break;
   case ReadyToBoot:
@@ -1232,8 +1230,6 @@ BoardInit (
     //
     MmioOr8 (PCH_PWRM_BASE_ADDRESS + R_PMC_PWRM_GEN_PMCON_B, (UINT8)B_PMC_PWRM_GEN_PMCON_B_SMI_LOCK);
 
-    ClearFspHob ();
-
     //
     // Lock down Tco WDT just before handling off to OS
     //
@@ -1241,6 +1237,7 @@ BoardInit (
     IoOr16 ((TcoBase + R_TCO_IO_TCO1_CNT), B_TCO_IO_TCO1_CNT_LOCK);
     break;
   case EndOfFirmware:
+    ClearFspHob ();
     break;
   default:
     break;


### PR DESCRIPTION
Current SBL calls ClearFspHob() too early. Since HOB is required
during the whole FSP life cycle. It is better to clear it at the
end after the last call. Otherwise, some previous API call will
potentically encounter issues.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>