### PR TITLE
Add 'acpi_rsdp' Linux kernel parameter in cmdline

### DIFF
--- a/BootloaderCommonPkg/Include/Library/LinuxLib.h
+++ b/BootloaderCommonPkg/Include/Library/LinuxLib.h
@@ -13,6 +13,8 @@
 
 #define BOOT_PARAMS_BASE      0x00090000
 #define LINUX_KERNEL_BASE     0x00100000
+#define CMDLINE_OFFSET        0xF000
+#define CMDLINE_LENGTH_MAX    0x800
 
 #define E820_RAM              1
 #define E820_RESERVED         2

--- a/BootloaderCommonPkg/Library/LinuxLib/LinuxLib.inf
+++ b/BootloaderCommonPkg/Library/LinuxLib/LinuxLib.inf
@@ -31,9 +31,11 @@
   BaseMemoryLib
   DebugLib
   PagingLib
+  PrintLib
 
 [Guids]
   gEfiGraphicsInfoHobGuid
   gLoaderMemoryMapInfoGuid
+  gLoaderSystemTableInfoGuid
 
 [Pcd]

--- a/PayloadPkg/OsLoader/OsLoader.h
+++ b/PayloadPkg/OsLoader/OsLoader.h
@@ -65,10 +65,6 @@
 
 #define DEFAULT_COMMAND_LINE     "console=ttyS0,115200\0"
 
-#define BOOT_PARAMS_BASE         0x00090000
-#define LINUX_KERNEL_BASE        0x00100000
-#define CMDLINE_OFFSET           0xF000
-#define CMDLINE_LENGTH_MAX       0x800
 #define EOF                      "<eof>"
 #define GPT_PART_ENTRIES_MAX     4
 


### PR DESCRIPTION
Recent Linux kernel accepts acpi_rsdp=0x.. in kernel command line.
This will make Linux kernel look for ACPI RSDP address in the kernel
commad line first prior to in DMI or F-segment.

Signed-off-by: Aiden Park <aiden.park@intel.com>