### PR TITLE
[APL] Fix PDR region stitching

### DIFF
--- a/Platform/ApollolakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/ApollolakeBoardPkg/Script/StitchIfwi.py
@@ -355,7 +355,7 @@ def gen_fit_xml (fit_dir, src, dst, btg_profile, spi_quad):
 
     # Enable PDR region
     node = tree.find('./FlashLayout/SubPartitions/PdrRegion/Enabled')
-    node.attrib['value'] = 'enabled'
+    node.attrib['value'] = 'Enabled'
     node = tree.find('./FlashLayout/SubPartitions/PdrRegion/InputFile')
     node.attrib['value'] = '$SourceDir\input\pdr.bin'
 
@@ -484,7 +484,7 @@ def stitch (stitch_dir, stitch_zip, btg_profile, spi_quad_mode, platform_data, f
     if not os.path.exists(input_pdr):
         print ("\nGenerating pdr.bin ...")
         fp = open (output_pdr, 'wb')
-        fp.write (b'\xff' * 0xFF000)
+        fp.write (b'\xff' * 0x1000)
         fp.close()
     else:
         shutil.copy (input_pdr, output_pdr)


### PR DESCRIPTION
Current APL StitchIfwi.py does not enable PDR region due to incorrect
XML option. This patch fixed this and also adjusted the default PDR
region to be 4KB to save space.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>