### PR TITLE
Python3 Next() compatibility fix

### DIFF
--- a/BootloaderCorePkg/Tools/CommonUtility.py
+++ b/BootloaderCorePkg/Tools/CommonUtility.py
@@ -243,7 +243,7 @@ def rsa_sign_file (priv_key, pub_key, hash_type, in_file, out_file, inc_dat = Fa
 def get_key_type (in_key):
     pub_key = gen_pub_key (in_key)
     pub_key_hdr = PUB_KEY_HDR.from_buffer(pub_key)
-    key_type = (key for key, value in PUB_KEY_TYPE.items() if value == pub_key_hdr.KeyType).next()
+    key_type = next((key for key, value in PUB_KEY_TYPE.items() if value == pub_key_hdr.KeyType))
     return '%s%d' % (key_type, (pub_key_hdr.KeySize - 4) * 8)
 
 def gen_pub_key (in_key, pub_key = None):

--- a/BootloaderCorePkg/Tools/GenContainer.py
+++ b/BootloaderCorePkg/Tools/GenContainer.py
@@ -355,7 +355,7 @@ class CONTAINER ():
     def locate_component (self, comp_name):
         component = None
         for each in self.header.comp_entry:
-            if each.name == comp_name.upper():
+            if each.name.decode() == comp_name.upper():
                 component = each
                 break;
         return component


### PR DESCRIPTION
In Python 3 built-in function next() is used to get the next result
from an iterator. next method causes post build failure.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>