### PR TITLE
Free memory using FreePages instead of Freepool

### DIFF
--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
@@ -24,27 +24,6 @@
 **/
 EFI_STATUS
 EFIAPI
-UpdateRegionLessthan4k (
-  IN  UINT64    Address,
-  IN  VOID      *Buffer,
-  IN  UINT32    Length
-  );
-
-/**
-  Update a region block.
-
-  This is the acture function to update boot meia. It will erase boot device,
-  write new data to boot device, and verify the written data.
-
-  @param[in] Address          The boot media address to be update.
-  @param[in] Buffer           The source buffer to write to the boot media.
-  @param[in] Length           The length of data to write to boot media.
-
-  @retval  EFI_SUCCESS        Update successfully.
-  @retval  others             Error happening when updating.
-**/
-EFI_STATUS
-EFIAPI
 UpdateRegionBlock (
   IN  UINT64    Address,
   IN  VOID      *Buffer,


### PR DESCRIPTION
Allocate pages is used now to allocate memory during block update
but was freed using freepool which is throwing exception. Changed
code to use FreePages

Also removed an unused function

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>