### PR TITLE
Execute version check only for SBL update

### DIFF
--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -362,6 +362,14 @@ VerifyFwVersion (
 
   CurrentBlVersion = NULL;
   CapsuleBlVersion = NULL;
+
+  //
+  // For now - Perform version check only for Slim Bootloader
+  //
+  if (CompareGuid(&ImageHdr->UpdateImageTypeId, &gSblFWUpdateImageFileGuid) != 0) {
+    return EFI_SUCCESS;
+  }
+
   //
   // Get base address of Stage 1A from current firmware
   //


### PR DESCRIPTION
This patch will run version check only for SBL update and will
skip for all other components.

Version check for all other components will be added in future
patches.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>