### PR TITLE
Change AddMemoryResourceRange API interface

### DIFF
--- a/BootloaderCommonPkg/Include/Library/BlMemoryAllocationLib.h
+++ b/BootloaderCommonPkg/Include/Library/BlMemoryAllocationLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -9,6 +9,12 @@
 #define __BL_MEMORY_ALLOCATION_LIB_H__
 
 #include <Library/MemoryAllocationLib.h>
+
+typedef struct {
+  EFI_PHYSICAL_ADDRESS  BaseAddress;
+  UINT32                NumberOfPages;
+  UINT32                Type;
+} EFI_MEMORY_RANGE_ENTRY;
 
 /**
   This function allocates temporary memory pool.

--- a/BootloaderCommonPkg/Library/FullMemoryAllocationLib/FullMemoryAllocationLib.c
+++ b/BootloaderCommonPkg/Library/FullMemoryAllocationLib/FullMemoryAllocationLib.c
@@ -1,57 +1,41 @@
 /** @file
   Support routines for memory allocation routines.
 
-  Copyright (c) 2006 - 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2006 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
 #include <Imem.h>
-
-typedef struct {
-  EFI_PHYSICAL_ADDRESS  BaseAddress;
-  UINT32                NumberOfPages;
-  UINT32                Type;
-} EFI_MEMORY_RANGE_ENTRY;
+#include <Library/BlMemoryAllocationLib.h>
 
 /**
   Add system memory resource for allocation.
 
   Add system range into the memory resource pool
 
-  @param  Base            The base of the normal memory range.
-  @param  Pages           The number of pages for the normal memory range.
-  @param  RsvdBase        The base of the reserved memory range.
-  @param  RsvdPages       The number of pages for the reserved memory range.
+  @param[in]  MemoryRanges    Memory range array structure.
+  @param[in]  Count           Memory range entry count.
+
 **/
 VOID
 EFIAPI
 AddMemoryResourceRange (
-  IN  UINT64   Base,
-  IN  UINT32   Pages,
-  IN  UINT64   RsvdBase,
-  IN  UINT32   RsvdPages
+  IN  EFI_MEMORY_RANGE_ENTRY  *MemoryRanges,
+  IN  UINT32                   Count
   )
 {
   UINTN                   Index;
-  EFI_MEMORY_RANGE_ENTRY  MemoryRanges[3];
 
   CoreInitializePool ();
   CoreInitializePages ();
 
-  MemoryRanges[0].BaseAddress   = Base;
-  MemoryRanges[0].NumberOfPages = Pages;
-  MemoryRanges[0].Type          = EfiBootServicesData;
-  MemoryRanges[1].BaseAddress   = RsvdBase;
-  MemoryRanges[1].NumberOfPages = RsvdPages;
-  MemoryRanges[1].Type          = EfiReservedMemoryType;
-  MemoryRanges[2].Type          = EfiMaxMemoryType;
-
-  for (Index = 0; (Index < ARRAY_SIZE (MemoryRanges)) && (MemoryRanges[Index].Type != EfiMaxMemoryType); Index++) {
-    CoreAddMemoryDescriptor (MemoryRanges[Index].Type, MemoryRanges[Index].BaseAddress, MemoryRanges[Index].NumberOfPages,
-                             MEMORY_ATTRIBUTE_DEFAULT);
+  for (Index = 0; (Index < Count) && (MemoryRanges[Index].Type != EfiMaxMemoryType); Index++) {
+    if (MemoryRanges[Index].NumberOfPages > 0) {
+      CoreAddMemoryDescriptor (MemoryRanges[Index].Type, MemoryRanges[Index].BaseAddress,
+                               MemoryRanges[Index].NumberOfPages, MEMORY_ATTRIBUTE_DEFAULT);
+    }
   }
-
 }
 
 

--- a/BootloaderCommonPkg/Library/FullMemoryAllocationLib/FullMemoryAllocationLib.inf
+++ b/BootloaderCommonPkg/Library/FullMemoryAllocationLib/FullMemoryAllocationLib.inf
@@ -31,6 +31,7 @@
 
 [Packages]
   MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
 
 [LibraryClasses]
   DebugLib

--- a/PayloadPkg/Include/Library/PayloadMemoryAllocationLib.h
+++ b/PayloadPkg/Include/Library/PayloadMemoryAllocationLib.h
@@ -1,32 +1,29 @@
 /** @file
   Payload specific memory allocation library.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017- 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 #ifndef _PAYLOAD_MEMORY_ALLOCATION_LIB_H_
 #define _PAYLOAD_MEMORY_ALLOCATION_LIB_H_
 
-#include <Library/MemoryAllocationLib.h>
+#include <Library/BlMemoryAllocationLib.h>
 
 /**
   Add system memory resource for allocation.
 
   Add system range into the memory resource pool
 
-  @param  Base            The base of the normal memory range.
-  @param  Pages           The number of pages for the normal memory range.
-  @param  RsvdBase        The base of the reserved memory range.
-  @param  RsvdPages       The number of pages for the reserved memory range.
+  @param[in]  MemoryRanges    Memory range array structure.
+  @param[in]  Count           Memory range entry count.
+
 **/
 VOID
 EFIAPI
 AddMemoryResourceRange (
-  IN  UINT64   Base,
-  IN  UINT32   Pages,
-  IN  UINT64   RsvdBase,
-  IN  UINT32   RsvdPages
+  IN  EFI_MEMORY_RANGE_ENTRY  *MemoryRanges,
+  IN  UINT32                   Count
   );
 
 /**

--- a/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
+++ b/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
@@ -1,7 +1,7 @@
 /** @file
   This file provides payload common library interfaces.
 
-  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -56,6 +56,7 @@ PayloadInit (
   EFI_STATUS                PcdStatus1;
   EFI_STATUS                PcdStatus2;
   CONTAINER_LIST            *ContainerList;
+  EFI_MEMORY_RANGE_ENTRY    MemoryRanges[2];
 
   PcdStatus1 = PcdSet32S (PcdPayloadHobList, (UINT32)HobList);
 
@@ -84,8 +85,13 @@ PayloadInit (
   StackBase = HeapBase - StackSize;
 
   // Add payload reserved memory region and free memory region
-  AddMemoryResourceRange (HeapBase, EFI_SIZE_TO_PAGES (HeapSize), \
-                          RsvdBase, EFI_SIZE_TO_PAGES ((UINT32)RsvdSize));
+  MemoryRanges[0].BaseAddress   = HeapBase;
+  MemoryRanges[0].NumberOfPages = EFI_SIZE_TO_PAGES (HeapSize);
+  MemoryRanges[0].Type          = EfiBootServicesData;
+  MemoryRanges[1].BaseAddress   = RsvdBase;
+  MemoryRanges[1].NumberOfPages = EFI_SIZE_TO_PAGES ((UINT32)RsvdSize);
+  MemoryRanges[1].Type          = EfiReservedMemoryType;
+  AddMemoryResourceRange (MemoryRanges, 2);
 
   GlobalDataPtr = AllocateZeroPool (sizeof (PAYLOAD_GLOBAL_DATA));
   ASSERT (GlobalDataPtr != NULL);


### PR DESCRIPTION
Current SBL AddMemoryResourceRange() API interface is not scalable.
If more memory type needs to be added, the interface does not allow
to do that. This patch changed the interface to use array and entry
count as parameter so that more ranges can be passed in using the
standard interfaces.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>