### PR TITLE
Move container initialization earlier

### DIFF
--- a/BootloaderCommonPkg/Include/Library/ContainerLib.h
+++ b/BootloaderCommonPkg/Include/Library/ContainerLib.h
@@ -51,8 +51,8 @@ typedef VOID (*LOAD_COMPONENT_CALLBACK) (UINT32 ProgressId, COMPONENT_CALLBACK_I
 typedef struct {
   UINT32           Signature;
   UINT32           HeaderCache;
+  UINT32           HeaderSize;
   UINT32           Base;
-  UINT32           Reserved;
 } CONTAINER_ENTRY;
 
 typedef struct {

--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -43,6 +43,7 @@ typedef enum {
   EnumBufPcdData,
   EnumBufPlatData,
   EnumBufCfgData,
+  EnumBufCtnList,
   EnumBufLogBuf,
   EnumBufMax
 } BUF_INFO_ID;

--- a/BootloaderCorePkg/Stage1A/Stage1A.h
+++ b/BootloaderCorePkg/Stage1A/Stage1A.h
@@ -27,6 +27,7 @@
 #include <Library/CpuExceptionLib.h>
 #include <Library/DebugLogBufferLib.h>
 #include <Library/DebugAgentLib.h>
+#include <Library/ContainerLib.h>
 #include <Library/StageLib.h>
 #include <Guid/FspHeaderFile.h>
 #include <Guid/FlashMapInfoGuid.h>

--- a/BootloaderCorePkg/Stage1A/Stage1A.inf
+++ b/BootloaderCorePkg/Stage1A/Stage1A.inf
@@ -62,6 +62,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdMaxLibraryDataEntry
   gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdDebugOutputDeviceMask
+  gPlatformCommonLibTokenSpaceGuid.PcdContainerMaxNumber
   gPlatformModuleTokenSpaceGuid.PcdStage1StackSize
   gPlatformModuleTokenSpaceGuid.PcdStage1BFdBase
   gPlatformModuleTokenSpaceGuid.PcdStage1BLoadBase

--- a/BootloaderCorePkg/Stage1B/Stage1B.inf
+++ b/BootloaderCorePkg/Stage1B/Stage1B.inf
@@ -63,7 +63,6 @@
 [Pcd]
   gPlatformCommonLibTokenSpaceGuid.PcdMaxLibraryDataEntry
   gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled
-  gPlatformCommonLibTokenSpaceGuid.PcdContainerMaxNumber
   gPlatformModuleTokenSpaceGuid.PcdStage1StackSize
   gPlatformModuleTokenSpaceGuid.PcdStage1DataSize
   gPlatformModuleTokenSpaceGuid.PcdFSPTBase


### PR DESCRIPTION
Current container library cannot be used before memory is initialized
because the structure will only be initialized after memory. This
patch moved the initialization into Stage1A so that the library can be
used much earlier. At this moment, the containers loaded before memory
will not be migrated into memory automatically. Instead, the container
structure will be reseted post memory to avoid potential invalid
pointer access.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>