### PR TITLE
Fix hash store buffer size issue in SBL global data

### DIFF
--- a/BootloaderCommonPkg/Include/Guid/KeyHashGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/KeyHashGuid.h
@@ -14,6 +14,8 @@
 ///
 extern EFI_GUID gPayloadKeyHashGuid;
 
+#define  HASH_STORE_SIGNATURE          SIGNATURE_32('_', 'H', 'S', '_')
+
 #define  COMP_TYPE_STAGE_1B            0
 #define  COMP_TYPE_STAGE_2             1
 #define  COMP_TYPE_PAYLOAD             2
@@ -64,7 +66,8 @@ typedef struct {
 typedef struct {
   UINT32             Signature;
   UINT8              Revision;
-  UINT8              Reserved[3];
+  UINT8              HeaderLength;
+  UINT8              Reserved[2];
   //
   // Total valid  hash store data including the header
   //

--- a/BootloaderCorePkg/Include/HashStore.h
+++ b/BootloaderCorePkg/Include/HashStore.h
@@ -10,8 +10,6 @@
 
 #include <Guid/KeyHashGuid.h>
 
-#define  HASH_STORE_SIGNATURE                SIGNATURE_32('_', 'H', 'S', '_')
-
 #define  HASH_INDEX_MAX_NUM                  8
 
 

--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -198,7 +198,7 @@ SecStartup2 (
       HashStoreTable = (HASH_STORE_TABLE *) BufPtr;
       HashStoreTable->TotalLength = PcdGet32 (PcdHashStoreSize);
 
-      BufPtr += ALIGN_UP (HashStoreTable->UsedLength, sizeof (UINTN));
+      BufPtr += ALIGN_UP (PcdGet32 (PcdHashStoreSize), sizeof (UINTN));
     }
 
     // Library data

--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -132,7 +132,8 @@ class HashStoreTable(Structure):
     _fields_ = [
         ('Signature',         ARRAY(c_char, 4)),
         ('Revision',          c_uint8),
-        ('Reserved',          ARRAY(c_uint8, 3)),
+        ('HeaderLength',      c_uint8),
+        ('Reserved',          ARRAY(c_uint8, 2)),
         ('UsedLength',        c_uint32),
         ('TotalLength',       c_uint32),
         ('Data',              ARRAY(c_uint8, 0)),
@@ -141,6 +142,7 @@ class HashStoreTable(Structure):
     def __init__(self):
         self.Signature = HashStoreTable.HASH_STORE_SIGNATURE
         self.Revision  = 1
+        self.HeaderLength  = sizeof(HashStoreTable)
 
 
 class ImageVer(Structure):


### PR DESCRIPTION
Current code only counted used hash store size as the whole
buffer size. This is not correct and will cause buffer overflow.
It is required to use the whole hash store buffer size including
the unused space at the end. This patch fixed this.
It also adds HeaderLength field in Hash Store header.
