### PR TITLE
GenContainer: Converge hash param and auth type usage

### DIFF
--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -539,10 +539,11 @@ def gen_payload_bin (fv_dir, pld_list, pld_bin, priv_key, hash_alg, brd_name = N
     alignment = 0x10
     key_dir  = os.path.dirname (priv_key)
     key_type = get_key_type(priv_key)
-    pld_list = [('EPLD', '%s' % epld_bin, '', key_type, '%s' % os.path.basename(priv_key), alignment, 0)]
+    auth_type = key_type + '_' + hash_alg
+    pld_list = [('EPLD', '%s' % epld_bin, '', auth_type, '%s' % os.path.basename(priv_key), alignment, 0)]
     for pld in ext_list:
         pld_list.append ((pld['name'], pld['file'], pld['algo'], hash_alg, '', 0, 0))
-    gen_container_bin ([pld_list], fv_dir, fv_dir, key_dir, '', hash_alg)
+    gen_container_bin ([pld_list], fv_dir, fv_dir, key_dir, '')
 
 def pub_key_valid (pubkey):
     if (len(pubkey) - sizeof(PUB_KEY_HDR)) in [0x104, 0x184]:

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -1201,7 +1201,7 @@ class Build(object):
         if getattr(self._board, "GetContainerList", None):
           container_list = self._board.GetContainerList ()
           component_dir = os.path.join(os.environ['PLT_SOURCE'], 'Platform', self._board.BOARD_PKG_NAME, 'Binaries')
-          gen_container_bin (container_list, self._fv_dir, component_dir, self._key_dir, '', HASH_VAL_STRING[self._board.SIGN_HASH_TYPE])
+          gen_container_bin (container_list, self._fv_dir, component_dir, self._key_dir, '')
 
         # patch stages
         self.patch_stages ()

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -173,12 +173,12 @@ class Board(BaseBoard):
         container_list.append ([
           # Name       | Image File |    CompressAlg  | AuthType   | Key File                     | Region Align | Region Size
           # ===================================================================================================================================
-          ('IPFW',      'SIIPFW.bin',    '',           'RSA2048',   'TestSigningPrivateKey.pem',    0,            0     ),   # Container Header
+          ('IPFW',      'SIIPFW.bin',    '',           'RSA2048_SHA2_256',   'TestSigningPrivateKey.pem',    0,            0     ),   # Container Header
           ('TST1',      '',              'Dummy',      '',          '',                             0,            0x2000),   # Component 1
           ('TST2',      '',              'Lz4',        '',          '',                             0,            0x3000),   # Component 2
-          ('TST3',      '',              'Lz4',        'RSA2048',   'TestSigningPrivateKey.pem',    0,            0x3000),   # Component 3
+          ('TST3',      '',              'Lz4',        'RSA2048_SHA2_256',   'TestSigningPrivateKey.pem',    0,            0x3000),   # Component 3
           ('TST4',      '',              'Lzma',       'SHA2_256',  '',                             0,            0x3000),   # Component 4
-          ('TST5',      '',              'Dummy',      'RSA2048',   'TestSigningPrivateKey.pem',    0,            0x3000),   # Component 5
+          ('TST5',      '',              'Dummy',      'RSA2048_SHA2_256',   'TestSigningPrivateKey.pem',    0,            0x3000),   # Component 5
           ('TST6',      '',              '',           '',          '',                             0,            0x1000),   # Component 6
         ])
         return container_list


### PR DESCRIPTION
In GenContainer tool auth definitions for RSA cases were
updated to include hash alg used. In current implementation
auth type is generated from hash type and private key while
container created. This patch removes hash type param
and auth type is used for hash alg generation.

Platform code to be updated as per updated auth definitions

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>