### PR TITLE
End firmware update incase of failure

### DIFF
--- a/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
+++ b/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
@@ -277,7 +277,7 @@ PrepareRegionsUpdate (
 **/
 EFI_STATUS
 EFIAPI
-EndFirmwareUpdate (
+PlatformEndFirmwareUpdate (
   VOID
   );
 
@@ -497,10 +497,8 @@ UpdateCsme (
 
   This function is responsible for clearing firmware update trigger.
 
-  @retval  EFI_SUCCESS        Update successfully.
-
 **/
-EFI_STATUS
+VOID
 EFIAPI
 ClearFwUpdateTrigger (
   VOID

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -703,10 +703,10 @@ ProcessCapsule (
       return Status;
     }
 
-    Status = ClearFwUpdateTrigger();
-    if (EFI_ERROR(Status)) {
-      DEBUG((DEBUG_ERROR, "Clearing firmware update trigger failed with error: %r\n", Status));
-    }
+    //
+    // Clear firmware update trigger
+    //
+    ClearFwUpdateTrigger();
   } else {
     return EFI_SUCCESS;
   }
@@ -1071,6 +1071,29 @@ GetRegionInfo (
   *NonRedundantRegionSize = GetRegionOffsetSize (FlashMap, FLASH_MAP_FLAGS_NON_REDUNDANT_REGION, NULL);
 
   return EFI_SUCCESS;
+}
+
+/**
+  End firmware update.
+
+  This function will clear firmware update trigger and end firmware update.
+
+  @retval  EFI_SUCCESS        Update successfully.
+  @retval  others             Error happened during end firmware update.
+
+**/
+EFI_STATUS
+EFIAPI
+EndFirmwareUpdate (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+
+  ClearFwUpdateTrigger ();
+
+  Status = PlatformEndFirmwareUpdate ();
+  return Status;
 }
 
 /**

--- a/Silicon/ApollolakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/ApollolakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -458,15 +458,13 @@ PrepareRegionsUpdate (
 **/
 EFI_STATUS
 EFIAPI
-EndFirmwareUpdate (
+PlatformEndFirmwareUpdate (
   VOID
   )
 {
   EFI_STATUS        Status;
   HECI_SERVICE      *HeciService;
   PLATFORM_SERVICE  *PlatformService;
-
-  ClearFwUpdateTrigger();
 
   DEBUG ((DEBUG_INFO, "Firmware update Done! clear CSE flag to normal boot mode.\n"));
 
@@ -502,10 +500,8 @@ EndFirmwareUpdate (
 
   This function is responsible for clearing firmware update trigger.
 
-  @retval  EFI_SUCCESS        Update successfully.
-
 **/
-EFI_STATUS
+VOID
 EFIAPI
 ClearFwUpdateTrigger (
   VOID
@@ -513,6 +509,4 @@ ClearFwUpdateTrigger (
 {
   // Clear platform firmware update trigger.
   MmioAnd32 (PMC_BASE_ADDRESS + R_PMC_BIOS_SCRATCHPAD, 0xFF00FFFF);
-
-  return EFI_SUCCESS;
 }

--- a/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -449,18 +449,14 @@ PrepareRegionsUpdate (
 
   This function is responsible for clearing firmware update trigger.
 
-  @retval  EFI_SUCCESS        Update successfully.
-
 **/
-EFI_STATUS
+VOID
 EFIAPI
 ClearFwUpdateTrigger (
   VOID
   )
 {
   IoAnd32(ACPI_BASE_ADDRESS + R_ACPI_IO_OC_WDT_CTL, 0xFF00FFFF);
-
-  return EFI_SUCCESS;
 }
 
 /**
@@ -476,7 +472,7 @@ ClearFwUpdateTrigger (
 **/
 EFI_STATUS
 EFIAPI
-EndFirmwareUpdate (
+PlatformEndFirmwareUpdate (
   VOID
   )
 {

--- a/Silicon/QemuSocPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/QemuSocPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -477,7 +477,7 @@ SetBootPartition (
 **/
 EFI_STATUS
 EFIAPI
-EndFirmwareUpdate (
+PlatformEndFirmwareUpdate (
   VOID
   )
 {
@@ -501,14 +501,12 @@ EndFirmwareUpdate (
 
   This function is responsible for clearing firmware update trigger.
 
-  @retval  EFI_SUCCESS        Update successfully.
-
 **/
-EFI_STATUS
+VOID
 EFIAPI
 ClearFwUpdateTrigger (
   VOID
   )
 {
-  return EFI_SUCCESS;
+  return;
 }


### PR DESCRIPTION
Current code does not clear firmware update trigger incase
of failures like, capsule image not found or capsule image
authentication failed.

Code is modified to fix this issue. As part of this change,
EndFirmwareUpdate function is moved from platform code to
core firmwareupdate.c. EndFirmwareUpdate function will call
ClearFwUpdateTrigger and this will end firmware update.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>