### PR TITLE
Support paging for Above4Gb addresses

### DIFF
--- a/BootloaderCommonPkg/Include/Library/PagingLib.h
+++ b/BootloaderCommonPkg/Include/Library/PagingLib.h
@@ -15,9 +15,10 @@
 #define  IA32_PG_PD                  BIT7
 
 typedef struct {
-  UINT32  Start;
-  UINT32  Limit;
-  UINT32  Mapping;
+  UINTN   Start;
+  UINTN   Limit;
+  UINTN   Mapping;
+  UINT32  PageSize;
 } MAP_RANGE;
 
 /**
@@ -32,6 +33,20 @@ UINT32
 EFIAPI
 GetPageTablesMemorySize (
   IN BOOLEAN     IsX64Mode
+  );
+
+/**
+  This function dumps the current PageTables
+
+  @param None
+
+  @retval None
+**/
+
+VOID
+EFIAPI
+DumpPageTables (
+  VOID
   );
 
 /**

--- a/BootloaderCommonPkg/Library/PagingLib/PagingLib.c
+++ b/BootloaderCommonPkg/Library/PagingLib/PagingLib.c
@@ -10,6 +10,11 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PagingLib.h>
+#include <Library/BootloaderCommonLib.h>
+
+#define IS_PD_SET     (((Address & 0xFFF) & IA32_PG_PD) == IA32_PG_PD)
+#define PD_SET_ADDR   (Address & ~(0xFFFF))
+#define PD_UNSET_ADDR (Address & ~(0xFFF))
 
 /**
   This function returns page tables memory size.
@@ -30,6 +35,116 @@ GetPageTablesMemorySize (
   } else {
     return 2 * SIZE_4KB;
   }
+}
+
+/**
+  This function dumps the current PageTables
+
+  @param None
+
+  @retval None
+**/
+
+VOID
+EFIAPI
+DumpPageTables (
+  VOID
+  )
+{
+  BOOLEAN       Is64Bit;
+  UINT64        *PagePml4;
+  UINT64        *PagePdp3;
+  UINT64        *PagePde2;
+  UINT64        *PagePte1;
+  UINT32        *Page32Pde2;
+  UINT32        *Page32Pte1;
+  UINT32        L4Idx;
+  UINT32        L3Idx;
+  UINT32        L2Idx;
+  UINT32        L1Idx;
+  UINTN         EntryNum;
+  UINTN         Address;
+  BOOLEAN       IsPdSet;
+
+  Is64Bit = IS_X64;
+  IsPdSet = FALSE;
+
+  if (Is64Bit) {
+    EntryNum    = 512;
+    PagePml4    = (UINT64 *) AsmReadCr3 ();
+    for (L4Idx  = 0; L4Idx < EntryNum; L4Idx++) {
+      Address   = (UINTN) PagePml4[L4Idx];
+      if (Address != 0) {
+        DEBUG ((DEBUG_INFO, "L4[%03d]=0x%016lX\t\t\t\t(@ 0x%08X)\n", L4Idx, Address, &PagePml4[L4Idx] ));
+      } else {
+        continue;
+      }
+      IsPdSet   = IS_PD_SET;
+      Address   = IsPdSet ? PD_SET_ADDR : PD_UNSET_ADDR;
+      if (!IsPdSet) {
+        PagePdp3   = (UINT64 *) Address;
+        for (L3Idx = 0; L3Idx < EntryNum; L3Idx++) {
+          Address  = (UINTN) PagePdp3[L3Idx];
+          if (Address != 0) {
+            DEBUG ((DEBUG_INFO, "\tL3[%03d]=0x%016lX\t\t\t(@ 0x%08X)\n", L3Idx, Address, &PagePdp3[L3Idx]));
+          } else {
+            continue;
+          }
+          IsPdSet  = IS_PD_SET;
+          Address  = IsPdSet ? PD_SET_ADDR : PD_UNSET_ADDR;
+          if (!IsPdSet) {
+            PagePde2   = (UINT64 *) Address;
+            for (L2Idx = 0; L2Idx < EntryNum; L2Idx++) {
+              Address  = (UINTN) PagePde2[L2Idx];
+              if (Address != 0) {
+                DEBUG ((DEBUG_INFO, "\t\tL2[%03d]=0x%016lX\t\t(@ 0x%08X)\n", L2Idx, Address, &PagePde2[L2Idx]));
+              } else {
+                continue;
+              }
+              IsPdSet  = IS_PD_SET;
+              Address  = IsPdSet ? PD_SET_ADDR : PD_UNSET_ADDR;
+              if (!IsPdSet ) {
+                PagePte1   = (UINT64 *) Address;
+                for (L1Idx = 0; L1Idx < EntryNum; L1Idx++) {
+                  Address  = (UINTN) PagePte1[L1Idx];
+                  if (Address != 0) {
+                    DEBUG ((DEBUG_INFO, "\t\t\tL1[%03d]=0x%016lX\t(@ 0x%08X)\n", L1Idx, Address, &PagePte1[L1Idx]));
+                  } else {
+                    continue;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  } else {
+    EntryNum    = 1024;
+    Page32Pde2  = (UINT32 *) AsmReadCr3 ();
+    for (L2Idx  = 0; L2Idx < EntryNum; L2Idx++) {
+      Address   = (UINTN) Page32Pde2[L2Idx];
+      if (Address != 0) {
+        DEBUG ((DEBUG_INFO, "L2[%03d]=0x%016lX\t\t\t(@ 0x%08X)\n", L2Idx, Address, &Page32Pde2[L2Idx]));
+      } else {
+        continue;
+      }
+      IsPdSet   = IS_PD_SET;
+      Address   = IsPdSet ? PD_SET_ADDR : PD_UNSET_ADDR;
+      if (!IsPdSet) {
+        Page32Pte1 = (UINT32 *) Address;
+        for (L1Idx = 0; L1Idx < EntryNum; L1Idx++) {
+          Address  = (UINTN) Page32Pte1[L1Idx];
+          if (Address != 0) {
+            DEBUG ((DEBUG_INFO, "\tL1[%03d]=0x%016lX\t\t(@ 0x%08X)\n", L1Idx, Address, &Page32Pte1[L1Idx]));
+          } else {
+            continue;
+          }
+        }
+      }
+    }
+  }
+
 }
 
 /**

--- a/BootloaderCommonPkg/Library/PagingLib/PagingMap.c
+++ b/BootloaderCommonPkg/Library/PagingLib/PagingMap.c
@@ -11,19 +11,27 @@
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PagingLib.h>
 
+#define PDE_PG_LVL  2
+#define PDP_PG_LVL  3
 
 /**
   Get shift bit number from address to page index
 
-  @retval    Bit to shift to get page index.
+  @param[in] Level    Page level.
+
+  @retval             Bit to shift to get specific page level index.
 
 **/
 UINT32
 GetPageShiftBits (
-  VOID
+  IN  UINT8   Level
 )
 {
-  return IsLongModeEnabled() ? 21 : 22;
+  if (Level == PDE_PG_LVL) {
+    return IsLongModeEnabled() ? 21 : 22;
+  } else {
+    return IsLongModeEnabled() ? 30 : 31;
+  }
 }
 
 /**
@@ -44,60 +52,101 @@ MapMemoryRange (
   )
 {
   UINTN          Idx;
+  UINTN          End;
   UINTN          EntryNum;
-  UINTN         *PageTable;
+  UINTN         *PageTable1G;
+  UINTN         *PageTable2M;
   UINTN         *PageTable4K;
-  UINT32         PageBase;
+  UINTN          PageBase;
   UINT32         Attribute;
-  UINT32         Address;
+  UINTN          Address;
   UINT32         PteOffset;
   UINT32         PdeOffset;
-  UINT32         Alignment;
+  UINT32         PdpOffset;
+  UINTN          Alignment;
   UINT32         PageBits;
 
-  Attribute    = IA32_PG_P | IA32_PG_RW | IA32_PG_AC;
+  Attribute = IA32_PG_P | IA32_PG_RW | IA32_PG_AC;
 
-  // Define CAR region and memory mapping
-  if (((Ranges[0].Start & 0xFFF) != 0) || ((Ranges[0].Limit & 0xFFF) != 0xFFF)) {
+  Alignment = Ranges[0].PageSize - 1;
+  // Check for Start and Limit PageSize alignment
+  if (((Ranges[0].Start & Alignment) != 0) || ((Ranges[0].Limit & Alignment) != Alignment)) {
+    return EFI_INVALID_PARAMETER;
+  }
+  // Check for Mapping PageSize alignment
+  if ( (Ranges[0].Mapping & Alignment) != 0) {
     return EFI_INVALID_PARAMETER;
   }
 
-  PageBits  = GetPageShiftBits ();
-  if (PageBits == 21) {
-    // 64 bit mode
-    PteOffset = 6 * EFI_PAGE_SIZE;
-    PdeOffset = 2 * EFI_PAGE_SIZE;
-    EntryNum  = 512;
-  } else {
-    // 32 bit mode
-    PteOffset = 1 * EFI_PAGE_SIZE;
-    PdeOffset = 0;
-    EntryNum  = 1024;
-  }
-
-  Alignment = (UINT32) LShiftU64 (1, PageBits) - 1;
-  PageBase  = Ranges[0].Start & ~Alignment;
-  if (((Ranges[0].Start & ~Alignment) != PageBase) || ((Ranges[0].Limit & ~Alignment) != PageBase)) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  // Create 4KB pages and remap the CAR region into a different memory location
-  PageTable4K = (UINTN *)((UINTN)PageBuffer + PteOffset);
-  Address = PageBase;
-  for (Idx = 0; Idx < EntryNum; Idx++) {
-    if ((Address >= Ranges[0].Start) && (Address <= Ranges[0].Limit)) {
-      PageTable4K[Idx]   = Ranges[0].Mapping + (Attribute | IA32_PG_PD);
-      Ranges[0].Mapping += SIZE_4KB;
+  switch (Ranges[0].PageSize) {
+  case SIZE_4KB:
+    PageBits  = GetPageShiftBits (PDE_PG_LVL);
+    if (PageBits == 21) {
+      // 64 bit mode
+      PteOffset = 6 * EFI_PAGE_SIZE;
+      PdeOffset = 2 * EFI_PAGE_SIZE;
+      EntryNum  = 512;
     } else {
-      PageTable4K[Idx]   = Address + (Attribute | IA32_PG_PD);
+      // 32 bit mode
+      PteOffset = 1 * EFI_PAGE_SIZE;
+      PdeOffset = 0;
+      EntryNum  = 1024;
     }
-    Address += SIZE_4KB;
+    PageTable4K = (UINTN *)((UINTN)PageBuffer + PteOffset);
+    PageTable2M = (UINTN *)((UINTN)PageBuffer + PdeOffset);
+    break;
+  case SIZE_1GB:
+    ASSERT (Ranges[0].Limit < SIZE_512GB);
+    PageBits    = GetPageShiftBits (PDP_PG_LVL);
+    PdpOffset   = 1 * EFI_PAGE_SIZE;
+    EntryNum    = 512;
+    PageTable1G = (UINTN *)((UINTN)PageBuffer + PdpOffset);
+    break;
+  default:
+    return EFI_INVALID_PARAMETER;
   }
 
-  // Split the 2MB page containing the CAR region into 4KB pages
-  Idx = (UINT32) RShiftU64 (PageBase, PageBits);
-  PageTable      = (UINTN *)((UINTN)PageBuffer + PdeOffset);
-  PageTable[Idx] = (UINTN)PageTable4K + Attribute;
+  Alignment = (UINTN) LShiftU64 (1, PageBits) - 1;
+  PageBase  = Ranges[0].Start & ~Alignment;
+
+  switch (Ranges[0].PageSize) {
+  case SIZE_4KB:
+    // Check if the limit is in the same page
+    if ((Ranges[0].Limit & ~Alignment) != PageBase) {
+      return EFI_INVALID_PARAMETER;
+    }
+
+    Address = PageBase;
+    // Create 4KB pages and remap the CAR region into a different memory location
+    for (Idx = 0; Idx < EntryNum; Idx++) {
+      if ((Address >= Ranges[0].Start) && (Address <= Ranges[0].Limit)) {
+        PageTable4K[Idx]   = Ranges[0].Mapping + (Attribute | IA32_PG_PD);
+        Ranges[0].Mapping += SIZE_4KB;
+      } else {
+        PageTable4K[Idx]   = Address + (Attribute | IA32_PG_PD);
+      }
+      Address += SIZE_4KB;
+    }
+
+    // Split the 2MB page containing the CAR region into 4KB pages
+    Idx = (UINT32) RShiftU64 (PageBase, PageBits);
+    PageTable2M[Idx] = (UINTN)PageTable4K + Attribute;
+
+    break;
+  case SIZE_1GB:
+    // Get the start and ending index into 1G table and add 1G entries
+    Address = Ranges[0].Mapping;
+    Idx = (UINT32) RShiftU64 (PageBase, PageBits);
+    End = (UINT32) RShiftU64 (Ranges[0].Limit + 1, PageBits);
+    for (; Idx < End; Idx++) {
+      PageTable1G[Idx] = Address + (Attribute | IA32_PG_PD);
+      Address += SIZE_1GB;
+    }
+
+    break;
+    default:
+      return EFI_INVALID_PARAMETER;
+  }
 
   return EFI_SUCCESS;
 }
@@ -139,7 +188,7 @@ UnmapMemoryRange (
   Attribute    = IA32_PG_P | IA32_PG_RW | IA32_PG_AC;
 
   // Remove 4KB pages from PDE
-  PageBits  = GetPageShiftBits ();
+  PageBits  = GetPageShiftBits (PDE_PG_LVL);
   if (PageBits == 21) {
     // 64 bit mode
     PdeOffset = 2 * EFI_PAGE_SIZE;
@@ -149,8 +198,8 @@ UnmapMemoryRange (
   }
 
   PageTable = (UINTN *)((UINTN)PageBuffer + PdeOffset);
-  Start = (UINT32) RShiftU64 (Ranges[0].Start, PageBits);
-  End   = (UINT32) RShiftU64 (Ranges[0].Limit, PageBits);
+  Start = (UINTN) RShiftU64 (Ranges[0].Start, PageBits);
+  End   = (UINTN) RShiftU64 (Ranges[0].Limit, PageBits);
   for (Idx = Start; Idx < End + 1; Idx++) {
     PageTable[Idx] = (UINTN)LShiftU64 (Idx, PageBits) | Attribute | IA32_PG_PD;
   }

--- a/BootloaderCorePkg/Library/StageLib/StageLib.c
+++ b/BootloaderCorePkg/Library/StageLib/StageLib.c
@@ -124,10 +124,11 @@ RemapStage (
     Stage1bBase = AllocateTemporaryMemory (PcdGet32 (PcdStage1BFdSize));
     DEBUG ((DEBUG_INFO, "Remapping Stage to 0x%08X\n", Stage1bBase));
     CopyMem (Stage1bBase, (VOID *)(UINTN)PcdGet32 (PcdStage1BFdBase), PcdGet32 (PcdStage1BFdSize));
-    RoundSize         = ALIGN_UP (PcdGet32 (PcdStage1BFdSize), EFI_PAGE_SIZE);
-    Ranges[0].Start   = PcdGet32 (PcdStage1BFdBase);
-    Ranges[0].Limit   = Ranges[0].Start + RoundSize - 1;
-    Ranges[0].Mapping = (UINT32)(UINTN)Stage1bBase;
+    RoundSize          = ALIGN_UP (PcdGet32 (PcdStage1BFdSize), EFI_PAGE_SIZE);
+    Ranges[0].Start    = (UINTN)PcdGet32 (PcdStage1BFdBase);
+    Ranges[0].Limit    = (UINTN)Ranges[0].Start + RoundSize - 1;
+    Ranges[0].Mapping  = (UINTN)Stage1bBase;
+    Ranges[0].PageSize = SIZE_4KB;
     Status = MapMemoryRange (Ranges, PageBuffer);
   }
   ASSERT_EFI_ERROR (Status);


### PR DESCRIPTION
This patch enhances MapMemoryRegion subroutine to
add PDP entries for mapping addresses > 4GiB.
Only 1:1 mapping is provided for Above4Gb addresses.
And linear addresses are mapped to 1GiB pages.

Signed-off-by: Sai Talamudupula <sai.kiran.talamudupula@intel.com>