### PR TITLE
Support 64-bit XHCI MMIO address

### DIFF
--- a/BootloaderCommonPkg/Include/Library/XhciLib.h
+++ b/BootloaderCommonPkg/Include/Library/XhciLib.h
@@ -22,7 +22,7 @@
 EFI_STATUS
 EFIAPI
 UsbInitCtrl (
-  IN     UINT32                          BaseAddress,
+  IN     UINTN                           BaseAddress,
   IN OUT EFI_HANDLE                     *UsbHostHandle
   );
 

--- a/BootloaderCommonPkg/Library/UsbInitLib/UsbInitLib.c
+++ b/BootloaderCommonPkg/Library/UsbInitLib/UsbInitLib.c
@@ -95,7 +95,7 @@ InitUsbDevices (
 {
   EFI_STATUS  Status;
   UINTN       PcieAddress;
-  UINT32      XhciMmioBase;
+  UINTN       XhciMmioBase;
   UINT32      Data;
   UINT8      *Class;
 
@@ -109,7 +109,7 @@ InitUsbDevices (
         (Class[2] == PCI_CLASS_SERIAL))) {
       // Enable XHCI controller
       MmioOr8 (PcieAddress + PCI_COMMAND_OFFSET, EFI_PCI_COMMAND_MEMORY_SPACE | EFI_PCI_COMMAND_BUS_MASTER);
-      XhciMmioBase = MmioRead32 (PcieAddress + PCI_BASE_ADDRESSREG_OFFSET) & ~0xF;
+      XhciMmioBase = (UINTN) MmioRead64 (PcieAddress + PCI_BASE_ADDRESSREG_OFFSET) & ~0xF;
 
       Status = UsbInitCtrl (XhciMmioBase, &mUsbInit.UsbHostHandle);
       DEBUG ((DEBUG_INFO, "Init USB XHCI - %r\n", Status));

--- a/BootloaderCommonPkg/Library/XhciLib/XhcPeim.c
+++ b/BootloaderCommonPkg/Library/XhciLib/XhcPeim.c
@@ -1483,7 +1483,7 @@ UsbDeinitCtrl (
 EFI_STATUS
 EFIAPI
 UsbInitCtrl (
-  IN     UINT32                          BaseAddress,
+  IN     UINTN                          BaseAddress,
   IN OUT EFI_HANDLE                     *UsbHostHandle
   )
 {
@@ -1506,7 +1506,7 @@ UsbInitCtrl (
   XhcDev = (PEI_XHC_DEV *) ((UINTN) TempPtr);
 
   XhcDev->Signature = USB_XHC_DEV_SIGNATURE;
-  XhcDev->UsbHostControllerBaseAddress = (UINT32) BaseAddress;
+  XhcDev->UsbHostControllerBaseAddress = BaseAddress;
   XhcDev->CapLength           = (UINT8) (XhcPeiReadCapRegister (XhcDev, XHC_CAPLENGTH_OFFSET) & 0x0FF);
   XhcDev->HcSParams1.Dword    = XhcPeiReadCapRegister (XhcDev, XHC_HCSPARAMS1_OFFSET);
   XhcDev->HcSParams2.Dword    = XhcPeiReadCapRegister (XhcDev, XHC_HCSPARAMS2_OFFSET);

--- a/BootloaderCommonPkg/Library/XhciLib/XhcPeim.h
+++ b/BootloaderCommonPkg/Library/XhciLib/XhcPeim.h
@@ -144,7 +144,7 @@ struct _PEI_XHC_DEV {
   UINTN                             Signature;
   PEI_USB2_HOST_CONTROLLER_PPI      Usb2HostControllerPpi;
   EFI_PEI_PPI_DESCRIPTOR            PpiDescriptor;
-  UINT32                            UsbHostControllerBaseAddress;
+  UINTN                             UsbHostControllerBaseAddress;
   USBHC_MEM_POOL                    *MemPool;
 
   //

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -266,6 +266,7 @@ class BaseBoard(object):
         self.HASH_STORE_SIZE       = 0x200  #Hash store size to be allocated in bootloader
 
         self.PCI_MEM64_BASE        = 0
+        self.BUILD_ARCH            = 'IA32'
 
         for key, value in list(kwargs.items()):
             setattr(self, '%s' % key, value)


### PR DESCRIPTION
If Platform code assigns 64-bit BAR address to XHCI,
get the full 64-bit address to access MMIO space.
Behavior is undefined if building IA32 and assigning
64-bit XHCI resources.

Signed-off-by: Sai Talamudupula <sai.kiran.talamudupula@intel.com>