### PR TITLE
[APL] Enable APL DMA protection code flow

### DIFF
--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -50,6 +50,7 @@ class Board(BaseBoard):
         self.ENABLE_SPLASH            = 1
         self.ENABLE_FRAMEBUFFER_INIT  = 1
         self.ENABLE_GRUB_CONFIG       = 1
+        self.ENABLE_DMA_PROTECTION    = 0
 
         # G9 for 384 | W7 Opt for SHA384| Ni  Opt for SHA256| V8 Opt for SHA256
         self.ENABLE_CRYPTO_SHA_OPT    = IPP_CRYPTO_OPTIMIZATION_MASK['SHA256_NI']

--- a/Platform/ApollolakeBoardPkg/Library/LoaderLib/LoaderLib.inf
+++ b/Platform/ApollolakeBoardPkg/Library/LoaderLib/LoaderLib.inf
@@ -26,6 +26,7 @@
   MdePkg/MdePkg.dec
   BootloaderCorePkg/BootloaderCorePkg.dec
   BootloaderCommonPkg/BootloaderCommonPkg.dec
+  Silicon/CommonSocPkg/CommonSocPkg.dec
   Silicon/ApollolakePkg/ApollolakePkg.dec
 
 [LibraryClasses]

--- a/Platform/ApollolakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.inf
+++ b/Platform/ApollolakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.inf
@@ -32,6 +32,7 @@
   BootloaderCommonPkg/BootloaderCommonPkg.dec
   Silicon/ApollolakePkg/ApollolakePkg.dec
   Platform/CommonBoardPkg/CommonBoardPkg.dec
