### PR TITLE
Improved thunk call for 32 bit FSP API

### DIFF
--- a/BootloaderCorePkg/Include/Library/FspApiLib.h
+++ b/BootloaderCorePkg/Include/Library/FspApiLib.h
@@ -139,4 +139,24 @@ FspResetHandler (
   IN  EFI_STATUS   Status
   );
 
+/**
+  Wrapper for a thunk  to transition from long mode to compatibility mode
+  to execute 32-bit code and then transit back to long mode.
+
+  @param[in] Function     The 32bit code entry to be executed.
+  @param[in] Param1       The first parameter to pass to 32bit code.
+  @param[in] Param2       The second parameter to pass to 32bit code.
+  @param[in] ExeInMem     If thunk needs to be executed from memory copy.
+
+  @return EFI_STATUS.
+**/
+EFI_STATUS
+EFIAPI
+Execute32BitCode (
+  IN UINT64      Function,
+  IN UINT64      Param1,
+  IN UINT64      Param2,
+  IN BOOLEAN     ExeInMem
+  );
+
 #endif

--- a/BootloaderCorePkg/Library/FspApiLib/FspApiLibInternal.h
+++ b/BootloaderCorePkg/Library/FspApiLib/FspApiLibInternal.h
@@ -23,14 +23,17 @@
   @param[in] Function     The 32bit code entry to be executed.
   @param[in] Param1       The first parameter to pass to 32bit code.
   @param[in] Param2       The second parameter to pass to 32bit code.
+  @param[in] ExeInMem     If thunk needs to be executed from memory copy.
 
   @return EFI_STATUS.
 **/
 EFI_STATUS
+EFIAPI
 Execute32BitCode (
   IN UINT64      Function,
   IN UINT64      Param1,
-  IN UINT64      Param2
+  IN UINT64      Param2,
+  IN BOOLEAN     ExeInMem
   );
 
 #endif

