### PR TITLE
[X64] Fix MpInit failure

### DIFF
--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
@@ -176,6 +176,7 @@ CpuInit (
 
 **/
 VOID
+EFIAPI
 ApFunc (
   UINT32                   Index,
   MP_DATA_EXCHANGE_STRUCT *mMpDataStructPtr


### PR DESCRIPTION
This will fix MpInit failure on X64 build.
The ApFunc() gets invalid parameters due to mismatched calling convention.
- Add EFIAPI to match calling convention

This can be verified with '-smp' option on QEMU target.
qemu-system-x86_64
  -machine q35 -m 256 -nographic -serial mon:stdio
  -pflash Outputs/qemu/SlimBootloader.bin
  -smp 255

Signed-off-by: Aiden Park <aiden.park@intel.com>