### PR TITLE
Add build hooks for board

### DIFF
--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -390,7 +390,16 @@ def gen_flash_map_bin (flash_map_file, comp_list):
     flash_map = FLASH_MAP()
     for comp in reversed(comp_list):
         desc  = FLASH_MAP_DESC ()
-        desc.sig    = FLASH_MAP.FLASH_MAP_COMPONENT_SIGNATURE[comp['bname']].encode()
+        if comp['bname'] not in FLASH_MAP.FLASH_MAP_COMPONENT_SIGNATURE:
+            if len(comp['bname']) < 4:
+                # For short names, prefix with '_'
+                bname = '_' * (4 - len(comp['bname'])) + comp['bname']
+            else:
+                # For long names, use the 1st 4 chars
+                bname = comp['bname'][:4]
+            desc.sig    = bname.encode()
+        else:
+            desc.sig    = FLASH_MAP.FLASH_MAP_COMPONENT_SIGNATURE[comp['bname']].encode()
         desc.flags  = comp['flag']
         desc.offset = comp['offset']
         desc.size   = comp['size']

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -288,6 +288,10 @@ class Build(object):
         self._comp_list                    = []
         self._region_list                  = []
 
+    def board_build_hook (self, phase):
+        if getattr(self._board, "PlatformBuildHook", None):
+            self._board.PlatformBuildHook (self, phase)
+
     def update_fit_table (self):
 
         if not self._board.HAVE_FIT_TABLE:
@@ -1163,7 +1167,9 @@ class Build(object):
         print("Build [%s] ..." % self._board.BOARD_NAME)
 
         # Run pre-build
+        self.board_build_hook ('pre-build:before')
         self.pre_build()
+        self.board_build_hook ('post-build:after')
 
         # Run build
         cmd_args = [
@@ -1180,7 +1186,9 @@ class Build(object):
         run_process (cmd_args)
 
         # Run post-build
+        self.board_build_hook ('post-build:before')
         self.post_build()
+        self.board_build_hook ('post-build:after')
 
         print("Done [%s] !" % self._board.BOARD_NAME)
 

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -86,6 +86,7 @@ class Board(BaseBoard):
         self.STAGE1B_SIZE         = 0x00030000
         self.STAGE2_SIZE          = 0x00018000
 
+        self.TEST_SIZE            = 0x00001000
         self.SIIPFW_SIZE          = 0x00010000
         self.EPAYLOAD_SIZE        = 0x0020D000
         self.PAYLOAD_SIZE         = 0x00020000
@@ -155,6 +156,14 @@ class Board(BaseBoard):
         # VbtFileName is the VBT file name. It needs to be located under platform
         #   VbtBin folder.
         self._MULTI_VBT_FILE      = {1:'Vbt800x600.dat', 2:'Vbt1024x768.dat'}
+
+    def PlatformBuildHook (self, build, phase):
+        if phase == 'post-build:before':
+          # Create PTEST.bin
+          bins = bytearray (b'12345678')
+          file = build._fv_dir + '/PTEST.bin'
+          with open(file, 'wb') as fd:
+              fd.write(bins)
 
     def GetPlatformDsc (self):
         dsc = {}
@@ -230,6 +239,7 @@ class Board(BaseBoard):
                     ('PAYLOAD.bin'  ,  'Lzma'    , self.PAYLOAD_SIZE,  STITCH_OPS.MODE_FILE_PAD, STITCH_OPS.MODE_POS_TAIL),
                     ('EPAYLOAD.bin' ,  ''        , self.EPAYLOAD_SIZE, STITCH_OPS.MODE_FILE_PAD, STITCH_OPS.MODE_POS_TAIL),
                     ('SIIPFW.bin'   ,  ''        , self.SIIPFW_SIZE,   STITCH_OPS.MODE_FILE_PAD, STITCH_OPS.MODE_POS_TAIL),
+                    ('PTEST.bin'    ,  ''        , self.TEST_SIZE,     STITCH_OPS.MODE_FILE_PAD, STITCH_OPS.MODE_POS_TAIL),
                     ]
                 ),
                 ('REDUNDANT_A.bin', [


### PR DESCRIPTION
This patch added build hooks for boards so that each board can do
specific actions in different build phases. This patch also added
an example for QEMU to use build hook to generate new binaries into
the flash layout.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>