### PR TITLE
Add SMBIOS entry in legacy region

### DIFF
--- a/BootloaderCorePkg/Library/SmbiosInitLib/SmbiosInitLib.c
+++ b/BootloaderCorePkg/Library/SmbiosInitLib/SmbiosInitLib.c
@@ -151,6 +151,11 @@ FinalizeSmbios (
   SmbiosEntry->IntermediateChecksum         = CalculateCheckSum8 ((UINT8 *)SmbiosEntry + 0x10, sizeof (SMBIOS_TABLE_ENTRY_POINT) - 0x10);
   SmbiosEntry->EntryPointStructureChecksum  = CalculateCheckSum8 ((UINT8 *)SmbiosEntry       , sizeof (SMBIOS_TABLE_ENTRY_POINT)       );
 
+  //
+  // Keep a copy in legacy F segment so that non-UEFI can locate it
+  //
+  CopyMem ((VOID *)0xFFF60, SmbiosEntry, sizeof (SMBIOS_TABLE_ENTRY_POINT));
+
   return Status;
 }
 


### PR DESCRIPTION
For non UEFI boot, it is required to put an SMBIOS entry in legacy F
segment at 16-byte aligned boundary so that OS can locate the SMBIOS
by searching the region. This patch added this logic to add SMBIOS
entry at fixed location 0xFFF60. ACPI table has the similar legacy
root pointer at fixed location 0xFFF80.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>