### PR TITLE
Extend Key Ids to include sign and size types.

### DIFF
--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -353,19 +353,6 @@ def get_payload_list (payloads):
 
     return pld_lst
 
-# Adjust hash type algorithm based on Public key file
-def adjust_hash_type (pub_key_file):
-    key_type =  get_key_type (pub_key_file)
-    if key_type ==  'RSA2048':
-        hash_type = 'SHA2_256'
-    elif key_type ==  'RSA3072':
-        hash_type = 'SHA2_384'
-    else:
-        hash_type = None
-
-    return hash_type
-
-
 def gen_pub_key_hash_store (signing_key, pub_key_hash_list, hash_alg, sign_scheme, pub_key_dir, out_file):
     # Build key hash blob
     key_hash_buf = bytearray ()

--- a/BootloaderCorePkg/Tools/CfgDataStitch.py
+++ b/BootloaderCorePkg/Tools/CfgDataStitch.py
@@ -87,8 +87,8 @@ def cfgdata_stitch(ifwi_file, ifwi_out_file, cfg_dir, key_file, script_dir, tool
             (script_dir, ['GenCfgData.py', 'CfgDataTool.py']),
             (cfg_dir, ['CfgDataDef.dsc']),
         ]
-    # Check for KEY_ID at end of string
-    if not key_file.endswith('KEY_ID'):
+    # Check for KEY_ID in key file string
+    if not key_file.startswith('KEY_ID'):
          chk_files.extend([(os.path.dirname(key_file), [os.path.basename(key_file)])])
 
     result = check_file_exist (chk_files)

--- a/BootloaderCorePkg/Tools/CfgDataTool.py
+++ b/BootloaderCorePkg/Tools/CfgDataTool.py
@@ -763,6 +763,9 @@ def CmdSign(Args):
     Fd.write (FileData)
     Fd.close ()
 
+    if Args.hash_alg is 'AUTO':
+        Args.hash_alg = adjust_hash_type(Args.cfg_pri_key)
+
     rsa_sign_file (Args.cfg_pri_key, None, Args.hash_alg, Args.sign_scheme, TmpFile, Args.cfg_out_file, True, True)
     if os.path.exists(TmpFile):
       os.remove(TmpFile)
@@ -921,7 +924,7 @@ def Main():
                             help='Configuration binary file')
     SignParser.add_argument('-o', dest='cfg_out_file', type=str, help='Signed configuration output binary file name to be generated', required=True)
     SignParser.add_argument('-k', dest='cfg_pri_key', type=str, help='Key Id or Private key file (PEM format) used to sign configuration data', required=True)
-    SignParser.add_argument('-a', dest='hash_alg', type=str, choices=['SHA2_256', 'SHA2_384'], help='Hash Type for signing',  default = 'SHA2_256')
+    SignParser.add_argument('-a', dest='hash_alg', type=str, choices=['SHA2_256', 'SHA2_384', 'AUTO'], help='Hash Type for signing. For AUTO hash type will be choosen based on key length',  default = 'AUTO')
     SignParser.add_argument('-s', dest='sign_scheme', type=str, choices=['RSA_PKCS1', 'RSA_PSS'], help='Signing Scheme',   default = 'RSA_PSS')
     SignParser.set_defaults(func=CmdSign)
 

--- a/BootloaderCorePkg/Tools/CommonUtility.py
+++ b/BootloaderCorePkg/Tools/CommonUtility.py
@@ -211,6 +211,17 @@ def run_process (arg_list, print_cmd = False, capture_out = False):
 
     return output
 
+# Adjust hash type algorithm based on Public key file
+def adjust_hash_type (pub_key_file):
+    key_type =  get_key_type (pub_key_file)
+    if key_type ==  'RSA2048':
+        hash_type = 'SHA2_256'
+    elif key_type ==  'RSA3072':
+        hash_type = 'SHA2_384'
+    else:
+        hash_type = None
+
+    return hash_type
 
 def rsa_sign_file (priv_key, pub_key, hash_type, sign_scheme, in_file, out_file, inc_dat = False, inc_key = False):
 

--- a/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
+++ b/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
@@ -16,7 +16,6 @@ import binascii
 from ctypes import *
 
 sys.dont_write_bytecode = True
