### PR TITLE
TPM and Measured boot support SHA384 and SM3

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -230,6 +230,16 @@
   # @Prompt Minimum length(in bytes) of the system preboot TCG event log area(LAML).
   gPlatformCommonLibTokenSpaceGuid.PcdTcgLogAreaMinLen|0x10000|UINT32|0x00010081
 
+[PcdsDynamic]
+  ## This PCD indicates the PCR bank to be enabled/supported by Slim Bootloader for measured boot
+  #  Based on the value set, PCR bank world be enabled and extended
+  #  This PCD could be updated based on TPM hash alg info from Config data blob
+  #     0x00000001    - SHA1.<BR>
+  #     0x00000002    - SHA2_256.<BR>
+  #     0x00000004    - SHA2_384.<BR>
+  #     0x00000008    - SHA2_512.<BR>
+  #     0x00000010    - SM3_256.<BR>
+  gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashMask    |         0x00000002 | UINT32  | 0x20000703
 
 
 [PcdsFeatureFlag]

--- a/BootloaderCommonPkg/Include/Library/ContainerLib.h
+++ b/BootloaderCommonPkg/Include/Library/ContainerLib.h
@@ -9,6 +9,8 @@
 #define _CONTAINER_LIB_H_
 
 #include <Library/PcdLib.h>
+#include <Library/CryptoLib.h>
+
 
 #define CONTAINER_LIST_SIGNATURE SIGNATURE_32('C','T','N', 'L')
 
@@ -33,7 +35,16 @@ typedef UINT8 AUTH_TYPE;
 // Attributes for COMPONENT_ENTRY
 #define COMPONENT_ENTRY_ATTR_RESERVED       BIT7
 
