### PR TITLE
Flexible end of manufaturing

### DIFF
--- a/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
+++ b/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
@@ -1,7 +1,7 @@
 /** @file
 The header file for firmware update library.
 
-Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -44,6 +44,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define FW_UPDATE_COMP_BIOS_REGION SIGNATURE_32('B', 'I', 'O', 'S')
 #define FW_UPDATE_COMP_CSME_REGION SIGNATURE_32('C', 'S', 'M', 'E')
 #define FW_UPDATE_COMP_CSME_DRIVER SIGNATURE_32('C', 'S', 'M', 'D')
+#define FW_UPDATE_COMP_CMD_UPDATE   SIGNATURE_32('C', 'M', 'D', 'I')
+
 
 #define FW_UPDATE_STATUS_SIGNATURE SIGNATURE_32 ('F', 'W', 'U', 'S')
 #define FW_UPDATE_STATUS_VERSION   0x1
@@ -503,4 +505,63 @@ EFIAPI
 ClearFwUpdateTrigger (
   VOID
   );
+
+
+/**
+  Main routine for Command updates.
+
+  This function has the logic to perform CMD  update.
+
+  @param[in] CapImage         The pointer to the firmware update capsule image.
+  @param[in] CapImageSize     The size of capsule image in bytes.
+
+  @retval  EFI_SUCCESS      Update successful
+  @retval  other            error status from the update routine
+**/
+EFI_STATUS
+FwCmdUpdateProcess (
+  IN  UINT8     *CapImage,
+  IN  UINTN     CapImageSize
+  );
+
+
+/**
+  Me Named Variable region lock
+
+  This function will do some command buffer parsing and check
+  for additional parameters
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      NVar region lock successfully.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+MeNvarRegionLock (
+  IN  CHAR8     *CmdDataBuf,
+  IN  UINT32     CmdDataSize
+  );
+
+/**
+  Flash descriptor region lock
+
+  This function will do some command buffer parsing and check
+  for additional parameters
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      Flash descriptor lock successfully.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+SetFlashDescriptorLock (
+   IN  CHAR8     *CmdDataBuf,
+   IN  UINT32     CmdDataSize
+   );
 #endif

--- a/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
+++ b/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
@@ -448,6 +448,8 @@ def main():
         'MISC': '66030B7A-47D1-4958-B73D-00B44B9DD4B6',  # SBL  COMPONENT
         'CSME': '43AEF186-0CA5-4230-B1BD-193FB4627201',  # IFWI ME/CSME
         'CSMD': '4A467997-A909-4678-910C-E0FE1C9056EA',  # CSME Update driver
+        'CMDI': '9034cab1-4d19-4856-a3cd-f074263c4a4d',  # FLEX Command
+
     }
 
     def ValidateUnsignedInteger(Argument):

--- a/PayloadPkg/FirmwareUpdate/CmdFwUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/CmdFwUpdate.c
@@ -1,0 +1,176 @@
+/** @file
+  This file contains implementation of Firmware Command update library.
+
+  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <PiPei.h>
+#include <Uefi/UefiBaseType.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/LitePeCoffLib.h>
+#include <Library/FirmwareUpdateLib.h>
+#include <Library/StringSUpportLib.h>
+
+
+#define FLASH_DESCRIPTOR_LOCK_STR     "FLASHDESCLOCK"
+#define NAMED_VARIABLE_LOCK_STR       "NVARLOCK"
+
+typedef UINT32 CMDI_TYPE;
+#define CMDI_TYPE_SPI_DESCRIPTOR_LOCK       BIT0
+#define CMDI_TYPE_NAMED_VARIABLE_LOCK       BIT1
+
+typedef struct {
+  // Commands requested
+  CMDI_TYPE   CmdRequested;
+  // Flash Descriptor Lock command Data
+  CHAR8        *FlashDescLockDataBuf;
+  // Flash Descriptor Lock command Data length
+  UINT32      FlashDescLockDataLen;
+  // NVar region Lock command Data
+  CHAR8        *NVarLockDataBuf;
+  // NVar region Lock command Data length
+  UINT32      NavrLockDataLen;
+} CMDI_DATA;
+
+
+/**
+  Find payload in the capsule image.
+
+  This function will parse through the capsule image to find the payload
+  matching the input guid.
+
+  This function if provided with an empty guid will return the first payload
+  found
+
+  @param[in] Signature      Signature of component to update.
+  @param[in] CapImage       Pointer to the capsule Image
+  @param[in] CapImageSize   Size of the capsule image in bytes
+  @param[in] ImageHdr       Pointer to the capsule Image header
+
+  @retval  EFI_SUCCESS      Found matching payload in the capsule.
+  @retval  EFI_NOT_FOUND    No matching payload found in the capsule.
+**/
+EFI_STATUS
+FindImage (
+  IN  UINT64                        Signature,
+  IN  UINT8                         *CapImage,
+  IN  UINT32                        CapImageSize,
+  OUT EFI_FW_MGMT_CAP_IMAGE_HEADER  **ImageHdr
+  );
+
+/*
+ Parse firmware update command data buffer
+
+ Command format:
+ {FLASHDESCLOCK}
+ {NVARLOCK}
+
+  @param[in]  Buffer      Command buffer.
+  @param[in]  BufLength   Command buffer length
+  @param[out] CmdiData    Command data parsed
+*/
+EFI_STATUS
+ParseCommandStringBuf(
+  IN  UINT8       *Buffer,
+  IN  UINTN       BufLength,
+  OUT CMDI_DATA   *CmdiData
+  )
+{
+  CHAR8      *CurrLine;
+  CHAR8      *NextLine;
+  CHAR8      *EndLine;
+  CHAR8      *EndString;
+  UINT32      LineLen;
+  EFI_STATUS  Status;
+
+  Status = EFI_SUCCESS;
+  CurrLine = (CHAR8 *) Buffer;
+
+  while ((CurrLine != NULL) && (CurrLine < (Buffer + BufLength))) {
+    NextLine = GetNextLine (CurrLine, &LineLen);
+    EndLine  = CurrLine + LineLen;
+    CurrLine = TrimLeft (CurrLine);
+
+    if (CurrLine[0] == '{') {
+      // String format found in line
+      CurrLine += 1;
+      EndString = AsciiStrStr(CurrLine, "}");
+
+      if(EndString != NULL) {
+        if(AsciiStrnCmp(CurrLine, FLASH_DESCRIPTOR_LOCK_STR, AsciiStrLen(FLASH_DESCRIPTOR_LOCK_STR)) == 0) {
+          CmdiData->FlashDescLockDataBuf = CurrLine;
+          CmdiData->FlashDescLockDataLen = EndString - CurrLine;
+          CmdiData->CmdRequested        |=  CMDI_TYPE_SPI_DESCRIPTOR_LOCK;
+        } else if (AsciiStrnCmp(CurrLine, NAMED_VARIABLE_LOCK_STR, AsciiStrLen(NAMED_VARIABLE_LOCK_STR)) == 0) {
+          CmdiData->NVarLockDataBuf      = CurrLine;
+          CmdiData->NavrLockDataLen      = EndString - CurrLine;
+          CmdiData->CmdRequested        |=  CMDI_TYPE_NAMED_VARIABLE_LOCK;
+        }
+      }
+    }
+    CurrLine = NextLine;
+  }
+
+  return Status;
+}
+
+
+/**
+  Main routine for firmware command updates.
+
+  This function has the logic to perform command updates.
+
+  @param[in] CapImage         The pointer to the firmware update capsule image.
+  @param[in] CapImageSize     The size of capsule image in bytes.
+
+  @retval  EFI_SUCCESS      Update successful
+  @retval  other            error status from the update routine
+**/
+EFI_STATUS
+FwCmdUpdateProcess (
+  IN  UINT8     *CapImage,
+  IN  UINTN     CapImageSize
+  )
+{
+  CMDI_DATA                       CmdData;
+  EFI_FW_MGMT_CAP_IMAGE_HEADER    *CapImageHdr;
+  EFI_STATUS                      Status;
+
+  if ((CapImage == NULL) ||  (CapImageSize == 0)){
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // Find the command update region
+  Status = FindImage (FW_UPDATE_COMP_CMD_UPDATE, CapImage, CapImageSize, &CapImageHdr);
+  if ((EFI_ERROR (Status)) || (CapImageHdr == NULL)) {
+    DEBUG((DEBUG_ERROR, "Finding CMDI update failed with Status = %r\n", Status));
+    return Status;
+  }
+
+  ZeroMem (&CmdData, sizeof (CmdData));
+
+  //Parse command data buffer
+  Status = ParseCommandStringBuf ((CHAR8 *)CapImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER), CapImageHdr->UpdateImageSize, &CmdData);
+  if (EFI_ERROR (Status)) {
+    DEBUG((DEBUG_ERROR, "Error in command parse Status = %r\n", Status));
+    return Status;
+  }
+
+  DEBUG((DEBUG_ERROR, "Commands Requested = 0x%x\n", CmdData.CmdRequested));
+
+  if(CmdData.CmdRequested & CMDI_TYPE_SPI_DESCRIPTOR_LOCK) {
+    DEBUG((DEBUG_ERROR, "FLASH DESCRIPTOR LOCK COMMAND RECEIVED!! \n"));
+    // Process SPI Descriptor Lock
+    Status = SetFlashDescriptorLock (CmdData.FlashDescLockDataBuf, CmdData.FlashDescLockDataLen);
+  }
+  if(CmdData.CmdRequested & CMDI_TYPE_NAMED_VARIABLE_LOCK) {
+    DEBUG((DEBUG_ERROR, "NVAR REGION LOCK COMMAND RECEIVED!! \n"));
+    // Process Named variable region lock
+    Status = MeNvarRegionLock (CmdData.NVarLockDataBuf, CmdData.NavrLockDataLen);
+  }
+  return Status;
+}

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -834,6 +834,7 @@ FindImage (
   return EFI_NOT_FOUND;
 }
 