-from BuildUtility import rsa_sign_file, gen_pub_key
 from CommonUtility import *
 
 class FmpCapsuleImageHeaderClass(object):
@@ -417,6 +416,9 @@ def SignImage(RawData, OutFile, HashType, SignScheme, PrivKey):
     elif key_type ==  'RSA3072':
         key_size = 384
 
+    if HashType is 'AUTO':
+        HashType = adjust_hash_type(PrivKey)
+
     header.FileGuid         = (c_ubyte *16).from_buffer_copy(FIRMWARE_UPDATE_IMAGE_FILE_GUID.bytes_le)
     header.HeaderSize       = sizeof(Firmware_Update_Header)
     header.FirmwreVersion   = 1
@@ -482,7 +484,7 @@ def main():
 
     parser.add_argument('-p',  '--payload', nargs=2, action='append', type=str, required=True, help='Specify payload information including GUID, FileName')
     parser.add_argument('-k',  '--priv_key', dest='PrivKey', type=str, required=True, help='Key Id or Private RSA 2048/RSA3072 key in PEM format to sign image')
-    parser.add_argument('-a',  '--alg_hash', dest='HashType', type=str, choices=['SHA2_256', 'SHA2_384'], default='SHA2_256', help='Hash type for signing')
+    parser.add_argument('-a',  '--alg_hash', dest='HashType', type=str, choices=['SHA2_256', 'SHA2_384', 'AUTO'], default='AUTO', help='Hash type for signing. For AUTO hash type will be choosen based on key length')
     parser.add_argument('-s',  '--sign_scheme', dest='SignScheme', type=str, choices=['RSA_PKCS1', 'RSA_PSS'], default='RSA_PSS', help='Signing Scheme types')
     parser.add_argument('-o',  '--output', dest='NewImage', type=str, required=True, help='Output file for signed image')
     parser.add_argument("-v",  "--verbose", dest='Verbose', action="store_true", help= "Turn on verbose output with informational messages printed, including capsule headers and warning messages.")

--- a/BootloaderCorePkg/Tools/GenContainer.py
+++ b/BootloaderCorePkg/Tools/GenContainer.py
@@ -578,7 +578,7 @@ class CONTAINER ():
 
             # create header entry
             auth_type_str = self.get_auth_type_str (self.header.auth_type)
-            key_file = 'CONTAINER_KEY_ID' if auth_type_str.startswith('RSA') else ''
+            key_file = 'KEY_ID_CONTAINER_RSA2048' if auth_type_str.startswith('RSA') else ''
             alignment = self.header.alignment
             image_type_str = CONTAINER.get_image_type_str(self.header.image_type)
             header = ['%s' % self.header.signature.decode(), file_name, image_type_str,  auth_type_str,  key_file]
@@ -587,7 +587,7 @@ class CONTAINER ():
             # create component entry
             for component in self.header.comp_entry:
                 auth_type_str = self.get_auth_type_str (component.auth_type)
-                key_file      = 'CONTAINER_COMP_KEY_ID' if auth_type_str.startswith('RSA') else ''
+                key_file      = 'KEY_ID_CONTAINER_COMP_RSA2048' if auth_type_str.startswith('RSA') else ''
                 lz_header = LZ_HEADER.from_buffer(component.data)
                 alg = LZ_HEADER._compress_alg[lz_header.signature]
                 if component.attribute & COMPONENT_ENTRY._attr['RESERVED']:

--- a/BootloaderCorePkg/Tools/GenerateKeys.py
+++ b/BootloaderCorePkg/Tools/GenerateKeys.py
@@ -35,21 +35,21 @@ def signing_priv_keys():
     signing_keys_list.append ([
       # Key ID                          | Key File Name start |
       # ===========================================================
-        # MASTER_KEY_ID is used for signing Slimboot Key Hash Manifest (KEYH Component)
-        ("MASTER_KEY_ID",               "MasterTestKey_Priv"),
+        # KEY_ID_MASTER is used for signing Slimboot Key Hash Manifest (KEYH Component)
+        ("KEY_ID_MASTER",               "MasterTestKey_Priv"),
 
-        # CFGDATA_KEY_ID is used for signing external Config data blob)
-        ("CFGDATA_KEY_ID",              "ConfigTestKey_Priv"),
+        # KEY_ID_CFGDATA is used for signing external Config data blob)
+        ("KEY_ID_CFGDATA",              "ConfigTestKey_Priv"),
 
-        # FIRMWAREUPDATE_KEY_ID is used for signing capsule firmware update image)
-        ("FIRMWAREUPDATE_KEY_ID",       "FirmwareUpdateTestKey_Priv"),
+        # KEY_ID_FIRMWAREUPDATE is used for signing capsule firmware update image)
+        ("KEY_ID_FIRMWAREUPDATE",       "FirmwareUpdateTestKey_Priv"),
 
-        # CONTAINER_KEY_ID is used for signing container header with mono signature
-        ("CONTAINER_KEY_ID",            "ContainerTestKey_Priv"),
+        # KEY_ID_CONTAINER is used for signing container header with mono signature
+        ("KEY_ID_CONTAINER",            "ContainerTestKey_Priv"),
 
-        # CONTAINER_COMP_KEY_ID is used for signing container components
+        # KEY_ID_CONTAINER_COMP is used for signing container components
         # One can add multiple component keys as needed.
-        ("CONTAINER_COMP_KEY_ID",       "ContainerCompTestKey_Priv"),
+        ("KEY_ID_CONTAINER_COMP",       "ContainerCompTestKey_Priv"),
         ])
 
     return signing_keys_list
@@ -59,8 +59,8 @@ def signing_pub_keys():
     signing_keys_list.append ([
       # Key ID                          | Key File Name start |
       # ===========================================================
-        # OS1_PUBLIC_KEY_ID is used for referencing Boot OS public keys
-        ("OS1_PUBLIC_KEY_ID",           "OS1_TestKey_Pub"),
+        # KEY_ID_OS1_PUBLIC is used for referencing Boot OS public keys
+        ("KEY_ID_OS1_PUBLIC",           "OS1_TestKey_Pub"),
 
         ])
 

--- a/BootloaderCorePkg/Tools/SingleSign.py
+++ b/BootloaderCorePkg/Tools/SingleSign.py
@@ -19,32 +19,36 @@ import struct
 import hashlib
 import string
 
