### PR TITLE
IPP Crypto SHA384 AVX and SES4 optimizations

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -63,10 +63,20 @@
   gPlatformCommonLibTokenSpaceGuid.PcdSupportedMediaTypeMask | 0xFFFFFFFF | UINT32  | 0x20000187
   gPlatformCommonLibTokenSpaceGuid.PcdMmcTuningLba           | 0x00000040 | UINT32  | 0x20000188
   gPlatformCommonLibTokenSpaceGuid.PcdSupportedFileSystemMask| 0x00000003 | UINT32  | 0x20000189
-  gPlatformCommonLibTokenSpaceGuid.PcdCryptoShaNiEnabled     | FALSE      | BOOLEAN | 0x20000200
+
+  ## This PCD indicates the IA32 optimizations enabled in IPP Crypto library
+  #  Based on the value set, required algorithm hash API would be enabled
+  #  Using an single PCD to all supported optimizations for SHA256 and SHA384
+  #     0x0001    - V8 Method SHA Extensions optimized implementation of a SHA-256 update.<BR>
+  #     0x0002    - Ni Method SHA Extensions optimized implementation of a SHA-256 update.<BR>
+  #     0x0004    - W7 Method SHA Extensions optimized implementation of a SHA-384 update.<BR>
+  #     0x0008    - G9 Method SHA Extensions optimized implementation of a SHA-384 update.<BR>
+  gPlatformCommonLibTokenSpaceGuid.PcdCryptoShaOptMask       | 0x0      | UINT32 | 0x20000200
+
   gPlatformCommonLibTokenSpaceGuid.PcdSeedListEnabled        | FALSE      | BOOLEAN | 0x20000203
   gPlatformCommonLibTokenSpaceGuid.PcdConsoleInDeviceMask    | 0x00000001 | UINT32  | 0x20000300
   gPlatformCommonLibTokenSpaceGuid.PcdConsoleOutDeviceMask   | 0x00000001 | UINT32  | 0x20000301
+
 
   ## The data buffer size used by debug port in debug communication library instances.
   #  Its value is not suggested to be changed in platform DSC file.

--- a/BootloaderCommonPkg/Include/Library/ExtraBaseLib.h
+++ b/BootloaderCommonPkg/Include/Library/ExtraBaseLib.h
@@ -33,4 +33,15 @@ AsmFlushCacheRange (
   IN      UINTN                     Length
   );
 
+/**
+  Enable CPU AVX support if the CPU is capable.
+  CPU.
+
+**/
+VOID
+EFIAPI
+AsmEnableAvx (
+  VOID
+);
+
 #endif

--- a/BootloaderCommonPkg/Library/ExtraBaseLib/ExtraBaseLib.inf
+++ b/BootloaderCommonPkg/Library/ExtraBaseLib/ExtraBaseLib.inf
@@ -22,7 +22,7 @@
 #
 
 [Sources.IA32]
-  Ia32/FlushCacheLineRange.nasm
+  Ia32/CpuSupport.nasm
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/BootloaderCommonPkg/Library/ExtraBaseLib/Ia32/CpuSupport.nasm
+++ b/BootloaderCommonPkg/Library/ExtraBaseLib/Ia32/CpuSupport.nasm
@@ -47,3 +47,36 @@ FlushExit:
     pop     ecx
     ret
 
+
+;------------------------------------------------------------------------------
+; VOID
+; EFIAPI
+; AsmEnableAvx (
+;   VOID
+;   );
+;------------------------------------------------------------------------------
+global ASM_PFX(AsmEnableAvx)
+ASM_PFX(AsmEnableAvx):
+    ;
+    ; Check if AVX is supported
+    ;
+    mov     eax, 1
+    cpuid
+    and     ecx, 014000000h
+    cmp     ecx, 014000000h       ; check both XSAVE and AVX feature flags
+    jne     NoAvxSupport
+
+    ;
+    ; Enable AVX
+    ;
+    mov     eax, cr4
+    or      eax, 00040000h
+    mov     cr4, eax
+    xor     ecx, ecx              ; XFEATURE_ENABLED_MASK register
+    xor     edx, edx
+    xor     eax, eax
+    mov     ax,  7h               ; mask in edx:eax
+    xsetbv
+
+NoAvxSupport:
+    ret

--- a/BootloaderCommonPkg/Library/IppCryptoLib/IppCryptoLib.inf
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/IppCryptoLib.inf
@@ -51,6 +51,8 @@
 [Sources.IA32]
   $(IPP_PATH)/Ia32/pcpsha256v8as.nasm
   $(IPP_PATH)/Ia32/pcpsha256nias.nasm
+  $(IPP_PATH)/Ia32/pcpsha512w7as.nasm
+  $(IPP_PATH)/Ia32/pcpsha512g9as.nasm
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -61,7 +63,7 @@
   DebugLib
 
 [FixedPcd]
