### PR TITLE
SMBIOS Implementation - Adding SMBIOS Default Table.

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -279,7 +279,7 @@
 
   gPlatformModuleTokenSpaceGuid.PcdSmbiosTablesBase  | 0x00000000
   gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsPtr  | 0x00000000
-  gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsCnt  | 0x0000
+  gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsCnt  | 0x40
   gPlatformModuleTokenSpaceGuid.PcdFuncCpuInitHook   | 0x00000000
 
 [PcdsFeatureFlag]

--- a/BootloaderCorePkg/Include/Library/SmbiosInitLib.h
+++ b/BootloaderCorePkg/Include/Library/SmbiosInitLib.h
@@ -54,6 +54,15 @@ AppendSmbiosType (
   );
 
 /**
+  This function is called to initialize the SmbiosStringsPtr.
+**/
+VOID
+EFIAPI
+InitSmbiosStringPtr (
+  VOID
+  );
+
+/**
   This function is called to initialize the SMBIOS tables.
 
   @retval       EFI_DEVICE_ERROR, if Smbios Entry is NULL
@@ -65,6 +74,5 @@ EFIAPI
 SmbiosInit (
   VOID
   );
-
 
 #endif

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -391,6 +391,10 @@ SecStartup (
   FspResetHandler (Status);
   ASSERT_EFI_ERROR (Status);
 
+  if (FixedPcdGetBool (PcdSmbiosEnabled)) {
+    InitSmbiosStringPtr ();
+  }
+
   BoardInit (PostSiliconInit);
   AddMeasurePoint (0x3040);
 

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -60,6 +60,8 @@ class Board(BaseBoard):
         self.ENABLE_LINUX_PAYLOAD     = 1
         self.ENABLE_CRYPTO_SHA_OPT    = 0
 
+        self.ENABLE_SMBIOS            = 1
+
         self.CPU_MAX_LOGICAL_PROCESSOR_NUMBER = 255
 
         # To enable source debug, set 1 to self.ENABLE_SOURCE_DEBUG


### PR DESCRIPTION
- Default SMBIOS Table initialized when SMBIOS is enabled.
- If required, Every Platform can override platform specific information.
- Enable SMBIOS in Qemu platform

Signed-off-by: Sm NARAYANAN <s.m.narayanan@intel.com>