### PR TITLE
Use AllocatePages for file buffer allocation

### DIFF
--- a/PayloadPkg/OsLoader/LoadImage.c
+++ b/PayloadPkg/OsLoader/LoadImage.c
@@ -232,7 +232,7 @@ GetBootImageFromFs (
     goto Done;
   }
 
-  Image = AllocatePool (ImageSize);
+  Image = AllocatePages (EFI_SIZE_TO_PAGES (ImageSize));
   if (Image == NULL) {
     Status = EFI_OUT_OF_RESOURCES;
     goto Done;
@@ -250,6 +250,7 @@ GetBootImageFromFs (
 
   LoadedImage->IasImage.Addr = Image;
   LoadedImage->IasImage.Size = (UINT32)ImageSize;
+  LoadedImage->IasImage.AllocType = ImageAllocateTypePage;
   if ( *((UINT32 *) Image) == CONTAINER_BOOT_SIGNATURE ) {
     LoadedImage->Flags      |= LOADED_IMAGE_CONTAINER;
   } else if ( *((UINT32 *) Image) == IAS_MAGIC_PATTERN ) {


### PR DESCRIPTION
Current SBL used AllocatePool for IAS image or container image
loading. It is not ideal since some file, such as InitRD, requires
page aligned address. It is better to use AllocatePages to allocate
the buffer instead. This patch fixed this.
It fixed #627.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>