### PR TITLE
Add a common api to patch PSS table

### DIFF
--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.h
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.h
@@ -73,30 +73,8 @@
 #define IOC_UART_PPR_CLK_M_DIV        0x40
 #define R_XHCI_MEM_DUAL_ROLE_CFG0     0x80D8
 
-#define NATIVE_PSTATE_LATENCY         10
-#define PSTATE_BM_LATENCY             10
 #define FVID_MAX_POWER                35000
 #define FVID_MIN_POWER                15000
-
-#pragma pack (1)
-typedef struct {
-  UINT8     NameOp;           // 12h ; First opcode is a NameOp
-  UINT8     PackageLead;      // 20h ; Package OpCode
-  UINT8     NumEntries;       // 06h ; Number of entries
-  UINT8     DwordPrefix1;     // 0Ch
-  UINT32    CoreFrequency;    // 00h
-  UINT8     DwordPrefix2;     // 0Ch
-  UINT32    Power;            // 00h
-  UINT8     DwordPrefix3;     // 0Ch
-  UINT32    TransLatency;     // 00h
-  UINT8     DwordPrefix4;     // 0Ch
-  UINT32    BMLatency;        // 00h
-  UINT8     DwordPrefix5;     // 0Ch
-  UINT32    Control;          // 00h
-  UINT8     DwordPrefix6;     // 0Ch
-  UINT32    Status;           // 00h
-} PSS_PACKAGE_LAYOUT;
-#pragma pack()
 
 typedef struct {
   UINT32    VendorDeviceId;   // Codec Vendor/Device ID

--- a/Platform/CommonBoardPkg/Include/Library/BoardSupportLib.h
+++ b/Platform/CommonBoardPkg/Include/Library/BoardSupportLib.h
@@ -12,6 +12,22 @@
 #include <Library/FirmwareUpdateLib.h>
 
 /**
+  A function pointer to get relative power number in mW
+
+  @param[in]  BaseRatio     Base bus ratio
+  @param[in]  CurrRatio     Current bus ratio to get relative power
+  @param[in]  BasePower     Base power number in mW
+
+  @retval                   Calculated power number in mW
+
+**/
+typedef UINT32 (EFIAPI *GET_RELATIVE_POWER_FUNC) (
+  UINT16  BaseRatio,
+  UINT16  CurrRatio,
+  UINT32  BasePower
+  );
+
+/**
   Fill the boot option list data with CFGDATA info
 
   @param[in, out]   OsBootOptionList pointer to boot option list.
@@ -70,6 +86,36 @@ SpiLoadExternalConfigData (
 EFI_STATUS
 CheckStateMachine (
   IN FW_UPDATE_STATUS    *pFwUpdStatus
+  );
+
+/**
+  Patch ACPI CPU Pss Table
+
+  This function will patch PSS table. Caller MUST guarantee valid table address.
+
+  @param[in,out]  PssTableAddr      Pointer to PSS Table to be updated
+  @param[in]      TurboBusRatio     Turbo bus ratio
+  @param[in]      MaxBusRatio       Maximum bus ratio
+  @param[in]      MinBusRatio       Mimimum bus ratio
+  @param[in]      PackageMaxPower   Maximum package power
+  @param[in]      PackageMinPower   Minimum package power
+  @param[in]      GetRelativePower  A func pointer to get relative power
+  @param[in]      DoListAll         List all from LFM to Turbo
+
+  @retval         EFI_SUCCESS       Patch done successfully
+  @retval         others            Error occured during patching the table
+
+**/
+EFI_STATUS
+AcpiPatchPssTable (
+  IN OUT  UINT8                          *PssTableAddr,
+  IN      UINT16                          TurboBusRatio,
+  IN      UINT16                          MaxBusRatio,
+  IN      UINT16                          MinBusRatio,
+  IN      UINT32                          PackageMaxPower,
+  IN      UINT32                          PackageMinPower,
+  IN      GET_RELATIVE_POWER_FUNC         GetRelativePower, OPTIONAL
+  IN      BOOLEAN                         DoListAll
   );
 
 #endif

--- a/Silicon/CoffeelakePkg/Include/CpuPowerMgmt.h
+++ b/Silicon/CoffeelakePkg/Include/CpuPowerMgmt.h
@@ -618,29 +618,6 @@ typedef struct {
   UINT16 VrVoltageLimit;
 } CPU_VR_OVERRIDE_TABLE;
 
-//
-// ASL PSS package structure layout
-//
-#pragma pack (1)
-typedef struct {
-  UINT8     NameOp;           // 12h ;First opcode is a NameOp.
-  UINT8     PackageLead;      // 20h ;First opcode is a NameOp.
-  UINT8     NumEntries;       // 06h ;First opcode is a NameOp.
-  UINT8     DwordPrefix1;     // 0Ch
-  UINT32    CoreFrequency;    // 00h
-  UINT8     DwordPrefix2;     // 0Ch
-  UINT32    Power;            // 00h
-  UINT8     DwordPrefix3;     // 0Ch
-  UINT32    TransLatency;     // 00h
-  UINT8     DwordPrefix4;     // 0Ch
-  UINT32    BmLatency;        // 00h
-  UINT8     DwordPrefix5;     // 0Ch
-  UINT32    Control;          // 00h
-  UINT8     DwordPrefix6;     // 0Ch
-  UINT32    Status;           // 00h
-} PSS_PACKAGE_LAYOUT;
-
-
 ///
 /// MSR_REGISTER definition as a Union of QWORDS, DWORDS and BYTES
 ///

--- a/Silicon/CoffeelakePkg/Include/PowerMgmtNvsStruct.h
+++ b/Silicon/CoffeelakePkg/Include/PowerMgmtNvsStruct.h
@@ -19,25 +19,4 @@ typedef struct _CPU_NVS_AREA_CONFIG {
   CPU_NVS_AREA *Area;
 } CPU_NVS_AREA_CONFIG;
 
-typedef struct _FVID_HEADER {
-  UINT32 Stepping;    ///< Matches value returned by CPUID function 1
-  UINT16 MaxBusRatio; ///< Matches BUS_RATIO_MAX field in PERF_STS_MSR
-  UINT16 EistStates;  ///< Number of states of FVID (N)
-} FVID_HEADER;
-
-typedef struct _FVID_STATE {
-  UINT32 State;           ///< State Number (0 - N-1)
-  UINT16 BusRatio;        ///< BUS_RATIO_SEL value to be written to PERF_CTL
-  UINT32 Power;           ///< Typical power consumed by CPU in this state
-  UINT32 Limit16State;    ///< State Number (0 - N-1) with limit 16 P-states
-  UINT16 Limit16BusRatio; ///< BUS_RATIO_SEL value to be written to PERF_CTL with limit 16 P-states
-  UINT32 Limit16Power;    ///< Typical power consumed by CPU in this state with limit 16 P-states
-} FVID_STATE;
-
-typedef union _FVID_TABLE {
-  FVID_HEADER FvidHeader;
-  FVID_STATE  FvidState;
-  UINT64      FvidData;
-} FVID_TABLE;
-
 #endif

--- a/Silicon/CoffeelakePkg/Include/Register/CpuRegs.h
+++ b/Silicon/CoffeelakePkg/Include/Register/CpuRegs.h
@@ -56,4 +56,8 @@
 #define MSR_PRMRR_PHYS_BASE                                           0x1F4
 #define MSR_PRMRR_PHYS_MASK                                           0x1F5
 
+#define MSR_TURBO_RATIO_LIMIT                                         0x000001AD
+#define MSR_PACKAGE_POWER_SKU_UNIT                                    0x00000606
+#define MSR_PACKAGE_POWER_LIMIT                                       0x00000610
+
 #endif


### PR DESCRIPTION
This will allow update PSS table in a common way.
For a platform specific power calculation,
a function pointer can be provided.

Signed-off-by: Aiden Park <aiden.park@intel.com>