### PR TITLE
IPP Crypto and Secure boot lib to support multiple hashes

### DIFF
--- a/BootloaderCommonPkg/Include/Library/CryptoLib.h
+++ b/BootloaderCommonPkg/Include/Library/CryptoLib.h
@@ -18,44 +18,44 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define SIGNATURE_IDENTIFIER     SIGNATURE_32 ('S', 'I', 'G', 'N')
 
 
-#define SIG_TYPE_RSA2048SHA256   0
-#define SIG_TYPE_RSA3072SHA384   1
+#define SIG_TYPE_RSA2048SHA256          0
+#define SIG_TYPE_RSA3072SHA384          1
 
 typedef UINT8 SIGN_TYPE;
-#define SIGNING_TYPE_RSA_PKCS_1_5     1
-#define SIGNING_TYPE_RSA_PSS          2
+#define SIGNING_TYPE_RSA_PKCS_1_5       1
+#define SIGNING_TYPE_RSA_PSS            2
 
 typedef UINT8 KEY_TYPE;
-#define KEY_TYPE_RSA                  1
+#define KEY_TYPE_RSA                    1
 
-#define RSA2048_NUMBYTES              256
-#define RSA3072_NUMBYTES              384
+#define RSA2048_NUMBYTES                256
+#define RSA3072_NUMBYTES                384
 
-#define RSA_MOD_SIZE 256 //hardcode n size to be 256
-#define RSA_E_SIZE   4   //hardcode e size to be 4
+#define RSA2048_MOD_SIZE                256 //n size to be 256
+#define RSA3072_MOD_SIZE                384 //n size to be 384
+#define RSA_MOD_SIZE_MAX                RSA3072_MOD_SIZE
+
+#define RSA_E_SIZE                       4   //hardcode e size to be 4
 
 typedef UINT8 HASH_ALG_TYPE;
-#define  HASH_TYPE_SHA256              1
-#define  HASH_TYPE_SHA384              2
-#define  HASH_TYPE_SHA512              3
-#define  HASH_TYPE_SM3                 4
+#define  HASH_TYPE_SHA256                1
+#define  HASH_TYPE_SHA384                2
+#define  HASH_TYPE_SHA512                3
+#define  HASH_TYPE_SM3                   4
 
-#define SHA256_DIGEST_SIZE       32
-#define SHA384_DIGEST_SIZE       48
-#define SM3_DIGEST_SIZE          32
-#define SHA512_DIGEST_SIZE       64
-#define HASH_DIGEST_MAX          SHA512_DIGEST_SIZE
+#define SHA256_DIGEST_SIZE               32
+#define SHA384_DIGEST_SIZE               48
+#define SM3_DIGEST_SIZE                  32
+#define SHA512_DIGEST_SIZE               64
+#define HASH_DIGEST_MAX                  SHA512_DIGEST_SIZE
 
-#define RSA2048NUMBYTES          256
-#define RSA3072NUMBYTES          384
+#define IPP_HASH_CTX_SIZE                256   //IPP Hash context size
 
-#define IPP_HASH_CTX_SIZE  256   //IPP Hash context size
-
-#define IPP_HASHLIB_SHA1         0x0001
-#define IPP_HASHLIB_SHA2_256     0x0002
-#define IPP_HASHLIB_SHA2_384     0x0004
-#define IPP_HASHLIB_SHA2_512     0x0008
-#define IPP_HASHLIB_SM3_256      0x0010
+#define IPP_HASHLIB_SHA1                 0x0001
+#define IPP_HASHLIB_SHA2_256             0x0002
+#define IPP_HASHLIB_SHA2_384             0x0004
+#define IPP_HASHLIB_SHA2_512             0x0008
+#define IPP_HASHLIB_SM3_256              0x0010
 
 
 typedef UINT8 HASH_CTX[IPP_HASH_CTX_SIZE];   //IPP Hash context buffer
@@ -96,9 +96,15 @@ typedef struct {
 } SIGNATURE_HDR;
 
 
