### PR TITLE
Fix Klockwork issue flagged in BootloaderCommonPkg

### DIFF
--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
@@ -760,6 +760,10 @@ LoadComponentWithCallback (
   // Component must have LOADER_COMPRESSED_HEADER
   Status = EFI_UNSUPPORTED;
   CompressHdr  = (LOADER_COMPRESSED_HEADER *)CompData;
+  if (CompressHdr == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
   if (IS_COMPRESSED (CompressHdr)) {
     SignedDataLen = sizeof (LOADER_COMPRESSED_HEADER) + CompressHdr->CompressedSize;
     if (SignedDataLen <= CompLen) {


### PR DESCRIPTION
Fix for: Klockwork flags possible null pointer variable 'CompressHdr' being dereferenced.

Signed-off-by: Vegnish Rao <vegnish.rao.paramesura.rao@intel.com>