### PR TITLE
Add features flag for pre-OS checker boot

### DIFF
--- a/BootloaderCommonPkg/Include/Guid/LoaderPlatformInfoGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/LoaderPlatformInfoGuid.h
@@ -25,6 +25,7 @@ extern EFI_GUID gLoaderPlatformInfoGuid;
 #define        FEATURE_MMC_TUNING               BIT2
 #define        FEATURE_MMC_FORCE_TUNING         BIT3
 #define        FEATURE_VERIFIED_BOOT            BIT4
+#define        FEATURE_PRE_OS_CHECKER_BOOT      BIT5
 
 //
 //Definition for LOADER_PLATFORM_INFO.HwState

--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -1091,13 +1091,15 @@ PayloadMain (
   )
 {
   OS_BOOT_OPTION_LIST   *OsBootOptionList;
+  LOADER_PLATFORM_INFO  *LoaderPlatformInfo;
+  OS_BOOT_OPTION         OsBootOption;
   BOOLEAN                BootShell;
   UINTN                  ShellTimeout;
-  OS_BOOT_OPTION         OsBootOption;
   UINT8                  CurrIdx;
   UINT8                  BootIdx;
 
   mEntryStack = Param;
+  LoaderPlatformInfo = (LOADER_PLATFORM_INFO *)GetLoaderPlatformInfoPtr();
 
   DEBUG ((DEBUG_INFO, "\n\n====================Os Loader====================\n\n"));
   AddMeasurePoint (0x4010);
@@ -1129,8 +1131,10 @@ PayloadMain (
   //
   // Load PreOsChecker
   //
-  if (FeaturePcdGet (PcdPreOsCheckerEnabled)) {
-    LoadPreOsChecker ();
+  if (LoaderPlatformInfo != NULL) {
+    if (FeaturePcdGet (PcdPreOsCheckerEnabled) && (LoaderPlatformInfo->LdrFeatures & FEATURE_PRE_OS_CHECKER_BOOT)) {
+      LoadPreOsChecker ();
+    }
   }
 
   while (OsBootOptionList != NULL) {


### PR DESCRIPTION
By adding an additional flag for the pre-OS
checker execution flow it is possible to determine
at run time whether to attempt loading/execution
of the pre-OS checker during OS Loader time. From
platform code the decision to attempt to run the
pre-OS checker can be controlled.

Signed-off-by: James Gutbub <james.gutbub@intel.com>