### PR TITLE
Capsule Firmware: Allign to updated publickey and Signature structure

### DIFF
--- a/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
+++ b/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
@@ -16,7 +16,7 @@ from ctypes import *
 
 sys.dont_write_bytecode = True
 from BuildUtility import rsa_sign_file, gen_pub_key
-
+from CommonUtility import *
 
 class FmpCapsuleImageHeaderClass(object):
     # typedef struct {
@@ -408,6 +408,12 @@ def SignImage(RawData, OutFile, HashType, PrivKey):
 
     file_size = len(RawData)
 
+    key_type = get_priv_key_type(PrivKey, get_openssl_path())
+    if key_type ==  'RSA2048':
+        key_size = 256
+    elif key_type ==  'RSA3072':
+        key_size = 384
+
     header.FileGuid         = (c_ubyte *16).from_buffer_copy(FIRMWARE_UPDATE_IMAGE_FILE_GUID.bytes_le)
     header.HeaderSize       = sizeof(Firmware_Update_Header)
     header.FirmwreVersion   = 1
@@ -415,7 +421,7 @@ def SignImage(RawData, OutFile, HashType, PrivKey):
     header.ImageOffset      = header.HeaderSize
     header.ImageSize        = file_size
     header.SignatureOffset  = header.ImageOffset + header.ImageSize
-    header.SignatureSize    = 256
+    header.SignatureSize    = sizeof(Signature) + key_size
     header.PubKeyOffset     = header.SignatureOffset + header.SignatureSize
 
     pubkey_file = 'fwu_public_key.bin'

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -853,6 +853,8 @@ AuthenticateCapsule (
   UINT8                     *Signature;
   FW_UPDATE_STATUS          FwUpdStatus;
   UINT32                    FwUpdStatusOffset;
+  PUB_KEY                   *PublicKey;
+  SIGNATURE                 *Sign;
 
   FwUpdStatusOffset = PcdGet32(PcdFwUpdStatusBase);
 
@@ -881,6 +883,9 @@ AuthenticateCapsule (
   Key       = FwImage + Header->PubKeyOffset;
   Signature = FwImage + Header->SignatureOffset;
 
+  Sign      = (SIGNATURE *) Signature;
+  PublicKey = (PUB_KEY *) Key;
+
   //
   // Copy fw update status structure to memory
   //
@@ -900,7 +905,7 @@ AuthenticateCapsule (
     }
   }
 
-  Status    = DoRsaVerify (FwImage, Header->SignatureOffset, COMP_TYPE_PUBKEY_FWU, Signature, Key, NULL, NULL);
+  Status    = DoRsaVerify (FwImage, Header->SignatureOffset, COMP_TYPE_PUBKEY_FWU, Sign, PublicKey, NULL, NULL);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "Image verification failed, %r!\n", Status));
     return EFI_SECURITY_VIOLATION;


### PR DESCRIPTION
GenCapsuleFirmware tool and consumer were updated to
allign new data structure.

This patch is dependent on https://github.com/slimbootloader/slimbootloader/pull/462

Test=Verified BIOS FW update on CFL

Signed-off-by: Subash Lakkimsetti <subashx.lakkimsetti@intel.com>