-  gPlatformCommonLibTokenSpaceGuid.PcdCryptoShaNiEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdCryptoShaOptMask
   gPlatformCommonLibTokenSpaceGuid.PcdIppHashLibSupportedMask
 
 [BuildOptions]

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/Ia32/pcpsha512g9as.nasm
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/Ia32/pcpsha512g9as.nasm
@@ -1,0 +1,425 @@
+;===============================================================================
+; Copyright 2014-2019 Intel Corporation
+; All Rights Reserved.
+;
+; If this  software was obtained  under the  Intel Simplified  Software License,
+; the following terms apply:
+;
+; The source code,  information  and material  ("Material") contained  herein is
+; owned by Intel Corporation or its  suppliers or licensors,  and  title to such
+; Material remains with Intel  Corporation or its  suppliers or  licensors.  The
+; Material  contains  proprietary  information  of  Intel or  its suppliers  and
+; licensors.  The Material is protected by  worldwide copyright  laws and treaty
+; provisions.  No part  of  the  Material   may  be  used,  copied,  reproduced,
+; modified, published,  uploaded, posted, transmitted,  distributed or disclosed
+; in any way without Intel's prior express written permission.  No license under
+; any patent,  copyright or other  intellectual property rights  in the Material
+; is granted to  or  conferred  upon  you,  either   expressly,  by implication,
+; inducement,  estoppel  or  otherwise.  Any  license   under such  intellectual
+; property rights must be express and approved by Intel in writing.
+;
+; Unless otherwise agreed by Intel in writing,  you may not remove or alter this
+; notice or  any  other  notice   embedded  in  Materials  by  Intel  or Intel's
+; suppliers or licensors in any way.
+;
+;
+; If this  software  was obtained  under the  Apache License,  Version  2.0 (the
+; "License"), the following terms apply:
+;
+; You may  not use this  file except  in compliance  with  the License.  You may
+; obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+;
+;
+; Unless  required  by   applicable  law  or  agreed  to  in  writing,  software
+; distributed under the License  is distributed  on an  "AS IS"  BASIS,  WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;
+; See the   License  for the   specific  language   governing   permissions  and
+; limitations under the License.
+;===============================================================================
+
+;
+;
+;     Purpose:  Cryptography Primitive.
+;               Message block processing according to SHA512
+;
+;     Content:
+;        UpdateSHA512
+;
+;
+
+    SECTION .text
+
+%define  IPP_ALIGN_FACTOR   32
+
+%macro LD_ADDR 2
+        lea      %1, %2
+%endmacro
+
+
+
+;;
+;; ENDIANNESS
+;;
+%macro ENDIANNESS 2
+   vpshufb  %1, %1, %2
+%endmacro
+
+
+;;
+;; Rotate Right
+;;
+%macro PRORQ 3
+   vpsllq   %3, %1, (64-%2)
+   vpsrlq   %1, %1, %2
+   vpor     %1, %1,%3
+%endmacro
+
+
+
+;;
+;; Init and Update W:
+;;
+;; j = 0-15
+;; W[j] = ENDIANNESS(src)
+;;
+;; j = 16-79
+;; W[j] = SIGMA1(W[j- 2]) + W[j- 7]
+;;       +SIGMA0(W[j-15]) + W[j-16]
+;;
+;; SIGMA0(x) = ROR64(x,1) ^ROR64(x,8) ^LSR64(x,7)
+;; SIGMA1(x) = ROR64(x,19)^ROR64(x,61)^LSR64(x,6)
+;;
+%macro SIGMA0 4
+   vpsrlq   %1, %2, 7
+   vmovdqa  %3, %2
+   PRORQ    %2, 1, %4
+   vpxor    %1, %1, %2
+   PRORQ    %3,8, %4
+   vpxor    %1, %1, %3
+%endmacro
+
+
+%macro SIGMA1 4
+   vpsrlq   %1, %2, 6
+   vmovdqa  %3, %2
+   PRORQ    %2, 19, %4
+   vpxor    %1, %1, %2
+   PRORQ    %3,61, %4
+   vpxor    %1, %1, %3
+%endmacro
+
+
+
+;;
+;; SHA512 step
+;;
+;;    Ipp64u T1 = H + SUM1(E) + CHJ(E,F,G) + K_SHA512[t] + W[t];
+;;    Ipp64u T2 =     SUM0(A) + MAJ(A,B,C);
+;;    D+= T1;
+;;    H = T1 + T2;
+;;
+;; where
+;;    SUM1(x) = ROR64(x,14) ^ ROR64(x,18) ^ ROR64(x,41)
+;;    SUM0(x) = ROR64(x,28) ^ ROR64(x,34) ^ ROR64(x,39)
+;;
+;;    CHJ(x,y,z) = (x & y) ^ (~x & z)                          => x&(y^z) ^z
+;;    MAJ(x,y,z) = (x & y) ^ (x & z) ^ (y & z) = (x&y)^((x^y)&z)
+;;
+;; Input:
+;;    A,B,C,D,E,F,G,H   - 8 digest's values
+;;    pW                - pointer to the W array
+;;    pK512             - pointer to the constants
+;;    pBuffer           - temporary buffer
+;; Output:
+;;    A,B,C,D*,E,F,G,H* - 8 digest's values (D and H updated)
+;;    pW                - pointer to the W array
+;;    pK512             - pointer to the constants
+;;    pBuffer           - temporary buffer (changed)
+;;
+%macro CHJ 5
+   vpxor       %1, %3,%4   ; R=(f^g)
+   vpand       %1, %1,%2   ; R=e & (f^g)
+   vpxor       %1, %1,%4   ; R=e & (f^g) ^g
+%endmacro
+
+
+%macro MAJ 5
+   vpxor       %5, %2,%3   ; T=a^b
+   vpand       %1, %2,%3   ; R=a&b
+   vpand       %5, %5,%4   ; T=(a^b)&c
+   vpxor       %1, %1,%5   ; R=(a&b)^((a^b)&c)
+%endmacro
+
+
+%macro SUM0 3
+   vmovdqa  %1,%2
+   PRORQ    %1,28,%3             ; R=ROR(X,28)
+   PRORQ    %2,34,%3             ; X=ROR(X,34)
+   vpxor    %1, %1,%2
+   PRORQ    %2,(39-34),%3        ; X=ROR(x,39)
+   vpxor    %1, %1,%2
+%endmacro
+
+
+%macro SUM1 3
+   vmovdqa  %1,%2
+   PRORQ    %1,14,%3             ; R=ROR(X,14)
+   PRORQ    %2,18,%3             ; X=ROR(X,18)
+   vpxor    %1, %1,%2
+   PRORQ    %2,(41-18),%3        ; X=ROR(x,41)
+   vpxor    %1, %1,%2
+%endmacro
+
+
+%macro SHA512_STEP 11
+   vmovdqa     oword [%11+0*oSize],%5   ; save E
+   vmovdqa     oword [%11+1*oSize],%1   ; save A
+
+   vmovdqa     oword [%11+2*oSize],%4   ; save D
+   vmovdqa     oword [%11+3*oSize],%8   ; save H
+
+   CHJ         %4,%5,%6,%7, %8                             ; t1 = h+CHJ(e,f,g)+pW[]+pK512[]
+   vmovq       %8, qword [%9]
+   vpaddq      %4, %4,%8                                 ; +[pW]
+   vmovq       %8, qword [%10]
+   vpaddq      %4, %4,%8                                 ; +[pK512]
+   vpaddq      %4, %4,oword [%11+3*oSize]
+   vmovdqa     oword [%11+3*oSize],%4   ; save t1
+
+   MAJ         %8,%1,%2,%3, %4        ; t2 = MAJ(a,b,c)
+   vmovdqa     oword [%11+4*oSize],%8   ; save t2
+
+   SUM1        %4,%5,%8             ; D = SUM1(e)
+   vpaddq      %4, %4,oword [%11+3*oSize]; t1 = h+CHJ(e,f,g)+pW[]+pK512[] + SUM1(e)
+
+   SUM0        %8,%1,%5             ; H = SUM0(a)
+   vpaddq      %8, %8,oword [%11+4*oSize]; t2 = MAJ(a,b,c)+SUM0(a)
+
+   vpaddq      %8, %8,%4            ; h = t1+t2
+   vpaddq      %4, %4,oword [%11+2*oSize]; d+= t1
+
+   vmovdqa     %5,oword [%11+0*oSize]   ; restore E
+   vmovdqa     %1,oword [%11+1*oSize]   ; restore A
+%endmacro
+
+
+ALIGN IPP_ALIGN_FACTOR
+SWP_BYTE:
+pByteSwp DB    7,6,5,4,3,2,1,0, 15,14,13,12,11,10,9,8
+
+;*******************************************************************************************
+;* Purpose:     Update internal digest according to message block
+;*
+;* void UpdateSHA512(DigestSHA512 digest, const Ipp64u* mblk, int mlen, const void* pParam)
+;*
+;*******************************************************************************************
+
+;;
+;; Lib = W7, V8, P8
+;;
+;; Caller = ippsSHA512Update
+;; Caller = ippsSHA512Final
+;; Caller = ippsSHA512MessageDigest
+;;
+;; Caller = ippsSHA384Update
+;; Caller = ippsSHA384Final
+;; Caller = ippsSHA384MessageDigest
+;;
+;; Caller = ippsHMACSHA512Update
+;; Caller = ippsHMACSHA512Final
+;; Caller = ippsHMACSHA512MessageDigest
+;;
+;; Caller = ippsHMACSHA384Update
+;; Caller = ippsHMACSHA384Final
+;; Caller = ippsHMACSHA384MessageDigest
+;;
+;; ALIGN IPP_ALIGN_FACTOR
+;; IPPASM UpdateSHA512 PROC NEAR C PUBLIC \
+;; USES esi edi,\
+;; digest:  PTR QWORD,\        ; digest address
+;; mblk:    PTR BYTE,\         ; buffer address
+;; mlen:    DWORD,\            ; buffer length
+;; pSHA512: PTR QWORD          ; address of SHA constants
+global ASM_PFX(UpdateSHA512G9)
+ASM_PFX(UpdateSHA512G9):
+%define  oSize        16
+%define  qSize        8
+%define  digest       [ebp+0x08]
+%define  mblk         [ebp+0x0C]
+%define  mlen         [ebp+0x10]
+%define  pSHA512      [ebp+0x14]
+%define  MBS_SHA512   128                  ; SHA512 block data size
+
+%define  sSize        5                    ; size of save area (oword)
+%define  dSize        8                    ; size of digest (oword)
+%define  wSize        80                   ; W values queue (qword)
+%define  stackSize    sSize*oSize+dSize*oSize+wSize*qSize
+
+%define  sOffset      0                    ; save area
+%define  dOffset      sOffset+sSize*oSize  ; digest offset
+%define  wOffset      dOffset+dSize*oSize  ; W values offset
+%define  acualOffset  wOffset+wSize*qSize  ; actual stack size offset
+
+
+   ; Save
+   push   ebp
+   mov    ebp,esp
+
+   push   ebx
+   push   esi
+   push   edi
+
+   ; Start
+   mov      edi,digest           ; digest address
+   mov      esi,mblk             ; source data address
+   mov      eax,mlen             ; source data length
+
+   mov      edx, pSHA512         ; table constant address
+
+   sub      esp,stackSize        ; allocate local buffer (probably unaligned)
+   mov      ecx,esp
+   and      esp,-16              ; 16-byte aligned stack
+   sub      ecx,esp
+   add      ecx,stackSize        ; acual stack size (bytes)
+   mov      [esp+acualOffset],ecx
+
+   vmovq    xmm0,qword [edi+qSize*0]    ; A = digest[0]
+   vmovq    xmm1,qword [edi+qSize*1]    ; B = digest[1]
+   vmovq    xmm2,qword [edi+qSize*2]    ; C = digest[2]
+   vmovq    xmm3,qword [edi+qSize*3]    ; D = digest[3]
+   vmovq    xmm4,qword [edi+qSize*4]    ; E = digest[4]
+   vmovq    xmm5,qword [edi+qSize*5]    ; F = digest[5]
+   vmovq    xmm6,qword [edi+qSize*6]    ; G = digest[6]
+   vmovq    xmm7,qword [edi+qSize*7]    ; H = digest[7]
+   vmovdqa  oword [esp+dOffset+oSize*0], xmm0
+   vmovdqa  oword [esp+dOffset+oSize*1], xmm1
+   vmovdqa  oword [esp+dOffset+oSize*2], xmm2
+   vmovdqa  oword [esp+dOffset+oSize*3], xmm3
+   vmovdqa  oword [esp+dOffset+oSize*4], xmm4
+   vmovdqa  oword [esp+dOffset+oSize*5], xmm5
+   vmovdqa  oword [esp+dOffset+oSize*6], xmm6
+   vmovdqa  oword [esp+dOffset+oSize*7], xmm7
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; process next data block
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+sha512_block_loop:
+
+;;
+;; initialize the first 16 qwords in the array W (remember about endian)
+;;
+  ;vmovdqa  xmm1, oword  pByteSwp ; load shuffle mask
+   LD_ADDR  ecx, [pByteSwp]
+   movdqa   xmm1, oword [ecx+(pByteSwp-SWP_BYTE)]
+   mov      ecx,0
+   ALIGN IPP_ALIGN_FACTOR
+loop1:
+   vmovdqu  xmm0, oword  [esi+ecx*qSize]   ; swap input
+   ENDIANNESS xmm0, xmm1
+   vmovdqa  oword [esp+wOffset+ecx*qSize],xmm0
+   add      ecx,oSize/qSize
+   cmp      ecx,16
+   jl       loop1
+
+;;
+;; initialize another 80-16 qwords in the array W
+;;
+     ALIGN IPP_ALIGN_FACTOR
+loop2:
+   vmovdqa  xmm1,oword [esp+ecx*qSize+wOffset- 2*qSize]       ; xmm1 = W[j-2]
+   SIGMA1   xmm0,xmm1,xmm2,xmm3
+
+   vmovdqu  xmm5,oword [esp+ecx*qSize+wOffset-15*qSize]       ; xmm5 = W[j-15]
+   SIGMA0   xmm4,xmm5,xmm6,xmm3
+
+   vmovdqu  xmm7,oword [esp+ecx*qSize+wOffset- 7*qSize]       ; W[j-7]
+   vpaddq   xmm0, xmm0,xmm4
+   vpaddq   xmm7, xmm7,oword [esp+ecx*qSize+wOffset-16*qSize] ; W[j-16]
+   vpaddq   xmm0, xmm0,xmm7
+   vmovdqa  oword [esp+ecx*qSize+wOffset],xmm0
+
+   add      ecx,oSize/qSize
+   cmp      ecx,80
+   jl       loop2
+
+;;
+;; init A,B,C,D,E,F,G,H by the internal digest
+;;
+   vmovdqa  xmm0,oword [esp+dOffset+oSize*0]    ; A = digest[0]
+   vmovdqa  xmm1,oword [esp+dOffset+oSize*1]    ; B = digest[1]
+   vmovdqa  xmm2,oword [esp+dOffset+oSize*2]    ; C = digest[2]
+   vmovdqa  xmm3,oword [esp+dOffset+oSize*3]    ; D = digest[3]
+   vmovdqa  xmm4,oword [esp+dOffset+oSize*4]    ; E = digest[4]
+   vmovdqa  xmm5,oword [esp+dOffset+oSize*5]    ; F = digest[5]
+   vmovdqa  xmm6,oword [esp+dOffset+oSize*6]    ; G = digest[6]
+   vmovdqa  xmm7,oword [esp+dOffset+oSize*7]    ; H = digest[7]
+
+;;
+;; perform 0-79 steps
+;;
+   xor      ecx,ecx
+  ALIGN IPP_ALIGN_FACTOR
+loop3:
+;;             A,   B,   C,   D,   E,   F,   G,   H     W[],                                             K[],                                  buffer
+;;             --------------------------------------------------------------------------------------------------------------------------------------
+   SHA512_STEP xmm0,xmm1,xmm2,xmm3,xmm4,xmm5,xmm6,xmm7, esp+ecx*qSize+wOffset+qSize*0, edx+ecx*qSize+qSize*0, esp
+   SHA512_STEP xmm7,xmm0,xmm1,xmm2,xmm3,xmm4,xmm5,xmm6, esp+ecx*qSize+wOffset+qSize*1, edx+ecx*qSize+qSize*1, esp
+   SHA512_STEP xmm6,xmm7,xmm0,xmm1,xmm2,xmm3,xmm4,xmm5, esp+ecx*qSize+wOffset+qSize*2, edx+ecx*qSize+qSize*2, esp
+   SHA512_STEP xmm5,xmm6,xmm7,xmm0,xmm1,xmm2,xmm3,xmm4, esp+ecx*qSize+wOffset+qSize*3, edx+ecx*qSize+qSize*3, esp
+   SHA512_STEP xmm4,xmm5,xmm6,xmm7,xmm0,xmm1,xmm2,xmm3, esp+ecx*qSize+wOffset+qSize*4, edx+ecx*qSize+qSize*4, esp
+   SHA512_STEP xmm3,xmm4,xmm5,xmm6,xmm7,xmm0,xmm1,xmm2, esp+ecx*qSize+wOffset+qSize*5, edx+ecx*qSize+qSize*5, esp
+   SHA512_STEP xmm2,xmm3,xmm4,xmm5,xmm6,xmm7,xmm0,xmm1, esp+ecx*qSize+wOffset+qSize*6, edx+ecx*qSize+qSize*6, esp
+   SHA512_STEP xmm1,xmm2,xmm3,xmm4,xmm5,xmm6,xmm7,xmm0, esp+ecx*qSize+wOffset+qSize*7, edx+ecx*qSize+qSize*7, esp
+
+
+   add      ecx,8
+   cmp      ecx,80
+   jl       loop3
+
+;;
+;; update digest
+;;
+   vpaddq   xmm0, xmm0,oword [esp+dOffset+oSize*0]    ; A += digest[0]
+   vpaddq   xmm1, xmm1,oword [esp+dOffset+oSize*1]    ; B += digest[1]
+   vpaddq   xmm2, xmm2,oword [esp+dOffset+oSize*2]    ; C += digest[2]
+   vpaddq   xmm3, xmm3,oword [esp+dOffset+oSize*3]    ; D += digest[3]
+   vpaddq   xmm4, xmm4,oword [esp+dOffset+oSize*4]    ; E += digest[4]
+   vpaddq   xmm5, xmm5,oword [esp+dOffset+oSize*5]    ; F += digest[5]
+   vpaddq   xmm6, xmm6,oword [esp+dOffset+oSize*6]    ; G += digest[6]
+   vpaddq   xmm7, xmm7,oword [esp+dOffset+oSize*7]    ; H += digest[7]
+
+   vmovdqa  oword [esp+dOffset+oSize*0],xmm0    ; digest[0] = A
+   vmovdqa  oword [esp+dOffset+oSize*1],xmm1    ; digest[1] = B
+   vmovdqa  oword [esp+dOffset+oSize*2],xmm2    ; digest[2] = C
+   vmovdqa  oword [esp+dOffset+oSize*3],xmm3    ; digest[3] = D
+   vmovdqa  oword [esp+dOffset+oSize*4],xmm4    ; digest[4] = E
+   vmovdqa  oword [esp+dOffset+oSize*5],xmm5    ; digest[5] = F
+   vmovdqa  oword [esp+dOffset+oSize*6],xmm6    ; digest[6] = G
+   vmovdqa  oword [esp+dOffset+oSize*7],xmm7    ; digest[7] = H
+
+   add         esi, MBS_SHA512
+   sub         eax, MBS_SHA512
+   jg          sha512_block_loop
+
+   vmovq    qword [edi+qSize*0], xmm0    ; A = digest[0]
+   vmovq    qword [edi+qSize*1], xmm1    ; B = digest[1]
+   vmovq    qword [edi+qSize*2], xmm2    ; C = digest[2]
+   vmovq    qword [edi+qSize*3], xmm3    ; D = digest[3]
+   vmovq    qword [edi+qSize*4], xmm4    ; E = digest[4]
+   vmovq    qword [edi+qSize*5], xmm5    ; F = digest[5]
+   vmovq    qword [edi+qSize*6], xmm6    ; G = digest[6]
+   vmovq    qword [edi+qSize*7], xmm7    ; H = digest[7]
+
+   add      esp,[esp+acualOffset]
+
+
+   ; Restore
+   pop    edi
+   pop    esi
+   pop    ebx
+   pop    ebp
+   ret
+

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/Ia32/pcpsha512w7as.nasm
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/Ia32/pcpsha512w7as.nasm
@@ -1,0 +1,420 @@
+;===============================================================================
+; Copyright 2014-2019 Intel Corporation
+; All Rights Reserved.
+;
+; If this  software was obtained  under the  Intel Simplified  Software License,
+; the following terms apply:
+;
+; The source code,  information  and material  ("Material") contained  herein is
+; owned by Intel Corporation or its  suppliers or licensors,  and  title to such
+; Material remains with Intel  Corporation or its  suppliers or  licensors.  The
+; Material  contains  proprietary  information  of  Intel or  its suppliers  and
+; licensors.  The Material is protected by  worldwide copyright  laws and treaty
+; provisions.  No part  of  the  Material   may  be  used,  copied,  reproduced,
+; modified, published,  uploaded, posted, transmitted,  distributed or disclosed
+; in any way without Intel's prior express written permission.  No license under
+; any patent,  copyright or other  intellectual property rights  in the Material
+; is granted to  or  conferred  upon  you,  either   expressly,  by implication,
+; inducement,  estoppel  or  otherwise.  Any  license   under such  intellectual
+; property rights must be express and approved by Intel in writing.
+;
+; Unless otherwise agreed by Intel in writing,  you may not remove or alter this
+; notice or  any  other  notice   embedded  in  Materials  by  Intel  or Intel's
+; suppliers or licensors in any way.
+;
+;
+; If this  software  was obtained  under the  Apache License,  Version  2.0 (the
+; "License"), the following terms apply:
+;
+; You may  not use this  file except  in compliance  with  the License.  You may
+; obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+;
+;
+; Unless  required  by   applicable  law  or  agreed  to  in  writing,  software
+; distributed under the License  is distributed  on an  "AS IS"  BASIS,  WITHOUT
+; WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;
+; See the   License  for the   specific  language   governing   permissions  and
+; limitations under the License.
+;===============================================================================
+
+;
+;
+;     Purpose:  Cryptography Primitive.
+;               Message block processing according to SHA512
+;
+;     Content:
+;        UpdateSHA512
+;
+;
+
+    SECTION .text
+
+%define  IPP_ALIGN_FACTOR   32
+
+%macro LD_ADDR 2
+       lea      %1, %2
+%endmacro
+
+%macro ENDIANNESS 2
+   pshufb   %1, %2
+%endmacro
+
+;;
+;; Rotate Right
+;;
+%macro PRORQ  3
+   movdqa   %3,%1
+   psrlq    %1,%2
+   psllq    %3,(64-%2)
+   por      %1,%3
+%endmacro
+
+
+;;
+;; Init and Update W:
+;;
+;; j = 0-15
+;; W[j] = ENDIANNESS(src)
+;;
+;; j = 16-79
+;; W[j] = SIGMA1(W[j- 2]) + W[j- 7]
+;;       +SIGMA0(W[j-15]) + W[j-16]
+;;
+;; SIGMA0(x) = ROR64(x,1) ^ROR64(x,8) ^LSR64(x,7)
+;; SIGMA1(x) = ROR64(x,19)^ROR64(x,61)^LSR64(x,6)
+;;
+%macro SIGMA0  4
+   movdqa   %1, %2
+   psrlq    %2, 7
+   movdqa   %3,%1
+   PRORQ    %1, 1, %4
+   pxor     %1, %2
+   PRORQ    %3,8, %4
+   pxor     %1, %3
+%endmacro
+
+%macro SIGMA1  4
+   movdqa   %1, %2
+   psrlq    %2, 6
+   movdqa   %3,%1
+   PRORQ    %1, 19, %4
+   pxor     %1, %2
+   PRORQ    %3,61, %4
+   pxor     %1, %3
+%endmacro
+
+
+;;
+;; SHA512 step
+;;
+;;    Ipp64u T1 = H + SUM1(E) + CHJ(E,F,G) + K_SHA512[t] + W[t];
+;;    Ipp64u T2 =     SUM0(A) + MAJ(A,B,C);
+;;    D+= T1;
+;;    H = T1 + T2;
+;;
+;; where
+;;    SUM1(x) = ROR64(x,14) ^ ROR64(x,18) ^ ROR64(x,41)
+;;    SUM0(x) = ROR64(x,28) ^ ROR64(x,34) ^ ROR64(x,39)
+;;
+;;    CHJ(x,y,z) = (x & y) ^ (~x & z)                          => x&(y^z) ^z
+;;    MAJ(x,y,z) = (x & y) ^ (x & z) ^ (y & z) = (x&y)^((x^y)&z)
+;;
+;; Input:
+;;    A,B,C,D,E,F,G,H   - 8 digest's values
+;;    pW                - pointer to the W array
+;;    pK512             - pointer to the constants
+;;    pBuffer           - temporary buffer
+;; Output:
+;;    A,B,C,D*,E,F,G,H* - 8 digest's values (D and H updated)
+;;    pW                - pointer to the W array
+;;    pK512             - pointer to the constants
+;;    pBuffer           - temporary buffer (changed)
+;;
+%macro  CHJ  5
+   movdqa      %1,%3   ; R=f
+   pxor        %1,%4   ; R=(f^g)
+   pand        %1,%2   ; R=e & (f^g)
+   pxor        %1,%4   ; R=e & (f^g) ^g
+%endmacro
+
+%macro  MAJ  5
+   movdqa      %5,%3   ; T=b
+   movdqa      %1,%2   ; R=a
+   pxor        %5,%2   ; T=a^b
+   pand        %1,%3   ; R=a&b
+   pand        %5,%4   ; T=(a^b)&c
+   pxor        %1,%5   ; R=(a&b)^((a^b)&c)
+%endmacro
+
+
+%macro SUM0  3
+   movdqa   %1,%2
+   PRORQ    %1,28,%3             ; R=ROR(X,28)
+   PRORQ    %2,34,%3             ; X=ROR(X,34)
+   pxor     %1,%2
+   PRORQ    %2,(39-34),%3        ; X=ROR(x,39)
+   pxor     %1,%2
+%endmacro
+
+%macro SUM1  3
+   movdqa   %1,%2
+   PRORQ    %1,14,%3             ; R=ROR(X,14)
+   PRORQ    %2,18,%3             ; X=ROR(X,18)
+   pxor     %1,%2
+   PRORQ    %2,(41-18),%3        ; X=ROR(x,41)
+   pxor     %1,%2
+%endmacro
+
+%macro SHA512_STEP  11
+   movdqa      oword [%11+0*oSize],%5   ; save E
+   movdqa      oword [%11+1*oSize],%1   ; save A
+
+   movdqa      oword [%11+2*oSize],%4   ; save D
+   movdqa      oword [%11+3*oSize],%8   ; save H
+
+   CHJ         %4,%5,%6,%7, %8                             ; t1 = h+CHJ(e,f,g)+pW[]+pK512[]
+   movq        %8, qword [%9]
+   paddq       %4, %8                                   ; +[pW]
+   movq        %8, qword [%10]
+   paddq       %4, %8                                   ; +[pK512]
+   paddq       %4,oword [%11+3*oSize]
+   movdqa      oword [%11+3*oSize],%4   ; save t1
+
+   MAJ         %8,%1,%2,%3, %4        ; t2 = MAJ(a,b,c)
+   movdqa      oword [%11+4*oSize],%8   ; save t2
+
+   SUM1        %4,%5,%8             ; D = SUM1(e)
+   paddq       %4,oword [%11+3*oSize]   ; t1 = h+CHJ(e,f,g)+pW[]+pK512[] + SUM1(e)
+
+   SUM0        %8,%1,%5             ; H = SUM0(a)
+   paddq       %8,oword [%11+4*oSize]   ; t2 = MAJ(a,b,c)+SUM0(a)
+
+   paddq       %8,%4               ; h = t1+t2
+   paddq       %4,oword [%11+2*oSize]   ; d+= t1
+
+   movdqa      %5,oword [%11+0*oSize]   ; restore E
+   movdqa      %1,oword [%11+1*oSize]   ; restore A
+%endmacro
+
+
+ALIGN IPP_ALIGN_FACTOR
+SWP_BYTE:
+pByteSwp DB    7,6,5,4,3,2,1,0, 15,14,13,12,11,10,9,8
+
+
+;*******************************************************************************************
+;* Purpose:     Update internal digest according to message block
+;*
+;* void UpdateSHA512(DigestSHA512 digest, const Ipp64u* mblk, int mlen, const void* pParam)
+;*
+;*******************************************************************************************
+
+;;
+;; Lib = W7, V8, P8
+;;
+;; Caller = ippsSHA512Update
+;; Caller = ippsSHA512Final
+;; Caller = ippsSHA512MessageDigest
+;;
+;; Caller = ippsSHA384Update
+;; Caller = ippsSHA384Final
+;; Caller = ippsSHA384MessageDigest
+;;
+;; Caller = ippsHMACSHA512Update
+;; Caller = ippsHMACSHA512Final
+;; Caller = ippsHMACSHA512MessageDigest
+;;
+;; Caller = ippsHMACSHA384Update
+;; Caller = ippsHMACSHA384Final
+;; Caller = ippsHMACSHA384MessageDigest
+;;
+ALIGN IPP_ALIGN_FACTOR
+;; IPPASM UpdateSHA512 PROC NEAR C PUBLIC \
+;; USES esi edi,\
+;; digest:  PTR QWORD,\        ; digest address
+;; mblk:    PTR BYTE,\         ; buffer address
+;; mlen:    DWORD,\            ; buffer length
+;; pSHA512: PTR QWORD         ; address of SHA constants
+global ASM_PFX(UpdateSHA512W7)
+ASM_PFX(UpdateSHA512W7):
+
+%define  oSize         16
+%define  qSize         8
+%define  digest       [ebp+0x08]
+%define  mblk         [ebp+0x0C]
+%define  mlen         [ebp+0x10]
+%define  pSHA512      [ebp+0x14]
+%define  MBS_SHA512   128                  ; SHA512 block data size
+
+%define  sSize         5                   ; size of save area (oword)
+%define  dSize         8                   ; size of digest (oword)
+%define  wSize        80                   ; W values queue (qword)
+%define  stackSize    sSize*oSize+dSize*oSize+wSize*qSize
+
+%define  sOffset      0                           ; save area
+%define  dOffset      sOffset+sSize*oSize ; digest offset
+%define  wOffset      dOffset+dSize*oSize ; W values offset
+%define  acualOffset  wOffset+wSize*qSize ; actual stack size offset
+
+   ; Save
+   push   ebp
+   mov    ebp,esp
+
+   push   ebx
+   push   esi
+   push   edi
+
+   ; Start
+   mov      edi,digest           ; digest address
+   mov      esi,mblk             ; source data address
+   mov      eax,mlen             ; source data length
+
+   mov      edx, pSHA512         ; table constant address
+
+   sub      esp,stackSize        ; allocate local buffer (probably unaligned)
+   mov      ecx,esp
+   and      esp,-16              ; 16-byte aligned stack
+   sub      ecx,esp
+   add      ecx,stackSize        ; acual stack size (bytes)
+   mov      [esp+acualOffset],ecx
+
+   movq     xmm0,qword [edi+qSize*0]    ; A = digest[0]
+   movq     xmm1,qword [edi+qSize*1]    ; B = digest[1]
+   movq     xmm2,qword [edi+qSize*2]    ; C = digest[2]
+   movq     xmm3,qword [edi+qSize*3]    ; D = digest[3]
+   movq     xmm4,qword [edi+qSize*4]    ; E = digest[4]
+   movq     xmm5,qword [edi+qSize*5]    ; F = digest[5]
+   movq     xmm6,qword [edi+qSize*6]    ; G = digest[6]
+   movq     xmm7,qword [edi+qSize*7]    ; H = digest[7]
+   movdqa   oword [esp+dOffset+oSize*0], xmm0
+   movdqa   oword [esp+dOffset+oSize*1], xmm1
+   movdqa   oword [esp+dOffset+oSize*2], xmm2
+   movdqa   oword [esp+dOffset+oSize*3], xmm3
+   movdqa   oword [esp+dOffset+oSize*4], xmm4
+   movdqa   oword [esp+dOffset+oSize*5], xmm5
+   movdqa   oword [esp+dOffset+oSize*6], xmm6
+   movdqa   oword [esp+dOffset+oSize*7], xmm7
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; process next data block
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+sha512_block_loop:
+
+;;
+;; initialize the first 16 qwords in the array W (remember about endian)
+;;
+
+  ;movdqa   xmm1, oword  pByteSwp ; load shuffle mask
+   LD_ADDR  ecx, [pByteSwp]
+   movdqa   xmm1, oword [ecx+(pByteSwp-SWP_BYTE)]
+
+   mov      ecx,0
+   ALIGN IPP_ALIGN_FACTOR
+loop1:
+   movdqu   xmm0, oword  [esi+ecx*qSize]   ; swap input
+   ENDIANNESS xmm0, xmm1
+   movdqa   oword [esp+wOffset+ecx*qSize],xmm0
+   add      ecx,oSize/qSize
+   cmp      ecx,16
+   jl       loop1
+
+;;
+;; initialize another 80-16 qwords in the array W
+;;
+   ALIGN IPP_ALIGN_FACTOR
+loop2:
+   movdqa   xmm1,oword [esp+ecx*qSize+wOffset- 2*qSize]    ; xmm1 = W[j-2]
+   SIGMA1   xmm0,xmm1,xmm2,xmm3
+
+   movdqu   xmm5,oword [esp+ecx*qSize+wOffset-15*qSize]    ; xmm5 = W[j-15]
+   SIGMA0   xmm4,xmm5,xmm6,xmm3
+
+   movdqu   xmm7,oword [esp+ecx*qSize+wOffset- 7*qSize]    ; W[j-7]
+   paddq    xmm0,xmm4
+   paddq    xmm7,oword [esp+ecx*qSize+wOffset-16*qSize]    ; W[j-16]
+   paddq    xmm0,xmm7
+   movdqa   oword [esp+ecx*qSize+wOffset],xmm0
+
+   add      ecx,oSize/qSize
+   cmp      ecx,80
+   jl       loop2
+
+;;
+;; init A,B,C,D,E,F,G,H by the internal digest
+;;
+   movdqa   xmm0,oword [esp+dOffset+oSize*0]    ; A = digest[0]
+   movdqa   xmm1,oword [esp+dOffset+oSize*1]    ; B = digest[1]
+   movdqa   xmm2,oword [esp+dOffset+oSize*2]    ; C = digest[2]
+   movdqa   xmm3,oword [esp+dOffset+oSize*3]    ; D = digest[3]
+   movdqa   xmm4,oword [esp+dOffset+oSize*4]    ; E = digest[4]
+   movdqa   xmm5,oword [esp+dOffset+oSize*5]    ; F = digest[5]
+   movdqa   xmm6,oword [esp+dOffset+oSize*6]    ; G = digest[6]
+   movdqa   xmm7,oword [esp+dOffset+oSize*7]    ; H = digest[7]
+
+;;
+;; perform 0-79 steps
+;;
+   xor      ecx,ecx
+  ALIGN IPP_ALIGN_FACTOR
+loop3:
+;;             A,   B,   C,   D,   E,   F,   G,   H     W[],                                             K[],                                  buffer
+;;             --------------------------------------------------------------------------------------------------------------------------------------
+   SHA512_STEP xmm0,xmm1,xmm2,xmm3,xmm4,xmm5,xmm6,xmm7, esp+ecx*qSize+wOffset+qSize*0, edx+ecx*qSize+qSize*0, esp
+   SHA512_STEP xmm7,xmm0,xmm1,xmm2,xmm3,xmm4,xmm5,xmm6, esp+ecx*qSize+wOffset+qSize*1, edx+ecx*qSize+qSize*1, esp
+   SHA512_STEP xmm6,xmm7,xmm0,xmm1,xmm2,xmm3,xmm4,xmm5, esp+ecx*qSize+wOffset+qSize*2, edx+ecx*qSize+qSize*2, esp
+   SHA512_STEP xmm5,xmm6,xmm7,xmm0,xmm1,xmm2,xmm3,xmm4, esp+ecx*qSize+wOffset+qSize*3, edx+ecx*qSize+qSize*3, esp
+   SHA512_STEP xmm4,xmm5,xmm6,xmm7,xmm0,xmm1,xmm2,xmm3, esp+ecx*qSize+wOffset+qSize*4, edx+ecx*qSize+qSize*4, esp
+   SHA512_STEP xmm3,xmm4,xmm5,xmm6,xmm7,xmm0,xmm1,xmm2, esp+ecx*qSize+wOffset+qSize*5, edx+ecx*qSize+qSize*5, esp
+   SHA512_STEP xmm2,xmm3,xmm4,xmm5,xmm6,xmm7,xmm0,xmm1, esp+ecx*qSize+wOffset+qSize*6, edx+ecx*qSize+qSize*6, esp
+   SHA512_STEP xmm1,xmm2,xmm3,xmm4,xmm5,xmm6,xmm7,xmm0, esp+ecx*qSize+wOffset+qSize*7, edx+ecx*qSize+qSize*7, esp
+
+   add      ecx,8
+   cmp      ecx,80
+   jl       loop3
+
+;;
+;; update digest
+;;
+   paddq    xmm0,oword [esp+dOffset+oSize*0]    ; A += digest[0]
+   paddq    xmm1,oword [esp+dOffset+oSize*1]    ; B += digest[1]
+   paddq    xmm2,oword [esp+dOffset+oSize*2]    ; C += digest[2]
+   paddq    xmm3,oword [esp+dOffset+oSize*3]    ; D += digest[3]
+   paddq    xmm4,oword [esp+dOffset+oSize*4]    ; E += digest[4]
+   paddq    xmm5,oword [esp+dOffset+oSize*5]    ; F += digest[5]
+   paddq    xmm6,oword [esp+dOffset+oSize*6]    ; G += digest[6]
+   paddq    xmm7,oword [esp+dOffset+oSize*7]    ; H += digest[7]
+
+   movdqa   oword [esp+dOffset+oSize*0],xmm0    ; digest[0] = A
+   movdqa   oword [esp+dOffset+oSize*1],xmm1    ; digest[1] = B
+   movdqa   oword [esp+dOffset+oSize*2],xmm2    ; digest[2] = C
+   movdqa   oword [esp+dOffset+oSize*3],xmm3    ; digest[3] = D
+   movdqa   oword [esp+dOffset+oSize*4],xmm4    ; digest[4] = E
+   movdqa   oword [esp+dOffset+oSize*5],xmm5    ; digest[5] = F
+   movdqa   oword [esp+dOffset+oSize*6],xmm6    ; digest[6] = G
+   movdqa   oword [esp+dOffset+oSize*7],xmm7    ; digest[7] = H
+
+   add         esi, MBS_SHA512
+   sub         eax, MBS_SHA512
+   jg          sha512_block_loop
+
+   movq     qword [edi+qSize*0], xmm0    ; A = digest[0]
+   movq     qword [edi+qSize*1], xmm1    ; B = digest[1]
+   movq     qword [edi+qSize*2], xmm2    ; C = digest[2]
+   movq     qword [edi+qSize*3], xmm3    ; D = digest[3]
+   movq     qword [edi+qSize*4], xmm4    ; E = digest[4]
+   movq     qword [edi+qSize*5], xmm5    ; F = digest[5]
+   movq     qword [edi+qSize*6], xmm6    ; G = digest[6]
+   movq     qword [edi+qSize*7], xmm7    ; H = digest[7]
+
+   add      esp,[esp+acualOffset]
+
+   ; Restore
+   pop    edi
+   pop    esi
+   pop    ebx
+   pop    ebp
+   ret
+

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcphash.h
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcphash.h
@@ -201,6 +201,8 @@ void UpdateSHA256(void* pHash, const Ipp8u* mblk, int mlen, const void* pParam);
 void UpdateSHA256V8(void* pHash, const Ipp8u* mblk, int mlen, const void* pParam);
 void UpdateSHA256Ni(void* pHash, const Ipp8u* mblk, int mlen, const void* pParam);
 void UpdateSHA512(void* pHash, const Ipp8u* mblk, int mlen, const void* pParam);
