### PR TITLE
Call DeInit() for every boot device

### DIFF
--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -1174,6 +1174,14 @@ PayloadMain (
       CopyMem ((VOID *)&OsBootOption, (VOID *)&OsBootOptionList->OsBootOption[CurrIdx], sizeof (OS_BOOT_OPTION));
       BootOsImage (&OsBootOption);
 
+      // De-init the current boot devices
+      // If USB keyboard console is used, don't DeInit USB yet at this moment.
+      // It will be handled just before transfering to OS.
+      if (!((OsBootOption.DevType == OsBootDeviceUsb) &&
+          ((PcdGet32 (PcdConsoleInDeviceMask) & ConsoleInUsbKeyboard) != 0))) {
+        MediaInitialize (0, DevDeinit);
+      }
+
       // Move to next boot option
       CurrIdx = GetNextBootOption (OsBootOptionList, CurrIdx);
       if (CurrIdx >= OsBootOptionList->OsBootOptionCount) {
@@ -1187,9 +1195,6 @@ PayloadMain (
     } else {
       break;
     }
-
-    // De-init boot devices while restarting payload.
-    DeinitBootDevices ();
   }
 
   CpuHalt (NULL);


### PR DESCRIPTION
Current SBL OsLoader call DeinitBootDevices() once at the end of
the boot option loop. This is not right because it will only DeInit
the current active boot device. Instead, DeInit() should be called
inside the loop for every boot device. Specially, if USB is used as
console, USB DeInit() cannot be called at the moment. It will be
deferred until OS transfering.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>