### PR TITLE
Add VTd PMR memory protection library

### DIFF
--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -1,7 +1,7 @@
 ## @file
 # This file is used to provide board specific image information.
 #
-#  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -169,7 +169,8 @@ class Board(BaseBoard):
             'FlashDescriptorLib|Silicon/ApollolakePkg/Library/FlashDescriptorLib/FlashDescriptorLib.inf',
             'VtdLib|Silicon/$(SILICON_PKG_NAME)/Library/VtdLib/VtdLib.inf',
             'SmbusLib|Silicon/$(SILICON_PKG_NAME)/Library/SmbusLib/SmbusLib.inf',
-            'HdaLib|Platform/$(BOARD_PKG_NAME)/Library/HdaLib/HdaLib.inf'
+            'HdaLib|Platform/$(BOARD_PKG_NAME)/Library/HdaLib/HdaLib.inf',
+            'VtdPmrLib|Silicon/CommonSocPkg/Library/VtdPmrLib/VtdPmrLib.inf'
         ]
         return dsc_libs
 

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -58,6 +58,7 @@
   BootOptionLib
   HdaLib
   BoardSupportLib
+  VtdPmrLib
 
 [Guids]
   gOsConfigDataGuid

--- a/Silicon/CommonSocPkg/Include/IndustryStandard/Vtd.h
+++ b/Silicon/CommonSocPkg/Include/IndustryStandard/Vtd.h
@@ -1,0 +1,355 @@
+/** @file
+  The definition for VTD register.
+  It is defined in "Intel VT for Direct IO Architecture Specification".
+
+  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __VTD_REG_H__
+#define __VTD_REG_H__
+
+#pragma pack(1)
+
+//
+// Translation Structure Formats
+//
+#define VTD_ROOT_ENTRY_NUMBER       256
+#define VTD_CONTEXT_ENTRY_NUMBER    256
+
+typedef union {
+  struct {
+    UINT32  Present:1;
+    UINT32  Reserved_1:11;
+    UINT32  ContextTablePointerLo:20;
+    UINT32  ContextTablePointerHi:32;
+
+    UINT64  Reserved_64;
+  } Bits;
+  struct {
+    UINT64  Uint64Lo;
+    UINT64  Uint64Hi;
+  } Uint128;
+} VTD_ROOT_ENTRY;
+
+typedef union {
+  struct {
+    UINT32  LowerPresent:1;
+    UINT32  Reserved_1:11;
+    UINT32  LowerContextTablePointerLo:20;
+    UINT32  LowerContextTablePointerHi:32;
+
+    UINT32  UpperPresent:1;
+    UINT32  Reserved_65:11;
+    UINT32  UpperContextTablePointerLo:20;
+    UINT32  UpperContextTablePointerHi:32;
+  } Bits;
+  struct {
+    UINT64  Uint64Lo;
+    UINT64  Uint64Hi;
+  } Uint128;
+} VTD_EXT_ROOT_ENTRY;
+
+typedef union {
+  struct {
+    UINT32  Present:1;
+    UINT32  FaultProcessingDisable:1;
+    UINT32  TranslationType:2;
+    UINT32  Reserved_4:8;
+    UINT32  SecondLevelPageTranslationPointerLo:20;
+    UINT32  SecondLevelPageTranslationPointerHi:32;
+
+    UINT32  AddressWidth:3;
+    UINT32  Ignored_67:4;
+    UINT32  Reserved_71:1;
+    UINT32  DomainIdentifier:16;
+    UINT32  Reserved_88:8;
+    UINT32  Reserved_96:32;
+  } Bits;
+  struct {
+    UINT64  Uint64Lo;
+    UINT64  Uint64Hi;
+  } Uint128;
+} VTD_CONTEXT_ENTRY;
+
+typedef union {
+  struct {
+    UINT32  Present:1;
+    UINT32  FaultProcessingDisable:1;
+    UINT32  TranslationType:3;
+    UINT32  ExtendedMemoryType:3;
+    UINT32  DeferredInvalidateEnable:1;
+    UINT32  PageRequestEnable:1;
+    UINT32  NestedTranslationEnable:1;
+    UINT32  PASIDEnable:1;
+    UINT32  SecondLevelPageTranslationPointerLo:20;
+    UINT32  SecondLevelPageTranslationPointerHi:32;
+
+    UINT32  AddressWidth:3;
+    UINT32  PageGlobalEnable:1;
+    UINT32  NoExecuteEnable:1;
+    UINT32  WriteProtectEnable:1;
+    UINT32  CacheDisable:1;
+    UINT32  ExtendedMemoryTypeEnable:1;
+    UINT32  DomainIdentifier:16;
+    UINT32  SupervisorModeExecuteProtection:1;
+    UINT32  ExtendedAccessedFlagEnable:1;
+    UINT32  ExecuteRequestsEnable:1;
+    UINT32  SecondLevelExecuteEnable:1;
+    UINT32  Reserved_92:4;
+    UINT32  PageAttributeTable0:3;
+    UINT32  Reserved_Pat0:1;
+    UINT32  PageAttributeTable1:3;
+    UINT32  Reserved_Pat1:1;
+    UINT32  PageAttributeTable2:3;
+    UINT32  Reserved_Pat2:1;
+    UINT32  PageAttributeTable3:3;
+    UINT32  Reserved_Pat3:1;
+    UINT32  PageAttributeTable4:3;
+    UINT32  Reserved_Pat4:1;
+    UINT32  PageAttributeTable5:3;
+    UINT32  Reserved_Pat5:1;
+    UINT32  PageAttributeTable6:3;
+    UINT32  Reserved_Pat6:1;
+    UINT32  PageAttributeTable7:3;
+    UINT32  Reserved_Pat7:1;
+
+    UINT32  PASIDTableSize:4;
+    UINT32  Reserved_132:8;
+    UINT32  PASIDTablePointerLo:20;
+    UINT32  PASIDTablePointerHi:32;
+
+    UINT32  Reserved_192:12;
+    UINT32  PASIDStateTablePointerLo:20;
+    UINT32  PASIDStateTablePointerHi:32;
+  } Bits;
+  struct {
+    UINT64  Uint64_1;
+    UINT64  Uint64_2;
+    UINT64  Uint64_3;
+    UINT64  Uint64_4;
+  } Uint256;
+} VTD_EXT_CONTEXT_ENTRY;
+
+typedef union {
+  struct {
+    UINT32  Present:1;
+    UINT32  Reserved_1:2;
+    UINT32  PageLevelCacheDisable:1;
+    UINT32  PageLevelWriteThrough:1;
+    UINT32  Reserved_5:6;
+    UINT32  SupervisorRequestsEnable:1;
+    UINT32  FirstLevelPageTranslationPointerLo:20;
+    UINT32  FirstLevelPageTranslationPointerHi:32;
+  } Bits;
+  UINT64    Uint64;
+} VTD_PASID_ENTRY;
+
+typedef union {
+  struct {
+    UINT32  Reserved_0:32;
+    UINT32  ActiveReferenceCount:16;
+    UINT32  Reserved_48:15;
+    UINT32  DeferredInvalidate:1;
+  } Bits;
+  UINT64    Uint64;
+} VTD_PASID_STATE_ENTRY;
+
+typedef union {
+  struct {
+    UINT32  Present:1;
+    UINT32  ReadWrite:1;
+    UINT32  UserSupervisor:1;
+    UINT32  PageLevelWriteThrough:1;
+    UINT32  PageLevelCacheDisable:1;
+    UINT32  Accessed:1;
+    UINT32  Dirty:1;
+    UINT32  PageSize:1; // It is PageAttribute:1 for 4K page entry
+    UINT32  Global:1;
+    UINT32  Ignored_9:1;
+    UINT32  ExtendedAccessed:1;
+    UINT32  Ignored_11:1;
+    // NOTE: There is PageAttribute:1 as bit12 for 1G page entry and 2M page entry
+    UINT32  AddressLo:20;
+    UINT32  AddressHi:20;
+    UINT32  Ignored_52:11;
+    UINT32  ExecuteDisable:1;
+  } Bits;
+  UINT64    Uint64;
+} VTD_FIRST_LEVEL_PAGING_ENTRY;
+
+typedef union {
+  struct {
+    UINT32  Read:1;
+    UINT32  Write:1;
+    UINT32  Execute:1;
+    UINT32  ExtendedMemoryType:3;
+    UINT32  IgnorePAT:1;
+    UINT32  PageSize:1;
+    UINT32  Ignored_8:3;
+    UINT32  Snoop:1;
+    UINT32  AddressLo:20;
+    UINT32  AddressHi:20;
+    UINT32  Ignored_52:10;
+    UINT32  TransientMapping:1;
+    UINT32  Ignored_63:1;
+  } Bits;
+  UINT64    Uint64;
+} VTD_SECOND_LEVEL_PAGING_ENTRY;
+
+//
+// Register Descriptions
+//
+#define R_VER_REG        0x00
+#define R_CAP_REG        0x08
+#define   B_CAP_REG_RWBF       BIT4
+#define R_ECAP_REG       0x10
+#define R_GCMD_REG       0x18
+#define   B_GMCD_REG_WBF       BIT27
+#define   B_GMCD_REG_SRTP      BIT30
+#define   B_GMCD_REG_TE        BIT31
+#define R_GSTS_REG       0x1C
+#define   B_GSTS_REG_WBF       BIT27
+#define   B_GSTS_REG_RTPS      BIT30
+#define   B_GSTS_REG_TE        BIT31
+#define R_RTADDR_REG     0x20
+#define R_CCMD_REG       0x28
+#define   B_CCMD_REG_CIRG_MASK    (BIT62|BIT61)
+#define   V_CCMD_REG_CIRG_GLOBAL  BIT61
+#define   V_CCMD_REG_CIRG_DOMAIN  BIT62
+#define   V_CCMD_REG_CIRG_DEVICE  (BIT62|BIT61)
+#define   B_CCMD_REG_ICC          BIT63
+#define R_FSTS_REG       0x34
+#define R_FECTL_REG      0x38
+#define R_FEDATA_REG     0x3C
+#define R_FEADDR_REG     0x40
+#define R_FEUADDR_REG    0x44
+#define R_AFLOG_REG      0x58
+
+#define R_IVA_REG        0x00 // + IRO
+#define   B_IVA_REG_AM_MASK       (BIT0|BIT1|BIT2|BIT3|BIT4|BIT5)
+#define   B_IVA_REG_AM_4K         0 // 1 page
+#define   B_IVA_REG_AM_2M         9 // 2M page
+#define   B_IVA_REG_IH            BIT6
+#define R_IOTLB_REG      0x08 // + IRO
+#define   B_IOTLB_REG_IIRG_MASK   (BIT61|BIT60)
+#define   V_IOTLB_REG_IIRG_GLOBAL BIT60
+#define   V_IOTLB_REG_IIRG_DOMAIN BIT61
+#define   V_IOTLB_REG_IIRG_PAGE   (BIT61|BIT60)
+#define   B_IOTLB_REG_IVT         BIT63
+
+#define R_FRCD_REG       0x00 // + FRO
+
+#define R_PMEN_ENABLE_REG         0x64
+#define R_PMEN_LOW_BASE_REG       0x68
+#define R_PMEN_LOW_LIMITE_REG     0x6C
+#define R_PMEN_HIGH_BASE_REG      0x70
+#define R_PMEN_HIGH_LIMITE_REG    0x78
+
+typedef union {
+  struct {
+    UINT8         ND:3; // Number of domains supported
+    UINT8         AFL:1; // Advanced Fault Logging
+    UINT8         RWBF:1; // Required Write-Buffer Flushing
+    UINT8         PLMR:1; // Protected Low-Memory Region
+    UINT8         PHMR:1; // Protected High-Memory Region
+    UINT8         CM:1; // Caching Mode
+
+    UINT8         SAGAW:5; // Supported Adjusted Guest Address Widths
+    UINT8         Rsvd_13:3;
+
+    UINT8         MGAW:6; // Maximum Guest Address Width
+    UINT8         ZLR:1; // Zero Length Read
+    UINT8         Rsvd_23:1;
+
+    UINT16        FRO:10; // Fault-recording Register offset
+    UINT16        SLLPS:4; // Second Level Large Page Support
+    UINT16        Rsvd_38:1;
+    UINT16        PSI:1; // Page Selective Invalidation
+
+    UINT8         NFR:8; // Number of Fault-recording Registers
+
+    UINT8         MAMV:6; // Maximum Address Mask Value
+    UINT8         DWD:1; // Write Draining
+    UINT8         DRD:1; // Read Draining
+
+    UINT8         FL1GP:1; // First Level 1-GByte Page Support
+    UINT8         Rsvd_57:2;
+    UINT8         PI:1; // Posted Interrupts Support
+    UINT8         Rsvd_60:4;
+  } Bits;
+  UINT64     Uint64;
+} VTD_CAP_REG;
+
+typedef union {
+  struct {
+    UINT8         C:1; // Page-walk Coherency
+    UINT8         QI:1; // Queued Invalidation support
+    UINT8         DT:1; // Device-TLB support
+    UINT8         IR:1; // Interrupt Remapping support
+    UINT8         EIM:1; // Extended Interrupt Mode
+    UINT8         Rsvd_5:1;
+    UINT8         PT:1; // Pass Through
+    UINT8         SC:1; // Snoop Control
+
+    UINT16        IRO:10; // IOTLB Register Offset
+    UINT16        Rsvd_18:2;
+    UINT16        MHMV:4; // Maximum Handle Mask Value
+
+    UINT8         ECS:1; // Extended Context Support
+    UINT8         MTS:1; // Memory Type Support
+    UINT8         NEST:1; // Nested Translation Support
+    UINT8         DIS:1; // Deferred Invalidate Support
+    UINT8         PASID:1; // Process Address Space ID Support
+    UINT8         PRS:1; // Page Request Support
+    UINT8         ERS:1; // Execute Request Support
+    UINT8         SRS:1; // Supervisor Request Support
+
+    UINT32        Rsvd_32:1;
+    UINT32        NWFS:1; // No Write Flag Support
+    UINT32        EAFS:1; // Extended Accessed Flag Support
+    UINT32        PSS:5; // PASID Size Supported
+    UINT32        Rsvd_40:24;
+  } Bits;
+  UINT64     Uint64;
+} VTD_ECAP_REG;
+
+typedef union {
+  struct {
+    UINT32   Rsvd_0:12;
+    UINT32   FILo:20;      // FaultInfo
+    UINT32   FIHi:32;      // FaultInfo
+
+    UINT32   SID:16;       // Source Identifier
+    UINT32   Rsvd_80:13;
+    UINT32   PRIV:1;       // Privilege Mode Requested
+    UINT32   EXE:1;        // Execute Permission Requested
+    UINT32   PP:1;         // PASID Present
+
+    UINT32   FR:8;         // Fault Reason
+    UINT32   PV:20;        // PASID Value
+    UINT32   AT:2;         // Address Type
+    UINT32   T:1;          // Type (0: Write, 1: Read)
+    UINT32   F:1;          // Fault
+  } Bits;
+  UINT64     Uint64[2];
+} VTD_FRCD_REG;
+
+typedef union {
+  struct {
+    UINT8    Function:3;
+    UINT8    Device:5;
+    UINT8    Bus;
+  } Bits;
+  struct {
+    UINT8    ContextIndex;
+    UINT8    RootIndex;
+  } Index;
+  UINT16     Uint16;
+} VTD_SOURCE_ID;
+
+#pragma pack()
+
+#endif
+

--- a/Silicon/CommonSocPkg/Include/Library/VtdPmrLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/VtdPmrLib.h
@@ -1,0 +1,61 @@
+/** @file
+  VT-d Protected Memory library inteerface definitions.
+
+  Copyright (c) 2010 - 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __VTD_PMR_LIB_H__
+#define __VTD_PMR_LIB_H__
+
+#include <IndustryStandard/Vtd.h>
+
+#define  VTD_ENGINE_ALL                   ((UINT64)(-1))
+
+typedef struct {
+  UINT64                                  EngineMask;
+  UINT8                                   HostAddressWidth;
+  UINTN                                   VTdEngineCount;
+  UINT64                                  VTdEngineAddress[0];
+} VTD_INFO;
+
+/**
+  Set DMA protected region.
+
+  @param VTdInfo            The VTd engine context information.
+  @param EngineMask         The mask of the VTd engine to be accessed.
+  @param LowMemoryBase      The protected low memory region base.
+  @param LowMemoryLength    The protected low memory region length.
+  @param HighMemoryBase     The protected high memory region base.
+  @param HighMemoryLength   The protected high memory region length.
+
+  @retval EFI_SUCCESS      The DMA protection is set.
+  @retval EFI_UNSUPPORTED  The DMA protection is not set.
+**/
+EFI_STATUS
+SetDmaProtectedRange (
+  IN VTD_INFO      *VTdInfo,
+  IN UINT64        EngineMask,
+  IN UINT32        LowMemoryBase,
+  IN UINT32        LowMemoryLength,
+  IN UINT64        HighMemoryBase,
+  IN UINT64        HighMemoryLength
+  );
+
+/**
+  Diable DMA protection.
+
+  @param VTdInfo            The VTd engine context information.
+  @param EngineMask         The mask of the VTd engine to be accessed.
+
+  @retval EFI_SUCCESS DMA protection is disabled.
+**/
+EFI_STATUS
+DisableDmaProtection (
+  IN VTD_INFO      *VTdInfo,
+  IN UINT64        EngineMask
+  );
+
+#endif
+

