### PR TITLE
Enhance debug log buffer as ring buffer

### DIFF
--- a/BootloaderCommonPkg/Include/Guid/LoaderPlatformDataGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/LoaderPlatformDataGuid.h
@@ -14,26 +14,14 @@
 ///
 extern EFI_GUID gLoaderPlatformDataGuid;
 
-#define  DEBUG_LOG_BUFFER_SIGNATURE         SIGNATURE_32 ('D', 'L', 'O', 'G')
-
 #define  DEBUG_OUTPUT_DEVICE_LOG_BUFFER     BIT0
 #define  DEBUG_OUTPUT_DEVICE_SERIAL_PORT    BIT1
 #define  DEBUG_OUTPUT_DEVICE_CONSOLE        BIT2
 
 typedef struct {
-  UINT32  Signature;
-  UINT8   HeaderLength;
-  UINT8   Attribute;
-  UINT8   Reserved[2];
-  UINT32  UsedLength;
-  UINT32  TotalLength;
-  UINT8   Buffer[0];
-} DEBUG_LOG_BUFFER_HEADER;
-
-typedef struct {
   UINT8                     Revision;
   UINT8                     Reserved0[3];
-  DEBUG_LOG_BUFFER_HEADER  *DebugLogBuffer;
+  VOID                     *DebugLogBuffer;
   VOID                     *ConfigDataPtr;
   VOID                     *ContainerList;
   VOID                     *DmaBufferPtr;

--- a/BootloaderCommonPkg/Include/Library/DebugLogBufferLib.h
+++ b/BootloaderCommonPkg/Include/Library/DebugLogBufferLib.h
@@ -9,6 +9,20 @@
 #ifndef __DEBUG_LOG_BUFFER_LIB_H__
 #define __DEBUG_LOG_BUFFER_LIB_H__
 
+#define  DEBUG_LOG_BUFFER_SIGNATURE         SIGNATURE_32 ('D', 'L', 'O', 'G')
+
+#define  DEBUG_LOG_BUFFER_ATTRIBUTE_FULL    BIT0
+
+typedef struct {
+  UINT32  Signature;
+  UINT8   HeaderLength;
+  UINT8   Attribute;
+  UINT8   Reserved[2];
+  UINT32  UsedLength;
+  UINT32  TotalLength;
+  UINT8   Buffer[0];
+} DEBUG_LOG_BUFFER_HEADER;
+
 /**
   Write data from buffer to console buffer.
 

--- a/BootloaderCommonPkg/Library/BootloaderCommonLib/BootloaderCommonLib.c
+++ b/BootloaderCommonPkg/Library/BootloaderCommonLib/BootloaderCommonLib.c
@@ -16,6 +16,7 @@
 #include <Library/HobLib.h>
 #include <Library/BootloaderCommonLib.h>
 #include <Library/SecureBootLib.h>
+#include <Library/DebugLogBufferLib.h>
 
 CONST CHAR8  mHex[]   = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 CONST CHAR8 *mStage[] = { "1A", "1B", "2", "PAYLOAD"};

--- a/BootloaderCommonPkg/Library/DebugLogBufferLib/DebugLogBufferLib.c
+++ b/BootloaderCommonPkg/Library/DebugLogBufferLib/DebugLogBufferLib.c
@@ -39,6 +39,7 @@ DebugLogBufferWrite (
   )
 {
   DEBUG_LOG_BUFFER_HEADER  *LogBufHdr;
+  UINTN                     RemainingBytes;
 
   // This function will be called by DEBUG or ASSERT macro.
   // So please DON'T use DEBUG/ASSERT macro inside this function,
@@ -48,14 +49,37 @@ DebugLogBufferWrite (
     return 0;
   }
 
+  if (LogBufHdr->Signature != DEBUG_LOG_BUFFER_SIGNATURE) {
+    return 0;
+  }
+
+  //
+  // Something wrong in Debug Log Buffer.
+  // Reset buffer index and continue to record logs.
+  //
+  if (LogBufHdr->UsedLength > LogBufHdr->TotalLength) {
+    LogBufHdr->UsedLength = LogBufHdr->HeaderLength;
+  }
+
+  RemainingBytes = 0;
   if (LogBufHdr->UsedLength + NumberOfBytes > LogBufHdr->TotalLength) {
-    NumberOfBytes = LogBufHdr->TotalLength - LogBufHdr->UsedLength;
+    RemainingBytes = LogBufHdr->UsedLength + NumberOfBytes - LogBufHdr->TotalLength;
+    NumberOfBytes  = LogBufHdr->TotalLength - LogBufHdr->UsedLength;
   }
 
   if (NumberOfBytes > 0) {
-    CopyMem ((UINT8 *)LogBufHdr + LogBufHdr->UsedLength, Buffer, NumberOfBytes);
+    CopyMem (&LogBufHdr->Buffer[LogBufHdr->UsedLength - LogBufHdr->HeaderLength], Buffer, NumberOfBytes);
     LogBufHdr->UsedLength += (UINT32)NumberOfBytes;
   }
 
-  return NumberOfBytes;
+  //
+  // Handle Ring Buffer
+  //
+  if (RemainingBytes > 0) {
+    CopyMem (&LogBufHdr->Buffer[0], Buffer + NumberOfBytes, RemainingBytes);
+    LogBufHdr->UsedLength = LogBufHdr->HeaderLength + (UINT32)RemainingBytes;
+    LogBufHdr->Attribute |= DEBUG_LOG_BUFFER_ATTRIBUTE_FULL;
+  }
+
+  return (NumberOfBytes + RemainingBytes);
 }

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -552,6 +552,11 @@ SecStartup2 (
         CopyMem ((VOID *)NewLogBuf, (VOID *)OldLogBuf, OldLogBuf->UsedLength);
         NewLogBuf->TotalLength = PcdGet32 (PcdLogBufferSize);
         LdrGlobal->LogBufPtr = NewLogBuf;
+        //
+        // No ring buffer manipulation here even if early log buffer was full.
+        // Simply clear FULL attribute and continue to overwrite logs.
+        //
+        NewLogBuf->Attribute &= (UINT8)~(DEBUG_LOG_BUFFER_ATTRIBUTE_FULL);
       }
     }
   }

--- a/PayloadPkg/OsLoader/OsLoader.h
+++ b/PayloadPkg/OsLoader/OsLoader.h
@@ -46,6 +46,7 @@
 #include <Library/ElfLib.h>
 #include <Library/LinuxLib.h>
 #include <Library/ContainerLib.h>
+#include <Library/DebugLogBufferLib.h>
 #include <Guid/SeedInfoHobGuid.h>
 #include <Guid/OsConfigDataHobGuid.h>
 #include <Guid/OsBootOptionGuid.h>


### PR DESCRIPTION
This will allow debug log buffer to record logs in ring buffer
if the buffer is full.

Signed-off-by: Aiden Park <aiden.park@intel.com>