### PR TITLE
Adjust GPIO based PayloadId selection policy

### DIFF
--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -650,26 +650,26 @@ UpdatePayloadId (
 
   PayloadId = 0;
   GenericCfgData = (GEN_CFG_DATA *)FindConfigDataByTag (CDATA_GEN_TAG);
-  if (GenericCfgData != NULL) {
-    if (GenericCfgData->PayloadId != AUTO_PAYLOAD_ID_SIGNATURE) {
-      PayloadId = GenericCfgData->PayloadId;
+  if ((GenericCfgData != NULL) && (GenericCfgData->PayloadId != AUTO_PAYLOAD_ID_SIGNATURE)) {
+    // If PayloadId is not AUTO, use it directly
+    PayloadId = GenericCfgData->PayloadId;
+  } else {
+    // If PayloadId is AUTO and GPIO PayloadId selection is enabled,
+    // adjust the PayloadId accordingly per GPIO level (0:UEFI  1:OsLoader).
+    GpioLevel = 1;
+    PlatCfgData = (PLATFORM_CFG_DATA *)FindConfigDataByTag (CDATA_PLATFORM_TAG);
+    if ((PlatCfgData != NULL) && (PlatCfgData->PayloadSelGpio.Enable != 0)) {
+      // The default GPIOSet to Pull Up 20K
+      GpioGetInputValue (PlatCfgData->PayloadSelGpio.PadInfo, 0x0C, &GpioLevel);
+      if (GpioLevel != 0) {
+        PayloadId = 0;
+      } else {
+        PayloadId = UEFI_PAYLOAD_ID_SIGNATURE;
+      }
+      DEBUG ((DEBUG_INFO, "Set PayloadId to 0x%08X based on GPIO config\n", PayloadId));
     }
   }
 
-  GpioLevel = 1;
-  PlatCfgData = (PLATFORM_CFG_DATA *)FindConfigDataByTag (CDATA_PLATFORM_TAG);
-  if ((PlatCfgData != NULL) && (PlatCfgData->PayloadSelGpio.Enable != 0)) {
-    // The default GPIOSet to Pull Up 20K
-    GpioGetInputValue (PlatCfgData->PayloadSelGpio.PadInfo, 0x0C, &GpioLevel);
-    if (GpioLevel != 0) {
-      PayloadId = 0;
-    } else {
-      if ((GenericCfgData != NULL) && (GenericCfgData->PayloadId == AUTO_PAYLOAD_ID_SIGNATURE)) {
-        PayloadId = UEFI_PAYLOAD_ID_SIGNATURE;
-      }
-    }
-    DEBUG ((DEBUG_INFO, "Set PayloadId to 0x%08X based on GPIO config\n", PayloadId));
-  }
   SetPayloadId (PayloadId);
 }
 


### PR DESCRIPTION
This patch updated the PayloadId detection logic on APL platform
to make it easy to understand.

The current policy is as below:
- If PayloadId CFGDATA is not AUTO, use whatever provided in CFGDATA.
- If PayloadId CFGDATA is AUTO, and GPIO based PayloadId detection
  is enabled, uses GPIO level to determine the actual PayloadId to
  use. (HIGH:OsLoader LOW:UEFI)
- If PayloadId CFGDATA is AUTO, and GPIO based PayloadId detection
  is disabled, uses default PlatfomrId 0 (OsLoader).

Signed-off-by: Maurice Ma <maurice.ma@intel.com>