### PR TITLE
Add PCI ARI Support

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -185,4 +185,4 @@
   gPlatformModuleTokenSpaceGuid.PcdPsdBiosEnabled         | FALSE      | BOOLEAN | 0x2000020E
   gPlatformModuleTokenSpaceGuid.PcdSmbiosEnabled          | FALSE      | BOOLEAN | 0x2000020F
   gPlatformModuleTokenSpaceGuid.PcdLinuxPayloadEnabled    | FALSE      | BOOLEAN | 0x20000210
-
+  gPlatformModuleTokenSpaceGuid.PcdAriSupport             | FALSE      | BOOLEAN | 0x20000211

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -303,6 +303,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdPreOsCheckerEnabled | $(ENABLE_PRE_OS_CHECKER)
   gPlatformCommonLibTokenSpaceGuid.PcdDmaProtectionEnabled | $(ENABLE_DMA_PROTECTION)
   gPlatformCommonLibTokenSpaceGuid.PcdMultiUsbBootDeviceEnabled |  $(ENABLE_MULTI_USB_BOOT_DEV)
+  gPlatformModuleTokenSpaceGuid.PcdAriSupport             | $(SUPPORT_ARI)
 
 !ifdef $(S3_DEBUG)
   gPlatformModuleTokenSpaceGuid.PcdS3DebugEnabled         | $(S3_DEBUG)

