### PR TITLE
Fix build issue

### DIFF
--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -48,7 +48,7 @@ def rebuild_basetools ():
 def prep_env ():
     # check python version first
     version = check_for_python ()
-    os.environ['PYTHON_COMMAND'] = sys.executable
+    os.environ['PYTHON_COMMAND'] = '"' + sys.executable + '"'
     print_tool_version_info(os.environ['PYTHON_COMMAND'], version.strip())
 
     sblsource = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
When python is installed to a path with spaces, it would build failed.
This patch will fix this issue.

Signed-off-by: Guo Dong <guo.dong@intel.com>