### PR TITLE
Fix AHCI library memory de-allocation issue

### DIFF
--- a/BootloaderCommonPkg/Library/AhciLib/AhciBlkIo.c
+++ b/BootloaderCommonPkg/Library/AhciLib/AhciBlkIo.c
@@ -282,6 +282,9 @@ AhciDeinitialize (
     return EFI_INVALID_PARAMETER;
   }
 
+  AhciReset (AhciController, 10000);
+  MmioAnd8 (AhciController->AhciPciCfgAddr + PCI_COMMAND_OFFSET,  (UINT8)(~(EFI_PCI_COMMAND_MEMORY_SPACE | EFI_PCI_COMMAND_BUS_MASTER)));
+
   Link  = AhciController->DeviceList.ForwardLink;
   while (Link != &AhciController->DeviceList) {
     AhciDeviceData = EFI_ATA_DEVICE_FROM_LINK (Link);
@@ -291,7 +294,7 @@ AhciDeinitialize (
 
   AhciRegisters = &AhciController->AhciRegisters;
 
-  if (AhciRegisters->AhciCommandTableMap != NULL) {
+  if (AhciRegisters->AhciCommandTable != NULL) {
     IoMmuFreeBuffer (
        EFI_SIZE_TO_PAGES (AhciRegisters->MaxCommandTableSize),
        AhciRegisters->AhciCommandTable,
@@ -299,7 +302,7 @@ AhciDeinitialize (
        );
   }
 
-  if (AhciRegisters->AhciCmdListMap != NULL) {
+  if (AhciRegisters->AhciCmdList != NULL) {
     IoMmuFreeBuffer (
        EFI_SIZE_TO_PAGES (AhciRegisters->MaxCommandListSize),
        AhciRegisters->AhciCmdList,
@@ -307,7 +310,7 @@ AhciDeinitialize (
        );
   }
 
-  if (AhciRegisters->AhciRFisMap != NULL) {
+  if (AhciRegisters->AhciRFis != NULL) {
     IoMmuFreeBuffer (
        EFI_SIZE_TO_PAGES (AhciRegisters->MaxReceiveFisSize),
        AhciRegisters->AhciRFis,
@@ -377,6 +380,7 @@ AhciInitialize (
   //
   // Enable AHCI controller
   //
+  AhciPrivateData->AhciPciCfgAddr = (UINT32)AhciHcPciBase;
   AhciPrivateData->AhciMemAddr = MmioRead32 (AhciHcPciBase + EFI_AHCI_BAR_OFFSET) & ~0xF;
   MmioOr8 (AhciHcPciBase + PCI_COMMAND_OFFSET, EFI_PCI_COMMAND_MEMORY_SPACE | EFI_PCI_COMMAND_BUS_MASTER);
 

--- a/BootloaderCommonPkg/Library/AhciLib/AhciMode.c
+++ b/BootloaderCommonPkg/Library/AhciLib/AhciMode.c
@@ -1881,7 +1881,7 @@ AhciCreateTransferDescriptor (
   // Map error or unable to map the whole CmdList buffer into a contiguous region.
   //
 Error1:
-  if (AhciRegisters->AhciCommandTableMap != NULL) {
+  if (AhciRegisters->AhciCommandTable != NULL) {
     IoMmuFreeBuffer (
        EFI_SIZE_TO_PAGES (AhciRegisters->MaxCommandTableSize),
        AhciRegisters->AhciCommandTable,
@@ -1892,7 +1892,7 @@ Error1:
   }
 
 Error3:
-  if (AhciRegisters->AhciCmdListMap != NULL) {
+  if (AhciRegisters->AhciCmdList != NULL) {
     IoMmuFreeBuffer (
        EFI_SIZE_TO_PAGES (AhciRegisters->MaxCommandListSize),
        AhciRegisters->AhciCmdList,
@@ -1903,7 +1903,7 @@ Error3:
   }
 
 Error5:
-  if (AhciRegisters->AhciRFisMap != NULL) {
+  if (AhciRegisters->AhciRFis != NULL) {
     IoMmuFreeBuffer (
        EFI_SIZE_TO_PAGES (AhciRegisters->MaxReceiveFisSize),
        AhciRegisters->AhciRFis,

--- a/BootloaderCommonPkg/Library/AhciLib/AhciMode.h
+++ b/BootloaderCommonPkg/Library/AhciLib/AhciMode.h
@@ -524,6 +524,7 @@ typedef struct {
 
 typedef struct {
   UINT32                    Signature;
+  UINT32                    AhciPciCfgAddr;
   UINT32                    AhciMemAddr;
   EFI_AHCI_REGISTERS        AhciRegisters;
   LIST_ENTRY                DeviceList;
@@ -651,6 +652,24 @@ AhciDmaTransfer (
   IN OUT VOID                       *MemoryAddr,
   IN     UINT32                     DataCount,
   IN     UINT64                     Timeout
+  );
+
+/**
+  Do AHCI HBA reset.
+
+  @param  AhciController              The AHCI controller protocol instance.
+  @param  Timeout            The timeout value of reset, uses 100ns as a unit.
+
+  @retval EFI_DEVICE_ERROR   AHCI controller is failed to complete hardware reset.
+  @retval EFI_TIMEOUT        The reset operation is time out.
+  @retval EFI_SUCCESS        AHCI controller is reset successfully.
+
+**/
+EFI_STATUS
+EFIAPI
+AhciReset (
+  IN  EFI_AHCI_CONTROLLER       *AhciController,
+  IN  UINT64                    Timeout
   );
 
 #endif


### PR DESCRIPTION
This patch fixed AHCI memory de-allocation issue by checking the
correct pointer before calling FreePool/FreePages.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>