### PR TITLE
Update AcpiPatchPssTable() parameter

### DIFF
--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1455,23 +1455,24 @@ CpuPssPatch (
 {
   MSR_REGISTER        PlatformInfoMsr;
   MSR_REGISTER        TurboRatioLimit;
-  UINT16              MaxBusRatio;
-  UINT16              MinBusRatio;
-  UINT16              TurboBusRatio;
+  PSS_PARAMS          PssParams;
 
   // Determine the bus ratio range
   PlatformInfoMsr.Qword = AsmReadMsr64 (MSR_PLATFORM_INFO);
-  MaxBusRatio           = PlatformInfoMsr.Bytes.SecondByte;
-  MinBusRatio           = PlatformInfoMsr.Bytes.SixthByte;
+  PssParams.MaxBusRatio = PlatformInfoMsr.Bytes.SecondByte;
+  PssParams.MinBusRatio = PlatformInfoMsr.Bytes.SixthByte;
   if ((Gnvs->CpuNvs.PpmFlags & PPM_TURBO) != 0) {
     TurboRatioLimit.Qword = AsmReadMsr64 (MSR_TURBO_RATIO_LIMIT);
-    TurboBusRatio = (UINT8) (TurboRatioLimit.Dwords.Low & B_MSR_TURBO_RATIO_LIMIT_1C);
+    PssParams.TurboBusRatio = (UINT16) (TurboRatioLimit.Dwords.Low & B_MSR_TURBO_RATIO_LIMIT_1C);
   } else {
-    TurboBusRatio = 0;
+    PssParams.TurboBusRatio = 0;
   }
+  PssParams.PackageMaxPower = FVID_MAX_POWER;
+  PssParams.PackageMinPower = FVID_MIN_POWER;
+  PssParams.GetRelativePower = NULL;
+  PssParams.DoListAll = TRUE;
 
-  AcpiPatchPssTable (PssTbl, TurboBusRatio, MaxBusRatio, MinBusRatio,
-    FVID_MAX_POWER, FVID_MIN_POWER, NULL, TRUE);
+  AcpiPatchPssTable (PssTbl, &PssParams);
 
   return;
 }

--- a/Platform/CommonBoardPkg/Include/Library/BoardSupportLib.h
+++ b/Platform/CommonBoardPkg/Include/Library/BoardSupportLib.h
@@ -28,6 +28,28 @@ typedef UINT32 (EFIAPI *GET_RELATIVE_POWER_FUNC) (
   );
 
 /**
+  All PSS calculation related parameters. GetRelativePower can be optional.
+
+  @param[in]      TurboBusRatio     Turbo bus ratio
+  @param[in]      MaxBusRatio       Maximum bus ratio
+  @param[in]      MinBusRatio       Mimimum bus ratio
+  @param[in]      PackageMaxPower   Maximum package power
+  @param[in]      PackageMinPower   Minimum package power
+  @param[in]      GetRelativePower  A func pointer to get relative power
+  @param[in]      DoListAll         List all from LFM to Turbo
+
+**/
+typedef struct {
+  UINT16                    TurboBusRatio;
+  UINT16                    MaxBusRatio;
+  UINT16                    MinBusRatio;
+  UINT32                    PackageMaxPower;
+  UINT32                    PackageMinPower;
+  GET_RELATIVE_POWER_FUNC   GetRelativePower;
+  BOOLEAN                   DoListAll;
+} PSS_PARAMS;
+
+/**
   Fill the boot option list data with CFGDATA info
 
   @param[in, out]   OsBootOptionList pointer to boot option list.
@@ -94,28 +116,15 @@ CheckStateMachine (
   This function will patch PSS table. Caller MUST guarantee valid table address.
 
   @param[in,out]  PssTableAddr      Pointer to PSS Table to be updated
-  @param[in]      TurboBusRatio     Turbo bus ratio
-  @param[in]      MaxBusRatio       Maximum bus ratio
-  @param[in]      MinBusRatio       Mimimum bus ratio
-  @param[in]      PackageMaxPower   Maximum package power
-  @param[in]      PackageMinPower   Minimum package power
-  @param[in]      GetRelativePower  A func pointer to get relative power
-  @param[in]      DoListAll         List all from LFM to Turbo
-
+  @param[in]      PssParams         All PSS calculation related info
   @retval         EFI_SUCCESS       Patch done successfully
   @retval         others            Error occured during patching the table
 
 **/
 EFI_STATUS
 AcpiPatchPssTable (
-  IN OUT  UINT8                          *PssTableAddr,
-  IN      UINT16                          TurboBusRatio,
-  IN      UINT16                          MaxBusRatio,
-  IN      UINT16                          MinBusRatio,
-  IN      UINT32                          PackageMaxPower,
-  IN      UINT32                          PackageMinPower,
-  IN      GET_RELATIVE_POWER_FUNC         GetRelativePower, OPTIONAL
-  IN      BOOLEAN                         DoListAll
+  IN OUT        UINT8                    *PssTableAddr,
+  IN      CONST PSS_PARAMS               *PssParams
   );
 
 #endif

--- a/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.c
+++ b/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.c
@@ -338,45 +338,50 @@ PatchPssEntry (
   This function will patch PSS table. Caller MUST guarantee valid table address.
 
   @param[in,out]  PssTableAddr      Pointer to PSS Table to be updated
-  @param[in]      TurboBusRatio     Turbo bus ratio
-  @param[in]      MaxBusRatio       Maximum bus ratio
-  @param[in]      MinBusRatio       Mimimum bus ratio
-  @param[in]      PackageMaxPower   Maximum package power
-  @param[in]      PackageMinPower   Minimum package power
-  @param[in]      GetRelativePower  A func pointer to get relative power
-  @param[in]      DoListAll         List all from LFM to Turbo
-
+  @param[in]      PssParams         All PSS calculation related info
   @retval         EFI_SUCCESS       Patch done successfully
   @retval         others            Error occured during patching the table
 
 **/
 EFI_STATUS
 AcpiPatchPssTable (
-  IN OUT  UINT8                          *PssTableAddr,
-  IN      UINT16                          TurboBusRatio,
-  IN      UINT16                          MaxBusRatio,
-  IN      UINT16                          MinBusRatio,
-  IN      UINT32                          PackageMaxPower,
-  IN      UINT32                          PackageMinPower,
-  IN      GET_RELATIVE_POWER_FUNC         GetRelativePower, OPTIONAL
-  IN      BOOLEAN                         DoListAll
+  IN OUT        UINT8                    *PssTableAddr,
+  IN      CONST PSS_PARAMS               *PssParams
   )
 {
-  UINT16                Turbo;
-  UINT16                MaxNumberOfStates;
-  UINT16                NumberOfStates;
-  UINT16                BusRatioRange;
-  UINT32                PowerRange;
-  UINT32                PowerStep;
-  UINT32                Power;
-  UINT16                NewPackageLength;
-  UINT16                Index;
-  UINT16               *PackageLength;
-  PSS_PACKAGE_LAYOUT   *PssPackage;
+  UINT16                    Turbo;
+  UINT16                    MaxNumberOfStates;
+  UINT16                    NumberOfStates;
+  UINT16                    BusRatioRange;
+  UINT32                    PowerRange;
+  UINT32                    PowerStep;
+  UINT32                    Power;
+  UINT16                    NewPackageLength;
+  UINT16                    Index;
+  UINT16                   *PackageLength;
+  PSS_PACKAGE_LAYOUT       *PssPackage;
+  UINT16                    TurboBusRatio;
+  UINT16                    MaxBusRatio;
+  UINT16                    MinBusRatio;
+  UINT32                    PackageMaxPower;
+  UINT32                    PackageMinPower;
+  GET_RELATIVE_POWER_FUNC   GetRelativePower;
+  BOOLEAN                   DoListAll;
 
-  if (PssTableAddr == NULL) {
+  if ((PssTableAddr == NULL) || (PssParams == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
+
+  //
+  // PSS params will be updated. Copy input params to keep the original(CONST).
+  //
+  TurboBusRatio = PssParams->TurboBusRatio;
+  MaxBusRatio = PssParams->MaxBusRatio;
+  MinBusRatio = PssParams->MinBusRatio;
+  PackageMaxPower = PssParams->PackageMaxPower;
+  PackageMinPower = PssParams->PackageMinPower;
+  GetRelativePower = PssParams->GetRelativePower;
+  DoListAll = PssParams->DoListAll;
 
   DEBUG ((DEBUG_VERBOSE, "PssTable 0x%p, TurboBusRatio %d, MaxBusRatio %d, "
     "MinBusRatio %d, PackageMaxPower %d, PackageMinPower %d, "


### PR DESCRIPTION
There are many parameter passing to AcpiPatchPssTable().
A single PSS_PARAMS structure pointer will be passed to simplify.

Signed-off-by: Aiden Park <aiden.park@intel.com>