### PR TITLE
[QEMU] Add test container data print

### DIFF
--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -279,6 +279,9 @@ BoardInit (
     Length = 0;
     Status = LoadComponent (SIGNATURE_32('I', 'P', 'F', 'W'), SIGNATURE_32('T', 'S', 'T', '3'), &Buffer,  &Length);
     DEBUG ((DEBUG_INFO, "Load IP firmware @ %p:0x%X - %r\n", Buffer, Length, Status));
+    if (!EFI_ERROR(Status)) {
+      DumpHex (2, 0, Length > 16 ? 16 : Length, Buffer);
+    }
     break;
 
   case PostPciEnumeration:


### PR DESCRIPTION
This patch printed out the loaded data from the test container.
It is helpful for tool to parse the boot log and verify if the
component inside the container has been loaded properly.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>