### PR TITLE
Add keypad arrow key support

### DIFF
--- a/BootloaderCommonPkg/Library/UsbKbLib/UsbKbLib.c
+++ b/BootloaderCommonPkg/Library/UsbKbLib/UsbKbLib.c
@@ -1,7 +1,7 @@
 /** @file
   USB keyboard library implementation.
 
-  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -15,7 +15,8 @@ CONST  CHAR8  *mKeyboardKeyMap[] = {
   "abcdefghijklmnopqrstuvwxyz1234567890\r\x1b\b\t -=[]\\ ;'`,./",
   "ABCDEFGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()\r\x1b\b\t _+{}| :\"~<>?",
   "/*-+\r1234567890.",
-  "CDBA"
+  "MQNP5OJRKIL",
+  "CDBA",
 };
 
 USB_KB_DEV     mUsbKbDevice;
@@ -582,15 +583,18 @@ ConvertKeyToAscii (
     return mKeyboardKeyMap[Shift][Key - 0x04];
   }
 
-  if (mUsbKbDevice.NumLockOn) {
-     if (Key >= 0x54 && Key <= 0x63) {
-       return mKeyboardKeyMap[2][Key - 0x54];
-     }
+  if (Key >= 0x54 && Key <= 0x63) {
+    // For keypad keys with NumLock on
+    if (mUsbKbDevice.NumLockOn || (Key < 0x59)) {
+      return mKeyboardKeyMap[2][Key - 0x54];
+    }
+    // For keypad keys with NumLock off
+    Key = (UINT8)mKeyboardKeyMap[3][Key - 0x59];
   }
 
   if (Key >= 0x4F && Key <= 0x52) {
     // Arrow key
-    return ARROW_KEY_MODIFIER | mKeyboardKeyMap[3][Key - 0x4F];
+    return ARROW_KEY_MODIFIER | mKeyboardKeyMap[4][Key - 0x4F];
   }
 
   if (Key == 0x53) {


### PR DESCRIPTION
This patch added support for arrow keys on PS2 numeric keypad.
The original code only supports the dedicated arrow keys.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>