### PR TITLE
Preserve ebx register in AsmEnableAvx()

### DIFF
--- a/BootloaderCommonPkg/Library/ExtraBaseLib/Ia32/CpuSupport.nasm
+++ b/BootloaderCommonPkg/Library/ExtraBaseLib/Ia32/CpuSupport.nasm
@@ -57,6 +57,7 @@ FlushExit:
 ;------------------------------------------------------------------------------
 global ASM_PFX(AsmEnableAvx)
 ASM_PFX(AsmEnableAvx):
+    push    ebx
     ;
     ; Check if AVX is supported
     ;
@@ -79,4 +80,5 @@ ASM_PFX(AsmEnableAvx):
     xsetbv
 
 NoAvxSupport:
+    pop     ebx
     ret

--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -243,6 +243,9 @@ SecStartup2 (
   BoardInit (PostTempRamInit);
   AddMeasurePoint (0x1040);
 
+  // Enable more CPU featurs
+  AsmEnableAvx ();
+
   if (DebugCodeEnabled()) {
     DEBUG ((DEBUG_INFO, "\n============= %a STAGE1A =============\n",mBootloaderName));
   } else {
@@ -314,9 +317,6 @@ SecStartup (
 
   TimeStamp     = ReadTimeStamp ();
   Stage1aAsmHob = (STAGE1A_ASM_HOB *)Params;
-
-  // Enable more CPU featurs
-  AsmEnableAvx ();
 
   // Init global data
   LdrGlobal = &LdrGlobalData;


### PR DESCRIPTION
System reset occurs after returning from AsmEnableAvx() in Stage1A.c
because ebx register is used for cpuid, but not restored.
- Save/Restore ebx register
- Move AsmEnableAvx () after init idt and serialport

Signed-off-by: Aiden Park <aiden.park@intel.com>