### PR TITLE
[APL] Enable firmware update trigger through sticky register

### DIFF
--- a/Platform/ApollolakeBoardPkg/Library/ShellExtensionLib/ShellExtensionLib.inf
+++ b/Platform/ApollolakeBoardPkg/Library/ShellExtensionLib/ShellExtensionLib.inf
@@ -31,6 +31,7 @@
   PayloadPkg/PayloadPkg.dec
   Platform/CommonBoardPkg/CommonBoardPkg.dec
   Platform/ApollolakeBoardPkg/ApollolakeBoardPkg.dec
+  Silicon/ApollolakePkg/ApollolakePkg.dec
 
 [LibraryClasses]
 

--- a/Platform/ApollolakeBoardPkg/Script/StitchLoader.py
+++ b/Platform/ApollolakeBoardPkg/Script/StitchLoader.py
@@ -426,6 +426,8 @@ def patch_flash_map (image_data, platform_data = 0xffffffff):
 
             comp  = IFWI_PARSER.locate_component (ifwi, path)
             if not comp:
+                if desc.sig == b'KEYH':
+                    continue
                 raise Exception("Cannot locate component '%s' in BPDT !" % path)
             if (desc.size == 0) and (desc.offset == 0):
                 desc.size = comp.length

--- a/Silicon/ApollolakePkg/Include/ScRegs/RegsPmc.h
+++ b/Silicon/ApollolakePkg/Include/ScRegs/RegsPmc.h
@@ -29,8 +29,8 @@
 ///
 /// PMC Registers
 ///
-#define PMC_BASE_ADDRESS                    PcdGet32(PcdPmcIpc1BaseAddress0)
-#define GCR_BASE_ADDRESS                    PcdGet32(PcdPmcGcrBaseAddress)
+#define PMC_BASE_ADDRESS                    0xFE042000
+#define GCR_BASE_ADDRESS                    0xFE043000
 
 #define PCI_DEVICE_NUMBER_PMC               13
 #define PCI_FUNCTION_NUMBER_PMC_SSRAM       3
@@ -42,6 +42,7 @@
 #define R_PMC_BASE                          0x10  ///< BAR0
 #define R_PMC_ACPI_BASE                     0x20  ///< BAR2
 #define R_PMC_GEN_PMCON_1                   0x1020  ///< General PM Configuration 1
+#define R_PMC_BIOS_SCRATCHPAD               0x1090  ///< BIOS_SCRATCHPAD
 #define B_PMC_GEN_PMCON_RTC_PWR_STS         BIT2    ///< RTC Power Status
 
 ///

--- a/Silicon/ApollolakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/ApollolakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -32,6 +32,7 @@
 #include <Service/PlatformService.h>
 #include <Service/HeciService.h>
 #include <Library/ResetSystemLib.h>
+#include <ScRegs/RegsPmc.h>
 
 #define FLASH_MAP_IN_FV_OFFSET   0xA4
 
@@ -465,6 +466,8 @@ EndFirmwareUpdate (
   HECI_SERVICE      *HeciService;
   PLATFORM_SERVICE  *PlatformService;
 
+  ClearFwUpdateTrigger();
+
   DEBUG ((DEBUG_INFO, "Firmware update Done! clear CSE flag to normal boot mode.\n"));
 
   HeciService = (HECI_SERVICE *) GetServiceBySignature (HECI_SERVICE_SIGNATURE);
@@ -508,5 +511,8 @@ ClearFwUpdateTrigger (
   VOID
   )
 {
+  // Clear platform firmware update trigger.
+  MmioAnd32 (PMC_BASE_ADDRESS + R_PMC_BIOS_SCRATCHPAD, 0xFF00FFFF);
+
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
This patch added code to:
  - Trigger FWU using sticky register in SBL Shell
  - Detect FWU mode using combination of sticky register and state
    machine
  - Clear the trigger flag at the end of FWU

Signed-off-by: Maurice Ma <maurice.ma@intel.com>