### PR TITLE
Add IoMmu support for NVMe library

### DIFF
--- a/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpress.h
+++ b/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpress.h
@@ -3,7 +3,7 @@
   NVM Express specification.
 
   (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
-  Copyright (c) 2013 - 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2013 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -27,6 +27,7 @@
 #include <Library/PciNvmCtrlLib.h>
 #include <Library/TimerLib.h>
 #include <Library/PciExpressLib.h>
+#include <Library/IoMmuLib.h>
 
 typedef struct _NVME_CONTROLLER_PRIVATE_DATA NVME_CONTROLLER_PRIVATE_DATA;
 typedef struct _NVME_DEVICE_PRIVATE_DATA     NVME_DEVICE_PRIVATE_DATA;
@@ -110,6 +111,7 @@ struct _NVME_CONTROLLER_PRIVATE_DATA {
   // 6th 4kB boundary is the start of I/O completion queue #2.
   //
   UINT8                               *Buffer;
+  UINT8                               *BufferPciAddr;
 
   //
   // Pointers to 4kB aligned submission & completion queues.

--- a/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressBlockIo.c
+++ b/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressBlockIo.c
@@ -2,12 +2,45 @@
   NvmExpressDxe driver is used to manage non-volatile memory subsystem which follows
   NVM Express specification.
 
-  Copyright (c) 2013 - 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2013 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
 #include "NvmExpress.h"
+
+/**
+  Get max transfer block number.
+
+  @param[in]  Private       The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+  @param[in]  BlockSize     The media block size.
+
+  @retval Max transfer block.
+
+**/
+STATIC
+UINT32
+GetMaxTransferBlockNumber (
+  IN  NVME_CONTROLLER_PRIVATE_DATA   *Private,
+  IN  UINT32                          BlockSize
+)
+{
+  UINT32  MaxTransferBlocks;
+  UINT32  MaxDmaTransferBlocks;
+
+  if (Private->ControllerData->Mdts != 0) {
+    MaxTransferBlocks = (1 << (Private->ControllerData->Mdts)) * (1 << (Private->Cap.Mpsmin + 12)) / BlockSize;
+  } else {
+    MaxTransferBlocks = 1024;
+  }
+
+  MaxDmaTransferBlocks = (PcdGet32 (PcdDmaBufferSize) >> 1) / BlockSize;
+  if (MaxDmaTransferBlocks < MaxTransferBlocks) {
+    MaxTransferBlocks = MaxDmaTransferBlocks;
+  }
+  return MaxTransferBlocks;
+}
+
 
 /**
   Read some sectors from the device.
@@ -156,7 +189,7 @@ WriteSectors (
 EFI_STATUS
 NvmeRead (
   IN     NVME_DEVICE_PRIVATE_DATA       *Device,
-  OUT VOID                           *Buffer,
+  OUT VOID                              *Buffer,
   IN     UINT64                         Lba,
   IN     UINTN                          Blocks
   )
@@ -186,12 +219,7 @@ NvmeRead (
   BlockSize     = Device->Media.BlockSize;
   OrginalBlocks = Blocks;
 
-  if (Private->ControllerData->Mdts != 0) {
-    MaxTransferBlocks = (1 << (Private->ControllerData->Mdts)) * (1 << (Private->Cap.Mpsmin + 12)) / BlockSize;
-  } else {
-    MaxTransferBlocks = 1024;
-  }
-
+  MaxTransferBlocks = GetMaxTransferBlockNumber (Private, BlockSize);
   while (Blocks > 0) {
     if (Blocks > MaxTransferBlocks) {
       Status = ReadSectors (Device, (UINT64) (UINTN)Buffer, Lba, MaxTransferBlocks);
@@ -261,12 +289,7 @@ NvmeWrite (
   BlockSize     = Device->Media.BlockSize;
   OrginalBlocks = Blocks;
 
-  if (Private->ControllerData->Mdts != 0) {
-    MaxTransferBlocks = (1 << (Private->ControllerData->Mdts)) * (1 << (Private->Cap.Mpsmin + 12)) / BlockSize;
-  } else {
-    MaxTransferBlocks = 1024;
-  }
-
+  MaxTransferBlocks = GetMaxTransferBlockNumber (Private, BlockSize);
   while (Blocks > 0) {
     if (Blocks > MaxTransferBlocks) {
       Status = WriteSectors (Device, (UINT64) (UINTN)Buffer, Lba, MaxTransferBlocks);

--- a/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressBlockIo.h
+++ b/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressBlockIo.h
@@ -1,7 +1,7 @@
 /** @file
   Header file for EFI_BLOCK_IO_PROTOCOL interface.
 
-Copyright (c) 2013 - 2016, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2013 - 2020, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressHci.h
+++ b/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressHci.h
@@ -3,7 +3,7 @@
   NVM Express specification.
 
   (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
-  Copyright (c) 2013 - 2015, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2013 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressLib.inf
+++ b/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressLib.inf
@@ -42,4 +42,7 @@
 [LibraryClasses]
   DebugLib
   PrintLib
+  IoMmuLib
 
+[Pcd]
+  gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferSize

--- a/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressPassthru.c
+++ b/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressPassthru.c
@@ -3,7 +3,7 @@
   NVM Express specification.
 
   (C) Copyright 2014 Hewlett-Packard Development Company, L.P.<BR>
-  Copyright (c) 2013 - 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2013 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -201,6 +201,7 @@ NvmeDumpStatus (
   @param[in]     Pages               The number of pages to be transfered.
   @param[out]    PrpListHost         The host base address of PRP lists.
   @param[in,out] PrpListNo           The number of PRP List.
+  @param[out]    Mapping             The mapping value returned from map.
 
   @retval The pointer to the first PRP List of the PRP lists.
 
@@ -210,7 +211,8 @@ NvmeCreatePrpList (
   IN     EFI_PHYSICAL_ADDRESS         PhysicalAddr,
   IN     UINTN                        Pages,
   OUT    VOID                         **PrpListHost,
-  IN OUT UINTN                        *PrpListNo
+  IN OUT UINTN                        *PrpListNo,
+  OUT VOID                            **Mapping
   )
 {
   UINTN                       PrpEntryNo;
@@ -220,7 +222,7 @@ NvmeCreatePrpList (
   UINT64                      Remainder;
   EFI_PHYSICAL_ADDRESS        PrpListPhyAddr;
   UINTN                       Bytes;
-  VOID                        *PrpList;
+  EFI_STATUS                  Status;
 
   //
   // The number of Prp Entry in a memory page.
@@ -241,15 +243,18 @@ NvmeCreatePrpList (
     Remainder = PrpEntryNo - 1;
   }
 
-  PrpList =  AllocatePages (*PrpListNo);
-  if (PrpList == NULL) {
+  Status = IoMmuAllocateBuffer (
+             *PrpListNo,
+             PrpListHost,
+             &PrpListPhyAddr,
+             Mapping
+             );
+  if (EFI_ERROR(Status) || (*PrpListHost == NULL)) {
     DEBUG ((DEBUG_ERROR, "NvmeCreatePrpList: create PrpList failure!\n"));
     goto EXIT;
   }
-  *PrpListHost = PrpList;
 
   Bytes = EFI_PAGES_TO_SIZE (*PrpListNo);
-  PrpListPhyAddr = (UINT64) (UINTN)PrpList;
 
   //
   // Fill all PRP lists except of last one.
@@ -285,7 +290,10 @@ NvmeCreatePrpList (
   return (VOID *) (UINTN)PrpListPhyAddr;
 
 EXIT:
-  FreePages (PrpList, *PrpListNo);
+  if (*PrpListHost != NULL) {
+    IoMmuFreeBuffer (*PrpListNo, *PrpListHost, *Mapping);
+    *PrpListHost = NULL;
+  }
   return NULL;
 }
 
@@ -336,9 +344,14 @@ NvmExpressPassThru (
   NVME_SQ                        *Sq;
   NVME_CQ                        *Cq;
   UINT16                         QueueId;
+  UINT16                         QueueSize;
   UINT32                         Bytes;
   UINT16                         Offset;
   EFI_PHYSICAL_ADDRESS           PhyAddr;
+  VOID                           *MapData;
+  VOID                           *MapMeta;
+  VOID                           *MapPrpList;
+  UINTN                          MapLength;
   UINT64                         *Prp;
   VOID                           *PrpListHost;
   UINTN                          PrpListNo;
@@ -347,8 +360,8 @@ NvmExpressPassThru (
   UINT32                         MaxTransLen;
   UINT32                         Data;
   NVME_PASS_THRU_ASYNC_REQ       *AsyncRequest;
-  //  EFI_TPL                        OldTpl;
   UINT64                         TimeCount;
+  EDKII_IOMMU_OPERATION          Flag;
 
   //
   // check the data fields in Packet parameter.
@@ -410,10 +423,14 @@ NvmExpressPassThru (
     }
   }
 
+  MapData     = NULL;
+  MapMeta     = NULL;
+  MapPrpList  = NULL;
   PrpListHost = NULL;
   PrpListNo   = 0;
   Prp         = NULL;
   Status      = EFI_SUCCESS;
+  QueueSize   = MIN (NVME_ASYNC_CSQ_SIZE, Private->Cap.Mqes) + 1;
 
   if (Packet->QueueType == NVME_ADMIN_QUEUE) {
     QueueId = 0;
@@ -426,7 +443,7 @@ NvmExpressPassThru (
       //
       // Submission queue full check.
       //
-      if ((Private->SqTdbl[QueueId].Sqt + 1) % (NVME_ASYNC_CSQ_SIZE + 1) ==
+      if ((Private->SqTdbl[QueueId].Sqt + 1) % QueueSize ==
           Private->AsyncSqHead) {
         return EFI_NOT_READY;
       }
@@ -462,17 +479,50 @@ NvmExpressPassThru (
   // processor and a PCI Bus Master. It's caller's responsbility to ensure this.
   //
   if (((Sq->Opc & (BIT0 | BIT1)) != 0) && (Sq->Opc != NVME_ADMIN_CRIOCQ_CMD) && (Sq->Opc != NVME_ADMIN_CRIOSQ_CMD)) {
-    if ((Packet->TransferLength == 0) || (Packet->TransferBuffer == NULL)) {
+    //
+    // If the NVMe cmd has data in or out, then mapping the user buffer to the PCI controller specific addresses.
+    //
+    if (((Packet->TransferLength != 0) && (Packet->TransferBuffer == NULL)) ||
+        ((Packet->TransferLength == 0) && (Packet->TransferBuffer != NULL))) {
       return EFI_INVALID_PARAMETER;
     }
 
-    PhyAddr = (UINT64) (UINTN)Packet->TransferBuffer;
+    if ((Sq->Opc & BIT0) != 0) {
+      Flag = EdkiiIoMmuOperationBusMasterRead;
+    } else {
+      Flag = EdkiiIoMmuOperationBusMasterWrite;
+    }
 
-    Sq->Prp[0] = PhyAddr;
-    Sq->Prp[1] = 0;
+    if ((Packet->TransferLength != 0) && (Packet->TransferBuffer != NULL)) {
+      MapLength = Packet->TransferLength;
+      Status    = IoMmuMap (
+                Flag,
+                Packet->TransferBuffer,
+                &MapLength,
+                &PhyAddr,
+                &MapData
+                );
+      if (EFI_ERROR (Status) || (Packet->TransferLength != MapLength)) {
+        return EFI_OUT_OF_RESOURCES;
+      }
+
+      Sq->Prp[0] = PhyAddr;
+      Sq->Prp[1] = 0;
+    }
 
     if ((Packet->MetadataLength != 0) && (Packet->MetadataBuffer != NULL)) {
-      PhyAddr = (UINT64) (UINTN)Packet->TransferBuffer;
+      MapLength = Packet->MetadataLength;
+      Status    = IoMmuMap (
+                Flag,
+                Packet->MetadataBuffer,
+                &MapLength,
+                &PhyAddr,
+                &MapMeta
+                );
+      if (EFI_ERROR (Status) || (Packet->MetadataLength != MapLength)) {
+        Status = EFI_OUT_OF_RESOURCES;
+        goto EXIT;
+      }
       Sq->Mptr = PhyAddr;
     }
   }
@@ -488,8 +538,9 @@ NvmExpressPassThru (
     // Create PrpList for remaining data buffer.
     //
     PhyAddr = (Sq->Prp[0] + EFI_PAGE_SIZE) & ~ (EFI_PAGE_SIZE - 1);
-    Prp = NvmeCreatePrpList (PhyAddr, EFI_SIZE_TO_PAGES (Offset + Bytes) - 1, &PrpListHost, &PrpListNo);
+    Prp = NvmeCreatePrpList (PhyAddr, EFI_SIZE_TO_PAGES (Offset + Bytes) - 1, &PrpListHost, &PrpListNo, &MapPrpList);
     if (Prp == NULL) {
+      Status = EFI_OUT_OF_RESOURCES;
       goto EXIT;
     }
 
@@ -528,7 +579,7 @@ NvmExpressPassThru (
   //
   if ((Event != NULL && *Event != NULL) && (QueueId != 0)) {
     Private->SqTdbl[QueueId].Sqt =
-      (Private->SqTdbl[QueueId].Sqt + 1) % (NVME_ASYNC_CSQ_SIZE + 1);
+      (Private->SqTdbl[QueueId].Sqt + 1) % QueueSize;
   } else {
     Private->SqTdbl[QueueId].Sqt ^= 1;
   }
@@ -537,8 +588,9 @@ NvmExpressPassThru (
   Status = NvmHcRwMmio (Private->NvmeHCBase, NVME_SQTDBL_OFFSET (QueueId, Private->Cap.Dstrd), FALSE, sizeof (Data),
                         &Data);
   if (EFI_ERROR (Status)) {
-    return Status;
+    goto EXIT;
   }
+
   //
   // For non-blocking requests, return directly if the command is placed
   // in the submission queue.
@@ -554,6 +606,9 @@ NvmExpressPassThru (
     AsyncRequest->Packet        = Packet;
     AsyncRequest->CommandId     = Sq->Cid;
     AsyncRequest->CallerEvent   = *Event;
+    AsyncRequest->MapData       = MapData;
+    AsyncRequest->MapMeta       = MapMeta;
+    AsyncRequest->MapPrpList    = MapPrpList;
     AsyncRequest->PrpListNo     = PrpListNo;
     AsyncRequest->PrpListHost   = PrpListHost;
 
@@ -583,17 +638,16 @@ NvmExpressPassThru (
     } else {
       Status = EFI_DEVICE_ERROR;
       //
-      // Copy the Respose Queue entry for this command to the callers response buffer
-      //
-      CopyMem (Packet->NvmeCompletion, Cq, sizeof (EFI_NVM_EXPRESS_COMPLETION));
-
-      //
       // Dump every completion entry status for debugging.
       //
       DEBUG_CODE_BEGIN();
       NvmeDumpStatus (Cq);
       DEBUG_CODE_END();
     }
+    //
+    // Copy the Respose Queue entry for this command to the callers response buffer
+    //
+    CopyMem (Packet->NvmeCompletion, Cq, sizeof (EFI_NVM_EXPRESS_COMPLETION));
   }
 
   if ((Private->CqHdbl[QueueId].Cqh ^= 1) == 0) {
@@ -617,6 +671,18 @@ NvmExpressPassThru (
   }
 
 EXIT:
+  if (MapData != NULL) {
+    IoMmuUnmap (MapData);
+  }
+
+  if (MapMeta != NULL) {
+    IoMmuUnmap (MapMeta);
+  }
+
+  if (MapPrpList != NULL) {
+    IoMmuFreeBuffer (PrpListNo, PrpListHost, MapPrpList);
+  }
+
   return Status;
 }
 


### PR DESCRIPTION
This patch added IoMmu support for NVMe block access library.
This will allow the library to use DMA buffer for I/O transactions.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>