### PR TITLE
Print exact address for Shell memory dump command

### DIFF
--- a/BootloaderCommonPkg/Library/ShellLib/CmdMm.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdMm.c
@@ -117,8 +117,12 @@ MmRead (
 
   // Pad backward to 16-byte boundary
   ItemsPerRow  = 16 / Width;
-  Start        = (Addr & 0xF) / Width;
-  Count       += Start;
+  if (Count == 1) {
+    Start = 0;
+  } else {
+    Start = (Addr & 0xF) / Width;
+  }
+  Count  += Start;
 
   if (Start > 0) {
     ShellPrint (L"%08X: ", Addr & ~0xF);


### PR DESCRIPTION
If dumping address not aligned at 16 boundary, the current Shell
will print the aligned address in the dump. It makes sense for
a memory block display, but it is a little bit confusing for single
memory address display. This patch fixed this issue by printing the
exact address when the display count is 1.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>