### PR TITLE
Add FSP boot performance data

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -47,6 +47,7 @@
   gEfiSystemNvDataFvGuid                        = { 0xFFF12B8D, 0x7696, 0x4C8B, { 0xA9, 0x85, 0x27, 0x47, 0x07, 0x5B, 0x4F, 0x50 } }
   gEfiVariableIndexTableGuid                    = { 0x8cfdb8c8, 0xd6b2, 0x40f3, { 0x8e, 0x97, 0x02, 0x30, 0x7c, 0xc9, 0x8b, 0x7c } }
   gEdkiiWorkingBlockSignatureGuid               = { 0x9e58292b, 0x7c68, 0x497d, { 0xa0, 0xce, 0x65,  0x0, 0xfd, 0x9f, 0x1b, 0x95 } }
+  gEdkiiFpdtExtendedFirmwarePerformanceGuid     = { 0x3b387bfd, 0x7abc, 0x4cf2, { 0xa0, 0xca, 0xb6, 0xa1, 0x6c, 0x1b, 0x1b, 0x25 } }
 
 [PcdsFixedAtBuild]
   gPlatformCommonLibTokenSpaceGuid.PcdMaxLibraryDataEntry    |          8 | UINT32 | 0x20000100
@@ -244,6 +245,11 @@
   ## This PCD defines length for DMA buffer alignment.
   # @Prompt DMA buffer allocation alignment when DMA protection is enabled.
   gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferAlignment | 0x00100000 | UINT32 | 0x00010091
+
+  ## This PCD defines bootloader boot performance related behavior
+  #     BIT0    - Print Slim Bootloader boot performance.<BR>
+  #     BIT1    - Print FSP HOB boot performance data.<BR>
+  gPlatformCommonLibTokenSpaceGuid.PcdBootPerformanceMask | 0x00000001 | UINT32 | 0x00010092
 
 [PcdsDynamic]
   ## This PCD indicates the PCR bank to be enabled/supported by Slim Bootloader for measured boot