--- a/BootloaderCorePkg/Library/FspApiLib/FspMemoryInit.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspMemoryInit.c
@@ -68,7 +68,7 @@ CallFspMemoryInit (
 
   DEBUG ((DEBUG_INFO, "Call FspMemoryInit ... "));
   if (IS_X64) {
-    Status = Execute32BitCode ((UINTN)FspMemoryInit, (UINTN)FspmUpd, (UINTN)HobList);
+    Status = Execute32BitCode ((UINTN)FspMemoryInit, (UINTN)FspmUpd, (UINTN)HobList, FALSE);
     Status = (UINTN)LShiftU64 (Status & ((UINTN)MAX_INT32 + 1), 32) | (Status & MAX_INT32);
   } else {
     Status = FspMemoryInit (&FspmUpd, HobList);

--- a/BootloaderCorePkg/Library/FspApiLib/FspNotifyPhase.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspNotifyPhase.c
@@ -49,7 +49,7 @@ CallFspNotifyPhase (
 
   DEBUG ((DEBUG_INFO, "Call FspNotifyPhase(%02X) ... ", Phase));
   if (IS_X64) {
-    Status = Execute32BitCode ((UINTN)NotifyPhase, (UINTN)&NotifyPhaseParams, (UINTN)0);
+    Status = Execute32BitCode ((UINTN)NotifyPhase, (UINTN)&NotifyPhaseParams, (UINTN)0, FALSE);
     Status = (UINTN)LShiftU64 (Status & ((UINTN)MAX_INT32 + 1), 32) | (Status & MAX_INT32);
   } else {
     Status = NotifyPhase (&NotifyPhaseParams);

--- a/BootloaderCorePkg/Library/FspApiLib/FspSiliconInit.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspSiliconInit.c
@@ -50,7 +50,7 @@ CallFspSiliconInit (
 
   DEBUG ((DEBUG_INFO, "Call FspSiliconInit ... \n"));
   if (IS_X64) {
-    Status = Execute32BitCode ((UINTN)FspSiliconInit, (UINTN)FspsUpd, (UINTN)0);
+    Status = Execute32BitCode ((UINTN)FspSiliconInit, (UINTN)FspsUpd, (UINTN)0, FALSE);
     Status = (UINTN)LShiftU64 (Status & ((UINTN)MAX_INT32 + 1), 32) | (Status & MAX_INT32);
   } else {
     Status = FspSiliconInit (&FspsUpd);

--- a/BootloaderCorePkg/Library/FspApiLib/FspTempRamExit.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspTempRamExit.c
@@ -46,7 +46,7 @@ CallFspTempRamExit (
 
   DEBUG ((DEBUG_INFO, "Call FspTempRamExit ... "));
   if (IS_X64) {
-    Status = Execute32BitCode ((UINTN)TempRamExit, (UINTN)0, (UINTN)0);
+    Status = Execute32BitCode ((UINTN)TempRamExit, (UINTN)0, (UINTN)0, TRUE);
     Status = (UINTN)LShiftU64 (Status & ((UINTN)MAX_INT32 + 1), 32) | (Status & MAX_INT32);
   } else {
     Status  = TempRamExit (NULL);

--- a/BootloaderCorePkg/Library/FspApiLib/Ia32/DispatchExecute.c
+++ b/BootloaderCorePkg/Library/FspApiLib/Ia32/DispatchExecute.c
@@ -20,16 +20,20 @@
   @param[in] Function     The 32bit code entry to be executed.
   @param[in] Param1       The first parameter to pass to 32bit code.
   @param[in] Param2       The second parameter to pass to 32bit code.
+  @param[in] ExeInMem     If thunk needs to be executed from memory copy.
 
-  @return EFI_STATUS.
+  @return EFI_UNSUPPORTED.   This should not be called in 32 bit mode.
 **/
 EFI_STATUS
+EFIAPI
 Execute32BitCode (
   IN UINT64      Function,
   IN UINT64      Param1,
-  IN UINT64      Param2
+  IN UINT64      Param2,
+  IN BOOLEAN     ExeInMem
   )
 {
-  return EFI_SUCCESS;
+  // 32 bit mode should not call this interface.
+  return EFI_UNSUPPORTED;
 }
 

--- a/BootloaderCorePkg/Library/FspApiLib/X64/Thunk64To32.nasm
+++ b/BootloaderCorePkg/Library/FspApiLib/X64/Thunk64To32.nasm
@@ -36,6 +36,7 @@
 ;----------------------------------------------------------------------------
 global ASM_PFX(AsmExecute32BitCode)
 ASM_PFX(AsmExecute32BitCode):
+AsmExecute32BitCodeStart:
     ;
     ; save IFLAG and disable it
     ;
@@ -73,9 +74,9 @@ ASM_PFX(AsmExecute32BitCode):
     ;
     ; Prepare the CS and return address for the transition from 32-bit to 64-bit mode
     ;
-    mov     rax, dword 0x10              ; load long mode selector
+    mov     rax, dword 0x20             ; load long mode selector
     shl     rax, 32
-    mov     r9,  ReloadCS                ;Assume the ReloadCS is under 4G
+    lea     r9,  [ReloadCS]             ;Assume the ReloadCS is under 4G
     or      rax, r9
     push    rax
     ;
@@ -89,7 +90,7 @@ ASM_PFX(AsmExecute32BitCode):
     ; save the 32-bit function entry and the return address into stack which will be
     ; retrieve in compatibility mode.
     ;
-    mov     rax, ReturnBack     ;Assume the ReloadCS is under 4G
+    lea     rax, [ReturnBack]     ;Assume the ReloadCS is under 4G
     shl     rax, 32
     or      rax, rcx
     push    rax
@@ -102,9 +103,9 @@ ASM_PFX(AsmExecute32BitCode):
     ;
     ; Change to Compatible Segment
     ;
-    mov     rcx, dword 0x8               ; load compatible mode selector
+    mov     rcx, dword 0x10     ; load compatible mode selector
     shl     rcx, 32
-    mov     rdx, Compatible   ; assume address < 4G
+    lea     rdx, [Compatible]   ; assume address < 4G
     or      rcx, rdx
     push    rcx
     retf
@@ -222,4 +223,23 @@ ReloadCS:
     popfq
 
     ret
+AsmExecute32BitCodeEnd:
 
+; Procedure:    AsmGetExecute32CodeLength
+;
+; Input:        None
+;
+; Output:       Length of the AsmGetExecute32Code function
+;
+; Prototype:    UINT32
+;               AsmGetExecute32CodeLength (
+;                 VOID
+;                 );
+;
+;
+; Description:  Get AsmGetExecute32Code function length
+;
+global ASM_PFX(AsmGetExecute32CodeLength)
+ASM_PFX(AsmGetExecute32CodeLength):
+    mov     rax, (AsmExecute32BitCodeEnd - AsmExecute32BitCodeStart)
+    ret

--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -36,10 +36,10 @@ mGdtEntries[STAGE_GDT_ENTRY_COUNT] = {
   /* selector { Global Segment Descriptor                              } */
   /* 0x00 */  {{0,      0,  0,  0,    0,  0,  0,  0,    0,  0, 0,  0,  0}}, //null descriptor
   /* 0x08 */  {{0xffff, 0,  0,  0x2,  1,  0,  1,  0xf,  0,  0, 1,  1,  0}}, //linear data segment descriptor
-  /* 0x10 */  {{0xffff, 0,  0,  0xf,  1,  0,  1,  0xf,  0,  0, 1,  1,  0}}, //linear code segment descriptor
+  /* 0x10 */  {{0xffff, 0,  0,  0xb,  1,  0,  1,  0xf,  0,  0, 1,  1,  0}}, //linear code segment descriptor
   /* 0x18 */  {{0xffff, 0,  0,  0x3,  1,  0,  1,  0xf,  0,  0, 1,  1,  0}}, //system data segment descriptor
   /* 0x20 */  {{0xffff, 0,  0,  0xb,  1,  0,  1,  0xf,  0,  1, 0,  1,  0}}, //linear code (64-bit) segment descriptor
-  /* 0x28 */  {{0xffff, 0,  0,  0xB,  1,  0,  1,  0x0,  0,  0, 0,  0,  0}}, //16-bit code segment descriptor
+  /* 0x28 */  {{0xffff, 0,  0,  0xb,  1,  0,  1,  0x0,  0,  0, 0,  0,  0}}, //16-bit code segment descriptor
   /* 0x30 */  {{0xffff, 0,  0,  0x2,  1,  0,  1,  0x0,  0,  0, 0,  0,  0}}, //16-bit data segment descriptor
 };
 


### PR DESCRIPTION
In certain condition, the FspTempRamExit() API will be executed from
CAR. If so, the thunk call itself cannot be in CAR otherwise the
call will hang immediately after the CAR teardown. To resolve it,
the thunk call needs to be copied over to memory before calling the
FspTempRamExit() API. This patch implemented this.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>