### PR TITLE
FspsUpd Updated to Global Variable

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -168,7 +168,7 @@
   gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsPtr       | 0x00000000 | UINT32 | 0x20000198
   gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsCnt       |     0x0000 | UINT16 | 0x20000199
   gPlatformModuleTokenSpaceGuid.PcdFuncCpuInitHook        | 0x00000000 | UINT32 | 0x2000019A
-
+  gPlatformModuleTokenSpaceGuid.PcdFspsUpdPtr             | 0x00000000 | UINT32 | 0x2000019B
 [PcdsFeatureFlag]
   # Determine if the Intel GFX device should be enabled or not in system
   gPlatformModuleTokenSpaceGuid.PcdIntelGfxEnabled        | TRUE       | BOOLEAN | 0x20000200

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -281,6 +281,7 @@
   gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsPtr  | 0x00000000
   gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsCnt  | 0x40
   gPlatformModuleTokenSpaceGuid.PcdFuncCpuInitHook   | 0x00000000
+  gPlatformModuleTokenSpaceGuid.PcdFspsUpdPtr        | 0x00000000
 
 [PcdsFeatureFlag]
   gPlatformCommonLibTokenSpaceGuid.PcdMinDecompression    | FALSE

--- a/BootloaderCorePkg/Library/FspApiLib/FspSiliconInit.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspSiliconInit.c
@@ -7,6 +7,7 @@
 
 #include <FspApiLibInternal.h>
 #include <Library/BoardInitLib.h>
+#include <Library/BlMemoryAllocationLib.h>
 
 
 /**
@@ -26,7 +27,7 @@ CallFspSiliconInit (
   VOID
   )
 {
-  UINT8                       FspsUpd[FixedPcdGet32 (PcdFSPSUpdSize)];
+  VOID                      *FspsUpdptr;
   UINT8                      *DefaultSiliconInitUpd;
   FSP_INFO_HEADER            *FspHeader;
   FSP_SILICON_INIT            FspSiliconInit;
@@ -36,13 +37,17 @@ CallFspSiliconInit (
 
   ASSERT (FspHeader->Signature == FSP_INFO_HEADER_SIGNATURE);
   ASSERT (FspHeader->ImageBase == PcdGet32 (PcdFSPSBase));
-
+  FspsUpdptr = AllocatePool (FspHeader->CfgRegionSize);
+  if (FspsUpdptr == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+  }
+  (VOID) PcdSet32S (PcdFspsUpdPtr,(UINT32)(UINTN)FspsUpdptr);
   // Copy default UPD data
   DefaultSiliconInitUpd = (UINT8 *)(UINTN)(FspHeader->ImageBase + FspHeader->CfgRegionOffset);
-  CopyMem (&FspsUpd, DefaultSiliconInitUpd, FspHeader->CfgRegionSize);
+  CopyMem (FspsUpdptr, DefaultSiliconInitUpd, FspHeader->CfgRegionSize);
 
   /* Update architectural UPD fields */
-  UpdateFspConfig (FspsUpd);
+  UpdateFspConfig (FspsUpdptr);
 
   ASSERT (FspHeader->FspSiliconInitEntryOffset != 0);
   FspSiliconInit = (FSP_SILICON_INIT)(UINTN)(FspHeader->ImageBase + \
@@ -50,10 +55,10 @@ CallFspSiliconInit (
 
   DEBUG ((DEBUG_INFO, "Call FspSiliconInit ... \n"));
   if (IS_X64) {
-    Status = Execute32BitCode ((UINTN)FspSiliconInit, (UINTN)FspsUpd, (UINTN)0, FALSE);
+    Status = Execute32BitCode ((UINTN)FspSiliconInit,(UINTN) FspsUpdptr, (UINTN)0, FALSE);
     Status = (UINTN)LShiftU64 (Status & ((UINTN)MAX_INT32 + 1), 32) | (Status & MAX_INT32);
   } else {
-    Status = FspSiliconInit (&FspsUpd);
+    Status = FspSiliconInit (FspsUpdptr);
   }
   DEBUG ((DEBUG_INFO, "%r\n", Status));
 

--- a/BootloaderCorePkg/Library/FspApiLib/FspsApiLib.inf
+++ b/BootloaderCorePkg/Library/FspApiLib/FspsApiLib.inf
@@ -47,6 +47,7 @@
 
 [Pcd]
   gPlatformModuleTokenSpaceGuid.PcdFSPSBase
+  gPlatformModuleTokenSpaceGuid.PcdFspsUpdPtr
 
 [FixedPcd]
   gPlatformModuleTokenSpaceGuid.PcdFSPSUpdSize


### PR DESCRIPTION
    FspsUpd variable made global so that it could be accessed out of
    FspSilicon function

    Patchable PCD has been created for FspsUpd and Memory pool allocated.

Signed-off-by: Perni <ramesh.chandra.perni@intel.com>