### PR TITLE
Added firmware update trigger script for yocto

### DIFF
--- a/BootloaderCorePkg/Tools/SblFwUpdate.py
+++ b/BootloaderCorePkg/Tools/SblFwUpdate.py
@@ -1,0 +1,45 @@
+## @ SblFwUpdate.py
+#
+# Copyright (c) 2017-2020, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+import os
+import re
+import sys
+import shutil
+import subprocess
+
+def Usage():
+    print ("SblFwUpdate")
+    print ("Usage:")
+    print ("    SblFwUpdate  <Input Capsule File>")
+
+def Main():
+    #
+    # Parse the options and args
+    #
+    argc = len(sys.argv)
+    if argc != 2:
+        Usage()
+        return 1
+
+    if not os.path.exists(sys.argv[1]) :
+        raise Exception ('%s file not found !' % sys.argv[1])
+
+    if not os.path.exists('/boot/efi/'):
+        raise Exception ('/boot/efi/ path not found !')
+
+    shutil.copy(sys.argv[1], '/boot/efi/FwuImage.bin')
+    fwucmd = "/sys/bus/wmi/devices/44FADEB1-B204-40F2-8581-394BBDC1B651/firmware_update_request"
+    ofile = open(fwucmd, "wb")
+    change=subprocess.Popen(["echo","1"], stdout=ofile)
+    ofile.close()
+    output = subprocess.check_output(['cat',fwucmd]).decode()
+    if output[0] is not '1':
+        raise Exception ('Triggering firmware update failed !')
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(Main())


### PR DESCRIPTION
Added firmware update trigger script for Linux

This script is intended to be called by firmware update
application to trigger firmware update after receiving
update capsule in Linux. This script is provided as a
reference implementation and does the following:

1. Copies the capsule to a known location where SBL
   will look for (/boot/efi/FwuImage.bin)

2. Signals FW update to SBL using the WMI interface
   provided by SBL. The WMI interface is provided
   by the ASL (https://github.com/slimbootloader/slimbootloader
/blob/master/Platform/CommonBoardPkg/AcpiTables/Dsdt/FwuWmi.asl)
   and linux kernel driver (https://lkml.org/lkml/2020/4/27/1289)

Reboot command was removed from the script, need to be
included if required.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>