### PR TITLE
Add support for 64bit compiling map file

### DIFF
--- a/BootloaderCorePkg/Tools/PatchFv.py
+++ b/BootloaderCorePkg/Tools/PatchFv.py
@@ -425,8 +425,8 @@ class Symbols:
             prefix = '_'
         else:
             #MSFT
-            #0003:00000190       _gComBase                  00007a50     SerialPo
-            patchMapFileMatchString =  "^\s[0-9a-fA-F]{4}:[0-9a-fA-F]{8}\s+(\w+)\s+([0-9a-fA-F]{8}\s+)"
+            #0003:00000190       _gComBase                     00007a50     SerialPort
+            patchMapFileMatchString =  "^\s[0-9a-fA-F]{4}:[0-9a-fA-F]{8}\s+(\w+)\s+([0-9a-fA-F]{8,16})\s+"
             matchKeyGroupIndex = 1
             matchSymbolGroupIndex  = 2
             prefix = ''
@@ -434,7 +434,10 @@ class Symbols:
         for reportLine in reportLines:
             match = re.match(patchMapFileMatchString, reportLine)
             if match is not None:
-                modSymbols[prefix + match.group(matchKeyGroupIndex)] = match.group(matchSymbolGroupIndex)
+                if prefix == '' and len(match.group(matchSymbolGroupIndex)) > 8:
+                    prefix = '_'
+                keyname = '%s' % (prefix + match.group(matchKeyGroupIndex))
+                modSymbols[keyname] = match.group(matchSymbolGroupIndex)
 
         # Handle extra module patchable PCD variable in Linux map since it might have different format
         # .data._gPcd_BinaryPatch_PcdVpdBaseAddress


### PR DESCRIPTION
This patch enhanced the map format parsing for map files generated
by x64 MSFT compiler.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>