### PR TITLE
[CFL] Trigger firmware update from OS

### DIFF
--- a/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
+++ b/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
@@ -24,6 +24,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define FW_UPDATE_SM_PART_A           0x7E
 #define FW_UPDATE_SM_PART_B           0x7D
 #define FW_UPDATE_SM_PART_AB          0x7C
+#define FW_UPDATE_SM_DONE             0x77 // Lower 3 bits are ignored
 
 #define FW_UPDATE_IMAGE_UPDATE_NONE         0xFF
 #define FW_UPDATE_IMAGE_UPDATE_PENDING      0xFE
@@ -543,5 +544,19 @@ UpdateCsme (
   IN  UINT32                        CapImageSize,
   IN  VOID                          *CsmeUpdInputData,
   IN  EFI_FW_MGMT_CAP_IMAGE_HEADER  *ImageHdr
+  );
+
+/**
+  Platform hook point to clear firmware update trigger.
+
+  This function is responsible for clearing firmware update trigger.
+
+  @retval  EFI_SUCCESS        Update successfully.
+
+**/
+EFI_STATUS
+EFIAPI
+ClearFwUpdateTrigger (
+  VOID
   );
 #endif

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -61,11 +61,17 @@ PreparePayload (
   UINT8                          HashIdx;
   COMPONENT_ENTRY               *ComponentEntry;
 
+  BootMode = GetBootMode();
+  //
+  // Force PayloadId to 0 during firmware update mode.
+  //
+  if (BootMode == BOOT_ON_FLASH_UPDATE) {
+    SetPayloadId(0);
+  }
   // Load payload to PcdPayloadLoadBase.
   PayloadId   = GetPayloadId ();
   DEBUG ((DEBUG_INFO, "Loading Payload ID 0x%08X\n", PayloadId));
   IsNormalPld = (PayloadId == 0) ? TRUE : FALSE;
-  BootMode = GetBootMode();
   if (BootMode == BOOT_ON_FLASH_UPDATE) {
     ContainerSig  = COMP_TYPE_FIRMWARE_UPDATE;
     ComponentName = FLASH_MAP_SIG_FWUPDATE;

--- a/Platform/CoffeelakeBoardPkg/AcpiTables/AcpiTables.inf
+++ b/Platform/CoffeelakeBoardPkg/AcpiTables/AcpiTables.inf
@@ -47,6 +47,7 @@
   CpuSsdt/ApTst.asl
   CpuSsdt/CpuSsdt.asl
   Psd/Psd.aslc
+  Platform/CommonBoardPkg/AcpiTables/Dsdt/AslInc.h
 
 [Binaries.IA32]
   ASL|Dsdt/NHLT.bin

--- a/Platform/CoffeelakeBoardPkg/AcpiTables/Dsdt/Dsdt.asl
+++ b/Platform/CoffeelakeBoardPkg/AcpiTables/Dsdt/Dsdt.asl
@@ -183,6 +183,8 @@ DefinitionBlock (
   Include ("SerialIoDevices.asl")
   Include ("PinDriverLib.asl")
 
+  Include ("FwuWmi.asl")
+
   If (LAnd(LNotEqual(WLGP, 0), LEqual(WLRP, 0x03))) {
     Scope(\_SB.PCI0.RP03) {
       Method (PPRW, 0) {

--- a/Platform/CoffeelakeBoardPkg/AcpiTables/Dsdt/Platform.asl
+++ b/Platform/CoffeelakeBoardPkg/AcpiTables/Dsdt/Platform.asl
@@ -1339,3 +1339,28 @@ Scope(\_SB)
 // -------------------------------------------------------
 //        CoExistence device ACPI implementation - End
 // -------------------------------------------------------
+
+OperationRegion (OCWD, SystemIO, (ACPI_BASE_ADDRESS + R_ACPI_IO_OC_WDT_CTL), 0x4)
+Field(OCWD, DWordAcc, NoLock, Preserve)
+{
+    ,      8,
+    ,      8,
+    FWSC,  8,    // Over-Clocking WDT Scratchpad (OC_WDT_SCRATCH)
+}
+
+//
+// Platform specific FWU trigger method
+//
+Method(FWUC, 2)
+{
+  If(LEqual(Arg0, Zero)) {
+    // Read
+    And(FWSC, 0x00FF, Local0)
+  } Else {
+    // Write
+    And(ToInteger(Arg1), 0xFF, Local0)
+    And(FWSC, 0xFF00, Local1)
+    Or(Local0, Local1, FWSC)
+  }
+  Return (Local0)
+}

--- a/Platform/CoffeelakeBoardPkg/Library/ShellExtensionLib/CmdFwUpdate.c
+++ b/Platform/CoffeelakeBoardPkg/Library/ShellExtensionLib/CmdFwUpdate.c
@@ -13,6 +13,8 @@
 #include <Library/DebugLib.h>
 #include <Library/ShellExtensionLib.h>
 #include <Library/FirmwareUpdateLib.h>
+#include <Register/PchRegsPmc.h>
+#include <PlatformBase.h>
 
 #define FWU_BOOT_MODE_OFFSET   0x40
 #define FWU_BOOT_MODE_VALUE    0x5A
@@ -62,12 +64,14 @@ ShellCommandFwUpdateFunc (
   )
 {
   PLATFORM_SERVICE      *PlatformService;
+  UINT32                OcWdtRegData;
 
   //
   // This is platform specific method. Here just use CMOS address 0x40.
   //
-  IoWrite8 (CMOS_ADDREG, FWU_BOOT_MODE_OFFSET);
-  IoWrite8 (CMOS_DATAREG, FWU_BOOT_MODE_VALUE);
+  OcWdtRegData = IoRead32 (ACPI_BASE_ADDRESS + R_ACPI_IO_OC_WDT_CTL);
+  OcWdtRegData |= BIT16;
+  IoWrite32 (ACPI_BASE_ADDRESS + R_ACPI_IO_OC_WDT_CTL, OcWdtRegData);
 
   //
   // Reset the platform

--- a/Platform/CoffeelakeBoardPkg/Library/ShellExtensionLib/ShellExtensionLib.inf
+++ b/Platform/CoffeelakeBoardPkg/Library/ShellExtensionLib/ShellExtensionLib.inf
@@ -30,6 +30,7 @@
   PayloadPkg/PayloadPkg.dec
   Platform/CommonBoardPkg/CommonBoardPkg.dec
   Platform/CoffeelakeBoardPkg/CoffeelakeBoardPkg.dec
+  Silicon/CoffeelakePkg/CoffeelakePkg.dec
 
 [LibraryClasses]
 

--- a/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -258,15 +258,17 @@ SpiControllerInitialize (
 BOOLEAN
 IsFirmwareUpdate ()
 {
-  UINT16  FirmwareUpdateStatus;
+  //
+  // Check if state machine is set to capsule processing mode.
+  //
+  if (CheckStateMachine (NULL) == EFI_SUCCESS) {
+    return TRUE;
+  }
 
   //
-  // This is platform specific method. Here just use COMS.
+  // Check if platform firmware update trigger is set.
   //
-  IoWrite8(0x70, 0x40);
-  FirmwareUpdateStatus = IoRead8(0x71);
-
-  if (FirmwareUpdateStatus == 0x5A) {
+  if (IoRead32 (ACPI_BASE_ADDRESS + R_ACPI_IO_OC_WDT_CTL) & BIT16) {
     return TRUE;
   }
 

--- a/Platform/CommonBoardPkg/Include/Library/BoardSupportLib.h
+++ b/Platform/CommonBoardPkg/Include/Library/BoardSupportLib.h
@@ -9,6 +9,7 @@
 #define _BOARD_SUPPORT_LIB_H_
 
 #include <Guid/OsBootOptionGuid.h>
+#include <Library/FirmwareUpdateLib.h>
 
 /**
   Fill the boot option list data with CFGDATA info
@@ -53,6 +54,22 @@ SpiLoadExternalConfigData (
   IN UINT32  Dst,
   IN UINT32  Src,
   IN UINT32  Len
+  );
+
+/**
+  Check state machine.
+
+  This function will check state machine to see if capsule is pending
+
+  @param[in]    pFwUpdStatus     Pointer to FW_UPDATE_STATUS structure.
+
+  @retval  EFI_SUCCESS           State machine initialized in reserved region.
+  @retval  EFI_UNSUPPORTED       Failure occured during state machine init.
+  @retval  others                Error occured during state machine init.
+**/
+EFI_STATUS
+CheckStateMachine (
+  IN FW_UPDATE_STATUS    *pFwUpdStatus
   );
 
 #endif

--- a/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -408,6 +408,25 @@ PrepareRegionsUpdate (
 }
 
 /**
+  Platform hook point to clear firmware update trigger.
+
+  This function is responsible for clearing firmware update trigger.
+
+  @retval  EFI_SUCCESS        Update successfully.
+
+**/
+EFI_STATUS
+EFIAPI
+ClearFwUpdateTrigger (
+  VOID
+  )
+{
+  IoAnd32(ACPI_BASE_ADDRESS + R_ACPI_IO_OC_WDT_CTL, 0xFF00FFFF);
+
+  return EFI_SUCCESS;
+}
+
+/**
   Platform hook point after firmware update is done.
 
   This function will do some platform specific things after all new firmware
@@ -424,24 +443,5 @@ EndFirmwareUpdate (
   VOID
   )
 {
-  UINT16   FirmwareUpdateStatus;
-
-  DEBUG ((DEBUG_INFO, "Firmware update Done! clear CSE flag to normal boot mode.\n"));
-
-  //
-  // This is platform specific method. Here just use COMS address 0x40.
-  //
-  IoWrite8 (CMOS_ADDREG, FWU_BOOT_MODE_OFFSET);
-  FirmwareUpdateStatus = IoRead8 (CMOS_DATAREG);
-
-  if (FirmwareUpdateStatus != 0) {
-    // clear it
-    IoWrite8 (CMOS_ADDREG, FWU_BOOT_MODE_OFFSET);
-    IoWrite8 (CMOS_DATAREG, 0x0);
-    FirmwareUpdateStatus = IoRead8 (CMOS_DATAREG);
-    DEBUG ((DEBUG_INFO, "Fw Update trigger status=0x%x, clear it!\n", FirmwareUpdateStatus));
-  }
   return EFI_SUCCESS;
 }
-
-

--- a/Silicon/QemuSocPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/QemuSocPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -496,4 +496,19 @@ EndFirmwareUpdate (
   return EFI_SUCCESS;
 }
 
+/**
+  Platform hook point to clear firmware update trigger.
 
+  This function is responsible for clearing firmware update trigger.
+
+  @retval  EFI_SUCCESS        Update successfully.
+
+**/
+EFI_STATUS
+EFIAPI
+ClearFwUpdateTrigger (
+  VOID
+  )
+{
+  return EFI_SUCCESS;
+}


### PR DESCRIPTION
This patch does the following

1) Enable triggering firmware update from OS
2) When firmware update mode is given control, state machine
   is set to capsule processing and firmware update platform
   specific trigger is cleared. State machine will be used
   hereafter to track firmware update
3) Created CheckStateMachine method in BoardSupportLib.c to
   check state machine to see if firmware update is in progress
   and set boot mode to firmware update.
4) Removed CMOS way of triggering firmware update and wrote code
   to use Over-Clocking WDT Scratchpad (OC_WDT_SCRATCH) bits for
   triggering firmware update
5) Update shell fwupdate command to use OC_WDT_SCRATCH bits.
6) Removed extra reset during sbl firmware update
7) Removed reset after updating configuration data update

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>