### PR TITLE
Add SBL x64 build for VTF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ ConfigDataDynamic.h
 ConfigDataStruct.h
 ConfigDataCommonStruct.h
 CfgDataDef.bsf
-ResetVector.ia32.raw
+ResetVector.*.raw
 Fsp.bsf
 FspDbg.bin
 FspRel.bin

--- a/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Bin/ResetVector.inf
+++ b/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Bin/ResetVector.inf
@@ -23,5 +23,8 @@
 [Binaries.Ia32]
   RAW|ResetVector.ia32.raw|*
 
+[Binaries.X64]
+  RAW|ResetVector.x64.raw|*
+
 [Depex]
   TRUE

--- a/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Build.py
+++ b/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Build.py
@@ -27,8 +27,11 @@ def FixupForRawSection(sectionFile):
 for filename in glob.glob(os.path.join('Bin', '*.raw')):
     os.remove(filename)
 
-
-arch = 'ia32'
+# It takes one argument to indicate build arch 'ia32' or 'x64'
+if len(sys.argv) < 2:
+    arch = 'ia32'
+else:
+    arch = sys.argv[1]
 debugType = None
 output = os.path.join('Bin', 'ResetVector')
 output += '.' + arch

--- a/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Ia16/Init16.asm
+++ b/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Ia16/Init16.asm
@@ -15,14 +15,14 @@ BITS    16
 ;
 EarlyBspInitReal16:
     mov     di, 'BP'
-    jmp     short Main16
+    jmp     Main16
 
 ;
 ; @param[out] DI    'AP' to indicate application processor
 ;
 EarlyApInitReal16:
     mov     di, 'AP'
-    jmp     short Main16
+    jmp     Main16
 
 ;
 ; Modified:  EAX

--- a/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Ia16/Real16ToFlat32.asm
+++ b/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Ia16/Real16ToFlat32.asm
@@ -77,6 +77,15 @@ LINEAR_CODE_SEL     equ $-GDT_BASE
     DB      0            ; base 31:24
 
 %ifdef ARCH_X64
+; not used. padding to ensure 0x20 is 64 bit segment descriptor
+LINEAR_ZERO_SEL     equ $-GDT_BASE
+    DW      0            ; limit 15:0
+    DW      0            ; base 15:0
+    DB      0            ; base 23:16
+    DB      0            ; sys flag, dpl, type
+    DB      0            ; limit 19:16, flags
+    DB      0            ; base 31:24
+
 ; linear code (64-bit) segment descriptor
 LINEAR_CODE64_SEL   equ $-GDT_BASE
     DW      0xffff       ; limit 15:0

