### PR TITLE
Add media DeInit for Shell FS command

### DIFF
--- a/BootloaderCommonPkg/Library/LoaderPerformanceLib/LoaderPerformanceLib.inf
+++ b/BootloaderCommonPkg/Library/LoaderPerformanceLib/LoaderPerformanceLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -37,6 +37,7 @@
 [Guids]
   gPeiFirmwarePerformanceGuid
   gEdkiiFpdtExtendedFirmwarePerformanceGuid
+  gLoaderFspInfoGuid
 
 [Pcd]
   gPlatformCommonLibTokenSpaceGuid.PcdBootPerformanceMask

--- a/BootloaderCommonPkg/Library/ShellLib/ShellLib.inf
+++ b/BootloaderCommonPkg/Library/ShellLib/ShellLib.inf
@@ -79,6 +79,7 @@
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
   gPlatformCommonLibTokenSpaceGuid.PcdMiniShellEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdConsoleInDeviceMask
 
 [Guids]
   gLoaderPerformanceInfoGuid


### PR DESCRIPTION
In Shell FS after media initialization,  the de-initialization
should be called to free all allocated memory.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>