### PR TITLE
Fix Stage1B/Payload loading failure on gcc built X64 target

### DIFF
--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -23,11 +23,9 @@
 
 #define  PCD_GET32_WITH_ADJUST(x)     GetAdjustedPcdBase (PcdGet32 (x))
 
-typedef  VOID   (*STAGE_ENTRY) (VOID *Params);
+typedef  VOID   (EFIAPI *STAGE_ENTRY)   (VOID *Params);
 
-typedef  VOID   (*PAYLOAD_ENTRY) (VOID *HobList, VOID *Params);
-
-typedef  VOID   (*KERNEL_ENTRY) (UINT32 Zero, UINT32 Arch, UINT32 Params);
+typedef  VOID   (EFIAPI *PAYLOAD_ENTRY) (VOID *HobList, VOID *Params);
 
 #pragma pack(1)
 

--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -478,6 +478,7 @@ SecStartup (
 
 **/
 VOID
+EFIAPI
 ContinueFunc (
   IN VOID  *Params
   )

--- a/BootloaderCorePkg/Stage1A/Stage1A.h
+++ b/BootloaderCorePkg/Stage1A/Stage1A.h
@@ -43,6 +43,7 @@
 
 **/
 VOID
+EFIAPI
 ContinueFunc (
   IN VOID  *Params
   );


### PR DESCRIPTION
This will fix stage transition failures for X64 targets built with gcc
which is caused by mis-matched EFIAPI calling convention.
- Add EFIAPI to STAGE_ENTRY interface for Stage1A -> Stage1B
- Add EFIAPI to PAYLOAD_ENTRY interface for Stage2->OsLoader Payload
- Remove unused KERNEL_ENTRY interface

Signed-off-by: Aiden Park <aiden.park@intel.com>