### PR TITLE
[CFL] Enable SBL X64 boot

### DIFF
--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -228,7 +228,7 @@ class BaseBoard(object):
         self.FWUPDATE_LOAD_BASE    = 0
 
         # OS Loader FD/FV sizes
-        self.OS_LOADER_FD_SIZE     = 0x00046000
+        self.OS_LOADER_FD_SIZE     = 0x0004A000
         self.OS_LOADER_FD_NUMBLK   = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.PLD_HEAP_SIZE         = 0x02000000

--- a/Platform/CoffeelakeBoardPkg/BoardConfig.py
+++ b/Platform/CoffeelakeBoardPkg/BoardConfig.py
@@ -89,7 +89,7 @@ class Board(BaseBoard):
         self.STAGE2_FD_SIZE       = 0x000E0000
 
         self.STAGE1_STACK_SIZE    = 0x00002000
-        self.STAGE1_DATA_SIZE     = 0x0000E000
+        self.STAGE1_DATA_SIZE     = 0x00014000
 
         self.PAYLOAD_EXE_BASE     = 0x00B00000
         self.PAYLOAD_SIZE         = 0x00028000


### PR DESCRIPTION
This patch adjusted the Stage1A heap size and OsLoader size to
satisfy CFL build and boot requirment. This has been tested on
UPX board. It has dependeny on preivous PR #636.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>