### PR TITLE
Add IoMmu support for XHCI library

### DIFF
--- a/BootloaderCommonPkg/Library/XhciLib/UsbHcMem.c
+++ b/BootloaderCommonPkg/Library/XhciLib/UsbHcMem.c
@@ -24,6 +24,9 @@ UsbHcAllocMemBlock (
   )
 {
   USBHC_MEM_BLOCK       *Block;
+  VOID                  *BufHost;
+  VOID                  *Mapping;
+  EFI_PHYSICAL_ADDRESS  MappedAddr;
   EFI_STATUS            Status;
   UINTN                 PageNumber;
   EFI_PHYSICAL_ADDRESS  TempPtr;
@@ -64,18 +67,20 @@ UsbHcAllocMemBlock (
 
   Block->Bits = (UINT8 *) (UINTN) TempPtr;
 
-  Status = PeiServicesAllocatePages (
-             EfiBootServicesData,
+  Status = IoMmuAllocateBuffer (
              Pages,
-             &TempPtr
+             &BufHost,
+             &MappedAddr,
+             &Mapping
              );
   if (EFI_ERROR (Status)) {
     return NULL;
   }
-  ZeroMem ((VOID *) (UINTN) TempPtr, EFI_PAGES_TO_SIZE (Pages));
+  ZeroMem ((VOID *) (UINTN) BufHost, EFI_PAGES_TO_SIZE (Pages));
 
-  Block->BufHost = (UINT8 *) (UINTN) TempPtr;;
-  Block->Buf = (UINT8 *) (UINTN) TempPtr;
+  Block->BufHost = (UINT8 *) (UINTN) BufHost;
+  Block->Buf = (UINT8 *) (UINTN) MappedAddr;
+  Block->Mapping  = Mapping;
   Block->Next = NULL;
 
   return Block;
@@ -95,6 +100,9 @@ UsbHcFreeMemBlock (
   )
 {
   ASSERT ((Pool != NULL) && (Block != NULL));
+
+  IoMmuFreeBuffer (EFI_SIZE_TO_PAGES (Block->BufLen), Block->BufHost, Block->Mapping);
+
   //
   // No free memory in PEI.
   //
@@ -313,31 +321,7 @@ UsbHcIsMemBlockEmpty (
   return TRUE;
 }
 
-/**
-  Unlink the memory block from the pool's list.
 
-  @param  Head          The block list head of the memory's pool.
-  @param  BlockToUnlink The memory block to unlink.
-
-**/
-VOID
-UsbHcUnlinkMemBlock (
-  IN USBHC_MEM_BLOCK    *Head,
-  IN USBHC_MEM_BLOCK    *BlockToUnlink
-  )
-{
-  USBHC_MEM_BLOCK       *Block;
-
-  ASSERT ((Head != NULL) && (BlockToUnlink != NULL));
-
-  for (Block = Head; Block != NULL; Block = Block->Next) {
-    if (Block->Next == BlockToUnlink) {
-      Block->Next         = BlockToUnlink->Next;
-      BlockToUnlink->Next = NULL;
-      break;
-    }
-  }
-}
 
 /**
   Initialize the memory management pool for the host controller.
@@ -560,6 +544,7 @@ UsbHcFreeMem (
   @param  HostAddress           The system memory address to map to the PCI controller.
   @param  DeviceAddress         The resulting map address for the bus master PCI controller to
                                 use to access the hosts HostAddress.
+  @param  Mapping               A resulting value to pass to Unmap().
 
   @retval EFI_SUCCESS           Success to allocate aligned pages.
   @retval EFI_INVALID_PARAMETER Pages or Alignment is not valid.
@@ -571,14 +556,13 @@ UsbHcAllocateAlignedPages (
   IN UINTN                      Pages,
   IN UINTN                      Alignment,
   OUT VOID                      **HostAddress,
-  OUT EFI_PHYSICAL_ADDRESS      *DeviceAddress
+  OUT EFI_PHYSICAL_ADDRESS      *DeviceAddress,
+  OUT VOID                      **Mapping
   )
 {
   EFI_STATUS            Status;
-  EFI_PHYSICAL_ADDRESS  Memory;
-  UINTN                 AlignedMemory;
-  UINTN                 AlignmentMask;
-  UINTN                 RealPages;
+  VOID                  *Memory;
+  EFI_PHYSICAL_ADDRESS  DeviceMemory;
 
   //
   // Alignment must be a power of two or zero.
@@ -594,42 +578,33 @@ UsbHcAllocateAlignedPages (
   }
 
   if (Alignment > EFI_PAGE_SIZE) {
-    //
-    // Calculate the total number of pages since alignment is larger than page size.
-    //
-    AlignmentMask  = Alignment - 1;
-    RealPages      = Pages + EFI_SIZE_TO_PAGES (Alignment);
-    //
-    // Make sure that Pages plus EFI_SIZE_TO_PAGES (Alignment) does not overflow.
-    //
-    ASSERT (RealPages > Pages);
-
-    Status = PeiServicesAllocatePages (
-               EfiBootServicesData,
+    Status = IoMmuAllocateAlignedBuffer (
                Pages,
-               &Memory
+               Alignment,
+               &Memory,
+               &DeviceMemory,
+               Mapping
                );
     if (EFI_ERROR (Status)) {
       return EFI_OUT_OF_RESOURCES;
     }
-    AlignedMemory = ((UINTN) Memory + AlignmentMask) & ~AlignmentMask;
   } else {
     //
     // Do not over-allocate pages in this case.
     //
-    Status = PeiServicesAllocatePages (
-               EfiBootServicesData,
+    Status = IoMmuAllocateBuffer (
                Pages,
-               &Memory
+               &Memory,
+               &DeviceMemory,
+               Mapping
                );
     if (EFI_ERROR (Status)) {
       return EFI_OUT_OF_RESOURCES;
     }
-    AlignedMemory = (UINTN) Memory;
   }
 
-  *HostAddress = (VOID *) AlignedMemory;
-  *DeviceAddress = (EFI_PHYSICAL_ADDRESS) AlignedMemory;
+  *HostAddress = Memory;
+  *DeviceAddress = DeviceMemory;
 
   return EFI_SUCCESS;
 }
@@ -639,17 +614,18 @@ UsbHcAllocateAlignedPages (
 
   @param  HostAddress           The system memory address to map to the PCI controller.
   @param  Pages                 The number of pages to free.
+  @param  Mapping               The mapping value returned from Map().
 
 **/
 VOID
 UsbHcFreeAlignedPages (
   IN VOID               *HostAddress,
-  IN UINTN              Pages
+  IN UINTN              Pages,
+  IN VOID               *Mapping
   )
 {
   ASSERT (Pages != 0);
-  //
-  // No free memory in PEI.
-  //
+
+  IoMmuFreeBuffer (Pages, HostAddress, Mapping);
 }
 

--- a/BootloaderCommonPkg/Library/XhciLib/UsbHcMem.h
+++ b/BootloaderCommonPkg/Library/XhciLib/UsbHcMem.h
@@ -1,7 +1,7 @@
 /** @file
 Private Header file for Usb Host Controller PEIM
 
-Copyright (c) 2014 - 2017, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2014, Intel Corporation. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -11,6 +11,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define _EFI_PEI_XHCI_MEM_H_
 
 #include <PiPei.h>
+
+#define  PeiServicesAllocatePages(a, b, c)   \
+         (((*(c) = (UINTN)AllocatePages (b)) != 0) ? EFI_SUCCESS : EFI_OUT_OF_RESOURCES)
 
 #define USBHC_MEM_DEFAULT_PAGES 16
 
@@ -22,6 +25,7 @@ struct _USBHC_MEM_BLOCK {
   UINT8                 *Buf;
   UINT8                 *BufHost;
   UINTN                 BufLen; // Memory size in bytes
+  VOID                  *Mapping;
   USBHC_MEM_BLOCK       *Next;
 };
 
@@ -105,6 +109,7 @@ UsbHcGetHostAddrForPciAddr (
   @param  HostAddress           The system memory address to map to the PCI controller.
   @param  DeviceAddress         The resulting map address for the bus master PCI controller to
                                 use to access the hosts HostAddress.
+  @param  Mapping               A resulting value to pass to Unmap().
 
   @retval EFI_SUCCESS           Success to allocate aligned pages.
   @retval EFI_INVALID_PARAMETER Pages or Alignment is not valid.
@@ -116,7 +121,8 @@ UsbHcAllocateAlignedPages (
   IN UINTN                      Pages,
   IN UINTN                      Alignment,
   OUT VOID                      **HostAddress,
-  OUT EFI_PHYSICAL_ADDRESS      *DeviceAddress
+  OUT EFI_PHYSICAL_ADDRESS      *DeviceAddress,
+  OUT VOID                      **Mapping
   );
 
 /**
@@ -124,12 +130,14 @@ UsbHcAllocateAlignedPages (
 
   @param  HostAddress           The system memory address to map to the PCI controller.
   @param  Pages                 The number of pages to free.
+  @param  Mapping               The mapping value returned from Map().
 
 **/
 VOID
 UsbHcFreeAlignedPages (
   IN VOID               *HostAddress,
-  IN UINTN              Pages
+  IN UINTN              Pages,
+  IN VOID               *Mapping
   );
 
 #endif

--- a/BootloaderCommonPkg/Library/XhciLib/XhcPeim.c
+++ b/BootloaderCommonPkg/Library/XhciLib/XhcPeim.c
@@ -204,29 +204,7 @@ XhcPeiReadCapRegister (
   return Data;
 }
 
-/**
-  Read XHCI door bell register.
 
-  @param  Xhc       The XHCI device.
-  @param  Offset    The offset of the door bell register.
-
-  @return The register content read
-
-**/
-UINT32
-XhcPeiReadDoorBellReg (
-  IN  PEI_XHC_DEV       *Xhc,
-  IN  UINT32            Offset
-  )
-{
-  UINT32                  Data;
-
-  ASSERT (Xhc->DBOff != 0);
-
-  Data = MmioRead32 (Xhc->UsbHostControllerBaseAddress + Xhc->DBOff + Offset);
-
-  return Data;
-}
 
 /**
   Write the data to the XHCI door bell register.
@@ -408,7 +386,7 @@ XhcPeiResetHC (
   MicroSecondDelay (1000);
   Status = XhcPeiWaitOpRegBit (Xhc, XHC_USBCMD_OFFSET, XHC_USBCMD_RESET, FALSE, Timeout);
 ON_EXIT:
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiResetHC: %r\n", Status));
+  DEBUG ((DEBUG_INFO, "XhcPeiResetHC: %r\n", Status));
   return Status;
 }
 
@@ -432,7 +410,7 @@ XhcPeiHaltHC (
 
   XhcPeiClearOpRegBit (Xhc, XHC_USBCMD_OFFSET, XHC_USBCMD_RUN);
   Status = XhcPeiWaitOpRegBit (Xhc, XHC_USBSTS_OFFSET, XHC_USBSTS_HALT, TRUE, Timeout);
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiHaltHC: %r\n", Status));
+  DEBUG ((DEBUG_INFO, "XhcPeiHaltHC: %r\n", Status));
   return Status;
 }
 
@@ -456,7 +434,7 @@ XhcPeiRunHC (
 
   XhcPeiSetOpRegBit (Xhc, XHC_USBCMD_OFFSET, XHC_USBCMD_RUN);
   Status = XhcPeiWaitOpRegBit (Xhc, XHC_USBSTS_OFFSET, XHC_USBSTS_HALT, FALSE, Timeout);
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiRunHC: %r\n", Status));
+  DEBUG ((DEBUG_INFO, "XhcPeiRunHC: %r\n", Status));
   return Status;
 }
 
@@ -540,7 +518,7 @@ XhcPeiControlTransfer (
   }
 
   if ((TransferDirection != EfiUsbNoData) &&
-      ((Data == NULL) || (*DataLength == 0))) {
+     ((Data == NULL) || (*DataLength == 0))) {
     return EFI_INVALID_PARAMETER;
   }
 
@@ -651,25 +629,32 @@ XhcPeiControlTransfer (
     //
     // The transfer timed out. Abort the transfer by dequeueing of the TD.
     //
-    RecoveryStatus = XhcPeiDequeueTrbFromEndpoint (Xhc, Urb);
-    if (EFI_ERROR (RecoveryStatus)) {
-      DEBUG ((DEBUG_ERROR, "XhcPeiControlTransfer: XhcPeiDequeueTrbFromEndpoint failed\n"));
+    RecoveryStatus = XhcPeiDequeueTrbFromEndpoint(Xhc, Urb);
+    if (EFI_ERROR(RecoveryStatus)) {
+      DEBUG((DEBUG_ERROR, "XhcPeiControlTransfer: XhcPeiDequeueTrbFromEndpoint failed\n"));
     }
-    goto FREE_URB;
+    XhcPeiFreeUrb (Xhc, Urb);
+    goto ON_EXIT;
   } else {
     if (*TransferResult == EFI_USB_NOERROR) {
       Status = EFI_SUCCESS;
-    } else if (*TransferResult == EFI_USB_ERR_STALL) {
-      RecoveryStatus = XhcPeiRecoverHaltedEndpoint (Xhc, Urb);
+    } else if ((*TransferResult == EFI_USB_ERR_STALL) || (*TransferResult == EFI_USB_ERR_BABBLE)) {
+      RecoveryStatus = XhcPeiRecoverHaltedEndpoint(Xhc, Urb);
       if (EFI_ERROR (RecoveryStatus)) {
         DEBUG ((DEBUG_ERROR, "XhcPeiControlTransfer: XhcPeiRecoverHaltedEndpoint failed\n"));
       }
       Status = EFI_DEVICE_ERROR;
-      goto FREE_URB;
+      XhcPeiFreeUrb (Xhc, Urb);
+      goto ON_EXIT;
     } else {
-      goto FREE_URB;
+      XhcPeiFreeUrb (Xhc, Urb);
+      goto ON_EXIT;
     }
   }
+  //
+  // Unmap data before consume.
+  //
+  XhcPeiFreeUrb (Xhc, Urb);
 
   //
   // Hook Get_Descriptor request from UsbBus as we need evaluate context and configure endpoint.
@@ -678,10 +663,9 @@ XhcPeiControlTransfer (
   //
   if ((Request->Request     == USB_REQ_GET_DESCRIPTOR) &&
       ((Request->RequestType == USB_REQUEST_TYPE (EfiUsbDataIn, USB_REQ_TYPE_STANDARD, USB_TARGET_DEVICE)) ||
-       ((Request->RequestType == USB_REQUEST_TYPE (EfiUsbDataIn, USB_REQ_TYPE_CLASS, USB_TARGET_DEVICE))))) {
+      ((Request->RequestType == USB_REQUEST_TYPE (EfiUsbDataIn, USB_REQ_TYPE_CLASS, USB_TARGET_DEVICE))))) {
     DescriptorType = (UINT8) (Request->Value >> 8);
-    if ((DescriptorType == USB_DESC_TYPE_DEVICE) && ((*DataLength == sizeof (EFI_USB_DEVICE_DESCRIPTOR))
-        || ((DeviceSpeed == EFI_USB_SPEED_FULL) && (*DataLength == 8)))) {
+    if ((DescriptorType == USB_DESC_TYPE_DEVICE) && ((*DataLength == sizeof (EFI_USB_DEVICE_DESCRIPTOR)) || ((DeviceSpeed == EFI_USB_SPEED_FULL) && (*DataLength == 8)))) {
       ASSERT (Data != NULL);
       //
       // Store a copy of device scriptor as hub device need this info to configure endpoint.
@@ -695,11 +679,10 @@ XhcPeiControlTransfer (
       } else {
         MaxPacket0 = Xhc->UsbDevContext[SlotId].DevDesc.MaxPacketSize0;
       }
-      Xhc->UsbDevContext[SlotId].ConfDesc = AllocateZeroPool (Xhc->UsbDevContext[SlotId].DevDesc.NumConfigurations * sizeof (
-                                              EFI_USB_CONFIG_DESCRIPTOR *));
+      Xhc->UsbDevContext[SlotId].ConfDesc = AllocateZeroPool (Xhc->UsbDevContext[SlotId].DevDesc.NumConfigurations * sizeof (EFI_USB_CONFIG_DESCRIPTOR *));
       if (Xhc->UsbDevContext[SlotId].ConfDesc == NULL) {
         Status = EFI_OUT_OF_RESOURCES;
-        goto FREE_URB;
+        goto ON_EXIT;
       }
       if (Xhc->HcCParams.Data.Csz == 0) {
         Status = XhcPeiEvaluateContext (Xhc, SlotId, MaxPacket0);
@@ -717,12 +700,12 @@ XhcPeiControlTransfer (
         Xhc->UsbDevContext[SlotId].ConfDesc[Index] = AllocateZeroPool (*DataLength);
         if (Xhc->UsbDevContext[SlotId].ConfDesc[Index] == NULL) {
           Status = EFI_OUT_OF_RESOURCES;
-          goto FREE_URB;
+          goto ON_EXIT;
         }
         CopyMem (Xhc->UsbDevContext[SlotId].ConfDesc[Index], Data, *DataLength);
       }
     } else if (((DescriptorType == USB_DESC_TYPE_HUB) ||
-                (DescriptorType == USB_DESC_TYPE_HUB_SUPER_SPEED)) && (*DataLength > 2)) {
+               (DescriptorType == USB_DESC_TYPE_HUB_SUPER_SPEED)) && (*DataLength > 2)) {
       ASSERT (Data != NULL);
       HubDesc = (EFI_USB_HUB_DESCRIPTOR *) Data;
       ASSERT (HubDesc->NumPorts <= 15);
@@ -767,7 +750,7 @@ XhcPeiControlTransfer (
     //
     // Hook Get_Status request from UsbBus to keep track of the port status change.
     //
-    State                       = * (UINT32 *) Data;
+    State                       = *(UINT32 *) Data;
     PortStatus.PortStatus       = 0;
     PortStatus.PortChangeStatus = 0;
 
@@ -836,11 +819,8 @@ XhcPeiControlTransfer (
 
     XhcPeiPollPortStatusChange (Xhc, Xhc->UsbDevContext[SlotId].RouteString, (UINT8)Request->Index, &PortStatus);
 
-    * (UINT32 *) Data = * (UINT32 *) &PortStatus;
+    *(UINT32 *) Data = *(UINT32 *) &PortStatus;
   }
-
-FREE_URB:
-  XhcPeiFreeUrb (Xhc, Urb);
 
 ON_EXIT:
 
@@ -990,15 +970,15 @@ XhcPeiBulkTransfer (
     //
     // The transfer timed out. Abort the transfer by dequeueing of the TD.
     //
-    RecoveryStatus = XhcPeiDequeueTrbFromEndpoint (Xhc, Urb);
-    if (EFI_ERROR (RecoveryStatus)) {
-      DEBUG ((DEBUG_ERROR, "XhcPeiBulkTransfer: XhcPeiDequeueTrbFromEndpoint failed\n"));
+    RecoveryStatus = XhcPeiDequeueTrbFromEndpoint(Xhc, Urb);
+    if (EFI_ERROR(RecoveryStatus)) {
+      DEBUG((DEBUG_ERROR, "XhcPeiBulkTransfer: XhcPeiDequeueTrbFromEndpoint failed\n"));
     }
   } else {
     if (*TransferResult == EFI_USB_NOERROR) {
       Status = EFI_SUCCESS;
-    } else if (*TransferResult == EFI_USB_ERR_STALL) {
-      RecoveryStatus = XhcPeiRecoverHaltedEndpoint (Xhc, Urb);
+    } else if ((*TransferResult == EFI_USB_ERR_STALL) || (*TransferResult == EFI_USB_ERR_BABBLE)) {
+      RecoveryStatus = XhcPeiRecoverHaltedEndpoint(Xhc, Urb);
       if (EFI_ERROR (RecoveryStatus)) {
         DEBUG ((DEBUG_ERROR, "XhcPeiBulkTransfer: XhcPeiRecoverHaltedEndpoint failed\n"));
       }
@@ -1048,7 +1028,7 @@ XhcPeiGetRootHubPortNumber (
   }
 
   *PortNumber = XhcDev->HcSParams1.Data.MaxPorts;
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiGetRootHubPortNumber: PortNumber = %x\n", *PortNumber));
+  DEBUG ((DEBUG_INFO, "XhcPeiGetRootHubPortNumber: PortNumber = %x\n", *PortNumber));
   return EFI_SUCCESS;
 }
 
@@ -1091,7 +1071,7 @@ XhcPeiClearRootHubPortFeature (
 
   Offset = (UINT32) (XHC_PORTSC_OFFSET + (0x10 * PortNumber));
   State = XhcPeiReadOpReg (Xhc, Offset);
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiClearRootHubPortFeature: Port: %x State: %x\n", PortNumber, State));
+  DEBUG ((DEBUG_INFO, "XhcPeiClearRootHubPortFeature: Port: %x State: %x\n", PortNumber, State));
 
   //
   // Mask off the port status change bits, these bits are
@@ -1100,92 +1080,92 @@ XhcPeiClearRootHubPortFeature (
   State &= ~ (BIT1 | BIT17 | BIT18 | BIT19 | BIT20 | BIT21 | BIT22 | BIT23);
 
   switch (PortFeature) {
-  case EfiUsbPortEnable:
-    //
-    // Ports may only be enabled by the xHC. Software cannot enable a port by writing a '1' to this flag.
-    // A port may be disabled by software writing a '1' to this flag.
-    //
-    State |= XHC_PORTSC_PED;
-    State &= ~XHC_PORTSC_RESET;
-    XhcPeiWriteOpReg (Xhc, Offset, State);
-    break;
-
-  case EfiUsbPortSuspend:
-    State |= XHC_PORTSC_LWS;
-    XhcPeiWriteOpReg (Xhc, Offset, State);
-    State &= ~XHC_PORTSC_PLS;
-    XhcPeiWriteOpReg (Xhc, Offset, State);
-    break;
-
-  case EfiUsbPortReset:
-    //
-    // PORTSC_RESET BIT(4) bit is RW1S attribute, which means Write-1-to-set status:
-    // Register bits indicate status when read, a clear bit may be set by
-    // writing a '1'. Writing a '0' to RW1S bits has no effect.
-    //
-    break;
-
-  case EfiUsbPortPower:
-    if (Xhc->HcCParams.Data.Ppc) {
+    case EfiUsbPortEnable:
       //
-      // Port Power Control supported
+      // Ports may only be enabled by the xHC. Software cannot enable a port by writing a '1' to this flag.
+      // A port may be disabled by software writing a '1' to this flag.
       //
-      State &= ~XHC_PORTSC_PP;
+      State |= XHC_PORTSC_PED;
+      State &= ~XHC_PORTSC_RESET;
       XhcPeiWriteOpReg (Xhc, Offset, State);
-    }
-    break;
+      break;
 
-  case EfiUsbPortOwner:
-    //
-    // XHCI root hub port don't has the owner bit, ignore the operation
-    //
-    break;
+    case EfiUsbPortSuspend:
+      State |= XHC_PORTSC_LWS;
+      XhcPeiWriteOpReg (Xhc, Offset, State);
+      State &= ~XHC_PORTSC_PLS;
+      XhcPeiWriteOpReg (Xhc, Offset, State);
+      break;
 
-  case EfiUsbPortConnectChange:
-    //
-    // Clear connect status change
-    //
-    State |= XHC_PORTSC_CSC;
-    XhcPeiWriteOpReg (Xhc, Offset, State);
-    break;
+    case EfiUsbPortReset:
+      //
+      // PORTSC_RESET BIT(4) bit is RW1S attribute, which means Write-1-to-set status:
+      // Register bits indicate status when read, a clear bit may be set by
+      // writing a '1'. Writing a '0' to RW1S bits has no effect.
+      //
+      break;
 
-  case EfiUsbPortEnableChange:
-    //
-    // Clear enable status change
-    //
-    State |= XHC_PORTSC_PEC;
-    XhcPeiWriteOpReg (Xhc, Offset, State);
-    break;
+    case EfiUsbPortPower:
+      if (Xhc->HcCParams.Data.Ppc) {
+        //
+        // Port Power Control supported
+        //
+        State &= ~XHC_PORTSC_PP;
+        XhcPeiWriteOpReg (Xhc, Offset, State);
+      }
+      break;
 
-  case EfiUsbPortOverCurrentChange:
-    //
-    // Clear PortOverCurrent change
-    //
-    State |= XHC_PORTSC_OCC;
-    XhcPeiWriteOpReg (Xhc, Offset, State);
-    break;
+    case EfiUsbPortOwner:
+      //
+      // XHCI root hub port don't has the owner bit, ignore the operation
+      //
+      break;
 
-  case EfiUsbPortResetChange:
-    //
-    // Clear Port Reset change
-    //
-    State |= XHC_PORTSC_PRC;
-    XhcPeiWriteOpReg (Xhc, Offset, State);
-    break;
+    case EfiUsbPortConnectChange:
+      //
+      // Clear connect status change
+      //
+      State |= XHC_PORTSC_CSC;
+      XhcPeiWriteOpReg (Xhc, Offset, State);
+      break;
 
-  case EfiUsbPortSuspendChange:
-    //
-    // Not supported or not related operation
-    //
-    break;
+    case EfiUsbPortEnableChange:
+      //
+      // Clear enable status change
+      //
+      State |= XHC_PORTSC_PEC;
+      XhcPeiWriteOpReg (Xhc, Offset, State);
+      break;
 
-  default:
-    Status = EFI_INVALID_PARAMETER;
-    break;
+    case EfiUsbPortOverCurrentChange:
+      //
+      // Clear PortOverCurrent change
+      //
+      State |= XHC_PORTSC_OCC;
+      XhcPeiWriteOpReg (Xhc, Offset, State);
+      break;
+
+    case EfiUsbPortResetChange:
+      //
+      // Clear Port Reset change
+      //
+      State |= XHC_PORTSC_PRC;
+      XhcPeiWriteOpReg (Xhc, Offset, State);
+      break;
+
+    case EfiUsbPortSuspendChange:
+      //
+      // Not supported or not related operation
+      //
+      break;
+
+    default:
+      Status = EFI_INVALID_PARAMETER;
+      break;
   }
 
 ON_EXIT:
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiClearRootHubPortFeature: PortFeature: %x Status = %r\n", PortFeature, Status));
+  DEBUG ((DEBUG_INFO, "XhcPeiClearRootHubPortFeature: PortFeature: %x Status = %r\n", PortFeature, Status));
   return Status;
 }
 
@@ -1226,7 +1206,7 @@ XhcPeiSetRootHubPortFeature (
 
   Offset = (UINT32) (XHC_PORTSC_OFFSET + (0x10 * PortNumber));
   State = XhcPeiReadOpReg (Xhc, Offset);
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiSetRootHubPortFeature: Port: %x State: %x\n", PortNumber, State));
+  DEBUG ((DEBUG_INFO, "XhcPeiSetRootHubPortFeature: Port: %x State: %x\n", PortNumber, State));
 
   //
   // Mask off the port status change bits, these bits are
@@ -1235,65 +1215,65 @@ XhcPeiSetRootHubPortFeature (
   State &= ~ (BIT1 | BIT17 | BIT18 | BIT19 | BIT20 | BIT21 | BIT22 | BIT23);
 
   switch (PortFeature) {
-  case EfiUsbPortEnable:
-    //
-    // Ports may only be enabled by the xHC. Software cannot enable a port by writing a '1' to this flag.
-    // A port may be disabled by software writing a '1' to this flag.
-    //
-    break;
-
-  case EfiUsbPortSuspend:
-    State |= XHC_PORTSC_LWS;
-    XhcPeiWriteOpReg (Xhc, Offset, State);
-    State &= ~XHC_PORTSC_PLS;
-    State |= (3 << 5) ;
-    XhcPeiWriteOpReg (Xhc, Offset, State);
-    break;
-
-  case EfiUsbPortReset:
-    //
-    // Make sure Host Controller not halt before reset it
-    //
-    if (XhcPeiIsHalt (Xhc)) {
-      Status = XhcPeiRunHC (Xhc, XHC_GENERIC_TIMEOUT);
-      if (EFI_ERROR (Status)) {
-        break;
-      }
-    }
-
-    //
-    // 4.3.1 Resetting a Root Hub Port
-    // 1) Write the PORTSC register with the Port Reset (PR) bit set to '1'.
-    // 2) Wait for a successful Port Status Change Event for the port, where the Port Reset Change (PRC)
-    //    bit in the PORTSC field is set to '1'.
-    //
-    State |= XHC_PORTSC_RESET;
-    XhcPeiWriteOpReg (Xhc, Offset, State);
-    XhcPeiWaitOpRegBit (Xhc, Offset, XHC_PORTSC_PRC, TRUE, XHC_GENERIC_TIMEOUT);
-    break;
-
-  case EfiUsbPortPower:
-    if (Xhc->HcCParams.Data.Ppc) {
+    case EfiUsbPortEnable:
       //
-      // Port Power Control supported
+      // Ports may only be enabled by the xHC. Software cannot enable a port by writing a '1' to this flag.
+      // A port may be disabled by software writing a '1' to this flag.
       //
-      State |= XHC_PORTSC_PP;
+      break;
+
+    case EfiUsbPortSuspend:
+      State |= XHC_PORTSC_LWS;
       XhcPeiWriteOpReg (Xhc, Offset, State);
-    }
-    break;
+      State &= ~XHC_PORTSC_PLS;
+      State |= (3 << 5) ;
+      XhcPeiWriteOpReg (Xhc, Offset, State);
+      break;
 
-  case EfiUsbPortOwner:
-    //
-    // XHCI root hub port don't has the owner bit, ignore the operation
-    //
-    break;
+    case EfiUsbPortReset:
+      //
+      // Make sure Host Controller not halt before reset it
+      //
+      if (XhcPeiIsHalt (Xhc)) {
+        Status = XhcPeiRunHC (Xhc, XHC_GENERIC_TIMEOUT);
+        if (EFI_ERROR (Status)) {
+          break;
+        }
+      }
 
-  default:
-    Status = EFI_INVALID_PARAMETER;
+      //
+      // 4.3.1 Resetting a Root Hub Port
+      // 1) Write the PORTSC register with the Port Reset (PR) bit set to '1'.
+      // 2) Wait for a successful Port Status Change Event for the port, where the Port Reset Change (PRC)
+      //    bit in the PORTSC field is set to '1'.
+      //
+      State |= XHC_PORTSC_RESET;
+      XhcPeiWriteOpReg (Xhc, Offset, State);
+      XhcPeiWaitOpRegBit(Xhc, Offset, XHC_PORTSC_PRC, TRUE, XHC_GENERIC_TIMEOUT);
+      break;
+
+    case EfiUsbPortPower:
+      if (Xhc->HcCParams.Data.Ppc) {
+        //
+        // Port Power Control supported
+        //
+        State |= XHC_PORTSC_PP;
+        XhcPeiWriteOpReg (Xhc, Offset, State);
+      }
+      break;
+
+    case EfiUsbPortOwner:
+      //
+      // XHCI root hub port don't has the owner bit, ignore the operation
+      //
+      break;
+
+    default:
+      Status = EFI_INVALID_PARAMETER;
   }
 
 ON_EXIT:
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiSetRootHubPortFeature: PortFeature: %x Status = %r\n", PortFeature, Status));
+  DEBUG ((DEBUG_INFO, "XhcPeiSetRootHubPortFeature: PortFeature: %x Status = %r\n", PortFeature, Status));
   return Status;
 }
 
@@ -1344,26 +1324,28 @@ XhcPeiGetRootHubPortStatus (
 
   Offset                        = (UINT32) (XHC_PORTSC_OFFSET + (0x10 * PortNumber));
   State                         = XhcPeiReadOpReg (Xhc, Offset);
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiGetRootHubPortStatus: Port: %x State: %x\n", PortNumber, State));
+  DEBUG ((DEBUG_INFO, "XhcPeiGetRootHubPortStatus: Port: %x State: %x\n", PortNumber, State));
 
   //
-  // According to XHCI 1.0 spec, bit 10~13 of the root port status register identifies the speed of the attached device.
+  // According to XHCI 1.1 spec November 2017,
+  // bit 10~13 of the root port status register identifies the speed of the attached device.
   //
   switch ((State & XHC_PORTSC_PS) >> 10) {
-  case 2:
-    PortStatus->PortStatus |= USB_PORT_STAT_LOW_SPEED;
-    break;
+    case 2:
+      PortStatus->PortStatus |= USB_PORT_STAT_LOW_SPEED;
+      break;
 
-  case 3:
-    PortStatus->PortStatus |= USB_PORT_STAT_HIGH_SPEED;
-    break;
+    case 3:
+      PortStatus->PortStatus |= USB_PORT_STAT_HIGH_SPEED;
+      break;
 
-  case 4:
-    PortStatus->PortStatus |= USB_PORT_STAT_SUPER_SPEED;
-    break;
+    case 4:
+    case 5:
+      PortStatus->PortStatus |= USB_PORT_STAT_SUPER_SPEED;
+      break;
 
-  default:
-    break;
+    default:
+      break;
   }
 
   //
@@ -1395,8 +1377,7 @@ XhcPeiGetRootHubPortStatus (
 
   for (Index = 0; Index < MapSize; Index++) {
     if (XHC_BIT_IS_SET (State, mUsbClearPortChangeMap[Index].HwState)) {
-      XhcPeiClearRootHubPortFeature (PeiServices, This, PortNumber,
-                                     (EFI_USB_PORT_FEATURE)mUsbClearPortChangeMap[Index].Selector);
+      XhcPeiClearRootHubPortFeature (PeiServices, This, PortNumber, (EFI_USB_PORT_FEATURE)mUsbClearPortChangeMap[Index].Selector);
     }
   }
 
@@ -1407,8 +1388,37 @@ XhcPeiGetRootHubPortStatus (
   ParentRouteChart.Dword = 0;
   XhcPeiPollPortStatusChange (Xhc, ParentRouteChart, PortNumber, PortStatus);
 
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiGetRootHubPortStatus: PortChangeStatus: %x PortStatus: %x\n", PortStatus->PortChangeStatus,
-          PortStatus->PortStatus));
+  DEBUG ((DEBUG_INFO, "XhcPeiGetRootHubPortStatus: PortChangeStatus: %x PortStatus: %x\n", PortStatus->PortChangeStatus, PortStatus->PortStatus));
+  return EFI_SUCCESS;
+}
+
+/**
+  One notified function to stop the Host Controller at the end of PEI
+
+  @param[in]  PeiServices        Pointer to PEI Services Table.
+  @param[in]  NotifyDescriptor   Pointer to the descriptor for the Notification event that
+                                 caused this function to execute.
+  @param[in]  Ppi                Pointer to the PPI data associated with this function.
+
+  @retval     EFI_SUCCESS  The function completes successfully
+  @retval     others
+**/
+EFI_STATUS
+EFIAPI
+XhcEndOfPei (
+  IN EFI_PEI_SERVICES           **PeiServices,
+  IN EFI_PEI_NOTIFY_DESCRIPTOR  *NotifyDescriptor,
+  IN VOID                       *Ppi
+  )
+{
+  PEI_XHC_DEV    *Xhc;
+
+  Xhc = PEI_RECOVERY_USB_XHC_DEV_FROM_THIS_NOTIFY(NotifyDescriptor);
+
+  XhcPeiHaltHC (Xhc, XHC_GENERIC_TIMEOUT);
+
+  XhcPeiFreeSched (Xhc);
+
   return EFI_SUCCESS;
 }
 
@@ -1426,7 +1436,7 @@ UsbDeinitCtrl (
   IN  EFI_HANDLE      UsbHostHandle
   )
 {
-  PEI_XHC_DEV                    *XhcDev;
+  PEI_XHC_DEV                    *Xhc;
   PEI_USB2_HOST_CONTROLLER_PPI   *This;
 
   if (UsbHostHandle == NULL) {
@@ -1434,10 +1444,11 @@ UsbDeinitCtrl (
   }
 
   This   = (PEI_USB2_HOST_CONTROLLER_PPI *)UsbHostHandle;
-  XhcDev = PEI_RECOVERY_USB_XHC_DEV_FROM_THIS (This);
+  Xhc    = PEI_RECOVERY_USB_XHC_DEV_FROM_THIS (This);
 
-  XhcPeiResetHC (XhcDev, XHC_RESET_TIMEOUT);
-  ASSERT (XhcPeiIsHalt (XhcDev));
+  XhcPeiHaltHC (Xhc, XHC_GENERIC_TIMEOUT);
+
+  XhcPeiFreeSched (Xhc);
 
   return EFI_SUCCESS;
 }
@@ -1493,14 +1504,14 @@ UsbInitCtrl (
   PageSize         = XhcPeiReadOpReg (XhcDev, XHC_PAGESIZE_OFFSET) & XHC_PAGESIZE_MASK;
   XhcDev->PageSize = 1 << (HighBitSet32 (PageSize) + 12);
 
-  DEBUG ((DEBUG_VERBOSE, "XhciPei: UsbHostControllerBaseAddress: %x\n", XhcDev->UsbHostControllerBaseAddress));
-  DEBUG ((DEBUG_VERBOSE, "XhciPei: CapLength:                    %x\n", XhcDev->CapLength));
-  DEBUG ((DEBUG_VERBOSE, "XhciPei: HcSParams1:                   %x\n", XhcDev->HcSParams1.Dword));
-  DEBUG ((DEBUG_VERBOSE, "XhciPei: HcSParams2:                   %x\n", XhcDev->HcSParams2.Dword));
-  DEBUG ((DEBUG_VERBOSE, "XhciPei: HcCParams:                    %x\n", XhcDev->HcCParams.Dword));
-  DEBUG ((DEBUG_VERBOSE, "XhciPei: DBOff:                        %x\n", XhcDev->DBOff));
-  DEBUG ((DEBUG_VERBOSE, "XhciPei: RTSOff:                       %x\n", XhcDev->RTSOff));
-  DEBUG ((DEBUG_VERBOSE, "XhciPei: PageSize:                     %x\n", XhcDev->PageSize));
+  DEBUG ((DEBUG_INFO, "XhciPei: UsbHostControllerBaseAddress: %x\n", XhcDev->UsbHostControllerBaseAddress));
+  DEBUG ((DEBUG_INFO, "XhciPei: CapLength:                    %x\n", XhcDev->CapLength));
+  DEBUG ((DEBUG_INFO, "XhciPei: HcSParams1:                   %x\n", XhcDev->HcSParams1.Dword));
+  DEBUG ((DEBUG_INFO, "XhciPei: HcSParams2:                   %x\n", XhcDev->HcSParams2.Dword));
+  DEBUG ((DEBUG_INFO, "XhciPei: HcCParams:                    %x\n", XhcDev->HcCParams.Dword));
+  DEBUG ((DEBUG_INFO, "XhciPei: DBOff:                        %x\n", XhcDev->DBOff));
+  DEBUG ((DEBUG_INFO, "XhciPei: RTSOff:                       %x\n", XhcDev->RTSOff));
+  DEBUG ((DEBUG_INFO, "XhciPei: PageSize:                     %x\n", XhcDev->PageSize));
 
   XhcPeiResetHC (XhcDev, XHC_RESET_TIMEOUT);
   ASSERT (XhcPeiIsHalt (XhcDev));

--- a/BootloaderCommonPkg/Library/XhciLib/XhcPeim.h
+++ b/BootloaderCommonPkg/Library/XhciLib/XhcPeim.h
@@ -1,7 +1,7 @@
 /** @file
 Private Header file for Usb Host Controller PEIM
 
-Copyright (c) 2014 - 2017, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2014 - 2016, Intel Corporation. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -20,9 +20,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/TimerLib.h>
 #include <Library/IoLib.h>
 #include <Library/MemoryAllocationLib.h>
-
-#define  PeiServicesAllocatePages(a, b, c)   \
-         (((*(c) = (UINTN)AllocatePages (b)) != 0) ? EFI_SUCCESS : EFI_OUT_OF_RESOURCES)
+#include <Library/IoMmuLib.h>
 
 typedef struct _PEI_XHC_DEV PEI_XHC_DEV;
 typedef struct _USB_DEV_CONTEXT USB_DEV_CONTEXT;
@@ -30,6 +28,9 @@ typedef struct _USB_DEV_CONTEXT USB_DEV_CONTEXT;
 #include "UsbHcMem.h"
 #include "XhciReg.h"
 #include "XhciSched.h"
+
+#undef  DEBUG_INFO
+#define DEBUG_INFO   DEBUG_VERBOSE
 
 #define CMD_RING_TRB_NUMBER         0x100
 #define TR_RING_TRB_NUMBER          0x100
@@ -147,6 +148,12 @@ struct _PEI_XHC_DEV {
   USBHC_MEM_POOL                    *MemPool;
 
   //
+  // EndOfPei callback is used to stop the XHC DMA operation
+  // after exit PEI phase.
+  //
+  EFI_PEI_NOTIFY_DESCRIPTOR         EndOfPeiNotifyList;
+
+  //
   // XHCI configuration data
   //
   UINT8                             CapLength;    ///< Capability Register Length
@@ -158,7 +165,9 @@ struct _PEI_XHC_DEV {
   UINT32                            PageSize;
   UINT32                            MaxScratchpadBufs;
   UINT64                            *ScratchBuf;
+  VOID                              *ScratchMap;
   UINT64                            *ScratchEntry;
+  UINTN                             *ScratchEntryMap;
   UINT64                            *DCBAA;
   UINT32                            MaxSlotsEn;
   //
@@ -178,6 +187,7 @@ struct _PEI_XHC_DEV {
 };
 
 #define PEI_RECOVERY_USB_XHC_DEV_FROM_THIS(a) CR (a, PEI_XHC_DEV, Usb2HostControllerPpi, USB_XHC_DEV_SIGNATURE)
+#define PEI_RECOVERY_USB_XHC_DEV_FROM_THIS_NOTIFY(a) CR (a, PEI_XHC_DEV, EndOfPeiNotifyList, USB_XHC_DEV_SIGNATURE)
 
 /**
   Initialize the memory management pool for the host controller.
@@ -235,5 +245,6 @@ UsbHcFreeMem (
   IN UINTN              Size
   )
 ;
+
 
 #endif

--- a/BootloaderCommonPkg/Library/XhciLib/XhciLib.inf
+++ b/BootloaderCommonPkg/Library/XhciLib/XhciLib.inf
@@ -42,3 +42,4 @@
   TimerLib
   BaseMemoryLib
   MemoryAllocationLib
+  IoMmuLib

--- a/BootloaderCommonPkg/Library/XhciLib/XhciReg.h
+++ b/BootloaderCommonPkg/Library/XhciLib/XhciReg.h
@@ -1,7 +1,7 @@
 /** @file
 Private Header file for Usb Host Controller PEIM
 
-Copyright (c) 2014, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2014 - 2018, Intel Corporation. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -75,9 +75,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define XHC_PORTSC_PED                  BIT1    // Port Enabled/Disabled
 #define XHC_PORTSC_OCA                  BIT3    // Over-current Active
 #define XHC_PORTSC_RESET                BIT4    // Port Reset
-#define XHC_PORTSC_PLS                  (BIT5|BIT6|BIT7|BIT8)   // Port Link State
+#define XHC_PORTSC_PLS                  (BIT5|BIT6|BIT7|BIT8)     // Port Link State
 #define XHC_PORTSC_PP                   BIT9    // Port Power
-#define XHC_PORTSC_PS                   (BIT10|BIT11|BIT12)     // Port Speed
+#define XHC_PORTSC_PS                   (BIT10|BIT11|BIT12|BIT13) // Port Speed
 #define XHC_PORTSC_LWS                  BIT16   // Port Link State Write Strobe
 #define XHC_PORTSC_CSC                  BIT17   // Connect Status Change
 #define XHC_PORTSC_PEC                  BIT18   // Port Enabled/Disabled Change
@@ -109,8 +109,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #pragma pack (1)
 typedef struct {
   UINT8                 MaxSlots;       // Number of Device Slots
-  UINT16                MaxIntrs: 11;   // Number of Interrupters
-  UINT16                Rsvd: 5;
+  UINT16                MaxIntrs:11;    // Number of Interrupters
+  UINT16                Rsvd:5;
   UINT8                 MaxPorts;       // Number of Ports
 } HCSPARAMS1;
 
@@ -123,12 +123,12 @@ typedef union {
 } XHC_HCSPARAMS1;
 
 typedef struct {
-  UINT32                Ist: 4;         // Isochronous Scheduling Threshold
-  UINT32                Erst: 4;        // Event Ring Segment Table Max
-  UINT32                Rsvd: 13;
-  UINT32                ScratchBufHi: 5; // Max Scratchpad Buffers Hi
-  UINT32                Spr: 1;         // Scratchpad Restore
-  UINT32                ScratchBufLo: 5; // Max Scratchpad Buffers Lo
+  UINT32                Ist:4;          // Isochronous Scheduling Threshold
+  UINT32                Erst:4;         // Event Ring Segment Table Max
+  UINT32                Rsvd:13;
+  UINT32                ScratchBufHi:5; // Max Scratchpad Buffers Hi
+  UINT32                Spr:1;          // Scratchpad Restore
+  UINT32                ScratchBufLo:5; // Max Scratchpad Buffers Lo
 } HCSPARAMS2;
 
 //
@@ -140,17 +140,17 @@ typedef union {
 } XHC_HCSPARAMS2;
 
 typedef struct {
-  UINT16                Ac64: 1;       // 64-bit Addressing Capability
-  UINT16                Bnc: 1;        // BW Negotiation Capability
-  UINT16                Csz: 1;        // Context Size
-  UINT16                Ppc: 1;        // Port Power Control
-  UINT16                Pind: 1;       // Port Indicators
-  UINT16                Lhrc: 1;       // Light HC Reset Capability
-  UINT16                Ltc: 1;        // Latency Tolerance Messaging Capability
-  UINT16                Nss: 1;        // No Secondary SID Support
-  UINT16                Pae: 1;        // Parse All Event Data
-  UINT16                Rsvd: 3;
-  UINT16                MaxPsaSize: 4; // Maximum Primary Stream Array Size
+  UINT16                Ac64:1;        // 64-bit Addressing Capability
+  UINT16                Bnc:1;         // BW Negotiation Capability
+  UINT16                Csz:1;         // Context Size
+  UINT16                Ppc:1;         // Port Power Control
+  UINT16                Pind:1;        // Port Indicators
+  UINT16                Lhrc:1;        // Light HC Reset Capability
+  UINT16                Ltc:1;         // Latency Tolerance Messaging Capability
+  UINT16                Nss:1;         // No Secondary SID Support
+  UINT16                Pae:1;         // Parse All Event Data
+  UINT16                Rsvd:3;
+  UINT16                MaxPsaSize:4;  // Maximum Primary Stream Array Size
   UINT16                ExtCapReg;     // xHCI Extended Capabilities Pointer
 } HCCPARAMS;
 
@@ -280,7 +280,7 @@ XhcPeiClearOpRegBit (
   @param  Offset        The offset of the operational register.
   @param  Bit           The bit of the register to wait for.
   @param  WaitToSet     Wait the bit to set or clear.
-  @param  Timeout       The time to wait before abort (in microsecond, us).
+  @param  Timeout       The time to wait before abort (in millisecond, ms).
 
   @retval EFI_SUCCESS   The bit successfully changed by host controller.
   @retval EFI_TIMEOUT   The time out occurred.
@@ -295,20 +295,6 @@ XhcPeiWaitOpRegBit (
   IN UINT32             Timeout
   );
 
-/**
-  Read XHCI door bell register.
-
-  @param  Xhc           The XHCI device.
-  @param  Offset        The offset of the door bell register.
-
-  @return The register content read
-
-**/
-UINT32
-XhcPeiReadDoorBellReg (
-  IN  PEI_XHC_DEV       *Xhc,
-  IN  UINT32            Offset
-  );
 
 /**
   Write the data to the XHCI door bell register.

--- a/BootloaderCommonPkg/Library/XhciLib/XhciSched.c
+++ b/BootloaderCommonPkg/Library/XhciLib/XhciSched.c
@@ -19,7 +19,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
   @return Created URB or NULL.
 
 **/
-URB *
+URB*
 XhcPeiCreateCmdTrb (
   IN PEI_XHC_DEV    *Xhc,
   IN TRB_TEMPLATE   *CmdTrb
@@ -126,7 +126,7 @@ ON_EXIT:
   @return Created URB or NULL
 
 **/
-URB *
+URB*
 XhcPeiCreateUrb (
   IN PEI_XHC_DEV                        *Xhc,
   IN UINT8                              BusAddr,
@@ -193,6 +193,8 @@ XhcPeiFreeUrb (
     return;
   }
 
+  IoMmuUnmap (Urb->DataMap);
+
   FreePool (Urb);
 }
 
@@ -220,6 +222,10 @@ XhcPeiCreateTransferTrb (
   UINTN                         TotalLen;
   UINTN                         Len;
   UINTN                         TrbNum;
+  EDKII_IOMMU_OPERATION         MapOp;
+  EFI_PHYSICAL_ADDRESS          PhyAddr;
+  VOID                          *Map;
+  EFI_STATUS                    Status;
 
   SlotId = XhcPeiBusDevAddrToSlotId (Xhc, Urb->Ep.BusAddr);
   if (SlotId == 0) {
@@ -232,17 +238,37 @@ XhcPeiCreateTransferTrb (
   Urb->Completed = 0;
   Urb->Result    = EFI_USB_NOERROR;
 
-  Dci       = XhcPeiEndpointToDci (Urb->Ep.EpAddr, (UINT8) (Urb->Ep.Direction));
-  EPRing    = (TRANSFER_RING *) (UINTN) Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci - 1];
+  Dci       = XhcPeiEndpointToDci (Urb->Ep.EpAddr, (UINT8)(Urb->Ep.Direction));
+  EPRing    = (TRANSFER_RING *) (UINTN) Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1];
   Urb->Ring = EPRing;
   OutputContext = Xhc->UsbDevContext[SlotId].OutputContext;
   if (Xhc->HcCParams.Data.Csz == 0) {
-    EPType  = (UINT8) ((DEVICE_CONTEXT *)OutputContext)->EP[Dci - 1].EPType;
+    EPType  = (UINT8) ((DEVICE_CONTEXT *)OutputContext)->EP[Dci-1].EPType;
   } else {
-    EPType  = (UINT8) ((DEVICE_CONTEXT_64 *)OutputContext)->EP[Dci - 1].EPType;
+    EPType  = (UINT8) ((DEVICE_CONTEXT_64 *)OutputContext)->EP[Dci-1].EPType;
   }
 
-  Urb->DataPhy = Urb->Data;
+  //
+  // No need to remap.
+  //
+  if ((Urb->Data != NULL) && (Urb->DataMap == NULL)) {
+    if (((UINT8) (Urb->Ep.Direction)) == EfiUsbDataIn) {
+      MapOp = EdkiiIoMmuOperationBusMasterWrite;
+    } else {
+      MapOp = EdkiiIoMmuOperationBusMasterRead;
+    }
+
+    Len = Urb->DataLen;
+    Status = IoMmuMap (MapOp, Urb->Data, &Len, &PhyAddr, &Map);
+
+    if (EFI_ERROR (Status) || (Len != Urb->DataLen)) {
+      DEBUG ((DEBUG_ERROR, "XhcCreateTransferTrb: Fail to map Urb->Data.\n"));
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    Urb->DataPhy  = (VOID *) ((UINTN) PhyAddr);
+    Urb->DataMap  = Map;
+  }
 
   //
   // Construct the TRB
@@ -250,166 +276,166 @@ XhcPeiCreateTransferTrb (
   XhcPeiSyncTrsRing (Xhc, EPRing);
   Urb->TrbStart = EPRing->RingEnqueue;
   switch (EPType) {
-  case ED_CONTROL_BIDIR:
-    //
-    // For control transfer, create SETUP_STAGE_TRB first.
-    //
-    TrbStart = (TRB *) (UINTN) EPRing->RingEnqueue;
-    TrbStart->TrbCtrSetup.bmRequestType = Urb->Request->RequestType;
-    TrbStart->TrbCtrSetup.bRequest      = Urb->Request->Request;
-    TrbStart->TrbCtrSetup.wValue        = Urb->Request->Value;
-    TrbStart->TrbCtrSetup.wIndex        = Urb->Request->Index;
-    TrbStart->TrbCtrSetup.wLength       = Urb->Request->Length;
-    TrbStart->TrbCtrSetup.Length        = 8;
-    TrbStart->TrbCtrSetup.IntTarget     = 0;
-    TrbStart->TrbCtrSetup.IOC           = 1;
-    TrbStart->TrbCtrSetup.IDT           = 1;
-    TrbStart->TrbCtrSetup.Type          = TRB_TYPE_SETUP_STAGE;
-    if (Urb->Ep.Direction == EfiUsbDataIn) {
-      TrbStart->TrbCtrSetup.TRT = 3;
-    } else if (Urb->Ep.Direction == EfiUsbDataOut) {
-      TrbStart->TrbCtrSetup.TRT = 2;
-    } else {
-      TrbStart->TrbCtrSetup.TRT = 0;
-    }
-    //
-    // Update the cycle bit
-    //
-    TrbStart->TrbCtrSetup.CycleBit = EPRing->RingPCS & BIT0;
-    Urb->TrbNum++;
+    case ED_CONTROL_BIDIR:
+      //
+      // For control transfer, create SETUP_STAGE_TRB first.
+      //
+      TrbStart = (TRB *) (UINTN) EPRing->RingEnqueue;
+      TrbStart->TrbCtrSetup.bmRequestType = Urb->Request->RequestType;
+      TrbStart->TrbCtrSetup.bRequest      = Urb->Request->Request;
+      TrbStart->TrbCtrSetup.wValue        = Urb->Request->Value;
+      TrbStart->TrbCtrSetup.wIndex        = Urb->Request->Index;
+      TrbStart->TrbCtrSetup.wLength       = Urb->Request->Length;
+      TrbStart->TrbCtrSetup.Length        = 8;
+      TrbStart->TrbCtrSetup.IntTarget     = 0;
+      TrbStart->TrbCtrSetup.IOC           = 1;
+      TrbStart->TrbCtrSetup.IDT           = 1;
+      TrbStart->TrbCtrSetup.Type          = TRB_TYPE_SETUP_STAGE;
+      if (Urb->Ep.Direction == EfiUsbDataIn) {
+        TrbStart->TrbCtrSetup.TRT = 3;
+      } else if (Urb->Ep.Direction == EfiUsbDataOut) {
+        TrbStart->TrbCtrSetup.TRT = 2;
+      } else {
+        TrbStart->TrbCtrSetup.TRT = 0;
+      }
+      //
+      // Update the cycle bit
+      //
+      TrbStart->TrbCtrSetup.CycleBit = EPRing->RingPCS & BIT0;
+      Urb->TrbNum++;
 
-    //
-    // For control transfer, create DATA_STAGE_TRB.
-    //
-    if (Urb->DataLen > 0) {
+      //
+      // For control transfer, create DATA_STAGE_TRB.
+      //
+      if (Urb->DataLen > 0) {
+        XhcPeiSyncTrsRing (Xhc, EPRing);
+        TrbStart = (TRB *) (UINTN) EPRing->RingEnqueue;
+        TrbStart->TrbCtrData.TRBPtrLo  = XHC_LOW_32BIT (Urb->DataPhy);
+        TrbStart->TrbCtrData.TRBPtrHi  = XHC_HIGH_32BIT (Urb->DataPhy);
+        TrbStart->TrbCtrData.Length    = (UINT32) Urb->DataLen;
+        TrbStart->TrbCtrData.TDSize    = 0;
+        TrbStart->TrbCtrData.IntTarget = 0;
+        TrbStart->TrbCtrData.ISP       = 1;
+        TrbStart->TrbCtrData.IOC       = 1;
+        TrbStart->TrbCtrData.IDT       = 0;
+        TrbStart->TrbCtrData.CH        = 0;
+        TrbStart->TrbCtrData.Type      = TRB_TYPE_DATA_STAGE;
+        if (Urb->Ep.Direction == EfiUsbDataIn) {
+          TrbStart->TrbCtrData.DIR = 1;
+        } else if (Urb->Ep.Direction == EfiUsbDataOut) {
+          TrbStart->TrbCtrData.DIR = 0;
+        } else {
+          TrbStart->TrbCtrData.DIR = 0;
+        }
+        //
+        // Update the cycle bit
+        //
+        TrbStart->TrbCtrData.CycleBit = EPRing->RingPCS & BIT0;
+        Urb->TrbNum++;
+      }
+      //
+      // For control transfer, create STATUS_STAGE_TRB.
+      // Get the pointer to next TRB for status stage use
+      //
       XhcPeiSyncTrsRing (Xhc, EPRing);
       TrbStart = (TRB *) (UINTN) EPRing->RingEnqueue;
-      TrbStart->TrbCtrData.TRBPtrLo  = XHC_LOW_32BIT (Urb->DataPhy);
-      TrbStart->TrbCtrData.TRBPtrHi  = XHC_HIGH_32BIT (Urb->DataPhy);
-      TrbStart->TrbCtrData.Length    = (UINT32) Urb->DataLen;
-      TrbStart->TrbCtrData.TDSize    = 0;
-      TrbStart->TrbCtrData.IntTarget = 0;
-      TrbStart->TrbCtrData.ISP       = 1;
-      TrbStart->TrbCtrData.IOC       = 1;
-      TrbStart->TrbCtrData.IDT       = 0;
-      TrbStart->TrbCtrData.CH        = 0;
-      TrbStart->TrbCtrData.Type      = TRB_TYPE_DATA_STAGE;
+      TrbStart->TrbCtrStatus.IntTarget = 0;
+      TrbStart->TrbCtrStatus.IOC       = 1;
+      TrbStart->TrbCtrStatus.CH        = 0;
+      TrbStart->TrbCtrStatus.Type      = TRB_TYPE_STATUS_STAGE;
       if (Urb->Ep.Direction == EfiUsbDataIn) {
-        TrbStart->TrbCtrData.DIR = 1;
+        TrbStart->TrbCtrStatus.DIR = 0;
       } else if (Urb->Ep.Direction == EfiUsbDataOut) {
-        TrbStart->TrbCtrData.DIR = 0;
+        TrbStart->TrbCtrStatus.DIR = 1;
       } else {
-        TrbStart->TrbCtrData.DIR = 0;
+        TrbStart->TrbCtrStatus.DIR = 0;
       }
       //
       // Update the cycle bit
       //
-      TrbStart->TrbCtrData.CycleBit = EPRing->RingPCS & BIT0;
+      TrbStart->TrbCtrStatus.CycleBit = EPRing->RingPCS & BIT0;
+      //
+      // Update the enqueue pointer
+      //
+      XhcPeiSyncTrsRing (Xhc, EPRing);
       Urb->TrbNum++;
-    }
-    //
-    // For control transfer, create STATUS_STAGE_TRB.
-    // Get the pointer to next TRB for status stage use
-    //
-    XhcPeiSyncTrsRing (Xhc, EPRing);
-    TrbStart = (TRB *) (UINTN) EPRing->RingEnqueue;
-    TrbStart->TrbCtrStatus.IntTarget = 0;
-    TrbStart->TrbCtrStatus.IOC       = 1;
-    TrbStart->TrbCtrStatus.CH        = 0;
-    TrbStart->TrbCtrStatus.Type      = TRB_TYPE_STATUS_STAGE;
-    if (Urb->Ep.Direction == EfiUsbDataIn) {
-      TrbStart->TrbCtrStatus.DIR = 0;
-    } else if (Urb->Ep.Direction == EfiUsbDataOut) {
-      TrbStart->TrbCtrStatus.DIR = 1;
-    } else {
-      TrbStart->TrbCtrStatus.DIR = 0;
-    }
-    //
-    // Update the cycle bit
-    //
-    TrbStart->TrbCtrStatus.CycleBit = EPRing->RingPCS & BIT0;
-    //
-    // Update the enqueue pointer
-    //
-    XhcPeiSyncTrsRing (Xhc, EPRing);
-    Urb->TrbNum++;
-    Urb->TrbEnd = (TRB_TEMPLATE *) (UINTN) TrbStart;
+      Urb->TrbEnd = (TRB_TEMPLATE *) (UINTN) TrbStart;
 
-    break;
+      break;
 
-  case ED_BULK_OUT:
-  case ED_BULK_IN:
-    TotalLen = 0;
-    Len      = 0;
-    TrbNum   = 0;
-    TrbStart = (TRB *) (UINTN) EPRing->RingEnqueue;
-    while (TotalLen < Urb->DataLen) {
-      if ((TotalLen + 0x10000) >= Urb->DataLen) {
-        Len = Urb->DataLen - TotalLen;
-      } else {
-        Len = 0x10000;
+    case ED_BULK_OUT:
+    case ED_BULK_IN:
+      TotalLen = 0;
+      Len      = 0;
+      TrbNum   = 0;
+      TrbStart = (TRB *) (UINTN) EPRing->RingEnqueue;
+      while (TotalLen < Urb->DataLen) {
+        if ((TotalLen + 0x10000) >= Urb->DataLen) {
+          Len = Urb->DataLen - TotalLen;
+        } else {
+          Len = 0x10000;
+        }
+        TrbStart = (TRB *)(UINTN)EPRing->RingEnqueue;
+        TrbStart->TrbNormal.TRBPtrLo  = XHC_LOW_32BIT((UINT8 *) Urb->DataPhy + TotalLen);
+        TrbStart->TrbNormal.TRBPtrHi  = XHC_HIGH_32BIT((UINT8 *) Urb->DataPhy + TotalLen);
+        TrbStart->TrbNormal.Length    = (UINT32) Len;
+        TrbStart->TrbNormal.TDSize    = 0;
+        TrbStart->TrbNormal.IntTarget = 0;
+        TrbStart->TrbNormal.ISP       = 1;
+        TrbStart->TrbNormal.IOC       = 1;
+        TrbStart->TrbNormal.Type      = TRB_TYPE_NORMAL;
+        //
+        // Update the cycle bit
+        //
+        TrbStart->TrbNormal.CycleBit = EPRing->RingPCS & BIT0;
+
+        XhcPeiSyncTrsRing (Xhc, EPRing);
+        TrbNum++;
+        TotalLen += Len;
       }
-      TrbStart = (TRB *) (UINTN)EPRing->RingEnqueue;
-      TrbStart->TrbNormal.TRBPtrLo  = XHC_LOW_32BIT ((UINT8 *) Urb->DataPhy + TotalLen);
-      TrbStart->TrbNormal.TRBPtrHi  = XHC_HIGH_32BIT ((UINT8 *) Urb->DataPhy + TotalLen);
-      TrbStart->TrbNormal.Length    = (UINT32) Len;
-      TrbStart->TrbNormal.TDSize    = 0;
-      TrbStart->TrbNormal.IntTarget = 0;
-      TrbStart->TrbNormal.ISP       = 1;
-      TrbStart->TrbNormal.IOC       = 1;
-      TrbStart->TrbNormal.Type      = TRB_TYPE_NORMAL;
-      //
-      // Update the cycle bit
-      //
-      TrbStart->TrbNormal.CycleBit = EPRing->RingPCS & BIT0;
 
-      XhcPeiSyncTrsRing (Xhc, EPRing);
-      TrbNum++;
-      TotalLen += Len;
-    }
+      Urb->TrbNum = TrbNum;
+      Urb->TrbEnd = (TRB_TEMPLATE *)(UINTN)TrbStart;
+      break;
 
-    Urb->TrbNum = TrbNum;
-    Urb->TrbEnd = (TRB_TEMPLATE *) (UINTN)TrbStart;
-    break;
+    case ED_INTERRUPT_OUT:
+    case ED_INTERRUPT_IN:
+      TotalLen = 0;
+      Len      = 0;
+      TrbNum   = 0;
+      TrbStart = (TRB *) (UINTN) EPRing->RingEnqueue;
+      while (TotalLen < Urb->DataLen) {
+        if ((TotalLen + 0x10000) >= Urb->DataLen) {
+          Len = Urb->DataLen - TotalLen;
+        } else {
+          Len = 0x10000;
+        }
+        TrbStart = (TRB *)(UINTN)EPRing->RingEnqueue;
+        TrbStart->TrbNormal.TRBPtrLo  = XHC_LOW_32BIT((UINT8 *) Urb->DataPhy + TotalLen);
+        TrbStart->TrbNormal.TRBPtrHi  = XHC_HIGH_32BIT((UINT8 *) Urb->DataPhy + TotalLen);
+        TrbStart->TrbNormal.Length    = (UINT32) Len;
+        TrbStart->TrbNormal.TDSize    = 0;
+        TrbStart->TrbNormal.IntTarget = 0;
+        TrbStart->TrbNormal.ISP       = 1;
+        TrbStart->TrbNormal.IOC       = 1;
+        TrbStart->TrbNormal.Type      = TRB_TYPE_NORMAL;
+        //
+        // Update the cycle bit
+        //
+        TrbStart->TrbNormal.CycleBit = EPRing->RingPCS & BIT0;
 
-  case ED_INTERRUPT_OUT:
-  case ED_INTERRUPT_IN:
-    TotalLen = 0;
-    Len      = 0;
-    TrbNum   = 0;
-    TrbStart = (TRB *) (UINTN) EPRing->RingEnqueue;
-    while (TotalLen < Urb->DataLen) {
-      if ((TotalLen + 0x10000) >= Urb->DataLen) {
-        Len = Urb->DataLen - TotalLen;
-      } else {
-        Len = 0x10000;
+        XhcPeiSyncTrsRing (Xhc, EPRing);
+        TrbNum++;
+        TotalLen += Len;
       }
-      TrbStart = (TRB *) (UINTN)EPRing->RingEnqueue;
-      TrbStart->TrbNormal.TRBPtrLo  = XHC_LOW_32BIT ((UINT8 *) Urb->DataPhy + TotalLen);
-      TrbStart->TrbNormal.TRBPtrHi  = XHC_HIGH_32BIT ((UINT8 *) Urb->DataPhy + TotalLen);
-      TrbStart->TrbNormal.Length    = (UINT32) Len;
-      TrbStart->TrbNormal.TDSize    = 0;
-      TrbStart->TrbNormal.IntTarget = 0;
-      TrbStart->TrbNormal.ISP       = 1;
-      TrbStart->TrbNormal.IOC       = 1;
-      TrbStart->TrbNormal.Type      = TRB_TYPE_NORMAL;
-      //
-      // Update the cycle bit
-      //
-      TrbStart->TrbNormal.CycleBit = EPRing->RingPCS & BIT0;
 
-      XhcPeiSyncTrsRing (Xhc, EPRing);
-      TrbNum++;
-      TotalLen += Len;
-    }
+      Urb->TrbNum = TrbNum;
+      Urb->TrbEnd = (TRB_TEMPLATE *)(UINTN)TrbStart;
+      break;
 
-    Urb->TrbNum = TrbNum;
-    Urb->TrbEnd = (TRB_TEMPLATE *) (UINTN)TrbStart;
-    break;
-
-  default:
-    DEBUG ((DEBUG_ERROR, "Not supported EPType 0x%x!\n", EPType));
-    return EFI_UNSUPPORTED;
+    default:
+      DEBUG ((DEBUG_ERROR, "Not supported EPType 0x%x!\n", EPType));
+      return EFI_UNSUPPORTED;
   }
 
   return EFI_SUCCESS;
@@ -446,13 +472,13 @@ XhcPeiRecoverHaltedEndpoint (
   }
   Dci = XhcPeiEndpointToDci (Urb->Ep.EpAddr, (UINT8) (Urb->Ep.Direction));
 
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiRecoverHaltedEndpoint: Recovery Halted Slot = %x, Dci = %x\n", SlotId, Dci));
+  DEBUG ((DEBUG_INFO, "XhcPeiRecoverHaltedEndpoint: Recovery Halted Slot = %x, Dci = %x\n", SlotId, Dci));
 
   //
   // 1) Send Reset endpoint command to transit from halt to stop state
   //
   Status = XhcPeiResetEndpoint (Xhc, SlotId, Dci);
-  if (EFI_ERROR (Status)) {
+  if (EFI_ERROR(Status)) {
     DEBUG ((DEBUG_ERROR, "XhcPeiRecoverHaltedEndpoint: Reset Endpoint Failed, Status = %r\n", Status));
     goto Done;
   }
@@ -461,7 +487,7 @@ XhcPeiRecoverHaltedEndpoint (
   // 2) Set dequeue pointer
   //
   Status = XhcPeiSetTrDequeuePointer (Xhc, SlotId, Dci, Urb);
-  if (EFI_ERROR (Status)) {
+  if (EFI_ERROR(Status)) {
     DEBUG ((DEBUG_ERROR, "XhcPeiRecoverHaltedEndpoint: Set Dequeue Pointer Failed, Status = %r\n", Status));
     goto Done;
   }
@@ -505,13 +531,13 @@ XhcPeiDequeueTrbFromEndpoint (
   }
   Dci = XhcPeiEndpointToDci (Urb->Ep.EpAddr, (UINT8) (Urb->Ep.Direction));
 
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiDequeueTrbFromEndpoint: Stop Slot = %x, Dci = %x\n", SlotId, Dci));
+  DEBUG ((DEBUG_INFO, "XhcPeiDequeueTrbFromEndpoint: Stop Slot = %x, Dci = %x\n", SlotId, Dci));
 
   //
   // 1) Send Stop endpoint command to stop endpoint.
   //
   Status = XhcPeiStopEndpoint (Xhc, SlotId, Dci);
-  if (EFI_ERROR (Status)) {
+  if (EFI_ERROR(Status)) {
     DEBUG ((DEBUG_ERROR, "XhcPeiDequeueTrbFromEndpoint: Stop Endpoint Failed, Status = %r\n", Status));
     goto Done;
   }
@@ -520,7 +546,7 @@ XhcPeiDequeueTrbFromEndpoint (
   // 2) Set dequeue pointer
   //
   Status = XhcPeiSetTrDequeuePointer (Xhc, SlotId, Dci, Urb);
-  if (EFI_ERROR (Status)) {
+  if (EFI_ERROR(Status)) {
     DEBUG ((DEBUG_ERROR, "XhcPeiDequeueTrbFromEndpoint: Set Dequeue Pointer Failed, Status = %r\n", Status));
     goto Done;
   }
@@ -633,8 +659,7 @@ XhcPeiCheckUrbResult (
     // Need convert pci device address to host address
     //
     PhyAddr = (EFI_PHYSICAL_ADDRESS) (EvtTrb->TRBPtrLo | LShiftU64 ((UINT64) EvtTrb->TRBPtrHi, 32));
-    TRBPtr = (TRB_TEMPLATE *) (UINTN) UsbHcGetHostAddrForPciAddr (Xhc->MemPool, (VOID *) (UINTN) PhyAddr,
-             sizeof (TRB_TEMPLATE));
+    TRBPtr = (TRB_TEMPLATE *) (UINTN) UsbHcGetHostAddrForPciAddr (Xhc->MemPool, (VOID *) (UINTN) PhyAddr, sizeof (TRB_TEMPLATE));
 
     //
     // Update the status of Urb according to the finished event regardless of whether
@@ -649,51 +674,50 @@ XhcPeiCheckUrbResult (
     }
 
     switch (EvtTrb->Completecode) {
-    case TRB_COMPLETION_STALL_ERROR:
-      CheckedUrb->Result  |= EFI_USB_ERR_STALL;
-      CheckedUrb->Finished = TRUE;
-      DEBUG ((DEBUG_ERROR, "XhcPeiCheckUrbResult: STALL_ERROR! Completecode = %x\n", EvtTrb->Completecode));
-      goto EXIT;
+      case TRB_COMPLETION_STALL_ERROR:
+        CheckedUrb->Result  |= EFI_USB_ERR_STALL;
+        CheckedUrb->Finished = TRUE;
+        DEBUG ((DEBUG_ERROR, "XhcPeiCheckUrbResult: STALL_ERROR! Completecode = %x\n", EvtTrb->Completecode));
+        goto EXIT;
 
-    case TRB_COMPLETION_BABBLE_ERROR:
-      CheckedUrb->Result  |= EFI_USB_ERR_BABBLE;
-      CheckedUrb->Finished = TRUE;
-      DEBUG ((DEBUG_ERROR, "XhcPeiCheckUrbResult: BABBLE_ERROR! Completecode = %x\n", EvtTrb->Completecode));
-      goto EXIT;
+      case TRB_COMPLETION_BABBLE_ERROR:
+        CheckedUrb->Result  |= EFI_USB_ERR_BABBLE;
+        CheckedUrb->Finished = TRUE;
+        DEBUG ((DEBUG_ERROR, "XhcPeiCheckUrbResult: BABBLE_ERROR! Completecode = %x\n", EvtTrb->Completecode));
+        goto EXIT;
 
-    case TRB_COMPLETION_DATA_BUFFER_ERROR:
-      CheckedUrb->Result  |= EFI_USB_ERR_BUFFER;
-      CheckedUrb->Finished = TRUE;
-      DEBUG ((DEBUG_ERROR, "XhcPeiCheckUrbResult: ERR_BUFFER! Completecode = %x\n", EvtTrb->Completecode));
-      goto EXIT;
+      case TRB_COMPLETION_DATA_BUFFER_ERROR:
+        CheckedUrb->Result  |= EFI_USB_ERR_BUFFER;
+        CheckedUrb->Finished = TRUE;
+        DEBUG ((DEBUG_ERROR, "XhcPeiCheckUrbResult: ERR_BUFFER! Completecode = %x\n", EvtTrb->Completecode));
+        goto EXIT;
 
-    case TRB_COMPLETION_USB_TRANSACTION_ERROR:
-      CheckedUrb->Result  |= EFI_USB_ERR_TIMEOUT;
-      CheckedUrb->Finished = TRUE;
-      DEBUG ((DEBUG_ERROR, "XhcPeiCheckUrbResult: TRANSACTION_ERROR! Completecode = %x\n", EvtTrb->Completecode));
-      goto EXIT;
+      case TRB_COMPLETION_USB_TRANSACTION_ERROR:
+        CheckedUrb->Result  |= EFI_USB_ERR_TIMEOUT;
+        CheckedUrb->Finished = TRUE;
+        DEBUG ((DEBUG_ERROR, "XhcPeiCheckUrbResult: TRANSACTION_ERROR! Completecode = %x\n", EvtTrb->Completecode));
+        goto EXIT;
 
-    case TRB_COMPLETION_SHORT_PACKET:
-    case TRB_COMPLETION_SUCCESS:
-      if (EvtTrb->Completecode == TRB_COMPLETION_SHORT_PACKET) {
-        DEBUG ((DEBUG_VERBOSE, "XhcPeiCheckUrbResult: short packet happens!\n"));
-      }
+      case TRB_COMPLETION_SHORT_PACKET:
+      case TRB_COMPLETION_SUCCESS:
+        if (EvtTrb->Completecode == TRB_COMPLETION_SHORT_PACKET) {
+          DEBUG ((DEBUG_VERBOSE, "XhcPeiCheckUrbResult: short packet happens!\n"));
+        }
 
-      TRBType = (UINT8) (TRBPtr->Type);
-      if ((TRBType == TRB_TYPE_DATA_STAGE) ||
-          (TRBType == TRB_TYPE_NORMAL) ||
-          (TRBType == TRB_TYPE_ISOCH)) {
-        CheckedUrb->Completed += (((TRANSFER_TRB_NORMAL *)TRBPtr)->Length - EvtTrb->Length);
-      }
+        TRBType = (UINT8) (TRBPtr->Type);
+        if ((TRBType == TRB_TYPE_DATA_STAGE) ||
+            (TRBType == TRB_TYPE_NORMAL) ||
+            (TRBType == TRB_TYPE_ISOCH)) {
+          CheckedUrb->Completed += (((TRANSFER_TRB_NORMAL*)TRBPtr)->Length - EvtTrb->Length);
+        }
 
-      break;
+        break;
 
-    default:
-      DEBUG ((DEBUG_ERROR, "XhcPeiCheckUrbResult: Transfer Default Error Occur! Completecode = 0x%x!\n",
-              EvtTrb->Completecode));
-      CheckedUrb->Result  |= EFI_USB_ERR_TIMEOUT;
-      CheckedUrb->Finished = TRUE;
-      goto EXIT;
+      default:
+        DEBUG ((DEBUG_ERROR, "XhcPeiCheckUrbResult: Transfer Default Error Occur! Completecode = 0x%x!\n", EvtTrb->Completecode));
+        CheckedUrb->Result  |= EFI_USB_ERR_TIMEOUT;
+        CheckedUrb->Finished = TRUE;
+        goto EXIT;
     }
 
     //
@@ -723,7 +747,7 @@ EXIT:
   //
   Low  = XhcPeiReadRuntimeReg (Xhc, XHC_ERDP_OFFSET);
   High = XhcPeiReadRuntimeReg (Xhc, XHC_ERDP_OFFSET + 4);
-  XhcDequeue = (UINT64) (LShiftU64 ((UINT64) High, 32) | Low);
+  XhcDequeue = (UINT64) (LShiftU64((UINT64) High, 32) | Low);
 
   PhyAddr = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Xhc->EventRing.EventRingDequeue, sizeof (TRB_TEMPLATE));
 
@@ -775,7 +799,7 @@ XhcPeiExecTransfer (
     if (SlotId == 0) {
       return EFI_DEVICE_ERROR;
     }
-    Dci  = XhcPeiEndpointToDci (Urb->Ep.EpAddr, (UINT8) (Urb->Ep.Direction));
+    Dci  = XhcPeiEndpointToDci (Urb->Ep.EpAddr, (UINT8)(Urb->Ep.Direction));
   }
 
   Status = EFI_SUCCESS;
@@ -829,13 +853,11 @@ XhcPeiPollPortStatusChange (
   UINT8             SlotId;
   USB_DEV_ROUTE     RouteChart;
 
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiPollPortStatusChange: PortChangeStatus: %x PortStatus: %x\n", PortState->PortChangeStatus,
-          PortState->PortStatus));
+  DEBUG ((DEBUG_INFO, "XhcPeiPollPortStatusChange: PortChangeStatus: %x PortStatus: %x\n", PortState->PortChangeStatus, PortState->PortStatus));
 
   Status = EFI_SUCCESS;
 
-  if ((PortState->PortChangeStatus & (USB_PORT_STAT_C_CONNECTION | USB_PORT_STAT_C_ENABLE | USB_PORT_STAT_C_OVERCURRENT |
-                                      USB_PORT_STAT_C_RESET)) == 0) {
+  if ((PortState->PortChangeStatus & (USB_PORT_STAT_C_CONNECTION | USB_PORT_STAT_C_ENABLE | USB_PORT_STAT_C_OVERCURRENT | USB_PORT_STAT_C_RESET)) == 0) {
     return EFI_SUCCESS;
   }
 
@@ -844,9 +866,8 @@ XhcPeiPollPortStatusChange (
     RouteChart.Route.RootPortNum = Port + 1;
     RouteChart.Route.TierNum     = 1;
   } else {
-    if (Port < 14) {
-      RouteChart.Route.RouteString = ParentRouteChart.Route.RouteString | (Port << (4 * (ParentRouteChart.Route.TierNum -
-                                     1)));
+    if(Port < 14) {
+      RouteChart.Route.RouteString = ParentRouteChart.Route.RouteString | (Port << (4 * (ParentRouteChart.Route.TierNum - 1)));
     } else {
       RouteChart.Route.RouteString = ParentRouteChart.Route.RouteString | (15 << (4 * (ParentRouteChart.Route.TierNum - 1)));
     }
@@ -1058,7 +1079,7 @@ XhcPeiInitializeDeviceSlot (
     return Status;
   }
   ASSERT (EvtTrb->SlotId <= Xhc->MaxSlotsEn);
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiInitializeDeviceSlot: Enable Slot Successfully, The Slot ID = 0x%x\n", EvtTrb->SlotId));
+  DEBUG ((DEBUG_INFO, "XhcPeiInitializeDeviceSlot: Enable Slot Successfully, The Slot ID = 0x%x\n", EvtTrb->SlotId));
   SlotId = (UINT8) EvtTrb->SlotId;
   ASSERT (SlotId != 0);
 
@@ -1134,8 +1155,7 @@ XhcPeiInitializeDeviceSlot (
   //
   EndpointTransferRing = AllocateZeroPool (sizeof (TRANSFER_RING));
   Xhc->UsbDevContext[SlotId].EndpointTransferRing[0] = EndpointTransferRing;
-  XhcPeiCreateTransferRing (Xhc, TR_RING_TRB_NUMBER,
-                            (TRANSFER_RING *) Xhc->UsbDevContext[SlotId].EndpointTransferRing[0]);
+  XhcPeiCreateTransferRing (Xhc, TR_RING_TRB_NUMBER, (TRANSFER_RING *) Xhc->UsbDevContext[SlotId].EndpointTransferRing[0]);
   //
   // 5) Initialize the Input default control Endpoint 0 Context (6.2.3).
   //
@@ -1212,11 +1232,11 @@ XhcPeiInitializeDeviceSlot (
              );
   if (!EFI_ERROR (Status)) {
     DeviceAddress = (UINT8) OutputContext->Slot.DeviceAddress;
-    DEBUG ((DEBUG_VERBOSE, "XhcPeiInitializeDeviceSlot: Address %d assigned successfully\n", DeviceAddress));
+    DEBUG ((DEBUG_INFO, "XhcPeiInitializeDeviceSlot: Address %d assigned successfully\n", DeviceAddress));
     Xhc->UsbDevContext[SlotId].XhciDevAddr = DeviceAddress;
   }
 
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiInitializeDeviceSlot: Enable Slot, Status = %r\n", Status));
+  DEBUG ((DEBUG_INFO, "XhcPeiInitializeDeviceSlot: Enable Slot, Status = %r\n", Status));
   return Status;
 }
 
@@ -1270,7 +1290,7 @@ XhcPeiInitializeDeviceSlot64 (
     return Status;
   }
   ASSERT (EvtTrb->SlotId <= Xhc->MaxSlotsEn);
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiInitializeDeviceSlot64: Enable Slot Successfully, The Slot ID = 0x%x\n", EvtTrb->SlotId));
+  DEBUG ((DEBUG_INFO, "XhcPeiInitializeDeviceSlot64: Enable Slot Successfully, The Slot ID = 0x%x\n", EvtTrb->SlotId));
   SlotId = (UINT8)EvtTrb->SlotId;
   ASSERT (SlotId != 0);
 
@@ -1346,8 +1366,7 @@ XhcPeiInitializeDeviceSlot64 (
   //
   EndpointTransferRing = AllocateZeroPool (sizeof (TRANSFER_RING));
   Xhc->UsbDevContext[SlotId].EndpointTransferRing[0] = EndpointTransferRing;
-  XhcPeiCreateTransferRing (Xhc, TR_RING_TRB_NUMBER,
-                            (TRANSFER_RING *) Xhc->UsbDevContext[SlotId].EndpointTransferRing[0]);
+  XhcPeiCreateTransferRing(Xhc, TR_RING_TRB_NUMBER, (TRANSFER_RING *) Xhc->UsbDevContext[SlotId].EndpointTransferRing[0]);
   //
   // 5) Initialize the Input default control Endpoint 0 Context (6.2.3).
   //
@@ -1424,11 +1443,11 @@ XhcPeiInitializeDeviceSlot64 (
              );
   if (!EFI_ERROR (Status)) {
     DeviceAddress = (UINT8) OutputContext->Slot.DeviceAddress;
-    DEBUG ((DEBUG_VERBOSE, "XhcPeiInitializeDeviceSlot64: Address %d assigned successfully\n", DeviceAddress));
+    DEBUG ((DEBUG_INFO, "XhcPeiInitializeDeviceSlot64: Address %d assigned successfully\n", DeviceAddress));
     Xhc->UsbDevContext[SlotId].XhciDevAddr = DeviceAddress;
   }
 
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiInitializeDeviceSlot64: Enable Slot, Status = %r\n", Status));
+  DEBUG ((DEBUG_INFO, "XhcPeiInitializeDeviceSlot64: Enable Slot, Status = %r\n", Status));
   return Status;
 }
 
@@ -1476,7 +1495,7 @@ XhcPeiDisableSlotCmd (
   //
   // Construct the disable slot command
   //
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiDisableSlotCmd: Disable device slot %d!\n", SlotId));
+  DEBUG ((DEBUG_INFO, "XhcPeiDisableSlotCmd: Disable device slot %d!\n", SlotId));
 
   ZeroMem (&CmdTrbDisSlot, sizeof (CmdTrbDisSlot));
   CmdTrbDisSlot.CycleBit = 1;
@@ -1532,7 +1551,7 @@ XhcPeiDisableSlotCmd (
   Xhc->UsbDevContext[SlotId].Enabled = FALSE;
   Xhc->UsbDevContext[SlotId].SlotId  = 0;
 
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiDisableSlotCmd: Disable Slot Command, Status = %r\n", Status));
+  DEBUG ((DEBUG_INFO, "XhcPeiDisableSlotCmd: Disable Slot Command, Status = %r\n", Status));
   return Status;
 }
 
@@ -1579,7 +1598,7 @@ XhcPeiDisableSlotCmd64 (
   //
   // Construct the disable slot command
   //
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiDisableSlotCmd64: Disable device slot %d!\n", SlotId));
+  DEBUG ((DEBUG_INFO, "XhcPeiDisableSlotCmd64: Disable device slot %d!\n", SlotId));
 
   ZeroMem (&CmdTrbDisSlot, sizeof (CmdTrbDisSlot));
   CmdTrbDisSlot.CycleBit = 1;
@@ -1625,7 +1644,7 @@ XhcPeiDisableSlotCmd64 (
   }
 
   if (Xhc->UsbDevContext[SlotId].OutputContext != NULL) {
-    UsbHcFreeMem (Xhc->MemPool, Xhc->UsbDevContext[SlotId].OutputContext, sizeof (DEVICE_CONTEXT_64));
+     UsbHcFreeMem (Xhc->MemPool, Xhc->UsbDevContext[SlotId].OutputContext, sizeof (DEVICE_CONTEXT_64));
   }
   //
   // Doesn't zero the entry because XhcAsyncInterruptTransfer() may be invoked to remove the established
@@ -1635,7 +1654,7 @@ XhcPeiDisableSlotCmd64 (
   Xhc->UsbDevContext[SlotId].Enabled = FALSE;
   Xhc->UsbDevContext[SlotId].SlotId  = 0;
 
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiDisableSlotCmd64: Disable Slot Command, Status = %r\n", Status));
+  DEBUG ((DEBUG_INFO, "XhcPeiDisableSlotCmd64: Disable Slot Command, Status = %r\n", Status));
   return Status;
 }
 
@@ -1711,122 +1730,119 @@ XhcPeiSetConfigCmd (
       }
 
       InputContext->InputControlContext.Dword2 |= (BIT0 << Dci);
-      InputContext->EP[Dci - 1].MaxPacketSize     = EpDesc->MaxPacketSize;
+      InputContext->EP[Dci-1].MaxPacketSize     = EpDesc->MaxPacketSize;
 
       if (DeviceSpeed == EFI_USB_SPEED_SUPER) {
         //
         // 6.2.3.4, shall be set to the value defined in the bMaxBurst field of the SuperSpeed Endpoint Companion Descriptor.
         //
-        InputContext->EP[Dci - 1].MaxBurstSize = 0x0;
+        InputContext->EP[Dci-1].MaxBurstSize = 0x0;
       } else {
-        InputContext->EP[Dci - 1].MaxBurstSize = 0x0;
+        InputContext->EP[Dci-1].MaxBurstSize = 0x0;
       }
 
       switch (EpDesc->Attributes & USB_ENDPOINT_TYPE_MASK) {
-      case USB_ENDPOINT_BULK:
-        if (Direction == EfiUsbDataIn) {
-          InputContext->EP[Dci - 1].CErr   = 3;
-          InputContext->EP[Dci - 1].EPType = ED_BULK_IN;
-        } else {
-          InputContext->EP[Dci - 1].CErr   = 3;
-          InputContext->EP[Dci - 1].EPType = ED_BULK_OUT;
-        }
+        case USB_ENDPOINT_BULK:
+          if (Direction == EfiUsbDataIn) {
+            InputContext->EP[Dci-1].CErr   = 3;
+            InputContext->EP[Dci-1].EPType = ED_BULK_IN;
+          } else {
+            InputContext->EP[Dci-1].CErr   = 3;
+            InputContext->EP[Dci-1].EPType = ED_BULK_OUT;
+          }
 
-        InputContext->EP[Dci - 1].AverageTRBLength = 0x1000;
-        if (Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci - 1] == NULL) {
-          EndpointTransferRing = AllocateZeroPool (sizeof (TRANSFER_RING));
-          Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci - 1] = (VOID *) EndpointTransferRing;
-          XhcPeiCreateTransferRing (Xhc, TR_RING_TRB_NUMBER,
-                                    (TRANSFER_RING *) Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci - 1]);
-        }
+          InputContext->EP[Dci-1].AverageTRBLength = 0x1000;
+          if (Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1] == NULL) {
+            EndpointTransferRing = AllocateZeroPool (sizeof (TRANSFER_RING));
+            Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1] = (VOID *) EndpointTransferRing;
+            XhcPeiCreateTransferRing (Xhc, TR_RING_TRB_NUMBER, (TRANSFER_RING *) Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1]);
+          }
 
-        break;
-      case USB_ENDPOINT_ISO:
-        if (Direction == EfiUsbDataIn) {
-          InputContext->EP[Dci - 1].CErr   = 0;
-          InputContext->EP[Dci - 1].EPType = ED_ISOCH_IN;
-        } else {
-          InputContext->EP[Dci - 1].CErr   = 0;
-          InputContext->EP[Dci - 1].EPType = ED_ISOCH_OUT;
-        }
-        //
-        // Get the bInterval from descriptor and init the the interval field of endpoint context.
-        // Refer to XHCI 1.1 spec section 6.2.3.6.
-        //
-        if (DeviceSpeed == EFI_USB_SPEED_FULL) {
-          Interval = EpDesc->Interval;
-          ASSERT (Interval >= 1 && Interval <= 16);
-          InputContext->EP[Dci - 1].Interval = Interval + 2;
-        } else if ((DeviceSpeed == EFI_USB_SPEED_HIGH) || (DeviceSpeed == EFI_USB_SPEED_SUPER)) {
-          Interval = EpDesc->Interval;
-          ASSERT (Interval >= 1 && Interval <= 16);
-          InputContext->EP[Dci - 1].Interval = Interval - 1;
-        }
-
-        //
-        // Do not support isochronous transfer now.
-        //
-        DEBUG ((DEBUG_VERBOSE, "XhcPeiSetConfigCmd: Unsupport ISO EP found, Transfer ring is not allocated.\n"));
-        EpDesc = (USB_ENDPOINT_DESCRIPTOR *) ((UINTN)EpDesc + EpDesc->Length);
-        continue;
-      case USB_ENDPOINT_INTERRUPT:
-        if (Direction == EfiUsbDataIn) {
-          InputContext->EP[Dci - 1].CErr   = 3;
-          InputContext->EP[Dci - 1].EPType = ED_INTERRUPT_IN;
-        } else {
-          InputContext->EP[Dci - 1].CErr   = 3;
-          InputContext->EP[Dci - 1].EPType = ED_INTERRUPT_OUT;
-        }
-        InputContext->EP[Dci - 1].AverageTRBLength = 0x1000;
-        InputContext->EP[Dci - 1].MaxESITPayload   = EpDesc->MaxPacketSize;
-        //
-        // Get the bInterval from descriptor and init the interval field of endpoint context
-        //
-        if ((DeviceSpeed == EFI_USB_SPEED_FULL) || (DeviceSpeed == EFI_USB_SPEED_LOW)) {
-          Interval = EpDesc->Interval;
+          break;
+        case USB_ENDPOINT_ISO:
+          if (Direction == EfiUsbDataIn) {
+            InputContext->EP[Dci-1].CErr   = 0;
+            InputContext->EP[Dci-1].EPType = ED_ISOCH_IN;
+          } else {
+            InputContext->EP[Dci-1].CErr   = 0;
+            InputContext->EP[Dci-1].EPType = ED_ISOCH_OUT;
+          }
           //
-          // Calculate through the bInterval field of Endpoint descriptor.
+          // Get the bInterval from descriptor and init the the interval field of endpoint context.
+          // Refer to XHCI 1.1 spec section 6.2.3.6.
           //
-          ASSERT (Interval != 0);
-          InputContext->EP[Dci - 1].Interval = (UINT32) HighBitSet32 ((UINT32) Interval) + 3;
-        } else if ((DeviceSpeed == EFI_USB_SPEED_HIGH) || (DeviceSpeed == EFI_USB_SPEED_SUPER)) {
-          Interval = EpDesc->Interval;
-          ASSERT (Interval >= 1 && Interval <= 16);
-          //
-          // Refer to XHCI 1.0 spec section 6.2.3.6, table 61
-          //
-          InputContext->EP[Dci - 1].Interval = Interval - 1;
-        }
+          if (DeviceSpeed == EFI_USB_SPEED_FULL) {
+            Interval = EpDesc->Interval;
+            ASSERT (Interval >= 1 && Interval <= 16);
+            InputContext->EP[Dci-1].Interval = Interval + 2;
+          } else if ((DeviceSpeed == EFI_USB_SPEED_HIGH) || (DeviceSpeed == EFI_USB_SPEED_SUPER)) {
+            Interval = EpDesc->Interval;
+            ASSERT (Interval >= 1 && Interval <= 16);
+            InputContext->EP[Dci-1].Interval = Interval - 1;
+          }
 
-        if (Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci - 1] == NULL) {
-          EndpointTransferRing = AllocateZeroPool (sizeof (TRANSFER_RING));
-          Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci - 1] = (VOID *) EndpointTransferRing;
-          XhcPeiCreateTransferRing (Xhc, TR_RING_TRB_NUMBER,
-                                    (TRANSFER_RING *) Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci - 1]);
-        }
-        break;
+          //
+          // Do not support isochronous transfer now.
+          //
+          DEBUG ((DEBUG_INFO, "XhcPeiSetConfigCmd: Unsupport ISO EP found, Transfer ring is not allocated.\n"));
+          EpDesc = (USB_ENDPOINT_DESCRIPTOR *)((UINTN)EpDesc + EpDesc->Length);
+          continue;
+        case USB_ENDPOINT_INTERRUPT:
+          if (Direction == EfiUsbDataIn) {
+            InputContext->EP[Dci-1].CErr   = 3;
+            InputContext->EP[Dci-1].EPType = ED_INTERRUPT_IN;
+          } else {
+            InputContext->EP[Dci-1].CErr   = 3;
+            InputContext->EP[Dci-1].EPType = ED_INTERRUPT_OUT;
+          }
+          InputContext->EP[Dci-1].AverageTRBLength = 0x1000;
+          InputContext->EP[Dci-1].MaxESITPayload   = EpDesc->MaxPacketSize;
+          //
+          // Get the bInterval from descriptor and init the interval field of endpoint context
+          //
+          if ((DeviceSpeed == EFI_USB_SPEED_FULL) || (DeviceSpeed == EFI_USB_SPEED_LOW)) {
+            Interval = EpDesc->Interval;
+            //
+            // Calculate through the bInterval field of Endpoint descriptor.
+            //
+            ASSERT (Interval != 0);
+            InputContext->EP[Dci-1].Interval = (UINT32) HighBitSet32 ((UINT32) Interval) + 3;
+          } else if ((DeviceSpeed == EFI_USB_SPEED_HIGH) || (DeviceSpeed == EFI_USB_SPEED_SUPER)) {
+            Interval = EpDesc->Interval;
+            ASSERT (Interval >= 1 && Interval <= 16);
+            //
+            // Refer to XHCI 1.0 spec section 6.2.3.6, table 61
+            //
+            InputContext->EP[Dci-1].Interval = Interval - 1;
+          }
 
-      case USB_ENDPOINT_CONTROL:
-        //
-        // Do not support control transfer now.
-        //
-        DEBUG ((DEBUG_VERBOSE, "XhcPeiSetConfigCmd: Unsupport Control EP found, Transfer ring is not allocated.\n"));
-      default:
-        DEBUG ((DEBUG_VERBOSE, "XhcPeiSetConfigCmd: Unknown EP found, Transfer ring is not allocated.\n"));
-        EpDesc = (USB_ENDPOINT_DESCRIPTOR *) ((UINTN)EpDesc + EpDesc->Length);
-        continue;
+          if (Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1] == NULL) {
+            EndpointTransferRing = AllocateZeroPool (sizeof (TRANSFER_RING));
+            Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1] = (VOID *) EndpointTransferRing;
+            XhcPeiCreateTransferRing (Xhc, TR_RING_TRB_NUMBER, (TRANSFER_RING *) Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1]);
+          }
+          break;
+
+        case USB_ENDPOINT_CONTROL:
+          //
+          // Do not support control transfer now.
+          //
+          DEBUG ((DEBUG_INFO, "XhcPeiSetConfigCmd: Unsupport Control EP found, Transfer ring is not allocated.\n"));
+        default:
+          DEBUG ((DEBUG_INFO, "XhcPeiSetConfigCmd: Unknown EP found, Transfer ring is not allocated.\n"));
+          EpDesc = (USB_ENDPOINT_DESCRIPTOR *)((UINTN)EpDesc + EpDesc->Length);
+          continue;
       }
 
       PhyAddr = UsbHcGetPciAddrForHostAddr (
                   Xhc->MemPool,
-                  ((TRANSFER_RING *) (UINTN) Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci - 1])->RingSeg0,
+                  ((TRANSFER_RING *) (UINTN) Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1])->RingSeg0,
                   sizeof (TRB_TEMPLATE) * TR_RING_TRB_NUMBER
                   );
-      PhyAddr &= ~ ((EFI_PHYSICAL_ADDRESS)0x0F);
-      PhyAddr |= (EFI_PHYSICAL_ADDRESS) ((TRANSFER_RING *) (UINTN) Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci -
-                                         1])->RingPCS;
-      InputContext->EP[Dci - 1].PtrLo = XHC_LOW_32BIT (PhyAddr);
-      InputContext->EP[Dci - 1].PtrHi = XHC_HIGH_32BIT (PhyAddr);
+      PhyAddr &= ~((EFI_PHYSICAL_ADDRESS)0x0F);
+      PhyAddr |= (EFI_PHYSICAL_ADDRESS)((TRANSFER_RING *) (UINTN) Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1])->RingPCS;
+      InputContext->EP[Dci-1].PtrLo = XHC_LOW_32BIT (PhyAddr);
+      InputContext->EP[Dci-1].PtrHi = XHC_HIGH_32BIT (PhyAddr);
 
       EpDesc = (USB_ENDPOINT_DESCRIPTOR *) ((UINTN) EpDesc + EpDesc->Length);
     }
@@ -1845,7 +1861,7 @@ XhcPeiSetConfigCmd (
   CmdTrbCfgEP.CycleBit = 1;
   CmdTrbCfgEP.Type     = TRB_TYPE_CON_ENDPOINT;
   CmdTrbCfgEP.SlotId   = Xhc->UsbDevContext[SlotId].SlotId;
-  DEBUG ((DEBUG_VERBOSE, "XhcSetConfigCmd: Configure Endpoint\n"));
+  DEBUG ((DEBUG_INFO, "XhcSetConfigCmd: Configure Endpoint\n"));
   Status = XhcPeiCmdTransfer (
              Xhc,
              (TRB_TEMPLATE *) (UINTN) &CmdTrbCfgEP,
@@ -1931,124 +1947,121 @@ XhcPeiSetConfigCmd64 (
       }
 
       InputContext->InputControlContext.Dword2 |= (BIT0 << Dci);
-      InputContext->EP[Dci - 1].MaxPacketSize     = EpDesc->MaxPacketSize;
+      InputContext->EP[Dci-1].MaxPacketSize     = EpDesc->MaxPacketSize;
 
       if (DeviceSpeed == EFI_USB_SPEED_SUPER) {
         //
         // 6.2.3.4, shall be set to the value defined in the bMaxBurst field of the SuperSpeed Endpoint Companion Descriptor.
         //
-        InputContext->EP[Dci - 1].MaxBurstSize = 0x0;
+        InputContext->EP[Dci-1].MaxBurstSize = 0x0;
       } else {
-        InputContext->EP[Dci - 1].MaxBurstSize = 0x0;
+        InputContext->EP[Dci-1].MaxBurstSize = 0x0;
       }
 
       switch (EpDesc->Attributes & USB_ENDPOINT_TYPE_MASK) {
-      case USB_ENDPOINT_BULK:
-        if (Direction == EfiUsbDataIn) {
-          InputContext->EP[Dci - 1].CErr   = 3;
-          InputContext->EP[Dci - 1].EPType = ED_BULK_IN;
-        } else {
-          InputContext->EP[Dci - 1].CErr   = 3;
-          InputContext->EP[Dci - 1].EPType = ED_BULK_OUT;
-        }
+        case USB_ENDPOINT_BULK:
+          if (Direction == EfiUsbDataIn) {
+            InputContext->EP[Dci-1].CErr   = 3;
+            InputContext->EP[Dci-1].EPType = ED_BULK_IN;
+          } else {
+            InputContext->EP[Dci-1].CErr   = 3;
+            InputContext->EP[Dci-1].EPType = ED_BULK_OUT;
+          }
 
-        InputContext->EP[Dci - 1].AverageTRBLength = 0x1000;
-        if (Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci - 1] == NULL) {
-          EndpointTransferRing = AllocateZeroPool (sizeof (TRANSFER_RING));
-          Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci - 1] = (VOID *) EndpointTransferRing;
-          XhcPeiCreateTransferRing (Xhc, TR_RING_TRB_NUMBER,
-                                    (TRANSFER_RING *) Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci - 1]);
-        }
+          InputContext->EP[Dci-1].AverageTRBLength = 0x1000;
+          if (Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1] == NULL) {
+            EndpointTransferRing = AllocateZeroPool (sizeof (TRANSFER_RING));
+            Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1] = (VOID *) EndpointTransferRing;
+            XhcPeiCreateTransferRing (Xhc, TR_RING_TRB_NUMBER, (TRANSFER_RING *) Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1]);
+          }
 
-        break;
-      case USB_ENDPOINT_ISO:
-        if (Direction == EfiUsbDataIn) {
-          InputContext->EP[Dci - 1].CErr   = 0;
-          InputContext->EP[Dci - 1].EPType = ED_ISOCH_IN;
-        } else {
-          InputContext->EP[Dci - 1].CErr   = 0;
-          InputContext->EP[Dci - 1].EPType = ED_ISOCH_OUT;
-        }
-        //
-        // Get the bInterval from descriptor and init the the interval field of endpoint context.
-        // Refer to XHCI 1.1 spec section 6.2.3.6.
-        //
-        if (DeviceSpeed == EFI_USB_SPEED_FULL) {
-          Interval = EpDesc->Interval;
-          ASSERT (Interval >= 1 && Interval <= 16);
-          InputContext->EP[Dci - 1].Interval = Interval + 2;
-        } else if ((DeviceSpeed == EFI_USB_SPEED_HIGH) || (DeviceSpeed == EFI_USB_SPEED_SUPER)) {
-          Interval = EpDesc->Interval;
-          ASSERT (Interval >= 1 && Interval <= 16);
-          InputContext->EP[Dci - 1].Interval = Interval - 1;
-        }
-
-        //
-        // Do not support isochronous transfer now.
-        //
-        DEBUG ((DEBUG_VERBOSE, "XhcPeiSetConfigCmd64: Unsupport ISO EP found, Transfer ring is not allocated.\n"));
-        EpDesc = (USB_ENDPOINT_DESCRIPTOR *) ((UINTN)EpDesc + EpDesc->Length);
-        continue;
-      case USB_ENDPOINT_INTERRUPT:
-        if (Direction == EfiUsbDataIn) {
-          InputContext->EP[Dci - 1].CErr   = 3;
-          InputContext->EP[Dci - 1].EPType = ED_INTERRUPT_IN;
-        } else {
-          InputContext->EP[Dci - 1].CErr   = 3;
-          InputContext->EP[Dci - 1].EPType = ED_INTERRUPT_OUT;
-        }
-        InputContext->EP[Dci - 1].AverageTRBLength = 0x1000;
-        InputContext->EP[Dci - 1].MaxESITPayload   = EpDesc->MaxPacketSize;
-        //
-        // Get the bInterval from descriptor and init the the interval field of endpoint context
-        //
-        if ((DeviceSpeed == EFI_USB_SPEED_FULL) || (DeviceSpeed == EFI_USB_SPEED_LOW)) {
-          Interval = EpDesc->Interval;
+          break;
+        case USB_ENDPOINT_ISO:
+          if (Direction == EfiUsbDataIn) {
+            InputContext->EP[Dci-1].CErr   = 0;
+            InputContext->EP[Dci-1].EPType = ED_ISOCH_IN;
+          } else {
+            InputContext->EP[Dci-1].CErr   = 0;
+            InputContext->EP[Dci-1].EPType = ED_ISOCH_OUT;
+          }
           //
-          // Calculate through the bInterval field of Endpoint descriptor.
+          // Get the bInterval from descriptor and init the the interval field of endpoint context.
+          // Refer to XHCI 1.1 spec section 6.2.3.6.
           //
-          ASSERT (Interval != 0);
-          InputContext->EP[Dci - 1].Interval = (UINT32) HighBitSet32 ( (UINT32) Interval) + 3;
-        } else if ((DeviceSpeed == EFI_USB_SPEED_HIGH) || (DeviceSpeed == EFI_USB_SPEED_SUPER)) {
-          Interval = EpDesc->Interval;
-          ASSERT (Interval >= 1 && Interval <= 16);
-          //
-          // Refer to XHCI 1.0 spec section 6.2.3.6, table 61
-          //
-          InputContext->EP[Dci - 1].Interval = Interval - 1;
-        }
+          if (DeviceSpeed == EFI_USB_SPEED_FULL) {
+            Interval = EpDesc->Interval;
+            ASSERT (Interval >= 1 && Interval <= 16);
+            InputContext->EP[Dci-1].Interval = Interval + 2;
+          } else if ((DeviceSpeed == EFI_USB_SPEED_HIGH) || (DeviceSpeed == EFI_USB_SPEED_SUPER)) {
+            Interval = EpDesc->Interval;
+            ASSERT (Interval >= 1 && Interval <= 16);
+            InputContext->EP[Dci-1].Interval = Interval - 1;
+          }
 
-        if (Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci - 1] == NULL) {
-          EndpointTransferRing = AllocateZeroPool (sizeof (TRANSFER_RING));
-          Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci - 1] = (VOID *) EndpointTransferRing;
-          XhcPeiCreateTransferRing (Xhc, TR_RING_TRB_NUMBER,
-                                    (TRANSFER_RING *) Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci - 1]);
-        }
-        break;
+          //
+          // Do not support isochronous transfer now.
+          //
+          DEBUG ((DEBUG_INFO, "XhcPeiSetConfigCmd64: Unsupport ISO EP found, Transfer ring is not allocated.\n"));
+          EpDesc = (USB_ENDPOINT_DESCRIPTOR *)((UINTN)EpDesc + EpDesc->Length);
+          continue;
+        case USB_ENDPOINT_INTERRUPT:
+          if (Direction == EfiUsbDataIn) {
+            InputContext->EP[Dci-1].CErr   = 3;
+            InputContext->EP[Dci-1].EPType = ED_INTERRUPT_IN;
+          } else {
+            InputContext->EP[Dci-1].CErr   = 3;
+            InputContext->EP[Dci-1].EPType = ED_INTERRUPT_OUT;
+          }
+          InputContext->EP[Dci-1].AverageTRBLength = 0x1000;
+          InputContext->EP[Dci-1].MaxESITPayload   = EpDesc->MaxPacketSize;
+          //
+          // Get the bInterval from descriptor and init the the interval field of endpoint context
+          //
+          if ((DeviceSpeed == EFI_USB_SPEED_FULL) || (DeviceSpeed == EFI_USB_SPEED_LOW)) {
+            Interval = EpDesc->Interval;
+            //
+            // Calculate through the bInterval field of Endpoint descriptor.
+            //
+            ASSERT (Interval != 0);
+            InputContext->EP[Dci-1].Interval = (UINT32) HighBitSet32( (UINT32) Interval) + 3;
+          } else if ((DeviceSpeed == EFI_USB_SPEED_HIGH) || (DeviceSpeed == EFI_USB_SPEED_SUPER)) {
+            Interval = EpDesc->Interval;
+            ASSERT (Interval >= 1 && Interval <= 16);
+            //
+            // Refer to XHCI 1.0 spec section 6.2.3.6, table 61
+            //
+            InputContext->EP[Dci-1].Interval = Interval - 1;
+          }
 
