### PR TITLE
Fix XHCI library memory de-allocation issue

### DIFF
--- a/BootloaderCommonPkg/Include/Library/XhciLib.h
+++ b/BootloaderCommonPkg/Include/Library/XhciLib.h
@@ -26,18 +26,4 @@ UsbInitCtrl (
   IN OUT EFI_HANDLE                     *UsbHostHandle
   );
 
-/**
-  USB deinitialization interface.
-
-  @param UsbHostHandle   USB host controller handle to deinitalize.
-
-  @retval EFI_SUCCESS              USB host controller was deinitialized successfully.
-  @retval EFI_INVALID_PARAMETER    USB host controller handle is invalid.
-**/
-EFI_STATUS
-EFIAPI
-UsbDeinitCtrl (
-  IN  EFI_HANDLE      UsbHostHandle
-  );
-
 #endif

--- a/BootloaderCommonPkg/Library/UsbInitLib/UsbInitLib.c
+++ b/BootloaderCommonPkg/Library/UsbInitLib/UsbInitLib.c
@@ -55,16 +55,21 @@ DeinitUsbDevices (
   )
 {
   EFI_STATUS  Status;
+  UINTN                Index;
 
   if (mUsbInit.UsbHostHandle == NULL) {
     return EFI_NOT_FOUND;
   }
 
   Status = UsbDeinitCtrl (mUsbInit.UsbHostHandle);
-  if (!EFI_ERROR (Status)) {
-    ZeroMem (&mUsbInit, sizeof(mUsbInit));
+
+  UsbDeInitBot ();
+
+  for (Index = 0; Index < mUsbInit.UsbIoCount; Index++) {
+    UsbDeinitDevice (mUsbInit.UsbIoArray[Index]);
   }
 
+  ZeroMem (&mUsbInit, sizeof(mUsbInit));
   return Status;
 }
 

--- a/BootloaderCommonPkg/Library/UsbInitLib/UsbInitLibInternal.h
+++ b/BootloaderCommonPkg/Library/UsbInitLib/UsbInitLibInternal.h
@@ -28,4 +28,45 @@ typedef struct {
   PEI_USB_IO_PPI                 *UsbIoArray[MAX_USB_DEVICE_NUMBER];
 } USB_INIT_INSTANCE;
 
+/**
+  This funciton de-allocate memory allocated for USB BOT devices.
+
+  @retval EFI_SUCCESS            This routinue alwasy return success.
+
+**/
+EFI_STATUS
+EFIAPI
+UsbDeInitBot (
+  VOID
+);
+
+/**
+  Free USB device memory.
+
+  @param  UsbIo     UsbIo instance associated with the device.
+
+  @retval EFI_SUCCESS            The usb device memory was de-allocated successfully.
+  @retval EFI_INVALID_PARAMETER  Invalid UsbIo instance.
+
+**/
+EFI_STATUS
+EFIAPI
+UsbDeinitDevice (
+  IN VOID     *UsbIo
+  );
+
+/**
+  USB deinitialization interface.
+
+  @param UsbHostHandle   USB host controller handle to deinitalize.
+
+  @retval EFI_SUCCESS              USB host controller was deinitialized successfully.
+  @retval EFI_INVALID_PARAMETER    USB host controller handle is invalid.
+**/
+EFI_STATUS
+EFIAPI
+UsbDeinitCtrl (
+  IN  EFI_HANDLE      UsbHostHandle
+  );
+
 #endif

--- a/BootloaderCommonPkg/Library/XhciLib/UsbHcMem.c
+++ b/BootloaderCommonPkg/Library/XhciLib/UsbHcMem.c
@@ -103,9 +103,13 @@ UsbHcFreeMemBlock (
 
   IoMmuFreeBuffer (EFI_SIZE_TO_PAGES (Block->BufLen), Block->BufHost, Block->Mapping);
 
-  //
-  // No free memory in PEI.
-  //
+  if (Block->Bits != NULL) {
+    FreePages (Block->Bits, EFI_SIZE_TO_PAGES (Block->BitsLen));
+  }
+
+  if (Block != NULL) {
+    FreePages (Block, EFI_SIZE_TO_PAGES (sizeof (USBHC_MEM_BLOCK)));
+  }
 }
 
 /**

--- a/BootloaderCommonPkg/Library/XhciLib/XhciSched.c
+++ b/BootloaderCommonPkg/Library/XhciLib/XhciSched.c
@@ -1533,6 +1533,7 @@ XhcPeiDisableSlotCmd (
   for (Index = 0; Index < Xhc->UsbDevContext[SlotId].DevDesc.NumConfigurations; Index++) {
     if (Xhc->UsbDevContext[SlotId].ConfDesc[Index] != NULL) {
       FreePool (Xhc->UsbDevContext[SlotId].ConfDesc[Index]);
+      Xhc->UsbDevContext[SlotId].ConfDesc[Index] = NULL;
     }
   }
 
@@ -3022,6 +3023,7 @@ XhcPeiFreeSched (
   //
   if (Xhc->MemPool != NULL) {
     UsbHcFreeMemPool (Xhc->MemPool);
+    FreePages (Xhc->MemPool, EFI_SIZE_TO_PAGES (sizeof (USBHC_MEM_POOL)));
     Xhc->MemPool = NULL;
   }
 }


### PR DESCRIPTION
This patch added code to XHCI de-initialization funciton to free
all used memory.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>