### PR TITLE
Added support for container component update-from-OS

### DIFF
--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -592,7 +592,7 @@ AuthenticateCapsule (
     }
   }
 
-  Status    = DoRsaVerify (FwImage, Header->SignatureOffset, HASH_USAGE_PUBKEY_FWU, SignatureHdr, PubKeyHdr, PcdGet8(PcdCompSignHashAlg), NULL, NULL);
+  Status = DoRsaVerify (FwImage, Header->SignatureOffset, HASH_USAGE_PUBKEY_FWU, SignatureHdr, PubKeyHdr, PcdGet8(PcdCompSignHashAlg), NULL, NULL);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "Image verification failed, %r!\n", Status));
     return EFI_SECURITY_VIOLATION;
@@ -894,7 +894,7 @@ ApplyFwImage (
     }
     break;
   default:
-    break;
+    Status = UpdateSblComponent (ImageHdr);
   }
 
   return Status;

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
@@ -45,6 +45,7 @@
   SecureBootLib
   LiteFvLib
   ConfigDataLib
+  ContainerLib
 
 [Guids]
   gLoaderMemoryMapInfoGuid

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
@@ -171,4 +171,20 @@ EFI_STATUS
 UpdateSystemFirmware (
   IN EFI_FW_MGMT_CAP_IMAGE_HEADER  *ImageHdr
   );
+
+/**
+  Perform Slim Bootloader component update.
+
+  This function will try to locate component in the flash map,
+  if found, will update the component.
+
+  @param[in] ImageHdr       Pointer to fw mgmt capsule Image header
+
+  @retval  EFI_SUCCESS      Update successful.
+  @retval  other            error occurred during firmware update
+**/
+EFI_STATUS
+UpdateSblComponent (
+  IN EFI_FW_MGMT_CAP_IMAGE_HEADER  *ImageHdr
+  );
 #endif


### PR DESCRIPTION
This patch added routines to support update for any
component identified by flash map. Also, if the capsule
container components inside the container, Support is added
to update these container components.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>