### PR TITLE
Use the common function from CommonUtility

### DIFF
--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -497,10 +497,10 @@ def gen_hash_file (src_path, hash_type, hash_path = '', is_key = False):
     with open(src_path,'rb') as fi:
         di = bytearray(fi.read())
     if is_key:
-        if len(di) != (0x104 + sizeof(PUB_KEY_HDR)):
+        key_len = 0x104
+        if len(di) != (key_len + sizeof(PUB_KEY_HDR)):
             raise Exception ("Invalid public key binary!")
         di = di[sizeof(PUB_KEY_HDR):]
-        di = di[:0x100] + di[0x100:]
     if hash_type == 'SHA2_256':
         ho = hashlib.sha256(di)
     else:

--- a/BootloaderCorePkg/Tools/CommonUtility.py
+++ b/BootloaderCorePkg/Tools/CommonUtility.py
@@ -95,7 +95,7 @@ HASH_DIGEST_SIZE = {
             "SM3_256"     : 32,
     }
 
-def print_bytes (data, indent=0, offset=0, show_ascii = True):
+def print_bytes (data, indent=0, offset=0, show_ascii = False):
     bytes_per_line = 16
     printable = ' ' + string.ascii_letters + string.digits + string.punctuation
     str_fmt = '{:s}{:04x}: {:%ds} {:s}' % (bytes_per_line * 3)

--- a/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
+++ b/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
@@ -408,7 +408,7 @@ def SignImage(RawData, OutFile, HashType, PrivKey):
 
     file_size = len(RawData)
 
-    key_type = get_rsa_priv_key_type(PrivKey, get_openssl_path())
+    key_type = get_key_type (PrivKey)
     if key_type ==  'RSA2048':
         key_size = 256
     elif key_type ==  'RSA3072':


### PR DESCRIPTION
This patch removed duplicated RSA signing implemention in
CfgDataTool script and used the common one in CommonUtility.
It also removed PrintByteArray(), and use common print_bytes()
instead.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>