### PR TITLE
Booting linux from BIOS and PDR region.

### DIFF
--- a/BootloaderCommonPkg/Library/SpiBlockIoLib/SpiBlockIoLib.c
+++ b/BootloaderCommonPkg/Library/SpiBlockIoLib/SpiBlockIoLib.c
@@ -80,7 +80,7 @@ SpiReadBlocks (
     return EFI_NO_MEDIA;
   }
 
-  Status = mSpiService->SpiRead (FlashRegionAll, (UINT32) (Address * SPI_BLOCK_SIZE), (UINT32)BufferSize, Buffer);
+  Status = mSpiService->SpiRead (RegionType, (UINT32) (Address), (UINT32)BufferSize, Buffer);
 
   return Status;
 }
@@ -110,9 +110,7 @@ SpiGetMediaInfo (
 {
   // This Lib will only support Images in PDR region
   // And need minor update this lib to support it.
-  return EFI_UNSUPPORTED;
 
-#if 0
   EFI_STATUS  Status;
   UINT32 FlashBase;
   UINT32 FlashSize;
@@ -131,5 +129,4 @@ SpiGetMediaInfo (
   DevBlockInfo->BlockSize = SPI_BLOCK_SIZE;
 
   return Status;
-#endif
 }

--- a/PayloadPkg/OsLoader/LoadImage.c
+++ b/PayloadPkg/OsLoader/LoadImage.c
@@ -51,6 +51,7 @@ GetBootImageFromRawPartition (
   VOID                      *BlockData;
   EFI_LBA                    LbaAddr;
   UINT8                      SwPart;
+  UINT64                     Address;
   CONTAINER_HDR             *ContainerHdr;
 
   SwPart  = BootOption->Image[LoadedImage->LoadImageType].LbaImage.SwPart;
@@ -93,12 +94,20 @@ GetBootImageFromRawPartition (
   if (BlockData == NULL) {
     return EFI_OUT_OF_RESOURCES;
   }
+
+  if ( BootOption->DevType == OsBootDeviceMemory ) {
+    Address =  LogicBlkDev.StartBlock + LbaAddr;
+  } else {
+    Address =  LbaAddr;
+  }
+
   Status = MediaReadBlocks (
              BootOption->HwPart,
-             LogicBlkDev.StartBlock + LbaAddr,
+             Address,
              AlignedHeaderSize,
              BlockData
              );
+
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_INFO, "Read image error, Status = %r\n", Status));
     return Status;
@@ -152,12 +161,20 @@ GetBootImageFromRawPartition (
   //
   // Read the rest of the IAS image into the buffer
   //
+
+  if ( BootOption->DevType == OsBootDeviceMemory ) {
+    Address =  LogicBlkDev.StartBlock + LbaAddr + AlignedHeaderSize;
+  } else {
+    Address =  LbaAddr + AlignedHeaderSize;
+  }
+
   Status = MediaReadBlocks (
              BootOption->HwPart,
-             LogicBlkDev.StartBlock + LbaAddr + (AlignedHeaderSize / BlockSize),
+             Address,
              (AlignedImageSize - AlignedHeaderSize),
              (VOID *)((UINTN)Buffer + AlignedHeaderSize)
              );
+
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_INFO, "Read rest of image error, Status = %r\n", Status));
     FreePages (Buffer, EFI_SIZE_TO_PAGES (AlignedImageSize));

--- a/Platform/CommonBoardPkg/CfgData/Template_BootOption.dsc
+++ b/Platform/CommonBoardPkg/CfgData/Template_BootOption.dsc
@@ -50,8 +50,9 @@
 
     # !BSF NAME:{Hardware Partition}
     # !BSF TYPE:{Combo}
-    # !BSF OPTION:{0:User Partition, 1:Boot Partition 1, 2:Boot Partition 2}
-    # !BSF HELP:{Specify hardware partition number}
+    # !BSF OPTION:{0:User Partition, 1:Boot Partition 1, 2:Boot Partition 2, 3:Boot Partition 3, 4:Boot Partition 4}
+    # !BSF HELP:{Specify hardware partition number.}
+    # !BSF HELP:{+ If boot device type is SPI, the hardware partition refers to SPI flash region: 0-Descriptor, 1-BIOS, 2-ME, 3-GbE, 4-PDR Regions}
     # !BSF CONDITION:{$ImageType_$(1) < 0xFE}
     gCfgData.HwPart_$(1)                    |      * | 0x01 | $(6)
 


### PR DESCRIPTION
SPI driver is updated to support read linux from
BIOS and PDR region, When boot device SPI is
selected.

Signed-off-by: Mutha <naga.naveen.mutha@intel.com>