### PR TITLE
Add DMA protection in core code

### DIFF
--- a/BootloaderCommonPkg/Include/Guid/LoaderPlatformDataGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/LoaderPlatformDataGuid.h
@@ -36,6 +36,7 @@ typedef struct {
   DEBUG_LOG_BUFFER_HEADER  *DebugLogBuffer;
   VOID                     *ConfigDataPtr;
   VOID                     *ContainerList;
+  VOID                     *DmaBufferPtr;
 } LOADER_PLATFORM_DATA;
 
 #endif

--- a/BootloaderCommonPkg/Library/FullMemoryAllocationLib/Page.c
+++ b/BootloaderCommonPkg/Library/FullMemoryAllocationLib/Page.c
@@ -51,7 +51,7 @@ CONST EFI_MEMORY_TYPE_STATISTICS mMemoryTypeStatisticsInit[EfiMaxMemoryType + 1]
   { 0, 0, 0, 0, EfiMaxMemoryType, FALSE, FALSE },  // EfiBootServicesCode
   { 0, MAX_ADDRESS, 0, 0, EfiMaxMemoryType, FALSE, FALSE },  // EfiBootServicesData
   { 0, 0, 0, 0, EfiMaxMemoryType, TRUE,  TRUE  },  // EfiRuntimeServicesCode
-  { 0, 0, 0, 0, EfiMaxMemoryType, TRUE,  TRUE  },  // EfiRuntimeServicesData
+  { 0, MAX_ADDRESS, 0, 0, EfiMaxMemoryType, TRUE,  TRUE  },  // EfiRuntimeServicesData
   { 0, MAX_ADDRESS, 0, 0, EfiMaxMemoryType, FALSE, FALSE },  // EfiConventionalMemory
   { 0, 0, 0, 0, EfiMaxMemoryType, FALSE, FALSE },  // EfiUnusableMemory
   { 0, 0, 0, 0, EfiMaxMemoryType, TRUE,  FALSE },  // EfiACPIReclaimMemory

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -309,6 +309,7 @@
   gPayloadTokenSpaceGuid.PcdCsmeUpdateEnabled             | $(ENABLE_CSME_UPDATE)
   gPlatformCommonLibTokenSpaceGuid.PcdEmmcHs400SupportEnabled | $(ENABLE_EMMC_HS400)
   gPlatformCommonLibTokenSpaceGuid.PcdPreOsCheckerEnabled | $(ENABLE_PRE_OS_CHECKER)
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaProtectionEnabled | $(ENABLE_DMA_PROTECTION)
 
 !ifdef $(S3_DEBUG)
   gPlatformModuleTokenSpaceGuid.PcdS3DebugEnabled         | $(S3_DEBUG)

