### PR TITLE
[APL] Enable X64 boot

### DIFF
--- a/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -47,6 +47,7 @@
 #include <PlatformData.h>
 #include <Register/RegsSpi.h>
 
+#define APL_FSP_STACK_TOP       0xFEF40000
 #define MRC_PARAMS_BYTE_OFFSET_MRC_VERSION 14
 
 CONST PLT_DEVICE  mPlatformDevices[]= {
@@ -613,7 +614,7 @@ UpdateFspConfig (
   // The NVS buffer will be loaded to PcdStage1BLoadBase FindNvsData()
   // The PcdStage1BLoadBase is not used any more after Stage1B is loaded, so reuse it to save CAR space.
   //
-  Fspmcfg->VariableNvsBufferPtr      = (VOID *)(UINTN)PcdGet32 (PcdStage1BLoadBase);
+  Fspmcfg->VariableNvsBufferPtr      = (VOID *)(UINTN)APL_FSP_STACK_TOP;
 
   //
   // This will be done by configuration data
@@ -1830,9 +1831,8 @@ FindNvsData (
   MrcNvDataOffset = 0;
   MrcParamsOffset = MrcNvDataOffset + RegionSize;
 
-  // Reuse Stage1B loading base as buffer for decompression
   // All MRC NVS data should be less than 64KB
-  MrcVarData   = (VOID *)(UINTN)PcdGet32 (PcdStage1BLoadBase);
+  MrcVarData   = (VOID *)(UINTN)APL_FSP_STACK_TOP;
   MrcParamData = (UINT8 *)MrcVarData + SIZE_1KB;
   MemPool      = (UINT8 *)MrcVarData + SIZE_64KB;
 


### PR DESCRIPTION
This patch enabled APL X64 boot. In X64 mode, more heap is required
for Stage1A since it needs to build page tables. As part of it, APL
CAR region map has been re-arranged so as to save more space. This
has been tested on LeafHill CRB board.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>