### PR TITLE
Support media instance in 'fs' shell command

### DIFF
--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext2FsLs.c
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext2FsLs.c
@@ -136,7 +136,7 @@ Ext2fsLs (
   Fp = (FILE *)File->FileSystemSpecificData;
 
   if ((Fp->DiskInode.Ext2DInodeMode & EXT2_IFMT) == EXT2_IFREG) {
-    CONSOLE_PRINT_UNICODE ((L"  %-16a %d\n", File->FileNamePtr, Fp->DiskInode.Ext2DInodeSize));
+    CONSOLE_PRINT_UNICODE ((L"  %-16a %u\n", File->FileNamePtr, Fp->DiskInode.Ext2DInodeSize));
     return EFI_SUCCESS;
   } else if ((Fp->DiskInode.Ext2DInodeMode & EXT2_IFMT) != EXT2_IFDIR) {
     return EFI_NOT_FOUND;
@@ -223,7 +223,7 @@ Ext2fsLs (
           FileSize = Fp->DiskInode.Ext2DInodeSize;
         }
         Status = RETURN_SUCCESS;
-        CONSOLE_PRINT_UNICODE ((L"  %-16a %d\n", New->EntryName, FileSize));
+        CONSOLE_PRINT_UNICODE ((L"  %-16a %u\n", New->EntryName, FileSize));
       }
       PNames = New->EntryNext;
     } while (PNames != NULL);

--- a/BootloaderCommonPkg/Library/FatLib/FatLib.c
+++ b/BootloaderCommonPkg/Library/FatLib/FatLib.c
@@ -41,7 +41,7 @@ PrintFileName (
   if (File->Attributes & FAT_ATTR_DIRECTORY) {
     CONSOLE_PRINT_UNICODE ((L"  %s/\n", FileName));
   } else {
-    CONSOLE_PRINT_UNICODE ((L"  %-16s %d\n", FileName, File->FileSize));
+    CONSOLE_PRINT_UNICODE ((L"  %-16s %u\n", FileName, File->FileSize));
   }
 }
 


### PR DESCRIPTION
The 'fs' shell command initializes media device with media type info,
but it's not able to initialize another controller of same media type.
Therefore, 'fs init' accepts device instance number.
ex) SATA(0), SATA device instance 1, hwpart 2, swpart 3
    fs init 0:1 2 3

Additionally, print file size in unsigned format in 'fs ls'.

Signed-off-by: Aiden Park <aiden.park@intel.com>