### PR TITLE
Allow using bootloader stack to call FspMemoryInit

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -144,6 +144,9 @@
   # If static patching is not required, zero default value can be used with no issue.
   #
   gPlatformModuleTokenSpaceGuid.PcdFSPSBase               | 0xFF000000 | UINT32 | 0x20000100
+  # Switch FSP-M stack top to new value.
+  # 0: do not switch,  0xffffffff: switch to default,  others: switch to specific value
+  gPlatformModuleTokenSpaceGuid.PcdFSPMStackTop           | 0x00000000 | UINT32 | 0x20000101
   gPlatformModuleTokenSpaceGuid.PcdAcpiTablesMaxEntry     |         32 | UINT32 | 0x2000000C
   gPlatformModuleTokenSpaceGuid.PcdAcpiTablesRsdp         | 0x00000000 | UINT32 | 0x2000000D
   gPlatformModuleTokenSpaceGuid.PcdAcpiTablesAddress      | 0xFF000000 | UINT32 | 0x20000110

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -216,6 +216,7 @@
   gPlatformModuleTokenSpaceGuid.PcdFSPMUpdSize            | $(FSP_M_UPD_SIZE)
   gPlatformModuleTokenSpaceGuid.PcdFSPSSize               | $(FSP_S_SIZE)
   gPlatformModuleTokenSpaceGuid.PcdFSPSUpdSize            | $(FSP_S_UPD_SIZE)
+  gPlatformModuleTokenSpaceGuid.PcdFSPMStackTop           | $(FSP_M_STACK_TOP)
 
   gPlatformModuleTokenSpaceGuid.PcdTopSwapRegionSize      | $(TOP_SWAP_SIZE)
   gPlatformModuleTokenSpaceGuid.PcdRedundantRegionSize    | $(REDUNDANT_SIZE)
@@ -247,7 +248,7 @@
 
   gPlatformCommonLibTokenSpaceGuid.PcdIppHashLibSupportedMask    | $(IPP_HASH_LIB_SUPPORTED_MASK)
 
- gPlatformCommonLibTokenSpaceGuid.PcdCompSignHashAlg             | $(SIGN_HASH_TYPE)
+  gPlatformCommonLibTokenSpaceGuid.PcdCompSignHashAlg             | $(SIGN_HASH_TYPE)
 
 [PcdsPatchableInModule]
   gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel   | 0x8000004F

--- a/BootloaderCorePkg/Library/FspApiLib/FspApiLibInternal.h
+++ b/BootloaderCorePkg/Library/FspApiLib/FspApiLibInternal.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -15,6 +15,25 @@
 #include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/BootloaderCommonLib.h>
