### PR TITLE
Skip submodules during PatchCheck.py

### DIFF
--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -1,7 +1,7 @@
 ## @file
 #  Check a patch for various format issues
 #
-#  Copyright (c) 2015 - 2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2015 - 2020, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -9,7 +9,7 @@
 from __future__ import print_function
 
 VersionNumber = '0.1'
-__copyright__ = "Copyright (c) 2015 - 2016, Intel Corporation  All rights reserved."
+__copyright__ = "Copyright (c) 2015 - 2020, Intel Corporation  All rights reserved."
 
 import email
 import argparse
@@ -313,7 +313,10 @@ class GitDiffCheck:
             elif line.startswith('-'):
                 pass
             elif line.startswith('+'):
-                self.check_added_line(line[1:])
+                if re.search("\+Subproject commit [0-9a-f]{40}", line):
+                    pass
+                else:
+                    self.check_added_line(line[1:])
             elif line.startswith('\r\n'):
                 pass
             elif line.startswith(r'\ No newline '):


### PR DESCRIPTION
If a submodule is being updated in a
commit there is inadvertently some line
ending issues that will cause PatchCheck.py
to report an error; since we cannot change
the line ending in the submodule files
we should skip over a line in a patch that
matches the format of a submodule being
updated.

Signed-off-by: James Gutbub <james.gutbub@intel.com>