### PR TITLE
Add PciGetMaxBusNumber for PCI Bridge Subordinate Bus

### DIFF
--- a/BootloaderCorePkg/Library/PciEnumerationLib/InternalPciEnumerationLib.h
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/InternalPciEnumerationLib.h
@@ -81,6 +81,11 @@ struct _PCI_BAR_RESOURCE {
   PCI_BAR                                  *PciBar;
 };
 
+typedef struct {
+  UINT8                                     BusBase;
+  UINT8                                     BusLimit;
+} PCI_BUS_NUM_RANGE;
+
 typedef struct _PCI_IO_DEVICE              PCI_IO_DEVICE;
 
 struct _PCI_IO_DEVICE {
@@ -100,6 +105,11 @@ struct _PCI_IO_DEVICE {
   // BAR for this PCI Device
   //
   PCI_BAR                                   PciBar[PCI_MAX_BAR];
+
+  //
+  // Bus number ranges for a PCI Root Bridge device
+  //
+  PCI_BUS_NUM_RANGE                         BusNumberRanges;
 
   //
   // ARI (Alternative Routing ID)


### PR DESCRIPTION
At PciScanBus, a PCI bridge sets PCI Bridge Subordinate Bus to 0xFF
temporary to go thru any PPB. But, a platform has some reserved buses
(ex. 0xFB-0xFF) on PCI hierarchy, and writing 0xFF regardless of
reserved bus ranges causes system hang.

Therefore, PciGetMaxBusNumber will be used for PCI Bridge Subordinate
Bus and it gets the number of buses from PCI Enum Policy to skip the
reserved buses.

Signed-off-by: Aiden Park <aiden.park@intel.com>