### PR TITLE
[QEMU] Fix GPIO pointer check condition

### DIFF
--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -213,7 +213,7 @@ GpioInit (
     Offset += GpioCfgHdr->GpioItemSize;
   }
 
-  if (GpioCfgBaseHdr != NULL) {
+  if (GpioCfgCurrHdr != NULL) {
     CopyMem (GpioTable, GpioCfgCurrHdr->GpioTableData, GpioCfgCurrHdr->GpioItemCount * GpioCfgCurrHdr->GpioItemSize);
     GpioEntries += GpioCfgCurrHdr->GpioItemCount;
   }


### PR DESCRIPTION
This patch fixed incorrect GPIO pointer check while appending new GPIO
entries for QEMU.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>