### PR TITLE
Add IoMmu support for AHCI library

### DIFF
--- a/BootloaderCommonPkg/Library/AhciLib/AhciBlkIo.c
+++ b/BootloaderCommonPkg/Library/AhciLib/AhciBlkIo.c
@@ -290,25 +290,29 @@ AhciDeinitialize (
   }
 
   AhciRegisters = &AhciController->AhciRegisters;
-  if (AhciRegisters->AhciCommandTable != NULL) {
-    FreePages (
-      AhciController->AhciRegisters.AhciCommandTable,
-      EFI_SIZE_TO_PAGES ((UINTN) AhciRegisters->MaxCommandTableSize)
-      );
+
+  if (AhciRegisters->AhciCommandTableMap != NULL) {
+    IoMmuFreeBuffer (
+       EFI_SIZE_TO_PAGES (AhciRegisters->MaxCommandTableSize),
+       AhciRegisters->AhciCommandTable,
+       AhciRegisters->AhciCommandTableMap
+       );
   }
 
-  if (AhciRegisters->AhciCmdList != NULL) {
-    FreePages (
-      AhciRegisters->AhciCmdList,
-      EFI_SIZE_TO_PAGES ((UINTN) AhciRegisters->MaxCommandListSize)
-      );
+  if (AhciRegisters->AhciCmdListMap != NULL) {
+    IoMmuFreeBuffer (
+       EFI_SIZE_TO_PAGES (AhciRegisters->MaxCommandListSize),
+       AhciRegisters->AhciCmdList,
+       AhciRegisters->AhciCmdListMap
+       );
   }
 
-  if (AhciRegisters->AhciRFis != NULL) {
-    FreePages (
-      AhciRegisters->AhciRFis,
-      EFI_SIZE_TO_PAGES ((UINTN) AhciRegisters->MaxReceiveFisSize)
-      );
+  if (AhciRegisters->AhciRFisMap != NULL) {
+    IoMmuFreeBuffer (
+       EFI_SIZE_TO_PAGES (AhciRegisters->MaxReceiveFisSize),
+       AhciRegisters->AhciRFis,
+       AhciRegisters->AhciRFisMap
+       );
   }
 
   FreePool (AhciController);

--- a/BootloaderCommonPkg/Library/AhciLib/AhciDevice.h
+++ b/BootloaderCommonPkg/Library/AhciLib/AhciDevice.h
@@ -18,6 +18,7 @@
 #include <Library/TimerLib.h>
 #include <Library/DebugLib.h>
 #include <Library/IoLib.h>
+#include <Library/IoMmuLib.h>
 #include "AhciMode.h"
 
 #define  ATA_ATAPI_DEVICE_SIGNATURE     SIGNATURE_32 ('a', 'd', 'e', 'v')

--- a/BootloaderCommonPkg/Library/AhciLib/AhciLib.inf
+++ b/BootloaderCommonPkg/Library/AhciLib/AhciLib.inf
@@ -37,3 +37,7 @@
   BaseMemoryLib
   MemoryAllocationLib
   IoMmuLib
+
+[Pcd]
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferSize
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaProtectionEnabled

--- a/BootloaderCommonPkg/Library/AhciLib/AhciMode.h
+++ b/BootloaderCommonPkg/Library/AhciLib/AhciMode.h
@@ -509,14 +509,17 @@ typedef union {
 
 typedef struct {
   EFI_AHCI_RECEIVED_FIS     *AhciRFis;
+  VOID                      *AhciRFisMap;
   EFI_AHCI_COMMAND_LIST     *AhciCmdList;
+  VOID                      *AhciCmdListMap;
   EFI_AHCI_COMMAND_TABLE    *AhciCommandTable;
+  VOID                      *AhciCommandTableMap;
   EFI_AHCI_RECEIVED_FIS     *AhciRFisPciAddr;
   EFI_AHCI_COMMAND_LIST     *AhciCmdListPciAddr;
   EFI_AHCI_COMMAND_TABLE    *AhciCommandTablePciAddr;
-  UINT64                    MaxCommandListSize;
-  UINT64                    MaxCommandTableSize;
-  UINT64                    MaxReceiveFisSize;
+  UINT32                    MaxCommandListSize;
+  UINT32                    MaxCommandTableSize;
+  UINT32                    MaxReceiveFisSize;
 } EFI_AHCI_REGISTERS;
 
 typedef struct {


### PR DESCRIPTION
This patch added support for IoMmu interfaces. It will allow the
library to use DMA buffer for I/O transactions.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>