### PR TITLE
Enforce Python 3.6 or above for build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - chmod -R a+w .
 
 env:
-  - BUILD_TARGET=qemu  PYTHON_VER=2
+  - BUILD_TARGET=qemu  PYTHON_VER=3
   - BUILD_TARGET=apl   PYTHON_VER=2  BUILD_REL=-r
   - BUILD_TARGET=apl   PYTHON_VER=3
   - BUILD_TARGET=cfl   PYTHON_VER=2

--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -2,7 +2,7 @@
 ## @ BuildUtility.py
 # Build bootloader main script
 #
-# Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2020, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -783,6 +783,19 @@ def gen_ver_info_txt (ver_file, ver_info):
     h_file.write('Dirty         = %d\n'    % ver_info.ImageVersion.Dirty)
     h_file.close()
 
+def check_for_python():
+    '''
+    Verify Python executable is at required version
+    '''
+    cmd = [sys.executable, '-c', 'import sys; import platform; print(platform.python_version())']
+    version = run_process (cmd, capture_out = True).strip()
+    ver_parts = version.split('.')
+    # Require Python 3.6 or above
+    if not (len(ver_parts) >= 2 and int(ver_parts[0]) >= 3 and int(ver_parts[1]) >= 6):
+        print('WARNING: Python version %s is unsupported, potential build issue might encounter !\n         '
+              'Please consider installing and using Python 3.6 or above to launch build script !\n') % version
+
+    return version
 
 def check_for_openssl():
     '''

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -2,7 +2,7 @@
 ## @ BuildLoader.py
 # Build bootloader main script
 #
-# Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2020, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 
 ##
@@ -25,20 +25,11 @@ import multiprocessing
 from   ctypes import *
 from   BuildUtility import *
 
+
 def rebuild_basetools ():
     exe_list = 'GenFfs  GenFv  GenFw  GenSec  Lz4Compress  LzmaCompress'.split()
     ret = 0
     sblsource = os.environ['SBL_SOURCE']
-
-    cmd = [sys.executable, '-c', 'import sys; import platform; print(", ".join([sys.executable, platform.python_version()]))']
-    py_out = run_process (cmd, capture_out = True)
-    parts  = py_out.split(',')
-    if len(parts) > 1:
-        py_exe, py_ver = parts
-        os.environ['PYTHON_COMMAND'] = py_exe
-        print ('Using %s, Version %s' % (os.environ['PYTHON_COMMAND'], py_ver.rstrip()))
-    else:
-        os.environ['PYTHON_COMMAND'] = 'python'
 
     if os.name == 'posix':
         if not check_files_exist (exe_list, os.path.join(sblsource, 'BaseTools', 'Source', 'C', 'bin')):
@@ -55,6 +46,11 @@ def rebuild_basetools ():
         sys.exit(1)
 
 def prep_env ():
+    # check python version first
+    version = check_for_python ()
+    os.environ['PYTHON_COMMAND'] = sys.executable
+    print ('Using %s, Version %s' % (os.environ['PYTHON_COMMAND'], version.strip()))
+
     sblsource = os.path.dirname(os.path.realpath(__file__))
     os.chdir(sblsource)
     if os.name == 'posix':


### PR DESCRIPTION
Since Python 2.7 is EOL already. SBL needs to drop the support.
This patch enforced the python version to be 3.6 or above for SBL
build.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>