### PR TITLE
Add support to report free memory resource

### DIFF
--- a/BootloaderCommonPkg/Library/FullMemoryAllocationLib/Page.c
+++ b/BootloaderCommonPkg/Library/FullMemoryAllocationLib/Page.c
@@ -1162,24 +1162,23 @@ CoreFreePoolPages (
 }
 
 /**
-  Finds first free range between specified min and max address.
+  Finds all used pages for given type and count for size.
 
-  @param[in]  MinAddress             The address that the range must be above
-  @param[in]  MaxAddress             The address that the range must be below
+  @param  MemType     The type of memory to count.
 
-  @retval     The memory range entry pointer to MEMORY_MAP structure.
-              NULL if no free range is found.
+  @retval     The total used memory size.
 
 **/
-MEMORY_MAP *
-CoreFindFirstFreeRange (
-  IN UINT64           MinAddress,
-  IN UINT64           MaxAddress
+UINT64
+CoreGetUsedMemorySize (
+  IN EFI_MEMORY_TYPE  MemType
   )
 {
   LIST_ENTRY      *Link;
   MEMORY_MAP      *Entry;
+  UINT64           Length;
 
+  Length = 0;
   Entry = NULL;
   for (Link = gMemoryMap.ForwardLink; Link != &gMemoryMap; Link = Link->ForwardLink) {
     Entry = CR (Link, MEMORY_MAP, Link, MEMORY_MAP_SIGNATURE);
@@ -1187,21 +1186,15 @@ CoreFindFirstFreeRange (
     //
     // If it's not a free entry, don't bother with it
     //
-    if (Entry->Type != EfiConventionalMemory) {
-      continue;
-    }
-
+    if (Entry->Type == MemType) {
     //
     // If desc is past max allowed address or below min allowed address, skip it
     //
-    if ((Entry->Start >= MaxAddress) || (Entry->End < MinAddress)) {
-      continue;
+      Length += (Entry->End - Entry->Start + 1);
     }
-
-    return Entry;
   }
 
-  return NULL;
+  return Length;
 }
 
 /**
@@ -1224,7 +1217,6 @@ GetMemoryResourceInfo (
   OUT  UINT64           *EndAddr    OPTIONAL
   )
 {
-  MEMORY_MAP     *Entry;
   UINT64          Start;
   UINT64          End;
 
@@ -1244,12 +1236,10 @@ GetMemoryResourceInfo (
   }
 
   if (FreeAddr != NULL) {
-    Entry = CoreFindFirstFreeRange (Start, End);
-    if (Entry != NULL) {
-      *FreeAddr = Entry->End;
-    } else {
-      *FreeAddr = End;
-    }
+    // Memory might be allocated in fragmented parts.
+    // Here use a calculated virtual free memory address instead.
+    // UsedMemory = EndAddr - FreeAddr
+    *FreeAddr = End - CoreGetUsedMemorySize (Type);
   }
 
   return EFI_SUCCESS;


### PR DESCRIPTION
This patch added support to report free memory resource lenghth.
It will search for all used memory pages and add them together.
The "virtual" free address will be returned to indicate the
virtual start point of the free memory top. It is virtual since the
memory allocation can be fragmented. This is just an indicator to
calculate the actual used memory size:
  UsedMemSize = EndAddr - FreeAddr

Signed-off-by: Maurice Ma <maurice.ma@intel.com>