-typedef VOID (*LOAD_COMPONENT_CALLBACK) (UINT32 ProgressId);
+
+typedef struct {
+  UINT32           ComponentType;
+  UINT8           *CompBuf;
+  UINT32           CompLen;
+  HASH_ALG_TYPE    HashAlg;
+  UINT8           *HashData;
+} COMPONENT_CALLBACK_INFO;
+
+typedef VOID (*LOAD_COMPONENT_CALLBACK) (UINT32 ProgressId, COMPONENT_CALLBACK_INFO *CbInfo);
 
 typedef struct {
   UINT32           Signature;

--- a/BootloaderCommonPkg/Include/Library/TpmLib.h
+++ b/BootloaderCommonPkg/Include/Library/TpmLib.h
@@ -129,11 +129,39 @@ TpmExtendPcrAndLogEvent (
 
 
 /**
-  Retrieve hash of a firmware stage from Component hash table and extend it
-  in PCR 0 with EV_POST_CODE event type.
+  Extend Config Data Hash provided into PCR 1 with Ext Config Data event type.
 
-  @param[in] ComponentType    Stage whose measurement need to be extended.
-  @param[in] Signature        Signature of the component
+  @param[in] Digest                    Hash Digest to extend
+  @param[in] HashAlg                   Hash Alg to extend
+  @param[in] Src                       Config Buffer Address
+  @param[in] CfgDataLen                Data Len
+
+  @retval RETURN_SUCCESS               Operation completed successfully.
+  @retval RETURN_INVALID_PARAMETER     Invalid Digest  buf
+
+  @retval Others                       Unable to extend stage hash.
+**/
+RETURN_STATUS
+TpmExtendConfigData (
+  IN       UINT8            *Digest,
+  IN       HASH_ALG_TYPE     HashAlg,
+  IN       UINT8            *Src,
+  IN       UINT32            CfgDataLen
+  );
+
+
+/**
+  Extend hash of a firmware stage component. in PCR 0 with EV_POST_CODE event type
+  Hash extend would be in either of ways
+  Check Hash and Hash Alg provided and extend if they are valid
+  Retriev Hash from Component hash table
+  Calcluate Hash using source buf and length provided
+
+  @param[in] ComponentType             Stage whose measurement need to be extended.
+  @param[in] Digest                    Hash Digest to extend
+  @param[in] HashDataAlg               Hash Alg to extend
+  @param[in] Src                       Buffer Address
+  @param[in] CfgDataLen                Data Len
 
   @retval RETURN_SUCCESS      Operation completed successfully.
   @retval Others              Unable to extend stage hash.
@@ -141,25 +169,10 @@ TpmExtendPcrAndLogEvent (
 RETURN_STATUS
 TpmExtendStageHash (
   IN       UINT8            ComponentType,
-  IN       UINT32           Signature
-  );
-
-
-/**
-  Extend  hash provided in PCR 0 with EV_POST_CODE event type.
-
-  @param[in] Digest                    Hash Digest to extend
-  @param[in] HashAlg                   Hash Alg to extend
-
-  @retval RETURN_SUCCESS               Operation completed successfully.
-  @retval RETURN_INVALID_PARAMETER     Imvalid Digest  buf
-
-  @retval Others                       Unable to extend stage hash.
-**/
-RETURN_STATUS
-TpmExtendHash (
-  IN       UINT8            *Src,
-  IN       HASH_ALG_TYPE     HashAlg
+  IN       UINT8           *HashData,
+  IN       HASH_ALG_TYPE    HashDataAlg,
+  IN       UINT8           *Src,
+  IN       UINT32           Length
   );
 
 /**

--- a/BootloaderCommonPkg/Include/Library/TpmLib.h
+++ b/BootloaderCommonPkg/Include/Library/TpmLib.h
@@ -11,6 +11,8 @@
 #include <IndustryStandard/Tpm20.h>
 #include <IndustryStandard/UefiTcgPlatform.h>
 #include <IndustryStandard/Tpm2Acpi.h>
+#include <Library/CryptoLib.h>
+
 
 #define ACPI_SSDT_TPM2_DEVICE_OEM_TABLE_ID  SIGNATURE_64('T', 'p', 'm', '2', 'T', 'a', 'b', 'l')
 
@@ -79,6 +81,30 @@ MeasureSeparatorEvent (
 
 
 /**
+Hash and Extend a PCR and log it into TCG event log.
+
+@param[in] PcrHandle    PCR index to extend.
+@param[in] Data         Data pointer.
+@param[in] Length       Data Length.
+@param[in] EventType    EventType to be logged in TCG Event log.
+@param[in] EventSize    size of the event.
+@param[in] Event        Event data.
+
+@retval RETURN_SUCCESS      Operation completed successfully.
+@retval Others              Unable to extend PCR.
+**/
+RETURN_STATUS
+TpmHashAndExtendPcrEventLog (
+IN         TPMI_DH_PCR               PcrHandle,
+IN         UINT8                     *Data,
+IN         UINT32                    Length,
+IN         TCG_EVENTTYPE             EventType,
+IN         UINT32                    EventSize,
+IN  CONST  UINT8                     *Event
+);
+
+
+/**
   Extend a PCR and log it into TCG event log.
 
   @param[in] PcrHandle    PCR index to extend.
@@ -107,13 +133,15 @@ TpmExtendPcrAndLogEvent (
   in PCR 0 with EV_POST_CODE event type.
 
   @param[in] ComponentType    Stage whose measurement need to be extended.
+  @param[in] Signature        Signature of the component
 
   @retval RETURN_SUCCESS      Operation completed successfully.
   @retval Others              Unable to extend stage hash.
 **/
 RETURN_STATUS
 TpmExtendStageHash (
-  IN       UINT8            ComponentType
+  IN       UINT8            ComponentType,
+  IN       UINT32           Signature
   );
 
 
@@ -121,7 +149,7 @@ TpmExtendStageHash (
   Extend  hash provided in PCR 0 with EV_POST_CODE event type.
 
   @param[in] Digest                    Hash Digest to extend
-  @param[in] HashAlg                   Tcg Alg to extend
+  @param[in] HashAlg                   Hash Alg to extend
 
   @retval RETURN_SUCCESS               Operation completed successfully.
   @retval RETURN_INVALID_PARAMETER     Imvalid Digest  buf
@@ -130,8 +158,8 @@ TpmExtendStageHash (
 **/
 RETURN_STATUS
 TpmExtendHash (
-  IN       UINT8            *Digest,
-  IN       UINT8             HashAlg
+  IN       UINT8            *Src,
+  IN       HASH_ALG_TYPE     HashAlg
   );
 
 /**
@@ -162,5 +190,18 @@ TpmLogEvent (
 RETURN_STATUS
 TpmIndicateReadyToBoot (
   VOID
+  );
+
+
+/**
+  Get Crypto Lib Hash alg required by bootloader.
+
+  @param  TcgAlgMask    TCG Alg Mask
+
+  @retval CryptoHashAlg Crypo Hash Alg.
+**/
+UINT8
+GetCryptoHashAlg (
+  UINT32 TcgAlgMask
   );
 #endif  // _TPM_LIB_H

--- a/BootloaderCommonPkg/Library/SecureBootLib/SecureBootHash.c
+++ b/BootloaderCommonPkg/Library/SecureBootLib/SecureBootHash.c
@@ -39,7 +39,6 @@ CalculateHash  (
   UINT8 DigestSize;
   UINT8 *HashRetVal;
 
-
   if(Digest != NULL){
     if (HashAlg == HASH_TYPE_SHA256) {
       HashRetVal = Sha256 (Data, Length, Digest);

--- a/BootloaderCommonPkg/Library/TpmLib/Tpm2Help.c
+++ b/BootloaderCommonPkg/Library/TpmLib/Tpm2Help.c
@@ -12,6 +12,7 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
+#include <Library/CryptoLib.h>
 
 typedef struct {
   TPMI_ALG_HASH              HashAlgo;

--- a/BootloaderCommonPkg/Library/TpmLib/TpmEventLog.c
+++ b/BootloaderCommonPkg/Library/TpmLib/TpmEventLog.c
@@ -259,10 +259,28 @@ TpmLogSpecIDEvent (
   if ((ActivePcr & HASH_ALG_SHA256) != 0) {
     DigestSize[NumberOfAlgorithms].algorithmId = TPM_ALG_SHA256;
     DigestSize[NumberOfAlgorithms].digestSize = SHA256_DIGEST_SIZE;
-
-    DigestSize = &DigestSize[1];
-    ++NumberOfAlgorithms;
+    NumberOfAlgorithms++;
   }
+
+  if ((ActivePcr & HASH_ALG_SHA384) != 0) {
+    DigestSize[NumberOfAlgorithms].algorithmId = TPM_ALG_SHA384;
+    DigestSize[NumberOfAlgorithms].digestSize = SHA384_DIGEST_SIZE;
+    NumberOfAlgorithms++;
+  }
+
+  if ((ActivePcr & HASH_ALG_SHA512) != 0) {
+    DigestSize[NumberOfAlgorithms].algorithmId = TPM_ALG_SHA512;
+    DigestSize[NumberOfAlgorithms].digestSize = SHA512_DIGEST_SIZE;
+    NumberOfAlgorithms++;
+  }
+
+  if ((ActivePcr & HASH_ALG_SM3_256) != 0) {
+    DigestSize[NumberOfAlgorithms].algorithmId = TPM_ALG_SM3_256;
+    DigestSize[NumberOfAlgorithms].digestSize = SM3_DIGEST_SIZE;
+    NumberOfAlgorithms++;
+  }
+
+  DigestSize = &DigestSize[NumberOfAlgorithms];
 
   CopyMem (SpecIdEvent + 1, &NumberOfAlgorithms, sizeof (NumberOfAlgorithms));
 
@@ -345,13 +363,13 @@ TpmLogEvent (
 **/
 VOID
 TpmLogLocalityEvent (
-  IN UINT8 StartupLocality
+  IN UINT8 StartupLocality,
+  IN UINT32 ActivePcrBanks
   )
 {
   TCG_EfiStartupLocalityEvent     StartupLocalityEvent;
   TCG_PCR_EVENT2_HDR              PcrEventHdr;
   TPML_DIGEST_VALUES              *Digests;
-  UINT32                          ActivePcrBanks;
   TPM_LIB_PRIVATE_DATA            *TpmLibData;
 
   CopyMem (StartupLocalityEvent.Signature, TCG_EfiStartupLocalityEvent_SIGNATURE,
@@ -366,15 +384,28 @@ TpmLogLocalityEvent (
   Digests = &PcrEventHdr.Digests;
   Digests->count = 0;
 
-  ActivePcrBanks = HASH_ALG_SHA256;
   TpmLibData = TpmLibGetPrivateData ();
   if (TpmLibData != NULL) {
     ActivePcrBanks = TpmLibData->ActivePcrBanks;
   }
-
   if ((ActivePcrBanks & HASH_ALG_SHA256) != 0) {
     Digests->digests[Digests->count].hashAlg = TPM_ALG_SHA256;
     ZeroMem (& (Digests->digests[Digests->count].digest), GetHashSizeFromAlgo (TPM_ALG_SHA256));
+    Digests->count = Digests->count + 1;
+  }
+  if ((ActivePcrBanks & HASH_ALG_SHA384) != 0) {
+    Digests->digests[Digests->count].hashAlg = TPM_ALG_SHA384;
+    ZeroMem (& (Digests->digests[Digests->count].digest), GetHashSizeFromAlgo (TPM_ALG_SHA384));
+    Digests->count = Digests->count + 1;
+  }
+  if ((ActivePcrBanks & HASH_ALG_SHA512) != 0) {
+    Digests->digests[Digests->count].hashAlg = TPM_ALG_SHA512;
+    ZeroMem (& (Digests->digests[Digests->count].digest), GetHashSizeFromAlgo (TPM_ALG_SHA512));
+    Digests->count = Digests->count + 1;
+  }
+  if ((ActivePcrBanks & HASH_ALG_SM3_256) != 0) {
+    Digests->digests[Digests->count].hashAlg = TPM_ALG_SM3_256;
+    ZeroMem (& (Digests->digests[Digests->count].digest), GetHashSizeFromAlgo (TPM_ALG_SM3_256));
     Digests->count = Digests->count + 1;
   }
 

--- a/BootloaderCommonPkg/Library/TpmLib/TpmEventLog.h
+++ b/BootloaderCommonPkg/Library/TpmLib/TpmEventLog.h
@@ -46,7 +46,8 @@ TpmLogSpecIDEvent (
 **/
 VOID
 TpmLogLocalityEvent (
-  IN UINT8 StartupLocality
+  IN UINT8 StartupLocality,
+  IN UINT32 ActivePcrBank
   );
 
 #endif //_TPM_EVENT_LIB_H_

--- a/BootloaderCommonPkg/Library/TpmLib/TpmLib.inf
+++ b/BootloaderCommonPkg/Library/TpmLib/TpmLib.inf
@@ -41,6 +41,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdTcgLogAreaMinLen          ## CONSUMES
   gPlatformCommonLibTokenSpaceGuid.PcdTpmLibId                  ## CONSUMES
   gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled       ## CONSUMES
+  gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashMask      ## CONSUMES
 
 [LibraryClasses]
   BaseLib

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -313,6 +313,7 @@
 
 [PcdsDynamicDefault]
   gEfiMdePkgTokenSpaceGuid.PcdPlatformBootTimeOut         | 2
+  gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashMask | 0x00000002
 
 ###############################################################################
 ##

--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -83,6 +83,7 @@ typedef struct {
 
 typedef struct {
   UINT32        PayloadBase;
+  UINT32        CfgDataAddr;
   UINT8         ConfigDataHashValid;
   UINT8         ConfigDataHash[HASH_DIGEST_MAX];
 } STAGE1B_PARAM;

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -75,7 +75,7 @@ PrepareStage2 (
 
   // Extend hash of Stage2 image into TPM.
   if (MEASURED_BOOT_ENABLED() && (GetBootMode() != BOOT_ON_S3_RESUME)) {
-    TpmExtendStageHash (COMP_TYPE_STAGE_2);
+    TpmExtendStageHash (COMP_TYPE_STAGE_2, FLASH_MAP_SIG_STAGE2);
     AddMeasurePoint (0x20C0);
   }
 

--- a/BootloaderCorePkg/Stage2/Stage2.inf
+++ b/BootloaderCorePkg/Stage2/Stage2.inf
@@ -131,6 +131,7 @@
   gPlatformModuleTokenSpaceGuid.PcdSmbiosTablesSize
   gPlatformModuleTokenSpaceGuid.PcdSmbiosEnabled
   gPlatformModuleTokenSpaceGuid.PcdLinuxPayloadEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashMask
 
 [Depex]
   TRUE

--- a/PayloadPkg/OsLoader/OsLoader.h
+++ b/PayloadPkg/OsLoader/OsLoader.h
@@ -136,7 +136,7 @@ typedef struct {
   IMAGE_DATA              IasImage;
   EFI_HANDLE              HwPartHandle;
   LOADED_IMAGE_TYPE       Image;
-  UINT8                   ImageHash[SHA256_DIGEST_SIZE];
+  UINT8                   ImageHash[HASH_DIGEST_MAX];
   RESERVED_CMDLINE_DATA   ReservedCmdlineData;
 } LOADED_IMAGE;
 


### PR DESCRIPTION
Current Slimbootloader supports only TPM for SHA256 PCR
This patch introduces flexibility for user to select TPM
PCR bank available while build. Support of SHA384 and
SM3 to TPM measured boot are added.

For first boot SHA256/default TPM PCR would be available which
is default for most supported TPM's. Selected TPM PCR will be
available after reboot.

TPM selection would be based on config data and support would
be added in subsequent patches.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>