### PR TITLE
Enable QEMU Stage1A boot in X64 mode

### DIFF
--- a/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
+++ b/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
@@ -17,6 +17,8 @@
 #include <Library/BaseLib.h>
 #include <Library/CryptoLib.h>
 
+#define  IS_X64                       (sizeof(UINT64) == sizeof(UINTN))
+
 #define  STACK_DEBUG_FILL_PATTERN     0x5AA55AA5
 #define  UEFI_PAYLOAD_ID_SIGNATURE    SIGNATURE_32('U', 'E', 'F', 'I')
 #define  LINX_PAYLOAD_ID_SIGNATURE    SIGNATURE_32('L', 'I', 'N', 'X')

--- a/BootloaderCommonPkg/Include/Library/PagingLib.h
+++ b/BootloaderCommonPkg/Include/Library/PagingLib.h
@@ -219,4 +219,13 @@ IsLongModeSupported (
   VOID
   );
 
+/**
+  This function create and load 4GB identical mapping paging table.
+**/
+VOID
+EFIAPI
+LoadPageTable (
+  VOID
+  );
+
 #endif

--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
@@ -700,6 +700,7 @@ LoadComponentWithCallback (
   UINT8                     AuthType;
   UINT32                    DecompressedLen;
   UINT32                    CompLen;
+  UINT32                    CompLoc;
   UINT32                    AllocLen;
   UINT32                    SignedDataLen;
   UINT32                    DstLen;
@@ -714,12 +715,11 @@ LoadComponentWithCallback (
     // Check if it is component type
     Usage        =  1 << ContainerSig;
     ContainerSig = 0;
-
-    Status = GetComponentInfo (ComponentName, (UINT32 *)&CompData,  &CompLen);
+    Status = GetComponentInfo (ComponentName, &CompLoc, &CompLen);
     if (EFI_ERROR (Status)) {
       return EFI_NOT_FOUND;
     }
-
+    CompData = (VOID *)(UINTN)CompLoc;
     if (FeaturePcdGet (PcdVerifiedBootEnabled)) {
       if(FixedPcdGet8(PcdCompSignHashAlg) == HASH_TYPE_SHA256) {
         AuthType = AUTH_TYPE_SHA2_256;

--- a/BootloaderCommonPkg/Library/LinuxLib/LinuxLib.c
+++ b/BootloaderCommonPkg/Library/LinuxLib/LinuxLib.c
@@ -347,6 +347,15 @@ LinuxBoot (
       } else {
         JumpToKernel ((VOID *)KernelStart, Bp);
       }
+    } else {
+      if ((Bp->Hdr.XloadFlags & BIT0) == BIT0) {
+        DEBUG ((DEBUG_INFO, "Jump to 64-bit kernel entrypoint ...\n"));
+        KernelStart += 0x200;
+        JumpToKernel ((VOID *)KernelStart, Bp);
+      } else {
+        // In long mode already, but kernel is not 64-bit
+        DEBUG ((DEBUG_ERROR, "Unsupported kernel mode !\n"));
+      }
     }
   }
   CpuDeadLoop ();

--- a/BootloaderCommonPkg/Library/LinuxLib/X64/JumpToKernel.nasm
+++ b/BootloaderCommonPkg/Library/LinuxLib/X64/JumpToKernel.nasm
@@ -18,7 +18,9 @@
 ;------------------------------------------------------------------------------
 global ASM_PFX(JumpToKernel)
 ASM_PFX(JumpToKernel):
-    hlt
+    mov     rsi, rdx
+    call    rcx
+    ret
 
 ;------------------------------------------------------------------------------
 ; VOID
@@ -30,6 +32,4 @@ ASM_PFX(JumpToKernel):
 ;------------------------------------------------------------------------------
 global ASM_PFX(JumpToKernel64)
 ASM_PFX(JumpToKernel64):
-    mov     rsi, rdx
-    call    rcx
-    hlt
+    jmp    JumpToKernel

--- a/BootloaderCommonPkg/Library/PagingLib/Paging32To64.c
+++ b/BootloaderCommonPkg/Library/PagingLib/Paging32To64.c
@@ -542,7 +542,7 @@ IsLongModeEnabled (
   UINT64  Msr;
 
   Msr = AsmReadMsr64 (0xc0000080);
-  return ((Msr & BIT0) == BIT0) ? TRUE : FALSE;
+  return ((Msr & BIT8) == BIT8) ? TRUE : FALSE;
 }
 
 /**

--- a/BootloaderCommonPkg/Library/PagingLib/PagingLib.c
+++ b/BootloaderCommonPkg/Library/PagingLib/PagingLib.c
@@ -5,8 +5,10 @@
 
 **/
 
-#include <Base.h>
+#include <PiPei.h>
 #include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
 #include <Library/PagingLib.h>
 
 //
@@ -166,4 +168,40 @@ GetPageTablesMemorySize (
   )
 {
   return 2 * SIZE_4KB;
+}
+
+
+/**
+  This function create and load 4GB identical mapping paging table.
+**/
+VOID
+EFIAPI
+LoadPageTable (
+  VOID
+  )
+{
+  VOID     *Buffer;
+  UINT64   *PageTable;
+  UINT64    Base;
+  UINTN     Idx;
+
+  Buffer    = AllocatePages (8);
+  ZeroMem (Buffer, 2 * EFI_PAGE_SIZE);
+
+  PageTable    = (UINT64 *)Buffer;
+  PageTable[0] = (UINTN)PageTable + EFI_PAGE_SIZE * 1 + 0x23;
+
+  PageTable    = (UINT64 *)((UINTN)Buffer + EFI_PAGE_SIZE * 1);
+  PageTable[0] = (UINTN)PageTable + EFI_PAGE_SIZE * 1 + 0x23;
+  PageTable[1] = (UINTN)PageTable + EFI_PAGE_SIZE * 2 + 0x23;
+  PageTable[2] = (UINTN)PageTable + EFI_PAGE_SIZE * 3 + 0x23;
+  PageTable[3] = (UINTN)PageTable + EFI_PAGE_SIZE * 4 + 0x23;
+
+  Base = 0;
+  PageTable    = (UINT64 *)((UINTN)Buffer + EFI_PAGE_SIZE * 2);
+  for (Idx = 0; Idx < 2048; Idx++) {
+    PageTable[Idx] = Base + 0xE3;
+    Base += SIZE_2MB;
+  }
+  AsmWriteCr3 ((UINTN)Buffer);
 }

--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -52,11 +52,11 @@ typedef enum {
 typedef struct {
   UINT32        LdrGlobal;
   UINT32        Reserved;
-  UINT64        IdtTable[STAGE_IDT_ENTRY_COUNT];
+  IA32_IDT_GATE_DESCRIPTOR  IdtTable[STAGE_IDT_ENTRY_COUNT];
 } STAGE_IDT_TABLE;
 
 typedef struct {
-  UINT64        GdtTable[STAGE_GDT_ENTRY_COUNT];
+  IA32_SEGMENT_DESCRIPTOR   GdtTable[STAGE_GDT_ENTRY_COUNT];
 } STAGE_GDT_TABLE;
 
 typedef struct {

--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -32,7 +32,7 @@ typedef  VOID   (*KERNEL_ENTRY) (UINT32 Zero, UINT32 Arch, UINT32 Params);
 #pragma pack(1)
 
 #define  STAGE_IDT_ENTRY_COUNT        34
-#define  STAGE_GDT_ENTRY_COUNT        6
+#define  STAGE_GDT_ENTRY_COUNT        7
 
 #define  PLATFORM_NAME_SIZE           8
 

--- a/BootloaderCorePkg/Library/AcpiInitLib/X64/S3Wake.nasm
+++ b/BootloaderCorePkg/Library/AcpiInitLib/X64/S3Wake.nasm
@@ -2,12 +2,13 @@
 ;   This is the assembly code for transferring to control to OS S3 waking vector
 ;   for IA32 platform
 ;
-; Copyright (c) 2006 - 2020, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
 ;
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ;;
 
+DEFAULT REL
 SECTION .text
 
 global ASM_PFX(WakeUpBuffer)
@@ -16,7 +17,32 @@ ASM_PFX(WakeUpBuffer):
 
 global ASM_PFX(WakeUp)
 ASM_PFX(WakeUp):
+    push  rbp
+    mov   ebp, esp
+    mov   edx, dword [ASM_PFX(WakeUpBuffer)]
+    lea   eax, [jmp_retf - ASM_PFX(WakeUp) + edx ]
+    push  28h               ; CS
+    push  rax
+    mov   ecx, [ebp + 8]
+    shrd  ebx, ecx, 20
+    and   ecx, 0fh
+    mov   bx, cx
+    lea   eax, [os_jmp_addr - ASM_PFX(WakeUp) + edx ]
+    mov   [eax], ebx
     retf
+jmp_retf:
+    db    0b8h, 30h, 0      ; mov ax, 30h as selector
+    mov   ds, ax
+    mov   es, ax
+    mov   fs, ax
+    mov   gs, ax
+    mov   ss, ax
+    mov   rax, cr0          ; Get control register 0
+    db    66h
+    db    83h, 0e0h, 0feh   ; and    eax, 0fffffffeh  ; Clear PE bit (bit #0)
+    db    0fh, 22h, 0c0h    ; mov    cr0, eax         ; Activate real mode
+    db    0eah              ; jmp far @jmp_addr
+os_jmp_addr   dd  0
 
 global ASM_PFX(WakeUpSize)
 ASM_PFX(WakeUpSize):

--- a/BootloaderCorePkg/Library/CpuExceptionLib/CpuExceptionLib.inf
+++ b/BootloaderCorePkg/Library/CpuExceptionLib/CpuExceptionLib.inf
@@ -30,6 +30,7 @@
 
 [Sources.X64]
   X64/CpuExceptionHandler.c
+  X64/ExceptionHandler.nasm
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/BootloaderCorePkg/Library/CpuExceptionLib/X64/CpuExceptionHandler.c
+++ b/BootloaderCorePkg/Library/CpuExceptionLib/X64/CpuExceptionHandler.c
@@ -22,11 +22,72 @@ CONST UINT32 mErrorCodeFlag = 0x00027d00;
 VOID
 EFIAPI
 CommonExceptionHandler (
-  IN UINT32        *Stack,
+  IN UINTN         *Stack,
   IN UINT8          ExceptionType
   )
 {
+  UINTN  *Ptr;
+
+  // Skip the ExceptionType on the stack
+  Ptr = Stack + 1;
+
+  // Skip the ErrorCode on the stack
+  if (ExceptionType < CPU_EXCEPTION_NUM) {
+    if (mErrorCodeFlag & (1 << ExceptionType)) {
+      Ptr++;
+    }
+  }
+
+  DEBUG ((DEBUG_ERROR, "Exception #%d from 0x%04X:0x%08X !!!\n", ExceptionType, (UINT32)Ptr[1], (UINT32)Ptr[0]));
   CpuHalt (NULL);
+}
+
+/**
+  Update exception handler in IDT table .
+
+  This function is used to update the IDT exception handler with current stage.
+
+  @param[in]  IdtDescritor   If non-zero, it is new IDT descriptor to be updated.
+                             if it is 0,  the IDT descriptor will be retrieved from IDT base register.
+
+**/
+STATIC
+VOID
+UpdateExceptionHandler2 (
+  IN VOID                    *IdtDescriptor
+)
+{
+  IA32_IDT_GATE_DESCRIPTOR       *IdtEntry;
+  VOID                           *InterruptHandler;
+  UINT32                          Index;
+  IA32_DESCRIPTOR                 Idtr;
+  EXCEPTION_HANDLER_TEMPLATE_MAP  TemplateMap;
+  UINT16                          Cs;
+
+  if (IdtDescriptor == NULL) {
+    AsmReadIdtr (&Idtr);
+  } else {
+    Idtr = *(IA32_DESCRIPTOR *) IdtDescriptor;
+  }
+
+  Cs = AsmReadCs ();
+  AsmGetTemplateAddressMap (&TemplateMap);
+  IdtEntry = (IA32_IDT_GATE_DESCRIPTOR *)Idtr.Base;
+  for (Index = 0; Index < CPU_EXCEPTION_NUM; Index ++) {
+    InterruptHandler = (VOID *)(UINTN)(TemplateMap.ExceptionStart + TemplateMap.ExceptionStubHeaderSize * Index);
+    IdtEntry->Uint128.Uint64   = 0;
+    IdtEntry->Uint128.Uint64_1 = 0;
+    IdtEntry->Bits.OffsetLow   = (UINT16)(UINTN)InterruptHandler;
+    IdtEntry->Bits.OffsetHigh  = (UINT16)((UINTN)InterruptHandler >> 16);
+    IdtEntry->Bits.OffsetUpper = (UINT32)((UINTN)InterruptHandler >> 32);
+    IdtEntry->Bits.Selector    = Cs;
+    IdtEntry->Bits.GateType    = IA32_IDT_GATE_TYPE_INTERRUPT_32;
+    IdtEntry++;
+  }
+
+  if (IdtDescriptor != NULL) {
+    AsmWriteIdtr (&Idtr);
+  }
 }
 
 /**
@@ -43,4 +104,5 @@ UpdateExceptionHandler (
   IN IA32_DESCRIPTOR         *IdtDescriptor
 )
 {
+  UpdateDebugAgentIdt (IdtDescriptor, UpdateExceptionHandler2);
 }

--- a/BootloaderCorePkg/Library/CpuExceptionLib/X64/CpuExceptionHandler.c
+++ b/BootloaderCorePkg/Library/CpuExceptionLib/X64/CpuExceptionHandler.c
@@ -51,8 +51,8 @@ CommonExceptionHandler (
                              if it is 0,  the IDT descriptor will be retrieved from IDT base register.
 
 **/
-STATIC
 VOID
+EFIAPI
 UpdateExceptionHandler2 (
   IN VOID                    *IdtDescriptor
 )

--- a/BootloaderCorePkg/Library/CpuExceptionLib/X64/ExceptionHandler.nasm
+++ b/BootloaderCorePkg/Library/CpuExceptionLib/X64/ExceptionHandler.nasm
@@ -1,0 +1,84 @@
+;------------------------------------------------------------------------------ ;
+; Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Module Name:
+;
+;   ExceptionHandler.Asm
+;
+; Abstract:
+;
+;   IA32 CPU Exception Handler
+;
+; Notes:
+;
+;------------------------------------------------------------------------------
+
+extern ASM_PFX(CommonExceptionHandler)
+
+
+SECTION .text
+
+;
+; exception handler stub table
+;
+ALIGN   4
+AsmIdtVectorBegin:
+%rep  32
+    db      0x6a        ; push  #VectorNum
+    db      ($ - AsmIdtVectorBegin) / ((AsmIdtVectorEnd - AsmIdtVectorBegin) / 32) ; VectorNum
+    jmp     ASM_PFX(CommonInterruptEntry)
+%endrep
+AsmIdtVectorEnd:
+
+;----------------------------------------------------------------------------;
+; CommonInterruptEntry                                                       ;
+;----------------------------------------------------------------------------;
+; The follow algorithm is used for the common interrupt routine.
+; Stack:
+; +---------------------+
+; +    EFlags           +
+; +---------------------+
+; +    CS               +
+; +---------------------+
+; +    EIP              +
+; +---------------------+
+; +    Error Code       +
+; +---------------------+
+; +    Vector Number    +
+; +---------------------+
+global ASM_PFX(CommonInterruptEntry)
+ASM_PFX(CommonInterruptEntry):
+    cli
+    mov     rcx, rsp
+    mov     rdx, [rsp]
+    call    ASM_PFX(CommonExceptionHandler)
+    jmp     $
+
+;----------------------------------------------------------------------------;
+; _AsmGetTemplateAddressMap                                                  ;
+;----------------------------------------------------------------------------;
+;
+; VOID
+; AsmGetTemplateAddressMap (
+;     EXCEPTION_HANDLER_TEMPLATE_MAP *AddressMap
+;   );
+;
+; Routine Description:
+;
+;  Return address map of interrupt handler template so that C code can generate
+;  interrupt table.
+;
+; Arguments:
+;  AddressMap:  Address of EXCEPTION_HANDLER_TEMPLATE_MAP structure
+;
+; Returns:
+;   Nothing
+;-----------------------------------------------------------------------------;
+global ASM_PFX(AsmGetTemplateAddressMap)
+ASM_PFX(AsmGetTemplateAddressMap):
+    mov     rax, AsmIdtVectorBegin
+    mov     [rcx], rax
+    mov     rax, (AsmIdtVectorEnd - AsmIdtVectorBegin) / 32
+    mov     [rcx + 8], rax
+    ret

--- a/BootloaderCorePkg/Library/FspApiLib/FspMemoryInit.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspMemoryInit.c
@@ -58,7 +58,7 @@ CallFspMemoryInit (
   FspmUpdCommon = (FSPM_UPD_COMMON *)FspmUpd;
   FspmUpdCommon->FspmArchUpd.BootLoaderTolumSize = 0;
   FspmUpdCommon->FspmArchUpd.BootMode            = (UINT32)GetBootMode();
-  FspmUpdCommon->FspmArchUpd.NvsBufferPtr        = FindNvsData();
+  FspmUpdCommon->FspmArchUpd.NvsBufferPtr        = (UINT32)(UINTN)FindNvsData();
 
   UpdateFspConfig (FspmUpd);
 
@@ -67,7 +67,12 @@ CallFspMemoryInit (
                                            FspHeader->FspMemoryInitEntryOffset);
 
   DEBUG ((DEBUG_INFO, "Call FspMemoryInit ... "));
-  Status = FspMemoryInit (&FspmUpd, HobList);
+  if (IS_X64) {
+    Status = Execute32BitCode ((UINTN)FspMemoryInit, (UINTN)FspmUpd, (UINTN)HobList);
+    Status = (UINTN)LShiftU64 (Status & ((UINTN)MAX_INT32 + 1), 32) | (Status & MAX_INT32);
+  } else {
+    Status = FspMemoryInit (&FspmUpd, HobList);
+  }
   DEBUG ((DEBUG_INFO, "%r\n", Status));
 
   return Status;

--- a/BootloaderCorePkg/Library/FspApiLib/FspNotifyPhase.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspNotifyPhase.c
@@ -48,7 +48,12 @@ CallFspNotifyPhase (
   NotifyPhaseParams.Phase = Phase;
 
   DEBUG ((DEBUG_INFO, "Call FspNotifyPhase(%02X) ... ", Phase));
-  Status = NotifyPhase (&NotifyPhaseParams);
+  if (IS_X64) {
+    Status = Execute32BitCode ((UINTN)NotifyPhase, (UINTN)&NotifyPhaseParams, (UINTN)0);
+    Status = (UINTN)LShiftU64 (Status & ((UINTN)MAX_INT32 + 1), 32) | (Status & MAX_INT32);
+  } else {
+    Status = NotifyPhase (&NotifyPhaseParams);
+  }
   DEBUG ((DEBUG_INFO, "%r\n", Status));
 
   return Status;

--- a/BootloaderCorePkg/Library/FspApiLib/FspSiliconInit.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspSiliconInit.c
@@ -49,7 +49,12 @@ CallFspSiliconInit (
                                              FspHeader->FspSiliconInitEntryOffset);
 
   DEBUG ((DEBUG_INFO, "Call FspSiliconInit ... \n"));
-  Status = FspSiliconInit (&FspsUpd);
+  if (IS_X64) {
+    Status = Execute32BitCode ((UINTN)FspSiliconInit, (UINTN)FspsUpd, (UINTN)0);
+    Status = (UINTN)LShiftU64 (Status & ((UINTN)MAX_INT32 + 1), 32) | (Status & MAX_INT32);
+  } else {
+    Status = FspSiliconInit (&FspsUpd);
+  }
   DEBUG ((DEBUG_INFO, "%r\n", Status));
 
   return Status;

--- a/BootloaderCorePkg/Library/FspApiLib/FspTempRamExit.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspTempRamExit.c
@@ -45,7 +45,12 @@ CallFspTempRamExit (
   TempRamExit = (FSP_TEMP_RAM_EXIT)(UINTN)(FspHeader->ImageBase + FspHeader->TempRamExitEntryOffset);
 
   DEBUG ((DEBUG_INFO, "Call FspTempRamExit ... "));
-  Status  = TempRamExit (NULL);
+  if (IS_X64) {
+    Status = Execute32BitCode ((UINTN)TempRamExit, (UINTN)0, (UINTN)0);
+    Status = (UINTN)LShiftU64 (Status & ((UINTN)MAX_INT32 + 1), 32) | (Status & MAX_INT32);
+  } else {
+    Status  = TempRamExit (NULL);
+  }
   DEBUG ((DEBUG_INFO, "%r\n", Status));
 
   return Status;

--- a/BootloaderCorePkg/Library/FspApiLib/FspmApiLib.inf
+++ b/BootloaderCorePkg/Library/FspApiLib/FspmApiLib.inf
@@ -20,6 +20,13 @@
 #  VALID_ARCHITECTURES           = IA32 X64 IPF EBC
 #
 
+[Sources.X64]
+  X64/DispatchExecute.c
+  X64/Thunk64To32.nasm
+
+[Sources.IA32]
+  Ia32/DispatchExecute.c
+
 [Sources]
   FspApiLibInternal.h
   FspTempRamExit.c

--- a/BootloaderCorePkg/Library/FspApiLib/FspsApiLib.inf
+++ b/BootloaderCorePkg/Library/FspApiLib/FspsApiLib.inf
@@ -20,6 +20,13 @@
 #  VALID_ARCHITECTURES           = IA32 X64 IPF EBC
 #
 
+[Sources.X64]
+  X64/DispatchExecute.c
+  X64/Thunk64To32.nasm
+
+[Sources.IA32]
+  Ia32/DispatchExecute.c
+
 [Sources]
   FspApiLibInternal.h
   FspSiliconInit.c

--- a/BootloaderCorePkg/Library/FspApiLib/FsptApiLib.inf
+++ b/BootloaderCorePkg/Library/FspApiLib/FsptApiLib.inf
@@ -20,7 +20,7 @@
 #  VALID_ARCHITECTURES           = IA32 X64 IPF EBC
 #
 
-[Sources.IA32]
+[Sources.Ia32]
   Ia32/FspTempRamInit.nasm
 
 [Sources.X64]

--- a/BootloaderCorePkg/Library/FspApiLib/Ia32/DispatchExecute.c
+++ b/BootloaderCorePkg/Library/FspApiLib/Ia32/DispatchExecute.c
@@ -1,20 +1,17 @@
 /** @file
+  Execute 32-bit code in Long Mode.
+  Provide a thunk function to transition from long mode to compatibility mode to execute 32-bit code and then transit
+  back to long mode.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2018, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
-#ifndef _FSP_API_LIB_INTERNAL_H_
-#define _FSP_API_LIB_INTERNAL_H_
-
 #include <PiPei.h>
-#include <Guid/FspHeaderFile.h>
-#include <FspEas/FspApi.h>
-#include <Library/PcdLib.h>
-#include <Library/DebugLib.h>
-#include <Library/BaseMemoryLib.h>
-#include <Library/BootloaderCommonLib.h>
+#include <Library/BaseLib.h>
+#include <FspEas.h>
+
 
 /**
   Wrapper for a thunk  to transition from long mode to compatibility mode to execute 32-bit code and then transit back to
@@ -31,6 +28,8 @@ Execute32BitCode (
   IN UINT64      Function,
   IN UINT64      Param1,
   IN UINT64      Param2
-  );
+  )
+{
+  return EFI_SUCCESS;
+}
 
-#endif

--- a/BootloaderCorePkg/Library/FspApiLib/X64/DispatchExecute.c
+++ b/BootloaderCorePkg/Library/FspApiLib/X64/DispatchExecute.c
@@ -1,0 +1,109 @@
+/** @file
+  Execute 32-bit code in Long Mode.
+  Provide a thunk function to transition from long mode to compatibility mode to execute 32-bit code and then transit
+  back to long mode.
+
+  Copyright (c) 2014 - 2018, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+#include <Library/BaseLib.h>
+#include <FspEas.h>
+
+#pragma pack(1)
+typedef union {
+  struct {
+    UINT32  LimitLow    : 16;
+    UINT32  BaseLow     : 16;
+    UINT32  BaseMid     : 8;
+    UINT32  Type        : 4;
+    UINT32  System      : 1;
+    UINT32  Dpl         : 2;
+    UINT32  Present     : 1;
+    UINT32  LimitHigh   : 4;
+    UINT32  Software    : 1;
+    UINT32  Reserved    : 1;
+    UINT32  DefaultSize : 1;
+    UINT32  Granularity : 1;
+    UINT32  BaseHigh    : 8;
+  } Bits;
+  UINT64  Uint64;
+} IA32_GDT;
+#pragma pack()
+
+STATIC
+GLOBAL_REMOVE_IF_UNREFERENCED IA32_GDT mGdtEntries[] = {
+  {{0,      0,  0,  0,    0,  0,  0,  0,    0,  0, 0,  0,  0}}, /* 0x0:  reserve */
+  {{0xFFFF, 0,  0,  0xB,  1,  0,  1,  0xF,  0,  0, 1,  1,  0}}, /* 0x8:  compatibility mode */
+  {{0xFFFF, 0,  0,  0xB,  1,  0,  1,  0xF,  0,  1, 0,  1,  0}}, /* 0x10: for long mode */
+  {{0xFFFF, 0,  0,  0x3,  1,  0,  1,  0xF,  0,  0, 1,  1,  0}}, /* 0x18: data */
+  {{0,      0,  0,  0,    0,  0,  0,  0,    0,  0, 0,  0,  0}}, /* 0x20: reserve */
+};
+
+//
+// IA32 Gdt register
+//
+STATIC
+GLOBAL_REMOVE_IF_UNREFERENCED IA32_DESCRIPTOR mGdt = {
+  sizeof (mGdtEntries) - 1,
+  (UINTN) mGdtEntries
+  };
+
+/**
+  Assembly function to transition from long mode to compatibility mode to execute 32-bit code and then transit back to
+  long mode.
+
+  @param[in] Function     The 32bit code entry to be executed.
+  @param[in] Param1       The first parameter to pass to 32bit code
+  @param[in] Param2       The second parameter to pass to 32bit code
+  @param[in] InternalGdtr The GDT and GDT descriptor used by this library
+
+  @return status.
+**/
+UINT32
+EFIAPI
+AsmExecute32BitCode (
+  IN UINT64           Function,
+  IN UINT64           Param1,
+  IN UINT64           Param2,
+  IN IA32_DESCRIPTOR  *InternalGdtr
+  );
+
+/**
+  Wrapper for a thunk  to transition from long mode to compatibility mode to execute 32-bit code and then transit back to
+  long mode.
+
+  @param[in] Function     The 32bit code entry to be executed.
+  @param[in] Param1       The first parameter to pass to 32bit code.
+  @param[in] Param2       The second parameter to pass to 32bit code.
+
+  @return EFI_STATUS.
+**/
+EFI_STATUS
+Execute32BitCode (
+  IN UINT64      Function,
+  IN UINT64      Param1,
+  IN UINT64      Param2
+  )
+{
+  EFI_STATUS       Status;
+  IA32_DESCRIPTOR  Idtr;
+  IA32_DESCRIPTOR  IdtrNul;
+
+  //
+  // Idtr might be changed inside of FSP. 32bit FSP only knows the <4G address.
+  // If IDTR.Base is >4G, FSP can not handle. So we need save/restore IDTR here for X64 only.
+  // Interrupt is already disabled here, so it is safety to update IDTR.
+  //
+  IdtrNul.Base  = 0x00;
+  IdtrNul.Limit = 0x07;
+  AsmReadIdtr (&Idtr);
+  AsmWriteIdtr (&IdtrNul);
+  Status = AsmExecute32BitCode (Function, Param1, Param2, &mGdt);
+  AsmWriteIdtr (&Idtr);
+
+  return Status;
+}
+

--- a/BootloaderCorePkg/Library/FspApiLib/X64/FspTempRamInit.nasm
+++ b/BootloaderCorePkg/Library/FspApiLib/X64/FspTempRamInit.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2006 - 2020, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ;
@@ -17,6 +17,9 @@
 
 SECTION .text
 
-global  ASM_PFX(FspTempRamInit)
-ASM_PFX(FspTempRamInit):
-        ret
+;
+; FspTampInit has been moved into VTF0 in x64 mode
+;
+global ASM_PFX(DummyCode)
+ASM_PFX(DummyCode):
+    ret

--- a/BootloaderCorePkg/Library/FspApiLib/X64/Thunk64To32.nasm
+++ b/BootloaderCorePkg/Library/FspApiLib/X64/Thunk64To32.nasm
@@ -1,0 +1,225 @@
+;
+; Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;
+; Module Name:
+;
+;    Thunk64To32.nasm
+;
+; Abstract:
+;
+;   This is the assembly code to transition from long mode to compatibility mode to execute 32-bit code and then
+;   transit back to long mode.
+;
+;-------------------------------------------------------------------------------
+    DEFAULT REL
+    SECTION .text
+;----------------------------------------------------------------------------
+; Procedure:    AsmExecute32BitCode
+;
+; Input:        None
+;
+; Output:       None
+;
+; Prototype:    UINT32
+;               AsmExecute32BitCode (
+;                 IN UINT64           Function,
+;                 IN UINT64           Param1,
+;                 IN UINT64           Param2,
+;                 IN IA32_DESCRIPTOR  *InternalGdtr
+;                 );
+;
+;
+; Description:  A thunk function to execute 32-bit code in long mode.
+;
+;----------------------------------------------------------------------------
+global ASM_PFX(AsmExecute32BitCode)
+ASM_PFX(AsmExecute32BitCode):
+    ;
+    ; save IFLAG and disable it
+    ;
+    pushfq
+    cli
+
+    ;
+    ; save original GDTR and CS
+    ;
+    mov     rax, ds
+    push    rax
+    mov     rax, cs
+    push    rax
+    sub     rsp, 0x10
+    sgdt    [rsp]
+    ;
+    ; load internal GDT
+    ;
+    lgdt    [r9]
+    ;
+    ; Save general purpose register and rflag register
+    ;
+    pushfq
+    push    rdi
+    push    rsi
+    push    rbp
+    push    rbx
+
+    ;
+    ; save CR3
+    ;
+    mov     rax, cr3
+    mov     rbp, rax
+
+    ;
+    ; Prepare the CS and return address for the transition from 32-bit to 64-bit mode
+    ;
+    mov     rax, dword 0x10              ; load long mode selector
+    shl     rax, 32
+    mov     r9,  ReloadCS                ;Assume the ReloadCS is under 4G
+    or      rax, r9
+    push    rax
+    ;
+    ; Save parameters for 32-bit function call
+    ;
+    mov     rax, r8
+    shl     rax, 32
+    or      rax, rdx
+    push    rax
+    ;
+    ; save the 32-bit function entry and the return address into stack which will be
+    ; retrieve in compatibility mode.
+    ;
+    mov     rax, ReturnBack     ;Assume the ReloadCS is under 4G
+    shl     rax, 32
+    or      rax, rcx
+    push    rax
+
+    ;
+    ; let rax save DS
+    ;
+    mov     rax, dword 0x18
+
+    ;
+    ; Change to Compatible Segment
+    ;
+    mov     rcx, dword 0x8               ; load compatible mode selector
+    shl     rcx, 32
+    mov     rdx, Compatible   ; assume address < 4G
+    or      rcx, rdx
+    push    rcx
+    retf
+
+Compatible:
+    ; reload DS/ES/SS to make sure they are correct referred to current GDT
+    mov     ds, ax
+    mov     es, ax
+    mov     ss, ax
+
+    ;
+    ; Disable paging
+    ;
+    mov     rcx, cr0
+    btc     ecx, 31
+    mov     cr0, rcx
+    ;
+    ; Clear EFER.LME
+    ;
+    mov     ecx, 0xC0000080
+    rdmsr
+    btc     eax, 8
+    wrmsr
+
+; Now we are in protected mode
+    ;
+    ; Call 32-bit function. Assume the function entry address and parameter value is less than 4G
+    ;
+    pop    rax                 ; Here is the function entry
+    ;
+    ; Now the parameter is at the bottom of the stack,  then call in to IA32 function.
+    ;
+    jmp   rax
+ReturnBack:
+
+    mov   ebx, eax             ; save return status
+    pop   rcx                  ; drop param1
+    pop   rcx                  ; drop param2
+
+    ;
+    ; restore CR4
+    ;
+    mov     rax, cr4
+    bts     eax, 5
+    mov     cr4, rax
+
+    ;
+    ; restore CR3
+    ;
+    mov     eax, ebp
+    mov     cr3, rax
+
+    ;
+    ; Set EFER.LME to re-enable ia32-e
+    ;
+    mov     ecx, 0xC0000080
+    rdmsr
+    bts     eax, 8
+    wrmsr
+    ;
+    ; Enable paging
+    ;
+    mov     rax, cr0
+    bts     eax, 31
+    mov     cr0, rax
+; Now we are in compatible mode
+
+    ;
+    ; Reload cs register
+    ;
+    retf
+ReloadCS:
+    ;
+    ; Now we're in Long Mode
+    ;
+    ;
+    ; Restore C register and eax hold the return status from 32-bit function.
+    ; Note: Do not touch rax from now which hold the return value from IA32 function
+    ;
+    mov     eax, ebx ; put return status to EAX
+    pop     rbx
+    pop     rbp
+    pop     rsi
+    pop     rdi
+    popfq
+    ;
+    ; Switch to original GDT and CS. here rsp is pointer to the original GDT descriptor.
+    ;
+    lgdt    [rsp]
+    ;
+    ; drop GDT descriptor in stack
+    ;
+    add     rsp, 0x10
+    ;
+    ; switch to original CS and GDTR
+    ;
+    pop     r9                 ; get  CS
+    shl     r9,  32            ; rcx[32..47] <- Cs
+    mov     rcx, .0
+    or      rcx, r9
+    push    rcx
+    retf
+.0:
+    ;
+    ; Reload original DS/ES/SS
+    ;
+    pop     rcx
+    mov     ds, rcx
+    mov     es, rcx
+    mov     ss, rcx
+
+    ;
+    ; Restore IFLAG
+    ;
+    popfq
+
+    ret
+

--- a/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Main.asm
+++ b/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Main.asm
@@ -52,7 +52,7 @@ align 16
     ; Below fields will be patched by post build process
     ;
 BuildPatchData:
-    DD      0x55AA0FF0 ; Signature
+    DD      0x55AA0FF0 ; Pagee Table Offset
     DD      0x12345678 ; FSP-T Base
 TempRamInitStack:
     DD      ADDR_OF(TempRamInitDone)
@@ -93,6 +93,10 @@ FspApiSuccess:
     mov     ebp, ecx
     mov     esp, edx
 
+    ; Create page tables
+    ;   ECX: Page base
+    mov     eax, ADDR_OF(BuildPatchData)
+    add     ecx, dword [eax + 0x00]
     OneTimeCall  PreparePagingTable
 
     ;

--- a/BootloaderCorePkg/Stage1A/Ia32/Vtf0/PageTables.asm
+++ b/BootloaderCorePkg/Stage1A/Ia32/Vtf0/PageTables.asm
@@ -86,4 +86,5 @@ pageTableEntriesLoop:
     mov     [(ecx * 8 + esi + (0x2000 - 8)) + 4], edx
     loop    pageTableEntriesLoop
 
+    mov     eax, esi
     OneTimeCallRet  PreparePagingTable

--- a/BootloaderCorePkg/Stage1A/X64/SecEntry.nasm
+++ b/BootloaderCorePkg/Stage1A/X64/SecEntry.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2016 - 2017, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2016 - 2020, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ;

--- a/BootloaderCorePkg/Stage1A/X64/SecEntry.nasm
+++ b/BootloaderCorePkg/Stage1A/X64/SecEntry.nasm
@@ -1,6 +1,6 @@
 ;------------------------------------------------------------------------------
 ;
-; Copyright (c) 2016 - 2020, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2016 - 2017, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ;
@@ -19,12 +19,84 @@ SECTION .text
 
 extern  ASM_PFX(SecStartup)
 extern  ASM_PFX(TempRamInitParams)
+extern  ASM_PFX(PcdGet32(PcdStage1StackSize))
+extern  ASM_PFX(PcdGet32(PcdStage1DataSize))
+extern  ASM_PFX(PcdGet32(PcdStage1StackBaseOffset))
 
 
 global  ASM_PFX(_ModuleEntryPoint)
 ASM_PFX(_ModuleEntryPoint):
+        movd    mm0, eax
+
+        ;
+        ; Read time stamp in esi
+        ;
+        mov     rbx, rdx
+        rdtsc
+        mov     rsi, rdx
+        shl     rsi, 32
+        add     rsi, rax
+        mov     rdx, rbx
+
+        ;
+        ; Add a dummy reference to TempRamInitParams to prevent
+        ; compiler from removing this symbol
+        ;
+        mov     rax, ASM_PFX(TempRamInitParams)
+
+        ;
+        ; Setup stack
+        ; ECX: Bootloader stack base
+        ; EDX: Bootloader stack top
+        ;
+        mov     rax, ASM_PFX(PcdGet32(PcdStage1StackBaseOffset))
+        mov     eax, dword [rax]
+        mov     rsp, rax
+        add     rsp, rcx
+        mov     rax, ASM_PFX(PcdGet32(PcdStage1StackSize))
+        mov     eax, dword [rax]
+        add     rsp, rax
+
+        ;
+        ; Check stage1 stack base offset
+        ;
+        xor     rbx, rbx             ; Use EBX for Status
+        mov     rax, ASM_PFX(PcdGet32(PcdStage1DataSize))
+        mov     eax, dword [rax]
+        add     rax, rsp
+        cmp     rax, rdx
+        jle     CheckStackRangeDone
+
+        ;
+        ; Error in stack range
+        ;
+        bts     rbx, 1               ; Set BIT1 in Status
+        mov     rsp, rdx             ; Set ESP to the end
+
+CheckStackRangeDone:
+        ;
+        ; CpuBist error check
+        ;
+        movd    eax, mm0
+        emms                         ; Exit MMX Instruction
+        cmp     eax, 0
+        jz      CheckStatusDone
+
+        ;
+        ; Error in CpuBist
+        ;
+        bts     rbx, 0               ; Set BIT0 in Status
+
+CheckStatusDone:
+        ; Setup HOB
+        push    rbx                  ; Status
+        push    rsi                  ; TimeStamp[0] [63:0]
+        shl     rdx, 32              ; Move CarTop to high 32bit
+        add     rdx, rcx             ; Add back CarBase
+        push    rdx
+        mov     rcx, rsp             ; Argument 1
+
+        sub     rsp, 32              ; 32 bytes shadow store for x64
         call    ASM_PFX(SecStartup)  ; Jump to C code
         jmp     $
 
-        ; To avoid compiler optimization
-        jmp     ASM_PFX(TempRamInitParams)

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -63,6 +63,7 @@ PrepareStage2 (
   )
 {
   UINT32                    Dst;
+  VOID                     *DstAdr;
   UINT32                    DstLen;
   EFI_STATUS                Status;
   UINT32                    Delta;
@@ -70,20 +71,21 @@ PrepareStage2 (
 
 
   if (FixedPcdGetBool (PcdStage2LoadHigh)) {
-    Dst = 0;
+    DstAdr = NULL;
   } else {
-    Dst = PCD_GET32_WITH_ADJUST (PcdStage2FdBase);
+    DstAdr = (VOID *)(UINTN)PCD_GET32_WITH_ADJUST (PcdStage2FdBase);
   }
 
   AddMeasurePoint (0x2080);
   Status = LoadComponentWithCallback (COMP_TYPE_STAGE_2, FLASH_MAP_SIG_STAGE2,
-                                     (VOID *)&Dst, &DstLen, LoadComponentCallback);
+                                     &DstAdr, &DstLen, LoadComponentCallback);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "Loading Stage2 error - %r !", Status));
     return 0;
   }
+  AddMeasurePoint (0x20C0);
 
-   AddMeasurePoint (0x20C0);
+  Dst = (UINT32)(UINTN)DstAdr;
 
   // Rebase Stage2 if required
   if (Dst != PCD_GET32_WITH_ADJUST (PcdStage2FdBase)) {
@@ -421,6 +423,7 @@ SecStartup2 (
   BoardInit (PreMemoryInit);
 
   // Initialize memory
+  HobList = NULL;
   DEBUG ((DEBUG_INIT, "Memory Init\n"));
   AddMeasurePoint (0x2020);
   Status = CallFspMemoryInit (PCD_GET32_WITH_ADJUST (PcdFSPMBase), &HobList);
@@ -569,6 +572,12 @@ SecStartup2 (
   if (ContainerList != NULL) {
     ContainerList->Signature   = CONTAINER_LIST_SIGNATURE;
     ContainerList->TotalLength = AllocateLen;
+  }
+
+  if (IS_X64) {
+    // Load new paging table from memory
+    DEBUG ((DEBUG_INFO, "Load paging table\n"));
+    LoadPageTable ();
   }
 
   // Call back into board hooks post memory

--- a/BootloaderCorePkg/Stage1B/X64/Stage1BArch.c
+++ b/BootloaderCorePkg/Stage1B/X64/Stage1BArch.c
@@ -75,32 +75,4 @@ RemapStage (
   VOID
   )
 {
-  RANGE                Ranges[2];
-  UINT32               RoundSize;
-  VOID                *IbbMemBase;
-  UINT64              *PageEntry;
-  UINT32               Start;
-  UINT32               End;
-  UINT32               Curr;
-  UINTN                PageTable;
-
-  IbbMemBase  = AllocateTemporaryMemory (PcdGet32 (PcdStage1BFdSize));
-
-  DEBUG ((DEBUG_INFO, "Enable Paging ...\n"));
-  CopyMem (IbbMemBase, (VOID *)(UINTN)PcdGet32 (PcdStage1BFdBase), PcdGet32 (PcdStage1BFdSize));
-  EnableCodeExecution ();
-
-  RoundSize         = ALIGN_UP (PcdGet32 (PcdStage1BFdSize), EFI_PAGE_SIZE);
-  Ranges[0].Start   = PcdGet32 (PcdStage1BFdBase);
-  Ranges[0].Limit   = Ranges[0].Start + RoundSize - 1;
-  Ranges[0].Mapping = (UINT32)(UINTN)IbbMemBase;
-
-  Start = Ranges[0].Start & ~(SIZE_2MB - 1);
-  End   = (Ranges[0].Limit + SIZE_2MB) & ~(SIZE_2MB - 1);
-  PageTable = AsmReadCr3();
-  PageEntry = (UINT64 *)(UINTN)(PageTable + SIZE_4KB * 2);
-  for (Curr = Start; Curr <= End; Curr += SIZE_2MB) {
-    PageEntry[(Curr >> 21)] = (Ranges[0].Mapping + (Curr - Start)) | 0xE3;
-  }
-  AsmWriteCr3 (PageTable);
 }

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -67,6 +67,7 @@ PreparePayload (
   EFI_STATUS                     Status;
   UINT32                         Dst;
   UINT32                         DstLen;
+  VOID                          *DstAdr;
   BOOLEAN                        IsNormalPld;
   UINT32                         PayloadId;
   UINT32                         ContainerSig;
@@ -107,8 +108,9 @@ PreparePayload (
 
   AddMeasurePoint (0x3100);
   DstLen = 0;
+  DstAdr = NULL;
   Status = LoadComponentWithCallback (ContainerSig, ComponentName,
-                                     (VOID *)&Dst, &DstLen, LoadComponentCallback);
+                                      &DstAdr, &DstLen, LoadComponentCallback);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "Loading payload error - %r !", Status));
     return 0;
@@ -116,6 +118,7 @@ PreparePayload (
 
   AddMeasurePoint (0x3150);
 
+  Dst = (UINT32)(UINTN)DstAdr;
   Stage2Param->PayloadActualLength = DstLen;
   DEBUG ((DEBUG_INFO, "Load Payload ID 0x%08X @ 0x%08X\n", PayloadId, Dst));
   return Dst;

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -632,7 +632,14 @@ class Build(object):
         if self._arch == 'X64':
             # Find signature at top 4KB
             vtf_patch_data_base = get_vtf_patch_base (os.path.join(self._fv_dir, 'STAGE1A.fd'))
+            page_table_len = 0x8000
+            if self._board.STAGE1_DATA_SIZE < page_table_len:
+                raise Exception ("STAGE1_DATA_SIZE is too small to build x64 page table, "
+                                 "it requires at least 0x%X !" % page_table_len)
+            page_tbl_off = self._board.STAGE1_STACK_BASE_OFFSET + self._board.STAGE1_STACK_SIZE + \
+                           self._board.STAGE1_DATA_SIZE - page_table_len
             extra_cmd.extend ([
+                "0x%08X, 0x%08X,                                        @Page Table Offset" % (vtf_patch_data_base + 0x00, page_tbl_off),
                 "0x%08X, _BASE_STAGE1A_ - _OFFS_STAGE1A_,                    @FSP-T Base" % (vtf_patch_data_base + 0x04),
                 "0x%08X, Stage1A:_TempRamInitParams,                         @FSP-T UPD"  % (vtf_patch_data_base + 0x0C),
             ])

--- a/IntelFsp2Pkg/Include/FspEas/FspApi.h
+++ b/IntelFsp2Pkg/Include/FspEas/FspApi.h
@@ -57,12 +57,12 @@ typedef struct {
   /// Pointer to the non-volatile storage (NVS) data buffer.
   /// If it is NULL it indicates the NVS data is not available.
   ///
-  VOID                        *NvsBufferPtr;
+  UINT32                      NvsBufferPtr;
   ///
   /// Pointer to the temporary stack base address to be
   /// consumed inside FspMemoryInit() API.
   ///
-  VOID                        *StackBase;
+  UINT32                      StackBase;
   ///
   /// Temporary stack size to be consumed inside
   /// FspMemoryInit() API.

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -138,7 +138,7 @@ class Board(BaseBoard):
             self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.STAGE1_STACK_SIZE    = 0x00002000
-        self.STAGE1_DATA_SIZE     = 0x00006000
+        self.STAGE1_DATA_SIZE     = 0x0000E000
 
         self.CFG_DATABASE_SIZE    = self.CFGDATA_SIZE
 


### PR DESCRIPTION
This patch added necessary changes to enable QEMU boot through
Stage1A in X64 SBL build.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>