+  Silicon/CommonSocPkg/CommonSocPkg.dec
   Platform/ApollolakeBoardPkg/ApollolakeBoardPkg.dec
 
 [LibraryClasses]

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -671,6 +671,42 @@ UpdatePayloadId (
 }
 
 /**
+  Build VT-d information to prepare PMR program
+
+**/
+STATIC
+VOID
+BuildVtdInfo (
+  VOID
+  )
+{
+  VTD_INFO     *VtdInfo;
+  UINT32        McD0BaseAddress;
+  UINT32        MchBar;
+  UINT32        Idx;
+  UINT32        VtdIdx;
+  UINT32        Data;
+  UINT32        RegOff[2] = {R_SA_MCHBAR_VTD1_OFFSET, R_SA_MCHBAR_VTD2_OFFSET};
+
+  VtdInfo = &((PLATFORM_DATA *)GetPlatformDataPtr ())->VtdInfo;
+  McD0BaseAddress = MM_PCI_ADDRESS (SA_MC_BUS, 0, 0, 0);
+  MchBar          = MmioRead32 (McD0BaseAddress + R_SA_MCHBAR_REG) & ~BIT0;
+  VtdInfo->HostAddressWidth = 38;
+
+  VtdIdx = 0;
+  for (Idx = 0; Idx < ARRAY_SIZE(RegOff); Idx++) {
+    Data = MmioRead32 (MchBar + RegOff[Idx]) & ~3;
+    if (Data != 0) {
+      DEBUG ((DEBUG_INFO, "VT-d Engine %d @ 0x%08X\n", VtdIdx, Data));
+      VtdInfo->VTdEngineAddress[VtdIdx++] = Data;
+      ASSERT (VtdIdx <= ARRAY_SIZE(VtdInfo->VTdEngineAddress));
+    }
+  }
+
+  VtdInfo->VTdEngineCount = VtdIdx;
+}
+
+/**
   Board specific hook points.
 
   Implement board specific initialization during the boot flow.
@@ -690,6 +726,7 @@ BoardInit (
   LOADER_GLOBAL_DATA *LdrGlobal;
   UINT32              TsegBase;
   UINT64              TsegSize;
+  VTD_INFO           *VtdInfo;
 
   switch (InitPhase) {
   case PreSiliconInit:
@@ -731,6 +768,12 @@ BoardInit (
       PciWrite8 (PCI_LIB_ADDRESS(SA_IGD_BUS, SA_IGD_DEV, SA_IGD_FUN_0, PCI_COMMAND_OFFSET), \
                  EFI_PCI_COMMAND_MEMORY_SPACE | EFI_PCI_COMMAND_BUS_MASTER);
     }
+    // Enable DMA protection
+    if (FeaturePcdGet (PcdDmaProtectionEnabled)) {
+      BuildVtdInfo ();
+      VtdInfo = &((PLATFORM_DATA *)GetPlatformDataPtr ())->VtdInfo;
+      SetDmaProtection (VtdInfo, TRUE);
+    }
     BuildOsConfigDataHob ();
     break;
   case PostPciEnumeration:
@@ -768,6 +811,11 @@ BoardInit (
     break;
   case EndOfFirmware:
     ClearFspHob ();
+    if (FeaturePcdGet (PcdDmaProtectionEnabled)) {
+      // Disable DMA protection
+      VtdInfo = &((PLATFORM_DATA *)GetPlatformDataPtr ())->VtdInfo;
+      SetDmaProtection (VtdInfo, FALSE);
+    }
     EnterIaUnTrustMode ();
     // Clear known MCA logged in BANK4 and enable this MCA again
     AsmWriteMsr64 (IA32_MC4_STATUS, 0);
@@ -1302,7 +1350,6 @@ UpdateOsBootMediumInfo (
     DEBUG ((DEBUG_INFO, "Set boot to shell!\n"));
     OsBootOptionList->BootToShell = 1;
   }
-
 }
 
 /**

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.h
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.h
@@ -41,6 +41,7 @@
 #include <Library/SpiFlashLib.h>
 #include <Library/TpmLib.h>
 #include <Library/VtdLib.h>
+#include <Library/VtdPmrLib.h>
 #include <RegAccess.h>
 #include <IndustryStandard/Pci.h>
 #include <IndustryStandard/Acpi.h>

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -100,4 +100,7 @@
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegBase
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegSize
   gPlatformModuleTokenSpaceGuid.PcdFuncCpuInitHook
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaProtectionEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferAlignment
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferSize
   gPlatformCommonLibTokenSpaceGuid.PcdEmmcHs400SupportEnabled

--- a/Platform/CoffeelakeBoardPkg/BoardConfig.py
+++ b/Platform/CoffeelakeBoardPkg/BoardConfig.py
@@ -51,6 +51,7 @@ class Board(BaseBoard):
         self.HAVE_PSD_TABLE       = 1
         self.ENABLE_GRUB_CONFIG   = 1
         self.ENABLE_CSME_UPDATE   = 0
+        self.ENABLE_DMA_PROTECTION    = 0
         self.DEBUG_PORT_NUMBER    = 0xFF
 
         # CSME update library is required to enable this option and will be available as part of CSME kit
@@ -157,6 +158,7 @@ class Board(BaseBoard):
             'PsdLib|Silicon/$(SILICON_PKG_NAME)/Library/PsdLib/PsdLib.inf',
             'HeciLib|Silicon/$(SILICON_PKG_NAME)/Library/HeciLib/HeciLib.inf',
             'ShellExtensionLib|Platform/$(BOARD_PKG_NAME)/Library/ShellExtensionLib/ShellExtensionLib.inf',
+            'VtdPmrLib|Silicon/CommonSocPkg/Library/VtdPmrLib/VtdPmrLib.inf'
         ]
         if self.BUILD_CSME_UPDATE_DRIVER:
             dsc_libs['IA32'].append ('MeFwUpdateLib|Silicon/$(SILICON_PKG_NAME)/Library/MeFwUpdateLib/MeFwUpdateLib.inf')

--- a/Platform/CoffeelakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.inf
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.inf
@@ -33,6 +33,7 @@
   Silicon/CoffeelakePkg/CoffeelakePkg.dec
   Platform/CoffeelakeBoardPkg/CoffeelakeBoardPkg.dec
   Platform/CommonBoardPkg/CommonBoardPkg.dec
+  Silicon/CommonSocPkg/CommonSocPkg.dec
 
 [LibraryClasses]
   BaseLib

--- a/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -223,6 +223,9 @@ UpdateFspConfig (
     DEBUG ((DEBUG_INFO, "FSP-M variables for Intel(R) SGX were NOT updated.\n"));
   }
 
+  // Enable VT-d
+  FspmcfgTest->VtdDisable = 0;
+
   Fspmcfg->PlatformDebugConsent = MemCfgData->PlatformDebugConsent;
   Fspmcfg->PchTraceHubMode      = MemCfgData->PchTraceHubMode;
 }

--- a/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
@@ -32,6 +32,7 @@
   Silicon/CommonSocPkg/CommonSocPkg.dec
   Platform/CommonBoardPkg/CommonBoardPkg.dec
   Platform/CoffeelakeBoardPkg/CoffeelakeBoardPkg.dec
+  Silicon/CommonSocPkg/CommonSocPkg.dec
 
 [LibraryClasses]
   BaseLib

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -62,6 +62,7 @@
 #include <Library/SmbiosInitLib.h>
 #include <IndustryStandard/SmBios.h>
 #include <VerInfo.h>
+#include <Library/VtdPmrLib.h>
 #include <Library/S3SaveRestoreLib.h>
 #include "GpioTables.h"
 #include <Library/PchSpiLib.h>
@@ -906,6 +907,42 @@ UpdatePayloadId (
 }
 
 /**
+  Build VT-d information to prepare PMR program
+
+**/
+STATIC
+VOID
+BuildVtdInfo (
+  VOID
+  )
+{
+  VTD_INFO     *VtdInfo;
+  UINT32        McD0BaseAddress;
+  UINT32        MchBar;
+  UINT32        Idx;
+  UINT32        VtdIdx;
+  UINT32        Data;
+  UINT32        RegOff[2] = {R_SA_MCHBAR_VTD1_OFFSET, R_SA_MCHBAR_VTD3_OFFSET};
+
+  VtdInfo = &((PLATFORM_DATA *)GetPlatformDataPtr ())->VtdInfo;
+  McD0BaseAddress = MM_PCI_ADDRESS (SA_MC_BUS, 0, 0, 0);
+  MchBar          = MmioRead32 (McD0BaseAddress + R_SA_MCHBAR) & ~BIT0;
+  VtdInfo->HostAddressWidth = 39;
+
+  VtdIdx = 0;
+  for (Idx = 0; Idx < ARRAY_SIZE(RegOff); Idx++) {
+    Data = MmioRead32 (MchBar + RegOff[Idx]) & ~3;
+    if (Data != 0) {
+      DEBUG ((DEBUG_INFO, "VT-d Engine %d @ 0x%08X\n", VtdIdx, Data));
+      VtdInfo->VTdEngineAddress[VtdIdx++] = Data;
+      ASSERT (VtdIdx <= ARRAY_SIZE(VtdInfo->VTdEngineAddress));
+    }
+  }
+
+  VtdInfo->VTdEngineCount = VtdIdx;
+}
+
+/**
   Initialize Board specific things in Stage2 Phase
 
   @param[in]  InitPhase            Indicates a board init phase to be initialized
@@ -927,7 +964,7 @@ BoardInit (
   UINT32          AddressPort;
   UINTN           SpiBar0;
   UINT32          Length;
-
+  VTD_INFO                  *VtdInfo;
   EFI_PEI_GRAPHICS_INFO_HOB *FspGfxHob;
   LOADER_GLOBAL_DATA        *LdrGlobal;
 
@@ -991,6 +1028,13 @@ BoardInit (
     //
     if (FeaturePcdGet (PcdSmbiosEnabled)) {
       InitializeSmbiosInfo ();
+    }
+
+    // Enable DMA protection
+    if (FeaturePcdGet (PcdDmaProtectionEnabled)) {
+      BuildVtdInfo ();
+      VtdInfo = &((PLATFORM_DATA *)GetPlatformDataPtr ())->VtdInfo;
+      SetDmaProtection (VtdInfo, TRUE);
     }
     break;
   case PrePciEnumeration:
@@ -1091,6 +1135,11 @@ BoardInit (
     break;
   case EndOfFirmware:
     ClearFspHob ();
+    if (FeaturePcdGet (PcdDmaProtectionEnabled)) {
+      // Disable DMA protection
+      VtdInfo = &((PLATFORM_DATA *)GetPlatformDataPtr ())->VtdInfo;
+      SetDmaProtection (VtdInfo, FALSE);
+    }
     break;
   default:
     break;

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -54,6 +54,7 @@
   PsdLib
   S3SaveRestoreLib
   BoardSupportLib
+  VtdPmrLib
 
 [Guids]
   gSmmInformationGuid
@@ -84,3 +85,6 @@
   gPlatformModuleTokenSpaceGuid.PcdSmbiosTablesBase
   gPlatformModuleTokenSpaceGuid.PcdSmbiosEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdEmmcHs400SupportEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaProtectionEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferAlignment
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferSize

--- a/Silicon/ApollolakePkg/Include/PlatformData.h
+++ b/Silicon/ApollolakePkg/Include/PlatformData.h
@@ -10,6 +10,7 @@
 
 #include <Library/BootGuardLib.h>
 #include <Library/BootloaderCoreLib.h>
+#include <Library/VtdPmrLib.h>
 
 typedef enum {
   BootModeTargetNormal    = 0,
@@ -123,6 +124,7 @@ typedef struct {
   BOOT_GUARD_INFO     BtGuardInfo;
   VOID               *LoaderSeedList;
   PLAT_FEATURES       PlatformFeatures;
+  VTD_INFO            VtdInfo;
 } PLATFORM_DATA;
 
 typedef struct {

--- a/Silicon/ApollolakePkg/Library/PsdLib/PsdLib.inf
+++ b/Silicon/ApollolakePkg/Library/PsdLib/PsdLib.inf
@@ -27,6 +27,7 @@ MdePkg/MdePkg.dec
 IntelFsp2Pkg/IntelFsp2Pkg.dec
 BootloaderCorePkg/BootloaderCorePkg.dec
 BootloaderCommonPkg/BootloaderCommonPkg.dec
+Silicon/CommonSocPkg/CommonSocPkg.dec
 Silicon/ApollolakePkg/ApollolakePkg.dec
 Platform/ApollolakeBoardPkg/ApollolakeBoardPkg.dec
 

--- a/Silicon/CoffeelakePkg/Include/PlatformData.h
+++ b/Silicon/CoffeelakePkg/Include/PlatformData.h
@@ -10,6 +10,7 @@
 
 #include <Library/BootGuardLib.h>
 #include <Library/BootloaderCoreLib.h>
+#include <Library/VtdPmrLib.h>
 
 typedef struct {
   UINT8               PlatformId : 5;
@@ -21,6 +22,7 @@ typedef struct {
 
 typedef struct {
   BOOT_GUARD_INFO     BtGuardInfo;
+  VTD_INFO            VtdInfo;
 } PLATFORM_DATA;
 
 #endif /* __PLATFORM_DATA_H__ */

