### PR TITLE
Use PcdCompSignHash alg for pubkey verification for non zero usage

### DIFF
--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
@@ -288,6 +288,7 @@ AuthenticateComponent (
   UINT8                    *SigPtr;
   UINT8                    *KeyPtr;
   SIGNATURE_HDR            *SignHdr;
+  UINT8                     HashAlg;
 
   if (!FeaturePcdGet (PcdVerifiedBootEnabled)) {
     Status = EFI_SUCCESS;
@@ -301,8 +302,15 @@ AuthenticateComponent (
       SigPtr   = (UINT8 *) AuthData;
       SignHdr  = (SIGNATURE_HDR *) SigPtr;
       KeyPtr   = (UINT8 *)SignHdr + sizeof(SIGNATURE_HDR) + SignHdr->SigSize ;
+
+      if (Usage == 0x0) {
+        HashAlg =  GetHashAlg(AuthType);
+      }  else {
+        HashAlg =  PcdGet8(PcdCompSignHashAlg);
+      }
+
       Status   = DoRsaVerify (Data, Length, Usage, SignHdr,
-                             (PUB_KEY_HDR *) KeyPtr, GetHashAlg(AuthType), HashData, NULL);
+                             (PUB_KEY_HDR *) KeyPtr, HashAlg, HashData, NULL);
     } else if (AuthType == AUTH_TYPE_NONE) {
       Status = EFI_SUCCESS;
     } else {


### PR DESCRIPTION
PublicKey hashes stored in HashStore use hash alg type of
PcdCompSignHash defined with Build config. In container we support cases where hash type
could differ from Sbl signing hash. For example Slimboot could
be configured to RSA3K and SHA384 at build. Container Boot image
could happen to be signed with RSA2K and SHA256.

Assigning pubkey verification hash type to PcdCompSignHash
for valid USAGE cases.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>