### PR TITLE
Add IoMmu support for eMMC library

### DIFF
--- a/BootloaderCommonPkg/Library/MmcAccessLib/MmcAccessLib.inf
+++ b/BootloaderCommonPkg/Library/MmcAccessLib/MmcAccessLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -38,8 +38,11 @@
   IoLib
   DebugLib
   TimerLib
+  IoMmuLib
 
 [Pcd]
   gPlatformCommonLibTokenSpaceGuid.PcdEmmcBlockDeviceLibId
   gPlatformCommonLibTokenSpaceGuid.PcdEmmcMaxRwBlockNumber
   gPlatformCommonLibTokenSpaceGuid.PcdEmmcHs400SupportEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferSize
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaProtectionEnabled

--- a/BootloaderCommonPkg/Library/MmcAccessLib/SdMmcPciHcDxe.h
+++ b/BootloaderCommonPkg/Library/MmcAccessLib/SdMmcPciHcDxe.h
@@ -94,6 +94,7 @@ typedef struct {
   VOID                                *Data;
   UINT32                              DataLen;
   BOOLEAN                             Read;
+
   EFI_PHYSICAL_ADDRESS                DataPhy;
   VOID                                *DataMap;
   SD_MMC_HC_TRANSFER_MODE             Mode;
@@ -102,6 +103,8 @@ typedef struct {
   UINT64                              Timeout;
 
   SD_MMC_HC_ADMA_DESC_LINE            *AdmaDesc;
+  EFI_PHYSICAL_ADDRESS                AdmaDescPhy;
+  VOID                                *AdmaMap;
   UINT32                              AdmaPages;
 
   SD_MMC_HC_PRIVATE_DATA              *Private;


### PR DESCRIPTION
This patch added support for IoMmu interfaces. This will allow the
eMMC library to use DMA buffer for I/O transactions.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>