### PR TITLE
Add multiple USB boot device support

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -265,5 +265,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdMiniShellEnabled        | FALSE      | BOOLEAN | 0x20000217
   # This PCD will enable DMA protection
   gPlatformCommonLibTokenSpaceGuid.PcdDmaProtectionEnabled    | FALSE      | BOOLEAN | 0x20000218
+  # This PCD will enable multiple USB mass storage boot device support
+  gPlatformCommonLibTokenSpaceGuid.PcdMultiUsbBootDeviceEnabled   | FALSE  | BOOLEAN | 0x20000219
 
 

--- a/BootloaderCommonPkg/Library/UsbBlockIoLib/UsbBlockIoLib.inf
+++ b/BootloaderCommonPkg/Library/UsbBlockIoLib/UsbBlockIoLib.inf
@@ -47,5 +47,5 @@
 
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdUsbTransferTimeoutValue  ## CONSUMES
-
+  gPlatformCommonLibTokenSpaceGuid.PcdMultiUsbBootDeviceEnabled ## CONSUMES
 

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -310,6 +310,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdEmmcHs400SupportEnabled | $(ENABLE_EMMC_HS400)
   gPlatformCommonLibTokenSpaceGuid.PcdPreOsCheckerEnabled | $(ENABLE_PRE_OS_CHECKER)
   gPlatformCommonLibTokenSpaceGuid.PcdDmaProtectionEnabled | $(ENABLE_DMA_PROTECTION)
+  gPlatformCommonLibTokenSpaceGuid.PcdMultiUsbBootDeviceEnabled |  $(ENABLE_MULTI_USB_BOOT_DEV)
 
 !ifdef $(S3_DEBUG)
   gPlatformModuleTokenSpaceGuid.PcdS3DebugEnabled         | $(S3_DEBUG)

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -186,6 +186,7 @@ class BaseBoard(object):
         self.ENABLE_CSME_UPDATE    = 0
         self.ENABLE_EMMC_HS400     = 1
         self.ENABLE_DMA_PROTECTION = 0
+        self.ENABLE_MULTI_USB_BOOT_DEV = 0
 
         self.BUILD_CSME_UPDATE_DRIVER    = 0
 


### PR DESCRIPTION
When multiple USB mass storage boot devices are connected, current
SBL will only boot from the 1st one enumerated by the USB bus. This
patch added support to boot from the remaining devices. This feature
will be controlled by PcdMultiUsbBootDeviceEnabled. And it can be
overridden by board using ENABLE_MULTI_USB_BOOT_DEV. When it is enabled
for USB block IO interface, the hardware partition n boot option
will be used to indicate the index of the USB mass storage devvice.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>