### PR TITLE
Adjust hash algorithm used for KEYH based on key size

### DIFF
--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -344,6 +344,18 @@ def get_payload_list (payloads):
 
     return pld_lst
 
+# Adjust hash type algorithm based on Public key file
+def adjust_hash_type (pub_key_file):
+    key_type =  get_key_type (pub_key_file)
+    if key_type ==  'RSA2048':
+        hash_type = 'SHA2_256'
+    elif key_type ==  'RSA3072':
+        hash_type = 'SHA2_384'
+    else:
+        hash_type = None
+
+    return hash_type
+
 
 def gen_pub_key_hash_store (signing_key, pub_key_hash_list, hash_alg, sign_scheme, pub_key_dir, out_file):
     # Build key hash blob
@@ -352,10 +364,11 @@ def gen_pub_key_hash_store (signing_key, pub_key_hash_list, hash_alg, sign_schem
     for usage, key_file in pub_key_hash_list:
         pub_key_file = os.path.dirname(out_file) + '/PUBKEY%02d.bin' % idx
         gen_pub_key (os.path.join(pub_key_dir, key_file), pub_key_file)
-        hash_data = gen_hash_file (pub_key_file, hash_alg, None, True)
+        key_hash_alg = adjust_hash_type (pub_key_file)
+        hash_data = gen_hash_file (pub_key_file, key_hash_alg, None, True)
         key_hash_entry = HashStoreData()
         key_hash_entry.Usage     = usage
-        key_hash_entry.HashAlg   = HASH_TYPE_VALUE[hash_alg]
+        key_hash_entry.HashAlg   = HASH_TYPE_VALUE[key_hash_alg]
         key_hash_entry.DigestLen = len(hash_data)
         key_hash_buf.extend (bytearray(key_hash_entry) + hash_data)
         idx += 1

--- a/BootloaderCorePkg/Tools/CommonUtility.py
+++ b/BootloaderCorePkg/Tools/CommonUtility.py
@@ -276,8 +276,14 @@ def rsa_sign_file (priv_key, pub_key, hash_type, sign_scheme, in_file, out_file,
         gen_file_from_object (out_file, bins)
 
 def get_key_type (in_key):
-    pub_key = gen_pub_key (in_key)
-    pub_key_hdr = PUB_KEY_HDR.from_buffer(pub_key)
+
+    # Check for public key in binary format.
+    key = bytearray(get_file_data(in_key))
+    pub_key_hdr = PUB_KEY_HDR.from_buffer(key)
+    if pub_key_hdr.Identifier != b'PUBK':
+        pub_key = gen_pub_key (in_key)
+        pub_key_hdr = PUB_KEY_HDR.from_buffer(pub_key)
+
     key_type = next((key for key, value in PUB_KEY_TYPE.items() if value == pub_key_hdr.KeyType))
     return '%s%d' % (key_type, (pub_key_hdr.KeySize - 4) * 8)
 


### PR DESCRIPTION
PublicKey hashes stored in HashStore use hash alg type of
PcdCompSignHash defined with Build config. In container we
support cases where hash type could differ from Sbl default
signing hash.

Adjust the hash algorithm in external KeyHashStore manifest
based on key size. Use SHA256 for size 2K and SHA384 for 3K.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>