--- a/BootloaderCommonPkg/Library/LoaderPerformanceLib/ExtendedFirmwarePerformance.h
+++ b/BootloaderCommonPkg/Library/LoaderPerformanceLib/ExtendedFirmwarePerformance.h
@@ -1,0 +1,263 @@
+/** @file
+  This file defines edk2 extended firmware performance records.
+  These records will be added into ACPI FPDT Firmware Basic Boot Performance Table.
+
+Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __EXTENDED_FIRMWARE_PERFORMANCE_H__
+#define __EXTENDED_FIRMWARE_PERFORMANCE_H__
+
+#include <IndustryStandard/Acpi.h>
+
+//
+// Known performance tokens
+//
+#define SEC_TOK                         "SEC"             ///< SEC Phase
+#define DXE_TOK                         "DXE"             ///< DXE Phase
+#define PEI_TOK                         "PEI"             ///< PEI Phase
+#define BDS_TOK                         "BDS"             ///< BDS Phase
+#define DRIVERBINDING_START_TOK         "DB:Start:"       ///< Driver Binding Start() function call
+#define DRIVERBINDING_SUPPORT_TOK       "DB:Support:"     ///< Driver Binding Support() function call
+#define DRIVERBINDING_STOP_TOK          "DB:Stop:"        ///< Driver Binding Stop() function call
+#define LOAD_IMAGE_TOK                  "LoadImage:"      ///< Load a dispatched module
+#define START_IMAGE_TOK                 "StartImage:"     ///< Dispatched Modules Entry Point execution
+#define PEIM_TOK                        "PEIM"            ///< PEIM Modules Entry Point execution
+
+//
+// Misc defines
+//
+#define FPDT_RECORD_REVISION_1      (0x01)
+
+//
+// Length field in EFI_ACPI_5_0_FPDT_PERFORMANCE_RECORD_HEADER is a UINT8, thus:
+//
+#define FPDT_MAX_PERF_RECORD_SIZE   (MAX_UINT8)
+
+//
+// FPDT Record Types
+//
+#define FPDT_GUID_EVENT_TYPE               0x1010
+#define FPDT_DYNAMIC_STRING_EVENT_TYPE     0x1011
+#define FPDT_DUAL_GUID_STRING_EVENT_TYPE   0x1012
+#define FPDT_GUID_QWORD_EVENT_TYPE         0x1013
+#define FPDT_GUID_QWORD_STRING_EVENT_TYPE  0x1014
+
+//
+// EDKII extended Fpdt record structures
+//
+#define FPDT_STRING_EVENT_RECORD_NAME_LENGTH 24
+
+#pragma pack(1)
+//
+// FPDT Boot Performance Guid Event Record Structure
+//
+typedef struct {
+  EFI_ACPI_5_0_FPDT_PERFORMANCE_RECORD_HEADER Header;
+  ///
+  /// ProgressID < 0x10 are reserved for core performance entries.
+  /// Start measurement point shall have lowered one nibble set to zero and
+  /// corresponding end points shall have lowered one nibble set to non-zero value;
+  /// keeping other nibbles same as start point.
+  ///
+  UINT16                                      ProgressID;
+  ///
+  /// APIC ID for the processor in the system used as a timestamp clock source.
+  /// If only one timestamp clock source is used, this field is Reserved and populated as 0.
+  ///
+  UINT32                                      ApicID;
+  ///
+  /// 64-bit value (nanosecond) describing elapsed time since the most recent deassertion of processor reset.
+  ///
+  UINT64                                      Timestamp;
+  ///
+  /// If ProgressID < 0x10, GUID of the referenced module; otherwise, GUID of the module logging the event.
+  ///
+  EFI_GUID                                    Guid;
+} FPDT_GUID_EVENT_RECORD;
+
+//
+// FPDT Boot Performance Dynamic String Event Record Structure
+//
+typedef struct {
+  EFI_ACPI_5_0_FPDT_PERFORMANCE_RECORD_HEADER Header;
+  ///
+  /// ProgressID < 0x10 are reserved for core performance entries.
+  /// Start measurement point shall have lowered one nibble set to zero and
+  /// corresponding end points shall have lowered one nibble set to non-zero value;
+  /// keeping other nibbles same as start point.
+  ///
+  UINT16                                      ProgressID;
+  ///
+  /// APIC ID for the processor in the system used as a timestamp clock source.
+  /// If only one timestamp clock source is used, this field is Reserved and populated as 0.
+  ///
+  UINT32                                      ApicID;
+  ///
+  /// 64-bit value (nanosecond) describing elapsed time since the most recent deassertion of processor reset.
+  ///
+  UINT64                                      Timestamp;
+  ///
+  /// If ProgressID < 0x10, GUID of the referenced module; otherwise, GUID of the module logging the event.
+  ///
+  EFI_GUID                                    Guid;
+  ///
+  /// ASCII string describing the module. Padding supplied at the end if necessary with null characters (0x00).
+  /// It may be module name, function name, or token name.
+  ///
+  CHAR8                                       String[0];
+} FPDT_DYNAMIC_STRING_EVENT_RECORD;
+
+//
+// FPDT Boot Performance Dual GUID String Event Record Structure
+//
+typedef struct {
+  EFI_ACPI_5_0_FPDT_PERFORMANCE_RECORD_HEADER Header;
+  ///
+  /// ProgressID < 0x10 are reserved for core performance entries.
+  /// Start measurement point shall have lowered one nibble set to zero and
+  /// corresponding end points shall have lowered one nibble set to non-zero value;
+  /// keeping other nibbles same as start point.
+  ///
+  UINT16                                      ProgressID;
+  ///
+  /// APIC ID for the processor in the system used as a timestamp clock source.
+  /// If only one timestamp clock source is used, this field is Reserved and populated as 0.
+  ///
+  UINT32                                      ApicID;
+  ///
+  /// 64-bit value (nanosecond) describing elapsed time since the most recent deassertion of processor reset.
+  ///
+  UINT64                                      Timestamp;
+  ///
+  /// GUID of the module logging the event.
+  ///
+  EFI_GUID                                    Guid1;
+  ///
+  /// Event or Ppi or Protocol GUID for Callback.
+  ///
+  EFI_GUID                                    Guid2;
+  ///
+  /// ASCII string describing the module. Padding supplied at the end if necessary with null characters (0x00).
+  /// It is the function name.
+  ///
+  CHAR8                                       String[0];
+} FPDT_DUAL_GUID_STRING_EVENT_RECORD;
+
+//
+// FPDT Boot Performance GUID Qword Event Record Structure
+//
+typedef struct {
+  EFI_ACPI_5_0_FPDT_PERFORMANCE_RECORD_HEADER Header;
+  ///
+  /// ProgressID < 0x10 are reserved for core performance entries.
+  /// Start measurement point shall have lowered one nibble set to zero and
+  /// corresponding end points shall have lowered one nibble set to non-zero value;
+  /// keeping other nibbles same as start point.
+  ///
+  UINT16                                      ProgressID;
+  ///
+  /// APIC ID for the processor in the system used as a timestamp clock source.
+  /// If only one timestamp clock source is used, this field is Reserved and populated as 0.
+  ///
+  UINT32                                      ApicID;
+  ///
+  /// 64-bit value (nanosecond) describing elapsed time since the most recent deassertion of processor reset.
+  ///
+  UINT64                                      Timestamp;
+  ///
+  /// GUID of the module logging the event
+  ///
+  EFI_GUID                                    Guid;
+  ///
+  /// Qword of misc data, meaning depends on the ProgressId
+  ///
+  UINT64                                      Qword;
+} FPDT_GUID_QWORD_EVENT_RECORD;
+
+//
+// FPDT Boot Performance GUID Qword String Event Record Structure
+//
+typedef struct {
+  EFI_ACPI_5_0_FPDT_PERFORMANCE_RECORD_HEADER Header;
+  ///
+  /// ProgressID < 0x10 are reserved for core performance entries.
+  /// Start measurement point shall have lowered one nibble set to zero and
+  /// corresponding end points shall have lowered one nibble set to non-zero value;
+  /// keeping other nibbles same as start point.
+  ///
+  UINT16                                      ProgressID;
+  ///
+  /// APIC ID for the processor in the system used as a timestamp clock source.
+  /// If only one timestamp clock source is used, this field is Reserved and populated as 0.
+  ///
+  UINT32                                      ApicID;
+  ///
+  /// 64-bit value (nanosecond) describing elapsed time since the most recent deassertion of processor reset.
+  ///
+  UINT64                                      Timestamp;
+  ///
+  /// GUID of the module logging the event
+  ///
+  EFI_GUID                                    Guid;
+  ///
+  /// Qword of misc data, meaning depends on the ProgressId
+  ///
+  UINT64                                      Qword;
+  ///
+  /// ASCII string describing the module. Padding supplied at the end if necessary with null characters (0x00).
+  ///
+  CHAR8                                       String[0];
+} FPDT_GUID_QWORD_STRING_EVENT_RECORD;
+
+#pragma pack()
+
+//
+// Union of all FPDT records
+//
+typedef union {
+  EFI_ACPI_5_0_FPDT_PERFORMANCE_RECORD_HEADER  RecordHeader;
+  FPDT_GUID_EVENT_RECORD                       GuidEvent;
+  FPDT_DYNAMIC_STRING_EVENT_RECORD             DynamicStringEvent;
+  FPDT_DUAL_GUID_STRING_EVENT_RECORD           DualGuidStringEvent;
+  FPDT_GUID_QWORD_EVENT_RECORD                 GuidQwordEvent;
+  FPDT_GUID_QWORD_STRING_EVENT_RECORD          GuidQwordStringEvent;
+} FPDT_RECORD;
+
+//
+// Union of all pointers to FPDT records
+//
+typedef union {
+  EFI_ACPI_5_0_FPDT_PERFORMANCE_RECORD_HEADER  *RecordHeader;
+  FPDT_GUID_EVENT_RECORD                       *GuidEvent;
+  FPDT_DYNAMIC_STRING_EVENT_RECORD             *DynamicStringEvent;
+  FPDT_DUAL_GUID_STRING_EVENT_RECORD           *DualGuidStringEvent;
+  FPDT_GUID_QWORD_EVENT_RECORD                 *GuidQwordEvent;
+  FPDT_GUID_QWORD_STRING_EVENT_RECORD          *GuidQwordStringEvent;
+} FPDT_RECORD_PTR;
+
+///
+/// Hob:
+///   GUID - gEdkiiFpdtExtendedFirmwarePerformanceGuid;
+///   Data - FPDT_PEI_EXT_PERF_HEADER + one or more FPDT records
+///
+typedef struct {
+  UINT32                SizeOfAllEntries;
+  UINT32                LoadImageCount;
+  UINT32                HobIsFull;
+} FPDT_PEI_EXT_PERF_HEADER;
+
+typedef struct {
+  CONST CHAR8           *Token;           ///< Measured token string name.
+  CONST CHAR8           *Module;          ///< Module string name.
+  UINT64                StartTimeStamp;   ///< Start time point.
+  UINT32                Type;             ///< Rec type.
+  UINT32                Identifier;       ///< Identifier.
+  EFI_GUID              ModuleGuid;
+} MEASUREMENT_RECORD;
+
+extern EFI_GUID gEdkiiFpdtExtendedFirmwarePerformanceGuid;
+
+#endif

--- a/BootloaderCommonPkg/Library/LoaderPerformanceLib/LoaderPerformanceLib.inf
+++ b/BootloaderCommonPkg/Library/LoaderPerformanceLib/LoaderPerformanceLib.inf
@@ -36,5 +36,7 @@
 
 [Guids]
   gPeiFirmwarePerformanceGuid
+  gEdkiiFpdtExtendedFirmwarePerformanceGuid
 
 [Pcd]
+  gPlatformCommonLibTokenSpaceGuid.PcdBootPerformanceMask


### PR DESCRIPTION
FSP could produce a FSP boot performance HOB.
So add the capability to print FSP performance data.
Also add a PcdBootPerformanceMask to enable/disable
boot performance data print.

Signed-off-by: Guo Dong <guo.dong@intel.com>