### PR TITLE
added /Download to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ FspRel.bin
 /Stitch
 /Build
 /Conf
+/Download
 /PayloadPkg/PayloadBins
 Platform/ApollolakeBoardPkg/VbtBin
 Platform/CoffeelakeBoardPkg/VbtBin


### PR DESCRIPTION
The change in slimbootloader/documentation from pull request [#67](https://github.com/slimbootloader/documentation/pull/67) creates the directory 'Download/', which needs to be ignored by git.