### PR TITLE
Fix NVMe library memory de-allocation issue

### DIFF
--- a/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressHci.h
+++ b/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressHci.h
@@ -97,5 +97,19 @@ NvmeIdentifyNamespace (
   IN VOID                              *Buffer
   );
 
+/**
+  Disable the Nvm Express controller.
+
+  @param  Private          The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+
+  @return EFI_SUCCESS      Successfully disable the controller.
+  @return EFI_DEVICE_ERROR Fail to disable the controller.
+
+**/
+EFI_STATUS
+NvmeDisableController (
+  IN NVME_CONTROLLER_PRIVATE_DATA     *Private
+  );
+
 #endif
 

--- a/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressPassthru.c
+++ b/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressPassthru.c
@@ -679,7 +679,7 @@ EXIT:
     IoMmuUnmap (MapMeta);
   }
 
-  if (MapPrpList != NULL) {
+  if (PrpListHost != NULL) {
     IoMmuFreeBuffer (PrpListNo, PrpListHost, MapPrpList);
   }
 


### PR DESCRIPTION
This patch added NVMe de-initialization function to stop the controller
and de-allocate all memory allocated.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>