-      case USB_ENDPOINT_CONTROL:
-        //
-        // Do not support control transfer now.
-        //
-        DEBUG ((DEBUG_VERBOSE, "XhcPeiSetConfigCmd64: Unsupport Control EP found, Transfer ring is not allocated.\n"));
-      default:
-        DEBUG ((DEBUG_VERBOSE, "XhcPeiSetConfigCmd64: Unknown EP found, Transfer ring is not allocated.\n"));
-        EpDesc = (USB_ENDPOINT_DESCRIPTOR *) ((UINTN)EpDesc + EpDesc->Length);
-        continue;
+          if (Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1] == NULL) {
+            EndpointTransferRing = AllocateZeroPool (sizeof (TRANSFER_RING));
+            Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1] = (VOID *) EndpointTransferRing;
+            XhcPeiCreateTransferRing (Xhc, TR_RING_TRB_NUMBER, (TRANSFER_RING *) Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1]);
+          }
+          break;
+
+        case USB_ENDPOINT_CONTROL:
+          //
+          // Do not support control transfer now.
+          //
+          DEBUG ((DEBUG_INFO, "XhcPeiSetConfigCmd64: Unsupport Control EP found, Transfer ring is not allocated.\n"));
+        default:
+          DEBUG ((DEBUG_INFO, "XhcPeiSetConfigCmd64: Unknown EP found, Transfer ring is not allocated.\n"));
+          EpDesc = (USB_ENDPOINT_DESCRIPTOR *)((UINTN)EpDesc + EpDesc->Length);
+          continue;
       }
 
       PhyAddr = UsbHcGetPciAddrForHostAddr (
                   Xhc->MemPool,
-                  ((TRANSFER_RING *) (UINTN) Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci - 1])->RingSeg0,
+                  ((TRANSFER_RING *) (UINTN) Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1])->RingSeg0,
                   sizeof (TRB_TEMPLATE) * TR_RING_TRB_NUMBER
                   );
 
