### PR TITLE
Firmware update in command mode

### DIFF
--- a/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
+++ b/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
@@ -1,7 +1,7 @@
 /** @file
 The header file for firmware update library.
 
-Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -44,6 +44,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define FW_UPDATE_COMP_BIOS_REGION SIGNATURE_32('B', 'I', 'O', 'S')
 #define FW_UPDATE_COMP_CSME_REGION SIGNATURE_32('C', 'S', 'M', 'E')
 #define FW_UPDATE_COMP_CSME_DRIVER SIGNATURE_32('C', 'S', 'M', 'D')
+#define FW_UPDATE_COMP_CMD_REQUEST SIGNATURE_32('C', 'M', 'D', 'I')
+
 
 #define FW_UPDATE_STATUS_SIGNATURE SIGNATURE_32 ('F', 'W', 'U', 'S')
 #define FW_UPDATE_STATUS_VERSION   0x1
@@ -503,4 +505,25 @@ EFIAPI
 ClearFwUpdateTrigger (
   VOID
   );
+
+
+/**
+  Flash descriptor region lock
+
+  This function will do some command buffer parsing and check
+  for additional parameters
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      Flash descriptor lock successfully.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+SetFlashDescriptorLock (
+   IN  CHAR8     *CmdDataBuf,
+   IN  UINTN     CmdDataSize
+   );
 #endif

--- a/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
+++ b/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
@@ -448,6 +448,8 @@ def main():
         'MISC': '66030B7A-47D1-4958-B73D-00B44B9DD4B6',  # SBL  COMPONENT
         'CSME': '43AEF186-0CA5-4230-B1BD-193FB4627201',  # IFWI ME/CSME
         'CSMD': '4A467997-A909-4678-910C-E0FE1C9056EA',  # CSME Update driver
+        'CMDI': '9034cab1-4d19-4856-a3cd-f074263c4a4d',  # Command request
+
     }
 
     def ValidateUnsignedInteger(Argument):

--- a/PayloadPkg/FirmwareUpdate/CmdFwUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/CmdFwUpdate.c
@@ -1,0 +1,147 @@
+/** @file
+  This file contains implementation of Firmware Command update library.
+
+  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <PiPei.h>
+#include <Uefi/UefiBaseType.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/LitePeCoffLib.h>
+#include <Library/FirmwareUpdateLib.h>
+#include <Library/StringSupportLib.h>
+#include "FirmwareUpdateHelper.h"
+
+
+#define FLASH_DESCRIPTOR_LOCK_STR     "FLASHDESCLOCK"
+
+typedef UINT32 CMDI_TYPE;
+#define CMDI_TYPE_SPI_DESCRIPTOR_LOCK       BIT0
+
+
+/*
+  Firmware update command handler
+
+  This function would parse the command and execute the
+  functionality requested.
+
+  @param[in]  CmdBuf            Command buffer.
+  @param[in]  BufLen            Command buffer length
+  @param[out] CmdProcessed      Command type processed
+
+  @retval  EFI_SUCCESS      Update successful
+  @retval  other            error status from the update routine
+*/
+EFI_STATUS
+FwUpdateCmdHandler (
+  IN  CHAR8      *CmdBuf,
+  IN  UINTN      BufLen,
+  OUT UINT32     *CmdProcessed
+   )
+{
+  EFI_STATUS Status;
+
+  Status = EFI_SUCCESS;
+  *CmdProcessed = 0;
+
+  if(AsciiStrnCmp(CmdBuf, FLASH_DESCRIPTOR_LOCK_STR, AsciiStrLen(FLASH_DESCRIPTOR_LOCK_STR)) == 0) {
+      *CmdProcessed  =  CMDI_TYPE_SPI_DESCRIPTOR_LOCK;
+      Status = SetFlashDescriptorLock (CmdBuf, BufLen);
+  }
+
+  return Status;
+}
+
+
+/*
+ Parse firmware update command data buffer
+
+ Command format:
+ {FLASHDESCLOCK}
+ {Command2}
+
+  @param[in]  Buffer            Command buffer.
+  @param[in]  BufLength         Command buffer length
+  @param[out] CmdsProcessed     Commands processed
+
+  @retval  EFI_SUCCESS      Update successful
+  @retval  other            error status from the update routine
+*/
+EFI_STATUS
+ParseCommandStringBuf(
+  IN  UINT8       *Buffer,
+  IN  UINTN       BufLength,
+  OUT CMDI_TYPE   *CmdsProcessed
+  )
+{
+  CHAR8      *CurrLine;
+  CHAR8      *NextLine;
+  CHAR8      *EndString;
+  UINT32      LineLen;
+  UINT32      CommandType;
+  EFI_STATUS  Status;
+
+  *CmdsProcessed = 0;
+
+  Status = EFI_SUCCESS;
+  CurrLine = (CHAR8 *) Buffer;
+
+  while ((CurrLine != NULL) && (CurrLine < ((CHAR8 *) Buffer + BufLength))) {
+    NextLine = GetNextLine (CurrLine, &LineLen);
+    CurrLine = TrimLeft (CurrLine);
+
+    if (CurrLine[0] == '{') {
+      // String format found in line
+      CurrLine += 1;
+      EndString = AsciiStrStr(CurrLine, "}");
+
+      if(EndString != NULL) {
+        // Invoke Fw command handler
+        Status = FwUpdateCmdHandler (CurrLine, EndString - CurrLine, &CommandType);
+        *CmdsProcessed |= CommandType;
+      }
+    }
+    CurrLine = NextLine;
+  }
+
+  return Status;
+}
+
+
+/**
+  Main routine for firmware command updates.
+
+  This function has the logic to perform command updates.
+
+  @param[in] CapImageHdr    Pointer to fw mgmt capsule Image header
+
+  @retval  EFI_SUCCESS      Update successful
+  @retval  other            error status from the update routine
+**/
+EFI_STATUS
+FwCmdUpdateProcess (
+  EFI_FW_MGMT_CAP_IMAGE_HEADER  *CapImageHdr
+  )
+{
+  CMDI_TYPE                       CmdsProcessed;
+  EFI_STATUS                      Status;
+
+  if (CapImageHdr == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //Parse command data buffer
+  Status = ParseCommandStringBuf ((UINT8 *)CapImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER), CapImageHdr->UpdateImageSize, &CmdsProcessed);
+  if (EFI_ERROR (Status)) {
+    DEBUG((DEBUG_ERROR, "Error in command parse Status = %r\n", Status));
+    return Status;
+  }
+
+  DEBUG((DEBUG_INFO, "Commands processed = 0x%x\n", CmdsProcessed));
+
+  return Status;
+}

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -834,6 +834,7 @@ FindImage (
   return EFI_NOT_FOUND;
 }
 