+void UpdateSHA512W7 (void* uniHash, const Ipp8u* mblk, int mlen, const void* uniPraram);
+void UpdateSHA512G9 (void* uniHash, const Ipp8u* mblk, int mlen, const void* uniPraram);
 void UpdateMD5   (void* pHash, const Ipp8u* mblk, int mlen, const void* pParam);
 void UpdateSM3   (void* pHash, const Ipp8u* mblk, int mlen, const void* pParam);
 

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpsha256ca.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpsha256ca.c
@@ -167,14 +167,20 @@ void UpdateSHA256Compact(void* uniHash, const Ipp8u* mblk, int mlen, const void*
 
 void UpdateSHA256(void* pHash, const Ipp8u* pMsg, int msgLen, const void* pParam)
 {
-#if FixedPcdGetBool (PcdCryptoShaNiEnabled)
-    UpdateSHA256Ni(pHash, pMsg, msgLen, pParam);
+#if defined(_SLIMBOOT_OPT)
+
+  if (FixedPcdGet32 (PcdCryptoShaOptMask) & IPP_CRYPTO_SHA256_NI) {
+      UpdateSHA256Ni(pHash, pMsg, msgLen, pParam);
+   } else {
+      UpdateSHA256V8(pHash, pMsg, msgLen, pParam);
+   }
+
 #else
-#if defined(_ALG_SHA256_COMPACT_)
+  #if defined(_ALG_SHA256_COMPACT_)
     UpdateSHA256Compact(pHash, pMsg, msgLen, pParam);
-#else
+  #else
     UpdateSHA256V8(pHash, pMsg, msgLen, pParam);
-#endif
+  #endif
 #endif
 }
 

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpsha512ca.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpsha512ca.c
@@ -82,7 +82,7 @@ static void sha512_384_hashInit(void* pHash)
 
 static void sha512_hashUpdate(void* pHash, const Ipp8u* pMsg, int msgLen)
 {
-   UpdateSHA512(pHash, pMsg, msgLen, sha512_cnt);
+   UpdateSHA512 (pHash, pMsg, msgLen, sha512_cnt);
 }
 
 /* convert hash into big endian */
@@ -144,7 +144,7 @@ static void cpFinalizeSHA512(DigestSHA512 pHash,
    ((Ipp64u*)(buffer+bufferLen))[-1] = ENDIANNESS64(lenLo);
 
    /* copmplete hash computation */
-   UpdateSHA512(pHash, buffer, bufferLen, sha512_cnt);
+   UpdateSHA512 (pHash, buffer, bufferLen, sha512_cnt);
 }
 
 // #endif /* #if !defined(_PCP_SHA512_STUFF_H) */
@@ -429,28 +429,16 @@ IPPFUN( const IppsHashMethod*, ippsHashMethod_SHA512, (void) )
    (A) = _T1+_T2; \
 }
 
