### PR TITLE
Fix QEMU Flash read issue after erasing

### DIFF
--- a/Silicon/QemuSocPkg/Library/SpiFlashLib/SpiFlashLib.c
+++ b/Silicon/QemuSocPkg/Library/SpiFlashLib/SpiFlashLib.c
@@ -406,5 +406,9 @@ SpiFlashErase (
     Ptr += 0x1000;
   }
 
+  if (ByteCount > 0) {
+    *(Ptr - 1) = READ_ARRAY_CMD;
+  }
+
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
After erasing flash on QEMU, it needs to be returned to normal
read state to allow normal read access. However, this is missing
in current SBL QEMU SpiFlashLib.  This patched added the code to
switch back to read mode. It also fixed #552.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>