+
 /**
   Perform Firmware update.
 
@@ -850,10 +851,10 @@ FindImage (
 **/
 EFI_STATUS
 ApplyFwImage (
-  IN    UINT8                        *CapImage,
-  IN    UINT32                       CapImageSize,
+  IN    UINT8                         *CapImage,
+  IN    UINT32                         CapImageSize,
   IN    EFI_FW_MGMT_CAP_IMAGE_HEADER  *ImageHdr,
-    OUT BOOLEAN                       *ResetRequired
+  OUT BOOLEAN                         *ResetRequired
   )
 {
   EFI_STATUS      Status;
@@ -892,6 +893,9 @@ ApplyFwImage (
         *ResetRequired = TRUE;
       }
     }
+    break;
+  case FW_UPDATE_COMP_CMD_REQUEST:
+    Status = FwCmdUpdateProcess (ImageHdr);
     break;
   default:
     Status = UpdateSblComponent (ImageHdr);

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
@@ -27,6 +27,7 @@
   GetCapsuleImage.c
   CsmeFwUpdate.c
   ErrorList.c
+  CmdFwUpdate.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -47,6 +48,7 @@
   LiteFvLib
   ConfigDataLib
   ContainerLib
+  StringSupportLib
 
 [Guids]
   gLoaderMemoryMapInfoGuid

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
@@ -166,4 +166,20 @@ EFI_STATUS
 UpdateSblComponent (
   IN EFI_FW_MGMT_CAP_IMAGE_HEADER  *ImageHdr
   );
+
+
+/**
+  Main routine for Command updates.
+
+  This function has the logic to perform CMD  update.
+
+  @param[in] CapImageHdr    The pointer to the firmware update capsule image.
+
+  @retval  EFI_SUCCESS      Update successful
+  @retval  other            error status from the update routine
+**/
+EFI_STATUS
+FwCmdUpdateProcess (
+  EFI_FW_MGMT_CAP_IMAGE_HEADER  *CapImageHdr
+  );
 #endif

--- a/Silicon/ApollolakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/ApollolakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -495,6 +495,7 @@ PlatformEndFirmwareUpdate (
   return EFI_SUCCESS;
 }
 
+
 /**
   Platform hook point to clear firmware update trigger.
 
@@ -509,4 +510,28 @@ ClearFwUpdateTrigger (
 {
   // Clear platform firmware update trigger.
   MmioAnd32 (PMC_BASE_ADDRESS + R_PMC_BIOS_SCRATCHPAD, 0xFF00FFFF);
+}
+
+
+/**
+  Flash descriptor region lock
+
+  This function will do some command buffer parsing and check
+  for additional parameters
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      Flash descriptor lock successfully.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+SetFlashDescriptorLock (
+  IN  CHAR8      *CmdDataBuf,
+  IN  UINTN      CmdDataSize
+  )
+{
+  return EFI_UNSUPPORTED;
 }

--- a/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -478,3 +478,27 @@ PlatformEndFirmwareUpdate (
 {
   return EFI_SUCCESS;
 }
+
+
+/**
+  Flash descriptor region lock
+
+  This function will do some command buffer parsing and check
+  for additional parameters
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      Flash descriptor lock successfully.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+SetFlashDescriptorLock (
+  IN  CHAR8      *CmdDataBuf,
+  IN  UINTN      CmdDataSize
+  )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/Silicon/QemuSocPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/QemuSocPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -510,3 +510,27 @@ ClearFwUpdateTrigger (
 {
   return;
 }
+
+
+/**
+  Flash descriptor region lock
+
+  This function will do some command buffer parsing and check
+  for additional parameters
+
+  @param[in]  CmdDataBuf    Pointer to command buffer
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      Flash descriptor lock successfully.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+SetFlashDescriptorLock (
+  IN  CHAR8      *CmdDataBuf,
+  IN  UINTN      CmdDataSize
+   )
+{
+  return EFI_UNSUPPORTED;
+}


### PR DESCRIPTION
This patch adds generic functionality to process Flash descriptor lock. It follows
Capsule Firmware update flow and interface is updated. Command (CMDI) interface is added
to GenCapsuleFirmware which takes file with command as input.

Sample Command format in text file input,
{FLASHDESCLOCK}

Firmware update lib handler parses high level commands
Specific command process and functionlity would be
performed by platform specific libraries.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>