-/*F*
-//    Name: UpdateSHA512
-//
-// Purpose: Update internal hash according to input message stream.
-//
-// Parameters:
-//    uniHash  pointer to in/out hash
-//    mblk     pointer to message stream
-//    mlen     message stream length (multiple by message block size)
-//    uniParam pointer to the optional parameter
-//
-*F*/
+
 #if defined(_ALG_SHA512_COMPACT_)
 #pragma message("SHA512 compact")
 
-void UpdateSHA512(void* uniHash, const Ipp8u* mblk, int mlen, const void* uniPraram)
+void UpdateSHA512Compact(void* uniHash, const Ipp8u* mblk, int mlen, const void* uniPraram)
 {
    Ipp32u* data = (Ipp32u*)mblk;
 
    Ipp64u* digest = (Ipp64u*)uniHash;
    Ipp64u* SHA512_cnt_loc = (Ipp64u*)uniPraram;
-
 
    for(; mlen>=MBS_SHA512; data += MBS_SHA512/sizeof(Ipp32u), mlen -= MBS_SHA512) {
       int t;
@@ -501,9 +489,9 @@ void UpdateSHA512(void* uniHash, const Ipp8u* mblk, int mlen, const void* uniPra
       }
    }
 }
+#endif
 
-#else
-void UpdateSHA512(void* uniHash, const Ipp8u* mblk, int mlen, const void* uniPraram)
+void UpdateSHA512Normal(void* uniHash, const Ipp8u* mblk, int mlen, const void* uniPraram)
 {
    Ipp32u* data = (Ipp32u*)mblk;
 
@@ -560,6 +548,39 @@ void UpdateSHA512(void* uniHash, const Ipp8u* mblk, int mlen, const void* uniPra
       digest[7] += v[7];
    }
 }