+
+/**
+  Switch to new stack and then call specified function with arguments.
+
+  @param[in] Function     The 32bit code entry to be executed.
+  @param[in] Context1     The first parameter to pass to 32bit code.
+  @param[in] Context2     The second parameter to pass to 32bit code.
+  @param[in] NewStack     The new stack top to use.
+
+  @return    EFI_STATUS returned from the 32bit code.
+**/
+EFI_STATUS
+EFIAPI
+FspmSwitchStack (
+  IN VOID        *EntryPoint,
+  IN VOID        *Context1,   OPTIONAL
+  IN VOID        *Context2,   OPTIONAL
+  IN VOID        *NewStack
+  );
 
 /**
   Wrapper for a thunk  to transition from long mode to compatibility mode to execute 32-bit code and then transit back to

--- a/BootloaderCorePkg/Library/FspApiLib/FspmApiLib.inf
+++ b/BootloaderCorePkg/Library/FspApiLib/FspmApiLib.inf
@@ -23,9 +23,11 @@
 [Sources.X64]
   X64/DispatchExecute.c
   X64/Thunk64To32.nasm
+  X64/FspSwitchStack.nasm
 
 [Sources.IA32]
   Ia32/DispatchExecute.c
+  Ia32/FspSwitchStack.nasm
 
 [Sources]
   FspApiLibInternal.h
@@ -48,6 +50,7 @@
 [Pcd]
   gPlatformModuleTokenSpaceGuid.PcdFSPMBase
   gPlatformModuleTokenSpaceGuid.PcdFSPSBase
+  gPlatformModuleTokenSpaceGuid.PcdFSPMStackTop
 
 [FixedPcd]
   gPlatformModuleTokenSpaceGuid.PcdFSPMUpdSize

--- a/BootloaderCorePkg/Library/FspApiLib/Ia32/FspSwitchStack.nasm
+++ b/BootloaderCorePkg/Library/FspApiLib/Ia32/FspSwitchStack.nasm
@@ -1,0 +1,42 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;
+; Module Name:
+;
+;  FspSwitchStack.nasm
+;
+; Abstract:
+;
+;  This is the code that will call into FspMemoryInit API with a new stack.
+;
+;------------------------------------------------------------------------------
+
+SECTION .text
+
+;------------------------------------------------------------------------------
+; EFI_STATUS
+; EFIAPI
+; FspmSwitchStack (
+;   IN VOID        *EntryPoint,
+;   IN VOID        *Context1,   OPTIONAL
+;   IN VOID        *Context2,   OPTIONAL
+;   IN VOID        *NewStack
+;   );
+;------------------------------------------------------------------------------
+global ASM_PFX(FspmSwitchStack)
+ASM_PFX(FspmSwitchStack):
+    push  ebp
+    mov   ebp, esp
+    mov   esp, [ebp + 20]    ; switch stack
+    sub   esp, 8
+    mov   eax, [ebp + 16]
+    mov   [esp + 4], eax     ; prepare 2nd parameter
+    mov   eax, [ebp + 12]
+    mov   [esp], eax         ; prepare 1st parameter
+    call  dword [ebp + 8]
+    mov   esp, ebp
+    pop   ebp
+    ret

--- a/BootloaderCorePkg/Library/FspApiLib/X64/DispatchExecute.c
+++ b/BootloaderCorePkg/Library/FspApiLib/X64/DispatchExecute.c
@@ -121,4 +121,3 @@ Execute32BitCode (
 
   return Status;
 }
-

--- a/BootloaderCorePkg/Library/FspApiLib/X64/FspSwitchStack.nasm
+++ b/BootloaderCorePkg/Library/FspApiLib/X64/FspSwitchStack.nasm
@@ -1,0 +1,42 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;
+; Module Name:
+;
+;  FspSwitchStack.nasm
+;
+; Abstract:
+;
+;  This is the code that will call into FspMemoryInit API with a new stack.
+;
+;------------------------------------------------------------------------------
+
+    DEFAULT REL
+    SECTION .text
+;---------------------
+
+extern ASM_PFX(Execute32BitCode)
+
+;------------------------------------------------------------------------------
+; EFI_STATUS
+; EFIAPI
+; FspmSwitchStack (
+;   IN VOID        *EntryPoint,
+;   IN VOID        *Context1,   OPTIONAL
+;   IN VOID        *Context2,   OPTIONAL
+;   IN VOID        *NewStack
+;   );
+;------------------------------------------------------------------------------
+global ASM_PFX(FspmSwitchStack)
+ASM_PFX(FspmSwitchStack):
+    push  rbp
+    mov   rbp, rsp
+    mov   rsp, r9      ; Set new stack
+    mov   r9,  0       ; 4th parameter for Execute32BitCode
+    call  ASM_PFX(Execute32BitCode)
+    mov   rsp, rbp     ; Restore old stack
+    pop   rbp
+    ret

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -219,6 +219,7 @@ class BaseBoard(object):
         self.BPM_SIZE              = 0x1000 # valid only if ACM_SIZE > 0
         self.CFG_DATABASE_SIZE     = 0
 
+        self.FSP_M_STACK_TOP       = 0
         self.STAGE1A_XIP           = 1
         self.STAGE1B_XIP           = 1
         self.STAGE1_STACK_BASE_OFFSET = 0


### PR DESCRIPTION
FSP 2.1 introduced new requirement to use bootloader stack for FSP-M. It
will cause issue for SBL since SBL only uses a small stack in Stage1. To
address this isue, a new PCD PcdFSPMStackTop is added to control the
stack settings for FSP-M.
  - If it is 0, it will not switch stack before calling FspMemoryInit API.
  - If it is 0xffffffff, it will switch to the new default FSP before
    calling FspMemoryInit API.
  - For other values, it will switch to the new stack at specified value
    before calling FspMemoryInit API.
This PCD will be set automatically by FSP_M_STACK_TOP variable in
BoardConfig.py file.

This code has been tested on UP Extreme board with latest FSP version.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>