### PR TITLE
Allow more flexible DSC customization by board

### DIFF
--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -725,7 +725,17 @@ class Build(object):
                     value = '0x%08X' % value
             lines.append('  DEFINE %-24s = %s\n'   % (attr, value))
 
-        if getattr(self._board, "GetDscLibrarys", None):
+        if getattr(self._board, "GetPlatformDsc", None):
+            dsc_dict = self._board.GetPlatformDsc()
+            for sect in dsc_dict:
+                lines.append('\n# Platform specific sections\n')
+                lines.append('[%s]\n' % sect)
+                for line in dsc_dict[sect]:
+                    lines.append('  %s\n' % line)
+                lines.append('\n')
+
+        elif getattr(self._board, "GetDscLibrarys", None):
+            # Deprecated, please use GetPlatformDsc instead
             libsdict = self._board.GetDscLibrarys()
             for arch in libsdict:
                 lines.append('\n# Platform specific libraries\n')

--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -149,9 +149,8 @@ class Board(BaseBoard):
         self._CFGDATA_INT_FILE = ['CfgData_Int_LeafHill.dlt']
         self._CFGDATA_EXT_FILE = ['CfgData_Ext_Gpmrb.dlt', 'CfgData_Ext_Up2.dlt','CfgData_Ext_OxbHill.dlt','CfgData_Ext_MB3.dlt','CfgData_Ext_JuniperHill.dlt']
 
-    def GetDscLibrarys (self, BuildPkgName = "BootLoaderCorePkg"):
-        dsc_libs = {}
-        # These libraries will be added into the DSC files
+    def GetPlatformDsc (self):
+        dsc = {}
         common_libs = [
             'LoaderLib|Platform/$(BOARD_PKG_NAME)/Library/LoaderLib/LoaderLib.inf',
             'SerialPortLib|Silicon/$(SILICON_PKG_NAME)/Library/SerialPortLib/SerialPortLib.inf',
@@ -174,8 +173,8 @@ class Board(BaseBoard):
             'HdaLib|Platform/$(BOARD_PKG_NAME)/Library/HdaLib/HdaLib.inf',
             'VtdPmrLib|Silicon/CommonSocPkg/Library/VtdPmrLib/VtdPmrLib.inf'
         ]
-        dsc_libs[self.BUILD_ARCH] = common_libs
-        return dsc_libs
+        dsc['LibraryClasses.%s' % self.BUILD_ARCH] = common_libs
+        return dsc
 
     def GetFlashMapList (self):
         img_list  = self.GetImageLayout ()

--- a/Platform/CoffeelakeBoardPkg/BoardConfig.py
+++ b/Platform/CoffeelakeBoardPkg/BoardConfig.py
@@ -137,9 +137,8 @@ class Board(BaseBoard):
         self._CFGDATA_INT_FILE    = ['CfgDataInt_Cfls.dlt', 'CfgDataInt_Cflh.dlt', 'CfgDataInt_Whl.dlt']
         self._CFGDATA_EXT_FILE    = ['CfgDataExt_Upx.dlt']
 
-    def GetDscLibrarys (self):
-        dsc_libs = {}
-        # These libraries will be added into the DSC files
+    def GetPlatformDsc (self):
+        dsc = {}
         common_libs = [
             'LoaderLib|Platform/CommonBoardPkg/Library/LoaderLib/LoaderLib.inf',
             'PlatformHookLib|Silicon/$(SILICON_PKG_NAME)/Library/PlatformHookLib/PlatformHookLib.inf',
@@ -162,8 +161,8 @@ class Board(BaseBoard):
         ]
         if self.BUILD_CSME_UPDATE_DRIVER:
             common_libs.append ('MeFwUpdateLib|Silicon/$(SILICON_PKG_NAME)/Library/MeFwUpdateLib/MeFwUpdateLib.inf')
-        dsc_libs[self.BUILD_ARCH] = common_libs        
-        return dsc_libs
+        dsc['LibraryClasses.%s' % self.BUILD_ARCH] = common_libs
+        return dsc
 
     def GetImageLayout (self):
         img_list = []

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -157,17 +157,18 @@ class Board(BaseBoard):
         #   VbtBin folder.
         self._MULTI_VBT_FILE      = {1:'Vbt800x600.dat', 2:'Vbt1024x768.dat'}
 
-    def GetDscLibrarys (self):
-        dsc_libs = {}
-        # These libraries will be added into the DSC files
-        common_libs = [
+    def GetPlatformDsc (self):
+        dsc = {}
+        dsc['LibraryClasses.%s' % self.BUILD_ARCH] = [
             'LoaderLib|Platform/CommonBoardPkg/Library/LoaderLib/LoaderLib.inf',
             'PlatformHookLib|Silicon/$(SILICON_PKG_NAME)/Library/PlatformHookLib/PlatformHookLib.inf',
             'GpioLib|Silicon/$(SILICON_PKG_NAME)/Library/GpioLib/GpioLib.inf',
             'SpiFlashLib|Silicon/$(SILICON_PKG_NAME)/Library/SpiFlashLib/SpiFlashLib.inf',
         ]
-        dsc_libs[self.BUILD_ARCH] = common_libs        
-        return dsc_libs
+        dsc['PcdsFeatureFlag.%s' % self.BUILD_ARCH] = [
+            'gPlatformCommonLibTokenSpaceGuid.PcdMultiUsbBootDeviceEnabled | TRUE'
+        ]
+        return dsc
 
     def GetKeyHashList (self):
         # Define a set of new key used for different purposes


### PR DESCRIPTION
Current build only allows board to customize the DSC libraries.
It is better to allow more flexible DSC customization. This patch
enabled this capability. Board can override library, PCDs, etc.
As part of it, the old GetDscLibrary() interface will be deprecated.
Please use GetPlatformDsc() instead.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>