### PR TITLE
Fix USB boot assertion

### DIFF
--- a/BootloaderCommonPkg/Library/UfsBlockIoLib/UfsHcMem.c
+++ b/BootloaderCommonPkg/Library/UfsBlockIoLib/UfsHcMem.c
@@ -268,17 +268,16 @@ UfsFreeMemPool (
   )
 {
   UFS_PEIM_MEM_BLOCK         *Block;
+  UFS_PEIM_MEM_BLOCK         *Current;
 
-  ASSERT (Pool->Head != NULL);
+  Block = Pool->Head;
+  ASSERT (Block != NULL);
 
-  //
-  // Unlink all the memory blocks from the pool, then free them.
-  //
-  for (Block = Pool->Head->Next; Block != NULL; Block = Pool->Head->Next) {
-    UfsFreeMemBlock (Pool, Block);
+  while (Block != NULL) {
+    Current = Block;
+    Block   = Block->Next;
+    UfsFreeMemBlock (Pool, Current);
   }
-
-  UfsFreeMemBlock (Pool, Pool->Head);
 
   return EFI_SUCCESS;
 }

--- a/BootloaderCommonPkg/Library/XhciLib/UsbHcMem.c
+++ b/BootloaderCommonPkg/Library/XhciLib/UsbHcMem.c
@@ -374,21 +374,17 @@ UsbHcFreeMemPool (
   IN USBHC_MEM_POOL     *Pool
   )
 {
-  USBHC_MEM_BLOCK       *Block;
+  USBHC_MEM_BLOCK         *Block;
+  USBHC_MEM_BLOCK         *Current;
 
-  ASSERT (Pool->Head != NULL);
+  Block = Pool->Head;
+  ASSERT (Block != NULL);
 
-  //
-  // Unlink all the memory blocks from the pool, then free them.
-  // UsbHcUnlinkMemBlock can't be used to unlink and free the
-  // first block.
-  //
-  for (Block = Pool->Head->Next; Block != NULL; Block = Pool->Head->Next) {
-    //UsbHcUnlinkMemBlock (Pool->Head, Block);
-    UsbHcFreeMemBlock (Pool, Block);
+  while (Block != NULL) {
+    Current = Block;
+    Block   = Block->Next;
+    UsbHcFreeMemBlock (Pool, Current);
   }
-
-  UsbHcFreeMemBlock (Pool, Pool->Head);
 }
 
 /**


### PR DESCRIPTION
Assertion will occur when booting from USB behind hubs. This was
caused by duplicated freeing the same address page. The for loop
in UsbHcFreeMemPool() does not move to next node in the list. The
similar bug exists in UFS driver. This patch fixed both.

It fixed #659.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>