### PR TITLE
Pass Hash Alg param for verifying hash data with RsaVerify

### DIFF
--- a/BootloaderCommonPkg/Include/Library/ContainerLib.h
+++ b/BootloaderCommonPkg/Include/Library/ContainerLib.h
@@ -17,6 +17,7 @@
 #define PROGESS_ID_AUTHENTICATE       3
 #define PROGESS_ID_DECOMPRESS         4
 
+typedef UINT8 AUTH_TYPE;
 #define AUTH_TYPE_NONE                0
 #define AUTH_TYPE_SHA2_256            1
 #define AUTH_TYPE_SHA2_384            2

--- a/BootloaderCommonPkg/Include/Library/CryptoLib.h
+++ b/BootloaderCommonPkg/Include/Library/CryptoLib.h
@@ -38,6 +38,7 @@ typedef UINT8 KEY_TYPE;
 #define RSA_E_SIZE                       4   //hardcode e size to be 4
 
 typedef UINT8 HASH_ALG_TYPE;
+#define  HASH_TYPE_NONE                  0
 #define  HASH_TYPE_SHA256                1
 #define  HASH_TYPE_SHA384                2
 #define  HASH_TYPE_SHA512                3

--- a/BootloaderCommonPkg/Include/Library/SecureBootLib.h
+++ b/BootloaderCommonPkg/Include/Library/SecureBootLib.h
@@ -71,6 +71,7 @@ DoHashVerify (
   @param[in]  Usage           Hash usage.
   @param[in]  SignatureHdr    Signature header for singanture data.
   @param[in]  PubKeyHdr       Public key header for key data
+  @param[in]  PubKeyHashAlg   Hash Alg for PubKeyHash.
   @param[in]  PubKeyHash      Public key hash value when ComponentType is not used.
   @param[out] OutHash         Calculated data hash value.
 
@@ -88,6 +89,7 @@ DoRsaVerify (
   IN       HASH_COMP_USAGE  Usage,
   IN CONST SIGNATURE_HDR   *SignatureHdr,
   IN       PUB_KEY_HDR     *PubKeyHdr,
+  IN       UINT8            PubKeyHashAlg,
   IN       UINT8           *PubKeyHash      OPTIONAL,
   OUT      UINT8           *OutHash         OPTIONAL
   );

--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
@@ -231,6 +231,32 @@ LocateComponentEntryFromContainer (
 }
 
 /**
+  This function returns the hash alg type from auth type.
+
+  @param[in] AuthType    Authorization Type.
+
+  @retval         Hash Algorithm Type.
+
+**/
+HASH_ALG_TYPE
+GetHashAlg(
+  AUTH_TYPE AuthType
+  )
+{
+  HASH_ALG_TYPE HashAlg;
+
+  HashAlg = HASH_TYPE_NONE;
+
+  if(AuthType == AUTH_TYPE_SIG_RSA2048_SHA256){
+    HashAlg = HASH_TYPE_SHA256;
+  } else if (AuthType == AUTH_TYPE_SIG_RSA3072_SHA384){
+    HashAlg = HASH_TYPE_SHA384;
+  }
+
+  return HashAlg;
+}
+
+/**
   Authenticate a container header or component.
 
   @param[in] Data         Data buffer to be authenticated.
@@ -273,7 +299,7 @@ AuthenticateComponent (
       SignHdr  = (SIGNATURE_HDR *) SigPtr;
       KeyPtr   = (UINT8 *)SignHdr + sizeof(SIGNATURE_HDR) + SignHdr->SigSize ;
       Status   = DoRsaVerify (Data, Length, Usage, SignHdr,
-                             (PUB_KEY_HDR *) KeyPtr, HashData, NULL);
+                             (PUB_KEY_HDR *) KeyPtr, GetHashAlg(AuthType), HashData, NULL);
     } else if (AuthType == AUTH_TYPE_NONE) {
       Status = EFI_SUCCESS;
     } else {

--- a/BootloaderCommonPkg/Library/IasImageLib/IasImage.c
+++ b/BootloaderCommonPkg/Library/IasImageLib/IasImage.c
@@ -105,7 +105,7 @@ IsIasImageValid (
 
 
   Status = DoRsaVerify ((CONST UINT8 *)Hdr, ((UINT32)IAS_PAYLOAD_END (Hdr)) - ((UINT32)Hdr),
-                         HASH_USAGE_PUBKEY_OS, SignHdr, PubKeyHdr, NULL, ImageHash);
+                         HASH_USAGE_PUBKEY_OS, SignHdr, PubKeyHdr, PcdGet8(PcdCompSignHashAlg), NULL, ImageHash);
   if (EFI_ERROR (Status) != EFI_SUCCESS) {
     DEBUG ((DEBUG_ERROR, "IAS image verification failed!\n"));
     return NULL;

--- a/BootloaderCommonPkg/Library/IasImageLib/IasImageLib.inf
+++ b/BootloaderCommonPkg/Library/IasImageLib/IasImageLib.inf
@@ -40,3 +40,4 @@
 
 [Pcd]
   gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdCompSignHashAlg

--- a/BootloaderCommonPkg/Library/SecureBootLib/SecureBootRsa.c
+++ b/BootloaderCommonPkg/Library/SecureBootLib/SecureBootRsa.c
@@ -22,6 +22,7 @@
   @param[in]  Usage           Hash usage.
   @param[in]  Signature       Signature header for singanture data.
   @param[in]  PubKeyHdr       Public key header for key data
+  @param[in]  PubKeyHashAlg   Hash Alg for PubKeyHash.
   @param[in]  PubKeyHash      Public key hash value when ComponentType is not used.
   @param[out] OutHash         Calculated data hash value.
 
@@ -39,6 +40,7 @@ DoRsaVerify (
   IN       HASH_COMP_USAGE  Usage,
   IN CONST SIGNATURE_HDR   *SignatureHdr,
   IN       PUB_KEY_HDR     *PubKeyHdr,
+  IN       UINT8            PubKeyHashAlg,
   IN       UINT8           *PubKeyHash      OPTIONAL,
   OUT      UINT8           *OutHash         OPTIONAL
   )
@@ -55,7 +57,7 @@ DoRsaVerify (
   }
 
   // Verify public key first
-  Status = DoHashVerify (PublicKey->KeyData, PublicKey->KeySize, Usage, SignatureHdr->HashAlg, PubKeyHash);
+  Status = DoHashVerify (PublicKey->KeyData, PublicKey->KeySize, Usage, PubKeyHashAlg, PubKeyHash);
   if (RETURN_ERROR (Status)) {
     return Status;
   }

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -156,7 +156,7 @@ AppendHashStore (
     SignHdr   = (SIGNATURE_HDR *) AuthInfo;
     PubKeyHdr = (PUB_KEY_HDR *)((UINT8 *)SignHdr + sizeof(SIGNATURE_HDR) + SignHdr->SigSize);
     Status = DoRsaVerify ((UINT8 *)OemKeyHashBlob, OemKeyHashBlob->UsedLength,
-                          HASH_USAGE_PUBKEY_MASTER, SignHdr, PubKeyHdr, NULL, NULL);
+                          HASH_USAGE_PUBKEY_MASTER, SignHdr, PubKeyHdr, PcdGet8(PcdCompSignHashAlg), NULL, NULL);
   }
   if (EFI_ERROR (Status)) {
     return EFI_SECURITY_VIOLATION;
@@ -225,7 +225,7 @@ CreateConfigDatabase (
         SignHdr   = (SIGNATURE_HDR *)((UINT8 *) CfgBlob + CfgBlob->UsedLength);
         PubKeyHdr = (PUB_KEY_HDR *)((UINT8 *)SignHdr + sizeof(SIGNATURE_HDR) + SignHdr->SigSize);
         Status  = DoRsaVerify ((UINT8 *)CfgBlob, CfgBlob->UsedLength, HASH_USAGE_PUBKEY_CFG_DATA,
-                    SignHdr, PubKeyHdr, NULL, Stage1bParam->ConfigDataHash);
+                    SignHdr, PubKeyHdr, PcdGet8(PcdCompSignHashAlg), NULL, Stage1bParam->ConfigDataHash);
         if (EFI_ERROR (Status)) {
           DEBUG ((DEBUG_INFO, "EXT CFG Data ignored ... %r\n", Status));
           ExtCfgAddPtr = NULL;

--- a/BootloaderCorePkg/Stage1B/Stage1B.inf
+++ b/BootloaderCorePkg/Stage1B/Stage1B.inf
@@ -97,6 +97,7 @@
   gPlatformModuleTokenSpaceGuid.PcdEarlyLogBufferSize
   gPlatformModuleTokenSpaceGuid.PcdLogBufferSize
   gPlatformModuleTokenSpaceGuid.PcdCfgDataIntBase
+  gPlatformCommonLibTokenSpaceGuid.PcdCompSignHashAlg
 
 [Depex]
   TRUE

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -855,7 +855,7 @@ AuthenticateCapsule (
     }
   }
 
-  Status    = DoRsaVerify (FwImage, Header->SignatureOffset, HASH_USAGE_PUBKEY_FWU, SignatureHdr, PubKeyHdr, NULL, NULL);
+  Status    = DoRsaVerify (FwImage, Header->SignatureOffset, HASH_USAGE_PUBKEY_FWU, SignatureHdr, PubKeyHdr, PcdGet8(PcdCompSignHashAlg), NULL, NULL);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "Image verification failed, %r!\n", Status));
     return EFI_SECURITY_VIOLATION;

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
@@ -66,6 +66,7 @@
   gPayloadTokenSpaceGuid.PcdRsvdRegionBase
   gPlatformCommonLibTokenSpaceGuid.PcdLowestSupportedFwVer
   gPayloadTokenSpaceGuid.PcdCsmeUpdateEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdCompSignHashAlg
 
 [Depex]
   TRUE


### PR DESCRIPTION
Hash verification of Public key hash should be based on
hash alg used with Hash store. Previously hash alg in
signature info is used. There would be instances where
hashstore hash algorithm differs from signing alg.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>