### PR TITLE
 PSD Fixed memory overwrite issue.

### DIFF
--- a/Silicon/ApollolakePkg/Library/PsdLib/PsdLib.c
+++ b/Silicon/ApollolakePkg/Library/PsdLib/PsdLib.c
@@ -218,8 +218,7 @@ UpdateAcpiPsdTable (
   mPsdt->Header.OemRevision             = EFI_ACPI_OEM_REVISION;
   mPsdt->Header.CreatorId               = EFI_ACPI_CREATOR_ID;
   mPsdt->Header.CreatorRevision         = EFI_ACPI_CREATOR_REVISION;
-  ZeroMem( mPsdt +  sizeof (EFI_ACPI_DESCRIPTION_HEADER) , \
-     sizeof(EFI_ACPI_PSD_TABLE) - sizeof(EFI_ACPI_DESCRIPTION_HEADER) );
+
   DEBUG( (DEBUG_INFO, "Address of PSD_TABLE=%x\n", mPsdt));
   DEBUG( (DEBUG_INFO, "PSD Values: Signature=%x\n", mPsdt->Header.Signature) );
   DEBUG( (DEBUG_INFO, "PSD Values: Length=%x\n", mPsdt->Header.Length ));

--- a/Silicon/CoffeelakePkg/Library/PsdLib/PsdLib.c
+++ b/Silicon/CoffeelakePkg/Library/PsdLib/PsdLib.c
@@ -288,8 +288,7 @@ UpdateAcpiPsdTable (
   mPsdt->Header.OemRevision             = PSDS_EFI_ACPI_OEM_REVISION;
   mPsdt->Header.CreatorId               = PSDS_EFI_ACPI_CREATOR_ID;
   mPsdt->Header.CreatorRevision         = PSDS_EFI_ACPI_CREATOR_REVISION;
-  ZeroMem( mPsdt +  sizeof (EFI_ACPI_DESCRIPTION_HEADER) , \
-     sizeof(EFI_ACPI_PSD_TABLE) - sizeof(EFI_ACPI_DESCRIPTION_HEADER) );
+
   DEBUG( (DEBUG_INFO, "Address of PSD_TABLE=%x\n", mPsdt));
   DEBUG( (DEBUG_INFO, "PSD Values: Signature=%x\n", mPsdt->Header.Signature) );
   DEBUG( (DEBUG_INFO, "PSD Values: Length=%x\n", mPsdt->Header.Length ));


### PR DESCRIPTION
  platform security discovery driver having bug it was wrongly doing
  pointer arithmetic and causing memory overwrite. this may cause intermittent
  fault.

  removing ZeroMem call since its not required, ACPI table is already zero memory allocated.

Signed-off-by: Prakash Chandra <prakash1.chandra@intel.com>