--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -144,9 +144,15 @@ typedef struct {
   +------------------------------+  ACPI Reclaim MEM Base
   |       PLD Reserved MEM       |
   +------------------------------+  PLD Reserved MEM Base
+  |         DMA Buffer           |
+  +------------------------------+  DMA Buffer MEM Base
+  |          PLD Heap            |
+  +------------------------------+  PLD Heap MEM Base
+  |          PLD Stack           |
+  +------------------------------+  PLD Stack MEM Base
 
         Loader Reserved MEM
-  +------------------------------+  StackTop
+  +------------------------------+  FSP Reserved MEM Base
   |       LDR Stack (Down)       |
   |                              |
   |         LDR HOB (Up)         |
@@ -178,6 +184,7 @@ typedef struct {
   UINT32            MemPoolStart;
   UINT32            MemPoolCurrTop;
   UINT32            MemPoolCurrBottom;
+  UINT32            MemUsableTop;
   UINT32            PayloadId;
   UINT32            DebugPrintErrorLevel;
   UINT8             DebugPortIdx;
@@ -197,6 +204,7 @@ typedef struct {
   VOID             *ContainerList;
   VOID             *S3DataPtr;
   VOID             *DebugDataPtr;
+  VOID             *DmaBufferPtr;
   UINT8             PlatformName[PLATFORM_NAME_SIZE];
   UINT32            LdrFeatures;
   BL_PERF_DATA      PerfData;
@@ -439,6 +447,30 @@ GetComponentPcdInfo (
   IN  UINT32     Signature,
   OUT UINT32     *Base,
   OUT UINT32     *Size
+  );
+
+/**
+  This function retrieves DMA buffer base.
+
+  @retval    DMA buffer base.
+
+**/
+VOID *
+EFIAPI
+GetDmaBufferPtr (
+  VOID
+  );
+
+/**
+  This function retrieves usable memory top.
+
+  @retval    Usable memory top.
+
+**/
+UINT32
+EFIAPI
+GetUsableMemoryTop (
+  VOID
   );
 
 #endif

--- a/BootloaderCorePkg/Library/BootloaderCoreLib/BootloaderCoreLib.c
+++ b/BootloaderCorePkg/Library/BootloaderCoreLib/BootloaderCoreLib.c
@@ -377,3 +377,33 @@ SetHobList (
   GetLoaderGlobalDataPointer()->LdrHobList = HobList;
 }
 
+
+/**
+  This function retrieves DMA buffer base.
+
+  @retval    DMA buffer base.
+
+**/
+VOID *
+EFIAPI
+GetDmaBufferPtr (
+  VOID
+  )
+{
+  return GetLoaderGlobalDataPointer()->DmaBufferPtr;
+}
+
+/**
+  This function retrieves usable memory top.
+
+  @retval    Usable memory top.
+
+**/
+UINT32
+EFIAPI
+GetUsableMemoryTop (
+  VOID
+  )
+{
+  return GetLoaderGlobalDataPointer()->MemUsableTop;
+}

--- a/BootloaderCorePkg/Library/MemoryAllocationLib/MemoryAllocationLib.c
+++ b/BootloaderCorePkg/Library/MemoryAllocationLib/MemoryAllocationLib.c
@@ -287,3 +287,46 @@ FreePool (
   )
 {
 }
+
+/**
+  Allocates one or more 4KB pages of type EfiRuntimeServicesData.
+
+  Allocates the number of 4KB pages of type EfiRuntimeServicesData and returns a pointer to the
+  allocated buffer.  The buffer returned is aligned on a 4KB boundary.  If Pages is 0, then NULL
+  is returned.  If there is not enough memory remaining to satisfy the request, then NULL is
+  returned.
+
+  @param  Pages                 The number of 4 KB pages to allocate.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+EFIAPI
+AllocateRuntimePages (
+  IN UINTN  Pages
+  )
+{
+  return NULL;
+}
+
+/**
+  Allocates a buffer of type EfiRuntimeServicesData.
+
+  Allocates the number bytes specified by AllocationSize of type EfiRuntimeServicesData and returns
+  a pointer to the allocated buffer.  If AllocationSize is 0, then a valid buffer of 0 size is
+  returned.  If there is not enough memory remaining to satisfy the request, then NULL is returned.
+
+  @param  AllocationSize        The number of bytes to allocate.
+
+  @return A pointer to the allocated buffer or NULL if allocation fails.
+
+**/
+VOID *
+EFIAPI
+AllocateRuntimePool (
+  IN UINTN  AllocationSize
+  )
+{
+  return NULL;
+}

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -348,6 +348,7 @@ SecStartup2 (
   UINT32                    MemPoolStart;
   UINT32                    MemPoolEnd;
   UINT32                    MemPoolCurrTop;
+  UINT32                    DmaBuffer;
   UINT32                    AllocateLen;
   UINT32                    Offset;
   UINT32                    Delta;
@@ -455,6 +456,16 @@ SecStartup2 (
   LdrGlobal->MemPoolStart      = MemPoolStart;
   LdrGlobal->MemPoolCurrTop    = MemPoolCurrTop;
   LdrGlobal->MemPoolCurrBottom = MemPoolStart;
+  LdrGlobal->MemUsableTop      = (UINT32)(FspReservedMemBase + FspReservedMemSize);
+
+  if (FeaturePcdGet (PcdDmaProtectionEnabled)) {
+    DmaBuffer = MemPoolStart - (PcdGet32 (PcdLoaderAcpiNvsSize) + PcdGet32 (PcdLoaderAcpiReclaimSize)
+                + PcdGet32 (PcdPayloadReservedMemSize) + PcdGet32 (PcdDmaBufferSize));
+    DmaBuffer = ALIGN_DOWN (DmaBuffer, PcdGet32 (PcdDmaBufferAlignment));
+  } else {
+    DmaBuffer = 0;
+  }
+  LdrGlobal->DmaBufferPtr      = (VOID *)(UINTN)DmaBuffer;
 
   DEBUG_CODE_BEGIN ();
   // Initialize HOB/Stack region with known pattern so that the usage can be detected

--- a/BootloaderCorePkg/Stage1B/Stage1B.inf
+++ b/BootloaderCorePkg/Stage1B/Stage1B.inf
@@ -100,6 +100,12 @@
   gPlatformModuleTokenSpaceGuid.PcdCfgDataIntBase
   gPlatformCommonLibTokenSpaceGuid.PcdCompSignHashAlg
   gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashMask
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaProtectionEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferAlignment
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferSize
+  gPlatformModuleTokenSpaceGuid.PcdPayloadReservedMemSize
+  gPlatformModuleTokenSpaceGuid.PcdLoaderAcpiNvsSize
+  gPlatformModuleTokenSpaceGuid.PcdLoaderAcpiReclaimSize
 
 [Depex]
   TRUE

--- a/BootloaderCorePkg/Stage2/Stage2Support.c
+++ b/BootloaderCorePkg/Stage2/Stage2Support.c
@@ -493,6 +493,7 @@ BuildExtraInfoHob (
     LoaderPlatformData->DebugLogBuffer = (DEBUG_LOG_BUFFER_HEADER *) GetDebugLogBufferPtr ();
     LoaderPlatformData->ConfigDataPtr  = GetConfigDataPtr ();
     LoaderPlatformData->ContainerList  = GetContainerListPtr ();
+    LoaderPlatformData->DmaBufferPtr   = GetDmaBufferPtr ();
   }
 
   // Build flash map info hob

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -185,6 +185,7 @@ class BaseBoard(object):
         self.ENABLE_CONTAINER_BOOT = 1
         self.ENABLE_CSME_UPDATE    = 0
         self.ENABLE_EMMC_HS400     = 1
+        self.ENABLE_DMA_PROTECTION = 0
 
         self.BUILD_CSME_UPDATE_DRIVER    = 0
 

--- a/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
+++ b/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
@@ -69,6 +69,8 @@ PayloadInit (
   // +--------------------------------------------+ RsvdBase + RsvdSize
   // |   Reserved memory for Payload              |
   // +--------------------------------------------+ RsvdBase
+  // |   + DMA buffer                             |
+  // +--------------------------------------------+ DmaBase
   // |   + Payload heap                           |
   // +--------------------------------------------+ HeapBase
   // |   + Payload stack                          |

--- a/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.inf
+++ b/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.inf
@@ -54,3 +54,6 @@
   gPayloadTokenSpaceGuid.PcdGlobalDataAddress
   gPlatformCommonLibTokenSpaceGuid.PcdEmmcMaxRwBlockNumber
   gPlatformCommonLibTokenSpaceGuid.PcdPcdLibId
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaProtectionEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferSize
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferAlignment

--- a/Silicon/CommonSocPkg/Include/Library/VtdPmrLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/VtdPmrLib.h
@@ -17,45 +17,27 @@ typedef struct {
   UINT64                                  EngineMask;
   UINT8                                   HostAddressWidth;
   UINTN                                   VTdEngineCount;
-  UINT64                                  VTdEngineAddress[0];
+  UINT64                                  VTdEngineAddress[1];
 } VTD_INFO;
 
 /**
-  Set DMA protected region.
+  Enable or disable DMA protection using VTD PMR.
 
-  @param VTdInfo            The VTd engine context information.
-  @param EngineMask         The mask of the VTd engine to be accessed.
-  @param LowMemoryBase      The protected low memory region base.
-  @param LowMemoryLength    The protected low memory region length.
-  @param HighMemoryBase     The protected high memory region base.
-  @param HighMemoryLength   The protected high memory region length.
+  This function will enable/disable DMA protection.
 
-  @retval EFI_SUCCESS      The DMA protection is set.
-  @retval EFI_UNSUPPORTED  The DMA protection is not set.
+  @param[in] VtdInfo            VT-d info structure pointer.
+  @param[in] Enable             Enable/Disable DMA protection.
+
+  @retval     EFI_UNSUPPORTED   DMA protection is not supported.
+  @retval     EFI_SUCCESS       DMA protection is enabled or disabled successfully.
+
 **/
 EFI_STATUS
-SetDmaProtectedRange (
-  IN VTD_INFO      *VTdInfo,
-  IN UINT64        EngineMask,
-  IN UINT32        LowMemoryBase,
-  IN UINT32        LowMemoryLength,
-  IN UINT64        HighMemoryBase,
-  IN UINT64        HighMemoryLength
-  );
-
-/**
-  Diable DMA protection.
-
-  @param VTdInfo            The VTd engine context information.
-  @param EngineMask         The mask of the VTd engine to be accessed.
-
-  @retval EFI_SUCCESS DMA protection is disabled.
-**/
-EFI_STATUS
-DisableDmaProtection (
-  IN VTD_INFO      *VTdInfo,
-  IN UINT64        EngineMask
-  );
+EFIAPI
+SetDmaProtection (
+  IN  VTD_INFO     *VtdInfo,
+  IN  BOOLEAN       Enable
+);
 
 #endif
 

--- a/Silicon/CommonSocPkg/Library/VtdPmrLib/VtdPmrLib.inf
+++ b/Silicon/CommonSocPkg/Library/VtdPmrLib/VtdPmrLib.inf
@@ -26,6 +26,7 @@
   MdePkg/MdePkg.dec
   BootloaderCommonPkg/BootloaderCommonPkg.dec
   Silicon/CommonSocPkg/CommonSocPkg.dec
+  BootloaderCorePkg/BootloaderCorePkg.dec
 
 [LibraryClasses]
   BaseLib
@@ -35,4 +36,7 @@
 
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaProtectionEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferAlignment
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferSize
 


### PR DESCRIPTION
This patch added DMA memory type into memory allocation pool for payloads.
This DMA memory buffer with PcdDmaBufferSize is located at address
aligned at PcdDmaBufferAlignment after Payload reserved memory. Memory
type EfiRuntimeServicesData is used to indicate DMA memory type.

Stage1B calculates the DMA memory location using fixed PCDs so that
platform can set up DMA protection as early as possible after memory is
ready. In Stage1B or Stage2 platform code should use platform VTd
information to setup PMR to protect all low memory except for the DMA
buffer range. DMA memory will be added into memory pool at the entry
point of the payload. Before transfering to OS, the DMA memory protection
can be disabled, and the DMA memory pool can be reclaimed for OS usage.

Currently only boot media device will utilize the DMA buffer range for
block access operations. So it should only be required by payloads. GFX,
when enabled, will also use DMA. It will be targeted to the system stolen
memory which is not protected by PMR.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>