### PR TITLE
Add CFGDATA length check in the build process

### DIFF
--- a/BootloaderCorePkg/Tools/CfgDataTool.py
+++ b/BootloaderCorePkg/Tools/CfgDataTool.py
@@ -368,7 +368,11 @@ class CCfgData:
             CfgItemList.append([(bytearray(CfgTagHdr), CondBin, DataBin[:DataLen]), PidMask, PidMask, IsBuiltIn])
             Offset += CfgDlen
 
+        if (Offset != Length) or (Length % 4 != 0):
+            raise Exception("Invalid CFGDATA binary blob format for file '%s' !" % CfgBinFile)
+
         self.CfgDataBase[CfgBinFile] = (CfgItemList, CfgBlobHeader, IsBuiltIn)
+
 
     def Merge(self, CfgItem, PidMask):
         CfgData = CfgItem[0]


### PR DESCRIPTION
This patch added checks for the CFGDATA length in CfgDataTool.py.
It will help catch invalid CFGDATA format during the build process.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>