+
+/*F*
+//    Name: UpdateSHA512
+//
+// Purpose: Update internal hash according to input message stream.
+//
+// Parameters:
+//    uniHash  pointer to in/out hash
+//    mblk     pointer to message stream
+//    mlen     message stream length (multiple by message block size)
+//    uniParam pointer to the optional parameter
+//
+*F*/
+
+void UpdateSHA512(void* uniHash, const Ipp8u* mblk, int mlen, const void* uniPraram)
+{
+#if defined(_SLIMBOOT_OPT)
+
+   if (FixedPcdGet32 (PcdCryptoShaOptMask) & IPP_CRYPTO_SHA384_G9) {
+      UpdateSHA512G9 (uniHash, mblk, mlen, uniPraram);
+   } else {
+      UpdateSHA512W7 (uniHash, mblk, mlen, uniPraram);
+   }
+
+#else
+
+#if  defined(_ALG_SHA512_COMPACT_)
+  UpdateSHA512Compact (uniHash, mblk, mlen, uniPraram);
+#else
+  UpdateSHA512Normal (uniHash, mblk, mlen, uniPraram);
 #endif
+
+#endif //_SLIMBOOT_OPT
+}
 
 #endif

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpvariant_abl.h
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpvariant_abl.h
@@ -14,15 +14,18 @@
 #define _DISABLE_ALG_MD5_
 
 #if defined(_SLIMBOOT_OPT)
