### PR TITLE
Fix memory leak issue in OsLoader

### DIFF
--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -1007,7 +1007,7 @@ BootOsImage (
 
 Exit:
   if (LoadedImageHandle != NULL) {
-    UnloadBootImages (LoadedImageHandle);
+    UnloadBootImages (LoadedImageHandle, FALSE);
   }
 
   if (FsHandle != NULL) {

--- a/PayloadPkg/OsLoader/OsLoader.h
+++ b/PayloadPkg/OsLoader/OsLoader.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -222,13 +222,15 @@ GetLoadedImageByType (
 
   This function will clean up all temporary resources used to load Boot Image.
 
-  @param[in]  LoadedImageHandle Loaded Image handle
-
+  @param[in]  LoadedImageHandle   Loaded Image handle.
+  @param[in]  KeepRootNode        TRUE,  do not free memory for LOADED_IMAGES_INFO root node.
+                                  FALSE, free memory for LOADED_IMAGES_INFO root node.
 **/
 VOID
 EFIAPI
 UnloadBootImages (
-  IN  EFI_HANDLE       LoadedImageHandle
+  IN  EFI_HANDLE       LoadedImageHandle,
+  IN  BOOLEAN          KeepRootNode
   );
 
 /**


### PR DESCRIPTION
This patch fixed an issue which will cause memory leak in OsLoader.
The previous LoadedImagesInfo should be de-allocated before reusing
for other image loading. Or memory leak will occur.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>