### PR TITLE
Remove wbinvd() in warm reset

### DIFF
--- a/BootloaderCommonPkg/Library/ResetSystemLib/ResetSystemLib.c
+++ b/BootloaderCommonPkg/Library/ResetSystemLib/ResetSystemLib.c
@@ -84,11 +84,6 @@ ResetSystem (
 {
   switch (ResetType) {
   case EfiResetWarm:
-    //
-    // Flush the cache in case the changes are needed in next boot.
-    //
-    AsmWbinvd ();
-
     ResetWarm ();
     break;
 

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -455,7 +455,12 @@ ResetSystemIocIpc (
   UINT32                    PciBar;
   UINT32                    Data32;
 
-  if (ResetType == EfiResetCold) {
+  if (ResetType == EfiResetWarm) {
+    //
+    // Flush the cache in case the changes are needed in next boot.
+    //
+    AsmWbinvd ();
+  } else if (ResetType == EfiResetCold) {
     IocUartData = (IOC_UART_CFG_DATA *)FindConfigDataByTag (CDATA_IOC_UART_TAG);
     if (IocUartData == NULL) {
       DEBUG ((DEBUG_WARN, "CDATA_IOC_UART_TAG Not Found\n"));


### PR DESCRIPTION
The unnecessary wbinvd() is removed from the common ResetSystemLib,
and it moves to a platform specific reset routine.

Signed-off-by: Aiden Park <aiden.park@intel.com>