### PR TITLE
Fix BaseTools FFS map file dependency issue

### DIFF
--- a/BaseTools/Source/Python/AutoGen/GenMake.py
+++ b/BaseTools/Source/Python/AutoGen/GenMake.py
@@ -714,7 +714,7 @@ cleanlib:
                     if Dst not in self.ResultFileList:
                         self.ResultFileList.append(Dst)
                     if '%s :' %(Dst) not in self.BuildTargetList:
-                        self.BuildTargetList.append("%s :" %(Dst))
+                        self.BuildTargetList.append("%s : %s" %(Dst, Src))
                         self.BuildTargetList.append('\t' + self._CP_TEMPLATE_[self._FileType] %{'Src': Src, 'Dst': Dst})
 
             FfsCmdList = Cmd[0]


### PR DESCRIPTION
With the lastest EDK2 201911 BaseTools, the generated Makefile has
missing dependcy file for the map file target. It results in staled
map file when source code is modified.  This patch added the missing
dependencies.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>