### PR TITLE
Support X64 UEFI payload

### DIFF
--- a/BootloaderCommonPkg/Library/LitePeCoffLib/LitePeCoffLib.c
+++ b/BootloaderCommonPkg/Library/LitePeCoffLib/LitePeCoffLib.c
@@ -303,7 +303,13 @@ PeCoffGetPreferredBase (
   if (Hdr.Te->Signature == EFI_TE_IMAGE_HEADER_SIGNATURE) {
     ImageBase = (UINT32)Hdr.Te->ImageBase + Hdr.Te->StrippedSize - sizeof (EFI_TE_IMAGE_HEADER);
   } else if (Hdr.Pe32->Signature == EFI_IMAGE_NT_SIGNATURE) {
-    ImageBase = Hdr.Pe32->OptionalHeader.ImageBase;
+    if (Hdr.Pe32->OptionalHeader.Magic == EFI_IMAGE_NT_OPTIONAL_HDR32_MAGIC) {
+      ImageBase = Hdr.Pe32->OptionalHeader.ImageBase;
+    } else if (Hdr.Pe32->OptionalHeader.Magic == EFI_IMAGE_NT_OPTIONAL_HDR64_MAGIC) {
+      ImageBase = (UINT32)Hdr.Pe32Plus->OptionalHeader.ImageBase;
+    } else {
+      return RETURN_UNSUPPORTED;
+    }
   } else {
     return RETURN_UNSUPPORTED;
   }

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -139,7 +139,7 @@ NormalBootPath (
   UINT32                         *Dst;
   PAYLOAD_ENTRY                   PldEntry;
   VOID                           *PldHobList;
-  UINT32                          PldBase;
+  UINTN                          PldBase;
   LOADER_GLOBAL_DATA             *LdrGlobal;
   EFI_STATUS                      Status;
   BOOLEAN                         CallBoardNotify;
@@ -258,7 +258,7 @@ NormalBootPath (
   DEBUG ((DEBUG_INFO, "Payload entry: 0x%08X\n", PldEntry));
   if (PldEntry != NULL) {
     DEBUG ((DEBUG_INIT, "Jump to payload\n\n"));
-    PldEntry (PldHobList, (VOID *)(UINTN)PldBase);
+    PldEntry (PldHobList, (VOID *)PldBase);
   }
 }
 


### PR DESCRIPTION
IA32 UEFI payload uses PE format and X64 UEFI payload uses
PE+ format. So update LitePeCofflib to support both PE and
PE+.

Signed-off-by: Guo Dong <guo.dong@intel.com>