### PR TITLE
Add PCI Enumeration policy info

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -1,7 +1,7 @@
 ## @file
 # Provides bootloader driver related package definitions.
 #
-# Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2020, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -93,6 +93,26 @@
   gPlatformModuleTokenSpaceGuid.PcdOsBootOptionNumber     | 0x00000008 | UINT32 | 0x200000A3
   gPlatformModuleTokenSpaceGuid.PcdServiceNumber          | 0x00000004 | UINT32 | 0x200000A4
 
+  #
+  # typedef struct {
+  #   UINT8           DowngradeIo32;  // default: 1
+  #   UINT8           DowngradeMem64; // default: 1
+  #   UINT8           DowngradePMem64;// default: 1
+  #   UINT8           Reserved;
+  #   UINT8           BusScanType;    // default:0 (0: list, 1: range)
+  #   UINT8           NumOfBus;       // the number of BusScanItems
+  #   UINT8           BusScanItems[0];
+  # } PCI_ENUM_POLICY_INFO;
+  #
+  # Update BoardConfig.py if necessary
+  # self._PCI_ENUM_DOWNGRADE_IO32   = 0
+  # self._PCI_ENUM_DOWNGRADE_MEM64  = 0
+  # self._PCI_ENUM_DOWNGRADE_PMEM64 = 0
+  # self._PCI_ENUM_BUS_SCAN_TYPE    = 1
+  # self._PCI_ENUM_BUS_SCAN_ITEMS   = '0,0xff'
+  gPlatformModuleTokenSpaceGuid.PcdPciEnumPolicyInfo      | {0x00}     | VOID*  | 0x200000A5
+  gPlatformModuleTokenSpaceGuid.PcdPciResourceMem64Base   | 0x0000000000000000  | UINT64     | 0x200000A6
+
   gPlatformModuleTokenSpaceGuid.PcdLoaderHobStackSize     | 0x00040000 | UINT32 | 0x200000B0
   gPlatformModuleTokenSpaceGuid.PcdEarlyLogBufferSize     | 0x00000400 | UINT32 | 0x200000B1
   gPlatformModuleTokenSpaceGuid.PcdLogBufferSize          | 0x00008000 | UINT32 | 0x200000B2
@@ -145,7 +165,6 @@
   gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsPtr       | 0x00000000 | UINT32 | 0x20000198
   gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsCnt       |     0x0000 | UINT16 | 0x20000199
   gPlatformModuleTokenSpaceGuid.PcdFuncCpuInitHook        | 0x00000000 | UINT32 | 0x2000019A
-
 
 [PcdsFeatureFlag]
   # Determine if the Intel GFX device should be enabled or not in system

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -160,6 +160,8 @@
   gPlatformModuleTokenSpaceGuid.PcdPciMmcfgBase           | $(PCI_EXPRESS_BASE)
   gPlatformModuleTokenSpaceGuid.PcdPciResourceIoBase      | $(PCI_IO_BASE)
   gPlatformModuleTokenSpaceGuid.PcdPciResourceMem32Base   | $(PCI_MEM32_BASE)
+  gPlatformModuleTokenSpaceGuid.PcdPciEnumPolicyInfo      | $(PCI_ENUM_POLICY_INFO)
+  gPlatformModuleTokenSpaceGuid.PcdPciResourceMem64Base   | $(PCI_MEM64_BASE)
 
   gPlatformModuleTokenSpaceGuid.PcdLoaderReservedMemSize  | $(LOADER_RSVD_MEM_SIZE)
   gPlatformModuleTokenSpaceGuid.PcdLoaderAcpiNvsSize      | $(LOADER_ACPI_NVS_MEM_SIZE)

--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.inf
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -42,3 +42,5 @@
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress  ## CONSUMES
   gPlatformModuleTokenSpaceGuid.PcdPciResourceIoBase
   gPlatformModuleTokenSpaceGuid.PcdPciResourceMem32Base
+  gPlatformModuleTokenSpaceGuid.PcdPciEnumPolicyInfo
+  gPlatformModuleTokenSpaceGuid.PcdPciResourceMem64Base

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -1,7 +1,7 @@
 ## @file
 # This file is used to provide board specific image information.
 #
-#  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -35,6 +35,18 @@ class Board(BaseBoard):
         self.BOARD_PKG_NAME       = 'QemuBoardPkg'
         self.SILICON_PKG_NAME     = 'QemuSocPkg'
 
+        #
+        # By default,
+        # _PCI_ENUM_DOWNGRADE_IO32  : 1
+        # _PCI_ENUM_DOWNGRADE_MEM64 : 1
+        # _PCI_ENUM_DOWNGRADE_PMEM64: 1
+        # _PCI_ENUM_BUS_SCAN_TYPE   : 0 (0: list, 1: range)
+        #
+        #self._PCI_ENUM_DOWNGRADE_IO32   = 0
+        #self._PCI_ENUM_DOWNGRADE_MEM64  = 0
+        #self._PCI_ENUM_DOWNGRADE_PMEM64 = 0
+        #self._PCI_ENUM_BUS_SCAN_TYPE    = 1
+        self._PCI_ENUM_BUS_SCAN_ITEMS = '0,10,0x35,128,0xff'
         self.PCI_IO_BASE              = 0x00002000
         self.PCI_MEM32_BASE           = 0x80000000
         self.USB_KB_POLLING_TIMEOUT   = 10


### PR DESCRIPTION
PciEnumeration() scans a single PCI root bridge currently.
The PCI_ENUM_POLICY_INFO structure will be generated at build time,
and this will allow PCI enumeration more flexible.

typedef struct {
  UINT8           DowngradeIo32;	// default:1
  UINT8           DowngradeMem64; // default:1
  UINT8           DowngradePMem64;// default:1
  UINT8           Reserved;
  UINT8           BusScanType;    // default:0 (0: list, 1: range)
  UINT8           NumOfBus;       // the number of BusScanItems
  UINT8           BusScanItems[0];
} PCI_ENUM_POLICY_INFO;

Signed-off-by: Aiden Park <aiden.park@intel.com>