--- a/BootloaderCorePkg/Stage1A/Ia32/Vtf0/PageTables.asm
+++ b/BootloaderCorePkg/Stage1A/Ia32/Vtf0/PageTables.asm
@@ -1,0 +1,89 @@
+;------------------------------------------------------------------------------
+; @file
+; Main routine of the pre-SEC code up through the jump into SEC
+;
+; Copyright (c) 2008 - 2015, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;------------------------------------------------------------------------------
+
+%define FSP_HEADER_TEMPRAMINIT_OFFSET 0x30
+%define PAGE_REGION_SIZE              0x6000
+
+%define PAGE_PRESENT            0x01
+%define PAGE_READ_WRITE         0x02
+%define PAGE_USER_SUPERVISOR    0x04
+%define PAGE_WRITE_THROUGH      0x08
+%define PAGE_CACHE_DISABLE      0x010
+%define PAGE_ACCESSED           0x020
+%define PAGE_DIRTY              0x040
+%define PAGE_PAT                0x080
+%define PAGE_GLOBAL             0x0100
+%define PAGE_2M_MBO             0x080
+%define PAGE_2M_PAT             0x01000
+
+%define PAGE_2M_PDE_ATTR (PAGE_2M_MBO + \
+                          PAGE_ACCESSED + \
+                          PAGE_DIRTY + \
+                          PAGE_READ_WRITE + \
+                          PAGE_PRESENT)
+
+%define PAGE_PDP_ATTR    (PAGE_ACCESSED + \
+                          PAGE_READ_WRITE + \
+                          PAGE_PRESENT)
+
+BITS    32
+PreparePagingTable:
+    ; Input:
+    ;   ECX:  Page table base, need 6 pages
+    ; Modify:
+    ;   ECX, EDX, ESI
+
+    ;
+    ; Set up identical paging table for x64
+    ;
+    mov     esi, ecx
+    mov     ecx, PAGE_REGION_SIZE / 4
+    xor     eax, eax
+    xor     edx, edx
+clearPageTablesMemoryLoop:
+    mov     dword[ecx * 4 + esi - 4], eax
+    loop    clearPageTablesMemoryLoop
+
+    ;
+    ; Top level Page Directory Pointers (1 * 512GB entry)
+    ;
+    lea     eax, [esi + (0x1000) + PAGE_PDP_ATTR]
+    mov     dword[esi + (0)], eax
+    mov     dword[esi + (4)], edx
+
+    ;
+    ; Next level Page Directory Pointers (4 * 1GB entries => 4GB)
+    ;
+    lea     eax, [esi + (0x2000) + PAGE_PDP_ATTR]
+    mov     dword[esi + (0x1000)], eax
+    mov     dword[esi + (0x1004)], edx
+    lea     eax, [esi + (0x3000) + PAGE_PDP_ATTR]
+    mov     dword[esi + (0x1008)], eax
+    mov     dword[esi + (0x100C)], edx
+    lea     eax, [esi + (0x4000) + PAGE_PDP_ATTR]
+    mov     dword[esi + (0x1010)], eax
+    mov     dword[esi + (0x1014)], edx
+    lea     eax, [esi + (0x5000) + PAGE_PDP_ATTR]
+    mov     dword[esi + (0x1018)], eax
+    mov     dword[esi + (0x101C)], edx
+
+    ;
+    ; Page Table Entries (2048 * 2MB entries => 4GB)
+    ;
+    mov     ecx, 0x800
+pageTableEntriesLoop:
+    mov     eax, ecx
+    dec     eax
+    shl     eax, 21
+    add     eax, PAGE_2M_PDE_ATTR
+    mov     [ecx * 8 + esi + (0x2000 - 8)], eax
+    mov     [(ecx * 8 + esi + (0x2000 - 8)) + 4], edx
+    loop    pageTableEntriesLoop
+
+    OneTimeCallRet  PreparePagingTable

--- a/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Vtf0.nasmb
+++ b/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Vtf0.nasmb
@@ -18,6 +18,9 @@
 
 %include "CommonMacros.inc"
 %include "Ia16/Real16ToFlat32.asm"
+%ifdef ARCH_X64
+  %include "PageTables.asm"
+%endif
 %include "Main.asm"
 %include "Ia16/Init16.asm"
 %include "Ia16/ResetVectorVtf0.asm"

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -269,6 +269,7 @@ class Build(object):
         self._workspace                    = os.environ['WORKSPACE']
         self._board                        = board
         self._image                        = "SlimBootloader.bin"
+        self._arch                         = board.BUILD_ARCH
         self._target                       = 'RELEASE' if board.RELEASE_MODE  else 'NOOPT' if board.NO_OPT_MODE else 'DEBUG'
         self._fsp_basename                 = 'FspDbg'  if board.FSPDEBUG_MODE else 'FspRel'
         self._fv_dir                       = os.path.join(self._workspace, 'Build', 'BootloaderCorePkg', '%s_%s' % (self._target, self._toolchain), 'FV')
@@ -626,6 +627,14 @@ class Build(object):
             "<Stage1A:__gPcd_BinaryPatch_PcdVerInfoBase>,  {3473A022-C3C2-4964-B309-22B3DFB0B6CA:0x1C}, @Patch VerInfo",
             "<Stage1A:__gPcd_BinaryPatch_PcdFileDataBase>, {EFAC3859-B680-4232-A159-F886F2AE0B83:0x1C}, @Patch PcdBase"
         ]
