### PR TITLE
[APL] Allow relative path for workspace directory

### DIFF
--- a/Platform/ApollolakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/ApollolakeBoardPkg/Script/StitchIfwi.py
@@ -624,7 +624,7 @@ def main():
 
     args = ap.parse_args()
 
-    stitch_dir = args.stitch_dir
+    stitch_dir = os.path.abspath (args.stitch_dir)
     if clean (stitch_dir, args.clean):
         raise Exception ('Stitching clean up failed !')
 


### PR DESCRIPTION
For APL StitchIfwi.py script, if relative path is provided for the
stitching workspace, the stitching process will error out. This
patch fixed this issue by converting the relative path to absolute
path before passing it into the stitching functions.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>