### PR TITLE
[Stage1] Add Stage1 stack base setup offset

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -66,6 +66,7 @@
 
   gPlatformModuleTokenSpaceGuid.PcdStage1StackSize        | 0x00000000 | UINT32 | 0x20000060
   gPlatformModuleTokenSpaceGuid.PcdStage1DataSize         | 0x00000000 | UINT32 | 0x20000061
+  gPlatformModuleTokenSpaceGuid.PcdStage1StackBaseOffset  | 0x00000000 | UINT32 | 0x20000062
   gPlatformModuleTokenSpaceGuid.PcdCfgDatabaseSize        | 0x00000000 | UINT32 | 0x20000063
   gPlatformModuleTokenSpaceGuid.PcdStage2LoadHigh         | FALSE      | BOOLEAN| 0x20000068
   gPlatformModuleTokenSpaceGuid.PcdPayloadLoadHigh        | FALSE      | BOOLEAN| 0x20000069

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -190,6 +190,7 @@
   gPlatformModuleTokenSpaceGuid.PcdStage2FvSize           | $(STAGE2_FV_SIZE)
 
   gPlatformModuleTokenSpaceGuid.PcdStage1StackSize        | $(STAGE1_STACK_SIZE)
+  gPlatformModuleTokenSpaceGuid.PcdStage1StackBaseOffset  | $(STAGE1_STACK_BASE_OFFSET)
   gPlatformModuleTokenSpaceGuid.PcdStage1DataSize         | $(STAGE1_DATA_SIZE)
   gPlatformModuleTokenSpaceGuid.PcdStage2LoadHigh         | $(STAGE2_LOAD_HIGH)
 

--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -62,7 +62,11 @@ typedef struct {
   UINT32        CarBase;
   UINT32        CarTop;
   UINT64        TimeStamp;
-  UINT32        CpuBist;
+  struct _STATUS {
+    UINT32      CpuBist           :  1;
+    UINT32      StackOutOfRange   :  1;
+    UINT32      RsvdBits          : 30;
+  } Status;
 } STAGE1A_ASM_PARAM;
 
 typedef struct {

--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -336,8 +336,12 @@ SecStartup2 (
     DEBUG ((DEBUG_INIT, "\n%a\n", mBootloaderName));
   }
 
-  if (Stage1aAsmParam->CpuBist != 0) {
+  if (Stage1aAsmParam->Status.CpuBist != 0) {
     CpuHalt ("CPU BIST failure!\n");
+  }
+
+  if (Stage1aAsmParam->Status.StackOutOfRange != 0) {
+    CpuHalt ("Stack base offset is too big!\n");
   }
 
   if (FlashMap == NULL) {
@@ -407,7 +411,7 @@ SecStartup (
   // Init global data
   LdrGlobal = &LdrGlobalData;
   ZeroMem (LdrGlobal, sizeof (LOADER_GLOBAL_DATA));
-  StackTop = Stage1aAsmParam->CarBase + PcdGet32 (PcdStage1StackSize);
+  StackTop = (UINT32)(UINTN)Params + sizeof (STAGE1A_ASM_PARAM);
   LdrGlobal->Signature             = LDR_GDATA_SIGNATURE;
   LdrGlobal->LoaderStage           = LOADER_STAGE_1A;
   LdrGlobal->StackTop              = StackTop;

--- a/BootloaderCorePkg/Stage1A/Stage1A.inf
+++ b/BootloaderCorePkg/Stage1A/Stage1A.inf
@@ -65,7 +65,7 @@
   gPlatformModuleTokenSpaceGuid.PcdHashStoreBase
   gPlatformModuleTokenSpaceGuid.PcdVerInfoBase
   gPlatformModuleTokenSpaceGuid.PcdStage1DataSize
-  gPlatformModuleTokenSpaceGuid.PcdStage1StackSize
+  gPlatformModuleTokenSpaceGuid.PcdStage1StackBaseOffset
   gPlatformModuleTokenSpaceGuid.PcdStage1BXip
   gPlatformModuleTokenSpaceGuid.PcdCfgDatabaseSize
   gPlatformModuleTokenSpaceGuid.PcdStage1AXip

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -206,6 +206,7 @@ class BaseBoard(object):
 
         self.STAGE1A_XIP           = 1
         self.STAGE1B_XIP           = 1
+        self.STAGE1_STACK_BASE_OFFSET = 0x00000000
         self.STAGE2_XIP            = 0
         self.STAGE2_LOAD_HIGH      = 1
         self.PAYLOAD_LOAD_HIGH     = 1


### PR DESCRIPTION
This patch allows to setup Stage1 stack/data in any CAR range.
By default, the stack base offset is 0 from CarBase.

Signed-off-by: Aiden Park <aiden.park@intel.com>