-#define RSA_SIGNATURE_SIZE         (RSA2048_NUMBYTES + sizeof(SIGNATURE_HDR))
-#define RSA_KEYSIZE_SIZE           (RSA_MOD_SIZE + RSA_E_SIZE + sizeof(PUB_KEY_HDR))
-#define RSA_SIGNATURE_AND_KEY_SIZE  (RSA_SIGNATURE_SIZE + RSA_KEYSIZE_SIZE)
+#define RSA2048_SIGNATURE_SIZE             (RSA2048_NUMBYTES + sizeof(SIGNATURE_HDR))
+#define RSA2048_KEYSIZE_SIZE               (RSA2048_MOD_SIZE + RSA_E_SIZE + sizeof(PUB_KEY_HDR))
+#define RSA2048_SIGNATURE_AND_KEY_SIZE     (RSA2048_SIGNATURE_SIZE + RSA2048_KEYSIZE_SIZE)
+
+#define RSA3072_SIGNATURE_SIZE             (RSA3072_NUMBYTES + sizeof(SIGNATURE_HDR))
+#define RSA3072_KEYSIZE_SIZE               (RSA3072_MOD_SIZE + RSA_E_SIZE + sizeof(PUB_KEY_HDR))
+#define RSA3072_SIGNATURE_AND_KEY_SIZE     (RSA3072_SIGNATURE_SIZE + RSA3072_KEYSIZE_SIZE)
+
+#define SIGNATURE_AND_KEY_SIZE_MAX         RSA3072_SIGNATURE_AND_KEY_SIZE
 
 /**
   Computes the SHA-256 message digest of a input data buffer.

--- a/BootloaderCommonPkg/Include/Library/IasImageLib.h
+++ b/BootloaderCommonPkg/Include/Library/IasImageLib.h
@@ -70,9 +70,10 @@ typedef struct {        /* a file (sub-image) inside a boot image */
 
 //
 // IAS Pub Key format for use
+// Supported for only RSA2048
 //
 typedef struct {
-  UINT8 Modulus[RSA_MOD_SIZE];
+  UINT8 Modulus[RSA2048_MOD_SIZE];
   UINT8 PubExp[RSA_E_SIZE];
 } IAS_PUB_KEY;
 

--- a/BootloaderCommonPkg/Include/Library/SecureBootLib.h
+++ b/BootloaderCommonPkg/Include/Library/SecureBootLib.h
@@ -14,6 +14,27 @@
 #define  SIG_TYPE_RSA2048_SHA256       0
 #define  SIG_TYPE_RSA3072_SHA384       1
 
