### PR TITLE
Reprogram SMRR base and mask on S3 path for CFL

### DIFF
--- a/BootloaderCorePkg/Include/Library/S3SaveRestoreLib.h
+++ b/BootloaderCorePkg/Include/Library/S3SaveRestoreLib.h
@@ -13,6 +13,7 @@
 
 #define SMMBASE_INFO_COMM_ID  1
 #define S3_SAVE_REG_COMM_ID   2
+#define BL_SW_SMI_COMM_ID     3
 
 //
 // Format to share info between bootloader and payload.
@@ -89,7 +90,26 @@ typedef struct {
   CPU_SMMBASE     SmmBase[];
 } SMMBASE_INFO;
 
+typedef struct {
+  BL_PLD_COMM_HDR BlSwSmiHdr;
+  UINT8           BlSwSmiHandlerInput;
+} BL_SW_SMI_INFO;
+
 #pragma pack()
+
+/**
+  Trigger Payload software SMI
+
+  This function triggers software SMI. SMI number will be obtained
+  from SMM communication area.
+
+  @param[in]  SwSmiNumber   Software smi number to be triggered.
+
+**/
+VOID
+TriggerPayloadSwSmi (
+  IN UINT8  SwSmiNumber
+);
 
 /**
   This function appends information in TSEG area

--- a/BootloaderCorePkg/Library/S3SaveRestoreLib/S3SaveRestore.c
+++ b/BootloaderCorePkg/Library/S3SaveRestoreLib/S3SaveRestore.c
@@ -21,6 +21,7 @@ typedef VOID   (*REG_WRITE) (UINTN, UINT32);
 
 #define NUM_TYPE    2
 #define NUM_WIDTH   3
+#define REG_APM_CNT   0xB2
 
 const REG_WRITE  mRegWrite[NUM_TYPE][NUM_WIDTH] = {
   { (REG_WRITE) MmioWrite8, (REG_WRITE) MmioWrite16, (REG_WRITE) MmioWrite32 },
@@ -37,6 +38,23 @@ const UINT8 mWidthToIdx[NUM_WIDTH][2] = {
   { 1, WIDE16 },
   { 2, WIDE32 }
 };
+
+/**
+  Trigger payload software SMI
+
+  This function triggers software SMI. SMI number will be obtained
+  from SMM communication area.
+
+  @param[in]  SwSmiNumber   Software smi number to be triggered.
+
+**/
+VOID
+TriggerPayloadSwSmi (
+  IN UINT8  SwSmiNumber
+)
+{
+  IoWrite8(REG_APM_CNT, SwSmiNumber);
+}
 
 /**
   This function appends information in TSEG area

--- a/BootloaderCorePkg/Library/S3SaveRestoreLib/S3SaveRestoreLib.inf
+++ b/BootloaderCorePkg/Library/S3SaveRestoreLib/S3SaveRestoreLib.inf
@@ -35,5 +35,3 @@
 
 [Guids]
   gSmmInformationGuid
-
-[Pcd]


### PR DESCRIPTION
This patch will generate a SW smi on S3 resume path when using
UEFI payload. Handler for this Sw smi in UEFI payload will
program SMRR base and mask for BSP and all AP's.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>