### PR TITLE
Update Intel FSP git repository URL

### DIFF
--- a/Silicon/ApollolakePkg/FspBin/FspBin.inf
+++ b/Silicon/ApollolakePkg/FspBin/FspBin.inf
@@ -9,7 +9,7 @@
 ##
 
 [UserExtensions.SBL."CloneRepo"]
-  REPO    = https://github.com/IntelFsp/FSP.git
+  REPO    = https://github.com/intel/FSP.git
   COMMIT  = 7222054e9b7fc2d021fc404f87b4719d99b4c8ec
 
 [UserExtensions.SBL."CopyList"]

--- a/Silicon/CoffeelakePkg/FspBin/FspBin.inf
+++ b/Silicon/CoffeelakePkg/FspBin/FspBin.inf
@@ -10,7 +10,7 @@
 
 
 [UserExtensions.SBL."CloneRepo"]
-  REPO    = https://github.com/IntelFsp/FSP.git
+  REPO    = https://github.com/intel/FSP.git
   COMMIT  = 59964173e18950debcc6b8856c5c928935ce0b4f
 
 [UserExtensions.SBL."CopyList"]


### PR DESCRIPTION
From https://github.com/IntelFsp/FSP.git
To   https://github.com/intel/FSP.git

Signed-off-by: Aiden Park <aiden.park@intel.com>