### PR TITLE
Remove Verified Boot Hash Mask

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -124,7 +124,7 @@
   gPlatformModuleTokenSpaceGuid.PcdTopSwapRegionSize      | 0x00000000 | UINT32 | 0x200000C0
   gPlatformModuleTokenSpaceGuid.PcdRedundantRegionSize    | 0x00000000 | UINT32 | 0x200000C1
 
-  gPlatformModuleTokenSpaceGuid.PcdVerifiedBootHashMask   | 0x00000000 | UINT32 | 0x200000D0
+  gPlatformModuleTokenSpaceGuid.PcdVerifiedBootStage1B   | 0x0 | BOOLEAN | 0x200000D0
 
   gPlatformModuleTokenSpaceGuid.PcdCpuMaxLogicalProcessorNumber | 16   | UINT32 | 0x200000E0
   gPlatformModuleTokenSpaceGuid.PcdMaxServiceNumber       | 8          | UINT32 | 0x200000E1

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -226,7 +226,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdConsoleInDeviceMask  | $(CONSOLE_IN_DEVICE_MASK)
   gPlatformCommonLibTokenSpaceGuid.PcdConsoleOutDeviceMask | $(CONSOLE_OUT_DEVICE_MASK)
 
-  gPlatformModuleTokenSpaceGuid.PcdVerifiedBootHashMask   | $(VERIFIED_BOOT_HASH_MASK)
+  gPlatformModuleTokenSpaceGuid.PcdVerifiedBootStage1B   | $(VERIFIED_BOOT_STAGE_1B)
   gPlatformCommonLibTokenSpaceGuid.PcdCryptoShaOptMask    | $(ENABLE_CRYPTO_SHA_OPT)
 
   gPlatformCommonLibTokenSpaceGuid.PcdSpiIasImageRegionType    | $(SPI_IAS_REGION_TYPE)

