### PR TITLE
Fix invalid PPB check in PciGetMaxBusNumber()

### DIFF
--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
@@ -646,7 +646,10 @@ PciGetMaxBusNumber (
 {
   UINT8             MaxBusNumber;
 
-  if ((Bridge != NULL) && ((Bridge->Address & BIT31) != 0)) {
+  //
+  // No Bridge type check here. A caller must guarantee IS_PCI_BRIDGE(Bridge)
+  //
+  if (Bridge != NULL) {
     MaxBusNumber = Bridge->BusNumberRanges.BusLimit;
   } else {
     MaxBusNumber = PCI_MAX_BUS;


### PR DESCRIPTION
A PPB PCI_IO_DEVICE instance has BIT31 in its Address field to identify
the device as PPB type. But, the bit is set after scanning the PPB.
This skips PPB type check in PciGetMaxBusNumber() and let a caller
guarantee PPB type check instead of adding a field in PCI_IO_DEVICE
for PPB device.

Signed-off-by: Aiden Park <aiden.park@intel.com>