### PR TITLE
Fix incorrect BOM ID detection for UP Xtreme board

### DIFF
--- a/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -54,7 +54,7 @@ CONST UINT32 mUpxGpioBomPad[]  = {
   GPIO_CNL_LP_GPP_C10,  // BRD_ID2
   GPIO_CNL_LP_GPP_C9,   // BRD_ID1
   GPIO_CNL_LP_GPP_C8,   // BRD_ID0
-  GPIO_CNL_LP_GPP_A23,  // DDR_ID2
+  GPIO_CNL_LP_GPP_A12,  // DDR_ID2
   GPIO_CNL_LP_GPP_A18,  // DDR_ID1
   GPIO_CNL_LP_GPP_C11   // DDR_ID0
 };
@@ -323,7 +323,7 @@ PlatformIdInitialize (
       if (EFI_ERROR(Status)) {
         break;
       }
-      BomId = (BomId << 1) + (GpioData & 1);
+      BomId = (BomId << 1) + ((GpioData & BIT1) >> 1);
     }
 
     if (Idx == ARRAY_SIZE(mUpxGpioBomPad)) {


### PR DESCRIPTION
This patch fixed incorrect GPIO pin used for BOM ID detection for
UPX board.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>