### PR TITLE
Add CurrentBoot CFGDATA option

### DIFF
--- a/Platform/CommonBoardPkg/CfgData/CfgData_Common.dsc
+++ b/Platform/CommonBoardPkg/CfgData/CfgData_Common.dsc
@@ -21,20 +21,20 @@
   #
   # --------------------------------------------------------------------------------------
   # !BSF PAGE:{GEN}
-  gCfgData.CfgHeader              |      * | 0x04 | {0x01:2b, ((_LENGTH_GEN_CFG_DATA_+8)/4):10b, 0:4b, 0:4b, _TAG_GEN_CFG_DATA_:12b}
-  gCfgData.CondValue              |      * | 0x04 | 0x00000000
+  gCfgData.CfgHeader                   |      * | 0x04 | {0x01:2b, ((_LENGTH_GEN_CFG_DATA_+8)/4):10b, 0:4b, 0:4b, _TAG_GEN_CFG_DATA_:12b}
+  gCfgData.CondValue                   |      * | 0x04 | 0x00000000
 
   # !HDR HEADER:{ON}
   # !HDR EMBED:{GEN_CFG_DATA:TAG_010:START}
   # !BSF NAME:{Debug Print Level}
   # !BSF TYPE:{EditNum, HEX, (0x00000000,0xFFFFFFFF)}
   # !BSF HELP:{Specify debug print level}
-  gCfgData.DebugPrintLevel        |      * | 0x04 | 0x8000004F
+  gCfgData.DebugPrintLevel             |      * | 0x04 | 0x8000004F
 
   # !BSF NAME:{Payload ID}
   # !BSF TYPE:{EditText}
   # !BSF HELP:{Specify payload ID string. Empty will boot default payload. Otherwise, boot specified payload ID in multi-payload binary.}
-  gCfgData.PayloadId             |      * | 0x04 | ''
+  gCfgData.PayloadId                   |      * | 0x04 | ''
 
   # !BSF NAME:{OS Crash Memory Size}
   # !BSF TYPE:{Combo}
@@ -51,5 +51,11 @@
   # !BSF HELP:{Enable or disable Rpmb Key Provisioning}
   gCfgData.RpmbKeyProvisioning         |      * | 0x01 | 0
 
-  gCfgData.Reserved                    |      * | 0x01 | 0
+  # !BSF PAGE:{OS}
+  # !BSF NAME:{Current Boot Option}
+  # !BSF OPTION:{ 16:AUTO, 0:0, 1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8, 9:9, 10:10, 11:11, 10:10, 11:11, 12:12, 13:13, 14:14, 15:15}
+  # !BSF HELP:{Set the current boot option. It indicates the boot option index (0-15) to be tried first on the boot flow. }
+  # !BSF HELP:{+AUTO allows platform to set current boot option using platform specific policy. }
+  gCfgData.CurrentBoot                 |      * | 0x01 | 0
+
   # !HDR EMBED:{GEN_CFG_DATA:TAG_010:END}

--- a/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.c
+++ b/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.c
@@ -58,6 +58,7 @@ FillBootOptionListFromCfgData (
   IN OUT   OS_BOOT_OPTION_LIST   *OsBootOptionList
 )
 {
+  GEN_CFG_DATA               *GenCfgData;
   OS_BOOT_OPTION             *BootOption;
   OS_BOOT_OPTION             *BootOptionCfgData;
   UINT8                       PrevBootOptionIndex;
@@ -121,7 +122,18 @@ FillBootOptionListFromCfgData (
     }
   }
 
-  DEBUG ((DEBUG_INFO, "Created %d OS boot options\n",  OsBootOptionList->OsBootOptionCount));
+  GenCfgData = (GEN_CFG_DATA *)FindConfigDataByTag (CDATA_GEN_TAG);
+  if (GenCfgData != NULL) {
+    OsBootOptionList->CurrentBoot = GenCfgData->CurrentBoot;
+    if (OsBootOptionList->CurrentBoot != MAX_BOOT_OPTION_CFGDATA_ENTRY) {
+      if (OsBootOptionList->CurrentBoot >= OsBootOptionList->OsBootOptionCount) {
+        OsBootOptionList->CurrentBoot = 0;
+      }
+    }
+  }
+
+  DEBUG ((DEBUG_INFO, "Created %d OS boot options (Current: %d)\n",  \
+          OsBootOptionList->OsBootOptionCount, OsBootOptionList->CurrentBoot));
 }
 
 /**

--- a/Platform/QemuBoardPkg/CfgData/CfgDataExt_Brd1.dlt
+++ b/Platform/QemuBoardPkg/CfgData/CfgDataExt_Brd1.dlt
@@ -16,5 +16,6 @@ PLATFORMID_CFG_DATA.PlatformId | 1
 PLAT_NAME_CFG_DATA.PlatformName            | 'QEMU_01'
 
 GEN_CFG_DATA.PayloadId                     | 'AUTO'
+GEN_CFG_DATA.CurrentBoot                   | 16
 
 !include CfgDataExt_Inc.dlt

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -406,25 +406,31 @@ UpdateOsBootMediumInfo (
 
   FillBootOptionListFromCfgData (OsBootOptionList);
 
-  //
-  // Read boot order, it is passed in by QEMU command
-  //   QEMU boot order (a=1 c=2 d=3 n=4 at CMOS 0x3D)
-  //   By default, this CMOS value at offset 0x3D is 0x03
-  //   Use '-boot order=c' or default to boot from eMMC
-  //   Use '-boot order=d' to boot from SATA
-  //   Use '-boot order=n' to boot from NVMe
-  //
-  IoWrite8 (0x70, 0x3D);
-  BootOrder = IoRead8  (0x71);
+  if (OsBootOptionList->CurrentBoot == MAX_BOOT_OPTION_CFGDATA_ENTRY) {
+    //
+    // Read boot order, it is passed in by QEMU command
+    //   QEMU boot order (a=1 c=2 d=3 n=4 at CMOS 0x3D)
+    //   By default, this CMOS value at offset 0x3D is 0x03
+    //   Use '-boot order=c' or default to boot from eMMC
+    //   Use '-boot order=d' to boot from SATA
+    //   Use '-boot order=n' to boot from NVMe
+    //
+    IoWrite8 (0x70, 0x3D);
+    BootOrder = IoRead8  (0x71);
 
-  if ((BootOrder & 0x0F) == 3) {
-    // SATA boot first
-    OsBootOptionList->CurrentBoot = 1;
-  } else if ((BootOrder & 0x0F) == 4) {
-    // NVMe boot first
-    OsBootOptionList->CurrentBoot = 2;
-  } else {
-    // SD boot first
+    if ((BootOrder & 0x0F) == 3) {
+      // SATA boot first
+      OsBootOptionList->CurrentBoot = 1;
+    } else if ((BootOrder & 0x0F) == 4) {
+      // NVMe boot first
+      OsBootOptionList->CurrentBoot = 2;
+    } else {
+      // SD boot first
+      OsBootOptionList->CurrentBoot = 0;
+    }
+  }
+
+  if (OsBootOptionList->CurrentBoot >= OsBootOptionList->OsBootOptionCount) {
     OsBootOptionList->CurrentBoot = 0;
   }
 }


### PR DESCRIPTION
Current SBL does not provide CFGDATA to change the current boot
option although it can be done in SBL shell. This patch added this
into CFGDATA so that it can changed using board CFGDATA. A special
option AUTO is introduced to indicate the priority between CFGDATA
and board specific overriding. When AUTO is selected, board specific
overriding should be used. Otherwise, CFGDATA should be used for
CurrentBoot option.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>