### PR TITLE
Fix FPDT size issue

### DIFF
--- a/BootloaderCorePkg/Include/Library/AcpiInitLib.h
+++ b/BootloaderCorePkg/Include/Library/AcpiInitLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -42,17 +42,6 @@ typedef struct {
   EFI_ACPI_5_0_FPDT_PERFORMANCE_TABLE_HEADER  Header;    ///< Common ACPI table header.
   EFI_ACPI_5_0_FPDT_S3_RESUME_RECORD          S3Resume;  ///< Basic S3 Resume performance record.
 } S3_PERFORMANCE_TABLE;
-
-///
-/// This table includes all FPDT related tables.
-/// Make sure the first table is FIRMWARE_PERFORMANCE_TABLE table which would be visible to others.
-/// The other tables would are implementation specific
-///
-typedef struct {
-  FIRMWARE_PERFORMANCE_TABLE             FirmwarePerfTable;
-  BOOT_PERFORMANCE_TABLE                 BootPointerRecord;
-  S3_PERFORMANCE_TABLE                   S3PointerRecord;
-} INTERNAL_FIRMWARE_PERFORMANCE_TABLE;
 
 #pragma pack()
 

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiFpdt.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiFpdt.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -183,13 +183,15 @@ UpdateFpdtS3Table (
   Update Firmware Performance Data Table (FPDT).
 
   @param[in] Table          Pointer of ACPI FPDT Table.
+  @param[out] ExtraSize     Extra size the table needed.
 
   @retval EFI_SUCCESS       Update ACPI FPDT table successfully.
   @retval Others            Failed to update FPDT table.
  **/
 EFI_STATUS
 UpdateFpdt (
-  IN VOID                             *Table
+  IN  UINT8                           *Table,
+  OUT UINT32                          *ExtraSize
   )
 {
   FIRMWARE_PERFORMANCE_TABLE          *Fpdt;
@@ -214,8 +216,10 @@ UpdateFpdt (
     CopyMem (S3PerfTable, &mS3PerformanceTableTemplate, sizeof (mS3PerformanceTableTemplate));
     UpdateFpdtBootTable (BootPerfTable);
 
-    // Fixup FPDT table length
-    Fpdt->Header.Length = sizeof (INTERNAL_FIRMWARE_PERFORMANCE_TABLE);
+    if (ExtraSize != NULL) {
+      *ExtraSize = (UINT8 *) (S3PerfTable + 1) - Table - Fpdt->Header.Length;
+    }
+
   }
 
   return  EFI_SUCCESS;

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -50,14 +50,16 @@ typedef struct {
 /**
   Update Firmware Performance Data Table (FPDT).
 
-  @param[in] Table          Pointer of ACPI FPDT Table.
+  @param[in]  Table         Pointer of ACPI FPDT Table.
+  @param[out] ExtraSize     Extra size the table needed.
 
   @retval EFI_SUCCESS       Update ACPI FPDT table successfully.
   @retval Others            Failed to update FPDT table.
  **/
 EFI_STATUS
 UpdateFpdt (
-  IN VOID                             *Table
+  IN  UINT8                             *Table,
+  OUT UINT32                            *ExtraSize
   );
 
 const EFI_ACPI_5_0_ROOT_SYSTEM_DESCRIPTION_POINTER RsdpTmp = {
@@ -519,6 +521,7 @@ AcpiInit (
   UINT32                    SectionLen;
   UINT32                    UpdateRdstXsdt;
   EFI_STATUS                Status;
+  UINT32                    ExtraSize;
 
   Facs = NULL;
   Dsdt = NULL;
@@ -577,6 +580,7 @@ AcpiInit (
     }
 
     UpdateRdstXsdt = 1;
+    ExtraSize      = 0;
 
     switch (Table->Signature) {
     case EFI_ACPI_5_0_FIXED_ACPI_DESCRIPTION_TABLE_SIGNATURE:
@@ -608,7 +612,7 @@ AcpiInit (
       break;
     case EFI_ACPI_5_0_FIRMWARE_PERFORMANCE_DATA_TABLE_SIGNATURE:
       // FPDT
-      Status = UpdateFpdt (Current);
+      Status = UpdateFpdt (Current, &ExtraSize);
       if (Status != EFI_SUCCESS) {
         return Status;
       }
@@ -641,7 +645,7 @@ AcpiInit (
     SectionLen = * (UINT32 *) (TblPtr - 4) & 0x00FFFFFF;
     TblPtr = TblPtr + ((SectionLen + 3) & ~3);
 
-    TotalSize = ((EFI_ACPI_COMMON_HEADER *)Current)->Length;
+    TotalSize = ((EFI_ACPI_COMMON_HEADER *)Current)->Length + ExtraSize;
     Current += TotalSize;
   }
 

--- a/Platform/CommonBoardPkg/AcpiTables/Fpdt/Fpdt.aslc
+++ b/Platform/CommonBoardPkg/AcpiTables/Fpdt/Fpdt.aslc
@@ -1,7 +1,7 @@
 /**@file
   This file contains a structure definition for the ACPI FPDT Table.
 
-  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -21,16 +21,10 @@
 #define EFI_ACPI_FPDT_CREATOR_ID       SIGNATURE_32('C','R','E','A')
 #define EFI_ACPI_FPDT_CREATOR_REVISION 0x0100000D
 
-INTERNAL_FIRMWARE_PERFORMANCE_TABLE  FPDT = {
-  { //FIRMWARE_PERFORMANCE_TABLE
+FIRMWARE_PERFORMANCE_TABLE  FPDT = {
     {
       EFI_ACPI_5_0_FIRMWARE_PERFORMANCE_DATA_TABLE_SIGNATURE,
-      //
-      // The FPDT table length should be sizeof (FIRMWARE_PERFORMANCE_TABLE).
-      // Here INTERNAL_FIRMWARE_PERFORMANCE_TABLE includes other tables,  later code will
-      // update the tables and this length in runtime.
-      //
-      sizeof (INTERNAL_FIRMWARE_PERFORMANCE_TABLE),
+      sizeof (FIRMWARE_PERFORMANCE_TABLE),
       EFI_ACPI_5_0_FIRMWARE_PERFORMANCE_DATA_TABLE_REVISION,    // Revision
       0x00,                             // Checksum will be updated at runtime
       EFI_ACPI_FPDT_OEM_ID,             // OEMID, a 6 bytes long field
@@ -63,7 +57,6 @@ INTERNAL_FIRMWARE_PERFORMANCE_TABLE  FPDT = {
       0,  // Reserved
       0   // S3PerformanceTablePointer will be updated at runtime.
     }
-  }
 };
 
 


### PR DESCRIPTION
FPDT size should be FIRMWARE_PERFORMANCE_TABLE. And updated
this logic to correct the size and adjust next ACPI table
starting address.

Signed-off-by: Guo Dong <guo.dong@intel.com>