### PR TITLE
[X64] Support S3 resume on 64-bit build

### DIFF
--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
@@ -727,7 +727,11 @@ FindAcpiWakeVectorAndJump (
     Hdr = (EFI_ACPI_COMMON_HEADER *) (UINTN)XsdtEntry[Index];
     if (Hdr->Signature == EFI_ACPI_5_0_FIXED_ACPI_DESCRIPTION_TABLE_SIGNATURE) {
       Facp = (EFI_ACPI_5_0_FIXED_ACPI_DESCRIPTION_TABLE *) Hdr;
-      Facs = (EFI_ACPI_5_0_FIRMWARE_ACPI_CONTROL_STRUCTURE *)(UINTN)Facp->FirmwareCtrl;
+      if (Facp->XFirmwareCtrl != 0) {
+        Facs = (EFI_ACPI_5_0_FIRMWARE_ACPI_CONTROL_STRUCTURE *)(UINTN)Facp->XFirmwareCtrl;
+      } else {
+        Facs = (EFI_ACPI_5_0_FIRMWARE_ACPI_CONTROL_STRUCTURE *)(UINTN)Facp->FirmwareCtrl;
+      }
       if (Facs->Signature == EFI_ACPI_5_0_FIRMWARE_ACPI_CONTROL_STRUCTURE_SIGNATURE) {
         WakeVector = Facs->FirmwareWakingVector;
         // Calculate CRC32 for 0x00000000 ---> BootLoaderRsvdMemBase and
@@ -737,7 +741,7 @@ FindAcpiWakeVectorAndJump (
             return;
           }
         }
-        CopyMem ((VOID *)(UINTN)WakeUpBuffer, &WakeUp, WakeUpSize);
+        CopyMem ((VOID *)(UINTN)WakeUpBuffer, (VOID *)(UINTN)&WakeUp, WakeUpSize);
         DoWake = (DOWAKEUP)(UINTN)WakeUpBuffer;
         DEBUG ((DEBUG_INIT, "Jump to Wake vector = 0x%x\n", WakeVector));
         DoWake (WakeVector);


### PR DESCRIPTION
This will support S3 resume path on X64 thru 16-bit waking vector.
- Port WakeUp code from EDKII
- Remove duplicated calls of FindS3Info from CpuInit
- Verified with Yocto on a WHL board
- TBD: 64-bit waking vector with supported OS

Signed-off-by: Aiden Park <aiden.park@intel.com>