-      PhyAddr &= ~ ((EFI_PHYSICAL_ADDRESS)0x0F);
-      PhyAddr |= (EFI_PHYSICAL_ADDRESS) ((TRANSFER_RING *) (UINTN) Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci -
-                                         1])->RingPCS;
+      PhyAddr &= ~((EFI_PHYSICAL_ADDRESS)0x0F);
+      PhyAddr |= (EFI_PHYSICAL_ADDRESS)((TRANSFER_RING *) (UINTN) Xhc->UsbDevContext[SlotId].EndpointTransferRing[Dci-1])->RingPCS;
 
-      InputContext->EP[Dci - 1].PtrLo = XHC_LOW_32BIT (PhyAddr);
-      InputContext->EP[Dci - 1].PtrHi = XHC_HIGH_32BIT (PhyAddr);
+      InputContext->EP[Dci-1].PtrLo = XHC_LOW_32BIT (PhyAddr);
+      InputContext->EP[Dci-1].PtrHi = XHC_HIGH_32BIT (PhyAddr);
 
       EpDesc = (USB_ENDPOINT_DESCRIPTOR *) ((UINTN)EpDesc + EpDesc->Length);
     }
@@ -2067,7 +2080,7 @@ XhcPeiSetConfigCmd64 (
   CmdTrbCfgEP.CycleBit = 1;
   CmdTrbCfgEP.Type     = TRB_TYPE_CON_ENDPOINT;
   CmdTrbCfgEP.SlotId   = Xhc->UsbDevContext[SlotId].SlotId;
-  DEBUG ((DEBUG_VERBOSE, "XhcSetConfigCmd64: Configure Endpoint\n"));
+  DEBUG ((DEBUG_INFO, "XhcSetConfigCmd64: Configure Endpoint\n"));
   Status = XhcPeiCmdTransfer (
              Xhc,
              (TRB_TEMPLATE *) (UINTN) &CmdTrbCfgEP,
@@ -2123,7 +2136,7 @@ XhcPeiEvaluateContext (
   CmdTrbEvalu.CycleBit = 1;
   CmdTrbEvalu.Type     = TRB_TYPE_EVALU_CONTXT;
   CmdTrbEvalu.SlotId   = Xhc->UsbDevContext[SlotId].SlotId;
-  DEBUG ((DEBUG_VERBOSE, "XhcEvaluateContext: Evaluate context\n"));
+  DEBUG ((DEBUG_INFO, "XhcEvaluateContext: Evaluate context\n"));
   Status = XhcPeiCmdTransfer (
              Xhc,
              (TRB_TEMPLATE *) (UINTN) &CmdTrbEvalu,
@@ -2177,7 +2190,7 @@ XhcPeiEvaluateContext64 (
   CmdTrbEvalu.CycleBit = 1;
   CmdTrbEvalu.Type     = TRB_TYPE_EVALU_CONTXT;
   CmdTrbEvalu.SlotId   = Xhc->UsbDevContext[SlotId].SlotId;
-  DEBUG ((DEBUG_VERBOSE, "XhcEvaluateContext64: Evaluate context 64\n"));
+  DEBUG ((DEBUG_INFO, "XhcEvaluateContext64: Evaluate context 64\n"));
   Status = XhcPeiCmdTransfer (
              Xhc,
              (TRB_TEMPLATE *) (UINTN) &CmdTrbEvalu,
@@ -2232,7 +2245,7 @@ XhcPeiConfigHubContext (
   //
   // Copy the slot context from OutputContext to Input context
   //
-  CopyMem (& (InputContext->Slot), & (OutputContext->Slot), sizeof (SLOT_CONTEXT));
+  CopyMem(&(InputContext->Slot), &(OutputContext->Slot), sizeof (SLOT_CONTEXT));
   InputContext->Slot.Hub     = 1;
   InputContext->Slot.PortNum = PortNum;
   InputContext->Slot.TTT     = TTT;
@@ -2245,7 +2258,7 @@ XhcPeiConfigHubContext (
   CmdTrbCfgEP.CycleBit = 1;
   CmdTrbCfgEP.Type     = TRB_TYPE_CON_ENDPOINT;
   CmdTrbCfgEP.SlotId   = Xhc->UsbDevContext[SlotId].SlotId;
-  DEBUG ((DEBUG_VERBOSE, "Configure Hub Slot Context\n"));
+  DEBUG ((DEBUG_INFO, "Configure Hub Slot Context\n"));
   Status = XhcPeiCmdTransfer (
              Xhc,
              (TRB_TEMPLATE *) (UINTN) &CmdTrbCfgEP,
@@ -2300,7 +2313,7 @@ XhcPeiConfigHubContext64 (
   //
   // Copy the slot context from OutputContext to Input context
   //
-  CopyMem (& (InputContext->Slot), & (OutputContext->Slot), sizeof (SLOT_CONTEXT_64));
+  CopyMem(&(InputContext->Slot), &(OutputContext->Slot), sizeof (SLOT_CONTEXT_64));
   InputContext->Slot.Hub     = 1;
   InputContext->Slot.PortNum = PortNum;
   InputContext->Slot.TTT     = TTT;
@@ -2313,7 +2326,7 @@ XhcPeiConfigHubContext64 (
   CmdTrbCfgEP.CycleBit = 1;
   CmdTrbCfgEP.Type     = TRB_TYPE_CON_ENDPOINT;
   CmdTrbCfgEP.SlotId   = Xhc->UsbDevContext[SlotId].SlotId;
-  DEBUG ((DEBUG_VERBOSE, "Configure Hub Slot Context 64\n"));
+  DEBUG ((DEBUG_INFO, "Configure Hub Slot Context 64\n"));
   Status = XhcPeiCmdTransfer (
              Xhc,
              (TRB_TEMPLATE *) (UINTN) &CmdTrbCfgEP,
@@ -2349,7 +2362,7 @@ XhcPeiStopEndpoint (
   EVT_TRB_COMMAND_COMPLETION    *EvtTrb;
   CMD_TRB_STOP_ENDPOINT         CmdTrbStopED;
 
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiStopEndpoint: Slot = 0x%x, Dci = 0x%x\n", SlotId, Dci));
+  DEBUG ((DEBUG_INFO, "XhcPeiStopEndpoint: Slot = 0x%x, Dci = 0x%x\n", SlotId, Dci));
 
   //
   // Send stop endpoint command to transit Endpoint from running to stop state
@@ -2365,7 +2378,7 @@ XhcPeiStopEndpoint (
              XHC_GENERIC_TIMEOUT,
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
-  if (EFI_ERROR (Status)) {
+  if (EFI_ERROR(Status)) {
     DEBUG ((DEBUG_ERROR, "XhcPeiStopEndpoint: Stop Endpoint Failed, Status = %r\n", Status));
   }
 
@@ -2395,7 +2408,7 @@ XhcPeiResetEndpoint (
   EVT_TRB_COMMAND_COMPLETION  *EvtTrb;
   CMD_TRB_RESET_ENDPOINT      CmdTrbResetED;
 
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiResetEndpoint: Slot = 0x%x, Dci = 0x%x\n", SlotId, Dci));
+  DEBUG ((DEBUG_INFO, "XhcPeiResetEndpoint: Slot = 0x%x, Dci = 0x%x\n", SlotId, Dci));
 
   //
   // Send stop endpoint command to transit Endpoint from running to stop state
@@ -2411,7 +2424,7 @@ XhcPeiResetEndpoint (
              XHC_GENERIC_TIMEOUT,
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
-  if (EFI_ERROR (Status)) {
+  if (EFI_ERROR(Status)) {
     DEBUG ((DEBUG_ERROR, "XhcPeiResetEndpoint: Reset Endpoint Failed, Status = %r\n", Status));
   }
 
@@ -2445,7 +2458,7 @@ XhcPeiSetTrDequeuePointer (
   CMD_SET_TR_DEQ_POINTER      CmdSetTRDeq;
   EFI_PHYSICAL_ADDRESS        PhyAddr;
 
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiSetTrDequeuePointer: Slot = 0x%x, Dci = 0x%x, Urb = 0x%x\n", SlotId, Dci, Urb));
+  DEBUG ((DEBUG_INFO, "XhcPeiSetTrDequeuePointer: Slot = 0x%x, Dci = 0x%x, Urb = 0x%x\n", SlotId, Dci, Urb));
 
   //
   // Send stop endpoint command to transit Endpoint from running to stop state
@@ -2464,7 +2477,7 @@ XhcPeiSetTrDequeuePointer (
              XHC_GENERIC_TIMEOUT,
              (TRB_TEMPLATE **) (UINTN) &EvtTrb
              );
-  if (EFI_ERROR (Status)) {
+  if (EFI_ERROR(Status)) {
     DEBUG ((DEBUG_ERROR, "XhcPeiSetTrDequeuePointer: Set TR Dequeue Pointer Failed, Status = %r\n", Status));
   }
 
@@ -2501,8 +2514,7 @@ XhcPeiCheckNewEvent (
   //
   // If the dequeue pointer is beyond the ring, then roll-back it to the begining of the ring.
   //
-  if ((UINTN) EvtRing->EventRingDequeue >= ((UINTN) EvtRing->EventRingSeg0 + sizeof (TRB_TEMPLATE) *
-      EvtRing->TrbNumber)) {
+  if ((UINTN) EvtRing->EventRingDequeue >= ((UINTN) EvtRing->EventRingSeg0 + sizeof (TRB_TEMPLATE) * EvtRing->TrbNumber)) {
     EvtRing->EventRingDequeue = EvtRing->EventRingSeg0;
   }
 
@@ -2570,7 +2582,7 @@ XhcPeiFreeEventRing (
   IN EVENT_RING         *EventRing
   )
 {
-  if (EventRing->EventRingSeg0 == NULL) {
+  if(EventRing->EventRingSeg0 == NULL) {
     return;
   }
 
@@ -2720,7 +2732,7 @@ XhcPeiSyncTrsRing (
       //
       // set cycle bit in Link TRB as normal
       //
-      ((LINK_TRB *)TrsTrb)->CycleBit = TrsRing->RingPCS & BIT0;
+      ((LINK_TRB*)TrsTrb)->CycleBit = TrsRing->RingPCS & BIT0;
       //
       // Toggle PCS maintained by software
       //
@@ -2818,6 +2830,7 @@ XhcPeiInitSched (
   UINT64                *ScratchEntry;
   EFI_PHYSICAL_ADDRESS  ScratchEntryPhy;
   UINT32                Index;
+  UINTN                 *ScratchEntryMap;
   EFI_STATUS            Status;
 
   //
@@ -2832,8 +2845,7 @@ XhcPeiInitSched (
   //
   Xhc->MaxSlotsEn = Xhc->HcSParams1.Data.MaxSlots;
   ASSERT (Xhc->MaxSlotsEn >= 1 && Xhc->MaxSlotsEn <= 255);
-  XhcPeiWriteOpReg (Xhc, XHC_CONFIG_OFFSET, (XhcPeiReadOpReg (Xhc,
-                    XHC_CONFIG_OFFSET) & ~XHC_CONFIG_MASK) | Xhc->MaxSlotsEn);
+  XhcPeiWriteOpReg (Xhc, XHC_CONFIG_OFFSET, (XhcPeiReadOpReg (Xhc, XHC_CONFIG_OFFSET) & ~XHC_CONFIG_MASK) | Xhc->MaxSlotsEn);
 
   //
   // The Device Context Base Address Array entry associated with each allocated Device Slot
@@ -2855,6 +2867,13 @@ XhcPeiInitSched (
   ASSERT (MaxScratchpadBufs <= 1023);
   if (MaxScratchpadBufs != 0) {
     //
+    // Allocate the buffer to record the Mapping for each scratch buffer in order to Unmap them
+    //
+    ScratchEntryMap = AllocateZeroPool (sizeof (UINTN) * MaxScratchpadBufs);
+    ASSERT (ScratchEntryMap != NULL);
+    Xhc->ScratchEntryMap = ScratchEntryMap;
+
+    //
     // Allocate the buffer to record the host address for each entry
     //
     ScratchEntry = AllocateZeroPool (sizeof (UINT64) * MaxScratchpadBufs);
@@ -2866,7 +2885,8 @@ XhcPeiInitSched (
                EFI_SIZE_TO_PAGES (MaxScratchpadBufs * sizeof (UINT64)),
                Xhc->PageSize,
                (VOID **) &ScratchBuf,
-               &ScratchPhy
+               &ScratchPhy,
+               &Xhc->ScratchMap
                );
     ASSERT_EFI_ERROR (Status);
 
@@ -2882,7 +2902,8 @@ XhcPeiInitSched (
                  EFI_SIZE_TO_PAGES (Xhc->PageSize),
                  Xhc->PageSize,
                  (VOID **) &ScratchEntry[Index],
-                 &ScratchEntryPhy
+                 &ScratchEntryPhy,
+                 (VOID **) &ScratchEntryMap[Index]
                  );
       ASSERT_EFI_ERROR (Status);
       ZeroMem ((VOID *) (UINTN) ScratchEntry[Index], Xhc->PageSize);
@@ -2895,7 +2916,7 @@ XhcPeiInitSched (
     // The Scratchpad Buffer Array contains pointers to the Scratchpad Buffers. Entry 0 of the
     // Device Context Base Address Array points to the Scratchpad Buffer Array.
     //
-    * (UINT64 *) Dcbaa = (UINT64) (UINTN) ScratchPhy;
+    *(UINT64 *) Dcbaa = (UINT64) (UINTN) ScratchPhy;
   }
 
   //
@@ -2911,7 +2932,7 @@ XhcPeiInitSched (
   XhcPeiWriteOpReg (Xhc, XHC_DCBAAP_OFFSET, XHC_LOW_32BIT (DcbaaPhy));
   XhcPeiWriteOpReg (Xhc, XHC_DCBAAP_OFFSET + 4, XHC_HIGH_32BIT (DcbaaPhy));
 
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiInitSched:DCBAA=0x%x\n", Xhc->DCBAA));
+  DEBUG ((DEBUG_INFO, "XhcPeiInitSched:DCBAA=0x%x\n", Xhc->DCBAA));
 
   //
   // Define the Command Ring Dequeue Pointer by programming the Command Ring Control Register
@@ -2925,8 +2946,7 @@ XhcPeiInitSched (
   // Transfer Ring it checks for a Cycle bit transition. If a transition detected, the ring is empty.
   // So we set RCS as inverted PCS init value to let Command Ring empty
   //
-  CmdRingPhy = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Xhc->CmdRing.RingSeg0,
-               sizeof (TRB_TEMPLATE) * CMD_RING_TRB_NUMBER);
+  CmdRingPhy = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, Xhc->CmdRing.RingSeg0, sizeof (TRB_TEMPLATE) * CMD_RING_TRB_NUMBER);
   ASSERT ((CmdRingPhy & 0x3F) == 0);
   CmdRingPhy |= XHC_CRCR_RCS;
   //
@@ -2936,14 +2956,14 @@ XhcPeiInitSched (
   XhcPeiWriteOpReg (Xhc, XHC_CRCR_OFFSET, XHC_LOW_32BIT (CmdRingPhy));
   XhcPeiWriteOpReg (Xhc, XHC_CRCR_OFFSET + 4, XHC_HIGH_32BIT (CmdRingPhy));
 
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiInitSched:XHC_CRCR=0x%x\n", Xhc->CmdRing.RingSeg0));
+  DEBUG ((DEBUG_INFO, "XhcPeiInitSched:XHC_CRCR=0x%x\n", Xhc->CmdRing.RingSeg0));
 
   //
   // Disable the 'interrupter enable' bit in USB_CMD
   // and clear IE & IP bit in all Interrupter X Management Registers.
   //
   XhcPeiClearOpRegBit (Xhc, XHC_USBCMD_OFFSET, XHC_USBCMD_INTE);
-  for (Index = 0; Index < (UINT16) (Xhc->HcSParams1.Data.MaxIntrs); Index++) {
+  for (Index = 0; Index < (UINT16)(Xhc->HcSParams1.Data.MaxIntrs); Index++) {
     XhcPeiClearRuntimeRegBit (Xhc, XHC_IMAN_OFFSET + (Index * 32), XHC_IMAN_IE);
     XhcPeiSetRuntimeRegBit (Xhc, XHC_IMAN_OFFSET + (Index * 32), XHC_IMAN_IP);
   }
@@ -2952,7 +2972,7 @@ XhcPeiInitSched (
   // Allocate EventRing for Cmd, Ctrl, Bulk, Interrupt, AsynInterrupt transfer
   //
   XhcPeiCreateEventRing (Xhc, &Xhc->EventRing);
-  DEBUG ((DEBUG_VERBOSE, "XhcPeiInitSched:XHC_EVENTRING=0x%x\n", Xhc->EventRing.EventRingSeg0));
+  DEBUG ((DEBUG_INFO, "XhcPeiInitSched:XHC_EVENTRING=0x%x\n", Xhc->EventRing.EventRingSeg0));
 }
 
 /**
@@ -2975,12 +2995,13 @@ XhcPeiFreeSched (
       //
       // Free Scratchpad Buffers
       //
-      UsbHcFreeAlignedPages ((VOID *) (UINTN) ScratchEntry[Index], EFI_SIZE_TO_PAGES (Xhc->PageSize));
+      UsbHcFreeAlignedPages ((VOID*) (UINTN) ScratchEntry[Index], EFI_SIZE_TO_PAGES (Xhc->PageSize), (VOID *) Xhc->ScratchEntryMap[Index]);
     }
     //
     // Free Scratchpad Buffer Array
     //
-    UsbHcFreeAlignedPages (Xhc->ScratchBuf, EFI_SIZE_TO_PAGES (Xhc->MaxScratchpadBufs * sizeof (UINT64)));
+    UsbHcFreeAlignedPages (Xhc->ScratchBuf, EFI_SIZE_TO_PAGES (Xhc->MaxScratchpadBufs * sizeof (UINT64)), Xhc->ScratchMap);
+    FreePool (Xhc->ScratchEntryMap);
     FreePool (Xhc->ScratchEntry);
   }
 
@@ -2989,7 +3010,7 @@ XhcPeiFreeSched (
     Xhc->CmdRing.RingSeg0 = NULL;
   }
 
-  XhcPeiFreeEventRing (Xhc, &Xhc->EventRing);
+  XhcPeiFreeEventRing (Xhc,&Xhc->EventRing);
 
   if (Xhc->DCBAA != NULL) {
     UsbHcFreeMem (Xhc->MemPool, Xhc->DCBAA, (Xhc->MaxSlotsEn + 1) * sizeof (UINT64));

--- a/BootloaderCommonPkg/Library/XhciLib/XhciSched.h
+++ b/BootloaderCommonPkg/Library/XhciLib/XhciSched.h
@@ -1,7 +1,7 @@
 /** @file
 Private Header file for Usb Host Controller PEIM
 
-Copyright (c) 2014 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2014 - 2015, Intel Corporation. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -78,15 +78,15 @@ typedef struct _USB_DEV_TOPOLOGY {
   //
   // The tier concatenation of down stream port.
   //
-  UINT32 RouteString: 20;
+  UINT32 RouteString:20;
   //
   // The root port number of the chain.
   //
-  UINT32 RootPortNum: 8;
+  UINT32 RootPortNum:8;
   //
   // The Tier the device reside.
   //
-  UINT32 TierNum: 4;
+  UINT32 TierNum:4;
 } USB_DEV_TOPOLOGY;
 
 //
@@ -125,10 +125,10 @@ typedef struct _TRB_TEMPLATE {
 
   UINT32                    Status;
 
-  UINT32                    CycleBit: 1;
-  UINT32                    RsvdZ1: 9;
-  UINT32                    Type: 6;
-  UINT32                    Control: 16;
+  UINT32                    CycleBit:1;
+  UINT32                    RsvdZ1:9;
+  UINT32                    Type:6;
+  UINT32                    Control:16;
 } TRB_TEMPLATE;
 
 typedef struct _TRANSFER_RING {
@@ -164,6 +164,7 @@ typedef struct _URB {
   VOID                              *Data;
   UINTN                             DataLen;
   VOID                              *DataPhy;
+  VOID                              *DataMap;
   EFI_ASYNC_USB_TRANSFER_CALLBACK   Callback;
   VOID                              *Context;
   //
@@ -198,8 +199,8 @@ typedef struct _URB {
 typedef struct _EVENT_RING_SEG_TABLE_ENTRY {
   UINT32                    PtrLo;
   UINT32                    PtrHi;
-  UINT32                    RingTrbSize: 16;
-  UINT32                    RsvdZ1: 16;
+  UINT32                    RingTrbSize:16;
+  UINT32                    RsvdZ1:16;
   UINT32                    RsvdZ2;
 } EVENT_RING_SEG_TABLE_ENTRY;
 
@@ -214,21 +215,21 @@ typedef struct _TRANSFER_TRB_NORMAL {
 
   UINT32                    TRBPtrHi;
 
-  UINT32                    Length: 17;
-  UINT32                    TDSize: 5;
-  UINT32                    IntTarget: 10;
+  UINT32                    Length:17;
+  UINT32                    TDSize:5;
+  UINT32                    IntTarget:10;
 
-  UINT32                    CycleBit: 1;
-  UINT32                    ENT: 1;
-  UINT32                    ISP: 1;
-  UINT32                    NS: 1;
-  UINT32                    CH: 1;
-  UINT32                    IOC: 1;
-  UINT32                    IDT: 1;
-  UINT32                    RsvdZ1: 2;
-  UINT32                    BEI: 1;
-  UINT32                    Type: 6;
-  UINT32                    RsvdZ2: 16;
+  UINT32                    CycleBit:1;
+  UINT32                    ENT:1;
+  UINT32                    ISP:1;
+  UINT32                    NS:1;
+  UINT32                    CH:1;
+  UINT32                    IOC:1;
+  UINT32                    IDT:1;
+  UINT32                    RsvdZ1:2;
+  UINT32                    BEI:1;
+  UINT32                    Type:6;
+  UINT32                    RsvdZ2:16;
 } TRANSFER_TRB_NORMAL;
 
 //
@@ -236,25 +237,25 @@ typedef struct _TRANSFER_TRB_NORMAL {
 // A Setup Stage TRB is created by system software to initiate a USB Setup packet on a control endpoint.
 //
 typedef struct _TRANSFER_TRB_CONTROL_SETUP {
-  UINT32                    bmRequestType: 8;
-  UINT32                    bRequest: 8;
-  UINT32                    wValue: 16;
+  UINT32                    bmRequestType:8;
+  UINT32                    bRequest:8;
+  UINT32                    wValue:16;
 
-  UINT32                    wIndex: 16;
-  UINT32                    wLength: 16;
+  UINT32                    wIndex:16;
+  UINT32                    wLength:16;
 
-  UINT32                    Length: 17;
-  UINT32                    RsvdZ1: 5;
-  UINT32                    IntTarget: 10;
+  UINT32                    Length:17;
+  UINT32                    RsvdZ1:5;
+  UINT32                    IntTarget:10;
 
-  UINT32                    CycleBit: 1;
-  UINT32                    RsvdZ2: 4;
-  UINT32                    IOC: 1;
-  UINT32                    IDT: 1;
-  UINT32                    RsvdZ3: 3;
-  UINT32                    Type: 6;
-  UINT32                    TRT: 2;
-  UINT32                    RsvdZ4: 14;
+  UINT32                    CycleBit:1;
+  UINT32                    RsvdZ2:4;
+  UINT32                    IOC:1;
+  UINT32                    IDT:1;
+  UINT32                    RsvdZ3:3;
+  UINT32                    Type:6;
+  UINT32                    TRT:2;
+  UINT32                    RsvdZ4:14;
 } TRANSFER_TRB_CONTROL_SETUP;
 
 //
@@ -266,21 +267,21 @@ typedef struct _TRANSFER_TRB_CONTROL_DATA {
 
   UINT32                    TRBPtrHi;
 
-  UINT32                    Length: 17;
-  UINT32                    TDSize: 5;
-  UINT32                    IntTarget: 10;
+  UINT32                    Length:17;
+  UINT32                    TDSize:5;
+  UINT32                    IntTarget:10;
 
-  UINT32                    CycleBit: 1;
-  UINT32                    ENT: 1;
-  UINT32                    ISP: 1;
-  UINT32                    NS: 1;
-  UINT32                    CH: 1;
-  UINT32                    IOC: 1;
-  UINT32                    IDT: 1;
-  UINT32                    RsvdZ1: 3;
-  UINT32                    Type: 6;
-  UINT32                    DIR: 1;
-  UINT32                    RsvdZ2: 15;
+  UINT32                    CycleBit:1;
+  UINT32                    ENT:1;
+  UINT32                    ISP:1;
+  UINT32                    NS:1;
+  UINT32                    CH:1;
+  UINT32                    IOC:1;
+  UINT32                    IDT:1;
+  UINT32                    RsvdZ1:3;
+  UINT32                    Type:6;
+  UINT32                    DIR:1;
+  UINT32                    RsvdZ2:15;
 } TRANSFER_TRB_CONTROL_DATA;
 
 //
@@ -291,18 +292,18 @@ typedef struct _TRANSFER_TRB_CONTROL_STATUS {
   UINT32                    RsvdZ1;
   UINT32                    RsvdZ2;
 
-  UINT32                    RsvdZ3: 22;
-  UINT32                    IntTarget: 10;
+  UINT32                    RsvdZ3:22;
+  UINT32                    IntTarget:10;
 
-  UINT32                    CycleBit: 1;
-  UINT32                    ENT: 1;
-  UINT32                    RsvdZ4: 2;
-  UINT32                    CH: 1;
-  UINT32                    IOC: 1;
-  UINT32                    RsvdZ5: 4;
-  UINT32                    Type: 6;
-  UINT32                    DIR: 1;
-  UINT32                    RsvdZ6: 15;
+  UINT32                    CycleBit:1;
+  UINT32                    ENT:1;
+  UINT32                    RsvdZ4:2;
+  UINT32                    CH:1;
+  UINT32                    IOC:1;
+  UINT32                    RsvdZ5:4;
+  UINT32                    Type:6;
+  UINT32                    DIR:1;
+  UINT32                    RsvdZ6:15;
 } TRANSFER_TRB_CONTROL_STATUS;
 
 //
@@ -315,17 +316,17 @@ typedef struct _EVT_TRB_TRANSFER {
 
   UINT32                    TRBPtrHi;
 
-  UINT32                    Length: 24;
-  UINT32                    Completecode: 8;
+  UINT32                    Length:24;
+  UINT32                    Completecode:8;
 
-  UINT32                    CycleBit: 1;
-  UINT32                    RsvdZ1: 1;
-  UINT32                    ED: 1;
-  UINT32                    RsvdZ2: 7;
-  UINT32                    Type: 6;
-  UINT32                    EndpointId: 5;
-  UINT32                    RsvdZ3: 3;
-  UINT32                    SlotId: 8;
+  UINT32                    CycleBit:1;
+  UINT32                    RsvdZ1:1;
+  UINT32                    ED:1;
+  UINT32                    RsvdZ2:7;
+  UINT32                    Type:6;
+  UINT32                    EndpointId:5;
+  UINT32                    RsvdZ3:3;
+  UINT32                    SlotId:8;
 } EVT_TRB_TRANSFER;
 
 //
@@ -338,14 +339,14 @@ typedef struct _EVT_TRB_COMMAND_COMPLETION {
 
   UINT32                    TRBPtrHi;
 
-  UINT32                    RsvdZ2: 24;
-  UINT32                    Completecode: 8;
+  UINT32                    RsvdZ2:24;
+  UINT32                    Completecode:8;
 
-  UINT32                    CycleBit: 1;
-  UINT32                    RsvdZ3: 9;
-  UINT32                    Type: 6;
-  UINT32                    VFID: 8;
-  UINT32                    SlotId: 8;
+  UINT32                    CycleBit:1;
+  UINT32                    RsvdZ3:9;
+  UINT32                    Type:6;
+  UINT32                    VFID:8;
+  UINT32                    SlotId:8;
 } EVT_TRB_COMMAND_COMPLETION;
 
 typedef union _TRB {
@@ -366,10 +367,10 @@ typedef struct _CMD_TRB_NO_OP {
   UINT32                    RsvdZ1;
   UINT32                    RsvdZ2;
 
-  UINT32                    CycleBit: 1;
-  UINT32                    RsvdZ3: 9;
-  UINT32                    Type: 6;
-  UINT32                    RsvdZ4: 16;
+  UINT32                    CycleBit:1;
+  UINT32                    RsvdZ3:9;
+  UINT32                    Type:6;
+  UINT32                    RsvdZ4:16;
 } CMD_TRB_NO_OP;
 
 //
@@ -382,10 +383,10 @@ typedef struct _CMD_TRB_ENABLE_SLOT {
   UINT32                    RsvdZ1;
   UINT32                    RsvdZ2;
 
-  UINT32                    CycleBit: 1;
-  UINT32                    RsvdZ3: 9;
-  UINT32                    Type: 6;
-  UINT32                    RsvdZ4: 16;
+  UINT32                    CycleBit:1;
+  UINT32                    RsvdZ3:9;
+  UINT32                    Type:6;
+  UINT32                    RsvdZ4:16;
 } CMD_TRB_ENABLE_SLOT;
 
 //
@@ -398,11 +399,11 @@ typedef struct _CMD_TRB_DISABLE_SLOT {
   UINT32                    RsvdZ1;
   UINT32                    RsvdZ2;
 
-  UINT32                    CycleBit: 1;
-  UINT32                    RsvdZ3: 9;
-  UINT32                    Type: 6;
-  UINT32                    RsvdZ4: 8;
-  UINT32                    SlotId: 8;
+  UINT32                    CycleBit:1;
+  UINT32                    RsvdZ3:9;
+  UINT32                    Type:6;
+  UINT32                    RsvdZ4:8;
+  UINT32                    SlotId:8;
 } CMD_TRB_DISABLE_SLOT;
 
 //
@@ -418,12 +419,12 @@ typedef struct _CMD_TRB_ADDRESS_DEVICE {
 
   UINT32                    RsvdZ1;
 
-  UINT32                    CycleBit: 1;
-  UINT32                    RsvdZ2: 8;
-  UINT32                    BSR: 1;
-  UINT32                    Type: 6;
-  UINT32                    RsvdZ3: 8;
-  UINT32                    SlotId: 8;
+  UINT32                    CycleBit:1;
+  UINT32                    RsvdZ2:8;
+  UINT32                    BSR:1;
+  UINT32                    Type:6;
+  UINT32                    RsvdZ3:8;
+  UINT32                    SlotId:8;
 } CMD_TRB_ADDRESS_DEVICE;
 
 //
@@ -438,12 +439,12 @@ typedef struct _CMD_TRB_CONFIG_ENDPOINT {
 
   UINT32                    RsvdZ1;
 
-  UINT32                    CycleBit: 1;
-  UINT32                    RsvdZ2: 8;
-  UINT32                    DC: 1;
-  UINT32                    Type: 6;
-  UINT32                    RsvdZ3: 8;
-  UINT32                    SlotId: 8;
+  UINT32                    CycleBit:1;
+  UINT32                    RsvdZ2:8;
+  UINT32                    DC:1;
+  UINT32                    Type:6;
+  UINT32                    RsvdZ3:8;
+  UINT32                    SlotId:8;
 } CMD_TRB_CONFIG_ENDPOINT;
 
 //
@@ -459,11 +460,11 @@ typedef struct _CMD_TRB_EVALUATE_CONTEXT {
 
   UINT32                    RsvdZ1;
 
-  UINT32                    CycleBit: 1;
-  UINT32                    RsvdZ2: 9;
-  UINT32                    Type: 6;
-  UINT32                    RsvdZ3: 8;
-  UINT32                    SlotId: 8;
+  UINT32                    CycleBit:1;
+  UINT32                    RsvdZ2:9;
+  UINT32                    Type:6;
+  UINT32                    RsvdZ3:8;
+  UINT32                    SlotId:8;
 } CMD_TRB_EVALUATE_CONTEXT;
 
 //
@@ -475,13 +476,13 @@ typedef struct _CMD_TRB_RESET_ENDPOINT {
   UINT32                    RsvdZ1;
   UINT32                    RsvdZ2;
 
-  UINT32                    CycleBit: 1;
-  UINT32                    RsvdZ3: 8;
-  UINT32                    TSP: 1;
-  UINT32                    Type: 6;
-  UINT32                    EDID: 5;
-  UINT32                    RsvdZ4: 3;
-  UINT32                    SlotId: 8;
+  UINT32                    CycleBit:1;
+  UINT32                    RsvdZ3:8;
+  UINT32                    TSP:1;
+  UINT32                    Type:6;
+  UINT32                    EDID:5;
+  UINT32                    RsvdZ4:3;
+  UINT32                    SlotId:8;
 } CMD_TRB_RESET_ENDPOINT;
 
 //
@@ -494,13 +495,13 @@ typedef struct _CMD_TRB_STOP_ENDPOINT {
   UINT32                    RsvdZ1;
   UINT32                    RsvdZ2;
 
-  UINT32                    CycleBit: 1;
-  UINT32                    RsvdZ3: 9;
-  UINT32                    Type: 6;
-  UINT32                    EDID: 5;
-  UINT32                    RsvdZ4: 2;
-  UINT32                    SP: 1;
-  UINT32                    SlotId: 8;
+  UINT32                    CycleBit:1;
+  UINT32                    RsvdZ3:9;
+  UINT32                    Type:6;
+  UINT32                    EDID:5;
+  UINT32                    RsvdZ4:2;
+  UINT32                    SP:1;
+  UINT32                    SlotId:8;
 } CMD_TRB_STOP_ENDPOINT;
 
 //
@@ -513,15 +514,15 @@ typedef struct _CMD_SET_TR_DEQ_POINTER {
 
   UINT32                    PtrHi;
 
-  UINT32                    RsvdZ1: 16;
-  UINT32                    StreamID: 16;
+  UINT32                    RsvdZ1:16;
+  UINT32                    StreamID:16;
 
-  UINT32                    CycleBit: 1;
-  UINT32                    RsvdZ2: 9;
-  UINT32                    Type: 6;
-  UINT32                    Endpoint: 5;
-  UINT32                    RsvdZ3: 3;
-  UINT32                    SlotId: 8;
+  UINT32                    CycleBit:1;
+  UINT32                    RsvdZ2:9;
+  UINT32                    Type:6;
+  UINT32                    Endpoint:5;
+  UINT32                    RsvdZ3:3;
+  UINT32                    SlotId:8;
 } CMD_SET_TR_DEQ_POINTER;
 
 //
@@ -533,43 +534,43 @@ typedef struct _LINK_TRB {
 
   UINT32                    PtrHi;
 
-  UINT32                    RsvdZ1: 22;
-  UINT32                    InterTarget: 10;
+  UINT32                    RsvdZ1:22;
+  UINT32                    InterTarget:10;
 
-  UINT32                    CycleBit: 1;
-  UINT32                    TC: 1;
-  UINT32                    RsvdZ2: 2;
-  UINT32                    CH: 1;
-  UINT32                    IOC: 1;
-  UINT32                    RsvdZ3: 4;
-  UINT32                    Type: 6;
-  UINT32                    RsvdZ4: 16;
+  UINT32                    CycleBit:1;
+  UINT32                    TC:1;
+  UINT32                    RsvdZ2:2;
+  UINT32                    CH:1;
+  UINT32                    IOC:1;
+  UINT32                    RsvdZ3:4;
+  UINT32                    Type:6;
+  UINT32                    RsvdZ4:16;
 } LINK_TRB;
 
 //
 // 6.2.2 Slot Context
 //
 typedef struct _SLOT_CONTEXT {
-  UINT32                    RouteString: 20;
-  UINT32                    Speed: 4;
-  UINT32                    RsvdZ1: 1;
-  UINT32                    MTT: 1;
-  UINT32                    Hub: 1;
-  UINT32                    ContextEntries: 5;
+  UINT32                    RouteString:20;
+  UINT32                    Speed:4;
+  UINT32                    RsvdZ1:1;
+  UINT32                    MTT:1;
+  UINT32                    Hub:1;
+  UINT32                    ContextEntries:5;
 
-  UINT32                    MaxExitLatency: 16;
-  UINT32                    RootHubPortNum: 8;
-  UINT32                    PortNum: 8;
+  UINT32                    MaxExitLatency:16;
+  UINT32                    RootHubPortNum:8;
+  UINT32                    PortNum:8;
 
-  UINT32                    TTHubSlotId: 8;
-  UINT32                    TTPortNum: 8;
-  UINT32                    TTT: 2;
-  UINT32                    RsvdZ2: 4;
-  UINT32                    InterTarget: 10;
+  UINT32                    TTHubSlotId:8;
+  UINT32                    TTPortNum:8;
+  UINT32                    TTT:2;
+  UINT32                    RsvdZ2:4;
+  UINT32                    InterTarget:10;
 
-  UINT32                    DeviceAddress: 8;
-  UINT32                    RsvdZ3: 19;
-  UINT32                    SlotState: 5;
+  UINT32                    DeviceAddress:8;
+  UINT32                    RsvdZ3:19;
+  UINT32                    SlotState:5;
 
   UINT32                    RsvdZ4;
   UINT32                    RsvdZ5;
@@ -578,26 +579,26 @@ typedef struct _SLOT_CONTEXT {
 } SLOT_CONTEXT;
 
 typedef struct _SLOT_CONTEXT_64 {
-  UINT32                    RouteString: 20;
-  UINT32                    Speed: 4;
-  UINT32                    RsvdZ1: 1;
-  UINT32                    MTT: 1;
-  UINT32                    Hub: 1;
-  UINT32                    ContextEntries: 5;
+  UINT32                    RouteString:20;
+  UINT32                    Speed:4;
+  UINT32                    RsvdZ1:1;
+  UINT32                    MTT:1;
+  UINT32                    Hub:1;
+  UINT32                    ContextEntries:5;
 
-  UINT32                    MaxExitLatency: 16;
-  UINT32                    RootHubPortNum: 8;
-  UINT32                    PortNum: 8;
+  UINT32                    MaxExitLatency:16;
+  UINT32                    RootHubPortNum:8;
+  UINT32                    PortNum:8;
 
-  UINT32                    TTHubSlotId: 8;
-  UINT32                    TTPortNum: 8;
-  UINT32                    TTT: 2;
-  UINT32                    RsvdZ2: 4;
-  UINT32                    InterTarget: 10;
+  UINT32                    TTHubSlotId:8;
+  UINT32                    TTPortNum:8;
+  UINT32                    TTT:2;
+  UINT32                    RsvdZ2:4;
+  UINT32                    InterTarget:10;
 
-  UINT32                    DeviceAddress: 8;
-  UINT32                    RsvdZ3: 19;
-  UINT32                    SlotState: 5;
+  UINT32                    DeviceAddress:8;
+  UINT32                    RsvdZ3:19;
+  UINT32                    SlotState:5;
 
   UINT32                    RsvdZ4;
   UINT32                    RsvdZ5;
@@ -621,28 +622,28 @@ typedef struct _SLOT_CONTEXT_64 {
 // 6.2.3 Endpoint Context
 //
 typedef struct _ENDPOINT_CONTEXT {
-  UINT32                    EPState: 3;
-  UINT32                    RsvdZ1: 5;
-  UINT32                    Mult: 2;
-  UINT32                    MaxPStreams: 5;
-  UINT32                    LSA: 1;
-  UINT32                    Interval: 8;
-  UINT32                    RsvdZ2: 8;
+  UINT32                    EPState:3;
+  UINT32                    RsvdZ1:5;
+  UINT32                    Mult:2;
+  UINT32                    MaxPStreams:5;
+  UINT32                    LSA:1;
+  UINT32                    Interval:8;
+  UINT32                    RsvdZ2:8;
 
-  UINT32                    RsvdZ3: 1;
-  UINT32                    CErr: 2;
-  UINT32                    EPType: 3;
-  UINT32                    RsvdZ4: 1;
-  UINT32                    HID: 1;
-  UINT32                    MaxBurstSize: 8;
-  UINT32                    MaxPacketSize: 16;
+  UINT32                    RsvdZ3:1;
+  UINT32                    CErr:2;
+  UINT32                    EPType:3;
+  UINT32                    RsvdZ4:1;
+  UINT32                    HID:1;
+  UINT32                    MaxBurstSize:8;
+  UINT32                    MaxPacketSize:16;
 
   UINT32                    PtrLo;
 
   UINT32                    PtrHi;
 
-  UINT32                    AverageTRBLength: 16;
-  UINT32                    MaxESITPayload: 16;
+  UINT32                    AverageTRBLength:16;
+  UINT32                    MaxESITPayload:16;
 
   UINT32                    RsvdZ5;
   UINT32                    RsvdZ6;
@@ -650,28 +651,28 @@ typedef struct _ENDPOINT_CONTEXT {
 } ENDPOINT_CONTEXT;
 
 typedef struct _ENDPOINT_CONTEXT_64 {
-  UINT32                    EPState: 3;
-  UINT32                    RsvdZ1: 5;
-  UINT32                    Mult: 2;
-  UINT32                    MaxPStreams: 5;
-  UINT32                    LSA: 1;
-  UINT32                    Interval: 8;
-  UINT32                    RsvdZ2: 8;
+  UINT32                    EPState:3;
+  UINT32                    RsvdZ1:5;
+  UINT32                    Mult:2;
+  UINT32                    MaxPStreams:5;
+  UINT32                    LSA:1;
+  UINT32                    Interval:8;
+  UINT32                    RsvdZ2:8;
 
-  UINT32                    RsvdZ3: 1;
-  UINT32                    CErr: 2;
-  UINT32                    EPType: 3;
-  UINT32                    RsvdZ4: 1;
-  UINT32                    HID: 1;
-  UINT32                    MaxBurstSize: 8;
-  UINT32                    MaxPacketSize: 16;
+  UINT32                    RsvdZ3:1;
+  UINT32                    CErr:2;
+  UINT32                    EPType:3;
+  UINT32                    RsvdZ4:1;
+  UINT32                    HID:1;
+  UINT32                    MaxBurstSize:8;
+  UINT32                    MaxPacketSize:16;
 
   UINT32                    PtrLo;
 
   UINT32                    PtrHi;
 
-  UINT32                    AverageTRBLength: 16;
-  UINT32                    MaxESITPayload: 16;
+  UINT32                    AverageTRBLength:16;
+  UINT32                    MaxESITPayload:16;
 
   UINT32                    RsvdZ5;
   UINT32                    RsvdZ6;
@@ -1157,7 +1158,7 @@ XhcPeiDequeueTrbFromEndpoint (
   @return Created URB or NULL
 
 **/
-URB *
+URB*
 XhcPeiCreateUrb (
   IN PEI_XHC_DEV                        *Xhc,
   IN UINT8                              DevAddr,


### PR DESCRIPTION
This patch synced up to the latest EDKII XHCI library and then
added support for IoMmu interfaces. This will allow the library
to use DMA buffer for I/O transactions.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>