-# KEY_SIZE_TYPE defines the key sizes to be used for signing
-# KEY_SIZE_TYPE = RSA2048 uses RSA 2K size keys
-# KEY_SIZE_TYPE = RSA3072 uses RSA 3K size keys
-KEY_SIZE_TYPE = 'RSA2048'
-
 SIGNING_KEY = {
-    # Key Id                    | Key File Name start |
-    # ===========================================================
-    # MASTER_KEY_ID is used for signing Slimboot Key Hash Manifest (KEYH Component)
-    "MASTER_KEY_ID"          :    "MasterTestKey_Priv",
+    # Key Id                                | Key File Name start |
+    # =================================================================
+    # KEY_ID_MASTER is used for signing Slimboot Key Hash Manifest container (KEYH Component)
+    "KEY_ID_MASTER_RSA2048"          :    "MasterTestKey_Priv_RSA2048.pem",
+    "KEY_ID_MASTER_RSA3072"          :    "MasterTestKey_Priv_RSA3072.pem",
 
-    # CFGDATA_KEY_ID is used for signing external Config data blob)
-    "CFGDATA_KEY_ID"         :    "ConfigTestKey_Priv",
+    # KEY_ID_CFGDATA is used for signing external Config data blob)
+    "KEY_ID_CFGDATA_RSA2048"         :    "ConfigTestKey_Priv_RSA2048.pem",
+    "KEY_ID_CFGDATA_RSA3072"         :    "ConfigTestKey_Priv_RSA3072.pem",
 
-    # FIRMWAREUPDATE_KEY_ID is used for signing capsule firmware update image)
-    "FIRMWAREUPDATE_KEY_ID"  :    "FirmwareUpdateTestKey_Priv",
+    # KEY_ID_FIRMWAREUPDATE is used for signing capsule firmware update image)
+    "KEY_ID_FIRMWAREUPDATE_RSA2048"  :    "FirmwareUpdateTestKey_Priv_RSA2048.pem",
+    "KEY_ID_FIRMWAREUPDATE_RSA3072"  :    "FirmwareUpdateTestKey_Priv_RSA3072.pem",
 
-    # CONTAINER_KEY_ID is used for signing container header with mono signature
-    "CONTAINER_KEY_ID"       :    "ContainerTestKey_Priv",
+    # KEY_ID_CONTAINER is used for signing container header with mono signature
+    "KEY_ID_CONTAINER_RSA2048"       :    "ContainerTestKey_Priv_RSA2048.pem",
+    "KEY_ID_CONTAINER_RSA3072"       :    "ContainerTestKey_Priv_RSA3072.pem",
 
     # CONTAINER_COMP1_KEY_ID is used for signing container components
-    "CONTAINER_COMP_KEY_ID" :    "ContainerCompTestKey_Priv",
+    "KEY_ID_CONTAINER_COMP_RSA2048" :    "ContainerCompTestKey_Priv_RSA2048.pem",
+    "KEY_ID_CONTAINER_COMP_RSA3072" :    "ContainerCompTestKey_Priv_RSA3072.pem",
 
-    # OS1_PUBLIC_KEY_ID, OS2_PUBLIC_KEY_ID is used for referencing Boot OS public keys
-    "OS1_PUBLIC_KEY_ID"      :    "OS1_TestKey_Pub",
-    "OS2_PUBLIC_KEY_ID"      :    "OS2_TestKey_Pub",
+    # KEY_ID_OS1_PUBLIC, KEY_ID_OS2_PUBLIC is used for referencing Boot OS public keys
+    "KEY_ID_OS1_PUBLIC_RSA2048"      :    "OS1_TestKey_Pub_RSA2048.pem",
+    "KEY_ID_OS1_PUBLIC_RSA3072"      :    "OS1_TestKey_Pub_RSA3072.pem",
+
+    "KEY_ID_OS2_PUBLIC_RSA2048"      :    "OS2_TestKey_Pub_RSA2048.pem",
+    "KEY_ID_OS2_PUBLIC_RSA3072"      :    "OS2_TestKey_Pub_RSA3072.pem",
+
     }
 
 MESSAGE_SBL_KEY_DIR = (
@@ -105,8 +109,8 @@ def check_file_pem_format (priv_key):
 def get_key_id (priv_key):
     # Extract base name if path is provided.
     key_name = os.path.basename(priv_key)
-    # Check for KEY_ID at end of string.
-    if (key_name.endswith('KEY_ID')):
+    # Check for KEY_ID in key naming.
+    if key_name.startswith('KEY_ID'):
         return key_name
     else:
         return None
@@ -138,7 +142,7 @@ def get_key_from_store (in_key):
     if priv_key is not None:
         if (priv_key in SIGNING_KEY):
             # Generate key file name from key id
-            priv_key_file = SIGNING_KEY[priv_key] + '_' + KEY_SIZE_TYPE +'.pem'
+            priv_key_file = SIGNING_KEY[priv_key]
         else:
             raise Exception('KEY_ID %s is not found in supported KEY IDs!!' % priv_key)
     elif check_file_pem_format(in_key) == True:

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -126,17 +126,19 @@ class BaseBoard(object):
 
         # NOTE: Variables starting with '_' will not be exported to Platform.dsc
 
-        # Default key dir is set by SBL_KEY_DIR. _KEY_DIR is set to NULL.
-        self._KEY_DIR = ''
-        self._MASTER_PRIVATE_KEY    = 'MASTER_KEY_ID'
-        self._CFGDATA_PRIVATE_KEY   = 'CFGDATA_KEY_ID'
-        self._CONTAINER_PRIVATE_KEY = 'CONTAINER_KEY_ID'
+
         self.LOGO_FILE              = 'Platform/CommonBoardPkg/Logo/Logo.bmp'
 
         self._RSA_SIGN_TYPE          = 'RSA2048'
         self._SIGN_HASH              = 'SHA2_256'
         self.SIGN_HASH_TYPE          = HASH_TYPE_VALUE[self._SIGN_HASH]
         self._SIGNING_SCHEME         = 'RSA_PSS'
+
+        # Default key dir is set by SBL_KEY_DIR. _KEY_DIR is set to NULL.
+        self._KEY_DIR = ''
+        self._MASTER_PRIVATE_KEY    = 'KEY_ID_MASTER' + '_' + self._RSA_SIGN_TYPE
+        self._CFGDATA_PRIVATE_KEY   = 'KEY_ID_CFGDATA' + '_' + self._RSA_SIGN_TYPE
+        self._CONTAINER_PRIVATE_KEY = 'KEY_ID_CONTAINER' + '_' + self._RSA_SIGN_TYPE
 
         self.VERINFO_IMAGE_ID       = 'SB_???? '
         self.VERINFO_PROJ_ID        = 1

--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -248,22 +248,22 @@ class Board(BaseBoard):
           (
             # Key for verifying Config data blob
             HASH_USAGE['PUBKEY_CFG_DATA'],
-            'CFGDATA_KEY_ID'
+            'KEY_ID_CFGDATA' + '_' + self._RSA_SIGN_TYPE
           ),
           (
             # Key for verifying firmware update
             HASH_USAGE['PUBKEY_FWU'],
-            'FIRMWAREUPDATE_KEY_ID'
+            'KEY_ID_FIRMWAREUPDATE' + '_' + self._RSA_SIGN_TYPE
           ),
           (
             # Key for verifying container header
             HASH_USAGE['PUBKEY_CONT_DEF'],
-            'CONTAINER_KEY_ID'
+            'KEY_ID_CONTAINER' + '_' + self._RSA_SIGN_TYPE
           ),
           (
             # key for veryfying OS image.
             HASH_USAGE['PUBKEY_OS'],
-            'OS1_PUBLIC_KEY_ID'
+            'KEY_ID_OS1_PUBLIC' + '_' + self._RSA_SIGN_TYPE
           ),
         ]
         return pub_key_list

