### PR TITLE
Fix UEFI payload loading issue

### DIFF
--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -108,7 +108,7 @@ PreparePayload (
 
   AddMeasurePoint (0x3100);
   DstLen = 0;
-  DstAdr = NULL;
+  DstAdr = (VOID *)(UINTN)Dst;
   Status = LoadComponentWithCallback (ContainerSig, ComponentName,
                                       &DstAdr, &DstLen, LoadComponentCallback);
   if (EFI_ERROR (Status)) {


### PR DESCRIPTION
After merging back x64 support, UEFI payload loading starts to fail
with SBL. It is due to the pointer was not properly initialized
for the component loading. This patch fixed this issue.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>