--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -193,7 +193,7 @@ PrepareStage1B (
   Hdr = (LOADER_COMPRESSED_HEADER *)(UINTN)Src;
 
   // Verify Stage 1B
-  if (FixedPcdGet32(PcdVerifiedBootHashMask) & (1 << COMP_TYPE_STAGE_1B)) {
+  if (FeaturePcdGet (PcdVerifiedBootEnabled)  && FixedPcdGetBool(PcdVerifiedBootStage1B)) {
     if (IS_COMPRESSED (Src)) {
       Length = sizeof (LOADER_COMPRESSED_HEADER) + Hdr->CompressedSize;
     }

--- a/BootloaderCorePkg/Stage1A/Stage1A.inf
+++ b/BootloaderCorePkg/Stage1A/Stage1A.inf
@@ -81,7 +81,7 @@
   gPlatformModuleTokenSpaceGuid.PcdEarlyLogBufferSize
   gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel
   gPlatformModuleTokenSpaceGuid.PcdFileDataBase
-  gPlatformModuleTokenSpaceGuid.PcdVerifiedBootHashMask
+  gPlatformModuleTokenSpaceGuid.PcdVerifiedBootStage1B
   gPlatformModuleTokenSpaceGuid.PcdHashStoreSize
   gPlatformCommonLibTokenSpaceGuid.PcdPcdLibId
   gPlatformCommonLibTokenSpaceGuid.PcdCompSignHashAlg

--- a/BootloaderCorePkg/Tools/GenContainer.py
+++ b/BootloaderCorePkg/Tools/GenContainer.py
@@ -171,7 +171,6 @@ class CONTAINER ():
 
     @staticmethod
     def get_auth_type_val (auth_type_str):
-        print ('auth_type_str %s' % auth_type_str)
         return CONTAINER._auth_type_value[auth_type_str]
 
     @staticmethod
@@ -644,7 +643,6 @@ def gen_container_bin (container_list, out_dir, inp_dir, key_dir = '.', tool_dir
         print ("Container '%s' was created successfully at:  \n  %s" % (container.header.signature.decode(), out_file))
 
 def adjust_auth_type (auth_type_str, key_path):
-    print('auth_type_str %s key_path %s' % (auth_type_str, key_path))
     if os.path.exists(key_path):
         sign_key_type = get_key_type(key_path)
         if auth_type_str != '':
@@ -660,7 +658,6 @@ def adjust_auth_type (auth_type_str, key_path):
     return auth_type_str
 
 def gen_layout (comp_list, img_type, auth_type_str, out_file, key_dir, key_file):
-    print ("auth_type_str1 %s" % auth_type_str)
     hash_type = CONTAINER._auth_to_hashalg_str[auth_type_str] if auth_type_str else ''
     auth_type = auth_type_str
     key_path  = os.path.join(key_dir, key_file)

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -158,7 +158,7 @@ class BaseBoard(object):
         self.ACPI_PM_TIMER_BASE     = 0x0408
         self.USB_KB_POLLING_TIMEOUT = 1
 
-        self.VERIFIED_BOOT_HASH_MASK  = 0x00000000
+        self.VERIFIED_BOOT_STAGE_1B   = 0x0
         self.BOOT_MEDIA_SUPPORT_MASK  = 0xFFFFFFFF
         self.FILE_SYSTEM_SUPPORT_MASK = 0x00000003
         self.DEBUG_OUTPUT_DEVICE_MASK = 0x00000003
@@ -1095,8 +1095,6 @@ class Build(object):
             mst_key = self._board._MASTER_PRIVATE_KEY
             if getattr(self._board, "GetKeyHashList", None):
                 key_hash_list = self._board.GetKeyHashList ()
-        else:
-            self._board.VERIFIED_BOOT_HASH_MASK = 0
 
         gen_pub_key_hash_store (mst_key, key_hash_list, HASH_VAL_STRING[self._board.SIGN_HASH_TYPE],
                                 self._board._SIGNING_SCHEME, self._key_dir, os.path.join(self._fv_dir, 'KEYHASH.bin'))

--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -103,10 +103,6 @@ class Board(BaseBoard):
         # EXT | FAT
         self.FILE_SYSTEM_SUPPORT_MASK  = 3
 
-        # FWU_PLD | PLD | Stage2 | Stage1B
-        # Stage1B is verified by CSE
-        self.VERIFIED_BOOT_HASH_MASK  = 0x000000E        # Stage1B is verified by CSE
-
         # Verify required minimum FSP version
         self.MIN_FSP_REVISION     = 0x01040301
         # Verify FSP image ID. Empty string means skipping verification

--- a/Platform/CoffeelakeBoardPkg/BoardConfig.py
+++ b/Platform/CoffeelakeBoardPkg/BoardConfig.py
@@ -74,10 +74,6 @@ class Board(BaseBoard):
         self.ENABLE_FWU           = 1
         self.ENABLE_SMBIOS        = 1
 
-        # FWU_PLD | PLD | Stage2 | Stage1B
-        # Stage1B is verified by ACM
-        self.VERIFIED_BOOT_HASH_MASK  = 0x000000E
-
         # Verify required minimum FSP version
         self.MIN_FSP_REVISION     = 0x07006440
         # Verify FSP image ID. Empty string means skipping verification

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -77,9 +77,8 @@ class Board(BaseBoard):
         # BIT0:Serial  BIT1:GFX
         self.CONSOLE_OUT_DEVICE_MASK = 0x00000001
 
-        # FWU_PLD | PLD | Stage2 | Stage1B
         # Let Stage1A verifies Stage1B
-        self.VERIFIED_BOOT_HASH_MASK  = 0x000000F
+        self.VERIFIED_BOOT_STAGE_1B  = 0x1
 
         self.STAGE1B_XIP          = 0
 


### PR DESCRIPTION
PcdVerifiedBootHashMask is no longer used while
verification except for stage1B. Remove Hash mask and
added PcdVerifiedBootStage1B for stage1B verification.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>