+/**
+  Calculate hash API.
+
+  @param[in]  Data           Data buffer pointer.
+  @param[in]  Length         Data buffer size.
+  @param[in]  HashAlg        Specify hash algrothsm.
+  @param[in,out]  OutHash    Hash of Data buffer
+
+
+  @retval RETURN_SUCCESS             Hash Calculation succeeded.
+  @retval RETRUN_INVALID_PARAMETER   Hash parameter is not valid.
+  @retval RETURN_UNSUPPORTED         Hash Alg type is not supported.
+
+**/
+RETURN_STATUS
+CalculateHash  (
+  IN CONST UINT8          *Data,
+  IN       UINT32          Length,
+  IN       UINT8           HashAlg,
+  IN OUT   UINT8          *OutHash
+  );
 
 /**
   Verify data block hash with the built-in one.

--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
@@ -267,7 +267,6 @@ AuthenticateComponent (
     if (AuthType == AUTH_TYPE_SHA2_256) {
       Status = DoHashVerify (Data, Length, Usage, HASH_TYPE_SHA256, HashData);
     } else if (AuthType == AUTH_TYPE_SIG_RSA2048_SHA256) {
-
       SigPtr   = (UINT8 *) AuthData;
       SignHdr  = (SIGNATURE_HDR *) SigPtr;
       KeyPtr   = (UINT8 *)SignHdr + sizeof(SIGNATURE_HDR) + SignHdr->SigSize ;

--- a/BootloaderCommonPkg/Library/IasImageLib/IasImage.c
+++ b/BootloaderCommonPkg/Library/IasImageLib/IasImage.c
@@ -99,7 +99,7 @@ IsIasImageValid (
   // The byte order of RSA public key exponent is opposite between what iastool.py
   // generates and what RsaVerify API expects. Thus reverse it here.
   //
-  for (Index = 0, KeyIdx = (RSA_E_SIZE + RSA_MOD_SIZE - 1); Index < RSA_E_SIZE; Index++, KeyIdx--) {
+  for (Index = 0, KeyIdx = (RSA_E_SIZE + RSA2048_MOD_SIZE - 1); Index < RSA_E_SIZE; Index++, KeyIdx--) {
     Key->PubExp[Index]  = ((UINT8 *) IAS_PUBLIC_KEY (Hdr))[KeyIdx];
   }
 

--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -8,6 +8,7 @@
 #ifndef _BOOTLOADER_CORE_LIB_H_
 #define _BOOTLOADER_CORE_LIB_H_
 #include <Library/BootloaderCommonLib.h>
+#include <Library/CryptoLib.h>
 #include <Guid/FlashMapInfoGuid.h>
 
 #define  MPLD_SIGNATURE               SIGNATURE_32 ('$', 'P', 'L', 'D')
@@ -66,7 +67,7 @@ typedef struct {
   UINT32        CarTop;
   UINT32        PayloadBase;
   UINT8         ConfigDataHashValid;
-  UINT8         ConfigDataHash[32];
+  UINT8         ConfigDataHash[HASH_DIGEST_MAX];
 } STAGE1B_HOB;
 
 typedef struct {
@@ -84,14 +85,6 @@ typedef struct {
   UINT32        EntrySize;
   UINT32        Reserved;
 } MULTI_PAYLOAD_HEADER;
-
-typedef struct {
-  UINT32        Name;
-  UINT32        Offset;
-  UINT32        Size;
-  UINT32        Reserved;
-  UINT8         Hash[32];
-} MULTI_PAYLOAD_ENTRY;
 
 typedef struct {
   UINT32        Signature;

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -122,7 +122,7 @@ AppendHashStore (
   UINT32               OemKeyHashCompBase;
   UINT32               OemKeyHashUsedLength;
   INT32                KeyHashSize;
-  UINT8                AuthInfo[RSA_SIGNATURE_AND_KEY_SIZE];
+  UINT8                AuthInfo[SIGNATURE_AND_KEY_SIZE_MAX];
   SIGNATURE_HDR       *SignHdr;
   PUB_KEY_HDR         *PubKeyHdr;
 
@@ -467,6 +467,7 @@ SecStartup2 (
   if (LdrGlobal->FlashMapPtr) {
     LdrGlobal->FlashMapPtr = (UINT8 *)LdrGlobal->FlashMapPtr + Delta;
   }
+
   if (LdrGlobal->LibDataPtr) {
     LibDataPtr  = (LIBRARY_DATA *) ((UINT8 *)LdrGlobal->LibDataPtr + Delta);
     AllocateLen = 0;

--- a/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
+++ b/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
@@ -166,7 +166,7 @@ GetCapsuleFromRawPartition (
     return EFI_NOT_FOUND;
   }
 
-  if (FwUpdHeader->PubKeySize != RSA_MOD_SIZE + RSA_E_SIZE + sizeof (UINT32)) {
+  if (FwUpdHeader->PubKeySize != RSA2048_MOD_SIZE + RSA_E_SIZE + sizeof (UINT32)) {
     DEBUG ((DEBUG_INFO, "Invalid Capsule image found, Public Key size mismatch\n"));
     return EFI_NOT_FOUND;
   }

--- a/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.c
+++ b/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.c
@@ -189,7 +189,7 @@ SpiLoadExternalConfigData (
 
   SignedLen = CfgBlob->UsedLength;
   if (FeaturePcdGet (PcdVerifiedBootEnabled)) {
-    SignedLen += RSA_SIGNATURE_AND_KEY_SIZE;
+    SignedLen += RSA2048_SIGNATURE_AND_KEY_SIZE;
   }
 
   if ((SignedLen > Len) || (SignedLen <= sizeof(CDATA_BLOB))) {


### PR DESCRIPTION
Hash and RSA signing parameters were hardcoded in
Crypto wrappers and secure boot libraries. This patch
address support for multiple hash and key sizes to 
these libraries.

Signed-off-by: Subash Lakkimsetti <subashx.lakkimsetti@intel.com>