### PR TITLE
Pointer type cast for both 32/64-bit operation

### DIFF
--- a/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
+++ b/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
@@ -98,6 +98,7 @@ typedef enum {
   @retval LOADER_STAGE  Current stage of bootloader execution.
 **/
 LOADER_STAGE
+EFIAPI
 GetLoaderStage (
   VOID
   );

--- a/BootloaderCommonPkg/Include/Library/DecompressLib.h
+++ b/BootloaderCommonPkg/Include/Library/DecompressLib.h
@@ -16,7 +16,7 @@
 
 #define  LZDM_SIGNATURE     SIGNATURE_32 ('L', 'Z', 'D', 'M')
 #define  LZ_SIGNATURE_16    SIGNATURE_16 ('L', 'Z')
-#define  IS_COMPRESSED(x)   (*(UINT16 *)(x) == LZ_SIGNATURE_16)
+#define  IS_COMPRESSED(x)   (*(UINT16 *)(UINTN)(x) == LZ_SIGNATURE_16)
 
 
 /**

--- a/BootloaderCommonPkg/Include/Library/FileSystemLib.h
+++ b/BootloaderCommonPkg/Include/Library/FileSystemLib.h
@@ -16,7 +16,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 // To redirect output message to consoles (serial, graphic console and etc.)
 //
-typedef UINTN (* CONSOLE_OUT_FUNC) (CONST CHAR16 *Format, ...);
+typedef UINTN (EFIAPI *CONSOLE_OUT_FUNC) (CONST CHAR16 *Format, ...);
 
 /**
   Initialize file systems.

--- a/BootloaderCommonPkg/Include/Library/IasImageLib.h
+++ b/BootloaderCommonPkg/Include/Library/IasImageLib.h
@@ -139,14 +139,14 @@ IasGetFiles (
 
 // Find the extended header, payload data and CRC, and the RSA signature from the generic header:
 #define IAS_EXT_HDR_SIZE(h)           ((h)->DataOffset - sizeof(IAS_HEADER))
-#define IAS_EXT_HDR(h)                ((UINT32*) (((UINT32) (h)) + sizeof(IAS_HEADER)))
-#define IAS_PAYLOAD(h)                ((((UINT32) (h)) + (h)->DataOffset))
+#define IAS_EXT_HDR(h)                ((UINT32*) (((UINT32)(UINTN)(h)) + sizeof(IAS_HEADER)))
+#define IAS_PAYLOAD(h)                ((((UINT32)(UINTN)(h)) + (h)->DataOffset))
 #define IAS_PAYLOAD_CRC(h)            (* (UINT32*) (((UINT32*) (h)) + (h)->DataOffset + (h)->DataLength))
 #define IAS_PAYLOAD_END(h)            (IAS_PAYLOAD(h) + (h)->DataLength + sizeof(UINT32))
-#define IAS_SIGNATURE(h)              (((UINT32) h) + ROUNDED_UP((h)->DataOffset + (h)->DataLength + sizeof(UINT32), 256))
+#define IAS_SIGNATURE(h)              (((UINT32)(UINTN)h) + ROUNDED_UP((h)->DataOffset + (h)->DataLength + sizeof(UINT32), 256))
 #define IAS_PUBLIC_KEY(h)             ((IAS_SIGNATURE(h) + 256))
 #define IAS_IMAGE_END(h)              ((IAS_PUBLIC_KEY(h) + (( (h)->ImageType  & 1<<9 ) == (1 <<9) ? 260 : 0)))
-#define IAS_IMAGE_SIZE(h)             (((UINT32) IAS_IMAGE_END(h)) - ((UINT32) h))
+#define IAS_IMAGE_SIZE(h)             (((UINT32) IAS_IMAGE_END(h)) - ((UINT32)(UINTN)h))
 
 // Note: Alignment argument must be a power of two.
 #define ROUNDED_DOWN(val, align)    ((val) & ~((align) - 1))

--- a/BootloaderCommonPkg/Include/Library/UsbBlockIoLib.h
+++ b/BootloaderCommonPkg/Include/Library/UsbBlockIoLib.h
@@ -10,7 +10,7 @@
 
 #include <BlockDevice.h>
 
-typedef EFI_STATUS (*USB_BLK_IO_CALLBACK) \
+typedef EFI_STATUS (EFIAPI *USB_BLK_IO_CALLBACK) \
 (EFI_PEI_RECOVERY_BLOCK_IO_PPI *UsbBlkIoPpi);
 
 /**

--- a/BootloaderCommonPkg/Include/Library/UsbBusLib.h
+++ b/BootloaderCommonPkg/Include/Library/UsbBusLib.h
@@ -10,7 +10,7 @@
 
 #include <Ppi/UsbIo.h>
 
-typedef EFI_STATUS (*USB_IO_CALLBACK) (PEI_USB_IO_PPI *UsbIoPpi);
+typedef EFI_STATUS (EFIAPI *USB_IO_CALLBACK) (PEI_USB_IO_PPI *UsbIoPpi);
 
 /**
   Enumerate devices on the USB bus.

--- a/BootloaderCommonPkg/Library/BootloaderCommonLib/BootloaderCommonLib.c
+++ b/BootloaderCommonPkg/Library/BootloaderCommonLib/BootloaderCommonLib.c
@@ -193,7 +193,7 @@ SetLibraryData (
   Status     = EFI_ABORTED;
   LibDataPtr = (LIBRARY_DATA *) GetLibraryDataPtr ();
   if (LibDataPtr != NULL) {
-    LibDataPtr[LibId].BufBase = (UINT32)BufPtr;
+    LibDataPtr[LibId].BufBase = (UINT32)(UINTN)BufPtr;
     LibDataPtr[LibId].BufSize = BufSize;
     Status = EFI_SUCCESS;
   }
@@ -292,13 +292,13 @@ DetectUsedStackBottom (
   StackBot = (UINT32 *) ((StackTop - StackSize) & ~ (sizeof (UINTN) - 1));
   ASSERT (*StackBot == STACK_DEBUG_FILL_PATTERN);
 
-  while ((UINT32)StackBot < StackTop) {
+  while ((UINT32)(UINTN)StackBot < StackTop) {
     if (*StackBot != STACK_DEBUG_FILL_PATTERN) {
       break;
     }
     StackBot++;
   }
-  return (UINT32)StackBot;
+  return (UINT32)(UINTN)StackBot;
 }
 
 /**

--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.c
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.c
@@ -108,7 +108,7 @@
   @retval other if error.
 **/
 STATIC
-INT32
+RETURN_STATUS
 BlockMap (
   IN  OPEN_FILE     *File,
   IN  INDPTR         FileBlock,
@@ -127,7 +127,7 @@ BlockMap (
   @retval other if error.
 **/
 STATIC
-INT32
+RETURN_STATUS
 SearchDirectory (
   IN      CHAR8         *Name,
   IN      INT32          Length,
@@ -148,7 +148,7 @@ SearchDirectory (
   @retval 0 if success
   @retval other if error.
 **/
-INT32
+RETURN_STATUS
 EFIAPI
 BDevStrategy (
   IN  VOID       *DevData,
@@ -193,7 +193,7 @@ BDevStrategy (
   @retval         0 if success
   @retval         other if error.
 **/
-INT32
+RETURN_STATUS
 EFIAPI
 ReadInode (
   IN    INODE32      INumber,
@@ -213,7 +213,7 @@ ReadInode (
   FileSystem = Fp->SuperBlockPtr;
 
   Ext2FsGrpDes = FileSystem->Ext2FsGrpDes;
-  Ext2FsGrpDes = (EXT2GD*)((UINT32)Ext2FsGrpDes + (INOTOCG(FileSystem, INumber) * FileSystem->Ext2FsGDSize));
+  Ext2FsGrpDes = (EXT2GD*)((UINTN)Ext2FsGrpDes + (INOTOCG(FileSystem, INumber) * FileSystem->Ext2FsGDSize));
 
   InodeSector = (DADDRESS) (Ext2FsGrpDes->Ext2BGDInodeTables + DivU64x32 (ModU64x32 ((INumber - 1), FileSystem->Ext2Fs.Ext2FsINodesPerGroup), FileSystem->Ext2FsInodesPerBlock));
 
@@ -261,7 +261,7 @@ ReadInode (
   @retval other if error.
 **/
 STATIC
-INT32
+RETURN_STATUS
 BlockMap (
   IN  OPEN_FILE     *File,
   IN  INDPTR         FileBlock,
@@ -444,7 +444,7 @@ BlockMap (
   @retval     0 if success
   @retval     other if error.
 **/
-INT32
+RETURN_STATUS
 EFIAPI
 BufReadFile (
   IN  OPEN_FILE     *File,
@@ -458,7 +458,7 @@ BufReadFile (
   INDPTR FileBlock;
   INDPTR DiskBlock;
   UINT32 BlockSize;
-  INT32 Rc;
+  RETURN_STATUS Rc;
 
   Fp = (FILE *)File->FileSystemSpecificData;
   FileSystem = Fp->SuperBlockPtr;
@@ -522,7 +522,7 @@ BufReadFile (
   @retval other if error.
 **/
 STATIC
-INT32
+RETURN_STATUS
 SearchDirectory (
   IN      CHAR8         *Name,
   IN      INT32          Length,
@@ -585,7 +585,7 @@ SearchDirectory (
   @retval 0 if superblock compute is success
   @retval other if error.
 **/
-INT32
+RETURN_STATUS
 EFIAPI
 ReadSBlock (
   IN      OPEN_FILE     *File,
@@ -596,7 +596,7 @@ ReadSBlock (
   UINT8 *Buffer;
   EXT2FS Ext2Fs;
   UINT32 BufSize;
-  INT32  Rc;
+  RETURN_STATUS Rc;
   UINT32 SbOffset;
 
   Rc = 0;
@@ -668,7 +668,7 @@ Exit:
   @retval 0 if Group descriptor read is success
   @retval other if error.
 **/
-INT32
+RETURN_STATUS
 EFIAPI
 ReadGDBlock (
   IN OUT  OPEN_FILE     *File,
@@ -730,7 +730,7 @@ Ext2fsOpen (
   INODE32 INumber;
   FILE *Fp;
   M_EXT2FS *FileSystem;
-  INT32 Rc;
+  RETURN_STATUS Rc;
 #ifndef LIBSA_NO_FS_SYMLINK
   INODE32 ParentInumber;
   INT32 Nlinks;

--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.h
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.h
@@ -435,7 +435,7 @@ typedef struct {
   @retval 0 if success
   @retval other if error.
 **/
-INT32
+RETURN_STATUS
 EFIAPI
 BDevStrategy (
   IN  VOID       *DevData,
@@ -525,7 +525,7 @@ Ext2fsLs (
   @retval 0 if superblock compute is success
   @retval other if error.
 **/
-INT32
+RETURN_STATUS
 EFIAPI
 ReadSBlock (
   IN      OPEN_FILE     *File,
@@ -541,7 +541,7 @@ ReadSBlock (
   @retval 0 if Group descriptor read is success
   @retval other if error.
 **/
-INT32
+RETURN_STATUS
 EFIAPI
 ReadGDBlock (
   IN OUT  OPEN_FILE     *File,
@@ -557,7 +557,7 @@ ReadGDBlock (
   @retval         0 if success
   @retval         other if error.
 **/
-INT32
+RETURN_STATUS
 EFIAPI
 ReadInode (
   IN    INODE32      INumber,
@@ -576,7 +576,7 @@ ReadInode (
   @retval     0 if success
   @retval     other if error.
 **/
-INT32
+RETURN_STATUS
 EFIAPI
 BufReadFile (
   IN  OPEN_FILE     *File,

--- a/BootloaderCommonPkg/Library/Ext23Lib/LibsaFsStand.h
+++ b/BootloaderCommonPkg/Library/Ext23Lib/LibsaFsStand.h
@@ -130,7 +130,8 @@ Gives the info of device block config.
 @retval EFI_SUCCESS       The function completed successfully.
 @retval !EFI_SUCCESS      Something error while read FILE.
 **/
-INT32
+RETURN_STATUS
+EFIAPI
 BDevStrategy (
   VOID     *DevData,
   INT32     ReadWrite,

--- a/BootloaderCommonPkg/Library/IasImageLib/IasImage.c
+++ b/BootloaderCommonPkg/Library/IasImageLib/IasImage.c
@@ -103,8 +103,7 @@ IsIasImageValid (
     Key->PubExp[Index]  = ((UINT8 *) IAS_PUBLIC_KEY (Hdr))[KeyIdx];
   }
 
-
-  Status = DoRsaVerify ((CONST UINT8 *)Hdr, ((UINT32)IAS_PAYLOAD_END (Hdr)) - ((UINT32)Hdr),
+  Status = DoRsaVerify ((CONST UINT8 *)Hdr, ((UINT32)IAS_PAYLOAD_END (Hdr)) - ((UINT32)(UINTN)Hdr),
                          HASH_USAGE_PUBKEY_OS, SignHdr, PubKeyHdr, PcdGet8(PcdCompSignHashAlg), NULL, IasImageInfo->HashData);
   if (EFI_ERROR (Status) != EFI_SUCCESS) {
     DEBUG ((DEBUG_ERROR, "IAS image verification failed!\n"));
@@ -114,7 +113,7 @@ IsIasImageValid (
 
   // populate IAS_IMAGE_INFO
   IasImageInfo->CompBuf  = (UINT8 *)Hdr;
-  IasImageInfo->CompLen  = ((UINT32)IAS_PAYLOAD_END (Hdr)) - ((UINT32)Hdr);
+  IasImageInfo->CompLen  = ((UINT32)IAS_PAYLOAD_END (Hdr)) - ((UINT32)(UINTN)Hdr);
   IasImageInfo->HashAlg  = PcdGet8(PcdCompSignHashAlg);
 
   return Hdr;
@@ -152,7 +151,7 @@ IasGetFiles (
     ZeroMem (Img, NumImg * sizeof (Img[0]));
 
     // Return Addr single entry (namely the entire payload) for plain images.
-    Img[0].Addr = Addr = (UINT32 *) IAS_PAYLOAD (IasImage);
+    Img[0].Addr = Addr = (UINT32 *)(UINTN)IAS_PAYLOAD (IasImage);
     Img[0].Size = Size = IasImage->DataLength;
     Img[0].AllocType = ImageAllocateTypePointer;
 

--- a/BootloaderCommonPkg/Library/LinuxLib/LinuxLib.c
+++ b/BootloaderCommonPkg/Library/LinuxLib/LinuxLib.c
@@ -110,7 +110,7 @@ DumpLinuxBootParams (
 
   DEBUG ((DEBUG_INFO, "CmdlineSize: 0x%x\n", Header->CmdlineSize));
   DEBUG ((DEBUG_INFO, "CmdLinePtr: 0x%x\n", Header->CmdLinePtr));
-  DEBUG ((DEBUG_INFO, "Cmd Args: %a\n", (CHAR8 *)Header->CmdLinePtr));
+  DEBUG ((DEBUG_INFO, "Cmd Args: %a\n", (CHAR8 *)(UINTN)Header->CmdLinePtr));
 
   DEBUG ((DEBUG_INFO, "RamDiskStart: 0x%x\n", Header->RamDiskStart));
   DEBUG ((DEBUG_INFO, "RamDisklen: 0x%x\n", Header->RamDisklen));
@@ -236,9 +236,9 @@ LoadBzImage (
   // Update boot params
   //
   Bp->Hdr.LoaderId     = 0xff;
-  Bp->Hdr.CmdLinePtr   = (UINT32)CmdLineBase;
+  Bp->Hdr.CmdLinePtr   = (UINTN)CmdLineBase;
   Bp->Hdr.CmdlineSize  = CmdLineLen;
-  Bp->Hdr.RamDiskStart = (UINT32)InitRdBase;
+  Bp->Hdr.RamDiskStart = (UINTN)InitRdBase;
   Bp->Hdr.RamDisklen   = InitRdLen;
 
   return EFI_SUCCESS;

--- a/BootloaderCommonPkg/Library/LiteFvLib/FvLib.c
+++ b/BootloaderCommonPkg/Library/LiteFvLib/FvLib.c
@@ -328,7 +328,7 @@ LoadFvImage (
 
   // Check preferred image base
   SecCoreImageBase = (UINTN)Section;
-  Status = PeCoffGetPreferredBase ((VOID *)SecCoreImageBase, &PreferredBase);
+  Status = PeCoffGetPreferredBase ((VOID *)(UINTN)SecCoreImageBase, &PreferredBase);
   if (EFI_ERROR (Status)) {
     return Status;
   }
@@ -340,7 +340,7 @@ LoadFvImage (
     SecCoreImageBase += Gap;
   }
 
-  Status = PeCoffLoaderGetEntryPoint ((VOID *)SecCoreImageBase, EntryPoint);
+  Status = PeCoffLoaderGetEntryPoint ((VOID *)(UINTN)SecCoreImageBase, EntryPoint);
 
   return Status;
 }

--- a/BootloaderCommonPkg/Library/LitePeCoffLib/LitePeCoffLib.c
+++ b/BootloaderCommonPkg/Library/LitePeCoffLib/LitePeCoffLib.c
@@ -150,7 +150,7 @@ PeCoffRelocateImage (
 
   Status = RETURN_SUCCESS;
 
-  if (!IsTePe32Image ((VOID *)ImageBase, &Hdr)) {
+  if (!IsTePe32Image ((VOID *)(UINTN)ImageBase, &Hdr)) {
     return RETURN_UNSUPPORTED;
   }
 
@@ -195,7 +195,7 @@ PeCoffRelocateImage (
   // changed the check to a greater-than-eight. It should be at least eight
   // because the PageRva and the BlockSize together take eight bytes. If less
   // than 8 are remaining, then those are the orphans and we need to disregard them.
-  RelocDataPtr =  (UINT16 *) (ImageBase + RelocSectionOffset);
+  RelocDataPtr =  (UINT16 *)(UINTN)(ImageBase + RelocSectionOffset);
   while (RelocSectionSize >= 8) {
     //DEBUG ((DEBUG_INFO, "RelocSectionSize = %08x\n", RelocSectionSize));
 
@@ -223,7 +223,7 @@ PeCoffRelocateImage (
       RelocSectionSize -= sizeof (UINT16);
       ImgOffset = PageRva + Offset - Adjust;
       // DEBUG ((DEBUG_INFO, "%d: PageRva: %08x Offset: %04x Type: %x \n", Index, PageRva, ImgOffset, Type));
-      Data = * (UINT32 *) (ImageBase + ImgOffset);
+      Data = * (UINT32 *)(UINTN)(ImageBase + ImgOffset);
       switch (Type) {
       case 0:
         break;
@@ -240,7 +240,7 @@ PeCoffRelocateImage (
         //DEBUG ((DEBUG_INFO, "Unknown Type!\n"));
         break;
       }
-      * (UINT32 *) (ImageBase + ImgOffset) = Data;
+      * (UINT32 *)(UINTN)(ImageBase + ImgOffset) = Data;
     }
   }
 

--- a/BootloaderCommonPkg/Library/LiteVariableLib/LiteVariableLib.c
+++ b/BootloaderCommonPkg/Library/LiteVariableLib/LiteVariableLib.c
@@ -72,7 +72,7 @@ GetVaraibelStoreBase (
     *Size = VarInstance->StoreSize;
   }
 
-  return (VOID *)VarInstance->StoreBase;
+  return (VOID *)(UINTN)VarInstance->StoreBase;
 }
 
 /**
@@ -97,13 +97,13 @@ EraseVariableStore (
   UINT32              RgnBase;
   UINT32              RgnSize;
 
-  DEBUG ((DEBUG_INFO, "  SPI ERASE: %08X  %08X\n", (UINT32)VariableStore, Length));
+  DEBUG ((DEBUG_INFO, "  SPI ERASE: %08X  %08X\n", (UINT32)(UINTN)VariableStore, Length));
   SpiService = (SPI_FLASH_SERVICE *)GetServiceBySignature (SPI_FLASH_SERVICE_SIGNATURE);
   if (SpiService != NULL) {
     Status = SpiService->SpiGetRegion (FlashRegionBios, &RgnBase, &RgnSize);
     if (!EFI_ERROR (Status)) {
       // BIOS region offset can be calculated by (HostAddress + BiosRgnLimit)
-      BiosRgnOffset = (UINT32)((UINT32)VariableStore + RgnSize);
+      BiosRgnOffset = (UINT32)((UINT32)(UINTN)VariableStore + RgnSize);
       Status = SpiService->SpiErase (FlashRegionBios, BiosRgnOffset, Length);
       AsmFlushCacheRange (VariableStore, Length);
     }
@@ -137,13 +137,13 @@ WriteVariableStore (
   UINT32              RgnBase;
   UINT32              RgnSize;
 
-  DEBUG ((DEBUG_INFO, "  SPI WRITE: %08X  %08X\n", (UINT32)VariableStore, Length));
+  DEBUG ((DEBUG_INFO, "  SPI WRITE: %08X  %08X\n", (UINT32)(UINTN)VariableStore, Length));
   SpiService = (SPI_FLASH_SERVICE *)GetServiceBySignature (SPI_FLASH_SERVICE_SIGNATURE);
   if (SpiService != NULL) {
     Status = SpiService->SpiGetRegion (FlashRegionBios, &RgnBase, &RgnSize);
     if (!EFI_ERROR (Status)) {
       // BIOS region offset can be calculated by (HostAddress + BiosRgnLimit)
-      BiosRgnOffset = (UINT32)((UINT32)VariableStore + RgnSize);
+      BiosRgnOffset = (UINT32)((UINT32)(UINTN)VariableStore + RgnSize);
       Status = SpiService->SpiWrite (FlashRegionBios, BiosRgnOffset, Length, Buffer);
       AsmFlushCacheRange (VariableStore, Length);
     }

--- a/BootloaderCommonPkg/Library/Lz4DecompressLib/Lz4DecompressLib.c
+++ b/BootloaderCommonPkg/Library/Lz4DecompressLib/Lz4DecompressLib.c
@@ -348,10 +348,10 @@ FORCE_INLINE int LZ4_decompress_generic (
         s = *ip++;
         length += s;
       } while (likely ((endOnInput) ? ip < iend - RUN_MASK : 1) && (s == 255));
-      if ((safeDecode) && unlikely ((size_t) (op + length) < (size_t) (op))) {
+      if ((safeDecode) && unlikely ((size_t)(UINTN)(op + length) < (size_t)(UINTN)(op))) {
         goto _output_error;  /* overflow detection */
       }
-      if ((safeDecode) && unlikely ((size_t) (ip + length) < (size_t) (ip))) {
+      if ((safeDecode) && unlikely ((size_t)(UINTN)(ip + length) < (size_t)(UINTN)(ip))) {
         goto _output_error;  /* overflow detection */
       }
     }
@@ -402,7 +402,7 @@ FORCE_INLINE int LZ4_decompress_generic (
         s = *ip++;
         length += s;
       } while (s == 255);
-      if ((safeDecode) && unlikely ((size_t) (op + length) < (size_t)op)) {
+      if ((safeDecode) && unlikely ((size_t)(UINTN)(op + length) < (size_t)(UINTN)op)) {
         goto _output_error;  /* overflow detection */
       }
     }

--- a/BootloaderCommonPkg/Library/MultibootLib/Multiboot.c
+++ b/BootloaderCommonPkg/Library/MultibootLib/Multiboot.c
@@ -43,11 +43,11 @@ GetMultibootHeader (
   UINT32                     Offset;
 
   // Multiboot header must be 32-bit aligned.
-  AlignedAddress = ((UINT32)ImageAddr + 3) & ~0x3;
+  AlignedAddress = ((UINT32)(UINTN)ImageAddr + 3) & ~0x3;
 
   // Multiboot header must completely within the first 8192 bytes of the image.
   for (Offset = 0; Offset < 8192 - sizeof (MULTIBOOT_HEADER); Offset += 4) {
-    MbHeader = (MULTIBOOT_HEADER *) (AlignedAddress + Offset);
+    MbHeader = (MULTIBOOT_HEADER *)(UINTN)(AlignedAddress + Offset);
     if ((MbHeader->Magic == MULTIBOOT_HEADER_MAGIC) &&
         (MbHeader->Magic + MbHeader->Flags + MbHeader->Checksum == 0)) {
       if ((MbHeader->Flags & (~SUPPORTED_FEATURES & 0xffff)) != 0) {
@@ -224,7 +224,7 @@ SetupMultibootInfo (
 
   // Arrange for passing this data to the image.
   MultiBoot->BootState.Eax = MULTIBOOT_INFO_MAGIC;
-  MultiBoot->BootState.Ebx = (UINT32) (MbInfo);
+  MultiBoot->BootState.Ebx = (UINT32)(UINTN)MbInfo;
 }
 
 
@@ -257,8 +257,8 @@ AlignMulitibootModules (
       }
       DEBUG ((DEBUG_INFO, "Align Module[%d] from 0x%x to 0x%p\n",
               Index, MbModule->Start, AlignedAddr));
-      CopyMem (AlignedAddr, (CONST VOID *)MbModule->Start, ModuleSize);
-      MbModule->Start = (UINT32) AlignedAddr;
+      CopyMem (AlignedAddr, (CONST VOID *)(UINTN)MbModule->Start, (UINTN)ModuleSize);
+      MbModule->Start = (UINT32)(UINTN)AlignedAddr;
     }
   }
 
@@ -318,13 +318,13 @@ SetupMultibootImage (
   } else {
     CopyMem (LoadAddr, MultiBoot->BootFile.Addr, sizeof (UINT32) * (LoadEnd - LoadAddr));
     DEBUG ((DEBUG_INFO, "Mb: copy image to 0x%p, Size=0x%x\n", LoadAddr, sizeof (UINT32) * (LoadEnd - LoadAddr)));
-    if ((UINT32)BssEnd != 0) {
+    if ((UINT32)(UINTN)BssEnd != 0) {
       ZeroMem ((VOID *) LoadEnd, BssEnd - LoadEnd);
     }
   }
 
   SetupMultibootInfo (MultiBoot);
-  MultiBoot->BootState.EntryPoint = (UINT32) MbHeader->EntryAddr;
+  MultiBoot->BootState.EntryPoint = (UINT32)(UINTN)MbHeader->EntryAddr;
   return EFI_SUCCESS;
 }
 
@@ -375,7 +375,7 @@ DumpMbInfo (
     for (Index = 0; Index < Mi->ModsCount; Index++) {
       DEBUG ((DEBUG_INFO, "- Mod[%d].Start:      %08x\n", Index, Mod[Index].Start));
       DEBUG ((DEBUG_INFO, "- Mod[%d].End:        %08x\n", Index, Mod[Index].End));
-      DEBUG ((DEBUG_INFO, "- Mod[%d].String:     %08x\n", Index, (UINT32)Mod[Index].String));
+      DEBUG ((DEBUG_INFO, "- Mod[%d].String:     %08x\n", Index, (UINT32)(UINTN)Mod[Index].String));
     }
   }
 
@@ -391,7 +391,7 @@ DumpMbInfo (
 
   if ((Mi->Flags & MULTIBOOT_INFO_HAS_MMAP)) {
     for (Offs = 0; Offs < Mi->MmapLength; Offs += Map->Size + sizeof (Map->Size)) {
-      Map = (VOID *) (((UINT32) (Mi->MmapAddr)) + Offs);
+      Map = (VOID *)((UINTN)Mi->MmapAddr + Offs);
       DEBUG ((DEBUG_INFO, "%3x: ", Offs));
       DEBUG ((DEBUG_INFO, "%016lX", Map->BaseAddr));
       DEBUG ((DEBUG_INFO, "--%016lX", Map->Length));

--- a/BootloaderCommonPkg/Library/ShellLib/CmdFs.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdFs.c
@@ -29,8 +29,8 @@ STATIC  EFI_HANDLE          mFsHandle     = NULL;
   @retval EFI_SUCCESS
 
 **/
-STATIC
 EFI_STATUS
+EFIAPI
 ShellCommandFsFunc (
   IN SHELL  *Shell,
   IN UINTN   Argc,
@@ -266,8 +266,8 @@ CmdFsInfo (
   @retval EFI_SUCCESS
 
 **/
-STATIC
 EFI_STATUS
+EFIAPI
 ShellCommandFsFunc (
   IN SHELL  *Shell,
   IN UINTN   Argc,

--- a/BootloaderCommonPkg/Library/ShellLib/CmdMm.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdMm.c
@@ -21,8 +21,8 @@
   @retval EFI_SUCCESS
 
 **/
-STATIC
 EFI_STATUS
+EFIAPI
 ShellCommandMmFunc (
   IN SHELL  *Shell,
   IN UINTN   Argc,
@@ -171,8 +171,8 @@ MmRead (
   @retval EFI_SUCCESS
 
 **/
-STATIC
 EFI_STATUS
+EFIAPI
 ShellCommandMmFunc (
   IN SHELL  *Shell,
   IN UINTN   Argc,

--- a/BootloaderCommonPkg/Library/ShellLib/CmdMmcDll.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdMmcDll.c
@@ -25,8 +25,8 @@
   @retval EFI_SUCCESS
 
 **/
-STATIC
 EFI_STATUS
+EFIAPI
 ShellCommandMmcDllFunc (
   IN SHELL  *Shell,
   IN UINTN   Argc,
@@ -86,8 +86,8 @@ GetMmcBaseAddress (
   @retval EFI_SUCCESS
 
 **/
-STATIC
 EFI_STATUS
+EFIAPI
 ShellCommandMmcDllFunc (
   IN SHELL  *Shell,
   IN UINTN   Argc,
@@ -97,7 +97,7 @@ ShellCommandMmcDllFunc (
   EFI_STATUS                Status;
   UINTN                     EmmcHcPciBase;
   EMMC_TUNING_DATA          EmmcTuningData;
-  UINT32                    VariableLen;
+  UINTN                     VariableLen;
 
   if ((Argc < 2) || (Argc > 3)) {
     goto usage;

--- a/BootloaderCommonPkg/Library/ShellLib/Shell.c
+++ b/BootloaderCommonPkg/Library/ShellLib/Shell.c
@@ -596,8 +596,8 @@ FindShellCommand (
   @retval 1                  Buffer1 name is greater than or equal to Buffer2 name.
 
 **/
-STATIC
 INTN
+EFIAPI
 CompareCommandEntry (
   IN CONST VOID                 *Buffer1,
   IN CONST VOID                 *Buffer2

--- a/BootloaderCommonPkg/Library/TpmLib/TpmEventLog.c
+++ b/BootloaderCommonPkg/Library/TpmLib/TpmEventLog.c
@@ -142,7 +142,7 @@ TpmTcgLogInit (
     // @todo UEFI BIOS fills the buffer with 0xFF. If we do this we will have to check for the
     // presence of 0xFFFFFFFF in EventSize to determine the location for new event while updating
     // TCG Event log
-    ZeroMem ((VOID *) ((UINT32)Lasa),  PcdGet32 (PcdTcgLogAreaMinLen));
+    ZeroMem ((VOID *)(UINTN)Lasa,  PcdGet32 (PcdTcgLogAreaMinLen));
     TpmLibSetEventLogData (Lasa, PcdGet32 (PcdTcgLogAreaMinLen));
 
     TpmLibData = TpmLibGetPrivateData ();
@@ -239,7 +239,7 @@ TpmLogSpecIDEvent (
   }
 
   // Create the event in TPM 1.2 format
-  FirstPcrEvent = (TCG_PCR_EVENT_HDR *)Lasa;
+  FirstPcrEvent = (TCG_PCR_EVENT_HDR *)(UINTN)Lasa;
   FirstPcrEvent->PCRIndex = 0;
   FirstPcrEvent->EventType = EV_NO_ACTION;
   ZeroMem (FirstPcrEvent->Digest.digest, sizeof (FirstPcrEvent->Digest));
@@ -330,11 +330,11 @@ TpmLogEvent (
   // Navigate log area to Locate the empty space for new event log
   // Note : First Event is of type TPM 1.2 (TCG_PCR_EVENT_HDR)
 
-  FirstEvent = (TCG_PCR_EVENT_HDR *) (Lasa);
+  FirstEvent = (TCG_PCR_EVENT_HDR *)(UINTN)Lasa;
   EmptySlot  = (TCG_PCR_EVENT2_HDR *)
                ((UINT8 *)FirstEvent + sizeof (TCG_PCR_EVENT_HDR) + FirstEvent->EventSize);
 
-  while (EmptySlot < (TCG_PCR_EVENT2_HDR *) (Lasa + Laml - 1)) {
+  while (EmptySlot < (TCG_PCR_EVENT2_HDR *)(UINTN)(Lasa + Laml - 1)) {
     EventSize = GetCompressedTCGEventSize (EmptySlot);
     if (EventSize == 0) {
       break;
@@ -346,7 +346,7 @@ TpmLogEvent (
   // Before adding new event, check if there is enough space available.
   EventSize = GetUnCompressedTCGEventSize (EventHdr);
 
-  if ( ((UINT8*)EmptySlot + EventSize) <= (UINT8*)(Lasa + Laml - 1)) {
+  if (((UINT8 *)EmptySlot + EventSize) <= (UINT8 *)(UINTN)(Lasa + Laml - 1)) {
     // Add the new event in the TCG 2.0 log area
     AddEventTCGLog ((UINT8 *)EmptySlot, EventHdr, EventData);
   } else {

--- a/BootloaderCommonPkg/Library/UfsBlockIoLib/UfsHci.c
+++ b/BootloaderCommonPkg/Library/UfsBlockIoLib/UfsHci.c
@@ -1114,6 +1114,7 @@ Exit:
 
 **/
 EFI_STATUS
+EFIAPI
 UfsExecScsiCmds (
   IN     UFS_PEIM_HC_PRIVATE_DATA      *Private,
   IN     UINT8                         Lun,

--- a/BootloaderCommonPkg/Library/UfsBlockIoLib/UfsInternal.h
+++ b/BootloaderCommonPkg/Library/UfsBlockIoLib/UfsInternal.h
@@ -190,6 +190,7 @@ typedef struct _UFS_DEVICE_MANAGEMENT_REQUEST_PACKET {
 
 **/
 EFI_STATUS
+EFIAPI
 UfsExecScsiCmds (
   IN     UFS_PEIM_HC_PRIVATE_DATA      *Private,
   IN     UINT8                         Lun,

--- a/BootloaderCommonPkg/Library/UfsBlockIoLib/UfsPciHc.h
+++ b/BootloaderCommonPkg/Library/UfsBlockIoLib/UfsPciHc.h
@@ -39,13 +39,12 @@ typedef struct {
 
 **/
 EFI_STATUS
+EFIAPI
 GetUfsHcMmioBar (
   IN     UFS_HC_PEI_PRIVATE_DATA      *Private,
   IN     UINT8                         ControllerId,
   OUT UINTN                         *MmioBar
   );
-
-
 
 /**
   The user code starts with this function.

--- a/BootloaderCorePkg/Include/Library/BoardInitLib.h
+++ b/BootloaderCorePkg/Include/Library/BoardInitLib.h
@@ -28,6 +28,7 @@
 
 **/
 VOID
+EFIAPI
 BoardInit (
   IN  BOARD_INIT_PHASE  InitPhase
   );
@@ -38,6 +39,7 @@ BoardInit (
   @param  FspUpdPtr            The pointer to the FSP-S/FSP-M UPD to be updated.
 **/
 VOID
+EFIAPI
 UpdateFspConfig (
   VOID     *FspUpdPtr
   );
@@ -46,6 +48,7 @@ UpdateFspConfig (
   Disable watch dog timer (Halt TCO timer).
 **/
 VOID
+EFIAPI
 DisableWatchDogTimer (
   VOID
   );
@@ -54,6 +57,7 @@ DisableWatchDogTimer (
   Enables the execution by writing to the MSR.
 **/
 VOID
+EFIAPI
 EnableCodeExecution (
   VOID
   );
@@ -99,6 +103,7 @@ SaveNvsData (
 
 **/
 EFI_STATUS
+EFIAPI
 BuildHobHandoffInfoTable (
   IN EFI_BOOT_MODE         BootMode,
   IN EFI_PHYSICAL_ADDRESS  MemoryBegin,
@@ -127,6 +132,7 @@ PlatformUpdateHobInfo (
 
 **/
 EFI_STATUS
+EFIAPI
 PlatformUpdateAcpiTable (
   IN UINT8    *Current
   );

--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -18,8 +18,8 @@
 #define  IS_FLASH_SPACE(x)            (((x) >= PcdGet32 (PcdFlashBaseAddress)) && \
                                       ((x) <= PcdGet32 (PcdFlashBaseAddress) + PcdGet32 (PcdFlashSize) - 1))
 
-#define  GET_STAGE_MODULE_ENTRY(x)    (STAGE_ENTRY) ((STAGE_HDR *)(x))->Entry
-#define  GET_STAGE_MODULE_BASE(x)     (STAGE_ENTRY) ((STAGE_HDR *)(x))->Base
+#define  GET_STAGE_MODULE_ENTRY(x)    (STAGE_ENTRY) (UINTN)((STAGE_HDR *)(UINTN)(x))->Entry
+#define  GET_STAGE_MODULE_BASE(x)     (STAGE_ENTRY) (UINTN)((STAGE_HDR *)(UINTN)(x))->Base
 
 #define  PCD_GET32_WITH_ADJUST(x)     GetAdjustedPcdBase (PcdGet32 (x))
 

--- a/BootloaderCorePkg/Include/Library/FspSupportLib.h
+++ b/BootloaderCorePkg/Include/Library/FspSupportLib.h
@@ -9,7 +9,7 @@
 #define __FSP_SUPPORT_LIB_H__
 
 typedef VOID \
-(*MEM_RES_HOB_CALLBACK) (EFI_HOB_RESOURCE_DESCRIPTOR *ResourceDescriptor, VOID *Param);
+(EFIAPI *MEM_RES_HOB_CALLBACK) (EFI_HOB_RESOURCE_DESCRIPTOR *ResourceDescriptor, VOID *Param);
 
 /**
   This function retrieves FSP Non-volatile Storage HOB buffer and size.
@@ -22,6 +22,7 @@ typedef VOID \
 
 **/
 VOID *
+EFIAPI
 GetFspNvsDataBuffer (
   CONST VOID             *HobListPtr,
   UINT32                 *Length
@@ -38,6 +39,7 @@ GetFspNvsDataBuffer (
 
 **/
 UINT64
+EFIAPI
 GetFspReservedMemoryFromGuid (
   CONST VOID     *HobListPtr,
   UINT64         *Length,

--- a/BootloaderCorePkg/Include/Library/SocInitLib.h
+++ b/BootloaderCorePkg/Include/Library/SocInitLib.h
@@ -11,6 +11,7 @@
   Enables the execution by writing to the MSR.
 **/
 VOID
+EFIAPI
 EnableCodeExecution (
   VOID
   );
@@ -19,6 +20,7 @@ EnableCodeExecution (
   Disable watch dog timer (Halt TCO timer).
 **/
 VOID
+EFIAPI
 DisableWatchDogTimer (
   VOID
   );

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiFpdt.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiFpdt.c
@@ -106,8 +106,8 @@ GetFpdtS3Table (
   UINT8                                        Index;
   BOOT_PERFORMANCE_TABLE                       *BootTable;
 
-  Rsdp = (EFI_ACPI_5_0_ROOT_SYSTEM_DESCRIPTION_POINTER *) AcpiTableBase;
-  Rsdt = (EFI_ACPI_DESCRIPTION_HEADER *) (UINTN) Rsdp->RsdtAddress;
+  Rsdp = (EFI_ACPI_5_0_ROOT_SYSTEM_DESCRIPTION_POINTER *)(UINTN)AcpiTableBase;
+  Rsdt = (EFI_ACPI_DESCRIPTION_HEADER *)(UINTN)Rsdp->RsdtAddress;
 
   NumEntries = (Rsdt->Length - sizeof(EFI_ACPI_DESCRIPTION_HEADER)) / sizeof(UINT32);
   RsdtEntry  = (UINT32 *) ((UINT8 *)Rsdt + sizeof (EFI_ACPI_DESCRIPTION_HEADER));

--- a/BootloaderCorePkg/Library/DebugDataLib/DebugDataLib.c
+++ b/BootloaderCorePkg/Library/DebugDataLib/DebugDataLib.c
@@ -59,7 +59,7 @@ S3DebugRestoreAndCompareCRC32 (
 
   DEBUG ((DEBUG_INFO, "Checking for unmatched-CRC Regions ...\n"));
   for (CrcRegionIdx = 0; SavedS3CrcTable[CrcRegionIdx].RegionSize != 0x00; CrcRegionIdx++) {
-    CalculateCrc32WithType ((UINT8 *) (VOID *) (SavedS3CrcTable[CrcRegionIdx].RegionBase),
+    CalculateCrc32WithType ((UINT8 *)(UINTN) SavedS3CrcTable[CrcRegionIdx].RegionBase,
                     (UINTN) (SavedS3CrcTable[CrcRegionIdx].RegionSize), Crc32TypeCastagnoli, &NewCrcValue);
     if (NewCrcValue != SavedS3CrcTable[CrcRegionIdx].RegionCrc32Value) {
       DEBUG ((DEBUG_INFO, "RegBase=0x%08X  RegLimit=0x%08X  RegSize=0x%08X  SavedS3CrcValue=0x%08X  NewCrcValue=0x%08X\n",
@@ -134,7 +134,7 @@ S3DebugCalculateCRC32 (
                                             S3CrcTable[CrcRegionIdx].RegionBase - 1;
     }
     S3CrcTable[CrcRegionIdx].RegionLimit = S3CrcTable[CrcRegionIdx].RegionBase + S3CrcTable[CrcRegionIdx].RegionSize - 1;
-    CalculateCrc32WithType ((UINT8 *) (VOID *) (S3CrcTable[CrcRegionIdx].RegionBase), (UINTN) (S3CrcTable[CrcRegionIdx].RegionSize),
+    CalculateCrc32WithType ((UINT8 *)(UINTN)S3CrcTable[CrcRegionIdx].RegionBase, (UINTN) (S3CrcTable[CrcRegionIdx].RegionSize),
                     Crc32TypeCastagnoli, & (S3CrcTable[CrcRegionIdx].RegionCrc32Value));
     DEBUG ((DEBUG_INFO, "RegBase=0x%08X RegLimit=0x%08X RegSize=0x%08X  CrcValue=0x%08X\n",
             S3CrcTable[CrcRegionIdx].RegionBase, S3CrcTable[CrcRegionIdx].RegionLimit, S3CrcTable[CrcRegionIdx].RegionSize,

--- a/BootloaderCorePkg/Library/FspApiLib/FspMemoryInit.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspMemoryInit.c
@@ -45,13 +45,13 @@ CallFspMemoryInit (
   FSPM_UPD_COMMON            *FspmUpdCommon;
   EFI_STATUS                  Status;
 
-  FspHeader = (FSP_INFO_HEADER *) (FspmBase + FSP_INFO_HEADER_OFF);
+  FspHeader = (FSP_INFO_HEADER *)(UINTN)(FspmBase + FSP_INFO_HEADER_OFF);
 
   ASSERT (FspHeader->Signature == FSP_INFO_HEADER_SIGNATURE);
   ASSERT (FspHeader->ImageBase == FspmBase);
 
   // Copy default UPD data
-  DefaultMemoryInitUpd = (UINT8 *) (FspHeader->ImageBase + FspHeader->CfgRegionOffset);
+  DefaultMemoryInitUpd = (UINT8 *)(UINTN)(FspHeader->ImageBase + FspHeader->CfgRegionOffset);
   CopyMem (&FspmUpd, DefaultMemoryInitUpd, FspHeader->CfgRegionSize);
 
   /* Update architectural UPD fields */
@@ -63,8 +63,8 @@ CallFspMemoryInit (
   UpdateFspConfig (FspmUpd);
 
   ASSERT (FspHeader->FspMemoryInitEntryOffset != 0);
-  FspMemoryInit = (FSP_MEMORY_INIT) (FspHeader->ImageBase + \
-                                     FspHeader->FspMemoryInitEntryOffset);
+  FspMemoryInit = (FSP_MEMORY_INIT)(UINTN)(FspHeader->ImageBase + \
+                                           FspHeader->FspMemoryInitEntryOffset);
 
   DEBUG ((DEBUG_INFO, "Call FspMemoryInit ... "));
   Status = FspMemoryInit (&FspmUpd, HobList);

--- a/BootloaderCorePkg/Library/FspApiLib/FspMisc.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspMisc.c
@@ -55,7 +55,7 @@ RebaseFspComponent (
 {
   FSP_INFO_HEADER   *FspHeader;
 
-  FspHeader = (FSP_INFO_HEADER *) (PcdGet32 (PcdFSPSBase) + Delta + FSP_INFO_HEADER_OFF);
+  FspHeader = (FSP_INFO_HEADER *)(UINTN)(PcdGet32 (PcdFSPSBase) + Delta + FSP_INFO_HEADER_OFF);
   FspHeader->ImageBase += Delta;
 
   return EFI_SUCCESS;

--- a/BootloaderCorePkg/Library/FspApiLib/FspNotifyPhase.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspNotifyPhase.c
@@ -33,7 +33,7 @@ CallFspNotifyPhase (
   NOTIFY_PHASE_PARAMS         NotifyPhaseParams;
   EFI_STATUS                  Status;
 
-  FspHeader = (FSP_INFO_HEADER *) (PcdGet32 (PcdFSPSBase) + FSP_INFO_HEADER_OFF);
+  FspHeader = (FSP_INFO_HEADER *)(UINTN)(PcdGet32 (PcdFSPSBase) + FSP_INFO_HEADER_OFF);
 
   ASSERT (FspHeader->Signature == FSP_INFO_HEADER_SIGNATURE);
   ASSERT (FspHeader->ImageBase == PcdGet32 (PcdFSPSBase));
@@ -42,8 +42,8 @@ CallFspNotifyPhase (
     return EFI_UNSUPPORTED;
   }
 
-  NotifyPhase = (FSP_NOTIFY_PHASE) (FspHeader->ImageBase +
-                                    FspHeader->NotifyPhaseEntryOffset);
+  NotifyPhase = (FSP_NOTIFY_PHASE)(UINTN)(FspHeader->ImageBase +
+                                          FspHeader->NotifyPhaseEntryOffset);
 
   NotifyPhaseParams.Phase = Phase;
 

--- a/BootloaderCorePkg/Library/FspApiLib/FspSiliconInit.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspSiliconInit.c
@@ -32,21 +32,21 @@ CallFspSiliconInit (
   FSP_SILICON_INIT            FspSiliconInit;
   EFI_STATUS                  Status;
 
-  FspHeader = (FSP_INFO_HEADER *) (PcdGet32 (PcdFSPSBase) + FSP_INFO_HEADER_OFF);
+  FspHeader = (FSP_INFO_HEADER *)(UINTN)(PcdGet32 (PcdFSPSBase) + FSP_INFO_HEADER_OFF);
 
   ASSERT (FspHeader->Signature == FSP_INFO_HEADER_SIGNATURE);
   ASSERT (FspHeader->ImageBase == PcdGet32 (PcdFSPSBase));
 
   // Copy default UPD data
-  DefaultSiliconInitUpd = (UINT8 *) (FspHeader->ImageBase + FspHeader->CfgRegionOffset);
+  DefaultSiliconInitUpd = (UINT8 *)(UINTN)(FspHeader->ImageBase + FspHeader->CfgRegionOffset);
   CopyMem (&FspsUpd, DefaultSiliconInitUpd, FspHeader->CfgRegionSize);
 
   /* Update architectural UPD fields */
   UpdateFspConfig (FspsUpd);
 
   ASSERT (FspHeader->FspSiliconInitEntryOffset != 0);
-  FspSiliconInit = (FSP_SILICON_INIT) (FspHeader->ImageBase + \
-                                       FspHeader->FspSiliconInitEntryOffset);
+  FspSiliconInit = (FSP_SILICON_INIT)(UINTN)(FspHeader->ImageBase + \
+                                             FspHeader->FspSiliconInitEntryOffset);
 
   DEBUG ((DEBUG_INFO, "Call FspSiliconInit ... \n"));
   Status = FspSiliconInit (&FspsUpd);

--- a/BootloaderCorePkg/Library/FspApiLib/FspTempRamExit.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspTempRamExit.c
@@ -37,12 +37,12 @@ CallFspTempRamExit (
   FSP_INFO_HEADER    *FspHeader;
   EFI_STATUS          Status;
 
-  FspHeader = (FSP_INFO_HEADER *) (FspmBase + FSP_INFO_HEADER_OFF);
+  FspHeader = (FSP_INFO_HEADER *)(UINTN)(FspmBase + FSP_INFO_HEADER_OFF);
   if (FspHeader->TempRamExitEntryOffset == 0) {
     return EFI_UNSUPPORTED;
   }
 
-  TempRamExit = (FSP_TEMP_RAM_EXIT) (FspHeader->ImageBase + FspHeader->TempRamExitEntryOffset);
+  TempRamExit = (FSP_TEMP_RAM_EXIT)(UINTN)(FspHeader->ImageBase + FspHeader->TempRamExitEntryOffset);
 
   DEBUG ((DEBUG_INFO, "Call FspTempRamExit ... "));
   Status  = TempRamExit (NULL);

--- a/BootloaderCorePkg/Library/HobBuildLib/HobBuildLib.c
+++ b/BootloaderCorePkg/Library/HobBuildLib/HobBuildLib.c
@@ -130,6 +130,7 @@ InternalPeiCreateHob (
 
 **/
 EFI_STATUS
+EFIAPI
 BuildHobHandoffInfoTable (
   IN EFI_BOOT_MODE         BootMode,
   IN EFI_PHYSICAL_ADDRESS  MemoryBegin,

--- a/BootloaderCorePkg/Library/MemoryAllocationLib/MemoryAllocationLib.c
+++ b/BootloaderCorePkg/Library/MemoryAllocationLib/MemoryAllocationLib.c
@@ -77,7 +77,7 @@ AllocatePool (
   Top -= AllocationSize;
   Top  = ALIGN_DOWN (Top, POOL_MIN_ALIGNMENT);
   InternalUpdateMemPoolTop (Top);
-  return (VOID *)Top;
+  return (VOID *)(UINTN)Top;
 }
 
 /**
@@ -139,7 +139,7 @@ AllocatePages (
   Top  = ALIGN_DOWN (Top, EFI_PAGE_SIZE);
   Top -= Pages * EFI_PAGE_SIZE;
   InternalUpdateMemPoolTop (Top);
-  return (VOID *)Top;
+  return (VOID *)(UINTN)Top;
 }
 
 /**
@@ -183,7 +183,7 @@ AllocateAlignedPages (
   }
   Top  = ALIGN_DOWN (Top, EFI_PAGE_SIZE);
   InternalUpdateMemPoolTop (Top);
-  return (VOID *)Top;
+  return (VOID *)(UINTN)Top;
 }
 
 /**
@@ -211,7 +211,7 @@ AllocateTemporaryMemory (
   Bottom  = ALIGN_UP (Bottom, POOL_MIN_ALIGNMENT);
   NewBottom = Bottom + AllocationSize;
   InternalUpdateMemPoolBottom (NewBottom);
-  return (VOID *)Bottom;
+  return (VOID *)(UINTN)Bottom;
 }
 
 /**
@@ -233,7 +233,7 @@ FreeTemporaryMemory (
   if (Buffer == NULL) {
     LdrGlobal->MemPoolCurrBottom = LdrGlobal->MemPoolStart;
   } else {
-    NewBottom = (UINT32)Buffer;
+    NewBottom = (UINT32)(UINTN)Buffer;
     if (NewBottom < LdrGlobal->MemPoolCurrBottom) {
       InternalUpdateMemPoolBottom (NewBottom);
     }

--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
@@ -798,6 +798,7 @@ PciScanBus (
 
 **/
 INTN
+EFIAPI
 ComparePciBarRes (
   IN CONST VOID                 *Buffer1,
   IN CONST VOID                 *Buffer2

--- a/BootloaderCorePkg/Library/S3SaveRestoreLib/S3SaveRestore.c
+++ b/BootloaderCorePkg/Library/S3SaveRestoreLib/S3SaveRestore.c
@@ -61,7 +61,7 @@ AppendS3Info (
   BL_PLD_COMM_HDR   *CommHdr;
 
   PlatformUpdateHobInfo (&gSmmInformationGuid, &LdrSmmInfo);
-  SmmBase = (UINT8 *) LdrSmmInfo.SmmBase;
+  SmmBase = (UINT8 *)(UINTN)LdrSmmInfo.SmmBase;
   if (LdrSmmInfo.Flags & SMM_FLAGS_4KB_COMMUNICATION) {
     SmmSize = SIZE_4KB;
   } else {
@@ -105,7 +105,7 @@ FindS3Info (
   BL_PLD_COMM_HDR   *CommHdr;
 
   PlatformUpdateHobInfo (&gSmmInformationGuid, &LdrSmmInfo);
-  SmmBase = (UINT8 *) LdrSmmInfo.SmmBase;
+  SmmBase = (UINT8 *)(UINTN)LdrSmmInfo.SmmBase;
   if (LdrSmmInfo.Flags & SMM_FLAGS_4KB_COMMUNICATION) {
     SmmSize = SIZE_4KB;
   } else {

--- a/BootloaderCorePkg/Library/SmbiosInitLib/SmbiosInitLib.c
+++ b/BootloaderCorePkg/Library/SmbiosInitLib/SmbiosInitLib.c
@@ -37,7 +37,7 @@ CheckSmbiosOverflow (
 {
   SMBIOS_TABLE_ENTRY_POINT      *SmbiosEntry;
 
-  SmbiosEntry = (SMBIOS_TABLE_ENTRY_POINT *) PcdGet32 (PcdSmbiosTablesBase);
+  SmbiosEntry = (SMBIOS_TABLE_ENTRY_POINT *)(UINTN)PcdGet32 (PcdSmbiosTablesBase);
   if (SmbiosEntry == NULL) {
     return EFI_DEVICE_ERROR;
   }
@@ -68,14 +68,14 @@ FindSmbiosType (
   SMBIOS_TABLE_ENTRY_POINT      *SmbiosEntry;
   UINT8                         *StringPtr;
 
-  SmbiosEntry = (SMBIOS_TABLE_ENTRY_POINT *) PcdGet32 (PcdSmbiosTablesBase);
+  SmbiosEntry = (SMBIOS_TABLE_ENTRY_POINT *)(UINTN)PcdGet32 (PcdSmbiosTablesBase);
   if (SmbiosEntry == NULL) {
     return NULL;
   }
 
-  TypeHdr = (SMBIOS_STRUCTURE *)(SmbiosEntry->TableAddress);
+  TypeHdr = (SMBIOS_STRUCTURE *)(UINTN)SmbiosEntry->TableAddress;
   for (; TypeHdr->Type != SMBIOS_TYPE_END_OF_TABLE;) {
-    if ( (UINT32)TypeHdr > (PcdGet32 (PcdSmbiosTablesBase) + (UINT32)PcdGet16 (PcdSmbiosTablesSize)) ) {
+    if ( (UINT32)(UINTN)TypeHdr > (PcdGet32 (PcdSmbiosTablesBase) + (UINT32)PcdGet16 (PcdSmbiosTablesSize)) ) {
       return NULL;
     }
     if (TypeHdr->Type == Type) {
@@ -117,7 +117,7 @@ FinalizeSmbios (
   EFI_STATUS                    Status;
   SMBIOS_TABLE_ENTRY_POINT      *SmbiosEntry;
 
-  SmbiosEntry = (SMBIOS_TABLE_ENTRY_POINT *) PcdGet32 (PcdSmbiosTablesBase);
+  SmbiosEntry = (SMBIOS_TABLE_ENTRY_POINT *)(UINTN)PcdGet32 (PcdSmbiosTablesBase);
   if (SmbiosEntry == NULL) {
     return EFI_DEVICE_ERROR;
   }
@@ -133,7 +133,7 @@ FinalizeSmbios (
   //
   // Create Type127 and update global Type127 for the next append
   //
-  Type127 = (SMBIOS_TABLE_TYPE127 *) (SmbiosEntry->TableAddress + SmbiosEntry->TableLength);
+  Type127 = (SMBIOS_TABLE_TYPE127 *)(UINTN)(SmbiosEntry->TableAddress + SmbiosEntry->TableLength);
   Type127->Hdr.Type = SMBIOS_TYPE_END_OF_TABLE;
   Type127->Hdr.Length = sizeof (SMBIOS_STRUCTURE);
   mType127Ptr = (VOID *) Type127;
@@ -183,7 +183,7 @@ AppendSmbiosType (
   EFI_STATUS                  Status;
   SMBIOS_STRUCTURE            *TypeHdr;
 
-  SmbiosEntry = (SMBIOS_TABLE_ENTRY_POINT *) PcdGet32 (PcdSmbiosTablesBase);
+  SmbiosEntry = (SMBIOS_TABLE_ENTRY_POINT *)(UINTN)PcdGet32 (PcdSmbiosTablesBase);
   if (SmbiosEntry == NULL || mType127Ptr == NULL || TypeLength > SMBIOS_TABLE_MAX_LENGTH) {
     return EFI_DEVICE_ERROR;
   }
@@ -242,7 +242,7 @@ GetSmbiosString (
   SMBIOS_TYPE_STRINGS       *SmbiosStrings;
   UINT16                    Index;
 
-  SmbiosStrings = (SMBIOS_TYPE_STRINGS *) PcdGet32 (PcdSmbiosStringsPtr);
+  SmbiosStrings = (SMBIOS_TYPE_STRINGS *)(UINTN)PcdGet32 (PcdSmbiosStringsPtr);
   if (SmbiosStrings == NULL) {
     return "Unknown";
   }
@@ -312,7 +312,7 @@ AddSmbiosType (
   UINT8                         StrIdx;
   UINT8                         NumStr;
 
-  SmbiosEntry = (SMBIOS_TABLE_ENTRY_POINT *) PcdGet32 (PcdSmbiosTablesBase);
+  SmbiosEntry = (SMBIOS_TABLE_ENTRY_POINT *)(UINTN)PcdGet32 (PcdSmbiosTablesBase);
 
   //
   // Prepare type info
@@ -400,7 +400,7 @@ SmbiosInit (
   //
   // Create Entry Point structure
   //
-  SmbiosEntryPoint = (SMBIOS_TABLE_ENTRY_POINT *) PcdGet32 (PcdSmbiosTablesBase);
+  SmbiosEntryPoint = (SMBIOS_TABLE_ENTRY_POINT *)(UINTN)PcdGet32 (PcdSmbiosTablesBase);
   if (SmbiosEntryPoint == NULL) {
     DEBUG ((DEBUG_INFO, "Memory not allocated for SMBIOS tables"));
     return EFI_DEVICE_ERROR;
@@ -413,7 +413,7 @@ SmbiosInit (
   SmbiosEntryPoint->TableLength                               = 0;
   *((UINT32 *)&(SmbiosEntryPoint->IntermediateAnchorString))  = SIGNATURE_32('_', 'D', 'M', 'I');
   SmbiosEntryPoint->IntermediateAnchorString[4]               = '_';
-  SmbiosEntryPoint->TableAddress                              = (UINT32)SmbiosEntryPoint + sizeof (SMBIOS_TABLE_ENTRY_POINT) + sizeof (UINT8);
+  SmbiosEntryPoint->TableAddress                              = (UINT32)(UINTN)SmbiosEntryPoint + sizeof (SMBIOS_TABLE_ENTRY_POINT) + sizeof (UINT8);
 
   //
   // Add common SMBIOS Types' information.

--- a/BootloaderCorePkg/Stage1A/Stage1A.h
+++ b/BootloaderCorePkg/Stage1A/Stage1A.h
@@ -76,7 +76,6 @@ LoadIdt (
 
 **/
 VOID
-EFIAPI
 ContinueFunc (
   IN VOID  *Params
   );

--- a/BootloaderCorePkg/Stage1B/Stage1B.h
+++ b/BootloaderCorePkg/Stage1B/Stage1B.h
@@ -50,6 +50,7 @@
 
 **/
 VOID
+EFIAPI
 ContinueFunc (
   IN      VOID                      *Context1,  OPTIONAL
   IN      VOID                      *Context2   OPTIONAL

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -152,7 +152,7 @@ NormalBootPath (
   LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer();
 
   // Load payload
-  Dst = (UINT32 *)PreparePayload (Stage2Param);
+  Dst = (UINT32 *)(UINTN)PreparePayload (Stage2Param);
   if (Dst == NULL) {
     CpuHalt ("Failed to load payload !");
   }
@@ -168,7 +168,7 @@ NormalBootPath (
   if (Dst[0] == 0x00005A4D) {
     // It is a PE format
     DEBUG ((DEBUG_INFO, "PE32 Format Payload\n"));
-    Status = PeCoffRelocateImage ((UINT32)Dst);
+    Status = PeCoffRelocateImage ((UINT32)(UINTN)Dst);
     if (!EFI_ERROR(Status)) {
       Status = PeCoffLoaderGetEntryPoint (Dst, (VOID *)&PldEntry);
     }
@@ -255,7 +255,7 @@ NormalBootPath (
   DEBUG ((DEBUG_INFO, "Payload entry: 0x%08X\n", PldEntry));
   if (PldEntry != NULL) {
     DEBUG ((DEBUG_INIT, "Jump to payload\n\n"));
-    PldEntry (PldHobList, (VOID *)PldBase);
+    PldEntry (PldHobList, (VOID *)(UINTN)PldBase);
   }
 }
 
@@ -359,7 +359,7 @@ SecStartup (
   Status = PcdSet32S (PcdGraphicsVbtAddress,   PCD_GET32_WITH_ADJUST (PcdGraphicsVbtAddress) + Delta);
   Status = PcdSet32S (PcdSplashLogoAddress,    PCD_GET32_WITH_ADJUST (PcdSplashLogoAddress) + Delta);
 
-  LdrGlobal->LdrHobList = (VOID *)LdrGlobal->MemPoolEnd;
+  LdrGlobal->LdrHobList = (VOID *)(UINTN)LdrGlobal->MemPoolEnd;
   BuildHobHandoffInfoTable (
     BootMode,
     (EFI_PHYSICAL_ADDRESS) (UINTN)LdrGlobal->LdrHobList,
@@ -453,7 +453,7 @@ SecStartup (
 
       S3Data = (S3_DATA *)LdrGlobal->S3DataPtr;
       if (BootMode != BOOT_ON_S3_RESUME) {
-        PlatformUpdateAcpiGnvs ((VOID *)AcpiGnvs);
+        PlatformUpdateAcpiGnvs ((VOID *)(UINTN)AcpiGnvs);
         S3Data->AcpiGnvs = AcpiGnvs;
         S3Data->AcpiBase = AcpiBase;
         DEBUG ((DEBUG_INIT, "ACPI Init\n"));
@@ -480,7 +480,7 @@ SecStartup (
   //
   if (FixedPcdGetBool (PcdSmbiosEnabled)) {
     SmbiosEntry = AllocateZeroPool (PcdGet16(PcdSmbiosTablesSize));
-    Status = PcdSet32S (PcdSmbiosTablesBase, (UINT32)SmbiosEntry);
+    Status = PcdSet32S (PcdSmbiosTablesBase, (UINT32)(UINTN)SmbiosEntry);
     Status = SmbiosInit ();
     if (EFI_ERROR(Status)) {
       DEBUG ((DEBUG_INFO, "SMBIOS init Status = %r\n", Status));

--- a/BootloaderCorePkg/Stage2/Stage2.h
+++ b/BootloaderCorePkg/Stage2/Stage2.h
@@ -160,6 +160,7 @@ InitializeService (
 
 **/
 VOID
+EFIAPI
 BoardNotifyPhase (
   IN BOARD_INIT_PHASE   Phase
   );

--- a/BootloaderCorePkg/Stage2/Stage2Support.c
+++ b/BootloaderCorePkg/Stage2/Stage2Support.c
@@ -24,6 +24,7 @@ const PLATFORM_SERVICE   mPlatformService = {
 
 **/
 VOID
+EFIAPI
 BoardNotifyPhase (
   IN BOARD_INIT_PHASE   Phase
   )
@@ -98,7 +99,7 @@ DisplaySplash (
 
   // Convert image from BMP format and write to frame buffer
   GopBlt = NULL;
-  SplashLogoBmp = (VOID *) PCD_GET32_WITH_ADJUST (PcdSplashLogoAddress);
+  SplashLogoBmp = (VOID *)(UINTN)PCD_GET32_WITH_ADJUST (PcdSplashLogoAddress);
   ASSERT (SplashLogoBmp != NULL);
   Status = DisplayBmpToFrameBuffer (SplashLogoBmp, (VOID **)&GopBlt, &GopBltSize, GfxInfoHob);
 
@@ -165,8 +166,8 @@ MemResHobCallback (
   @retval 1                  Buffer1 base is greater than or equal to Buffer2 base.
 
 **/
-STATIC
 INTN
+EFIAPI
 CompareMemoryMap (
   IN CONST VOID                 *Buffer1,
   IN CONST VOID                 *Buffer2

--- a/PayloadPkg/FirmwareUpdate/CsmeFwUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/CsmeFwUpdate.c
@@ -454,9 +454,9 @@ UpdateCsme (
     return Status;
   }
 
-  DriverPtr = (UINT32 *)((UINT32)CsmeDriverImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER));
+  DriverPtr = (UINT32 *)((UINTN)CsmeDriverImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER));
 
-  Status = PeCoffRelocateImage ((UINT32)DriverPtr);
+  Status = PeCoffRelocateImage ((UINT32)(UINTN)DriverPtr);
   if (EFI_ERROR(Status)) {
     DEBUG((DEBUG_ERROR, "Relocate CSME Update driver failed with status = %r\n", Status));
     return Status;
@@ -484,7 +484,7 @@ UpdateCsme (
   DEBUG((DEBUG_ERROR, "--------------------CSME FW Update START ---------------\n"));
   DEBUG((DEBUG_ERROR, "--------------------------------------------------------\n"));
 
-  DriverPtr = (UINT32 *)((UINT32)ImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER));
+  DriverPtr = (UINT32 *)((UINTN)ImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER));
 
   Status = StartCsmeUpdate((VOID *)DriverPtr, ImageHdr->UpdateImageSize, CsmeUpdateApi);
 

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -49,11 +49,11 @@ GetVersionfromFv (
   EFI_FFS_FILE_HEADER         *FfsFile;
   EFI_FIRMWARE_VOLUME_HEADER  *FvHeader;
 
-  FvHeader = (EFI_FIRMWARE_VOLUME_HEADER *)(*Stage1ABase);
+  FvHeader = (EFI_FIRMWARE_VOLUME_HEADER *)(UINTN)(*Stage1ABase);
   //
   // Stage 1A FD has FSPT FV first, so move on to the next FV
   //
-  FvHeader = (EFI_FIRMWARE_VOLUME_HEADER *)((UINT32)FvHeader + (UINT32)FvHeader->FvLength);
+  FvHeader = (EFI_FIRMWARE_VOLUME_HEADER *)((UINTN)FvHeader + (UINTN)FvHeader->FvLength);
 
   //
   // Get version info FFS from FV
@@ -748,7 +748,7 @@ ProcessCapsule (
     FwUpdCompStatus[Count].UpdatePending = FW_UPDATE_IMAGE_UPDATE_PENDING;
 
     ImgHeader = (EFI_FW_MGMT_CAP_IMAGE_HEADER *)((UINTN)ImgHeader + ImgHeader->UpdateImageSize + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER));
-    if ((UINT32)ImgHeader > (UINTN)((UINTN)CapHeader + FwUpdHeader->ImageSize)) {
+    if ((UINTN)ImgHeader > ((UINTN)CapHeader + FwUpdHeader->ImageSize)) {
       return EFI_NOT_FOUND;
     }
   }

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.c
@@ -429,7 +429,7 @@ UpdateContainerComp (
   //
   // Update the component
   //
-  ContainerHdr = (CONTAINER_HDR *)ContainerEntryPtr->HeaderCache;
+  ContainerHdr = (CONTAINER_HDR *)(UINTN)ContainerEntryPtr->HeaderCache;
   //
   // Component base = Container base + data offset from container base + offset of component inside container
   //

--- a/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
+++ b/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
@@ -254,7 +254,7 @@ LoadCapsuleImage (
   // If we do not have file system, try reading capsule from raw partition
   //
   if (CapsuleInfo->FsType >= EnumFileSystemMax) {
-    Status = GetCapsuleFromRawPartition (CapsuleInfo, HwPartHandle, CapsuleImage, CapsuleImageSize);
+    Status = GetCapsuleFromRawPartition (CapsuleInfo, HwPartHandle, CapsuleImage, (UINTN *)CapsuleImageSize);
     return Status;
   }
 
@@ -291,7 +291,7 @@ LoadCapsuleImage (
       goto Done;
     }
 
-    Status = GetFileSize (FileHandle, CapsuleImageSize);
+    Status = GetFileSize (FileHandle, (UINTN *)CapsuleImageSize);
     if (EFI_ERROR(Status)) {
       DEBUG((DEBUG_ERROR, " Get Capsule File '%s' size Status : %r\n", FileName, Status));
       goto Done;
@@ -303,7 +303,7 @@ LoadCapsuleImage (
       goto Done;
     }
 
-    Status = ReadFile (FileHandle, CapsuleImage, CapsuleImageSize);
+    Status = ReadFile (FileHandle, CapsuleImage, (UINTN *)CapsuleImageSize);
     if (EFI_ERROR(Status)) {
       DEBUG((DEBUG_ERROR, " Read Capsule File '%s' Status : %r\n", FileName, Status));
       goto Done;

--- a/PayloadPkg/Library/PayloadLib/PayloadLib.c
+++ b/PayloadPkg/Library/PayloadLib/PayloadLib.c
@@ -33,7 +33,7 @@ GetHobListPtr (
 {
   VOID                  *HobList;
 
-  HobList = (VOID *)PcdGet32 (PcdPayloadHobList);
+  HobList = (VOID *)(UINTN)PcdGet32 (PcdPayloadHobList);
   ASSERT (HobList != NULL);
 
   return HobList;
@@ -53,7 +53,7 @@ GetFlashMapPtr (
   FLASH_MAP             *FlashMap;
   EFI_HOB_GUID_TYPE     *GuidHob;
 
-  GuidHob = GetNextGuidHob (&gFlashMapInfoGuid, (VOID *)PcdGet32 (PcdPayloadHobList));
+  GuidHob = GetNextGuidHob (&gFlashMapInfoGuid, (VOID *)(UINTN)PcdGet32 (PcdPayloadHobList));
   if (GuidHob == NULL) {
     return NULL;
   }
@@ -80,7 +80,7 @@ GetPerfDataPtr (
 {
   PAYLOAD_GLOBAL_DATA     *PayloadGlobalDataPtr;
 
-  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *) PcdGet32 (PcdGlobalDataAddress);
+  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *)(UINTN)PcdGet32 (PcdGlobalDataAddress);
 
   return &PayloadGlobalDataPtr->PerfData;
 }
@@ -97,7 +97,7 @@ GetConfigDataPtr (
 {
   PAYLOAD_GLOBAL_DATA     *PayloadGlobalDataPtr;
 
-  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *) PcdGet32 (PcdGlobalDataAddress);
+  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *)(UINTN)PcdGet32 (PcdGlobalDataAddress);
 
   return PayloadGlobalDataPtr->CfgDataPtr;
 }
@@ -136,7 +136,7 @@ GetDebugLogBufferPtr (
 {
   PAYLOAD_GLOBAL_DATA     *PayloadGlobalDataPtr;
 
-  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *) PcdGet32 (PcdGlobalDataAddress);
+  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *)(UINTN)PcdGet32 (PcdGlobalDataAddress);
 
   return PayloadGlobalDataPtr->LogBufPtr;
 }
@@ -155,7 +155,7 @@ GetLibraryDataPtr (
 {
   PAYLOAD_GLOBAL_DATA     *PayloadGlobalDataPtr;
 
-  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *) PcdGet32 (PcdGlobalDataAddress);
+  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *)(UINTN)PcdGet32 (PcdGlobalDataAddress);
 
   return PayloadGlobalDataPtr->LibDataPtr;
 }
@@ -174,7 +174,7 @@ GetServiceListPtr (
 {
   PAYLOAD_GLOBAL_DATA     *PayloadGlobalDataPtr;
 
-  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *) PcdGet32 (PcdGlobalDataAddress);
+  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *)(UINTN)PcdGet32 (PcdGlobalDataAddress);
 
   return PayloadGlobalDataPtr->ServiceList;
 }
@@ -193,7 +193,7 @@ GetFeatureCfg (
 {
   PAYLOAD_GLOBAL_DATA     *PayloadGlobalDataPtr;
 
-  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *) PcdGet32 (PcdGlobalDataAddress);
+  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *)(UINTN)PcdGet32 (PcdGlobalDataAddress);
 
   return PayloadGlobalDataPtr->LdrFeatures;
 }
@@ -212,7 +212,7 @@ GetPcdDataPtr (
 {
   PAYLOAD_GLOBAL_DATA     *PayloadGlobalDataPtr;
 
-  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *) PcdGet32 (PcdGlobalDataAddress);
+  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *)(UINTN)PcdGet32 (PcdGlobalDataAddress);
 
   return PayloadGlobalDataPtr->PcdDataPtr;
 }
@@ -231,7 +231,7 @@ GetCurrentBootPartition (
   EFI_HOB_GUID_TYPE     *GuidHob;
   LOADER_PLATFORM_INFO  *LoaderPlatformInfo;
 
-  GuidHob = GetNextGuidHob (&gLoaderPlatformInfoGuid, (VOID *)PcdGet32 (PcdPayloadHobList));
+  GuidHob = GetNextGuidHob (&gLoaderPlatformInfoGuid, (VOID *)(UINTN)PcdGet32 (PcdPayloadHobList));
   if (GuidHob == NULL) {
     return 1;
   }
@@ -270,7 +270,7 @@ SetDeviceTable (
 {
   PAYLOAD_GLOBAL_DATA     *PayloadGlobalDataPtr;
 
-  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *) PcdGet32 (PcdGlobalDataAddress);
+  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *)(UINTN)PcdGet32 (PcdGlobalDataAddress);
 
   PayloadGlobalDataPtr->DeviceTable = DeviceTable;
 }
@@ -289,7 +289,7 @@ GetDeviceTable (
 {
   PAYLOAD_GLOBAL_DATA     *PayloadGlobalDataPtr;
 
-  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *) PcdGet32 (PcdGlobalDataAddress);
+  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *)(UINTN)PcdGet32 (PcdGlobalDataAddress);
 
   return PayloadGlobalDataPtr->DeviceTable;
 }
@@ -308,7 +308,7 @@ GetContainerListPtr (
 {
   PAYLOAD_GLOBAL_DATA     *PayloadGlobalDataPtr;
 
-  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *)PcdGet32 (PcdGlobalDataAddress);
+  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *)(UINTN)PcdGet32 (PcdGlobalDataAddress);
 
   return PayloadGlobalDataPtr->ContainerList;
 }
@@ -327,7 +327,7 @@ GetHashStorePtr (
 {
   PAYLOAD_GLOBAL_DATA     *PayloadGlobalDataPtr;
 
-  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *)PcdGet32 (PcdGlobalDataAddress);
+  PayloadGlobalDataPtr = (PAYLOAD_GLOBAL_DATA *)(UINTN)PcdGet32 (PcdGlobalDataAddress);
 
   return PayloadGlobalDataPtr->HashStorePtr;
 }

--- a/PayloadPkg/Library/PayloadSupportLib/PayloadSupportLib.c
+++ b/PayloadPkg/Library/PayloadSupportLib/PayloadSupportLib.c
@@ -30,7 +30,7 @@ GetSystemTableInfo (
 {
   EFI_HOB_GUID_TYPE             *GuidHob;
 
-  GuidHob = GetNextGuidHob (&gLoaderSystemTableInfoGuid, (VOID *)PcdGet32 (PcdPayloadHobList));
+  GuidHob = GetNextGuidHob (&gLoaderSystemTableInfoGuid, (VOID *)(UINTN)PcdGet32 (PcdPayloadHobList));
   if (GuidHob == NULL) {
     ASSERT (GuidHob);
     return NULL;
@@ -56,7 +56,7 @@ GetLoaderPlatformInfoPtr (
   LOADER_PLATFORM_INFO  *LoaderInfo;
   EFI_HOB_GUID_TYPE     *GuidHob;
 
-  GuidHob = GetNextGuidHob (&gLoaderPlatformInfoGuid, (VOID *)PcdGet32 (PcdPayloadHobList));
+  GuidHob = GetNextGuidHob (&gLoaderPlatformInfoGuid, (VOID *)(UINTN)PcdGet32 (PcdPayloadHobList));
   if (GuidHob == NULL) {
     return NULL;
   }
@@ -96,6 +96,9 @@ ParseAcpiTableInfo (
     Xsdt = NULL;
   }
   ASSERT (Xsdt != NULL);
+  if (Xsdt == NULL) {
+    return;
+  }
 
   Fadt = NULL;
   Mcfg = NULL;
@@ -138,7 +141,7 @@ GetMemoryMapInfo (
 {
   EFI_HOB_GUID_TYPE             *GuidHob;
 
-  GuidHob = GetNextGuidHob (&gLoaderMemoryMapInfoGuid, (VOID *)PcdGet32 (PcdPayloadHobList));
+  GuidHob = GetNextGuidHob (&gLoaderMemoryMapInfoGuid, (VOID *)(UINTN)PcdGet32 (PcdPayloadHobList));
   if (GuidHob == NULL) {
     ASSERT (GuidHob);
     return NULL;
@@ -278,7 +281,7 @@ GetLoaderPerformanceInfo (
   EFI_HOB_GUID_TYPE             *GuidHob;
   PERFORMANCE_INFO              *PerfInfo;
 
-  GuidHob = GetNextGuidHob (&gLoaderPerformanceInfoGuid, (VOID *)PcdGet32 (PcdPayloadHobList));
+  GuidHob = GetNextGuidHob (&gLoaderPerformanceInfoGuid, (VOID *)(UINTN)PcdGet32 (PcdPayloadHobList));
   if (GuidHob == NULL) {
     return RETURN_NOT_FOUND;
   }

--- a/PayloadPkg/Library/TrustyBootLib/TrustyBootLib.c
+++ b/PayloadPkg/Library/TrustyBootLib/TrustyBootLib.c
@@ -130,9 +130,9 @@ GetVmmBootParam (
   ReserveMemUnder1Mb (BootOsMbi, KB_ (8));
 
   // 64KB, SBL should reserve it in e820
-  VmmBootParam->HeapAddr = (UINT32) VmmImageData->VmmHeapAddr.Addr;
+  VmmBootParam->HeapAddr = (UINT32)(UINTN)VmmImageData->VmmHeapAddr.Addr;
   // 4MB, SBL should reserve it in e820
-  VmmBootParam->VmmRuntimeAddr = (UINT32) VmmImageData->VmmRuntimeAddr.Addr;
+  VmmBootParam->VmmRuntimeAddr = (UINT32)(UINTN)VmmImageData->VmmRuntimeAddr.Addr;
 
   return EFI_SUCCESS;
 }

--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -152,8 +152,8 @@ UpdateLoadedImage (
         CopyMem (&MultiBoot->MbModuleData[ModuleIndex].ImgFile, &File[Index + 1], sizeof (IMAGE_DATA));
 
         MultiBoot->MbModule[ModuleIndex].String = (UINT8 *) MultiBoot->MbModuleData[ModuleIndex].CmdFile.Addr;
-        MultiBoot->MbModule[ModuleIndex].Start  = (UINT32) MultiBoot->MbModuleData[ModuleIndex].ImgFile.Addr;
-        MultiBoot->MbModule[ModuleIndex].End    = (UINT32) MultiBoot->MbModuleData[ModuleIndex].ImgFile.Addr
+        MultiBoot->MbModule[ModuleIndex].Start  = (UINT32)(UINTN)MultiBoot->MbModuleData[ModuleIndex].ImgFile.Addr;
+        MultiBoot->MbModule[ModuleIndex].End    = (UINT32)(UINTN)MultiBoot->MbModuleData[ModuleIndex].ImgFile.Addr
           + MultiBoot->MbModuleData[ModuleIndex].ImgFile.Size;
 
         ModuleIndex++;
@@ -198,7 +198,7 @@ ParseContainerImage (
     return EFI_UNSUPPORTED;
   }
 
-  Status = RegisterContainer ((UINT32) ContainerHdr, LoadComponentCallback);
+  Status = RegisterContainer ((UINT32)(UINTN)ContainerHdr, LoadComponentCallback);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_INFO, "Image given is not a valid CONTAINER image\n"));
     return EFI_LOAD_ERROR;
@@ -383,27 +383,27 @@ SetupBootImage (
         DEBUG ((DEBUG_INFO, "and Image is Multiboot format\n"));
         SetupMultibootInfo (MultiBoot);
       }
-      MultiBoot->BootState.EntryPoint = (UINT32)EntryPoint;
+      MultiBoot->BootState.EntryPoint = (UINT32)(UINTN)EntryPoint;
     }
   } else if (IsMultiboot (BootFile->Addr)) {
     DEBUG ((DEBUG_INFO, "Boot image is Multiboot format...\n"));
     Status = SetupMultibootImage (MultiBoot);
   } else if ((LoadedImage->Flags & LOADED_IMAGE_PE32) != 0) {
     DEBUG ((DEBUG_INFO, "Boot image is PE32 format\n"));
-    Status = PeCoffRelocateImage ((UINT32)BootFile->Addr);
+    Status = PeCoffRelocateImage ((UINT32)(UINTN)BootFile->Addr);
     if (!EFI_ERROR (Status)) {
       Status = PeCoffLoaderGetEntryPoint (BootFile->Addr, (VOID **)&EntryPoint);
     }
     if (!EFI_ERROR (Status)) {
       // Reuse MultiBoot structure to store the PE32 entry point information
-      MultiBoot->BootState.EntryPoint = (UINT32)EntryPoint;
+      MultiBoot->BootState.EntryPoint = (UINT32)(UINTN)EntryPoint;
     }
   } else if ((LoadedImage->Flags & LOADED_IMAGE_FV) != 0) {
     DEBUG ((DEBUG_INFO, "Boot image is FV format\n"));
     Status = LoadFvImage ((UINT32 *)BootFile->Addr, BootFile->Size, (VOID **)&EntryPoint);
     if (!EFI_ERROR (Status)) {
       // Reuse MultiBoot structure to store the FV entry point information
-      MultiBoot->BootState.EntryPoint = (UINT32)EntryPoint;
+      MultiBoot->BootState.EntryPoint = (UINT32)(UINTN)EntryPoint;
     }
   } else {
     DEBUG ((DEBUG_INFO, "Assume BzImage...\n"));
@@ -591,8 +591,8 @@ StartBooting (
     // Use switch stack to ensure stack will be rolled back to original point.
     //
     SwitchStack (
-      (SWITCH_STACK_ENTRY_POINT)MultiBoot->BootState.EntryPoint,
-      (VOID *)PcdGet32 (PcdPayloadHobList),
+      (SWITCH_STACK_ENTRY_POINT)(UINTN)MultiBoot->BootState.EntryPoint,
+      (VOID *)(UINTN)PcdGet32 (PcdPayloadHobList),
       NULL,
       (VOID *)((UINT8 *)mEntryStack + 8)
       );

--- a/PayloadPkg/OsLoader/PreOsChecker.c
+++ b/PayloadPkg/OsLoader/PreOsChecker.c
@@ -134,10 +134,10 @@ StartPreOsChecker (
 
   PreOsParams.Version     = 0x1;
   PreOsParams.HeapSize    = EFI_SIZE_TO_PAGES (0);
-  PreOsParams.HeapAddr    = (UINT32) AllocatePages (PreOsParams.HeapSize);
+  PreOsParams.HeapAddr    = (UINT32)(UINTN)AllocatePages (PreOsParams.HeapSize);
   PreOsParams.HobListPtr  = PcdGet32 (PcdPayloadHobList);
 
-  PreOsParams.OsBootState.Esi     = (UINT32) OsBootParam;
+  PreOsParams.OsBootState.Esi     = (UINT32)(UINTN)OsBootParam;
   PreOsParams.OsBootState.Eip     = OsBootParam->Hdr.Code32Start;
   PreOsParams.OsBootState.Eflags  = 0;
 

--- a/Platform/ApollolakeBoardPkg/Library/IocIpcLib/IocIpcLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/IocIpcLib/IocIpcLib.c
@@ -97,8 +97,8 @@ UartWriteReg (
   @retval Others            The operation fails.
 
 **/
-STATIC
 EFI_STATUS
+EFIAPI
 IpcResetUart (
   IN  IOC_IPC_DEVICE    *IpcDevice
   )
@@ -123,8 +123,8 @@ IpcResetUart (
   @retval Others            The operation fails.
 
 **/
-STATIC
 EFI_STATUS
+EFIAPI
 IpcInitUart (
   IN IOC_IPC_DEVICE   *IpcDevice
   )
@@ -162,8 +162,8 @@ IpcInitUart (
   @retval Others            The operation fails.
 
 **/
-STATIC
 EFI_STATUS
+EFIAPI
 IpcSendUart (
   IN  IOC_IPC_DEVICE  *IpcDevice,
   IN  UINT8           Ch
@@ -194,8 +194,8 @@ IpcSendUart (
   @retval Others            The operation fails.
 
 **/
-STATIC
 EFI_STATUS
+EFIAPI
 IpcReceiveUart (
   IN  IOC_IPC_DEVICE    *IpcDevice,
   OUT CHAR8             *Buffer,

--- a/Platform/ApollolakeBoardPkg/Library/LoaderLib/LoaderLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/LoaderLib/LoaderLib.c
@@ -123,8 +123,8 @@ LoadStage1B (
     RingIdx = (UINT8) (ChunkIndex % NumberOfChunks);
     if ((State & (1 << RingIdx)) != 0) {
       /* Calculate the source and destionation address in ring buffer */
-      Src = (UINT8 *) (SramBase + ChunkSize * RingIdx);
-      Dst = (UINT8 *) (IbbDst  + ChunkSize * ChunkIndex);
+      Src = (UINT8 *)(UINTN)(SramBase + ChunkSize * RingIdx);
+      Dst = (UINT8 *)(UINTN)(IbbDst  + ChunkSize * ChunkIndex);
 
       if (IbbSizeLeft < ChunkSize) {
         Size = IbbSizeLeft;
@@ -133,7 +133,7 @@ LoadStage1B (
       }
 
       /* Move data from SRAM into temporary memory */
-      if ((UINT32)Src >= SRAM_REMAPPING) {
+      if ((UINT32)(UINTN)Src >= SRAM_REMAPPING) {
         AsmFlushCacheRange (Src, Size);
       }
       CopyMem (Dst, Src, Size);
@@ -197,7 +197,7 @@ LoadStage2 (
   }
 
   ImageSize = Size;
-  Hdr = (LOADER_COMPRESSED_HEADER *)Src;
+  Hdr = (LOADER_COMPRESSED_HEADER *)(UINTN)Src;
   if ((Hdr == NULL) || (ImageSize == 0)) {
     return EFI_NOT_FOUND;
   }
@@ -207,7 +207,7 @@ LoadStage2 (
   }
 
   if (Src != Dst) {
-    CopyMem ((VOID *)Dst, (VOID *)Src, ImageSize);
+    CopyMem ((VOID *)(UINTN)Dst, (VOID *)(UINTN)Src, ImageSize);
   }
 
   return EFI_SUCCESS;
@@ -236,7 +236,7 @@ LoadPayload (
   UINT32                          ActualSize;
   LOADER_COMPRESSED_HEADER       *Hdr;
 
-  Hdr = (LOADER_COMPRESSED_HEADER *)Src;
+  Hdr = (LOADER_COMPRESSED_HEADER *)(UINTN)Src;
   if (IS_COMPRESSED (Hdr)) {
     ActualSize = sizeof(LOADER_COMPRESSED_HEADER) + Hdr->CompressedSize;
   } else {
@@ -247,7 +247,7 @@ LoadPayload (
     if (Size < ActualSize) {
       return EFI_BUFFER_TOO_SMALL;
     }
-    CopyMem ((VOID *)Dst, (VOID *)Src, ActualSize);
+    CopyMem ((VOID *)(UINTN)Dst, (VOID *)(UINTN)Src, ActualSize);
   }
 
   return EFI_SUCCESS;

--- a/Platform/ApollolakeBoardPkg/Library/ShellExtensionLib/CmdCse.c
+++ b/Platform/ApollolakeBoardPkg/Library/ShellExtensionLib/CmdCse.c
@@ -21,6 +21,7 @@
 
 **/
 EFI_STATUS
+EFIAPI
 ShellCommandCseFunc (
   IN SHELL                  *Shell,
   IN UINTN                  Argc,

--- a/Platform/ApollolakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
@@ -71,6 +71,7 @@ EarlyPlatformDataCheck (
 
 **/
 VOID
+EFIAPI
 BoardInit (
   IN  BOARD_INIT_PHASE  InitPhase
   )

--- a/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -511,6 +511,7 @@ SetDebugLevelFromCfgData (
 
 **/
 VOID
+EFIAPI
 UpdateFspConfig (
   VOID     *FspmUpdPtr
   )
@@ -612,7 +613,7 @@ UpdateFspConfig (
   // The NVS buffer will be loaded to PcdStage1BLoadBase FindNvsData()
   // The PcdStage1BLoadBase is not used any more after Stage1B is loaded, so reuse it to save CAR space.
   //
-  Fspmcfg->VariableNvsBufferPtr      = (VOID *)PcdGet32 (PcdStage1BLoadBase);
+  Fspmcfg->VariableNvsBufferPtr      = (VOID *)(UINTN)PcdGet32 (PcdStage1BLoadBase);
 
   //
   // This will be done by configuration data
@@ -1701,6 +1702,7 @@ PlatformFeaturesInit (
 
 **/
 VOID
+EFIAPI
 BoardInit (
   IN  BOARD_INIT_PHASE  InitPhase
   )
@@ -1815,7 +1817,7 @@ FindNvsData (
 
   // Reuse Stage1B loading base as buffer for decompression
   // All MRC NVS data should be less than 64KB
-  MrcVarData   = (VOID *)PcdGet32 (PcdStage1BLoadBase);
+  MrcVarData   = (VOID *)(UINTN)PcdGet32 (PcdStage1BLoadBase);
   MrcParamData = (UINT8 *)MrcVarData + SIZE_1KB;
   MemPool      = (UINT8 *)MrcVarData + SIZE_64KB;
 
@@ -1827,7 +1829,7 @@ FindNvsData (
       break;
     }
 
-    CopyMem (&MrcParamHdr,  (UINT8 *)MrcDataBase + MrcParamsOffset, sizeof (MRC_PARAM_HDR));
+    CopyMem (&MrcParamHdr,  (UINT8 *)(UINTN)MrcDataBase + MrcParamsOffset, sizeof (MRC_PARAM_HDR));
     if (MrcParamHdr.Signature != MRC_PARAM_SIGNATURE) {
       Status = EFI_NOT_FOUND;
       break;
@@ -1837,14 +1839,14 @@ FindNvsData (
     DataSize       = MrcParamHdr.Length - sizeof (MRC_PARAM_HDR);
 
     DEBUG ((DEBUG_INFO, "Read MRC ParamData at 0x%X\n", MrcDataBase + MrcParamsOffset));
-    CopyMem (CompressedData, (UINT8 *)MrcDataBase + MrcParamsOffset + sizeof (MRC_PARAM_HDR), DataSize);
+    CopyMem (CompressedData, (UINT8 *)(UINTN)MrcDataBase + MrcParamsOffset + sizeof (MRC_PARAM_HDR), DataSize);
 
     DEBUG ((DEBUG_INFO, "Decompress ParamData\n"));
     DataSize = RleDecompressData (CompressedData, DataSize, MrcParamData);
 
     DEBUG ((DEBUG_INFO, "Read MRC VarData at 0x%X\n", MrcDataBase + MrcNvDataOffset));
     MrcVarHdr = (MRC_VAR_HDR *)MemPool;
-    CopyMem ((UINT8 *)MrcVarHdr, (UINT8 *)MrcDataBase + MrcNvDataOffset,  sizeof (MRC_VAR_HDR));
+    CopyMem ((UINT8 *)MrcVarHdr, (UINT8 *)(UINTN)MrcDataBase + MrcNvDataOffset,  sizeof (MRC_VAR_HDR));
 
     ActIdx = 0xFF;
     if (MrcVarHdr->Signature == MRC_VAR_SIGNATURE) {
@@ -1875,7 +1877,7 @@ FindNvsData (
 
     // Read NV data from the slot
     Offset = MrcNvDataOffset + sizeof (MRC_VAR_HDR) + ActIdx * MRC_VAR_SLOT_LENGTH;
-    CopyMem ((UINT8 *)MrcVarData, (UINT8 *)MrcDataBase + Offset, MRC_VAR_LENGTH);
+    CopyMem ((UINT8 *)MrcVarData, (UINT8 *)(UINTN)MrcDataBase + Offset, MRC_VAR_LENGTH);
 
   } while (EFI_ERROR (Status));
 

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -875,6 +875,7 @@ BuildVtdInfo (
 
 **/
 VOID
+EFIAPI
 BoardInit (
   IN  BOARD_INIT_PHASE    InitPhase
   )
@@ -999,6 +1000,7 @@ BoardInit (
 
 **/
 VOID
+EFIAPI
 UpdateFspConfig (
   VOID     *FspsUpdPtr
   )
@@ -1186,7 +1188,7 @@ UpdateFspConfig (
     FspsConfig->DspEndpointI2sHp          = HdaCfgData->DspEndpointI2sHp;
     FspsConfig->DspFeatureMask            = HdaCfgData->DspFeatureMask;
     FspsConfig->DspPpModuleMask           = HdaCfgData->DspPpModuleMask;
-    FspsConfig->HdaVerbTablePtr           = (UINT32) (&HdaVerbTableAlc662);
+    FspsConfig->HdaVerbTablePtr           = (UINT32)(UINTN)(&HdaVerbTableAlc662);
     FspsConfig->HdaVerbTableEntryNum      = 1;
 
     HdaEndpointBtRender.VirtualBusId      = HdaCfgData->VirtualIdBtRender;
@@ -1388,7 +1390,7 @@ SaveNvsData (
 
     DEBUG ((DEBUG_INFO, "Read MRC VarData at 0x%X\n", MrcDataBase + MrcNvDataOffset));
     MrcVarHdr = (MRC_VAR_HDR *)MemPool;
-    CopyMem ((UINT8 *)MrcVarHdr, (UINT8 *)MrcDataBase + MrcNvDataOffset, sizeof (MRC_VAR_HDR));
+    CopyMem ((UINT8 *)MrcVarHdr, (UINT8 *)(UINTN)MrcDataBase + MrcNvDataOffset, sizeof (MRC_VAR_HDR));
 
     ActIdx = 0xFF;
     if (MrcVarHdr->Signature == MRC_VAR_SIGNATURE) {
@@ -1719,7 +1721,7 @@ UpdateAcpiDsdt (
   for (; Ptr < End; Ptr++) {
     if (!PnvsFound && (*(UINT32 *)Ptr == SIGNATURE_32 ('P', 'N', 'V', 'S')) &&
          (*(Ptr - 1) == AML_EXT_REGION_OP)) {
-      * (UINT32 *) (Ptr + 6)  = (UINT32)&Gnvs->CpuNvs;
+      * (UINT32 *) (Ptr + 6)  = (UINT32)(UINTN)&Gnvs->CpuNvs;
       * (UINT16 *) (Ptr + 11) = (UINT16)sizeof(CPU_NVS_AREA);
       PnvsFound = TRUE;
     }

--- a/Platform/CoffeelakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
@@ -233,6 +233,7 @@ GetBootPartition (
 
 **/
 VOID
+EFIAPI
 BoardInit (
   IN  BOARD_INIT_PHASE  InitPhase
 )

--- a/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -90,6 +90,7 @@ SetDebugLevelFromCfgData (
 
 **/
 VOID
+EFIAPI
 UpdateFspConfig (
   VOID     *FspmUpdPtr
 )
@@ -126,8 +127,8 @@ UpdateFspConfig (
     CopyMem (&Fspmcfg->SpdAddressTable, MemCfgData->SpdAddressTable, sizeof(MemCfgData->SpdAddressTable));
   } else {
     SpdData[0] = 0;
-    SpdData[1] = (UINT32) (((MEM_SPD0_CFG_DATA *)FindConfigDataByTag (CDATA_MEM_SPD0_TAG))->MemorySpdPtr0);
-    SpdData[2] = (UINT32) (((MEM_SPD1_CFG_DATA *)FindConfigDataByTag (CDATA_MEM_SPD1_TAG))->MemorySpdPtr1);
+    SpdData[1] = (UINT32)(UINTN) (((MEM_SPD0_CFG_DATA *)FindConfigDataByTag (CDATA_MEM_SPD0_TAG))->MemorySpdPtr0);
+    SpdData[2] = (UINT32)(UINTN) (((MEM_SPD1_CFG_DATA *)FindConfigDataByTag (CDATA_MEM_SPD1_TAG))->MemorySpdPtr1);
 
     if (PlatformId == PLATFORM_ID_UPXTREME) {
       // For UPX, using BomID to decide SPD data instead.
@@ -606,6 +607,7 @@ EarlyBootDeviceInit (
 
 **/
 VOID
+EFIAPI
 BoardInit (
   IN  BOARD_INIT_PHASE  InitPhase
 )
@@ -683,10 +685,10 @@ FindNvsData (
     return NULL;
   }
 
-  if (*(UINT32 *)MrcData == 0xFFFFFFFF) {
+  if (*(UINT32 *)(UINTN)MrcData == 0xFFFFFFFF) {
     return NULL;
   } else {
-    return (VOID *)MrcData;
+    return (VOID *)(UINTN)MrcData;
   }
 }
 

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -309,8 +309,8 @@ ClearSmi (
   @retval                   Calculated power value in mW
 
 **/
-STATIC
 UINT32
+EFIAPI
 CalculateRelativePower (
   IN  UINT16  BaseRatio,
   IN  UINT16  CurrRatio,
@@ -507,7 +507,7 @@ UpdateBlRsvdRegion ()
     return Status;
   }
 
-  CopyMem (&FwUpdStatus, (VOID *)RsvdBase, sizeof(FW_UPDATE_STATUS));
+  CopyMem (&FwUpdStatus, (VOID *)(UINTN)RsvdBase, sizeof(FW_UPDATE_STATUS));
 
   if (FwUpdStatus.StateMachine == FW_UPDATE_SM_PART_AB) {
     Status = SpiFlashErase (FlashRegionBios, FlashMap->RomSize - (~RsvdBase + 1), RsvdSize);
@@ -949,6 +949,7 @@ BuildVtdInfo (
 
 **/
 VOID
+EFIAPI
 BoardInit (
   IN  BOARD_INIT_PHASE    InitPhase
 )
@@ -1193,6 +1194,7 @@ FindSerialIoIrq (
 
 **/
 VOID
+EFIAPI
 UpdateFspConfig (
   IN  VOID     *FspsUpdPtr
 )
@@ -1728,7 +1730,7 @@ SaveNvsData (
   // Compare input data against the stored MRC training data
   // if they match, no need to update again.
   //
-  if (CompareMem ((VOID *)Address, Buffer, Length) == 0) {
+  if (CompareMem ((VOID *)(UINTN)Address, Buffer, Length) == 0) {
     SetDramInitScratchpad ();
     return EFI_ALREADY_STARTED;
   }

--- a/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.c
+++ b/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.c
@@ -178,7 +178,7 @@ SpiLoadExternalConfigData (
   UINT32       Length;
 
   BlobSize = sizeof(CDATA_BLOB);
-  Buffer   = (UINT8 *)Dst;
+  Buffer   = (UINT8 *)(UINTN)Dst;
   Base     = 0;
 
   CfgDataLoadSrc = PcdGet32 (PcdCfgDataLoadSource);
@@ -198,7 +198,7 @@ SpiLoadExternalConfigData (
   } else if (CfgDataLoadSrc == FlashRegionBios) {
     Status = GetComponentInfo (FLASH_MAP_SIG_CFGDATA, &Base, &Length);
     if (!EFI_ERROR(Status)) {
-      CopyMem (Buffer, (VOID *)Base, BlobSize);
+      CopyMem (Buffer, (VOID *)(UINTN)Base, BlobSize);
     }
   }
   if (EFI_ERROR(Status)) {
@@ -226,7 +226,7 @@ SpiLoadExternalConfigData (
   // Read the full configuration data
   //
   if (Base > 0) {
-    CopyMem (Buffer + BlobSize, (VOID *)(Base + BlobSize), SignedLen - BlobSize);
+    CopyMem (Buffer + BlobSize, (VOID *)(UINTN)(Base + BlobSize), SignedLen - BlobSize);
   }
 
   return Status;
@@ -258,7 +258,7 @@ CheckStateMachine (
       DEBUG((DEBUG_ERROR, "Could not get component information for bootloader reserved region\n"));
       return Status;
     }
-    pFwUpdStatus = (FW_UPDATE_STATUS *)RsvdBase;
+    pFwUpdStatus = (FW_UPDATE_STATUS *)(UINTN)RsvdBase;
   }
 
   //

--- a/Platform/CommonBoardPkg/Library/LoaderLib/LoaderLib.c
+++ b/Platform/CommonBoardPkg/Library/LoaderLib/LoaderLib.c
@@ -33,7 +33,7 @@ LoadStage1B (
   )
 {
   if (Dst != Src) {
-    CopyMem ((VOID *)Dst, (VOID *)Src, Len);
+    CopyMem ((VOID *)(UINTN)Dst, (VOID *)(UINTN)Src, Len);
   }
   return EFI_SUCCESS;
 }
@@ -58,7 +58,7 @@ LoadStage2 (
   )
 {
   if (Dst != Src) {
-    CopyMem ((VOID *)Dst, (VOID *)Src, Len);
+    CopyMem ((VOID *)(UINTN)Dst, (VOID *)(UINTN)Src, Len);
   }
   return EFI_SUCCESS;
 }
@@ -88,7 +88,7 @@ LoadPayload (
   UINT32                          ActualSize;
   LOADER_COMPRESSED_HEADER       *Hdr;
 
-  Hdr = (LOADER_COMPRESSED_HEADER *)Src;
+  Hdr = (LOADER_COMPRESSED_HEADER *)(UINTN)Src;
   if (IS_COMPRESSED (Hdr)) {
     ActualSize = sizeof(LOADER_COMPRESSED_HEADER) + Hdr->CompressedSize;
   } else {
@@ -99,7 +99,7 @@ LoadPayload (
     if (Size < ActualSize) {
       return EFI_BUFFER_TOO_SMALL;
     }
-    CopyMem ((VOID *)Dst, (VOID *)Src, ActualSize);
+    CopyMem ((VOID *)(UINTN)Dst, (VOID *)(UINTN)Src, ActualSize);
   }
 
   return EFI_SUCCESS;

--- a/Platform/QemuBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
@@ -39,6 +39,7 @@ FSPT_UPD TempRamInitParams = {
 
 **/
 VOID
+EFIAPI
 BoardInit (
   IN  BOARD_INIT_PHASE  InitPhase
 )

--- a/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -179,6 +179,7 @@ VOID BoardDetection (
 
 **/
 VOID
+EFIAPI
 BoardInit (
   IN  BOARD_INIT_PHASE  InitPhase
 )
@@ -233,10 +234,10 @@ FindNvsData (
     return NULL;
   }
 
-  if (*(UINT32 *)MrcData == 0xFFFFFFFF) {
+  if (*(UINT32 *)(UINTN)MrcData == 0xFFFFFFFF) {
     return NULL;
   } else {
-    return (VOID *)MrcData;
+    return (VOID *)(UINTN)MrcData;
   }
 }
 

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -44,16 +44,19 @@ typedef struct {
 } GRAPHICS_DATA;
 
 UINT8
+EFIAPI
 GetSerialPortStrideSize (
   VOID
 );
 
 UINT32
+EFIAPI
 GetSerialPortBase (
   VOID
   );
 
 VOID
+EFIAPI
 EnableLegacyRegions (
   VOID
 );
@@ -125,7 +128,7 @@ LocateVbtByImageId (
   UINT32          VbtAddr;
   UINTN           Idx;
 
-  VbtMbHdr = (VBT_MB_HDR* )PcdGet32 (PcdGraphicsVbtAddress);
+  VbtMbHdr = (VBT_MB_HDR* )(UINTN)PcdGet32 (PcdGraphicsVbtAddress);
   if ((VbtMbHdr == NULL) || (VbtMbHdr->Signature != MVBT_SIGNATURE)) {
     return 0;
   }
@@ -134,7 +137,7 @@ LocateVbtByImageId (
   VbtEntry = (VBT_ENTRY_HDR *)&VbtMbHdr[1];
   for (Idx = 0; Idx < VbtMbHdr->EntryNum; Idx++) {
     if (VbtEntry->ImageId == ImageId) {
-      VbtAddr = (UINT32)VbtEntry->Data;
+      VbtAddr = (UINT32)(UINTN)VbtEntry->Data;
       break;
     }
     VbtEntry = (VBT_ENTRY_HDR *)((UINT8 *)VbtEntry + VbtEntry->Length);
@@ -229,6 +232,7 @@ GpioInit (
 
 **/
 VOID
+EFIAPI
 BoardInit (
   IN  BOARD_INIT_PHASE    InitPhase
 )

--- a/Silicon/ApollolakePkg/Library/BootGuardLib20/BootGuardLibrary.c
+++ b/Silicon/ApollolakePkg/Library/BootGuardLib20/BootGuardLibrary.c
@@ -116,7 +116,7 @@ FetchPreRBPData(
     // IBB hash will be populated by TXE after RBP. Just cache the IBB hash location here.
     FitData = FindFitEntryData (  FIT_TABLE_TYPE_TXE_SECURE_BOOT,   FIT_ENTRY_SUB_TYPE_IBB_HASH  );
     if (FitData != NULL) {
-      BtGuardInfo->IbbHash.HashPtr = (UINT32)FitData;
+      BtGuardInfo->IbbHash.HashPtr = (UINT32)(UINTN)FitData;
       DEBUG ((DEBUG_INFO, "IBB Hash: 0x%08x\n", BtGuardInfo->IbbHash.HashPtr));
     }
   }
@@ -138,7 +138,7 @@ FetchPostRBPData(
   UINT8 IbbHash[SHA256_DIGEST_SIZE];
 
   if ((BtGuardInfo->Bpm.Mb) && (BtGuardInfo->IbbHash.HashPtr != 0)) {
-    CopyMem (IbbHash, (VOID*)(BtGuardInfo->IbbHash.HashPtr), sizeof (IbbHash));
+    CopyMem (IbbHash, (VOID*)(UINTN)(BtGuardInfo->IbbHash.HashPtr), sizeof (IbbHash));
     CopyMem (BtGuardInfo->IbbHash.Hash, IbbHash, sizeof (BtGuardInfo->IbbHash));
 
     DEBUG ((DEBUG_INFO, "IBB Hash: 0x%08x\n", BtGuardInfo->IbbHash.Hash));

--- a/Silicon/ApollolakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/ApollolakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -247,7 +247,7 @@ PlatformGetStage1AOffset (
     for (Index = 0; Index < MaxEntries; Index++) {
       EntryDesc = FlashMapPtr->EntryDesc[Index];
       if (EntryDesc.Signature == FLASH_MAP_SIG_STAGE1A) {
-        *Base  = (UINT32)(Ptr + EntryDesc.Offset);
+        *Base  = (UINT32)(UINTN)(Ptr + EntryDesc.Offset);
         *Size  = EntryDesc.Size;
         Status = EFI_SUCCESS;
         break;

--- a/Silicon/ApollolakePkg/Library/HeciLib/HeciLib.c
+++ b/Silicon/ApollolakePkg/Library/HeciLib/HeciLib.c
@@ -126,7 +126,7 @@ WaitForCseReady (
 )
 {
   MicroSecondDelay (1);
-  volatile CseControlRegister *CseControlReg = (volatile CseControlRegister*)(*((UINT32*)Arg) + SEC_CSR_HA);
+  volatile CseControlRegister *CseControlReg = (volatile CseControlRegister*)(UINTN)(*((UINT32*)Arg) + SEC_CSR_HA);
   return (CseControlReg->r.SecRdyHra == 0 ? EFI_NOT_READY : EFI_SUCCESS);
 }
 
@@ -147,7 +147,7 @@ WaitForCseToHostInterrupt (
 )
 {
   MicroSecondDelay (1);
-  volatile HostControlRegister *HostControlReg = (volatile HostControlRegister*)(*((UINT32*)Arg) + H_CSR);
+  volatile HostControlRegister *HostControlReg = (volatile HostControlRegister*)(UINTN)(*((UINT32*)Arg) + H_CSR);
   return (HostControlReg->r.His == 0 ? EFI_NOT_READY : EFI_SUCCESS);
 }
 
@@ -168,7 +168,7 @@ WaitForCseRegCbrpCbwp (
 )
 {
   MicroSecondDelay (1);
-  volatile CseControlRegister *CseControlReg = (volatile CseControlRegister*)(*((UINT32*)Arg) + SEC_CSR_HA);
+  volatile CseControlRegister *CseControlReg = (volatile CseControlRegister*)(UINTN)(*((UINT32*)Arg) + SEC_CSR_HA);
   return (CseControlReg->r.SecCbrpHra == CseControlReg->r.SecCbwpHra ? EFI_NOT_READY : EFI_SUCCESS);
 }
 
@@ -188,7 +188,7 @@ WaitForResetStarted (
 )
 {
   MicroSecondDelay (1);
-  volatile HostControlRegister *HostControlReg = (volatile HostControlRegister*)(*((UINT32*)Arg) + H_CSR);
+  volatile HostControlRegister *HostControlReg = (volatile HostControlRegister*)(UINTN)(*((UINT32*)Arg) + H_CSR);
   return (HostControlReg->r.Hrdy == 1 ? EFI_NOT_READY : EFI_SUCCESS);
 }
 
@@ -204,7 +204,7 @@ WaitForResetStarted (
 STATIC
 EFI_STATUS
 HeciGetSecMode (
-  UINTN *SecMode
+  UINT32 *SecMode
 )
 {
   HECI_FWS_REGISTER SeCFirmwareStatus;
@@ -343,9 +343,9 @@ HeciSend (
   volatile CseControlRegister *CseControlReg;
 
   DEBUG ((DEBUG_VERBOSE, "Start HeciSend\n"));
-  HostControlReg = (volatile HostControlRegister *) (HeciBar + H_CSR);
-  CseControlReg = (volatile CseControlRegister *) (HeciBar + SEC_CSR_HA);
-  WriteBuffer = (UINT32*) (HeciBar + H_CB_WW);
+  HostControlReg = (volatile HostControlRegister *)(UINTN)(HeciBar + H_CSR);
+  CseControlReg = (volatile CseControlRegister *)(UINTN)(HeciBar + SEC_CSR_HA);
+  WriteBuffer = (UINT32*)(UINTN)(HeciBar + H_CB_WW);
   MessageBody = (UINT32*) Message;
 
   MaxBuffer = HostControlReg->r.Hcbd;
@@ -451,9 +451,9 @@ HeciReceive (
 
   DEBUG ((DEBUG_VERBOSE, "Start HeciReceive\n"));
 
-  HostControlReg = (volatile HostControlRegister*) (HeciBar + H_CSR);
+  HostControlReg = (volatile HostControlRegister*)(UINTN)(HeciBar + H_CSR);
 
-  ReadBuffer = (UINT32*) (HeciBar + SEC_CB_RW);
+  ReadBuffer = (UINT32*)(UINTN)(HeciBar + SEC_CB_RW);
   MessageBody = (UINT32*) Message;
   while (1) {
     DEBUG ((DEBUG_VERBOSE, "Waiting for CSE notify, HostControlReg: %08x\n", HostControlReg->Data));
@@ -666,7 +666,7 @@ CheckCseResetAndIssueHeciReset (
   volatile CseControlRegister *SecControlReg;
 
   *ResetStatus = FALSE;
-  SecControlReg = (volatile CseControlRegister *) (HeciBar + SEC_CSR_HA);
+  SecControlReg = (volatile CseControlRegister *)(UINTN)(HeciBar + SEC_CSR_HA);
   if (SecControlReg->r.SecRstHra == 1) {
     DEBUG ((DEBUG_INFO, "CSE IS IN RESET - executing HECI interface reset procedure\n"));
 

--- a/Silicon/ApollolakePkg/Library/PsdLib/PsdLib.c
+++ b/Silicon/ApollolakePkg/Library/PsdLib/PsdLib.c
@@ -157,7 +157,7 @@ GetIbbHashDataFromBpm (
   }
   DEBUG ((DEBUG_INFO, "SubPartitoinPayload BpmBase=0x%p, size=0x%x\n", BpmBase, BpmSize));
 
-  BpmData = (BPMDATA*)(BpmBase);
+  BpmData = (BPMDATA*)(UINTN)BpmBase;
   //IBBL Hash
   if(BpmData->IbblHash == NULL) {
     return RETURN_BUFFER_TOO_SMALL;

--- a/Silicon/ApollolakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
+++ b/Silicon/ApollolakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
@@ -14,6 +14,7 @@
   Disable watch dog timer (Halt TCO timer).
 **/
 VOID
+EFIAPI
 DisableWatchDogTimer (
   VOID
 )
@@ -28,6 +29,7 @@ DisableWatchDogTimer (
   Enables the execution by writing to the MSR.
 **/
 VOID
+EFIAPI
 EnableCodeExecution (
   VOID
 )

--- a/Silicon/CoffeelakePkg/Library/BootGuardLib/BootGuardTpmEventLogLib.c
+++ b/Silicon/CoffeelakePkg/Library/BootGuardLib/BootGuardTpmEventLogLib.c
@@ -543,7 +543,7 @@ CreateIbbHash (
   if (Sha256Init (&HashCtx,  sizeof (HASH_CTX)) == RETURN_SUCCESS) {
     for (Index = 0; Index < BpmIbb->SegmentCount; Index++) {
       if (BpmIbb->IbbSegment[Index].Flags == IBB_SEGMENT_FLAG_IBB) {
-        Sha256Update (&HashCtx, (VOID *)BpmIbb->IbbSegment[Index].Base, BpmIbb->IbbSegment[Index].Size);
+        Sha256Update (&HashCtx, (VOID *)(UINTN)BpmIbb->IbbSegment[Index].Base, BpmIbb->IbbSegment[Index].Size);
       }
     }
 

--- a/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -133,17 +133,17 @@ InitCsmeUpdInputData (
 
   CsmeUpdDriverInput = (CSME_UPDATE_DRIVER_INPUT *)AllocateZeroPool (sizeof(CSME_UPDATE_DRIVER_INPUT));
 
-  CsmeUpdDriverInput->AllocatePool     = (VOID *)((UINT32)AllocatePool);
-  CsmeUpdDriverInput->AllocateZeroPool = (VOID *)((UINT32)AllocateZeroPool);
-  CsmeUpdDriverInput->FreePool         = (VOID *)((UINT32)FreePool);
-  CsmeUpdDriverInput->CopyMem          = (VOID *)((UINT32)CopyMem);
-  CsmeUpdDriverInput->SetMem           = (VOID *)((UINT32)SetMem);
-  CsmeUpdDriverInput->CompareMem       = (VOID *)((UINT32)CompareMem);
-  CsmeUpdDriverInput->Stall            = (VOID *)((UINT32)MicroSecondDelay);
-  CsmeUpdDriverInput->PciRead          = (VOID *)((UINT32)PciReadBuffer);
-  CsmeUpdDriverInput->HeciReadMessage  = (VOID *)((UINT32)HeciReceive);
-  CsmeUpdDriverInput->HeciSendMessage  = (VOID *)((UINT32)HeciSend);
-  CsmeUpdDriverInput->HeciReset        = (VOID *)((UINT32)ResetHeciInterface);
+  CsmeUpdDriverInput->AllocatePool     = (VOID *)((UINTN)AllocatePool);
+  CsmeUpdDriverInput->AllocateZeroPool = (VOID *)((UINTN)AllocateZeroPool);
+  CsmeUpdDriverInput->FreePool         = (VOID *)((UINTN)FreePool);
+  CsmeUpdDriverInput->CopyMem          = (VOID *)((UINTN)CopyMem);
+  CsmeUpdDriverInput->SetMem           = (VOID *)((UINTN)SetMem);
+  CsmeUpdDriverInput->CompareMem       = (VOID *)((UINTN)CompareMem);
+  CsmeUpdDriverInput->Stall            = (VOID *)((UINTN)MicroSecondDelay);
+  CsmeUpdDriverInput->PciRead          = (VOID *)((UINTN)PciReadBuffer);
+  CsmeUpdDriverInput->HeciReadMessage  = (VOID *)((UINTN)HeciReceive);
+  CsmeUpdDriverInput->HeciSendMessage  = (VOID *)((UINTN)HeciSend);
+  CsmeUpdDriverInput->HeciReset        = (VOID *)((UINTN)ResetHeciInterface);
 
   return CsmeUpdDriverInput;
 }
@@ -406,7 +406,7 @@ GetFirmwareUpdateInfo (
       UpdateRegion                  = &UpdatePartition->FwRegion[2];
       UpdateRegion->ToUpdateAddress = NonRedundantRegionOffset;
       UpdateRegion->UpdateSize      = NonRedundantRegionSize;
-      UpdateRegion->SourceAddress   = (UINT8 *)((UINT32)ImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER) + NonRedundantRegionOffset);
+      UpdateRegion->SourceAddress   = (UINT8 *)((UINTN)ImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER) + NonRedundantRegionOffset);
       UpdatePartition->RegionCount += 1;
     }
   }

--- a/Silicon/CommonSocPkg/Include/Library/SpiFlashLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/SpiFlashLib.h
@@ -80,6 +80,7 @@ SpiFlashWrite (
   @exception EFI_UNSUPPORTED      The SC is not supported by this module
 **/
 EFI_STATUS
+EFIAPI
 SpiConstructor (
   VOID
   );

--- a/Silicon/CommonSocPkg/Library/VtdPmrLib/IntelVtdPmr.c
+++ b/Silicon/CommonSocPkg/Library/VtdPmrLib/IntelVtdPmr.c
@@ -454,7 +454,7 @@ SetDmaProtection (
   if (Enable) {
     MemTop   = GetUsableMemoryTop ();
     MemTop   = ALIGN_UP (MemTop, PcdGet32 (PcdDmaBufferAlignment));
-    DmaStart = (UINT32)GetDmaBufferPtr ();
+    DmaStart = (UINT32)(UINTN)GetDmaBufferPtr ();
     DmaEnd   = DmaStart + ALIGN_UP (PcdGet32 (PcdDmaBufferSize), PcdGet32 (PcdDmaBufferAlignment));
     Status = SetDmaProtectedRange (VtdInfo, VTD_ENGINE_ALL, 0, DmaStart, DmaEnd, MemTop - DmaEnd);
   } else {

--- a/Silicon/QemuSocPkg/Library/PlatformHookLib/PlatformHookLib.c
+++ b/Silicon/QemuSocPkg/Library/PlatformHookLib/PlatformHookLib.c
@@ -17,6 +17,7 @@
 
 **/
 UINT8
+EFIAPI
 GetSerialPortStrideSize (
   VOID
 )
@@ -31,6 +32,7 @@ GetSerialPortStrideSize (
 
 **/
 UINT32
+EFIAPI
 GetSerialPortBase (
   VOID
   )

--- a/Silicon/QemuSocPkg/Library/SpiFlashLib/SpiFlashLib.c
+++ b/Silicon/QemuSocPkg/Library/SpiFlashLib/SpiFlashLib.c
@@ -80,7 +80,7 @@ QemuFlashPtr (
   IN        UINTN                               Offset
   )
 {
-  return (UINT8 *)PcdGet32 (PcdFlashBaseAddress) + ((UINTN)Lba * PcdGet32 (PcdFlashBlockSize)) + Offset;
+  return (UINT8 *)(UINTN)PcdGet32 (PcdFlashBaseAddress) + ((UINTN)Lba * PcdGet32 (PcdFlashBlockSize)) + Offset;
 }
 
 /**
@@ -282,7 +282,7 @@ SpiFlashRead (
   }
 
   Status = EFI_SUCCESS;
-  CopyMem (Buffer, (VOID *)(Address + SpiInstance->StoreBase), ByteCount);
+  CopyMem (Buffer, (VOID *)(UINTN)(Address + SpiInstance->StoreBase), ByteCount);
 
   return Status;
 }
@@ -335,7 +335,7 @@ SpiFlashWrite (
   }
 
   Status = EFI_SUCCESS;
-  Ptr = (volatile UINT8 *)(Address + SpiInstance->StoreBase);
+  Ptr = (volatile UINT8 *)(UINTN)(Address + SpiInstance->StoreBase);
   for (Idx = 0; Idx < ByteCount; Idx++) {
     if (ByteCount < 0x1000) {
       *Ptr = READ_ARRAY_CMD;
@@ -398,7 +398,7 @@ SpiFlashErase (
     return EFI_INVALID_PARAMETER;
   }
 
-  Ptr = (volatile UINT8 *)(Address + SpiInstance->StoreBase);
+  Ptr = (volatile UINT8 *)(UINTN)(Address + SpiInstance->StoreBase);
 
   for (Offset = 0; Offset < ByteCount; Offset += 0x1000) {
     *Ptr = BLOCK_ERASE_CMD;

--- a/Silicon/QemuSocPkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
+++ b/Silicon/QemuSocPkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
@@ -12,6 +12,7 @@
   Disable watch dog timer (Halt TCO timer).
 **/
 VOID
+EFIAPI
 DisableWatchDogTimer (
   VOID
 )
@@ -22,6 +23,7 @@ DisableWatchDogTimer (
   Enables the execution by writing to the MSR.
 **/
 VOID
+EFIAPI
 EnableCodeExecution (
   VOID
 )

--- a/Silicon/QemuSocPkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/QemuSocPkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -15,6 +15,7 @@
   Enables the execution by writing to the MSR.
 **/
 VOID
+EFIAPI
 EnableCodeExecution (
   VOID
 )

--- a/Silicon/QemuSocPkg/Library/Stage2SocInitLib/Stage2SocInitLib.c
+++ b/Silicon/QemuSocPkg/Library/Stage2SocInitLib/Stage2SocInitLib.c
@@ -47,6 +47,7 @@ SocUpdateAcpiGnvs (
 }
 
 VOID
+EFIAPI
 EnableLegacyRegions (
   VOID
 )


### PR DESCRIPTION
This patch allows both 32/64-bit addressing properly.
- Pointer type cast with UINTN
- Add missing EFIAPI for APIs

Signed-off-by: Aiden Park <aiden.park@intel.com>