### PR TITLE
Fix ConfigEditor mouse scroll issue with Python3

### DIFF
--- a/BootloaderCorePkg/Tools/ConfigEditor.py
+++ b/BootloaderCorePkg/Tools/ConfigEditor.py
@@ -492,7 +492,7 @@ class Application(Frame):
             # Only scroll when it is in active area
             min, max = self.PageScroll.get()
             if not ((min == 0.0) and (max == 1.0)):
-                self.ConfCanvas.yview_scroll(-1 * (Event.delta / 120), 'units')
+                self.ConfCanvas.yview_scroll(-1 * int(Event.delta / 120), 'units')
 
     def UpdateVisibilityForWidget(self, Widget, Args):
 


### PR DESCRIPTION
Scrolling mouse in ConfigEditor with Python3 will trigger some
error message. During the scroll unit calculation, it is required
to convert float into int type. This patch fixed it.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>