### PR TITLE
[UP2] Add memory SKU 3 support

### DIFF
--- a/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -655,6 +655,21 @@ UpdateFspConfig (
         Fspmcfg->Ch3_RankEnable        = 3;
         Fspmcfg->Ch3_DramDensity       = 2;
         break;
+
+      case 3: /* 8GB  not fully supported */
+        Fspmcfg->DualRankSupportEnable = 1;
+        Fspmcfg->Ch0_RankEnable        = 1;
+        Fspmcfg->Ch0_DramDensity       = 2;
+        Fspmcfg->Ch1_RankEnable        = 1;
+        Fspmcfg->Ch1_DramDensity       = 2;
+
+        Fspmcfg->Ch2_RankEnable        = 1;
+        Fspmcfg->Ch2_DramDensity       = 2;
+        Fspmcfg->Ch3_RankEnable        = 1;
+        Fspmcfg->Ch3_DramDensity       = 2;
+        Fspmcfg->RmtCheckRun           = 3;
+        break;
+
       default:
         break;
     };


### PR DESCRIPTION
This patch added UP2 board memory SKU3 support. This was enabled
by trying different memory configurations to find the working
configurations. It might not be optimal, but a good start point.

Speical acknowlegement to andreyv1978 who did the enabling on his
board and contributed the code back.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>