+
 /**
   Perform Firmware update.
 
@@ -850,10 +851,10 @@ FindImage (
 **/
 EFI_STATUS
 ApplyFwImage (
-  IN    UINT8                        *CapImage,
-  IN    UINT32                       CapImageSize,
+  IN    UINT8                         *CapImage,
+  IN    UINT32                         CapImageSize,
   IN    EFI_FW_MGMT_CAP_IMAGE_HEADER  *ImageHdr,
-    OUT BOOLEAN                       *ResetRequired
+  OUT BOOLEAN                         *ResetRequired
   )
 {
   EFI_STATUS      Status;
@@ -892,6 +893,9 @@ ApplyFwImage (
         *ResetRequired = TRUE;
       }
     }
+    break;
+  case FW_UPDATE_COMP_CMD_UPDATE:
+    Status = FwCmdUpdateProcess (CapImage, CapImageSize);
     break;
   default:
     Status = UpdateSblComponent (ImageHdr);

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
@@ -27,6 +27,7 @@
   GetCapsuleImage.c
   CsmeFwUpdate.c
   ErrorList.c
+  CmdFwUpdate.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -47,6 +48,7 @@
   LiteFvLib
   ConfigDataLib
   ContainerLib
+  StringSupportLib
 
 [Guids]
   gLoaderMemoryMapInfoGuid

