### PR TITLE
TpmLib: Add appropriate safety comparison checks

### DIFF
--- a/BootloaderCommonPkg/Library/TpmLib/Tpm2Capability.c
+++ b/BootloaderCommonPkg/Library/TpmLib/Tpm2Capability.c
@@ -44,7 +44,7 @@ typedef struct {
   NOTE:
   To simplify this function, leave returned CapabilityData for caller to unpack since there are
   many capability categories and only few categories will be used in firmware. It means the caller
-  need swap the byte order for the feilds in CapabilityData.
+  need swap the byte order for the fields in CapabilityData.
 
   @param[in]  Capability         Group selection; determines the format of the response.
   @param[in]  Property           Further definition of information.
@@ -102,7 +102,7 @@ Tpm2GetCapability (
   //
   *MoreData = RecvBuffer.MoreData;
   //
-  // Does not unpack all possiable property here, the caller should unpack it and note the byte order.
+  // Does not unpack all possible property here, the caller should unpack it and note the byte order.
   //
   CopyMem (CapabilityData, &RecvBuffer.CapabilityData, RecvBufferSize - sizeof (TPM2_RESPONSE_HEADER) - sizeof (UINT8));
 

--- a/BootloaderCommonPkg/Library/TpmLib/Tpm2Help.c
+++ b/BootloaderCommonPkg/Library/TpmLib/Tpm2Help.c
@@ -145,7 +145,8 @@ CopyAuthSessionCommand (
   @param [in]  AuthSessionIn   Input AuthSession data in TPM2 response buffer
   @param [out] AuthSessionOut  Output AuthSession data
 
-  @return AuthSession size
+  @return 0    copy failed
+          else AuthSession size
 **/
 UINT32
 EFIAPI
@@ -166,6 +167,10 @@ CopyAuthSessionResponse (
   // nonce
   AuthSessionOut->nonce.size = SwapBytes16 (ReadUnaligned16 ((UINT16 *)Buffer));
   Buffer += sizeof (UINT16);
+  if (AuthSessionOut->nonce.size > sizeof(TPMU_HA)) {
+    DEBUG ((DEBUG_VERBOSE, "CopyAuthSessionResponse - nonce.size error %x\n", AuthSessionOut->nonce.size));
+    return 0;
+  }
 
   CopyMem (AuthSessionOut->nonce.buffer, Buffer, AuthSessionOut->nonce.size);
   Buffer += AuthSessionOut->nonce.size;
@@ -177,6 +182,10 @@ CopyAuthSessionResponse (
   // hmac
   AuthSessionOut->hmac.size = SwapBytes16 (ReadUnaligned16 ((UINT16 *)Buffer));
   Buffer += sizeof (UINT16);
+  if (AuthSessionOut->hmac.size > sizeof(TPMU_HA)) {
+    DEBUG ((DEBUG_VERBOSE, "CopyAuthSessionResponse - hmac.size error %x\n", AuthSessionOut->hmac.size));
+    return 0;
+  }
 
   CopyMem (AuthSessionOut->hmac.buffer, Buffer, AuthSessionOut->hmac.size);
   Buffer += AuthSessionOut->hmac.size;


### PR DESCRIPTION
*Safety comparison checks in accordance with TPM2.0 Specification data structures
*Fix comment typos