### PR TITLE
Add SmbusLib

### DIFF
--- a/BootloaderCommonPkg/Include/Guid/DeviceTableHobGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/DeviceTableHobGuid.h
@@ -14,6 +14,10 @@
 ///
 extern EFI_GUID gDeviceTableHobGuid;
 
+typedef enum {
+  PltDeviceSmbus = 0x20
+} PLT_MEDIUM_MISC_TYPE;
+
 typedef struct {
   UINT32        PciFunctionNumber:8;
   UINT32        PciDeviceNumber:8;

--- a/MdePkg/Include/Library/SmbusLib.h
+++ b/MdePkg/Include/Library/SmbusLib.h
@@ -1,0 +1,491 @@
+/** @file
+  Provides library functions to access SMBUS devices. Libraries of this class
+  must be ported to a specific SMBUS controller.
+
+Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __SMBUS_LIB__
+#define __SMBUS_LIB__
+
+/**
+  Macro that converts SMBUS slave address, SMBUS command, SMBUS data length,
+  and PEC to a value that can be passed to the SMBUS Library functions.
+
+  Computes an address that is compatible with the SMBUS Library functions.
+  The unused upper bits of SlaveAddress, Command, and Length are stripped
+  prior to the generation of the address.
+
+  @param  SlaveAddress    SMBUS Slave Address.  Range 0..127.
+  @param  Command         SMBUS Command.  Range 0..255.
+  @param  Length          SMBUS Data Length.  Range 0..32.
+  @param  Pec             TRUE if Packet Error Checking is enabled.  Otherwise FALSE.
+
+**/
+#define SMBUS_LIB_ADDRESS(SlaveAddress,Command,Length,Pec)  \
+  ( ((Pec) ? BIT22: 0)                  | \
+    (((SlaveAddress) & 0x7f) << 1)      | \
+    (((Command)      & 0xff) << 8)      | \
+    (((Length)       & 0x3f) << 16)       \
+  )
+
+/**
+  Macro that returns the SMBUS Slave Address value from an SmBusAddress Parameter value.
+
+  @param SmBusAddress   Address that encodes the SMBUS Slave Address, SMBUS Command, SMBUS Data Length, and PEC
+**/
+#define SMBUS_LIB_SLAVE_ADDRESS(SmBusAddress)      (((SmBusAddress) >> 1)  & 0x7f)
+
+/**
+  Macro that returns the SMBUS Command value from an SmBusAddress Parameter value.
+
+  @param SmBusAddress   Address that encodes the SMBUS Slave Address, SMBUS Command, SMBUS Data Length, and PEC
+**/
+#define SMBUS_LIB_COMMAND(SmBusAddress)            (((SmBusAddress) >> 8)  & 0xff)
+
+/**
+  Macro that returns the SMBUS Data Length value from an SmBusAddress Parameter value.
+
+  @param SmBusAddress Address that encodes the SMBUS Slave Address, SMBUS Command, SMBUS Data Length, and PEC
+**/
+#define SMBUS_LIB_LENGTH(SmBusAddress)             (((SmBusAddress) >> 16) & 0x3f)
+
+/**
+  Macro that returns the SMBUS PEC value from an SmBusAddress Parameter value.
+
+  @param SmBusAddress Address that encodes the SMBUS Slave Address, SMBUS Command, SMBUS Data Length, and PEC
+**/
+#define SMBUS_LIB_PEC(SmBusAddress)                ((BOOLEAN) (((SmBusAddress) & BIT22) != 0))
+
+/**
+  Macro that returns the set of reserved bits from an SmBusAddress Parameter value.
+
+  @param SmBusAddress Address that encodes the SMBUS Slave Address, SMBUS Command, SMBUS Data Length, and PEC
+**/
+#define SMBUS_LIB_RESERVED(SmBusAddress)           ((SmBusAddress) & ~(BIT23 - 2))
+
+/**
+  Executes an SMBUS quick read command.
+
+  Executes an SMBUS quick read command on the SMBUS device specified by SmBusAddress.
+  Only the SMBUS slave address field of SmBusAddress is required.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  If PEC is set in SmBusAddress, then ASSERT().
+  If Command in SmBusAddress is not zero, then ASSERT().
+  If Length in SmBusAddress is not zero, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                        SMBUS Command, SMBUS Data Length, and PEC.
+  @param  Status        Return status for the executed command.
+                        This is an optional parameter and may be NULL.
+                        RETURN_SUCCESS  The SMBUS command was executed.
+                        RETURN_TIMEOUT  A timeout occurred while executing the SMBUS command.
+                        RETURN_DEVICE_ERROR The request was not completed because a failure
+                        reflected in the Host Status Register bit.  Device errors are a result
+                        of a transaction collision, illegal command field, unclaimed cycle
+                        (host initiated), or bus errors (collisions).
+                        RETURN_UNSUPPORTED  The SMBus operation is not supported.
+
+**/
+VOID
+EFIAPI
+SmBusQuickRead (
+  IN  UINTN                     SmBusAddress,
+  OUT RETURN_STATUS             *Status       OPTIONAL
+  );
+
+/**
+  Executes an SMBUS quick write command.
+
+  Executes an SMBUS quick write command on the SMBUS device specified by SmBusAddress.
+  Only the SMBUS slave address field of SmBusAddress is required.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  If PEC is set in SmBusAddress, then ASSERT().
+  If Command in SmBusAddress is not zero, then ASSERT().
+  If Length in SmBusAddress is not zero, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                        SMBUS Command, SMBUS Data Length, and PEC.
+  @param  Status        Return status for the executed command.
+                        This is an optional parameter and may be NULL.
+                        RETURN_SUCCESS The SMBUS command was executed.
+                        RETURN_TIMEOUT A timeout occurred while executing the SMBUS command.
+                        RETURN_DEVICE_ERROR  The request was not completed because a failure
+                        reflected in the Host Status Register bit.  Device errors are a result
+                        of a transaction collision, illegal command field, unclaimed cycle
+                        (host initiated), or bus errors (collisions).
+                        RETURN_UNSUPPORTED  The SMBus operation is not supported.
+
+**/
+VOID
+EFIAPI
+SmBusQuickWrite (
+  IN  UINTN                     SmBusAddress,
+  OUT RETURN_STATUS             *Status       OPTIONAL
+  );
+
+/**
+  Executes an SMBUS receive byte command.
+
+  Executes an SMBUS receive byte command on the SMBUS device specified by SmBusAddress.
+  Only the SMBUS slave address field of SmBusAddress is required.
+  The byte received from the SMBUS is returned.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  If Command in SmBusAddress is not zero, then ASSERT().
+  If Length in SmBusAddress is not zero, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                        SMBUS Command, SMBUS Data Length, and PEC.
+  @param  Status        Return status for the executed command.
+                        This is an optional parameter and may be NULL.
+                        RETURN_SUCCESS The SMBUS command was executed.
+                        RETURN_TIMEOUT A timeout occurred while executing the SMBUS command.
+                        RETURN_DEVICE_ERROR  The request was not completed because a failure
+                        reflected in the Host Status Register bit.  Device errors are a result
+                        of a transaction collision, illegal command field, unclaimed cycle
+                        (host initiated), or bus errors (collisions).
+                        RETURN_CRC_ERROR  The checksum is not correct (PEC is incorrect)
+                        RETURN_UNSUPPORTED  The SMBus operation is not supported.
+
+  @return The byte received from the SMBUS.
+
+**/
+UINT8
+EFIAPI
+SmBusReceiveByte (
+  IN  UINTN          SmBusAddress,
+  OUT RETURN_STATUS  *Status        OPTIONAL
+  );
+
+/**
+  Executes an SMBUS send byte command.
+
+  Executes an SMBUS send byte command on the SMBUS device specified by SmBusAddress.
+  The byte specified by Value is sent.
+  Only the SMBUS slave address field of SmBusAddress is required.  Value is returned.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  If Command in SmBusAddress is not zero, then ASSERT().
+  If Length in SmBusAddress is not zero, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                        SMBUS Command, SMBUS Data Length, and PEC.
+  @param  Value         The 8-bit value to send.
+  @param  Status        Return status for the executed command.
+                        This is an optional parameter and may be NULL.
+                        RETURN_SUCCESS The SMBUS command was executed.
+                        RETURN_TIMEOUT A timeout occurred while executing the SMBUS command.
+                        RETURN_DEVICE_ERROR  The request was not completed because a failure
+                        reflected in the Host Status Register bit.  Device errors are a result
+                        of a transaction collision, illegal command field, unclaimed cycle
+                        (host initiated), or bus errors (collisions).
+                        RETURN_CRC_ERROR  The checksum is not correct (PEC is incorrect)
+                        RETURN_UNSUPPORTED  The SMBus operation is not supported.
+
+  @return The parameter of Value.
+
+**/
+UINT8
+EFIAPI
+SmBusSendByte (
+  IN  UINTN          SmBusAddress,
+  IN  UINT8          Value,
+  OUT RETURN_STATUS  *Status        OPTIONAL
+  );
+
+/**
+  Executes an SMBUS read data byte command.
+
+  Executes an SMBUS read data byte command on the SMBUS device specified by SmBusAddress.
+  Only the SMBUS slave address and SMBUS command fields of SmBusAddress are required.
+  The 8-bit value read from the SMBUS is returned.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  If Length in SmBusAddress is not zero, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param  SmBusAddress    Address that encodes the SMBUS Slave Address,
+                          SMBUS Command, SMBUS Data Length, and PEC.
+  @param  Status        Return status for the executed command.
+                        This is an optional parameter and may be NULL.
+                        RETURN_SUCCESS The SMBUS command was executed.
+                        RETURN_TIMEOUT A timeout occurred while executing the SMBUS command.
+                        RETURN_DEVICE_ERROR  The request was not completed because a failure
+                        reflected in the Host Status Register bit.  Device errors are a result
+                        of a transaction collision, illegal command field, unclaimed cycle
+                        (host initiated), or bus errors (collisions).
+                        RETURN_CRC_ERROR  The checksum is not correct (PEC is incorrect)
+                        RETURN_UNSUPPORTED  The SMBus operation is not supported.
+
+  @return The byte read from the SMBUS.
+
+**/
+UINT8
+EFIAPI
+SmBusReadDataByte (
+  IN  UINTN          SmBusAddress,
+  OUT RETURN_STATUS  *Status        OPTIONAL
+  );
+
+/**
+  Executes an SMBUS write data byte command.
+
+  Executes an SMBUS write data byte command on the SMBUS device specified by SmBusAddress.
+  The 8-bit value specified by Value is written.
+  Only the SMBUS slave address and SMBUS command fields of SmBusAddress are required.
+  Value is returned.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  If Length in SmBusAddress is not zero, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                        SMBUS Command, SMBUS Data Length, and PEC.
+  @param  Value         The 8-bit value to write.
+  @param  Status        Return status for the executed command.
+                        This is an optional parameter and may be NULL.
+                        RETURN_SUCCESS The SMBUS command was executed.
+                        RETURN_TIMEOUT A timeout occurred while executing the SMBUS command.
+                        RETURN_DEVICE_ERROR  The request was not completed because a failure
+                        reflected in the Host Status Register bit.  Device errors are a result
+                        of a transaction collision, illegal command field, unclaimed cycle
+                        (host initiated), or bus errors (collisions).
+                        RETURN_CRC_ERROR  The checksum is not correct (PEC is incorrect)
+                        RETURN_UNSUPPORTED  The SMBus operation is not supported.
+
+  @return The parameter of Value.
+
+**/
+UINT8
+EFIAPI
+SmBusWriteDataByte (
+  IN  UINTN          SmBusAddress,
+  IN  UINT8          Value,
+  OUT RETURN_STATUS  *Status        OPTIONAL
+  );
+
+/**
+  Executes an SMBUS read data word command.
+
+  Executes an SMBUS read data word command on the SMBUS device specified by SmBusAddress.
+  Only the SMBUS slave address and SMBUS command fields of SmBusAddress are required.
+  The 16-bit value read from the SMBUS is returned.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  If Length in SmBusAddress is not zero, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                        SMBUS Command, SMBUS Data Length, and PEC.
+  @param  Status        Return status for the executed command.
+                        This is an optional parameter and may be NULL.
+                        RETURN_SUCCESS The SMBUS command was executed.
+                        RETURN_TIMEOUT A timeout occurred while executing the SMBUS command.
+                        RETURN_DEVICE_ERROR  The request was not completed because a failure
+                        reflected in the Host Status Register bit.  Device errors are a result
+                        of a transaction collision, illegal command field, unclaimed cycle
+                        (host initiated), or bus errors (collisions).
+                        RETURN_CRC_ERROR  The checksum is not correct (PEC is incorrect)
+                        RETURN_UNSUPPORTED  The SMBus operation is not supported.
+
+  @return The byte read from the SMBUS.
+
+**/
+UINT16
+EFIAPI
+SmBusReadDataWord (
+  IN  UINTN          SmBusAddress,
+  OUT RETURN_STATUS  *Status        OPTIONAL
+  );
+
+/**
+  Executes an SMBUS write data word command.
+
+  Executes an SMBUS write data word command on the SMBUS device specified by SmBusAddress.
+  The 16-bit value specified by Value is written.
+  Only the SMBUS slave address and SMBUS command fields of SmBusAddress are required.
+  Value is returned.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  If Length in SmBusAddress is not zero, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                        SMBUS Command, SMBUS Data Length, and PEC.
+  @param  Value         The 16-bit value to write.
+  @param  Status        Return status for the executed command.
+                        This is an optional parameter and may be NULL.
+                        RETURN_SUCCESS The SMBUS command was executed.
+                        RETURN_TIMEOUT A timeout occurred while executing the SMBUS command.
+                        RETURN_DEVICE_ERROR  The request was not completed because a failure
+                        reflected in the Host Status Register bit.  Device errors are a result
+                        of a transaction collision, illegal command field, unclaimed cycle
+                        (host initiated), or bus errors (collisions).
+                        RETURN_CRC_ERROR  The checksum is not correct (PEC is incorrect)
+                        RETURN_UNSUPPORTED  The SMBus operation is not supported.
+
+  @return The parameter of Value.
+
+**/
+UINT16
+EFIAPI
+SmBusWriteDataWord (
+  IN  UINTN          SmBusAddress,
+  IN  UINT16         Value,
+  OUT RETURN_STATUS  *Status        OPTIONAL
+  );
+
+/**
+  Executes an SMBUS process call command.
+
+  Executes an SMBUS process call command on the SMBUS device specified by SmBusAddress.
+  The 16-bit value specified by Value is written.
+  Only the SMBUS slave address and SMBUS command fields of SmBusAddress are required.
+  The 16-bit value returned by the process call command is returned.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  If Length in SmBusAddress is not zero, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                        SMBUS Command, SMBUS Data Length, and PEC.
+  @param  Value         The 16-bit value to write.
+  @param  Status        Return status for the executed command.
+                        This is an optional parameter and may be NULL.
+                        RETURN_SUCCESS The SMBUS command was executed.
+                        RETURN_TIMEOUT A timeout occurred while executing the SMBUS command.
+                        RETURN_DEVICE_ERROR  The request was not completed because a failure
+                        reflected in the Host Status Register bit.  Device errors are a result
+                        of a transaction collision, illegal command field, unclaimed cycle
+                        (host initiated), or bus errors (collisions).
+                        RETURN_CRC_ERROR  The checksum is not correct (PEC is incorrect)
+                        RETURN_UNSUPPORTED  The SMBus operation is not supported.
+
+  @return The 16-bit value returned by the process call command.
+
+**/
+UINT16
+EFIAPI
+SmBusProcessCall (
+  IN  UINTN          SmBusAddress,
+  IN  UINT16         Value,
+  OUT RETURN_STATUS  *Status        OPTIONAL
+  );
+
+/**
+  Executes an SMBUS read block command.
+
+  Executes an SMBUS read block command on the SMBUS device specified by SmBusAddress.
+  Only the SMBUS slave address and SMBUS command fields of SmBusAddress are required.
+  Bytes are read from the SMBUS and stored in Buffer.
+  The number of bytes read is returned, and will never return a value larger than 32-bytes.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  It is the caller's responsibility to make sure Buffer is large enough for the total number of bytes read.
+  SMBUS supports a maximum transfer size of 32 bytes, so Buffer does not need to be any larger than 32 bytes.
+  If Length in SmBusAddress is not zero, then ASSERT().
+  If Buffer is NULL, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                        SMBUS Command, SMBUS Data Length, and PEC.
+  @param  Buffer        Pointer to the buffer to store the bytes read from the SMBUS.
+  @param  Status        Return status for the executed command.
+                        This is an optional parameter and may be NULL.
+                        RETURN_SUCCESS The SMBUS command was executed.
+                        RETURN_TIMEOUT A timeout occurred while executing the SMBUS command.
+                        RETURN_DEVICE_ERROR  The request was not completed because a failure
+                        reflected in the Host Status Register bit.  Device errors are a result
+                        of a transaction collision, illegal command field, unclaimed cycle
+                        (host initiated), or bus errors (collisions).
+                        RETURN_CRC_ERROR  The checksum is not correct (PEC is incorrect)
+                        RETURN_UNSUPPORTED  The SMBus operation is not supported.
+
+  @return The number of bytes read.
+
+**/
+UINTN
+EFIAPI
+SmBusReadBlock (
+  IN  UINTN          SmBusAddress,
+  OUT VOID           *Buffer,
+  OUT RETURN_STATUS  *Status        OPTIONAL
+  );
+
+/**
+  Executes an SMBUS write block command.
+
+  Executes an SMBUS write block command on the SMBUS device specified by SmBusAddress.
+  The SMBUS slave address, SMBUS command, and SMBUS length fields of SmBusAddress are required.
+  Bytes are written to the SMBUS from Buffer.
+  The number of bytes written is returned, and will never return a value larger than 32-bytes.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  If Length in SmBusAddress is zero or greater than 32, then ASSERT().
+  If Buffer is NULL, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                        SMBUS Command, SMBUS Data Length, and PEC.
+  @param  Buffer        Pointer to the buffer to store the bytes read from the SMBUS.
+  @param  Status        Return status for the executed command.
+                        This is an optional parameter and may be NULL.
+                        RETURN_TIMEOUT A timeout occurred while executing the SMBUS command.
+                        RETURN_DEVICE_ERROR  The request was not completed because a failure
+                        reflected in the Host Status Register bit.  Device errors are a result
+                        of a transaction collision, illegal command field, unclaimed cycle
+                        (host initiated), or bus errors (collisions).
+                        RETURN_CRC_ERROR  The checksum is not correct (PEC is incorrect)
+                        RETURN_UNSUPPORTED  The SMBus operation is not supported.
+
+  @return The number of bytes written.
+
+**/
+UINTN
+EFIAPI
+SmBusWriteBlock (
+  IN  UINTN          SmBusAddress,
+  OUT VOID           *Buffer,
+  OUT RETURN_STATUS  *Status        OPTIONAL
+  );
+
+/**
+  Executes an SMBUS block process call command.
+
+  Executes an SMBUS block process call command on the SMBUS device specified by SmBusAddress.
+  The SMBUS slave address, SMBUS command, and SMBUS length fields of SmBusAddress are required.
+  Bytes are written to the SMBUS from WriteBuffer.  Bytes are then read from the SMBUS into ReadBuffer.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  It is the caller's responsibility to make sure ReadBuffer is large enough for the total number of bytes read.
+  SMBUS supports a maximum transfer size of 32 bytes, so Buffer does not need to be any larger than 32 bytes.
+  If Length in SmBusAddress is zero or greater than 32, then ASSERT().
+  If WriteBuffer is NULL, then ASSERT().
+  If ReadBuffer is NULL, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                        SMBUS Command, SMBUS Data Length, and PEC.
+  @param  WriteBuffer   Pointer to the buffer of bytes to write to the SMBUS.
+  @param  ReadBuffer    Pointer to the buffer of bytes to read from the SMBUS.
+  @param  Status        Return status for the executed command.
+                        This is an optional parameter and may be NULL.
+                        RETURN_TIMEOUT A timeout occurred while executing the SMBUS command.
+                        RETURN_DEVICE_ERROR  The request was not completed because a failure
+                        reflected in the Host Status Register bit.  Device errors are a result
+                        of a transaction collision, illegal command field, unclaimed cycle
+                        (host initiated), or bus errors (collisions).
+                        RETURN_CRC_ERROR  The checksum is not correct (PEC is incorrect)
+                        RETURN_UNSUPPORTED  The SMBus operation is not supported.
+
+  @return The number of bytes written.
+
+**/
+UINTN
+EFIAPI
+SmBusBlockProcessCall (
+  IN  UINTN          SmBusAddress,
+  IN  VOID           *WriteBuffer,
+  OUT VOID           *ReadBuffer,
+  OUT RETURN_STATUS  *Status        OPTIONAL
+  );
+
+
+#endif

--- a/Silicon/CommonSocPkg/Library/SmbusLib/RegsSmbus.h
+++ b/Silicon/CommonSocPkg/Library/SmbusLib/RegsSmbus.h
@@ -1,0 +1,128 @@
+/** @file
+  Register names for PCH Smbus Device.
+
+  Conventions:
+
+  - Register definition format:
+    Prefix_[GenerationName]_[ComponentName]_SubsystemName_RegisterSpace_RegisterName
+  - Prefix:
+    Definitions beginning with "R_" are registers
+    Definitions beginning with "B_" are bits within registers
+    Definitions beginning with "V_" are meaningful values within the bits
+    Definitions beginning with "S_" are register size
+    Definitions beginning with "N_" are the bit position
+  - [GenerationName]:
+    Three letter acronym of the generation is used .
+    Register name without GenerationName applies to all generations.
+  - [ComponentName]:
+    This field indicates the component name that the register belongs to (e.g. PCH, SA etc.)
+    Register name without ComponentName applies to all components.
+    Register that is specific to -H denoted by "_PCH_H_" in component name.
+    Register that is specific to -LP denoted by "_PCH_LP_" in component name.
+  - SubsystemName:
+    This field indicates the subsystem name of the component that the register belongs to
+    (e.g. PCIE, USB, SATA, GPIO, PMC etc.).
+  - RegisterSpace:
+    MEM - MMIO space register of subsystem.
+    IO  - IO space register of subsystem.
+    PCR - Private configuration register of subsystem.
+    CFG - PCI configuration space register of subsystem.
+  - RegisterName:
+    Full register name.
+
+  Copyright (c) 2019 Intel Corporation. All rights reserved. <BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef _PCH_REGS_SMBUS_H_
+#define _PCH_REGS_SMBUS_H_
+
+//
+// SMBus Controller Registers
+//
+#define R_SMBUS_CFG_BASE                      0x20
+#define V_SMBUS_CFG_BASE_SIZE                 (1 << 5)
+#define B_SMBUS_CFG_BASE_BAR                  0x0000FFE0
+#define R_SMBUS_CFG_HOSTC                     0x40
+#define B_SMBUS_CFG_HOSTC_SPDWD               BIT4
+#define B_SMBUS_CFG_HOSTC_SSRESET             BIT3
+#define B_SMBUS_CFG_HOSTC_I2C_EN              BIT2
+#define B_SMBUS_CFG_HOSTC_SMI_EN              BIT1
+#define B_SMBUS_CFG_HOSTC_HST_EN              BIT0
+#define R_SMBUS_CFG_TCOBASE                   0x50
+#define B_SMBUS_CFG_TCOBASE_BAR               0x0000FFE0
+#define R_SMBUS_CFG_TCOCTL                    0x54
+#define B_SMBUS_CFG_TCOCTL_TCO_BASE_EN        BIT8
+#define B_SMBUS_CFG_TCOCTL_TCO_BASE_LOCK      BIT0
+#define R_SMBUS_CFG_64                        0x64
+#define R_SMBUS_CFG_80                        0x80
+
+//
+// SMBus I/O Registers
+//
+#define R_SMBUS_IO_HSTS                  0x00  ///< Host Status Register R/W
+#define B_SMBUS_IO_HBSY                  0x01
+#define B_SMBUS_IO_INTR                  0x02
+#define B_SMBUS_IO_DERR                  0x04
+#define B_SMBUS_IO_BERR                  0x08
+#define B_SMBUS_IO_FAIL                  0x10
+#define B_SMBUS_IO_SMBALERT_STS          0x20
+#define B_SMBUS_IO_IUS                   0x40
+#define B_SMBUS_IO_BYTE_DONE_STS         0x80
+#define B_SMBUS_IO_ERROR                 (B_SMBUS_IO_DERR | B_SMBUS_IO_BERR | B_SMBUS_IO_FAIL)
+#define B_SMBUS_IO_HSTS_ALL              0xFF
+#define R_SMBUS_IO_HCTL                  0x02  ///< Host Control Register R/W
+#define B_SMBUS_IO_INTREN                0x01
+#define B_SMBUS_IO_KILL                  0x02
+#define B_SMBUS_IO_SMB_CMD               0x1C
+#define V_SMBUS_IO_SMB_CMD_QUICK         0x00
+#define V_SMBUS_IO_SMB_CMD_BYTE          0x04
+#define V_SMBUS_IO_SMB_CMD_BYTE_DATA     0x08
+#define V_SMBUS_IO_SMB_CMD_WORD_DATA     0x0C
+#define V_SMBUS_IO_SMB_CMD_PROCESS_CALL  0x10
+#define V_SMBUS_IO_SMB_CMD_BLOCK         0x14
+#define V_SMBUS_IO_SMB_CMD_IIC_READ      0x18
+#define V_SMBUS_IO_SMB_CMD_BLOCK_PROCESS 0x1C
+#define B_SMBUS_IO_LAST_BYTE             0x20
+#define B_SMBUS_IO_START                 0x40
+#define B_SMBUS_IO_PEC_EN                0x80
+#define R_SMBUS_IO_HCMD                  0x03  ///< Host Command Register R/W
+#define R_SMBUS_IO_TSA                   0x04  ///< Transmit Slave Address Register R/W
+#define B_SMBUS_IO_RW_SEL                0x01
+#define B_SMBUS_IO_READ                  0x01  // RW
+#define B_SMBUS_IO_WRITE                 0x00  // RW
+#define B_SMBUS_IO_ADDRESS               0xFE
+#define R_SMBUS_IO_HD0                   0x05  ///< Data 0 Register R/W
+#define R_SMBUS_IO_HD1                   0x06  ///< Data 1 Register R/W
+#define R_SMBUS_IO_HBD                   0x07  ///< Host Block Data Register R/W
+#define R_SMBUS_IO_PEC                   0x08  ///< Packet Error Check Data Register R/W
+#define R_SMBUS_IO_RSA                   0x09  ///< Receive Slave Address Register R/W
+#define B_SMBUS_IO_SLAVE_ADDR            0x7F
+#define R_SMBUS_IO_SD                    0x0A  ///< Receive Slave Data Register R/W
+#define R_SMBUS_IO_AUXS                  0x0C  ///< Auxiliary Status Register R/WC
+#define B_SMBUS_IO_CRCE                  0x01
+#define B_SMBUS_IO_STCO                  0x02  ///< SMBus TCO Mode
+#define R_SMBUS_IO_AUXC                  0x0D  ///< Auxiliary Control Register R/W
+#define B_SMBUS_IO_AAC                   0x01
+#define B_SMBUS_IO_E32B                  0x02
+#define R_SMBUS_IO_SMLC                  0x0E  ///< SMLINK Pin Control Register R/W
+#define B_SMBUS_IO_SMLINK0_CUR_STS       0x01
+#define B_SMBUS_IO_SMLINK1_CUR_STS       0x02
+#define B_SMBUS_IO_SMLINK_CLK_CTL        0x04
+#define R_SMBUS_IO_SMBC                  0x0F  ///< SMBus Pin Control Register R/W
+#define B_SMBUS_IO_SMBCLK_CUR_STS        0x01
+#define B_SMBUS_IO_SMBDATA_CUR_STS       0x02
+#define B_SMBUS_IO_SMBCLK_CTL            0x04
+#define R_SMBUS_IO_SSTS                  0x10  ///< Slave Status Register R/WC
+#define B_SMBUS_IO_HOST_NOTIFY_STS       0x01
+#define R_SMBUS_IO_SCMD                  0x11  ///< Slave Command Register R/W
+#define B_SMBUS_IO_HOST_NOTIFY_INTREN    0x01
+#define B_SMBUS_IO_HOST_NOTIFY_WKEN      0x02
+#define B_SMBUS_IO_SMBALERT_DIS          0x04
+#define R_SMBUS_IO_NDA                   0x14  ///< Notify Device Address Register RO
+#define B_SMBUS_IO_DEVICE_ADDRESS        0xFE
+#define R_SMBUS_IO_NDLB                  0x16  ///< Notify Data Low Byte Register RO
+#define R_SMBUS_IO_NDHB                  0x17  ///< Notify Data High Byte Register RO
+
+#endif

--- a/Silicon/CommonSocPkg/Library/SmbusLib/SmbusLib.c
+++ b/Silicon/CommonSocPkg/Library/SmbusLib/SmbusLib.c
@@ -1,0 +1,948 @@
+/** @file
+  PCH SMBUS library implementation built upon I/O library.
+
+  Copyright (c) 2019 Intel Corporation. All rights reserved. <BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Base.h>
+#include <Library/SmbusLib.h>
+#include <Library/BaseLib.h>
+#include <Library/IoLib.h>
+#include <Library/PciLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BootloaderCommonLib.h>
+#include "RegsSmbus.h"
+
+/**
+  Gets Io port base address of Smbus Host Controller.
+
+  @retval The Io port base address of Smbus host controller.
+
+**/
+UINT16
+InternalGetSmbusIoPortBaseAddress (
+  VOID
+  )
+{
+  UINT32     SmbusPciBase;
+  UINT16     IoPortBaseAddress;
+
+  SmbusPciBase = GetDeviceAddr (PltDeviceSmbus, 0);
+  if ((SmbusPciBase & 0xFF000000) == 0) {
+    SmbusPciBase = TO_PCI_LIB_ADDRESS (SmbusPciBase);
+  }
+
+  IoPortBaseAddress = PciRead16 (SmbusPciBase + R_SMBUS_CFG_BASE);
+
+  //
+  // Make sure that the IO port base address has been properly set.
+  //
+  if ((IoPortBaseAddress == 0) || (IoPortBaseAddress == 0xFFFF)) {
+    ASSERT (FALSE);
+    return 0;
+  }
+
+  IoPortBaseAddress &= B_SMBUS_CFG_BASE_BAR;
+
+  return IoPortBaseAddress;
+}
+
+/**
+  Acquires the ownership of SMBUS.
+
+  This internal function reads the host state register.
+  If the SMBUS is not available, RETURN_TIMEOUT is returned;
+  Otherwise, it performs some basic initializations and returns
+  RETURN_SUCCESS.
+
+  @param[in]  IoPortBaseAddress The Io port base address of Smbus Host controller.
+
+  @retval     RETURN_SUCCESS    The SMBUS command was executed successfully.
+  @retval     RETURN_TIMEOUT    A timeout occurred while executing the SMBUS command.
+
+**/
+RETURN_STATUS
+InternalSmBusAcquire (
+  IN UINT16                   IoPortBaseAddress
+  )
+{
+  UINT8   HostStatus;
+
+  HostStatus = IoRead8 (IoPortBaseAddress + R_SMBUS_IO_HSTS);
+  if ((HostStatus & B_SMBUS_IO_IUS) != 0) {
+    return RETURN_TIMEOUT;
+  } else if ((HostStatus & B_SMBUS_IO_HBSY) != 0) {
+    //
+    // Clear host status register and exit.
+    //
+    IoWrite8 (IoPortBaseAddress + R_SMBUS_IO_HSTS, B_SMBUS_IO_HSTS_ALL);
+    return RETURN_TIMEOUT;
+  }
+  //
+  // Clear out any odd status information (Will Not Clear In Use).
+  //
+  IoWrite8 (IoPortBaseAddress + R_SMBUS_IO_HSTS, HostStatus);
+
+  return RETURN_SUCCESS;
+}
+
+/**
+  Starts the SMBUS transaction and waits until the end.
+
+  This internal function start the SMBUS transaction and waits until the transaction
+  of SMBUS is over by polling the INTR bit of Host status register.
+  If the SMBUS is not available, RETURN_TIMEOUT is returned;
+  Otherwise, it performs some basic initializations and returns
+  RETURN_SUCCESS.
+
+  @param[in]  IoPortBaseAddress   The Io port base address of Smbus Host controller.
+  @param[in]  HostControl         The Host control command to start SMBUS transaction.
+
+  @retval     RETURN_SUCCESS      The SMBUS command was executed successfully.
+  @retval     RETURN_CRC_ERROR    The checksum is not correct (PEC is incorrect).
+  @retval     RETURN_DEVICE_ERROR The request was not completed because a failure reflected
+                                  in the Host Status Register bit.  Device errors are
+                                  a result of a transaction collision, illegal command field,
+                                  unclaimed cycle (host initiated), or bus errors (collisions).
+
+**/
+RETURN_STATUS
+InternalSmBusStart (
+  IN  UINT16                  IoPortBaseAddress,
+  IN  UINT8                   HostControl
+  )
+{
+  UINT8   HostStatus;
+  UINT8   AuxiliaryStatus;
+
+  //
+  // Set Host Control Register (Initiate Operation, Interrupt disabled).
+  //
+  IoWrite8 (IoPortBaseAddress + R_SMBUS_IO_HCTL, (UINT8)(HostControl + B_SMBUS_IO_START));
+
+  do {
+    //
+    // Poll INTR bit of Host Status Register.
+    //
+    HostStatus = IoRead8 (IoPortBaseAddress + R_SMBUS_IO_HSTS);
+  } while ((HostStatus & (B_SMBUS_IO_INTR | B_SMBUS_IO_ERROR | B_SMBUS_IO_BYTE_DONE_STS)) == 0);
+
+  if ((HostStatus & B_SMBUS_IO_ERROR) == 0) {
+    return RETURN_SUCCESS;
+  }
+  //
+  // Clear error bits of Host Status Register.
+  //
+  IoWrite8 (IoPortBaseAddress + R_SMBUS_IO_HSTS, B_SMBUS_IO_ERROR);
+  //
+  // Read Auxiliary Status Register to judge CRC error.
+  //
+  AuxiliaryStatus = IoRead8 (IoPortBaseAddress + R_SMBUS_IO_AUXS);
+  if ((AuxiliaryStatus & B_SMBUS_IO_CRCE) != 0) {
+    return RETURN_CRC_ERROR;
+  }
+
+  return RETURN_DEVICE_ERROR;
+}
+
+/**
+  Executes an SMBUS quick, byte or word command.
+
+  This internal function executes an SMBUS quick, byte or word commond.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+
+  @param[in]  HostControl     The value of Host Control Register to set.
+  @param[in]  SmBusAddress    Address that encodes the SMBUS Slave Address,
+                              SMBUS Command, SMBUS Data Length, and PEC.
+  @param[in]  Value           The byte/word write to the SMBUS.
+  @param[out] Status          Return status for the executed command.
+                              This is an optional parameter and may be NULL.
+
+  @retval The byte/word read from the SMBUS.
+
+**/
+UINT16
+InternalSmBusNonBlock (
+  IN  UINT8                     HostControl,
+  IN  UINTN                     SmBusAddress,
+  IN  UINT16                    Value,
+  OUT RETURN_STATUS             *Status
+  )
+{
+  RETURN_STATUS                 ReturnStatus;
+  UINT16                        IoPortBaseAddress;
+  UINT8                         AuxiliaryControl;
+
+  IoPortBaseAddress = InternalGetSmbusIoPortBaseAddress ();
+
+  //
+  // Try to acquire the ownership of SMBUS.
+  //
+  ReturnStatus = InternalSmBusAcquire (IoPortBaseAddress);
+  if (RETURN_ERROR (ReturnStatus)) {
+    goto Done;
+  }
+  //
+  // Set the appropriate Host Control Register and auxiliary Control Register.
+  //
+  AuxiliaryControl = 0;
+  if (SMBUS_LIB_PEC (SmBusAddress)) {
+    AuxiliaryControl |= B_SMBUS_IO_AAC;
+  }
+  //
+  // Set Host Commond Register.
+  //
+  IoWrite8 (IoPortBaseAddress + R_SMBUS_IO_HCMD, (UINT8) SMBUS_LIB_COMMAND (SmBusAddress));
+  //
+  // Write value to Host Data 0 and Host Data 1 Registers.
+  //
+  IoWrite8 (IoPortBaseAddress + R_SMBUS_IO_HD0, (UINT8) Value);
+  IoWrite8 (IoPortBaseAddress + R_SMBUS_IO_HD1, (UINT8) (Value >> 8));
+  //
+  // Set Auxiliary Control Regiester.
+  //
+  IoWrite8 (IoPortBaseAddress + R_SMBUS_IO_AUXC, AuxiliaryControl);
+  //
+  // Set SMBUS slave address for the device to send/receive from.
+  //
+  IoWrite8 (IoPortBaseAddress + R_SMBUS_IO_TSA, (UINT8) SmBusAddress);
+  //
+  // Start the SMBUS transaction and wait for the end.
+  //
+  ReturnStatus = InternalSmBusStart (IoPortBaseAddress, HostControl);
+  //
+  // Read value from Host Data 0 and Host Data 1 Registers.
+  //
+  Value = (UINT16)(IoRead8 (IoPortBaseAddress + R_SMBUS_IO_HD1) << 8);
+  Value = (UINT16)(Value | IoRead8 (IoPortBaseAddress + R_SMBUS_IO_HD0));
+  //
+  // Clear Host Status Register and Auxiliary Status Register.
+  //
+  IoWrite8 (IoPortBaseAddress + R_SMBUS_IO_HSTS, B_SMBUS_IO_HSTS_ALL);
+  IoWrite8 (IoPortBaseAddress + R_SMBUS_IO_AUXS, B_SMBUS_IO_CRCE);
+
+Done:
+  if (Status != NULL) {
+    *Status = ReturnStatus;
+  }
+
+  return Value;
+}
+
+/**
+  Executes an SMBUS quick read command.
+
+  Executes an SMBUS quick read command on the SMBUS device specified by SmBusAddress.
+  Only the SMBUS slave address field of SmBusAddress is required.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  If PEC is set in SmBusAddress, then ASSERT().
+  If Command in SmBusAddress is not zero, then ASSERT().
+  If Length in SmBusAddress is not zero, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param[in]  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                            SMBUS Command, SMBUS Data Length, and PEC.
+  @param[out] Status        Return status for the executed command.
+                            This is an optional parameter and may be NULL.
+
+**/
+VOID
+EFIAPI
+SmBusQuickRead (
+  IN  UINTN                     SmBusAddress,
+  OUT RETURN_STATUS             *Status       OPTIONAL
+  )
+{
+  ASSERT (!SMBUS_LIB_PEC (SmBusAddress));
+  ASSERT (SMBUS_LIB_COMMAND (SmBusAddress)  == 0);
+  ASSERT (SMBUS_LIB_LENGTH (SmBusAddress)   == 0);
+  ASSERT (SMBUS_LIB_RESERVED (SmBusAddress) == 0);
+
+  if (SMBUS_LIB_PEC (SmBusAddress)           ||
+    (SMBUS_LIB_COMMAND (SmBusAddress)  != 0) ||
+    (SMBUS_LIB_LENGTH (SmBusAddress)   != 0) ||
+    (SMBUS_LIB_RESERVED (SmBusAddress) != 0))
+  {
+    if (Status != NULL) {
+      *Status = RETURN_INVALID_PARAMETER;
+    }
+    return;
+  }
+
+  InternalSmBusNonBlock (
+    V_SMBUS_IO_SMB_CMD_QUICK,
+    SmBusAddress | B_SMBUS_IO_READ,
+    0,
+    Status
+    );
+}
+
+/**
+  Executes an SMBUS quick write command.
+
+  Executes an SMBUS quick write command on the SMBUS device specified by SmBusAddress.
+  Only the SMBUS slave address field of SmBusAddress is required.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  If PEC is set in SmBusAddress, then ASSERT().
+  If Command in SmBusAddress is not zero, then ASSERT().
+  If Length in SmBusAddress is not zero, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param[in]  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                            SMBUS Command, SMBUS Data Length, and PEC.
+  @param[out] Status        Return status for the executed command.
+                            This is an optional parameter and may be NULL.
+
+**/
+VOID
+EFIAPI
+SmBusQuickWrite (
+  IN  UINTN                     SmBusAddress,
+  OUT RETURN_STATUS             *Status       OPTIONAL
+  )
+{
+  ASSERT (!SMBUS_LIB_PEC (SmBusAddress));
+  ASSERT (SMBUS_LIB_COMMAND (SmBusAddress)  == 0);
+  ASSERT (SMBUS_LIB_LENGTH (SmBusAddress)   == 0);
+  ASSERT (SMBUS_LIB_RESERVED (SmBusAddress) == 0);
+
+  if (SMBUS_LIB_PEC (SmBusAddress)           ||
+    (SMBUS_LIB_COMMAND (SmBusAddress)  != 0) ||
+    (SMBUS_LIB_LENGTH (SmBusAddress)   != 0) ||
+    (SMBUS_LIB_RESERVED (SmBusAddress) != 0))
+  {
+    if (Status != NULL) {
+      *Status = RETURN_INVALID_PARAMETER;
+    }
+    return;
+  }
+
+  InternalSmBusNonBlock (
+    V_SMBUS_IO_SMB_CMD_QUICK,
+    SmBusAddress | B_SMBUS_IO_WRITE,
+    0,
+    Status
+    );
+}
+
+/**
+  Executes an SMBUS receive byte command.
+
+  Executes an SMBUS receive byte command on the SMBUS device specified by SmBusAddress.
+  Only the SMBUS slave address field of SmBusAddress is required.
+  The byte received from the SMBUS is returned.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  If Command in SmBusAddress is not zero, then ASSERT().
+  If Length in SmBusAddress is not zero, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param[in]  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                            SMBUS Command, SMBUS Data Length, and PEC.
+  @param[out] Status        Return status for the executed command.
+                            This is an optional parameter and may be NULL.
+
+  @retval The byte received from the SMBUS.
+
+**/
+UINT8
+EFIAPI
+SmBusReceiveByte (
+  IN  UINTN          SmBusAddress,
+  OUT RETURN_STATUS  *Status        OPTIONAL
+  )
+{
+  ASSERT (SMBUS_LIB_COMMAND (SmBusAddress)  == 0);
+  ASSERT (SMBUS_LIB_LENGTH (SmBusAddress)   == 0);
+  ASSERT (SMBUS_LIB_RESERVED (SmBusAddress) == 0);
+
+  if ((SMBUS_LIB_COMMAND (SmBusAddress)  != 0) ||
+      (SMBUS_LIB_LENGTH (SmBusAddress)   != 0) ||
+      (SMBUS_LIB_RESERVED (SmBusAddress) != 0))
+  {
+    if (Status != NULL) {
+      *Status = RETURN_INVALID_PARAMETER;
+    }
+    return 0;
+  }
+
+  return (UINT8) InternalSmBusNonBlock (
+                   V_SMBUS_IO_SMB_CMD_BYTE,
+                   SmBusAddress | B_SMBUS_IO_READ,
+                   0,
+                   Status
+                   );
+}
+
+/**
+  Executes an SMBUS send byte command.
+
+  Executes an SMBUS send byte command on the SMBUS device specified by SmBusAddress.
+  The byte specified by Value is sent.
+  Only the SMBUS slave address field of SmBusAddress is required.  Value is returned.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  If Command in SmBusAddress is not zero, then ASSERT().
+  If Length in SmBusAddress is not zero, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param[in]  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                            SMBUS Command, SMBUS Data Length, and PEC.
+  @param[in]  Value         The 8-bit value to send.
+  @param[out] Status        Return status for the executed command.
+                            This is an optional parameter and may be NULL.
+
+  @retval The parameter of Value.
+
+**/
+UINT8
+EFIAPI
+SmBusSendByte (
+  IN  UINTN          SmBusAddress,
+  IN  UINT8          Value,
+  OUT RETURN_STATUS  *Status        OPTIONAL
+  )
+{
+  ASSERT (SMBUS_LIB_COMMAND (SmBusAddress)  == 0);
+  ASSERT (SMBUS_LIB_LENGTH (SmBusAddress)   == 0);
+  ASSERT (SMBUS_LIB_RESERVED (SmBusAddress) == 0);
+
+  if ((SMBUS_LIB_COMMAND (SmBusAddress)  != 0) ||
+      (SMBUS_LIB_LENGTH (SmBusAddress)   != 0) ||
+      (SMBUS_LIB_RESERVED (SmBusAddress) != 0))
+  {
+    if (Status != NULL) {
+      *Status = RETURN_INVALID_PARAMETER;
+    }
+    return 0;
+  }
+
+  return (UINT8) InternalSmBusNonBlock (
+                   V_SMBUS_IO_SMB_CMD_BYTE,
+                   SmBusAddress | B_SMBUS_IO_WRITE,
+                   Value,
+                   Status
+                   );
+}
+
+/**
+  Executes an SMBUS read data byte command.
+
+  Executes an SMBUS read data byte command on the SMBUS device specified by SmBusAddress.
+  Only the SMBUS slave address and SMBUS command fields of SmBusAddress are required.
+  The 8-bit value read from the SMBUS is returned.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  If Length in SmBusAddress is not zero, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param[in]  SmBusAddress    Address that encodes the SMBUS Slave Address,
+                              SMBUS Command, SMBUS Data Length, and PEC.
+  @param[out] Status          Return status for the executed command.
+                              This is an optional parameter and may be NULL.
+
+  @retval The byte read from the SMBUS.
+
+**/
+UINT8
+EFIAPI
+SmBusReadDataByte (
+  IN  UINTN          SmBusAddress,
+  OUT RETURN_STATUS  *Status        OPTIONAL
+  )
+{
+  ASSERT (SMBUS_LIB_LENGTH (SmBusAddress)   == 0);
+  ASSERT (SMBUS_LIB_RESERVED (SmBusAddress) == 0);
+
+  if ((SMBUS_LIB_LENGTH (SmBusAddress)   != 0) ||
+      (SMBUS_LIB_RESERVED (SmBusAddress) != 0))
+  {
+    if (Status != NULL) {
+      *Status = RETURN_INVALID_PARAMETER;
+    }
+    return 0;
+  }
+
+  return (UINT8) InternalSmBusNonBlock (
+                   V_SMBUS_IO_SMB_CMD_BYTE_DATA,
+                   SmBusAddress | B_SMBUS_IO_READ,
+                   0,
+                   Status
+                   );
+}
+
+/**
+  Executes an SMBUS write data byte command.
+
+  Executes an SMBUS write data byte command on the SMBUS device specified by SmBusAddress.
+  The 8-bit value specified by Value is written.
+  Only the SMBUS slave address and SMBUS command fields of SmBusAddress are required.
+  Value is returned.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  If Length in SmBusAddress is not zero, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param[in]  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                            SMBUS Command, SMBUS Data Length, and PEC.
+  @param[in]  Value         The 8-bit value to write.
+  @param[out] Status        Return status for the executed command.
+                            This is an optional parameter and may be NULL.
+
+  @retval The parameter of Value.
+
+**/
+UINT8
+EFIAPI
+SmBusWriteDataByte (
+  IN  UINTN          SmBusAddress,
+  IN  UINT8          Value,
+  OUT RETURN_STATUS  *Status        OPTIONAL
+  )
+{
+  ASSERT (SMBUS_LIB_LENGTH (SmBusAddress)   == 0);
+  ASSERT (SMBUS_LIB_RESERVED (SmBusAddress) == 0);
+
+  if ((SMBUS_LIB_LENGTH (SmBusAddress)   != 0) ||
+      (SMBUS_LIB_RESERVED (SmBusAddress) != 0))
+  {
+    if (Status != NULL) {
+      *Status = RETURN_INVALID_PARAMETER;
+    }
+    return 0;
+  }
+
+  return (UINT8) InternalSmBusNonBlock (
+                   V_SMBUS_IO_SMB_CMD_BYTE_DATA,
+                   SmBusAddress | B_SMBUS_IO_WRITE,
+                   Value,
+                   Status
+                   );
+}
+
+/**
+  Executes an SMBUS read data word command.
+
+  Executes an SMBUS read data word command on the SMBUS device specified by SmBusAddress.
+  Only the SMBUS slave address and SMBUS command fields of SmBusAddress are required.
+  The 16-bit value read from the SMBUS is returned.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  If Length in SmBusAddress is not zero, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param[in]  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                            SMBUS Command, SMBUS Data Length, and PEC.
+  @param[out] Status        Return status for the executed command.
+                            This is an optional parameter and may be NULL.
+
+  @retval The byte read from the SMBUS.
+
+**/
+UINT16
+EFIAPI
+SmBusReadDataWord (
+  IN  UINTN          SmBusAddress,
+  OUT RETURN_STATUS  *Status        OPTIONAL
+  )
+{
+  ASSERT (SMBUS_LIB_LENGTH (SmBusAddress)   == 0);
+  ASSERT (SMBUS_LIB_RESERVED (SmBusAddress) == 0);
+
+  if ((SMBUS_LIB_LENGTH (SmBusAddress)   != 0) ||
+      (SMBUS_LIB_RESERVED (SmBusAddress) != 0))
+  {
+    if (Status != NULL) {
+      *Status = RETURN_INVALID_PARAMETER;
+    }
+    return 0;
+  }
+
+  return InternalSmBusNonBlock (
+           V_SMBUS_IO_SMB_CMD_WORD_DATA,
+           SmBusAddress | B_SMBUS_IO_READ,
+           0,
+           Status
+           );
+}
+
+/**
+  Executes an SMBUS write data word command.
+
+  Executes an SMBUS write data word command on the SMBUS device specified by SmBusAddress.
+  The 16-bit value specified by Value is written.
+  Only the SMBUS slave address and SMBUS command fields of SmBusAddress are required.
+  Value is returned.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  If Length in SmBusAddress is not zero, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param[in]  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                            SMBUS Command, SMBUS Data Length, and PEC.
+  @param[in]  Value         The 16-bit value to write.
+  @param[out] Status        Return status for the executed command.
+                            This is an optional parameter and may be NULL.
+
+  @retval The parameter of Value.
+
+**/
+UINT16
+EFIAPI
+SmBusWriteDataWord (
+  IN  UINTN          SmBusAddress,
+  IN  UINT16         Value,
+  OUT RETURN_STATUS  *Status        OPTIONAL
+  )
+{
+  ASSERT (SMBUS_LIB_LENGTH (SmBusAddress)   == 0);
+  ASSERT (SMBUS_LIB_RESERVED (SmBusAddress) == 0);
+
+  if ((SMBUS_LIB_LENGTH (SmBusAddress)   != 0) ||
+      (SMBUS_LIB_RESERVED (SmBusAddress) != 0))
+  {
+    if (Status != NULL) {
+      *Status = RETURN_INVALID_PARAMETER;
+    }
+    return 0;
+  }
+
+  return InternalSmBusNonBlock (
+           V_SMBUS_IO_SMB_CMD_WORD_DATA,
+           SmBusAddress | B_SMBUS_IO_WRITE,
+           Value,
+           Status
+           );
+}
+
+/**
+  Executes an SMBUS process call command.
+
+  Executes an SMBUS process call command on the SMBUS device specified by SmBusAddress.
+  The 16-bit value specified by Value is written.
+  Only the SMBUS slave address and SMBUS command fields of SmBusAddress are required.
+  The 16-bit value returned by the process call command is returned.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  If Length in SmBusAddress is not zero, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param[in]  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                            SMBUS Command, SMBUS Data Length, and PEC.
+  @param[in]  Value         The 16-bit value to write.
+  @param[out] Status        Return status for the executed command.
+                            This is an optional parameter and may be NULL.
+
+  @retval The 16-bit value returned by the process call command.
+
+**/
+UINT16
+EFIAPI
+SmBusProcessCall (
+  IN  UINTN          SmBusAddress,
+  IN  UINT16         Value,
+  OUT RETURN_STATUS  *Status        OPTIONAL
+  )
+{
+  ASSERT (SMBUS_LIB_LENGTH (SmBusAddress)   == 0);
+  ASSERT (SMBUS_LIB_RESERVED (SmBusAddress) == 0);
+
+  if ((SMBUS_LIB_LENGTH (SmBusAddress)   != 0) ||
+      (SMBUS_LIB_RESERVED (SmBusAddress) != 0))
+  {
+    if (Status != NULL) {
+      *Status = RETURN_INVALID_PARAMETER;
+    }
+    return 0;
+  }
+
+  return InternalSmBusNonBlock (
+           V_SMBUS_IO_SMB_CMD_PROCESS_CALL,
+           SmBusAddress | B_SMBUS_IO_WRITE,
+           Value,
+           Status
+           );
+}
+
+/**
+  Executes an SMBUS block command.
+
+  Executes an SMBUS block read, block write and block write-block read command
+  on the SMBUS device specified by SmBusAddress.
+  Bytes are read from the SMBUS and stored in Buffer.
+  The number of bytes read is returned, and will never return a value larger than 32-bytes.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  It is the caller's responsibility to make sure Buffer is large enough for the total number of bytes read.
+  SMBUS supports a maximum transfer size of 32 bytes, so Buffer does not need to be any larger than 32 bytes.
+
+  @param[in]  HostControl     The value of Host Control Register to set.
+  @param[in]  SmBusAddress    Address that encodes the SMBUS Slave Address,
+                              SMBUS Command, SMBUS Data Length, and PEC.
+  @param[in]  WriteBuffer     Pointer to the buffer of bytes to write to the SMBUS.
+  @param[out] ReadBuffer      Pointer to the buffer of bytes to read from the SMBUS.
+  @param[out] Status          Return status for the executed command.
+                              This is an optional parameter and may be NULL.
+
+  @retval The number of bytes read from the SMBUS.
+
+**/
+UINTN
+InternalSmBusBlock (
+  IN  UINT8                     HostControl,
+  IN  UINTN                     SmBusAddress,
+  IN  UINT8                     *WriteBuffer,
+  OUT UINT8                     *ReadBuffer,
+  OUT RETURN_STATUS             *Status
+  )
+{
+  RETURN_STATUS                 ReturnStatus;
+  UINTN                         Index;
+  UINTN                         BytesCount;
+  UINT16                        IoPortBaseAddress;
+  UINT8                         AuxiliaryControl;
+
+  IoPortBaseAddress = InternalGetSmbusIoPortBaseAddress ();
+
+  BytesCount = SMBUS_LIB_LENGTH (SmBusAddress);
+
+  //
+  // Try to acquire the ownership of SMBUS.
+  //
+  ReturnStatus = InternalSmBusAcquire (IoPortBaseAddress);
+  if (RETURN_ERROR (ReturnStatus)) {
+    goto Done;
+  }
+  //
+  // Set the appropriate Host Control Register and auxiliary Control Register.
+  //
+  AuxiliaryControl = B_SMBUS_IO_E32B;
+  if (SMBUS_LIB_PEC (SmBusAddress)) {
+    AuxiliaryControl |= B_SMBUS_IO_AAC;
+  }
+  //
+  // Set Host Command Register.
+  //
+  IoWrite8 (IoPortBaseAddress + R_SMBUS_IO_HCMD, (UINT8) SMBUS_LIB_COMMAND (SmBusAddress));
+  //
+  // Set Auxiliary Control Regiester.
+  //
+  IoWrite8 (IoPortBaseAddress + R_SMBUS_IO_AUXC, AuxiliaryControl);
+  //
+  // Clear byte pointer of 32-byte buffer.
+  //
+  IoRead8 (IoPortBaseAddress + R_SMBUS_IO_HCTL);
+
+  if (WriteBuffer != NULL) {
+    //
+    // Write the number of block to Host Block Data Byte Register.
+    //
+    IoWrite8 (IoPortBaseAddress + R_SMBUS_IO_HD0, (UINT8) BytesCount);
+    //
+    // Write data block to Host Block Data Register.
+    //
+    for (Index = 0; Index < BytesCount; Index++) {
+      IoWrite8 (IoPortBaseAddress + R_SMBUS_IO_HBD, WriteBuffer[Index]);
+    }
+  }
+  //
+  // Set SMBUS slave address for the device to send/receive from.
+  //
+  IoWrite8 (IoPortBaseAddress + R_SMBUS_IO_TSA, (UINT8) SmBusAddress);
+  //
+  // Start the SMBUS transaction and wait for the end.
+  //
+  ReturnStatus = InternalSmBusStart (IoPortBaseAddress, HostControl);
+  if (RETURN_ERROR (ReturnStatus)) {
+    goto Done;
+  }
+
+  if (ReadBuffer != NULL) {
+    //
+    // Read the number of block from host block data byte register.
+    //
+    BytesCount = IoRead8 (IoPortBaseAddress + R_SMBUS_IO_HD0);
+    //
+    // Write data block from Host Block Data Register.
+    //
+    for (Index = 0; Index < BytesCount; Index++) {
+      ReadBuffer[Index] = IoRead8 (IoPortBaseAddress + R_SMBUS_IO_HBD);
+    }
+  }
+
+Done:
+  //
+  // Clear Host Status Register and Auxiliary Status Register.
+  //
+  IoWrite8 (IoPortBaseAddress + R_SMBUS_IO_HSTS, B_SMBUS_IO_HSTS_ALL);
+  IoWrite8 (IoPortBaseAddress + R_SMBUS_IO_AUXS, B_SMBUS_IO_CRCE);
+
+  if (Status != NULL) {
+    *Status = ReturnStatus;
+  }
+
+  return BytesCount;
+}
+
+/**
+  Executes an SMBUS read block command.
+
+  Executes an SMBUS read block command on the SMBUS device specified by SmBusAddress.
+  Only the SMBUS slave address and SMBUS command fields of SmBusAddress are required.
+  Bytes are read from the SMBUS and stored in Buffer.
+  The number of bytes read is returned, and will never return a value larger than 32-bytes.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  It is the caller's responsibility to make sure Buffer is large enough for the total number of bytes read.
+  SMBUS supports a maximum transfer size of 32 bytes, so Buffer does not need to be any larger than 32 bytes.
+  If Length in SmBusAddress is not zero, then ASSERT().
+  If Buffer is NULL, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param[in]  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                            SMBUS Command, SMBUS Data Length, and PEC.
+  @param[out] Buffer        Pointer to the buffer to store the bytes read from the SMBUS.
+  @param[out] Status        Return status for the executed command.
+                            This is an optional parameter and may be NULL.
+
+  @retval The number of bytes read.
+
+**/
+UINTN
+EFIAPI
+SmBusReadBlock (
+  IN  UINTN          SmBusAddress,
+  OUT VOID           *Buffer,
+  OUT RETURN_STATUS  *Status        OPTIONAL
+  )
+{
+  ASSERT (Buffer != NULL);
+  ASSERT (SMBUS_LIB_LENGTH (SmBusAddress)   == 0);
+  ASSERT (SMBUS_LIB_RESERVED (SmBusAddress) == 0);
+
+  if ((Buffer == NULL)                         ||
+      (SMBUS_LIB_LENGTH (SmBusAddress)   != 0) ||
+      (SMBUS_LIB_RESERVED (SmBusAddress) != 0))
+  {
+    if (Status != NULL) {
+      *Status = RETURN_INVALID_PARAMETER;
+    }
+    return 0;
+  }
+
+  return InternalSmBusBlock (
+           V_SMBUS_IO_SMB_CMD_BLOCK,
+           SmBusAddress | B_SMBUS_IO_READ,
+           NULL,
+           Buffer,
+           Status
+           );
+}
+
+/**
+  Executes an SMBUS write block command.
+
+  Executes an SMBUS write block command on the SMBUS device specified by SmBusAddress.
+  The SMBUS slave address, SMBUS command, and SMBUS length fields of SmBusAddress are required.
+  Bytes are written to the SMBUS from Buffer.
+  The number of bytes written is returned, and will never return a value larger than 32-bytes.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  If Length in SmBusAddress is zero or greater than 32, then ASSERT().
+  If Buffer is NULL, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param[in]  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                            SMBUS Command, SMBUS Data Length, and PEC.
+  @param[out] Buffer        Pointer to the buffer to store the bytes read from the SMBUS.
+  @param[out] Status        Return status for the executed command.
+                            This is an optional parameter and may be NULL.
+
+  @retval The number of bytes written.
+
+**/
+UINTN
+EFIAPI
+SmBusWriteBlock (
+  IN  UINTN          SmBusAddress,
+  OUT VOID           *Buffer,
+  OUT RETURN_STATUS  *Status        OPTIONAL
+  )
+{
+  ASSERT (Buffer != NULL);
+  ASSERT (SMBUS_LIB_LENGTH (SmBusAddress)   >= 1);
+  ASSERT (SMBUS_LIB_LENGTH (SmBusAddress)   <= 32);
+  ASSERT (SMBUS_LIB_RESERVED (SmBusAddress) == 0);
+
+  if ((Buffer == NULL)                         ||
+      (SMBUS_LIB_LENGTH (SmBusAddress)   == 0) ||
+      (SMBUS_LIB_LENGTH (SmBusAddress)   > 32) ||
+      (SMBUS_LIB_RESERVED (SmBusAddress) != 0))
+  {
+    if (Status != NULL) {
+      *Status = RETURN_INVALID_PARAMETER;
+    }
+    return 0;
+  }
+
+  return InternalSmBusBlock (
+           V_SMBUS_IO_SMB_CMD_BLOCK,
+           SmBusAddress | B_SMBUS_IO_WRITE,
+           Buffer,
+           NULL,
+           Status
+           );
+}
+
+/**
+  Executes an SMBUS block process call command.
+
+  Executes an SMBUS block process call command on the SMBUS device specified by SmBusAddress.
+  The SMBUS slave address, SMBUS command, and SMBUS length fields of SmBusAddress are required.
+  Bytes are written to the SMBUS from WriteBuffer.  Bytes are then read from the SMBUS into ReadBuffer.
+  If Status is not NULL, then the status of the executed command is returned in Status.
+  It is the caller's responsibility to make sure ReadBuffer is large enough for the total number of bytes read.
+  SMBUS supports a maximum transfer size of 32 bytes, so Buffer does not need to be any larger than 32 bytes.
+  If Length in SmBusAddress is zero or greater than 32, then ASSERT().
+  If WriteBuffer is NULL, then ASSERT().
+  If ReadBuffer is NULL, then ASSERT().
+  If any reserved bits of SmBusAddress are set, then ASSERT().
+
+  @param[in]  SmBusAddress  Address that encodes the SMBUS Slave Address,
+                            SMBUS Command, SMBUS Data Length, and PEC.
+  @param[in]  WriteBuffer   Pointer to the buffer of bytes to write to the SMBUS.
+  @param[out] ReadBuffer    Pointer to the buffer of bytes to read from the SMBUS.
+  @param[out] Status        Return status for the executed command.
+                            This is an optional parameter and may be NULL.
+
+  @retval The number of bytes written.
+
+**/
+UINTN
+EFIAPI
+SmBusBlockProcessCall (
+  IN  UINTN          SmBusAddress,
+  IN  VOID           *WriteBuffer,
+  OUT VOID           *ReadBuffer,
+  OUT RETURN_STATUS  *Status        OPTIONAL
+  )
+{
+  ASSERT (WriteBuffer != NULL);
+  ASSERT (ReadBuffer  != NULL);
+  ASSERT (SMBUS_LIB_LENGTH (SmBusAddress)   >= 1);
+  ASSERT (SMBUS_LIB_LENGTH (SmBusAddress)   <= 32);
+  ASSERT (SMBUS_LIB_RESERVED (SmBusAddress) == 0);
+
+  if ((WriteBuffer == NULL)                    ||
+      (ReadBuffer  == NULL)                    ||
+      (SMBUS_LIB_LENGTH (SmBusAddress)   == 0) ||
+      (SMBUS_LIB_LENGTH (SmBusAddress)   > 32) ||
+      (SMBUS_LIB_RESERVED (SmBusAddress) != 0))
+  {
+    if (Status != NULL) {
+      *Status = RETURN_INVALID_PARAMETER;
+    }
+    return 0;
+  }
+
+  return InternalSmBusBlock (
+           V_SMBUS_IO_SMB_CMD_BLOCK_PROCESS,
+           SmBusAddress | B_SMBUS_IO_WRITE,
+           WriteBuffer,
+           ReadBuffer,
+           Status
+           );
+}
+

--- a/Silicon/CommonSocPkg/Library/SmbusLib/SmbusLib.inf
+++ b/Silicon/CommonSocPkg/Library/SmbusLib/SmbusLib.inf
@@ -1,0 +1,35 @@
+## @file
+#
+#  Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION    = 0x00010017
+  BASE_NAME      = BaseSmbusLib
+  FILE_GUID      = 5C4D0430-F81B-42D3-BB88-4A6CD2796FF8
+  MODULE_TYPE    = BASE
+  VERSION_STRING = 1.0
+  LIBRARY_CLASS  = SmbusLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  RegsSmbus.h
+  SmbusLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+  Silicon/CommonSocPkg/CommonSocPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  IoLib
+


### PR DESCRIPTION
Add a common SmbusLib support for Intel PCH
Define PLT_MEDIUM_MISC_TYPE in device table for
devices that are not for OS boot.

Signed-off-by: Guo Dong <guo.dong@intel.com>