### PR TITLE
Fix build warning for missing header files

### DIFF
--- a/BootloaderCommonPkg/Library/IppCryptoLib/IppCryptoLib.inf
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/IppCryptoLib.inf
@@ -52,6 +52,7 @@
   $(IPP_PATH)/owndefs.h
   $(IPP_PATH)/pcpbnuarith.h
   $(IPP_PATH)/pcpbnu32misc.h
+  $(IPP_PATH)/pcprsa_pss_preproc.h
   $(IPP_PATH)/gsmodmethod.c
   $(IPP_PATH)/gsmodstuff.c
   $(IPP_PATH)/pcpbnca.c

--- a/BootloaderCommonPkg/Library/LoaderPerformanceLib/LoaderPerformanceLib.inf
+++ b/BootloaderCommonPkg/Library/LoaderPerformanceLib/LoaderPerformanceLib.inf
@@ -22,6 +22,7 @@
 [Sources]
   LoaderPerformanceAddLib.c
   LoaderPerformancePrintLib.c
+  ExtendedFirmwarePerformance.h
 
 [Packages]
   MdePkg/MdePkg.dec


### PR DESCRIPTION
This patch added missing C header files in INF file. It fixed the
build warning message.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>