### PR TITLE
[QEMU] Fix QEMU boot issue with new IPP library change

### DIFF
--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpsha256ca.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpsha256ca.c
@@ -168,13 +168,13 @@ void UpdateSHA256Compact(void* uniHash, const Ipp8u* mblk, int mlen, const void*
 void UpdateSHA256(void* pHash, const Ipp8u* pMsg, int msgLen, const void* pParam)
 {
 #if defined(_SLIMBOOT_OPT)
-
-  if (FixedPcdGet32 (PcdCryptoShaOptMask) & IPP_CRYPTO_SHA256_NI) {
+   #if (FixedPcdGet32 (PcdCryptoShaOptMask) & IPP_CRYPTO_SHA256_NI)
       UpdateSHA256Ni(pHash, pMsg, msgLen, pParam);
-   } else {
+   #elif (FixedPcdGet32 (PcdCryptoShaOptMask) & IPP_CRYPTO_SHA256_V8)
       UpdateSHA256V8(pHash, pMsg, msgLen, pParam);
-   }
-
+   #else
+      UpdateSHA256Compact(pHash, pMsg, msgLen, pParam);
+   #endif
 #else
   #if defined(_ALG_SHA256_COMPACT_)
     UpdateSHA256Compact(pHash, pMsg, msgLen, pParam);

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpsha512ca.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpsha512ca.c
@@ -565,13 +565,13 @@ void UpdateSHA512Normal(void* uniHash, const Ipp8u* mblk, int mlen, const void* 
 void UpdateSHA512(void* uniHash, const Ipp8u* mblk, int mlen, const void* uniPraram)
 {
 #if defined(_SLIMBOOT_OPT)
-
-   if (FixedPcdGet32 (PcdCryptoShaOptMask) & IPP_CRYPTO_SHA384_G9) {
+   #if (FixedPcdGet32 (PcdCryptoShaOptMask) & IPP_CRYPTO_SHA384_G9)
       UpdateSHA512G9 (uniHash, mblk, mlen, uniPraram);
-   } else {
+   #elif (FixedPcdGet32 (PcdCryptoShaOptMask) & IPP_CRYPTO_SHA384_W7)
       UpdateSHA512W7 (uniHash, mblk, mlen, uniPraram);
-   }
-
+   #else
+      UpdateSHA512Compact (uniHash, mblk, mlen, uniPraram);
+   #endif
 #else
 
 #if  defined(_ALG_SHA512_COMPACT_)

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpvariant_abl.h
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpvariant_abl.h
@@ -16,7 +16,8 @@
 #if defined(_SLIMBOOT_OPT)
   #define _SHA_NI_ENABLING_   _FEATURE_OFF_
   #define _DISABLE_ALG_SHA1_
-  //#define _ALG_SHA256_COMPACT_
+  #define _ALG_SHA512_COMPACT_
+  #define _ALG_SHA256_COMPACT_
   #define _ALG_SM3_COMPACT_
 #else
   #define _SHA_NI_ENABLING_ _FEATURE_ON_

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -46,11 +46,14 @@ class Board(BaseBoard):
         self.ENABLE_FWU               = 1
         self.ENABLE_GRUB_CONFIG       = 1
         self.ENABLE_LINUX_PAYLOAD     = 1
+        self.ENABLE_CRYPTO_SHA_OPT    = 0
 
         self.CPU_MAX_LOGICAL_PROCESSOR_NUMBER = 255
 
         # To enable source debug, set 1 to self.ENABLE_SOURCE_DEBUG
         # self.ENABLE_SOURCE_DEBUG  = 1
+
+
 
         # For test purpose
         # self.SKIP_STAGE1A_SOURCE_DEBUG = 1


### PR DESCRIPTION
The previoius IPP library updates used UpdateSHA256V8 as default for
SHA256. It works on real platform. However, QEMU's default CPU config
does not support SSE3 instructions and will generate exception. This
patch added the UpdateSHA256Compact as default SHA256 function if no
advanced optimization flags are set. The same is applied for SHA512
functions too.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>