--- a/BootloaderCorePkg/Library/PciEnumerationLib/InternalPciEnumerationLib.h
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/InternalPciEnumerationLib.h
@@ -86,6 +86,13 @@ struct _PCI_IO_DEVICE {
   PCI_BAR                                   PciBar[PCI_MAX_BAR];
 
   //
+  // ARI (Alternative Routing ID)
+  //
+  BOOLEAN                                   IsPciExp;
+  UINT8                                     PciExpressCapabilityOffset;
+  UINT32                                    AriCapabilityOffset;
+
+  //
   // The bridge device this pci device is subject to
   //
   PCI_IO_DEVICE                             *Parent;

--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciAri.c
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciAri.c
@@ -1,0 +1,96 @@
+/** @file
+
+  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi/UefiBaseType.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PciExpressLib.h>
+#include "InternalPciEnumerationLib.h"
+#include "PciCommand.h"
+
+/**
+  Initialize PciExpress Capability Offset
+
+  @param[in,out]  PciIoDevice     Pointer to instance of PCI_IO_DEVICE.
+
+**/
+VOID
+EFIAPI
+InitializePciExpCapability (
+  IN OUT  PCI_IO_DEVICE              *PciIoDevice
+  )
+{
+  EFI_STATUS            Status;
+
+  Status = LocateCapabilityRegBlock (
+           PciIoDevice,
+           EFI_PCI_CAPABILITY_ID_PCIEXP,
+           &PciIoDevice->PciExpressCapabilityOffset
+           );
+
+  if (!EFI_ERROR (Status)) {
+    PciIoDevice->IsPciExp = TRUE;
+  }
+}
+
+/**
+  Initialize ARI(Alternative Routing-ID Interpretation) devices
+
+  @param[in,out]  PciIoDevice     Pointer to instance of PCI_IO_DEVICE.
+
+**/
+VOID
+EFIAPI
+InitializeAri (
+  IN OUT  PCI_IO_DEVICE              *PciIoDevice
+  )
+{
+  PCI_IO_DEVICE        *Bridge;
+  EFI_STATUS            Status;
+  UINT32                Data32;
+
+  if ((PciIoDevice == NULL) || (PciIoDevice->Parent == NULL)) {
+    return;
+  }
+
+  //
+  // Check if the device is an ARI device.
+  //
+  Status = LocatePciExpressCapabilityRegBlock (
+             PciIoDevice,
+             EFI_PCIE_CAPABILITY_ID_ARI,
+             &PciIoDevice->AriCapabilityOffset
+             );
+
+  if (!EFI_ERROR (Status)) {
+    Bridge = PciIoDevice->Parent;
+
+    //
+    // Check if its parent supports ARI forwarding.
+    //
+    Data32 = PciExpressRead32 (Bridge->Address +
+                               Bridge->PciExpressCapabilityOffset +
+                               EFI_PCIE_CAPABILITY_DEVICE_CAPABILITIES_2_OFFSET);
+
+    if ((Data32 & EFI_PCIE_CAPABILITY_DEVICE_CAPABILITIES_2_ARI_FORWARDING) != 0) {
+      //
+      // ARI forward support in bridge, so enable it.
+      //
+      Data32 = PciExpressRead32 (Bridge->Address +
+                                 Bridge->PciExpressCapabilityOffset +
+                                 EFI_PCIE_CAPABILITY_DEVICE_CONTROL_2_OFFSET);
+
+      if ((Data32 & EFI_PCIE_CAPABILITY_DEVICE_CONTROL_2_ARI_FORWARDING) == 0) {
+        Data32 |= EFI_PCIE_CAPABILITY_DEVICE_CONTROL_2_ARI_FORWARDING;
+        PciExpressWrite32 (Bridge->Address +
+                           Bridge->PciExpressCapabilityOffset +
+                           EFI_PCIE_CAPABILITY_DEVICE_CONTROL_2_OFFSET,
+                           Data32);
+      }
+    }
+  }
+}

--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciAri.h
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciAri.h
@@ -1,0 +1,35 @@
+/** @file
+
+  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __PCI_ARI_H__
+#define __PCI_ARI_H__
+
+/**
+  Initialize PciExpress Capability Offset
+
+  @param[in,out]  PciIoDevice     Pointer to instance of PCI_IO_DEVICE.
+
+**/
+VOID
+EFIAPI
+InitializePciExpCapability (
+  IN OUT  PCI_IO_DEVICE              *PciIoDevice
+  );
+
+/**
+  Initialize ARI(Alternative Routing-ID Interpretation) devices
+
+  @param[in,out]  PciIoDevice     Pointer to instance of PCI_IO_DEVICE.
+
+**/
+VOID
+EFIAPI
+InitializeAri (
+  IN OUT  PCI_IO_DEVICE              *PciIoDevice
+  );
+
+#endif // __PCI_ARI_H__

--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciCommand.c
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciCommand.c
@@ -1,0 +1,157 @@
+/** @file
+  PCI command register operations supporting functions implementation for PCI Bus module.
+
+  Copyright (c) 2006 - 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi/UefiBaseType.h>
+#include <Library/DebugLib.h>
+#include <Library/PciExpressLib.h>
+#include "InternalPciEnumerationLib.h"
+
+/**
+  Check the capability supporting by given device.
+
+  @param[in]  PciIoDevice     Pointer to instance of PCI_IO_DEVICE.
+
+  @retval     TRUE            Capability supported.
+  @retval     FALSE           Capability not supported.
+
+**/
+BOOLEAN
+PciCapabilitySupport (
+  IN PCI_IO_DEVICE  *PciIoDevice
+  )
+{
+  if ((PciIoDevice->Pci.Hdr.Status & EFI_PCI_STATUS_CAPABILITY) != 0) {
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+/**
+  Locate capability register block per capability ID.
+
+  @param[in]      PciIoDevice       A pointer to the PCI_IO_DEVICE.
+  @param[in]      CapId             The capability ID.
+  @param[in, out] Offset            A pointer to the offset returned.
+
+  @retval EFI_SUCCESS      Successfully located capability register block.
+  @retval EFI_UNSUPPORTED  Pci device does not support capability.
+  @retval EFI_NOT_FOUND    Pci device support but can not find register block.
+
+**/
+EFI_STATUS
+LocateCapabilityRegBlock (
+  IN PCI_IO_DEVICE  *PciIoDevice,
+  IN UINT8          CapId,
+  IN OUT UINT8      *Offset
+  )
+{
+  UINT8   CapabilityPtr;
+  UINT16  CapabilityEntry;
+  UINT8   CapabilityID;
+
+  //
+  // To check the capability of this device supports
+  //
+  if (!PciCapabilitySupport (PciIoDevice)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  if (*Offset != 0) {
+    CapabilityPtr = *Offset;
+  } else {
+    if (IS_CARDBUS_BRIDGE (&PciIoDevice->Pci)) {
+      CapabilityPtr = PciExpressRead8 (PciIoDevice->Address + EFI_PCI_CARDBUS_BRIDGE_CAPABILITY_PTR);
+    } else {
+      CapabilityPtr = PciExpressRead8 (PciIoDevice->Address + PCI_CAPBILITY_POINTER_OFFSET);
+    }
+  }
+
+  while ((CapabilityPtr >= 0x40) && ((CapabilityPtr & 0x03) == 0x00)) {
+    CapabilityEntry = PciExpressRead16 (PciIoDevice->Address + CapabilityPtr);
+    CapabilityID    = (UINT8) CapabilityEntry;
+
+    if (CapabilityID == CapId) {
+      *Offset = CapabilityPtr;
+      return EFI_SUCCESS;
+    }
+
+    //
+    // Certain PCI device may incorrectly have capability pointing to itself,
+    // break to avoid dead loop.
+    //
+    if (CapabilityPtr == (UINT8) (CapabilityEntry >> 8)) {
+      break;
+    }
+
+    CapabilityPtr = (UINT8) (CapabilityEntry >> 8);
+  }
+
+  return EFI_NOT_FOUND;
+}
+
+/**
+  Locate PciExpress capability register block per capability ID.
+
+  @param[in]      PciIoDevice       A pointer to the PCI_IO_DEVICE.
+  @param[in]      CapId             The capability ID.
+  @param[in, out] Offset            A pointer to the offset returned.
+
+  @retval EFI_SUCCESS      Successfully located capability register block.
+  @retval EFI_UNSUPPORTED  Pci device does not support capability.
+  @retval EFI_NOT_FOUND    Pci device support but can not find register block.
+
+**/
+EFI_STATUS
+LocatePciExpressCapabilityRegBlock (
+  IN     PCI_IO_DEVICE *PciIoDevice,
+  IN     UINT16        CapId,
+  IN OUT UINT32        *Offset
+  )
+{
+  UINT32               CapabilityPtr;
+  UINT32               CapabilityEntry;
+  UINT16               CapabilityID;
+
+  //
+  // To check the capability of this device supports
+  //
+  if (!PciIoDevice->IsPciExp) {
+    return EFI_UNSUPPORTED;
+  }
+
+  if (*Offset != 0) {
+    CapabilityPtr = *Offset;
+  } else {
+    CapabilityPtr = EFI_PCIE_CAPABILITY_BASE_OFFSET;
+  }
+
+  while (CapabilityPtr != 0) {
+    //
+    // Mask it to DWORD alignment per PCI spec
+    //
+    CapabilityPtr &= 0xFFC;
+    CapabilityEntry = PciExpressRead32 (PciIoDevice->Address + CapabilityPtr);
+    if (CapabilityEntry == MAX_UINT32) {
+      DEBUG ((DEBUG_WARN, "PCI Address 0x08X failed to access at offset 0x%X\n",
+        PciIoDevice->Address, CapabilityPtr));
+      break;
+    }
+
+    CapabilityID = (UINT16) CapabilityEntry;
+
+    if (CapabilityID == CapId) {
+      *Offset = CapabilityPtr;
+      return EFI_SUCCESS;
+    }
+
+    CapabilityPtr = (CapabilityEntry >> 20) & 0xFFF;
+  }
+
+  return EFI_NOT_FOUND;
+}

--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciCommand.h
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciCommand.h
@@ -1,0 +1,64 @@
+/** @file
+  PCI command register operations supporting functions declaration for PCI Bus module.
+
+  Copyright (c) 2006 - 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __PCI_COMMAND_H__
+#define __PCI_COMMAND_H__
+
+/**
+  Check the capability supporting by given device.
+
+  @param[in]  PciIoDevice     Pointer to instance of PCI_IO_DEVICE.
+
+  @retval     TRUE            Capability supported.
+  @retval     FALSE           Capability not supported.
+
+**/
+BOOLEAN
+PciCapabilitySupport (
+  IN PCI_IO_DEVICE  *PciIoDevice
+  );
+
+/**
+  Locate capability register block per capability ID.
+
+  @param[in]      PciIoDevice       A pointer to the PCI_IO_DEVICE.
+  @param[in]      CapId             The capability ID.
+  @param[in, out] Offset            A pointer to the offset returned.
+
+  @retval EFI_SUCCESS      Successfully located capability register block.
+  @retval EFI_UNSUPPORTED  Pci device does not support capability.
+  @retval EFI_NOT_FOUND    Pci device support but can not find register block.
+
+**/
+EFI_STATUS
+LocateCapabilityRegBlock (
+  IN PCI_IO_DEVICE  *PciIoDevice,
+  IN UINT8          CapId,
+  IN OUT UINT8      *Offset
+  );
+
+/**
+  Locate PciExpress capability register block per capability ID.
+
+  @param[in]      PciIoDevice       A pointer to the PCI_IO_DEVICE.
+  @param[in]      CapId             The capability ID.
+  @param[in, out] Offset            A pointer to the offset returned.
+
+  @retval EFI_SUCCESS      Successfully located capability register block.
+  @retval EFI_UNSUPPORTED  Pci device does not support capability.
+  @retval EFI_NOT_FOUND    Pci device support but can not find register block.
+
+**/
+EFI_STATUS
+LocatePciExpressCapabilityRegBlock (
+  IN     PCI_IO_DEVICE *PciIoDevice,
+  IN     UINT16        CapId,
+  IN OUT UINT32        *Offset
+  );
+
+#endif // __PCI_COMMAND_H__

--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.inf
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.inf
@@ -21,6 +21,10 @@
 
 [Sources]
   InternalPciEnumerationLib.h
+  PciCommand.h
+  PciAri.h
+  PciCommand.c
+  PciAri.c
   PciEnumerationLib.c
 
 [Packages]
@@ -46,3 +50,4 @@
   gPlatformModuleTokenSpaceGuid.PcdPciResourceMem32Base
   gPlatformModuleTokenSpaceGuid.PcdPciEnumPolicyInfo
   gPlatformModuleTokenSpaceGuid.PcdPciResourceMem64Base
+  gPlatformModuleTokenSpaceGuid.PcdAriSupport


### PR DESCRIPTION
This will enable ARI(Alternative Routing-ID Interpretation).
- Controlled by PcdAriSupport (SUPPORT_ARI in BoardConfig)
- Disabled by default

Signed-off-by: Aiden Park <aiden.park@intel.com>