### PR TITLE
Output subregion values into delta file

### DIFF
--- a/BootloaderCorePkg/Tools/GenCfgData.py
+++ b/BootloaderCorePkg/Tools/GenCfgData.py
@@ -1897,16 +1897,21 @@ EndList
                 if TagName == '':
                     continue
 
+                ValStr = self.FormatDeltaValue (Item)
                 if not Item['subreg']:
-                    ValStr = self.FormatDeltaValue (Item)
                     Text = '%-40s | %s' % (FullName, ValStr)
                     if 'PLATFORMID_CFG_DATA.PlatformId' == FullName:
                         PlatformId = Array2Val(Item['value'])
                     else:
                         Lines.append(Text)
                 else:
+                    if Full:
+                        Text = '## %-40s | %s' % (FullName, ValStr)
+                        Lines.append(Text)
+
                     OldArray = OldData[Start:End]
                     NewArray = NewData[Start:End]
+
                     for SubItem in Item['subreg']:
                         NewBitValue = self.GetBsfBitFields(SubItem, NewArray)
                         OldBitValue = self.GetBsfBitFields(SubItem, OldArray)


### PR DESCRIPTION
This patch added subregion value output into full delta file so
that it is easier to update the value directly intead of fields.
For example, the new GPIO output in delta will be:
  ## GPIO_CFG_DATA.GpioPinConfig0_GPP_A00     | 0x350A581
  GPIO_CFG_DATA.GpioPinConfig0_GPP_A00.GPIOPADMode_GPP_A00 | 0x1
This 1st comment line is newly added by the patch.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>