### PR TITLE
Avoid hardcoded flashmap address

### DIFF
--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -47,8 +47,8 @@ GetFlashMapBufInfo (
   UINT32         Stage1aFvBase;
 
   FlashMap      = NULL;
-  FlashMapBase  = (* (UINT32 *)FLASH_MAP_ADDRESS);
   Stage1aFvBase = PcdGet32 (PcdStage1AFdBase) + PcdGet32 (PcdFSPTSize);
+  FlashMapBase  = (* (UINT32 *)(UINT32)(Stage1aFvBase + PcdGet32 (PcdStage1AFvSize) + FLASH_MAP_ADDRESS));
   if ( (FlashMapBase > Stage1aFvBase) && \
        (FlashMapBase + sizeof(FLASH_MAP) < Stage1aFvBase + PcdGet32 (PcdStage1AFvSize) - 1) ) {
     // Verify FLASH_MAP is valid before access


### PR DESCRIPTION
Current FLASH_MAP address is hard-coded at 0xFFFFFFF8. It will work
in most of the cases.  However, if region is added on top of the
Stage1A FV, it will cause FLASH_MAP address shift.  Instead, the code
can use relative address to locate FLASH_MAP.  The address can be
calculated with (Stage1AFvBase + Stage1AFvSize + 0xFFFFFFF8).

Signed-off-by: Maurice Ma <maurice.ma@intel.com>