### PR TITLE
Fix Klockwork issues flagged in BootloaderCommonPkg

### DIFF
--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
@@ -710,6 +710,7 @@ LoadComponentWithCallback (
   UINT32                    ComponentId;
 
   ComponentId = ContainerSig;
+  CompLoc = 0;
 
   if (ContainerSig < COMP_TYPE_INVALID) {
     // Check if it is component type


### PR DESCRIPTION
Fix for: Klockwork flags variable 'CompLoc' for being used uninitialized.

Signed-off-by: Vegnish Rao <vegnish.rao.paramesura.rao@intel.com>