--- a/Silicon/CommonSocPkg/Library/VtdPmrLib/IntelVtdPmr.c
+++ b/Silicon/CommonSocPkg/Library/VtdPmrLib/IntelVtdPmr.c
@@ -1,0 +1,411 @@
+/** @file
+
+  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+#include <Library/VtdPmrLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/IoLib.h>
+#include <Library/DebugLib.h>
+
+/**
+  Get protected low memory alignment.
+
+  @param HostAddressWidth   The host address width.
+  @param VtdUnitBaseAddress The base address of the VTd engine.
+
+  @return protected low memory alignment.
+**/
+UINT32
+GetPlmrAlignment (
+  IN UINT8         HostAddressWidth,
+  IN UINTN         VtdUnitBaseAddress
+  )
+{
+  UINT32        Data32;
+
+  MmioWrite32 (VtdUnitBaseAddress + R_PMEN_LOW_BASE_REG, 0xFFFFFFFF);
+  Data32 = MmioRead32 (VtdUnitBaseAddress + R_PMEN_LOW_BASE_REG);
+  Data32 = ~Data32 + 1;
+
+  return Data32;
+}
+
+/**
+  Get protected high memory alignment.
+
+  @param HostAddressWidth   The host address width.
+  @param VtdUnitBaseAddress The base address of the VTd engine.
+
+  @return protected high memory alignment.
+**/
+UINT64
+GetPhmrAlignment (
+  IN UINT8         HostAddressWidth,
+  IN UINTN         VtdUnitBaseAddress
+  )
+{
+  UINT64        Data64;
+
+  MmioWrite64 (VtdUnitBaseAddress + R_PMEN_HIGH_BASE_REG, 0xFFFFFFFFFFFFFFFF);
+  Data64 = MmioRead64 (VtdUnitBaseAddress + R_PMEN_HIGH_BASE_REG);
+  Data64 = ~Data64 + 1;
+  Data64 = Data64 & (LShiftU64 (1, HostAddressWidth) - 1);
+
+  return Data64;
+}
+
+/**
+  Get protected low memory alignment.
+
+  @param VTdInfo            The VTd engine context information.
+  @param EngineMask         The mask of the VTd engine to be accessed.
+
+  @return protected low memory alignment.
+**/
+UINT32
+GetLowMemoryAlignment (
+  IN VTD_INFO      *VTdInfo,
+  IN UINT64        EngineMask
+  )
+{
+  UINTN         Index;
+  UINT32        Alignment;
+  UINT32        FinalAlignment;
+
+  FinalAlignment = 0;
+  for (Index = 0; Index < VTdInfo->VTdEngineCount; Index++) {
+    if ((EngineMask & LShiftU64(1, Index)) == 0) {
+      continue;
+    }
+    Alignment = GetPlmrAlignment (VTdInfo->HostAddressWidth, (UINTN)VTdInfo->VTdEngineAddress[Index]);
+    if (FinalAlignment < Alignment) {
+      FinalAlignment = Alignment;
+    }
+  }
+  return FinalAlignment;
+}
+
+/**
+  Get protected high memory alignment.
+
+  @param VTdInfo            The VTd engine context information.
+  @param EngineMask         The mask of the VTd engine to be accessed.
+
+  @return protected high memory alignment.
+**/
+UINT64
+GetHighMemoryAlignment (
+  IN VTD_INFO      *VTdInfo,
+  IN UINT64        EngineMask
+  )
+{
+  UINTN         Index;
+  UINT64        Alignment;
+  UINT64        FinalAlignment;
+
+  FinalAlignment = 0;
+  for (Index = 0; Index < VTdInfo->VTdEngineCount; Index++) {
+    if ((EngineMask & LShiftU64(1, Index)) == 0) {
+      continue;
+    }
+    Alignment = GetPhmrAlignment (VTdInfo->HostAddressWidth, (UINTN)VTdInfo->VTdEngineAddress[Index]);
+    if (FinalAlignment < Alignment) {
+      FinalAlignment = Alignment;
+    }
+  }
+  return FinalAlignment;
+}
+
+/**
+  Enable PMR in the VTd engine.
+
+  @param VtdUnitBaseAddress The base address of the VTd engine.
+
+  @retval EFI_SUCCESS      The PMR is enabled.
+  @retval EFI_UNSUPPORTED  The PMR is not supported.
+**/
+EFI_STATUS
+EnablePmr (
+  IN UINTN         VtdUnitBaseAddress
+  )
+{
+  UINT32        Reg32;
+  VTD_CAP_REG   CapReg;
+
+  CapReg.Uint64 = MmioRead64 (VtdUnitBaseAddress + R_CAP_REG);
+  if (CapReg.Bits.PLMR == 0 || CapReg.Bits.PHMR == 0) {
+    return EFI_UNSUPPORTED;
+  }
+
+  Reg32 = MmioRead32 (VtdUnitBaseAddress + R_PMEN_ENABLE_REG);
+  if (Reg32 == 0xFFFFFFFF) {
+    DEBUG ((DEBUG_ERROR, "R_PMEN_ENABLE_REG - 0x%x\n", Reg32));
+    ASSERT(FALSE);
+  }
+
+  if ((Reg32 & BIT0) == 0) {
+    MmioWrite32 (VtdUnitBaseAddress + R_PMEN_ENABLE_REG, BIT31);
+    do {
+      Reg32 = MmioRead32 (VtdUnitBaseAddress + R_PMEN_ENABLE_REG);
+    } while((Reg32 & BIT0) == 0);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Disable PMR in the VTd engine.
+
+  @param VtdUnitBaseAddress The base address of the VTd engine.
+
+  @retval EFI_SUCCESS      The PMR is disabled.
+  @retval EFI_UNSUPPORTED  The PMR is not supported.
+**/
+EFI_STATUS
+DisablePmr (
+  IN UINTN         VtdUnitBaseAddress
+  )
+{
+  UINT32        Reg32;
+  VTD_CAP_REG   CapReg;
+
+  CapReg.Uint64 = MmioRead64 (VtdUnitBaseAddress + R_CAP_REG);
+  if (CapReg.Bits.PLMR == 0 || CapReg.Bits.PHMR == 0) {
+    return EFI_UNSUPPORTED;
+  }
+
+  Reg32 = MmioRead32 (VtdUnitBaseAddress + R_PMEN_ENABLE_REG);
+  if (Reg32 == 0xFFFFFFFF) {
+    DEBUG ((DEBUG_ERROR, "R_PMEN_ENABLE_REG - 0x%x\n", Reg32));
+    ASSERT(FALSE);
+  }
+
+  if ((Reg32 & BIT0) != 0) {
+    MmioWrite32 (VtdUnitBaseAddress + R_PMEN_ENABLE_REG, 0x0);
+    do {
+      Reg32 = MmioRead32 (VtdUnitBaseAddress + R_PMEN_ENABLE_REG);
+    } while((Reg32 & BIT0) != 0);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Set PMR region in the VTd engine.
+
+  @param HostAddressWidth   The host address width.
+  @param VtdUnitBaseAddress The base address of the VTd engine.
+  @param LowMemoryBase      The protected low memory region base.
+  @param LowMemoryLength    The protected low memory region length.
+  @param HighMemoryBase     The protected high memory region base.
+  @param HighMemoryLength   The protected high memory region length.
+
+  @retval EFI_SUCCESS      The PMR is set to protected region.
+  @retval EFI_UNSUPPORTED  The PMR is not supported.
+**/
+EFI_STATUS
+SetPmrRegion (
+  IN UINT8         HostAddressWidth,
+  IN UINTN         VtdUnitBaseAddress,
+  IN UINT32        LowMemoryBase,
+  IN UINT32        LowMemoryLength,
+  IN UINT64        HighMemoryBase,
+  IN UINT64        HighMemoryLength
+  )
+{
+  VTD_CAP_REG   CapReg;
+  UINT32        PlmrAlignment;
+  UINT64        PhmrAlignment;
+
+  DEBUG ((DEBUG_INFO, "VtdUnitBaseAddress - 0x%x\n", VtdUnitBaseAddress));
+
+  CapReg.Uint64 = MmioRead64 (VtdUnitBaseAddress + R_CAP_REG);
+  if (CapReg.Bits.PLMR == 0 || CapReg.Bits.PHMR == 0) {
+    DEBUG ((DEBUG_ERROR, "PLMR/PHMR unsupported\n"));
+    return EFI_UNSUPPORTED;
+  }
+
+  PlmrAlignment = GetPlmrAlignment (HostAddressWidth, VtdUnitBaseAddress);
+  PhmrAlignment = GetPhmrAlignment (HostAddressWidth, VtdUnitBaseAddress);
+  if ((LowMemoryBase    != ALIGN_VALUE(LowMemoryBase, PlmrAlignment)) ||
+      (LowMemoryLength  != ALIGN_VALUE(LowMemoryLength, PlmrAlignment)) ||
+      (HighMemoryBase   != ALIGN_VALUE(HighMemoryBase, PhmrAlignment)) ||
+      (HighMemoryLength != ALIGN_VALUE(HighMemoryLength, PhmrAlignment))) {
+    DEBUG ((DEBUG_ERROR, "PLMR/PHMR alignment issue, require 0x%08X\n", PlmrAlignment));
+    return EFI_UNSUPPORTED;
+  }
+
+  if (LowMemoryBase == 0 && LowMemoryLength == 0) {
+    LowMemoryBase = 0xFFFFFFFF;
+  }
+  if (HighMemoryBase == 0 && HighMemoryLength == 0) {
+    HighMemoryBase = 0xFFFFFFFFFFFFFFFF;
+  }
+
+  MmioWrite32 (VtdUnitBaseAddress + R_PMEN_LOW_BASE_REG,    LowMemoryBase);
+  MmioWrite32 (VtdUnitBaseAddress + R_PMEN_LOW_LIMITE_REG,  LowMemoryBase + LowMemoryLength - 1);
+  MmioWrite64 (VtdUnitBaseAddress + R_PMEN_HIGH_BASE_REG,   HighMemoryBase);
+  MmioWrite64 (VtdUnitBaseAddress + R_PMEN_HIGH_LIMITE_REG, HighMemoryBase + HighMemoryLength - 1);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Set DMA protected region.
+
+  @param VTdInfo            The VTd engine context information.
+  @param EngineMask         The mask of the VTd engine to be accessed.
+  @param LowMemoryBase      The protected low memory region base.
+  @param LowMemoryLength    The protected low memory region length.
+  @param HighMemoryBase     The protected high memory region base.
+  @param HighMemoryLength   The protected high memory region length.
+
+  @retval EFI_SUCCESS      The DMA protection is set.
+  @retval EFI_UNSUPPORTED  The DMA protection is not set.
+**/
+EFI_STATUS
+SetDmaProtectedRange (
+  IN VTD_INFO      *VTdInfo,
+  IN UINT64        EngineMask,
+  IN UINT32        LowMemoryBase,
+  IN UINT32        LowMemoryLength,
+  IN UINT64        HighMemoryBase,
+  IN UINT64        HighMemoryLength
+  )
+{
+  UINTN       Index;
+  EFI_STATUS  Status;
+
+  if ((VTdInfo == NULL) || (VTdInfo->VTdEngineCount == 0)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  DEBUG ((DEBUG_INFO, "SetDmaProtectedRange:\n  [0x%x, 0x%x]\n  [0x%016lx, 0x%016lx]\n",
+         LowMemoryBase, LowMemoryLength, HighMemoryBase, HighMemoryLength));
+
+  for (Index = 0; Index < VTdInfo->VTdEngineCount; Index++) {
+    if ((EngineMask & LShiftU64(1, Index)) == 0) {
+      continue;
+    }
+    DisablePmr ((UINTN)VTdInfo->VTdEngineAddress[Index]);
+    Status = SetPmrRegion (
+               VTdInfo->HostAddressWidth,
+               (UINTN)VTdInfo->VTdEngineAddress[Index],
+               LowMemoryBase,
+               LowMemoryLength,
+               HighMemoryBase,
+               HighMemoryLength
+               );
+    if (EFI_ERROR(Status)) {
+      return Status;
+    }
+    Status = EnablePmr ((UINTN)VTdInfo->VTdEngineAddress[Index]);
+    if (EFI_ERROR(Status)) {
+      return Status;
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Diable DMA protection.
+
+  @param VTdInfo            The VTd engine context information.
+  @param EngineMask         The mask of the VTd engine to be accessed.
+
+  @retval EFI_SUCCESS DMA protection is disabled.
+**/
+EFI_STATUS
+DisableDmaProtection (
+  IN VTD_INFO      *VTdInfo,
+  IN UINT64        EngineMask
+  )
+{
+  UINTN       Index;
+  EFI_STATUS  Status;
+
+  DEBUG ((DEBUG_INFO, "DisableDmaProtection\n"));
+
+  for (Index = 0; Index < VTdInfo->VTdEngineCount; Index++) {
+    if ((EngineMask & LShiftU64(1, Index)) == 0) {
+      continue;
+    }
+    Status = DisablePmr ((UINTN)VTdInfo->VTdEngineAddress[Index]);
+    if (EFI_ERROR(Status)) {
+      return Status;
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Return if the PMR is enabled.
+
+  @param VtdUnitBaseAddress The base address of the VTd engine.
+
+  @retval TRUE  PMR is enabled.
+  @retval FALSE PMR is disabled or unsupported.
+**/
+BOOLEAN
+IsPmrEnabled (
+  IN UINTN         VtdUnitBaseAddress
+  )
+{
+  UINT32        Reg32;
+  VTD_CAP_REG   CapReg;
+
+  CapReg.Uint64 = MmioRead64 (VtdUnitBaseAddress + R_CAP_REG);
+  if (CapReg.Bits.PLMR == 0 || CapReg.Bits.PHMR == 0) {
+    return FALSE;
+  }
+
+  Reg32 = MmioRead32 (VtdUnitBaseAddress + R_PMEN_ENABLE_REG);
+  if ((Reg32 & BIT0) == 0) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  Return the mask of the VTd engine which is enabled.
+
+  @param VTdInfo            The VTd engine context information.
+  @param EngineMask         The mask of the VTd engine to be accessed.
+
+  @return the mask of the VTd engine which is enabled.
+**/
+UINT64
+GetDmaProtectionEnabledEngineMask (
+  IN VTD_INFO      *VTdInfo,
+  IN UINT64        EngineMask
+  )
+{
+  UINTN       Index;
+  BOOLEAN     Result;
+  UINT64      EnabledEngineMask;
+
+  DEBUG ((DEBUG_INFO, "GetDmaProtectionEnabledEngineMask - 0x%lx\n", EngineMask));
+
+  EnabledEngineMask = 0;
+  for (Index = 0; Index < VTdInfo->VTdEngineCount; Index++) {
+    if ((EngineMask & LShiftU64(1, Index)) == 0) {
+      continue;
+    }
+    Result = IsPmrEnabled ((UINTN)VTdInfo->VTdEngineAddress[Index]);
+    if (Result) {
+      EnabledEngineMask |= LShiftU64(1, Index);
+    }
+  }
+
+  DEBUG ((DEBUG_INFO, "EnabledEngineMask - 0x%lx\n", EnabledEngineMask));
+  return EnabledEngineMask;
+}

--- a/Silicon/CommonSocPkg/Library/VtdPmrLib/VtdPmrLib.inf
+++ b/Silicon/CommonSocPkg/Library/VtdPmrLib/VtdPmrLib.inf
@@ -1,0 +1,38 @@
+## @file
+#
+#  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = VtdPmrLib
+  FILE_GUID                      = 891F1E7F-E48E-418A-BA80-A08D249CCCB8
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = VtdPmrLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  IntelVtdPmr.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+  Silicon/CommonSocPkg/CommonSocPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  PcdLib
+  IoLib
+  PciLib
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
+


### PR DESCRIPTION
This patch added the VTd PMR memory protection library. It can be
used to support DMA memory protection feature later on. It also
enabled basic build on APL platform so that it can be tested as part
of the automatic build.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>