### PR TITLE
Security version number to container

### DIFF
--- a/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
+++ b/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
@@ -46,7 +46,9 @@ typedef struct {
   UINT32        Signature;
   UINT32        CompressedSize;
   UINT32        Size;
-  UINT32        Reserved;
+  UINT16        Version;
+  UINT8         Svn;
+  UINT8         Attribute;
   UINT8         Data[];
 } LOADER_COMPRESSED_HEADER;
 

--- a/BootloaderCommonPkg/Include/Library/ContainerLib.h
+++ b/BootloaderCommonPkg/Include/Library/ContainerLib.h
@@ -67,7 +67,8 @@ typedef struct {
 
 typedef struct {
   UINT32           Signature;
-  UINT16           Version;
+  UINT8            Version;
+  UINT8            Svn;
   UINT16           DataOffset;
   UINT32           DataSize;
   UINT8            AuthType;

--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -353,7 +353,7 @@ def get_payload_list (payloads):
 
     return pld_lst
 
-def gen_pub_key_hash_store (signing_key, pub_key_hash_list, hash_alg, sign_scheme, pub_key_dir, out_file):
+def gen_pub_key_hash_store (signing_key, pub_key_hash_list, hash_alg, sign_scheme, svn, pub_key_dir, out_file):
     # Build key hash blob
     key_hash_buf = bytearray ()
     idx = 0
@@ -378,8 +378,8 @@ def gen_pub_key_hash_store (signing_key, pub_key_hash_list, hash_alg, sign_schem
     key_type = get_key_type(signing_key)
     sign_scheme = sign_scheme[sign_scheme.index("_")+1:]
     auth_type   = key_type + '_' + sign_scheme +  '_' + hash_alg
-    hash_store  = [('KEYH', key_store_cnt_file, '', auth_type, signing_key, 0x10, 0)]
-    hash_store.append ((HashStoreTable.HASH_STORE_SIGNATURE.decode(), key_store_bin_file, '', hash_alg, '', 0x10, 0))
+    hash_store  = [('KEYH', key_store_cnt_file, '', auth_type, signing_key, 0x10, 0, svn)]
+    hash_store.append ((HashStoreTable.HASH_STORE_SIGNATURE.decode(), key_store_bin_file, '', hash_alg, '', 0x10, 0, svn))
     out_dir = os.path.dirname(out_file)
     gen_container_bin ([hash_store], out_dir, out_dir, '', '')
 
@@ -591,14 +591,15 @@ def gen_payload_bin (fv_dir, arch_dir, pld_list, pld_bin, priv_key, hash_alg, si
         return
 
     # E-payloads container format
+    svn = 0x0
     alignment = 0x10
     key_dir  = os.path.dirname (priv_key)
     key_type = get_key_type(priv_key)
     sign_scheme = sign_scheme[sign_scheme.index("_")+1:]
     auth_type = key_type + '_' + sign_scheme +  '_' + hash_alg
-    pld_list = [('EPLD', '%s' % epld_bin, '', auth_type, '%s' % os.path.basename(priv_key), alignment, 0)]
+    pld_list = [('EPLD', '%s' % epld_bin, '', auth_type, '%s' % os.path.basename(priv_key), alignment, 0, svn)]
     for pld in ext_list:
-        pld_list.append ((pld['name'], pld['file'], pld['algo'], hash_alg, '', 0, 0))
+        pld_list.append ((pld['name'], pld['file'], pld['algo'], hash_alg, '', 0, 0, svn))
     gen_container_bin ([pld_list], fv_dir, fv_dir, key_dir, '')
 
 def pub_key_valid (pubkey):

--- a/BootloaderCorePkg/Tools/CommonUtility.py
+++ b/BootloaderCorePkg/Tools/CommonUtility.py
@@ -102,7 +102,9 @@ class LZ_HEADER(Structure):
         ('signature',       ARRAY(c_char, 4)),
         ('compressed_len',  c_uint32),
         ('length',          c_uint32),
-        ('reserved',        c_uint32)
+        ('version',         c_uint16),
+        ('svn',             c_uint8),
+        ('attribute',       c_uint8)
     ]
     _compress_alg = {
         b'LZDM' : 'Dummy',
@@ -334,7 +336,7 @@ def decompress (in_file, out_file, tool_dir = ''):
     run_process (cmdline, False, True)
     os.remove(temp)
 
-def compress (in_file, alg, out_path = '', tool_dir = ''):
+def compress (in_file, alg, svn=0, out_path = '', tool_dir = ''):
     if not os.path.isfile(in_file):
         raise Exception ("Invalid input file '%s' !" % in_file)
 
@@ -371,6 +373,7 @@ def compress (in_file, alg, out_path = '', tool_dir = ''):
     compress_data = get_file_data(out_file)
     lz_hdr = LZ_HEADER ()
     lz_hdr.signature = sig.encode()
+    lz_hdr.svn = svn
     lz_hdr.compressed_len = len(compress_data)
     lz_hdr.length = os.path.getsize(in_file)
     data = bytearray ()

--- a/BootloaderCorePkg/Tools/GenContainer.py
+++ b/BootloaderCorePkg/Tools/GenContainer.py
@@ -52,7 +52,8 @@ class CONTAINER_HDR (Structure):
     _pack_ = 1
     _fields_ = [
         ('signature',    ARRAY(c_char, 4)), # Identifies structure
-        ('version',      c_uint16),         # Header version
+        ('version',      c_uint8),          # Header version
+        ('svn',          c_uint8),          # Security version number
         ('data_offset',  c_uint16),         # Offset of payload (data) from header in byte
         ('data_size',    c_uint32),         # Size of payload (data) in byte
         ('auth_type',    c_uint8),          # Refer AUTH_TYPE_VALUE: 0 - "NONE"; 1- "SHA2_256";  2- "SHA2_384";  3- "RSA2048_PKCS1_SHA2_256"; 4 - RSA3072_PKCS1_SHA2_384;
@@ -304,6 +305,9 @@ class CONTAINER ():
         else:
             self.header.flags |= flags
 
+    def set_header_svn_info (self, svn):
+        self.header.svn = svn
+
     def set_header_auth_info (self, auth_type_str = None, priv_key = None):
         if priv_key is not None:
             self.header.priv_key   = priv_key
@@ -417,7 +421,7 @@ class CONTAINER ():
         is_mono_signing = True if layout[-1][0] == mono_sig else False
 
         # get the first entry in layout as CONTAINER_HDR
-        container_sig, container_file, image_type, auth_type, key_file, alignment, region_size = layout[0]
+        container_sig, container_file, image_type, auth_type, key_file, alignment, region_size, svn = layout[0]
 
         if alignment == 0:
             alignment = 0x1000
@@ -437,10 +441,11 @@ class CONTAINER ():
         # build header
         self.init_header (container_sig.encode(), alignment, image_type)
         self.set_header_auth_info (auth_type, key_path)
+        self.set_header_svn_info (svn)
 
         name_set = set()
         is_last_entry = False
-        for name, file, compress_alg, auth_type, key_file, alignment, region_size in layout[1:]:
+        for name, file, compress_alg, auth_type, key_file, alignment, region_size, svn in layout[1:]:
             if is_last_entry:
                 raise Exception ("'%s' must be the last entry in layout for monolithic signing!" % mono_sig)
             if compress_alg == '':
@@ -474,7 +479,7 @@ class CONTAINER ():
                     is_last_entry       = True
 
             # compress the component
-            lz_file = compress (in_file, compress_alg, self.out_dir, self.tool_dir)
+            lz_file = compress (in_file, compress_alg, svn, self.out_dir, self.tool_dir)
             component.data = bytearray(get_file_data (lz_file))
 
             # calculate the component auth info
@@ -530,7 +535,7 @@ class CONTAINER ():
 
         return out_file
 
-    def replace (self, comp_name, comp_file, comp_alg, key_file, new_name):
+    def replace (self, comp_name, comp_file, comp_alg, key_file, svn, new_name):
         if self.header.flags & CONTAINER_HDR._flags['MONO_SIGNING']:
             raise Exception ("Counld not replace component for monolithically signed container!")
 
@@ -548,7 +553,7 @@ class CONTAINER ():
         auth_type_str = self.get_auth_type_str (component.auth_type)
         data, hash_data, auth_data = self.get_auth_data (comp_file, auth_type_str)
         if auth_data is None:
-            lz_file = compress (comp_file, comp_alg, self.out_dir, self.tool_dir)
+            lz_file = compress (comp_file, comp_alg, svn, self.out_dir, self.tool_dir)
             if auth_type_str.startswith ('RSA') and key_file == '':
                 raise Exception ("Signing key needs to be specified !")
             hash_data, auth_data = CONTAINER.calculate_auth_data (lz_file, auth_type_str, key_file, self.out_dir)
@@ -582,27 +587,28 @@ class CONTAINER ():
             alignment = self.header.alignment
             image_type_str = CONTAINER.get_image_type_str(self.header.image_type)
             header = ['%s' % self.header.signature.decode(), file_name, image_type_str,  auth_type_str,  key_file]
-            layout = [(' Name', ' ImageFile', ' CompAlg', ' AuthType',  ' KeyFile', ' Alignment', ' Size')]
-            layout.append(tuple(["'%s'" % x for x in header] + ['0x%x' % alignment, '0']))
+            layout = [(' Name', ' ImageFile', ' CompAlg', ' AuthType',  ' KeyFile', ' Alignment', ' Size', 'svn')]
+            layout.append(tuple(["'%s'" % x for x in header] + ['0x%x' % alignment, '0', '0x%x' % self.header.svn]))
             # create component entry
             for component in self.header.comp_entry:
                 auth_type_str = self.get_auth_type_str (component.auth_type)
                 key_file      = 'KEY_ID_CONTAINER_COMP_RSA2048' if auth_type_str.startswith('RSA') else ''
                 lz_header = LZ_HEADER.from_buffer(component.data)
                 alg = LZ_HEADER._compress_alg[lz_header.signature]
+                svn = lz_header.svn
                 if component.attribute & COMPONENT_ENTRY._attr['RESERVED']:
                     comp_file = ''
                 else:
                     comp_file = component.name.decode() + '.bin'
                 comp = [component.name.decode(), comp_file, alg,  auth_type_str,  key_file]
-                layout.append(tuple(["'%s'" % x for x in comp] + ['0x%x' % (1 << component.alignment), '0x%x' % component.size]))
+                layout.append(tuple(["'%s'" % x for x in comp] + ['0x%x' % (1 << component.alignment), '0x%x' % component.size, '0x%x' % svn]))
 
             # write layout file
             layout_file = os.path.join(self.out_dir, self.header.signature.decode() + '.txt')
             fo = open (layout_file, 'w')
             fo.write ('# Container Layout File\n#\n')
             for idx, each in enumerate(layout):
-                line = ' %-6s, %-16s, %-10s, %-18s, %-30s, %-10s, %-10s' % each
+                line = ' %-6s, %-16s, %-10s, %-18s, %-30s, %-10s, %-10s, %-10s' % each
                 if idx == 0:
                     line = '#  %s\n' % line
                 else:
@@ -657,7 +663,7 @@ def adjust_auth_type (auth_type_str, key_path):
 
     return auth_type_str
 
-def gen_layout (comp_list, img_type, auth_type_str, out_file, key_dir, key_file):
+def gen_layout (comp_list, img_type, auth_type_str, svn, out_file, key_dir, key_file):
     hash_type = CONTAINER._auth_to_hashalg_str[auth_type_str] if auth_type_str else ''
     auth_type = auth_type_str
     key_path  = os.path.join(key_dir, key_file)
@@ -668,20 +674,22 @@ def gen_layout (comp_list, img_type, auth_type_str, out_file, key_dir, key_file)
     # prepare the layout from individual components from '-cl'
     if img_type not in CONTAINER_HDR._image_type.keys():
         raise Exception ("Invalid Container Type '%s' !" % img_type)
-    layout = "('BOOT', '%s', '%s', '%s' , '%s', 0x10, 0),\n" % (out_file, img_type, auth_type, key_file)
-    end_layout = "('_SG_', '', 'Dummy', '%s', '', 0, 0)," % (hash_type)
+    layout = "('BOOT', '%s', '%s', '%s' , '%s', 0x10, 0, %s),\n" % (out_file, img_type, auth_type, key_file, svn)
+    end_layout = "('_SG_', '', 'Dummy', '%s', '', 0, 0, %s)," % (hash_type, svn)
     for idx, each in enumerate(comp_list):
         parts = each.split(':')
         comp_name = parts[0]
         if len(comp_name) != 4:
             raise Exception ("Invalid component string format '%s' !" % each)
 
-        comp_file = ':'.join(parts[1:])
+        comp_file = ':'.join(parts[1:2])
+        com_svn   = ':'.join(parts[2:])
+
         if comp_name == 'INRD':
             align = 0x1000
         else:
             align = 0
-        layout += "('%s', '%s', 'Dummy', 'NONE', '', %s, 0),\n" % (comp_name, comp_file, align)
+        layout += "('%s', '%s', 'Dummy', 'NONE', '', %s, 0, %s),\n" % (comp_name, comp_file, align, com_svn)
     layout += end_layout
     return layout
 
@@ -715,7 +723,7 @@ def create_container (args):
         # Using component list
         if not key_file:
             raise Exception ("key_path expects a key file path !")
-        layout = gen_layout (args.comp_list, args.img_type, args.auth, out_file, key_dir, key_file)
+        layout = gen_layout (args.comp_list, args.img_type, args.auth, args.svn, out_file, key_dir, key_file)
     container_list = eval ('[[%s]]' % layout.replace('\\', '/'))
 
     comp_dir = os.path.abspath(args.comp_dir)
@@ -755,7 +763,7 @@ def replace_component (args):
     out_dir  = os.path.dirname(out_path)
     out_file = os.path.basename(out_path)
     container.set_dir_path (out_dir, '.', '.', tool_dir)
-    file = container.replace (args.comp_name, args.comp_file, args.compress, args.key_file, out_file)
+    file = container.replace (args.comp_name, args.comp_file, args.compress, args.key_file, args.svn, out_file)
     print ("Component '%s' was replaced successfully at:\n  %s" % (args.comp_name, file))
 
 def sign_component (args):
@@ -766,7 +774,7 @@ def sign_component (args):
     sign_file = os.path.abspath(args.out_file)
     out_dir   = os.path.dirname(sign_file)
 
-    lz_file = compress (args.comp_file, compress_alg, out_dir, args.tool_dir)
+    lz_file = compress (args.comp_file, compress_alg, 0, out_dir, args.tool_dir)
     data = bytearray(get_file_data (lz_file))
     hash_data, auth_data = CONTAINER.calculate_auth_data (lz_file, args.auth, args.key_file, out_dir)
 
@@ -803,6 +811,7 @@ def main():
                     'RSA3072_PKCS1_SHA2_384', 'RSA2048_PSS_SHA2_256', 'RSA3072_PSS_SHA2_384', 'NONE'], default='',  help='authentication algorithm')
     cmd_display.add_argument('-cd', dest='comp_dir', type=str, default='', help='Componet image input directory')
     cmd_display.add_argument('-td', dest='tool_dir', type=str, default='', help='Compression tool directory')
+    cmd_display.add_argument('-s', dest='svn', type=int, help='Security version number for Container header')
     cmd_display.set_defaults(func=create_container)
 
     # Command for extract
@@ -822,6 +831,7 @@ def main():
     cmd_display.add_argument('-c',  dest='compress', choices=['lz4', 'lzma', 'dummy'], default='dummy', help='compression algorithm')
     cmd_display.add_argument('-k',  dest='key_file',  type=str, default='', help='Key Id or Private key file path to sign component')
     cmd_display.add_argument('-td', dest='tool_dir', type=str, default='', help='Compression tool directory')
+    cmd_display.add_argument('-s', dest='svn', type=int, required=True, help='Security version number for Component')
     cmd_display.set_defaults(func=replace_component)
 
     # Command for sign

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -274,6 +274,7 @@ class BaseBoard(object):
 
         self.PCI_MEM64_BASE        = 0
         self.BUILD_ARCH            = 'IA32'
+        self.KEYH_SVN              = 0
 
         for key, value in list(kwargs.items()):
             setattr(self, '%s' % key, value)
@@ -1116,8 +1117,9 @@ class Build(object):
             if getattr(self._board, "GetKeyHashList", None):
                 key_hash_list = self._board.GetKeyHashList ()
 
+        svn = self._board.KEYH_SVN
         gen_pub_key_hash_store (mst_key, key_hash_list, HASH_VAL_STRING[self._board.SIGN_HASH_TYPE],
-                                self._board._SIGNING_SCHEME, self._key_dir, os.path.join(self._fv_dir, 'KEYHASH.bin'))
+                                self._board._SIGNING_SCHEME, svn, self._key_dir, os.path.join(self._fv_dir, 'KEYHASH.bin'))
 
         # create fit table
         if self._board.HAVE_FIT_TABLE:

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -78,7 +78,6 @@ class Board(BaseBoard):
         self._CFGDATA_PRIVATE_KEY   = 'KEY_ID_CFGDATA' + '_' + self._RSA_SIGN_TYPE
         self._CONTAINER_PRIVATE_KEY = 'KEY_ID_CONTAINER' + '_' + self._RSA_SIGN_TYPE
 
-
         # To enable source debug, set 1 to self.ENABLE_SOURCE_DEBUG
         # self.ENABLE_SOURCE_DEBUG  = 1
 
@@ -224,15 +223,16 @@ class Board(BaseBoard):
         container_list = []
         container_list_auth_type = self._RSA_SIGN_TYPE + '_'+ self._SIGNING_SCHEME[4:] + '_' + self._SIGN_HASH
         container_list.append ([
-          # Name       | Image File |    CompressAlg  | AuthType                           | Key File                              | Region Align | Region Size
-          # =====================================================================================================================================================
-          ('IPFW',      'SIIPFW.bin',    '',           container_list_auth_type,   'KEY_ID_CONTAINER'+'_'+self._RSA_SIGN_TYPE,             0,             0     ),   # Container Header
-          ('TST1',      '',              'Dummy',      '',                                     '',                                         0,             0x2000),   # Component 1
-          ('TST2',      '',              'Lz4',        '',                                     '',                                         0,             0x3000),   # Component 2
-          ('TST3',      '',              'Lz4',        container_list_auth_type,   'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE,        0,             0x3000),   # Component 3
-          ('TST4',      '',              'Lzma',       self._SIGN_HASH,                        '',                                         0,             0x3000),   # Component 4
-          ('TST5',      '',              'Dummy',      container_list_auth_type,   'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE,        0,             0x3000),   # Component 5
-          ('TST6',      '',              '',            '',                                    '',                                         0,             0x1000),   # Component 6
+
+          # Name       | Image File |    CompressAlg          | AuthType                               | Key File                    | Region Align | Region Size |  Svn Info
+          # ==================================================================================================================================================================
+          ('IPFW',      'SIIPFW.bin',    '',             container_list_auth_type,   'KEY_ID_CONTAINER'+'_'+self._RSA_SIGN_TYPE,            0,              0,         0),   # Container Header
+          ('TST1',      '',              'Dummy',               '',                                        '',                              0,              0x2000,    0),   # Component 1
+          ('TST2',      '',              'Lz4',                 '',                                        '',                              0,              0x3000,    0),   # Component 2
+          ('TST3',      '',              'Lz4',          container_list_auth_type,   'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE,       0,              0x3000,    0),   # Component 3
+          ('TST4',      '',              'Lzma',                   'SHA2_384',                               '',                            0,              0x3000,    0),   # Component 4
+          ('TST5',      '',              'Dummy',        container_list_auth_type,   'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE,       0,              0x3000,    0),   # Component 5
+          ('TST6',      '',               '',                    '',                                    '',                                 0,              0x1000,    0),   # Component 6
         ])
         return container_list
 


### PR DESCRIPTION
Add svn field to container generation. SVN need
to be verified while doing container capsule
update. svn is added as end parameter to layout.

Format expected for container creation using '-cl' option for specifying components,
CMDL:Inp\cmdline.txt:$SVN

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>