### PR TITLE
Use an variable for defining key type for signing interface

### DIFF
--- a/BootloaderCorePkg/Tools/SingleSign.py
+++ b/BootloaderCorePkg/Tools/SingleSign.py
@@ -22,7 +22,6 @@ import string
 # KEY_SIZE_TYPE defines the key sizes to be used for signing
 # KEY_SIZE_TYPE = RSA2048 uses RSA 2K size keys
 # KEY_SIZE_TYPE = RSA3072 uses RSA 3K size keys
-KEY_SIZE_TYPE = 'RSA2048'
 
 SIGNING_KEY = {
     # Key Id                    | Key File Name start |
@@ -94,6 +93,16 @@ def run_process (arg_list, print_cmd = False, capture_out = False):
 
     return output
 
+def get_key_sz_type ():
+
+    if 'KEY_SIZE_TYPE' not in os.environ:
+        # default Key size "RSA2048'
+        key_sz_type = 'RSA2048'
+    else:
+        key_sz_type = os.environ.get('KEY_SIZE_TYPE')
+
+    return key_sz_type
+
 def check_file_pem_format (priv_key):
     # Check for file .pem format
     key_name = os.path.basename(priv_key)
@@ -138,7 +147,7 @@ def get_key_from_store (in_key):
     if priv_key is not None:
         if (priv_key in SIGNING_KEY):
             # Generate key file name from key id
-            priv_key_file = SIGNING_KEY[priv_key] + '_' + KEY_SIZE_TYPE +'.pem'
+            priv_key_file = SIGNING_KEY[priv_key] + '_' + get_key_sz_type() +'.pem'
         else:
             raise Exception('KEY_ID %s is not found in supported KEY IDs!!' % priv_key)
     elif check_file_pem_format(in_key) == True:

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -1039,6 +1039,9 @@ class Build(object):
         if(IPP_CRYPTO_ALG_MASK[self._board._SIGN_HASH] & self._board.IPP_HASH_LIB_SUPPORTED_MASK) == 0:
             raise Exception  ('IPP_HASH_LIB_SUPPORTED_MASK is not set correctly!!')
 
+        # set Key size
+        os.environ['KEY_SIZE_TYPE'] = self._board._RSA_SIGN_TYPE
+
         # check if FSP binary exists
         fsp_dir  = os.path.join(plt_dir, 'Silicon', self._board.SILICON_PKG_NAME, "FspBin", self._board._FSP_PATH_NAME)
         work_dir = plt_dir

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -15,6 +15,7 @@ import sys
 sys.dont_write_bytecode = True
 sys.path.append (os.path.join('..', '..'))
 from BuildLoader import BaseBoard, STITCH_OPS, HASH_USAGE
+from BuildLoader import IPP_CRYPTO_OPTIMIZATION_MASK, IPP_CRYPTO_ALG_MASK, HASH_TYPE_VALUE
 
 class Board(BaseBoard):
 
@@ -60,14 +61,24 @@ class Board(BaseBoard):
         self.ENABLE_LINUX_PAYLOAD     = 1
         self.ENABLE_CRYPTO_SHA_OPT    = 0
 
+        # RSA2048 or RSA3072
+        self._RSA_SIGN_TYPE          = 'RSA3072'
+
+        # 'SHA2_256' or 'SHA2_384'
+        self._SIGN_HASH              = 'SHA2_384'
+
+        # 0x01 for SHA2_256 or 0x02 for SHA2_384
+        self.SIGN_HASH_TYPE          = HASH_TYPE_VALUE[self._SIGN_HASH]
+
+        # 0x0010  for SM3_256 | 0x0008 for SHA2_512 | 0x0004 for SHA2_384 | 0x0002 for SHA2_256 | 0x0001 for SHA1
+        self.IPP_HASH_LIB_SUPPORTED_MASK   = IPP_CRYPTO_ALG_MASK[self._SIGN_HASH]
+
         self.ENABLE_SMBIOS            = 1
 
         self.CPU_MAX_LOGICAL_PROCESSOR_NUMBER = 255
 
         # To enable source debug, set 1 to self.ENABLE_SOURCE_DEBUG
         # self.ENABLE_SOURCE_DEBUG  = 1
-
-
 
         # For test purpose
         # self.SKIP_STAGE1A_SOURCE_DEBUG = 1
@@ -212,12 +223,12 @@ class Board(BaseBoard):
         container_list.append ([
           # Name       | Image File |    CompressAlg  | AuthType             | Key File                      | Region Align | Region Size
           # ============================================================================================================================================
-          ('IPFW',      'SIIPFW.bin',    '',           'RSA2048_PSS_SHA2_256',   'CONTAINER_KEY_ID',            0,             0     ),   # Container Header
+          ('IPFW',      'SIIPFW.bin',    '',           'RSA3072_PSS_SHA2_384',   'CONTAINER_KEY_ID',            0,             0     ),   # Container Header
           ('TST1',      '',              'Dummy',      '',                   '',                                 0,             0x2000),   # Component 1
           ('TST2',      '',              'Lz4',        '',                   '',                                 0,             0x3000),   # Component 2
-          ('TST3',      '',              'Lz4',        'RSA2048_PSS_SHA2_256',   'CONTAINER_COMP_KEY_ID',        0,             0x3000),   # Component 3
-          ('TST4',      '',              'Lzma',       'SHA2_256',           '',                                 0,             0x3000),   # Component 4
-          ('TST5',      '',              'Dummy',      'RSA2048_PSS_SHA2_256',   'CONTAINER_COMP_KEY_ID',        0,             0x3000),   # Component 5
+          ('TST3',      '',              'Lz4',        'RSA3072_PSS_SHA2_384',   'CONTAINER_COMP_KEY_ID',        0,             0x3000),   # Component 3
+          ('TST4',      '',              'Lzma',       'SHA2_384',           '',                                 0,             0x3000),   # Component 4
+          ('TST5',      '',              'Dummy',      'RSA3072_PSS_SHA2_384',   'CONTAINER_COMP_KEY_ID',        0,             0x3000),   # Component 5
           ('TST6',      '',              '',           '',                   '',                                 0,             0x1000),   # Component 6
         ])
         return container_list

--- a/Platform/QemuBoardPkg/Script/TestCases/firmware_update.py
+++ b/Platform/QemuBoardPkg/Script/TestCases/firmware_update.py
@@ -257,8 +257,9 @@ def main():
     cmd = [ sys.executable,
             'BootloaderCorePkg/Tools/GenCapsuleFirmware.py',
             '-p',  'BIOS', bios_img,
-            '-k',  '../SblKeys/FirmwareUpdateTestKey_Priv_RSA2048.pem',
-            '-o',  '%s/FwuImage.bin' % fwu_dir
+            '-k',  '../SblKeys/FirmwareUpdateTestKey_Priv_RSA3072.pem',
+            '-o',  '%s/FwuImage.bin' % fwu_dir,
+            '-a',  'SHA2_384'
           ]
     try:
         output = subprocess.run (cmd)


### PR DESCRIPTION
Signing interface accepts KEY ID. Currently default
keys accessed are RSA2048. Based on crypto recommendation
some platfom would need RSA3072 as default.

Use KEY_SIZE_TYPE environment variable to define key type.
Default env setting would be RSA2048 in signing interface.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>