### PR TITLE
Fix GenCfgData script issue with Python 3

### DIFF
--- a/BootloaderCorePkg/Tools/GenCfgData.py
+++ b/BootloaderCorePkg/Tools/GenCfgData.py
@@ -1539,7 +1539,7 @@ EndList
             if Item['length'] == 0:
                 continue
             if Item['find']:
-                Offset = BinDat.find (Item['find'])
+                Offset = BinDat.find (Item['find'].encode())
                 if Offset >= 0:
                     BaseOff = Offset
                 else:


### PR DESCRIPTION
This patch fixed the GenCfgData failure with Python 3.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>