### PR TITLE
Disable malfunction USB2 port

### DIFF
--- a/Platform/CoffeelakeBoardPkg/BoardConfig.py
+++ b/Platform/CoffeelakeBoardPkg/BoardConfig.py
@@ -92,7 +92,7 @@ class Board(BaseBoard):
         self.STAGE1_DATA_SIZE     = 0x0000E000
 
         self.PAYLOAD_EXE_BASE     = 0x00B00000
-        self.PAYLOAD_SIZE         = 0x00025000
+        self.PAYLOAD_SIZE         = 0x00028000
         if len(self._PAYLOAD_NAME.split(';')) > 1:
             self.UEFI_VARIABLE_SIZE = 0x00040000
         else:

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1310,8 +1310,9 @@ UpdateFspConfig (
   }
 
   if (PlatformId == PLATFORM_ID_UPXTREME) {
-    // Workaround for USB issue on port 9, disable it for now
-    FspsUpd->FspsConfig.PortUsb20Enable[9] = 0;
+    // Workaround for USB issue on port 8, it does not respond to USB enumeration.
+    // Disable this port for now
+    FspsUpd->FspsConfig.PortUsb20Enable[7] = 0;
   }
 
   Length = GetPchXhciMaxUsb3PortNum ();


### PR DESCRIPTION
USB2 port 8 (index 7) is connected to MCU on UPX board. It does not
respond to USB enumeration.  The original code disabled port 10, but
it should be port 8. This patch fixed it.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>