--- a/Silicon/ApollolakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/ApollolakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -510,3 +510,49 @@ ClearFwUpdateTrigger (
   // Clear platform firmware update trigger.
   MmioAnd32 (PMC_BASE_ADDRESS + R_PMC_BIOS_SCRATCHPAD, 0xFF00FFFF);
 }
+
+/**
+  Me Named Variable region lock
+
+  This function will do some command buffer parsing and check
+  for additional parameters
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      NVar region lock successfully.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+MeNvarRegionLock (
+  IN  CHAR8      *CmdDataBuf,
+  IN  UINT32     CmdDataSize
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Flash descriptor region lock
+
+  This function will do some command buffer parsing and check
+  for additional parameters
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      Flash descriptor lock successfully.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+SetFlashDescriptorLock (
+  IN  CHAR8      *CmdDataBuf,
+  IN  UINT32     CmdDataSize
+  )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -478,3 +478,51 @@ PlatformEndFirmwareUpdate (
 {
   return EFI_SUCCESS;
 }
+
+
+/**
+  Me Named Variable region lock
+
+  This function will do some command buffer parsing and check
+  for additional parameters
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      NVar region lock successfully.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+MeNvarRegionLock (
+  IN  CHAR8      *CmdDataBuf,
+  IN  UINT32     CmdDataSize
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+
+/**
+  Flash descriptor region lock
+
+  This function will do some command buffer parsing and check
+  for additional parameters
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      Flash descriptor lock successfully.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+SetFlashDescriptorLock (
+  IN  CHAR8      *CmdDataBuf,
+  IN  UINT32     CmdDataSize
+  )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/Silicon/QemuSocPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/QemuSocPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -510,3 +510,51 @@ ClearFwUpdateTrigger (
 {
   return;
 }
+
+
+
+/**
+  Me Named Variable region lock
+
+  This function will do some command buffer parsing and check
+  for additional parameters
+
+  @param[in]  CmdDataBuf    Pointer to command buffer
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      NVar region lock successfully
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+MeNvarRegionLock (
+  IN  CHAR8      *CmdDataBuf,
+  IN  UINT32     CmdDataSize
+   )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Flash descriptor region lock
+
+  This function will do some command buffer parsing and check
+  for additional parameters
+
+  @param[in]  CmdDataBuf    Pointer to command buffer
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      Flash descriptor lock successfully.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+SetFlashDescriptorLock (
+  IN  CHAR8      *CmdDataBuf,
+  IN  UINT32     CmdDataSize
+   )
+{
+  return EFI_UNSUPPORTED;
+}


### PR DESCRIPTION
This patch adds generic functionality to
process the Flexible EOM features. It follows
Capsule Firmware update flow and interface is updated.
Command (CMDI) interface is added to GenCapsuleFirmware
which takes file with command as input.

Sample Command format in text file input,
{FLASHDESCLOCK}
{NVARLOCK}

Firmware update lib handler parses high level commands
Specific command process and functionlity would be
performed by platform specific libraries.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>