-  #define _SHA_NI_ENABLING_ _FEATURE_OFF_
+  #define _SHA_NI_ENABLING_   _FEATURE_OFF_
   #define _DISABLE_ALG_SHA1_
-  #define _DISABLE_ALG_SHA512_
-  #define _ALG_SHA256_COMPACT_
+  //#define _ALG_SHA256_COMPACT_
   #define _ALG_SM3_COMPACT_
 #else
   #define _SHA_NI_ENABLING_ _FEATURE_ON_
 #endif
 
-#define _ALG_SHA512_COMPACT_
+
+#define IPP_CRYPTO_SHA256_V8    0x0001
+#define IPP_CRYPTO_SHA256_NI    0x0002
+#define IPP_CRYPTO_SHA384_W7    0x0004
+#define IPP_CRYPTO_SHA384_G9    0x0008
 
 #endif /* _CP_VARIANT_ABL_H */

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -233,7 +233,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdConsoleOutDeviceMask | $(CONSOLE_OUT_DEVICE_MASK)
 
   gPlatformModuleTokenSpaceGuid.PcdVerifiedBootHashMask   | $(VERIFIED_BOOT_HASH_MASK)
-  gPlatformCommonLibTokenSpaceGuid.PcdCryptoShaNiEnabled  | $(ENABLE_CRYPTO_SHA_NI)
+  gPlatformCommonLibTokenSpaceGuid.PcdCryptoShaOptMask    | $(ENABLE_CRYPTO_SHA_OPT)
 
   gPlatformCommonLibTokenSpaceGuid.PcdSpiIasImageRegionType    | $(SPI_IAS_REGION_TYPE)
   gPlatformCommonLibTokenSpaceGuid.PcdSpiIasImage1RegionBase   | $(SPI_IAS1_BASE)