+
+        if self._arch == 'X64':
+            # Find signature at top 4KB
+            vtf_patch_data_base = get_vtf_patch_base (os.path.join(self._fv_dir, 'STAGE1A.fd'))
+            extra_cmd.extend ([
+                "0x%08X, _BASE_STAGE1A_ - _OFFS_STAGE1A_,                    @FSP-T Base" % (vtf_patch_data_base + 0x04),
+                "0x%08X, Stage1A:_TempRamInitParams,                         @FSP-T UPD"  % (vtf_patch_data_base + 0x0C),
+            ])
 
         extra_cmd.append (
             "0xFFFFFFF8, {3CEA8EF3-95FC-476F-ABA5-7EC5DFA1D77B:0x1C}, @Patch FlashMap",
@@ -1122,7 +1131,7 @@ class Build(object):
 
         # rebuild reset vector
         vtf_dir = os.path.join('BootloaderCorePkg', 'Stage1A', 'Ia32', 'Vtf0')
-        x = subprocess.call([sys.executable, 'Build.py'],  cwd=vtf_dir)
+        x = subprocess.call([sys.executable, 'Build.py', self._arch.lower()],  cwd=vtf_dir)
         if x: raise Exception ('Failed to build reset vector !')
 
     def build(self):
@@ -1136,7 +1145,7 @@ class Build(object):
             "build" if os.name == 'posix' else "build.bat",
             "--platform", os.path.join('BootloaderCorePkg', 'BootloaderCorePkg.dsc'),
             "-b",         self._target,
-            "--arch",     'IA32',
+            "--arch",     self._arch,
             "--tagname",  self._toolchain,
             "-n",         str(multiprocessing.cpu_count()),
             "-y",         "Report.log",
@@ -1188,17 +1197,17 @@ class Build(object):
         # create microcode binary
         if self._board.UCODE_SIZE > 0:
             shutil.copy (
-                os.path.join(self._fv_dir, '../IA32/Microcode.bin'),
+                os.path.join(self._fv_dir, '../%s/Microcode.bin' % self._arch),
                 os.path.join(self._fv_dir, "UCODE.bin"))
 
         # generate payload
-        gen_payload_bin (self._fv_dir, self._pld_list,
+        gen_payload_bin (self._fv_dir, self._arch, self._pld_list,
                          os.path.join(self._fv_dir, "PAYLOAD.bin"),
                          self._board._CONTAINER_PRIVATE_KEY, HASH_VAL_STRING[self._board.SIGN_HASH_TYPE], self._board.BOARD_PKG_NAME)
 
         # create firmware update key
         if self._board.ENABLE_FWU:
-            srcfile = "../IA32/PayloadPkg/FirmwareUpdate/FirmwareUpdate/OUTPUT/FirmwareUpdate.efi"
+            srcfile = "../%s/PayloadPkg/FirmwareUpdate/FirmwareUpdate/OUTPUT/FirmwareUpdate.efi" % self._arch
             shutil.copyfile(
                 os.path.join(self._fv_dir, srcfile),
                 os.path.join(self._fv_dir, "FWUPDATE.bin"))
@@ -1263,6 +1272,7 @@ def main():
             if args.board == name:
                 brdcfg = imp.load_source('BoardConfig', board_cfgs[index])
                 board  = brdcfg.Board(
+                                        BUILD_ARCH        = args.arch.upper(), \
                                         RELEASE_MODE      = args.release,     \
                                         NO_OPT_MODE       = args.noopt,       \
                                         FSPDEBUG_MODE     = args.fspdebug,    \
@@ -1279,6 +1289,7 @@ def main():
     buildp.add_argument('-v',  '--usever',  action='store_true', help='Use board version file')
     buildp.add_argument('-fp', dest='fsppath', type=str, help='FSP binary path relative to FspBin in Silicon folder', default='')
     buildp.add_argument('-fd', '--fspdebug', action='store_true', help='Use debug FSP binary')
+    buildp.add_argument('-a',  '--arch', choices=['ia32', 'x64'], help='Specify the ARCH for build. Default is to build IA32 image.', default ='ia32')
     buildp.add_argument('-no', '--noopt', action='store_true', help='No compile/link optimization for debugging purpose. Not enabled in Release build.')
     buildp.add_argument('-p',  '--payload' , dest='payload', type=str, help='Payload file name', default ='OsLoader.efi')
     buildp.add_argument('board', metavar='board', choices=board_names, help='Board Name (%s)' % ', '.join(board_names))


### PR DESCRIPTION
This an initial patch to add x64 build for SBL.  A new build flag
'-x64' is added to indicate x64 arch build. This cannot be fully
used at this moment because it has many dependencies on other x64
libraries. Only VTF reset vector x64 build is tested.

VTF x64 flow is different from IA32.  It switches to 32 bit
mode as usual and then calls into FspTempRamInit to set up CAR.
Once CAR is ready, it builds 4GB identical mapping page table for
x64 and then switches to x64 long mode. Finally, it locates the
STAGE1A entry point and tranfers the control to STAGE1A in pure
64 bit mode.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>