### PR TITLE
Remove TestSigningPrivateKey as default in GenContainer

### DIFF
--- a/BootloaderCorePkg/Tools/CfgDataStitch.py
+++ b/BootloaderCorePkg/Tools/CfgDataStitch.py
@@ -36,7 +36,7 @@ def check_file_exist (chk_files):
     return ''
 
 
-def cfgdata_stitch(ifwi_file, ifwi_out_file, cfg_dir, key_dir, script_dir, tool_dir, platform_id):
+def cfgdata_stitch(ifwi_file, ifwi_out_file, cfg_dir, key_file, script_dir, tool_dir, platform_id):
     if len (dlt_files) == 0:
         raise Exception("Please run the generated CfgDataStitch.py script instead of the original one in source tree !")
 
@@ -69,16 +69,8 @@ def cfgdata_stitch(ifwi_file, ifwi_out_file, cfg_dir, key_dir, script_dir, tool_
         else:
             script_dir = get_script_dir()
 
-    if key_dir == '':
-        if fv_dir:
-            key_dir = os.path.realpath(os.path.join(fv_dir, '../../../../BootloaderCorePkg/Tools/Keys'))
-        else:
-            key_dir = get_script_dir()
-
-    if os.path.isdir(key_dir):
-        key_file = os.path.join(key_dir, 'TestSigningPrivateKey.pem')
-    else:
-        key_file = key_dir
+    if key_file == '':
+        raise Exception("Key file is not specified!!")
 
     if os.name == 'nt' and 'OPENSSL_PATH' not in os.environ:
         os.environ['OPENSSL_PATH'] = "C:\\Openssl\\"
@@ -183,11 +175,11 @@ def main():
                     default='',
                     help='CFGDATA directory path')
     ap.add_argument('-k',
-                    '--key-dir',
-                    dest='key_dir',
+                    '--key-file',
+                    dest='key_file',
                     type=str,
                     default='',
-                    help='Signing key directory path')
+                    help='Signing key path')
     ap.add_argument('-s',
                     '--script-dir',
                     dest='script_dir',
@@ -210,7 +202,7 @@ def main():
     args = ap.parse_args()
 
     cfgdata_stitch(args.ifwi_image, args.output_file, args.cfgdata_dir,
-                   args.key_dir, args.script_dir, args.tool_dir, args.platform_id)
+                   args.key_file, args.script_dir, args.tool_dir, args.platform_id)
 
 
 if __name__ == '__main__':

--- a/BootloaderCorePkg/Tools/GenContainer.py
+++ b/BootloaderCorePkg/Tools/GenContainer.py
@@ -714,7 +714,7 @@ def create_container (args):
     else:
         # Using component list
         if not key_file:
-            key_file = 'TestSigningPrivateKey.pem'
+            raise Exception ("key_path expects a key file path !")
         layout = gen_layout (args.comp_list, args.img_type, args.auth, out_file, key_dir, key_file)
     container_list = eval ('[[%s]]' % layout.replace('\\', '/'))
 
@@ -793,11 +793,12 @@ def main():
     cmd_display = sub_parser.add_parser('create', help='create a container image')
     group = cmd_display.add_mutually_exclusive_group (required=True)
     # '-l' or '-cl', one of them is mandatory
-    group.add_argument('-l',  dest='layout',   type=str, help='Container layout intput file if no -cl')
+    group.add_argument('-l',  dest='layout',   type=str, help='Container layout input file if no -cl')
     group.add_argument('-cl', dest='comp_list',nargs='+', help='List of each component files, following XXXX:FileName format')
     cmd_display.add_argument('-t', dest='img_type',  type=str, default='CLASSIC', help='Container Image Type : [NORMAL, CLASSIC, MULTIBOOT]')
     cmd_display.add_argument('-o', dest='out_path',  type=str, default='.', help='Container output directory/file')
-    cmd_display.add_argument('-k', dest='key_path',  type=str, default='', help='Input key directory/file')
+    cmd_display.add_argument('-k', dest='key_path',  type=str, default='', help='Input key directory/file. Use key directoy path when container layout -l option is used \
+                                                                                 Use key file path when component files with -cl option is specified')
     cmd_display.add_argument('-a',  dest='auth', choices=['SHA2_256', 'SHA2_384', 'RSA2048_PKCS1_SHA2_256',
                     'RSA3072_PKCS1_SHA2_384', 'RSA2048_PSS_SHA2_256', 'RSA3072_PSS_SHA2_384', 'NONE'], default='',  help='authentication algorithm')
     cmd_display.add_argument('-cd', dest='comp_dir', type=str, default='', help='Componet image input directory')


### PR DESCRIPTION
TestSigningPrivateKey is defaulted for container
creation in non-layout form and key dir is used.
In CfgDataStitch also TestSigningPrivateKey is
defaulted when key dir is specified.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>