### PR TITLE
OsLoader clean-up to use common LinuxLib

### DIFF
--- a/BootloaderCommonPkg/Include/Library/LinuxLib.h
+++ b/BootloaderCommonPkg/Include/Library/LinuxLib.h
@@ -220,12 +220,13 @@ LoadBzImage (
 /**
   Update linux kernel boot parameters.
 
-  @retval EFI_SUCCESS        Linux boot parameters were updated successfully.
+  @param[in]  Bp             BootParams address to be updated
+
 **/
 VOID
 EFIAPI
 UpdateLinuxBootParams (
-  VOID
+  IN  BOOT_PARAMS            *Bp
   );
 
 /**

--- a/PayloadPkg/OsLoader/BootParameters.c
+++ b/PayloadPkg/OsLoader/BootParameters.c
@@ -200,7 +200,7 @@ DEBUG_CODE_BEGIN ();
     DumpMbInfo (&LoadedImage->Image.MultiBoot.MbInfo);
     DumpMbBootState (&LoadedImage->Image.MultiBoot.BootState);
   } else if ((LoadedImage->Flags & LOADED_IMAGE_LINUX) != 0) {
-    DumpLinuxBootParams (LoadedImage->Image.Linux.BootParams);
+    DumpLinuxBootParams (GetLinuxBootParams ());
   }
 DEBUG_CODE_END ();
 }
@@ -315,7 +315,7 @@ UpdateOsParameters (
 
   UpdateOsMemMap (LoadedImage);
   if ((LoadedImage->Flags & LOADED_IMAGE_LINUX) != 0) {
-    LoadedImage->Image.Linux.BootParams->Hdr.CmdlineSize = LoadedImage->Image.Linux.CmdFile.Size;
+    GetLinuxBootParams ()->Hdr.CmdlineSize = LoadedImage->Image.Linux.CmdFile.Size;
   }
   DEBUG ((DEBUG_INFO, "\nDump normal boot image info:\n"));
   DisplayInfo (LoadedImage);

--- a/PayloadPkg/OsLoader/OsLoader.h
+++ b/PayloadPkg/OsLoader/OsLoader.h
@@ -115,7 +115,6 @@ typedef struct {
   UINT16                  Reserved;
   UINT16                  ExtraBlobNumber;
   IMAGE_DATA              ExtraBlob[MAX_EXTRA_FILE_NUMBER];
-  BOOT_PARAMS             *BootParams;
 } LINUX_IMAGE;
 
 typedef struct {
@@ -359,20 +358,6 @@ UINT8
 GetNextBootOption (
   IN OS_BOOT_OPTION_LIST     *OsBootOptionList,
   IN UINT8                   BootOptionIndex
-  );
-
-/**
-  ASM function that goes into kernel image.
-
-  @param  KernelStart        Pointer to the start of kernel.
-  @param  KernelBootParams   Pointer to the boot parameter structure.
-
- **/
-VOID
-EFIAPI
-JumpToKernel (
-  VOID *KernelStart,
-  VOID *KernelBootParams
   );
 
 /**

--- a/PayloadPkg/OsLoader/PreOsChecker.c
+++ b/PayloadPkg/OsLoader/PreOsChecker.c
@@ -130,6 +130,7 @@ StartPreOsChecker (
   if (OsBootParam == NULL) {
     return EFI_INVALID_PARAMETER;
   }
+  UpdateLinuxBootParams (OsBootParam);
 
   PreOsParams.Version     = 0x1;
   PreOsParams.HeapSize    = EFI_SIZE_TO_PAGES (0);


### PR DESCRIPTION
This will allow OsLoader to use LinuxLib for legacy linux boot
and remove duplicated code.

Signed-off-by: Aiden Park <aiden.park@intel.com>