### PR TITLE
Optimize GDT loading in stage core code

### DIFF
--- a/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
+++ b/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
@@ -14,6 +14,7 @@
 #include <Guid/LoaderPlatformDataGuid.h>
 #include <Guid/DeviceTableHobGuid.h>
 #include <Guid/KeyHashGuid.h>
+#include <Library/BaseLib.h>
 #include <Library/CryptoLib.h>
 
 #define  STACK_DEBUG_FILL_PATTERN     0x5AA55AA5

--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -32,6 +32,7 @@ typedef  VOID   (*KERNEL_ENTRY) (UINT32 Zero, UINT32 Arch, UINT32 Params);
 #pragma pack(1)
 
 #define  STAGE_IDT_ENTRY_COUNT        34
+#define  STAGE_GDT_ENTRY_COUNT        6
 
 #define  PLATFORM_NAME_SIZE           8
 
@@ -52,6 +53,10 @@ typedef struct {
   UINT32        LdrGlobal;
   UINT64        IdtTable[STAGE_IDT_ENTRY_COUNT];
 } STAGE_IDT_TABLE;
+
+typedef struct {
+  UINT64        GdtTable[STAGE_GDT_ENTRY_COUNT];
+} STAGE_GDT_TABLE;
 
 typedef struct {
   UINT32        Entry;

--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -400,6 +400,7 @@ SecStartup (
 {
   LOADER_GLOBAL_DATA        LdrGlobalData;
   STAGE_IDT_TABLE           IdtTable;
+  STAGE_GDT_TABLE           GdtTable;
   LOADER_GLOBAL_DATA       *LdrGlobal;
   STAGE1A_ASM_PARAM        *Stage1aAsmParam;
   UINT32                    StackTop;
@@ -429,6 +430,7 @@ SecStartup (
   // the config data passed in or these defaults remain
   LdrGlobal->LdrFeatures           = FEATURE_MEASURED_BOOT | FEATURE_ACPI;
 
+  LoadGdt (&GdtTable);
   LoadIdt (&IdtTable, (UINT32)LdrGlobal);
   SetLoaderGlobalDataPointer (LdrGlobal);
 

--- a/BootloaderCorePkg/Stage1A/Stage1A.h
+++ b/BootloaderCorePkg/Stage1A/Stage1A.h
@@ -34,6 +34,19 @@
 #include <VerInfo.h>
 
 /**
+  Load GDT table for current processor.
+
+  It function initializes GDT table and loads it into current processor.
+
+  @param  GdtTable  Pointer to STAGE_GDT_TABLE structure.
+
+**/
+VOID
+LoadGdt (
+  IN STAGE_GDT_TABLE   *GdtTable
+  );
+
+/**
   Load IDT table for current processor.
 
   It function initializes the exception handlers in IDT table and

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -335,6 +335,7 @@ SecStartup2 (
   )
 {
   STAGE_IDT_TABLE          *IdtTablePtr;
+  STAGE_GDT_TABLE          *GdtTablePtr;
   STAGE1A_PARAM            *Stage1aParam;
   LOADER_GLOBAL_DATA       *LdrGlobal;
   LOADER_GLOBAL_DATA       *OldLdrGlobal;
@@ -442,6 +443,8 @@ SecStartup2 (
   LdrGlobal      = (LOADER_GLOBAL_DATA *)MemPoolCurrTop;
   MemPoolCurrTop = ALIGN_DOWN (MemPoolCurrTop - sizeof (STAGE_IDT_TABLE), 0x10);
   IdtTablePtr    = (STAGE_IDT_TABLE *)MemPoolCurrTop;
+  MemPoolCurrTop = ALIGN_DOWN (MemPoolCurrTop - sizeof (STAGE_GDT_TABLE), 0x10);
+  GdtTablePtr    = (STAGE_GDT_TABLE *)MemPoolCurrTop;
   MemPoolCurrTop = ALIGN_DOWN (MemPoolCurrTop, EFI_PAGE_SIZE);
 
   if (FixedPcdGetBool (PcdS3DebugEnabled)) {
@@ -477,6 +480,7 @@ SecStartup2 (
   DEBUG_CODE_END ();
 
   // Setup global data in memory
+  LoadGdt (GdtTablePtr);
   LoadIdt (IdtTablePtr, (UINT32)LdrGlobal);
   SetLoaderGlobalDataPointer (LdrGlobal);
   DEBUG ((DEBUG_INFO, "Loader global data @ 0x%08X\n", (UINT32)LdrGlobal));

--- a/BootloaderCorePkg/Stage1B/Stage1B.h
+++ b/BootloaderCorePkg/Stage1B/Stage1B.h
@@ -56,6 +56,19 @@ ContinueFunc (
   );
 
 /**
+  Load GDT table for current processor.
+
+  It function initializes GDT table and loads it into current processor.
+
+  @param  GdtTable  Pointer to STAGE_GDT_TABLE structure.
+
+**/
+VOID
+LoadGdt (
+  IN STAGE_GDT_TABLE   *GdtTable
+  );
+
+/**
   Load IDT table for current processor.
 
   It function initializes the exception handlers in IDT table and

--- a/BootloaderCorePkg/Stage2/Ia32/Stage2Arch.c
+++ b/BootloaderCorePkg/Stage2/Ia32/Stage2Arch.c
@@ -7,20 +7,6 @@
 
 #include "Stage2.h"
 
-//
-// Global Descriptor Table (GDT)
-//
-CONST GLOBAL_REMOVE_IF_UNREFERENCED IA32_SEGMENT_DESCRIPTOR mGdtEntries[] = {
-  /* selector { Global Segment Descriptor                              } */
-  /* 0x00 */  {{0,      0,  0,  0,    0,  0,  0,  0,    0,  0, 0,  0,  0}}, //null descriptor
-  /* 0x08 */  {{0xffff, 0,  0,  0x2,  1,  0,  1,  0xf,  0,  0, 1,  1,  0}}, //linear data segment descriptor
-  /* 0x10 */  {{0xffff, 0,  0,  0xf,  1,  0,  1,  0xf,  0,  0, 1,  1,  0}}, //linear code segment descriptor
-  /* 0x18 */  {{0xffff, 0,  0,  0x3,  1,  0,  1,  0xf,  0,  0, 1,  1,  0}}, //system data segment descriptor
-  /* 0x20 */  {{0xffff, 0,  0,  0x2,  1,  0,  1,  0x0,  0,  0, 0,  0,  0}}, //16-bit data segment descriptor
-  /* 0x28 */  {{0xffff, 0,  0,  0xB,  1,  0,  1,  0x0,  0,  0, 0,  0,  0}}, //16-bit code segment descriptor
-};
-
-
 /**
   Unmap the previous mapped stage images.
 
@@ -32,15 +18,6 @@ UnmapStage (
   VOID
   )
 {
-  IA32_DESCRIPTOR                 GdtDesc;
-
-  //
-  // Reload GDT table into Stage2 memory
-  //
-  GdtDesc.Base  = (UINTN)mGdtEntries;
-  GdtDesc.Limit = sizeof (mGdtEntries) - 1;
-  AsmWriteGdtr (&GdtDesc);
-
   //
   // Reload Exception handler
   //

--- a/BootloaderCorePkg/Stage2/Stage2Support.c
+++ b/BootloaderCorePkg/Stage2/Stage2Support.c
@@ -645,5 +645,3 @@ InitializeService (
   RegisterService ((VOID *)&mPlatformService);
 
 }
-
-


### PR DESCRIPTION
This patch opitmized GDT loading in different stages. The old code
put GDT in code segment so it needs to be relocated every time when
code relocation/remapping occurs. By putting GDT into heap, it avoids
the GDT reloading. It only needs to be done twice, PreMem and PostMem.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>