### PR TITLE
Increase hash store size allocated in bootloader

### DIFF
--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -267,7 +267,7 @@ class BaseBoard(object):
 
         self.IPP_HASH_LIB_SUPPORTED_MASK   = IPP_CRYPTO_ALG_MASK[self._SIGN_HASH]
 
-        self.HASH_STORE_SIZE       = 0x200  #Hash store size to be allocated in bootloader
+        self.HASH_STORE_SIZE       = 0x400  #Hash store size to be allocated in bootloader
 
         self.PCI_MEM64_BASE        = 0
         self.BUILD_ARCH            = 'IA32'


### PR DESCRIPTION
Maintaining individual public hashes for components in external key hash and
considering SHA384 size of hash store increases.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>