--- a/BootloaderCorePkg/Library/MpInitLib/Ia32/MpInitLib.c
+++ b/BootloaderCorePkg/Library/MpInitLib/Ia32/MpInitLib.c
@@ -6,8 +6,6 @@
 
 **/
 #include <MpInitLibInternal.h>
-#include <Library/BootloaderCoreLib.h>
-#include <Library/S3SaveRestoreLib.h>
 
 MP_ASSEMBLY_ADDRESS_MAP            mAddressMap;
 ALL_CPU_INFO                       mSysCpuInfo;
@@ -185,6 +183,9 @@ ApFunc (
   BOOLEAN            WaitTask;
   CPU_TASK_PROC      ApRunTask;
   volatile UINT32   *State;
+
+  // Enable more CPU featurs
+  AsmEnableAvx ();
 
   //
   // CPU specific init

--- a/BootloaderCorePkg/Library/MpInitLib/Ia32/MpInitLibInternal.h
+++ b/BootloaderCorePkg/Library/MpInitLib/Ia32/MpInitLibInternal.h
@@ -20,6 +20,9 @@
 #include <Library/MemoryAllocationLib.h>
 #include <Library/BootloaderCommonLib.h>
 #include <Library/MpInitLib.h>
+#include <Library/ExtraBaseLib.h>
+#include <Library/BootloaderCoreLib.h>
+#include <Library/S3SaveRestoreLib.h>
 
 #define   AP_BUFFER_ADDRESS        0x38000
 #define   AP_BUFFER_SIZE           0x8000

--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
@@ -39,6 +39,7 @@
   LocalApicLib
   SynchronizationLib
   SortLib
+  ExtraBaseLib
 
 [Guids]
 

--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -315,6 +315,9 @@ SecStartup (
   TimeStamp     = ReadTimeStamp ();
   Stage1aAsmHob = (STAGE1A_ASM_HOB *)Params;
 
+  // Enable more CPU featurs
+  AsmEnableAvx ();
+
   // Init global data
   LdrGlobal = &LdrGlobalData;
   ZeroMem (LdrGlobal, sizeof (LOADER_GLOBAL_DATA));

--- a/BootloaderCorePkg/Stage1A/Stage1A.h
+++ b/BootloaderCorePkg/Stage1A/Stage1A.h
@@ -10,6 +10,7 @@
 
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
+#include <Library/ExtraBaseLib.h>
 #include <Library/PcdLib.h>
 #include <Library/SocInitLib.h>
 #include <Library/BoardInitLib.h>

--- a/BootloaderCorePkg/Stage1A/Stage1A.inf
+++ b/BootloaderCorePkg/Stage1A/Stage1A.inf
@@ -50,6 +50,7 @@
   FspApiLib
   CpuExceptionLib
   DebugAgentLib
+  ExtraBaseLib
 
 [Guids]
   gPlatformModuleTokenSpaceGuid

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -25,6 +25,23 @@ import multiprocessing
 from   ctypes import *
 from   BuildUtility import *
 
+IPP_CRYPTO_OPTIMIZATION_MASK = {
+# {   Auth_type:        Hash_type}
+            "SHA256_V8"       : 0x0001,
+            "SHA256_NI"       : 0x0002,
+            "SHA384_W7"       : 0x0004,
+            "SHA384_G9"       : 0x0008,
+    }
+
+IPP_CRYPTO_ALG_MASK= {
+# {   Auth_type:        Hash_type}
+            "SHA1"           : 0x0001,
+            "SHA2_256"       : 0x0002,
+            "SHA2_384"       : 0x0004,
+            "SHA2_512"       : 0x0008,
+            "SM3_256"        : 0x0010
+    }
+
 def rebuild_basetools ():
     exe_list = 'GenFfs  GenFv  GenFw  GenSec  Lz4Compress  LzmaCompress'.split()
     ret = 0
@@ -184,7 +201,7 @@ class BaseBoard(object):
         self.ENABLE_SPLASH         = 0
         self.ENABLE_FRAMEBUFFER_INIT = 0
         self.ENABLE_PRE_OS_CHECKER = 0
-        self.ENABLE_CRYPTO_SHA_NI  = 0
+        self.ENABLE_CRYPTO_SHA_OPT  = IPP_CRYPTO_OPTIMIZATION_MASK['SHA256_V8']
         self.ENABLE_FWU            = 0
         self.ENABLE_SOURCE_DEBUG   = 0
         self.ENABLE_SMM_REBASE     = 0
@@ -259,7 +276,7 @@ class BaseBoard(object):
         self._CFGDATA_INT_FILE     = []
         self._CFGDATA_EXT_FILE     = []
 
-        self.IPP_HASH_LIB_SUPPORTED_MASK   = 0x0002 #SHA256 for default
+        self.IPP_HASH_LIB_SUPPORTED_MASK   = IPP_CRYPTO_ALG_MASK['SHA2_256']
 
         for key, value in list(kwargs.items()):
             setattr(self, '%s' % key, value)

--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -15,6 +15,7 @@ import sys
 sys.dont_write_bytecode = True
 sys.path.append (os.path.join('..', '..'))
 from BuildLoader import FLASH_MAP, BaseBoard, STITCH_OPS
+from BuildLoader import IPP_CRYPTO_OPTIMIZATION_MASK, IPP_CRYPTO_ALG_MASK
 
 class Board(BaseBoard):
     def __init__(self, *args, **kwargs):
@@ -44,12 +45,14 @@ class Board(BaseBoard):
         self.HAVE_PSD_TABLE       = 1
 
         self.ENABLE_FSP_LOAD_IMAGE    = 0
-        self.ENABLE_CRYPTO_SHA_NI     = 1
         self.ENABLE_VTD               = 1
         self.ENABLE_FWU               = 1
         self.ENABLE_SPLASH            = 1
         self.ENABLE_FRAMEBUFFER_INIT  = 1
         self.ENABLE_GRUB_CONFIG       = 1
+
+        # G9 for 384 | W7 Opt for SHA384| Ni  Opt for SHA256| V8 Opt for SHA256
+        self.ENABLE_CRYPTO_SHA_OPT    = IPP_CRYPTO_OPTIMIZATION_MASK['SHA256_NI']
 
         # To enable source debug, set 1 to self.ENABLE_SOURCE_DEBUG
         # self.ENABLE_SOURCE_DEBUG   = 1


### PR DESCRIPTION
Enable CPU AVX support if available. EnableAvx ASM is included as part ExtraLibs.

Add support for AVX and SES4 optimizations in IPP SHA384 is added to IPP crypto lib. PcdCryptoShaW7Enabled is added and default is set to SES4 (W7).