--- a/Silicon/CoffeelakePkg/Include/Register/SaRegs.h
+++ b/Silicon/CoffeelakePkg/Include/Register/SaRegs.h
@@ -29,7 +29,11 @@
 #define SA_MC_FUN                                   0x00
 #define V_SA_MC_VID                                 0x8086
 #define R_SA_MC_DEVICE_ID                           0x02
+#define R_SA_MCHBAR                                 0x48
 #define R_SA_MC_CAPID0_B                            0xE8
+
+#define R_SA_MCHBAR_VTD1_OFFSET                     0x5400  // HW UNIT1 for IGD
+#define R_SA_MCHBAR_VTD3_OFFSET                     0x5410  // HW UNIT3 for all other - PEG, USB, SATA etc
 
 #define CPUID_VERSION_INFO                          0x01
 #define CPUID_FULL_FAMILY_MODEL                     0x0FFF0FF0

--- a/Silicon/CommonSocPkg/Include/Library/VtdPmrLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/VtdPmrLib.h
@@ -10,6 +10,7 @@
 #define __VTD_PMR_LIB_H__
 
 #include <IndustryStandard/Vtd.h>
+#include <Library/PcdLib.h>
 
 #define  VTD_ENGINE_ALL                   ((UINT64)(-1))
 
@@ -17,7 +18,7 @@ typedef struct {
   UINT64                                  EngineMask;
   UINT8                                   HostAddressWidth;
   UINTN                                   VTdEngineCount;
-  UINT64                                  VTdEngineAddress[1];
+  UINT64                                  VTdEngineAddress[8];
 } VTD_INFO;
 
 /**


### PR DESCRIPTION
This patch added required code flow to prepare to enable DMA
protection for APL platform. Platform code needs to build a
VTD_INFO structure, and then call SetDmaProtection to enable
and disable DMA protection at different initialization phase.
Platform needs to enable DMA protection as early as possible
after memory is ready. For APL, since VT-d is only enabled
in FspSiliconInit, it was postponed to Stage2.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>