### PR TITLE
Zero the LOADER_PLATFORM_INFO HOB

### DIFF
--- a/BootloaderCorePkg/Stage2/Stage2Support.c
+++ b/BootloaderCorePkg/Stage2/Stage2Support.c
@@ -569,6 +569,7 @@ BuildExtraInfoHob (
   Length       = sizeof (LOADER_PLATFORM_INFO);
   LoaderPlatformInfo = BuildGuidHob (&gLoaderPlatformInfoGuid, Length);
   if (LoaderPlatformInfo != NULL) {
+    ZeroMem (LoaderPlatformInfo, Length);
     LoaderPlatformInfo->Revision = 2;
     LoaderPlatformInfo->BootPartition = GetCurrentBootPartition ();
     LoaderPlatformInfo->BootMode = GetBootMode ();


### PR DESCRIPTION
Just clear the memory after the HOB is built to avoid Platform
code forgot to init some fields.

Signed-off-by: Guo Dong <guo.dong@intel.com>