### PR TITLE
Enable RSA3072 and SHA384 signing support

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -105,6 +105,14 @@
   #     0x0010    - SM3_256.<BR>
   gPlatformCommonLibTokenSpaceGuid.PcdIppHashLibSupportedMask     |        0x02| UINT16 | 0x20000701
 
+  ## This PCD indicates the signing HASH algorithm used for Component signing
+  #  Based on the value set, the required algorithm should be used while verfication
+  #     0x01    - SHA2_256.<BR>
+  #     0x02    - SHA2_384.<BR>
+  #     0x03    - SHA2_512.<BR>
+  #     0x04    - SM3_256.<BR>
+  gPlatformCommonLibTokenSpaceGuid.PcdCompSignHashAlg                 |        0x01| UINT8 | 0x20000702
+
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   # For patchable PCDs, try to set the default as none-zero
   # It is to prevent it from being put into BSS section, thus cause patching issue

--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
@@ -266,7 +266,9 @@ AuthenticateComponent (
   } else {
     if (AuthType == AUTH_TYPE_SHA2_256) {
       Status = DoHashVerify (Data, Length, Usage, HASH_TYPE_SHA256, HashData);
-    } else if (AuthType == AUTH_TYPE_SIG_RSA2048_SHA256) {
+    } else if (AuthType == AUTH_TYPE_SHA2_384) {
+      Status = DoHashVerify (Data, Length, Usage, HASH_TYPE_SHA384, HashData);
+    } else if ((AuthType == AUTH_TYPE_SIG_RSA2048_SHA256) || ( AuthType == AUTH_TYPE_SIG_RSA3072_SHA384)) {
       SigPtr   = (UINT8 *) AuthData;
       SignHdr  = (SIGNATURE_HDR *) SigPtr;
       KeyPtr   = (UINT8 *)SignHdr + sizeof(SIGNATURE_HDR) + SignHdr->SigSize ;
@@ -653,7 +655,7 @@ LoadComponentWithCallback (
   BOOLEAN                   IsInFlash;
 
   if (ContainerSig < COMP_TYPE_INVALID) {
-    // Check if it is container signature or component type
+    // Check if it is component type
     Usage        =  1 << ContainerSig;
     ContainerSig = 0;
 
@@ -663,7 +665,13 @@ LoadComponentWithCallback (
     }
 
     if (FeaturePcdGet (PcdVerifiedBootEnabled)) {
-      AuthType = AUTH_TYPE_SHA2_256;
+      if(FixedPcdGet8(PcdCompSignHashAlg) == HASH_TYPE_SHA256) {
+        AuthType = AUTH_TYPE_SHA2_256;
+      } else if (FixedPcdGet8(PcdCompSignHashAlg) == HASH_TYPE_SHA384) {
+        AuthType = AUTH_TYPE_SHA2_384;
+      } else {
+        return EFI_UNSUPPORTED;
+      }
     } else {
       AuthType = AUTH_TYPE_NONE;
     }

--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.inf
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.inf
@@ -30,3 +30,4 @@
 [Pcd]
   gPlatformCommonLibTokenSpaceGuid.PcdContainerMaxNumber
   gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdCompSignHashAlg

--- a/BootloaderCommonPkg/Library/IppCryptoLib/rsa_verify.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/rsa_verify.c
@@ -28,7 +28,7 @@ int VerifyRsaSignature (CONST PUB_KEY_HDR *PubKeyHdr, CONST SIGNATURE_HDR *Signa
   Ipp8u  *rsa_n;
   Ipp8u  *rsa_e;
   Ipp16u  mod_len;
-  Ipp8u  bn_buf[3400];
+  Ipp8u  bn_buf[5200];
   IppsBigNumState *bn_rsa_n;
   IppsBigNumState *bn_rsa_e;
   Ipp8u *scratch_buf;

--- a/BootloaderCommonPkg/Library/SecureBootLib/SecureBootHash.c
+++ b/BootloaderCommonPkg/Library/SecureBootLib/SecureBootHash.c
@@ -39,6 +39,7 @@ CalculateHash  (
   UINT8 DigestSize;
   UINT8 *HashRetVal;
 
+
   if(Digest != NULL){
     if (HashAlg == HASH_TYPE_SHA256) {
       HashRetVal = Sha256 (Data, Length, Digest);
@@ -95,7 +96,8 @@ DoHashVerify (
   UINT8                DigestSize;
 
 
-  if ((Data == NULL) || (HashAlg != HASH_TYPE_SHA256)) {
+  if ((Data == NULL) ||
+      ((HashAlg != HASH_TYPE_SHA256) && (HashAlg != HASH_TYPE_SHA384))) {
     return RETURN_INVALID_PARAMETER;
   }
 

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -252,6 +252,7 @@
 
   gPlatformCommonLibTokenSpaceGuid.PcdIppHashLibSupportedMask    | $(IPP_HASH_LIB_SUPPORTED_MASK)
 
+ gPlatformCommonLibTokenSpaceGuid.PcdCompSignHashAlg             | $(SIGN_HASH_TYPE)
 
 [PcdsPatchableInModule]
   gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel   | 0x8000004F

--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -147,6 +147,7 @@ PrepareStage1B (
   UINT32                    Length;
   EFI_STATUS                Status;
   LOADER_COMPRESSED_HEADER *Hdr;
+  UINT8                     SignHashAlg;
 
   // Load Stage 1B
   Status = GetComponentInfo (FLASH_MAP_SIG_STAGE1B, &Src, &Length);
@@ -172,7 +173,13 @@ PrepareStage1B (
     if (IS_COMPRESSED (Src)) {
       Length = sizeof (LOADER_COMPRESSED_HEADER) + Hdr->CompressedSize;
     }
-    Status = DoHashVerify ((CONST UINT8 *)Src, Length, HASH_USAGE_STAGE_1B, HASH_TYPE_SHA256, NULL);
+    if(PcdGet8(PcdCompSignHashAlg) == HASH_TYPE_SHA256){
+      SignHashAlg = HASH_TYPE_SHA256;
+    } else if(PcdGet8(PcdCompSignHashAlg) == HASH_TYPE_SHA384){
+      SignHashAlg = HASH_TYPE_SHA384;
+    }
+
+    Status = DoHashVerify ((CONST UINT8 *)Src, Length, HASH_USAGE_STAGE_1B, SignHashAlg, NULL);
     AddMeasurePoint (0x10A0);
     if (EFI_ERROR (Status)) {
       if (Status != RETURN_NOT_FOUND) {

--- a/BootloaderCorePkg/Stage1A/Stage1A.inf
+++ b/BootloaderCorePkg/Stage1A/Stage1A.inf
@@ -81,6 +81,7 @@
   gPlatformModuleTokenSpaceGuid.PcdVerifiedBootHashMask
   gPlatformModuleTokenSpaceGuid.PcdHashStoreSize
   gPlatformCommonLibTokenSpaceGuid.PcdPcdLibId
+  gPlatformCommonLibTokenSpaceGuid.PcdCompSignHashAlg
 
 [Depex]
   TRUE

--- a/BootloaderCorePkg/Tools/CfgDataTool.py
+++ b/BootloaderCorePkg/Tools/CfgDataTool.py
@@ -759,7 +759,7 @@ def CmdSign(Args):
     Fd.write (FileData)
     Fd.close ()
 
-    rsa_sign_file (Args.cfg_pri_key, None, 'SHA2_256', TmpFile, Args.cfg_out_file, True, True)
+    rsa_sign_file (Args.cfg_pri_key, None, Args.hash_alg, TmpFile, Args.cfg_out_file, True, True)
     if os.path.exists(TmpFile):
       os.remove(TmpFile)
 
@@ -917,7 +917,7 @@ def Main():
                             help='Configuration binary file')
     SignParser.add_argument('-o', dest='cfg_out_file', type=str, help='Signed configuration output binary file name to be generated', required=True)
     SignParser.add_argument('-k', dest='cfg_pri_key', type=str, help='Private key file (PEM format) used to sign configuration data', required=True)
-    SignParser.add_argument('-auth', dest='auth_type', type=str, help='Auth Type with RSA signing',  default = 'RSA2048SHA256')
+    SignParser.add_argument('-a', dest='hash_alg', type=str, choices=['SHA2_256', 'SHA2_384'], help='Hash Type for signing',  default = 'SHA2_256')
     SignParser.set_defaults(func=CmdSign)
 
     ExtractParser = SubParser.add_parser('extract', help='extract a single config data to a file')

--- a/BootloaderCorePkg/Tools/CommonUtility.py
+++ b/BootloaderCorePkg/Tools/CommonUtility.py
@@ -47,6 +47,9 @@ HASH_TYPE_VALUE = {
             "SM3_256"     : 4,
     }
 
+# Hash values defined should match with cryptolib.h
+HASH_VAL_STRING = dict(map(reversed, HASH_TYPE_VALUE.items()))
+
 AUTH_TYPE_HASH_VALUE = {
             # Auth_type      : Hash_type
             "SHA2_256"       : 1,
@@ -227,7 +230,7 @@ def rsa_sign_file (priv_key, pub_key, hash_type, in_file, out_file, inc_dat = Fa
     sign = SIGNATURE_HDR()
     sign.SigSize = len(out_data)
     sign.SigType = SIGN_TYPE_SCHEME['RSA_PCKS_1_5']
-    sign.HashAlg = HASH_TYPE_VALUE['SHA2_256']
+    sign.HashAlg = HASH_TYPE_VALUE[hash_type]
 
     bins.extend(bytearray(sign) + out_data)
     if inc_key:

--- a/BootloaderCorePkg/Tools/GenContainer.py
+++ b/BootloaderCorePkg/Tools/GenContainer.py
@@ -22,7 +22,7 @@ class COMPONENT_ENTRY (Structure):
         ('size',        c_uint32),   # Region/Component size in byte
         ('attribute',   c_uint8),    # Attribute:  BIT7 Reserved component entry
         ('alignment',   c_uint8),    # This image need to be loaded to memory  in (1 << Alignment) address
-        ('auth_type',   c_uint8),    # Refer AUTH_TYPE_VALUE: 0 - "NONE"; 1- "SHA2_256";  2- "RSA2048SHA256"; 3- "SHA2_384"; 4 - RSA3072SHA384
+        ('auth_type',   c_uint8),    # Refer AUTH_TYPE_VALUE: 0 - "NONE"; 1- "SHA2_256";  2- "SHA2_384";  3- "RSA2048SHA256"; 4 - RSA3072SHA384
         ('hash_size',   c_uint8)     # Hash data size, it could be image hash or public key hash
         ]
 
@@ -216,10 +216,11 @@ class CONTAINER ():
     @staticmethod
     def get_pub_key_hash (key, hash_type):
         # calculate publish key hash
+        dh = bytearray (key)[sizeof(PUB_KEY_HDR):]
         if hash_type == 'SHA2_256':
-            dh = bytearray (key)[sizeof(PUB_KEY_HDR):]
-            dh = dh[:0x100] + dh[0x100:]
             return bytearray(hashlib.sha256(dh).digest())
+        elif hash_type == 'SHA2_384':
+            return bytearray(hashlib.sha384(dh).digest())
         else:
             raise Exception ("Unsupported hash type in get_pub_key_hash!")
 
@@ -234,7 +235,10 @@ class CONTAINER ():
         elif auth_type in ["SHA2_256"]:
             data = get_file_data (file)
             hash_data.extend (hashlib.sha256(data).digest())
-        elif auth_type in ['RSA2048']:
+        elif auth_type in ["SHA2_384"]:
+            data = get_file_data (file)
+            hash_data.extend (hashlib.sha384(data).digest())
+        elif auth_type in ['RSA2048', 'RSA3072']:
             pub_key = os.path.join(out_dir, basename + '.pub')
             di = gen_pub_key (priv_key, pub_key)
             key_hash = CONTAINER.get_pub_key_hash (di, hash_type)
@@ -292,7 +296,9 @@ class CONTAINER ():
                 data = file_data[:sizeof(lz_header) + lz_header.compressed_len]
                 if auth_type_str in ["SHA2_256"]:
                     hash_data.extend (hashlib.sha256(data).digest())
-                elif auth_type_str in ['RSA2048']:
+                if auth_type_str in ["SHA2_384"]:
+                    hash_data.extend (hashlib.sha384(data).digest())
+                elif auth_type_str in ['RSA2048', 'RSA3072']:
                     offset += ((CONTAINER.get_auth_size (auth_type_str)))
                     key_hash = self.get_pub_key_hash (file_data[offset:])
                     hash_data.extend (key_hash)
@@ -592,12 +598,13 @@ def gen_container_bin (container_list, out_dir, inp_dir, key_dir = '.', tool_dir
         out_file = container.create (each)
         print ("Container '%s' was created successfully at:  \n  %s" % (container.header.signature.decode(), out_file))
 
-def gen_layout (comp_list, img_type, out_file, key_file):
+def gen_layout (comp_list, img_type, sign_hash_alg, out_file, key_dir, key_file):
+    sign_key_type = get_key_type(os.path.join(key_dir, key_file))
     # prepare the layout from individual components from '-cl'
     if img_type not in CONTAINER_HDR._image_type.keys():
         raise Exception ("Invalid Container Type '%s' !" % img_type)
-    layout = "('BOOT', '%s', '%s', 'RSA2048' , '%s', 0x10, 0),\n" % (out_file, img_type, key_file)
-    end_layout = "('_SG_', '', 'Dummy', 'SHA2_256', '', 0, 0),"
+    layout = "('BOOT', '%s', '%s', '%s' , '%s', 0x10, 0),\n" % (out_file, img_type, sign_key_type, key_file)
+    end_layout = "('_SG_', '', 'Dummy', '%s', '', 0, 0)," %(sign_hash_alg)
     for idx, each in enumerate(comp_list):
         parts = each.split(':')
         comp_name = parts[0]
@@ -639,11 +646,11 @@ def create_container (args):
             out_dir = os.path.dirname(args.out_path)
             out_file = os.path.basename(args.out_path)
 
-        layout = gen_layout (args.comp_list, args.img_type, out_file, key_file)
+        layout = gen_layout (args.comp_list, args.img_type, args.hash_type, out_file, key_dir, key_file)
     comp_dir = args.comp_dir if args.comp_dir else def_inp_dir
     tool_dir = args.tool_dir if args.tool_dir else def_inp_dir
     container_list = eval ('[[%s]]' % layout.replace('\\', '/'))
-    gen_container_bin (container_list, out_dir, comp_dir, key_dir, tool_dir)
+    gen_container_bin (container_list, out_dir, comp_dir, key_dir, tool_dir, args.hash_type)
 
 def extract_container (args):
     tool_dir = args.tool_dir if args.tool_dir else '.'
@@ -662,16 +669,11 @@ def replace_component (args):
     print ("Component '%s' was replaced successfully at:\n  %s" % (args.comp_name, file))
 
 def sign_component (args):
-    auth_dict = {
-        'none'    : 'NONE',
-        'sha256'  : 'SHA2_256',
-        'rsa2048' : 'RSA2048',
-    }
     compress_alg = args.compress
     compress_alg = compress_alg[0].upper() + compress_alg[1:]
     lz_file = compress (args.comp_file, compress_alg, args.out_dir, args.tool_dir)
     data = bytearray(get_file_data (lz_file))
-    hash_data, auth_data = CONTAINER.calculate_auth_data (lz_file, auth_dict[args.auth], args.key_file, args.out_dir, args.hash_type)
+    hash_data, auth_data = CONTAINER.calculate_auth_data (lz_file, args.auth, args.key_file, args.out_dir, args.hash_type)
     sign_file = os.path.join (args.out_dir, args.sign_file)
     data.extend (b'\xff' * get_padding_length(len(data)))
     data.extend (auth_data)
@@ -701,7 +703,7 @@ def main():
     cmd_display.add_argument('-t', dest='img_type',  type=str, default='CLASSIC', help='Container Image Type : [NORMAL, CLASSIC, MULTIBOOT]')
     cmd_display.add_argument('-o', dest='out_path',  type=str, default='.', help='Container output directory/file')
     cmd_display.add_argument('-k', dest='key_path',  type=str, default='', help='Input key directory/file')
-    cmd_display.add_argument('-ht', dest='hash_type', type=str, default='SHA2_256', help='Hash Alg for signing')
+    cmd_display.add_argument('-ht', dest='hash_type', type=str, choices=['SHA2_256', 'SHA2_384'], default='SHA2_256', help='Hash Alg for signing')
     cmd_display.add_argument('-cd', dest='comp_dir', type=str, default='', help='Componet image input directory')
     cmd_display.add_argument('-td', dest='tool_dir', type=str, default='', help='Compression tool directory')
     cmd_display.set_defaults(func=create_container)
@@ -722,7 +724,7 @@ def main():
     cmd_display.add_argument('-f',  dest='comp_file',  type=str, required=True, help='Component input file path')
     cmd_display.add_argument('-c',  dest='compress', choices=['lz4', 'lzma', 'dummy'], default='dummy', help='compression algorithm')
     cmd_display.add_argument('-k',  dest='key_file',  type=str, default='', help='Private key file path to sign component')
-    cmd_display.add_argument('-ht', dest='hash_type', type=str, default='SHA2_256', help='Hash Alg for signing')
+    cmd_display.add_argument('-ht', dest='hash_type', type=str, choices=['SHA2_256', 'SHA2_384'], default='SHA2_256', help='Hash Alg for signing')
     cmd_display.add_argument('-od', dest='out_dir',  type=str, default='.', help='Output directory')
     cmd_display.add_argument('-td', dest='tool_dir', type=str, default='', help='Compression tool directory')
     cmd_display.set_defaults(func=replace_component)
@@ -732,9 +734,9 @@ def main():
     cmd_display.add_argument('-f',  dest='comp_file',  type=str, required=True, help='Component input file path')
     cmd_display.add_argument('-o',  dest='sign_file',  type=str, default='', help='Signed output image name')
     cmd_display.add_argument('-c',  dest='compress', choices=['lz4', 'lzma', 'dummy'],  default='dummy', help='compression algorithm')
-    cmd_display.add_argument('-a',  dest='auth', choices=['rsa2048', 'sha256', 'none'], default='none',  help='authentication algorithm')
+    cmd_display.add_argument('-a',  dest='auth', choices=['SHA2_256', 'SHA2_384', 'RSA2048', 'RSA3072' 'none'], default='none',  help='authentication algorithm')
     cmd_display.add_argument('-k',  dest='key_file',  type=str, default='', help='Private key file path to sign component')
-    cmd_display.add_argument('-ht', dest='hash_type', type=str, default='SHA2_256', help='Hash Alg for signing')
+    cmd_display.add_argument('-ht', dest='hash_type', type=str,  choices=['SHA2_256', 'SHA2_384'], default='SHA2_256', help='Signing Hash Alg when auth type is RSA2048,RSA3072')
     cmd_display.add_argument('-od', dest='out_dir',  type=str, default='.', help='Output directory')
     cmd_display.add_argument('-td', dest='tool_dir', type=str, default='',  help='Compression tool directory')
     cmd_display.set_defaults(func=sign_component)

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -140,7 +140,7 @@ class BaseBoard(object):
         self.LOGO_FILE              = 'Platform/CommonBoardPkg/Logo/Logo.bmp'
 
         self.RSA_SIGN_TYPE          = 'RSA2048'
-        self.SIGN_HASH_TYPE         = 'SHA2_256'
+        self.SIGN_HASH_TYPE         = HASH_TYPE_VALUE['SHA2_256']
         self.VERINFO_IMAGE_ID       = 'SB_???? '
         self.VERINFO_PROJ_ID        = 1
         self.VERINFO_CORE_MAJOR_VER = 0
@@ -507,7 +507,7 @@ class Build(object):
 
         hash_idx   = 0
         hash_store = HashStoreTable.from_buffer(stage1_bins, hs_offset)
-        hash_len   = HASH_DIGEST_SIZE[self._board.SIGN_HASH_TYPE]
+        hash_len   = HASH_DIGEST_SIZE[HASH_VAL_STRING[self._board.SIGN_HASH_TYPE]]
         hash_store_data_buf = bytearray()
         hash_store.UsedLength = sizeof(HashStoreTable())
         for hash_file, usage in hash_file_list:
@@ -527,7 +527,7 @@ class Build(object):
             # update hash data
             hashstoredata = HashStoreData()
             hashstoredata.Usage   = usage
-            hashstoredata.HashAlg = HASH_TYPE_VALUE[self._board.SIGN_HASH_TYPE]
+            hashstoredata.HashAlg = self._board.SIGN_HASH_TYPE
             hashstoredata.DigestLen = hash_len
 
             hash_store.UsedLength += hash_len + sizeof(HashStoreData())
@@ -887,7 +887,7 @@ class Build(object):
                     if src == 'STAGE2.fd':
                         raise Exception ("STAGE2.fd must be compressed, please change BoardConfig.py file !")
                 if src not in rgn_name_list:
-                    gen_hash_file (src_path, self._board.SIGN_HASH_TYPE, '', False)
+                    gen_hash_file (src_path, HASH_VAL_STRING[self._board.SIGN_HASH_TYPE], '', False)
 
                 if mode != STITCH_OPS.MODE_FILE_NOP:
                     dst_path = bas_path + '.pad'
@@ -1033,7 +1033,7 @@ class Build(object):
         key_hash_list = []
         mst_key = None
         if self._board.HAVE_VERIFIED_BOOT:
-            hash_store_size = sizeof(HashStoreTable) + (sizeof(HashStoreData) + HASH_DIGEST_SIZE[self._board.SIGN_HASH_TYPE]) * HashStoreTable().HASH_STORE_MAX_IDX_NUM
+            hash_store_size = sizeof(HashStoreTable) + (sizeof(HashStoreData) + HASH_DIGEST_SIZE[HASH_VAL_STRING[self._board.SIGN_HASH_TYPE]]) * HashStoreTable().HASH_STORE_MAX_IDX_NUM
             gen_file_with_size (os.path.join(self._fv_dir, 'HashStore.bin'), hash_store_size)
 
             #Intialize with HashStoreTable
@@ -1050,7 +1050,7 @@ class Build(object):
         else:
             self._board.VERIFIED_BOOT_HASH_MASK = 0
 
-        gen_pub_key_hash_store (mst_key, key_hash_list, self._board.SIGN_HASH_TYPE,
+        gen_pub_key_hash_store (mst_key, key_hash_list, HASH_VAL_STRING[self._board.SIGN_HASH_TYPE],
                                 self._key_dir, os.path.join(self._fv_dir, 'KEYHASH.bin'))
 
         # create fit table
@@ -1098,14 +1098,14 @@ class Build(object):
             mst_priv_key     = self._board._MASTER_PRIVATE_KEY
             mst_pub_key_file = os.path.join(self._fv_dir, "MSTKEY.bin")
             gen_pub_key (mst_priv_key, mst_pub_key_file)
-            gen_hash_file (mst_pub_key_file, self._board.SIGN_HASH_TYPE, '', True)
+            gen_hash_file (mst_pub_key_file, HASH_VAL_STRING[self._board.SIGN_HASH_TYPE], '', True)
 
         # create configuration data
         if self._board.CFGDATA_SIZE > 0:
             # create config data files
             gen_config_file (self._fv_dir, self._board.BOARD_PKG_NAME, self._board._PLATFORM_ID,
                              self._board._CFGDATA_PRIVATE_KEY, self._board.CFG_DATABASE_SIZE, self._board.CFGDATA_SIZE,
-                             self._board._CFGDATA_INT_FILE, self._board._CFGDATA_EXT_FILE, self._board.SIGN_HASH_TYPE)
+                             self._board._CFGDATA_INT_FILE, self._board._CFGDATA_EXT_FILE, HASH_VAL_STRING[self._board.SIGN_HASH_TYPE])
 
         # rebuild reset vector
         vtf_dir = os.path.join('BootloaderCorePkg', 'Stage1A', 'Ia32', 'Vtf0')
@@ -1181,7 +1181,7 @@ class Build(object):
         # generate payload
         gen_payload_bin (self._fv_dir, self._pld_list,
                          os.path.join(self._fv_dir, "PAYLOAD.bin"),
-                         self._board._CONTAINER_PRIVATE_KEY, self._board.BOARD_PKG_NAME)
+                         self._board._CONTAINER_PRIVATE_KEY, HASH_VAL_STRING[self._board.SIGN_HASH_TYPE], self._board.BOARD_PKG_NAME)
 
         # create firmware update key
         if self._board.ENABLE_FWU:
@@ -1201,7 +1201,7 @@ class Build(object):
         if getattr(self._board, "GetContainerList", None):
           container_list = self._board.GetContainerList ()
           component_dir = os.path.join(os.environ['PLT_SOURCE'], 'Platform', self._board.BOARD_PKG_NAME, 'Binaries')
-          gen_container_bin (container_list, self._fv_dir, component_dir, self._key_dir, '', self._board.SIGN_HASH_TYPE)
+          gen_container_bin (container_list, self._fv_dir, component_dir, self._key_dir, '', HASH_VAL_STRING[self._board.SIGN_HASH_TYPE])
 
         # patch stages
         self.patch_stages ()


### PR DESCRIPTION
 Enable RSA3072 and SHA384 signing support

    This patch introduces support for RSA3K and SHA384 signing
    And verifications support to Slimbootloader. Component hash
    verification is done using PcdCompSignHashAlg.

    To enable RSA3072 and SHA384,
     - Signing hash algorithm SIGN_HASH_TYPE should be set to ‘SHA2_384’
     - RSA 3K private keys should be configured in platform board configs.
     - Set IPP_CRYPTO_ALG_MASK to inlcude SHA2_384
     - Enable required IPP_CRYPTO_OPTIMIZATION_MASK
     - Default siging hash type is set to SHA2_256. Use hash type option
       while using the tools as Gencontainer, CfgDataTool in standalone
      mode.

Pending: Measured boot support for SHA384  to be enabled.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>