--- a/Platform/CoffeelakeBoardPkg/BoardConfig.py
+++ b/Platform/CoffeelakeBoardPkg/BoardConfig.py
@@ -167,22 +167,22 @@ class Board(BaseBoard):
           (
             # Key for verifying Config data blob
             HASH_USAGE['PUBKEY_CFG_DATA'],
-            'CFGDATA_KEY_ID'
+            'KEY_ID_CFGDATA' + '_' + self._RSA_SIGN_TYPE
           ),
           (
             # Key for verifying firmware update
             HASH_USAGE['PUBKEY_FWU'],
-            'FIRMWAREUPDATE_KEY_ID'
+            'KEY_ID_FIRMWAREUPDATE' + '_' + self._RSA_SIGN_TYPE
           ),
           (
             # Key for verifying container header
             HASH_USAGE['PUBKEY_CONT_DEF'],
-            'CONTAINER_KEY_ID'
+            'KEY_ID_CONTAINER' + '_' + self._RSA_SIGN_TYPE
           ),
           (
             # key for veryfying OS image.
             HASH_USAGE['PUBKEY_OS'],
-            'OS1_PUBLIC_KEY_ID'
+            'KEY_ID_OS1_PUBLIC' + '_' + self._RSA_SIGN_TYPE
           ),
         ]
         return pub_key_list

--- a/Platform/QemuBoardPkg/Script/TestCases/firmware_update.py
+++ b/Platform/QemuBoardPkg/Script/TestCases/firmware_update.py
@@ -257,7 +257,7 @@ def main():
     cmd = [ sys.executable,
             'BootloaderCorePkg/Tools/GenCapsuleFirmware.py',
             '-p',  'BIOS', bios_img,
-            '-k',  '../SblKeys/FirmwareUpdateTestKey_Priv_RSA2048.pem',
+            '-k',  '../SblKeys/FirmwareUpdateTestKey_Priv_RSA3072.pem',
             '-o',  '%s/FwuImage.bin' % fwu_dir
           ]
     try:


### PR DESCRIPTION
KEY IDs are extended to include key type and sizes.
Platforms can configure corresponding RSA2048 and
RSA3072 KEY IDs. Updated tools to adjust hash type
based on key size.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>