### PR TITLE
Fix smbiosview issue on Uefi payload

### DIFF
--- a/BootloaderCorePkg/Library/SmbiosInitLib/SmbiosInitLib.c
+++ b/BootloaderCorePkg/Library/SmbiosInitLib/SmbiosInitLib.c
@@ -167,6 +167,7 @@ FinalizeSmbios (
   Type127 = (SMBIOS_TABLE_TYPE127 *)(UINTN)(SmbiosEntry->TableAddress + SmbiosEntry->TableLength);
   Type127->Hdr.Type = SMBIOS_TYPE_END_OF_TABLE;
   Type127->Hdr.Length = sizeof (SMBIOS_STRUCTURE);
+  Type127->Hdr.Handle = SmbiosEntry->NumberOfSmbiosStructures++;
   mType127Ptr = (VOID *) Type127;
 
   SmbiosEntry->TableLength += sizeof (SMBIOS_STRUCTURE) + TYPE_TERMINATOR_SIZE;
@@ -219,10 +220,11 @@ AppendSmbiosType (
     return EFI_DEVICE_ERROR;
   }
 
+  TypeHdr = (SMBIOS_STRUCTURE *) TypeData;
+
   //
   // Check if the type is already added during Smbios init
   //
-  TypeHdr = (SMBIOS_STRUCTURE *) TypeData;
   if (TypeHdr->Type == SMBIOS_TYPE_BIOS_INFORMATION   ||
       TypeHdr->Type == SMBIOS_TYPE_SYSTEM_INFORMATION ||
       TypeHdr->Type == SMBIOS_TYPE_BASEBOARD_INFORMATION) {
@@ -244,6 +246,13 @@ AppendSmbiosType (
   SmbiosEntry->TableLength -= ( ((SMBIOS_STRUCTURE *)mType127Ptr)->Length + TYPE_TERMINATOR_SIZE);
   CopyMem (mType127Ptr, TypeData, TypeLength);
   SmbiosEntry->TableLength += TypeLength;
+
+  //
+  // Not incrementing the NumberOfSmbiosStructures here,
+  // as FinalizeSmbios () will do it again. That can be
+  // counted towards the newly added type structure.
+  //
+  TypeHdr->Handle = SmbiosEntry->NumberOfSmbiosStructures;
 
   //
   // After appending, update with Typ127 and patch entry point
@@ -403,6 +412,12 @@ AddSmbiosType (
     *MaxLength = TypeLength;
   }
   SmbiosEntry->TableLength += TypeLength;
+
+  //
+  // According to SMBIOS spec, Handle field is used to
+  // get a particular smbios type structure.
+  //
+  TypePtr.Hdr->Handle = SmbiosEntry->NumberOfSmbiosStructures++;
 
   return TypeAddr;
 


### PR DESCRIPTION
Smbios spec advises to use 'Handle' field in the
Type header to get the type information. This patch
updates the Handle field with the 'Type' value to
be unique. Also, update the Entry Point struct to
report the number of Types implemented currently.

Signed-off-by: Sai Talamudupula <sai.kiran.talamudupula@intel.com>