### PR TITLE
Fix several minor issues in the code

### DIFF
--- a/BootloaderCommonPkg/Library/BootloaderCommonLib/BootloaderCommonLib.c
+++ b/BootloaderCommonPkg/Library/BootloaderCommonLib/BootloaderCommonLib.c
@@ -390,6 +390,10 @@ GetComponentInfoByPartition (
   }
 
   FlashMapPtr = GetFlashMapPtr ();
+  if (FlashMapPtr == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
   RomBase = (UINT32) (0x100000000ULL - FlashMapPtr->RomSize);
 
   //
@@ -481,6 +485,10 @@ GetComponentHash (
 
   HashEntryPtr = HashStorePtr->Data;
   HashEndPtr   = (UINT8 *) HashStorePtr +  HashStorePtr->UsedLength;
+
+  if (HashEntryPtr >= HashEndPtr) {
+    return EFI_INVALID_PARAMETER;
+  }
 
   while (HashEntryPtr < HashEndPtr) {
 

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -1004,6 +1004,7 @@ InitFirmwareUpdate (
         }
       } else {
         DEBUG((DEBUG_ERROR, "FindImage failed with Status = %r\n", Status));
+        continue;
       }
 
       //

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.c
@@ -458,6 +458,8 @@ UpdateSblComponent (
   EFI_STATUS    Status;
   FLASH_MAP_ENTRY_DESC  *Entry;
 
+  Status = EFI_NOT_FOUND;
+
   DEBUG ((DEBUG_INFO, "UpdateSblComponent : %x \n", (UINT32)ImageHdr->UpdateHardwareInstance));
 
   if ((UINT32)RShiftU64 (ImageHdr->UpdateHardwareInstance, 32)){


### PR DESCRIPTION
1) GetComponentInfoByPartition does not check FlashMapPtr, added code
   to return error if FlashMapPtr is NULL

2) In GetComponentHash function, there is no check for if HashEntryPtr is
   greater than or equal to HashEndPtr. In this case HashEntryData will be
   corrupted.

3) In InitFirmwareUpdate function, if we could not find corresponding image in
   capsule, there is an error message but after that we continue to update
   reserved region based on ImageHdr which is not valid. Added code to continue
   if image is not found in capsule.

4) In UpdateSblComponent function, Status is uninitialized. Initialized Status to
   not found.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>