### PR TITLE
Configdata firmware update svn check

### DIFF
--- a/BootloaderCommonPkg/Include/Library/ConfigDataLib.h
+++ b/BootloaderCommonPkg/Include/Library/ConfigDataLib.h
@@ -74,6 +74,35 @@ typedef struct {
   UINT32  TotalLength;
 } CDATA_BLOB;
 
+//
+// This data structure is same as CDATA_BLOB
+// Its represents contents stored to flash.
+//
+typedef struct {
+  UINT32  Signature;
+  //
+  // This header Length
+  //
+  UINT8   HeaderLength;
+  UINT8   Attribute;
+  //
+  // Security version number
+  // This is available only in flash. It would be overwritten by CDATA_BLOB.InternalDataOffset in runtime
+  //
+  UINT8   Svn;
+
+  // Reserved
+  UINT8   Rsvd;
+  //
+  // The total valid configuration data length including this header.
+  //
+  UINT32  UsedLength;
+  //
+  // The total space for configration data
+  //
+  UINT32  TotalLength;
+} CDATA_BLOB_ON_FLASH;
+
 #define  CDATA_HDR_WORD(ch)   (*(UINT32 *)(ch))
 
 /**

--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -429,7 +429,7 @@ def gen_flash_map_bin (flash_map_file, comp_list):
 def copy_expanded_file (src, dst):
     gen_cfg_data ("GENDLT", src, dst)
 
-def gen_config_file (fv_dir, brd_name, platform_id, pri_key, cfg_db_size, cfg_size, cfg_int, cfg_ext, sign_scheme, hash_type):
+def gen_config_file (fv_dir, brd_name, platform_id, pri_key, cfg_db_size, cfg_size, cfg_int, cfg_ext, sign_scheme, hash_type, svn):
     # Remove previous generated files
     for file in glob.glob(os.path.join(fv_dir, "CfgData*.*")):
             os.remove(file)
@@ -512,7 +512,7 @@ def gen_config_file (fv_dir, brd_name, platform_id, pri_key, cfg_db_size, cfg_si
 
     cfg_final_file = os.path.join(fv_dir, "CFGDATA.bin")
     if pri_key:
-        cfg_data_tool ('sign', ['-k', pri_key, '-a', hash_type, '-s', sign_scheme, cfg_merged_bin_file], cfg_final_file)
+        cfg_data_tool ('sign', ['-k', pri_key, '-a', hash_type, '-s', sign_scheme, '-svn', str(svn), cfg_merged_bin_file], cfg_final_file)
     else:
         shutil.copy(cfg_merged_bin_file, cfg_final_file)
 

--- a/BootloaderCorePkg/Tools/CfgDataTool.py
+++ b/BootloaderCorePkg/Tools/CfgDataTool.py
@@ -21,7 +21,8 @@ class CDATA_BLOB_HEADER(Structure):
         ('Signature', ARRAY(c_char, 4)),
         ('HeaderLength', c_uint8),
         ('Attribute', c_uint8),
-        ('Reserved', ARRAY(c_char, 2)),
+        ('Svn', c_uint8),
+        ('Reserved', ARRAY(c_char, 1)),
         ('UsedLength', c_uint32),
         ('TotalLength', c_uint32),
     ]
@@ -42,7 +43,8 @@ class CCfgData:
             ('Signature', ARRAY(c_char, 4)),
             ('HeaderLength', c_uint8),
             ('Attribute', c_uint8),
-            ('Reserved', ARRAY(c_char, 2)),
+            ('Svn', c_uint8),
+            ('Reserved', ARRAY(c_char, 1)),
             ('UsedLength', c_uint32),
             ('TotalLength', c_uint32),
         ]
@@ -758,6 +760,8 @@ def CmdSign(Args):
         raise Exception("Invalid config binary file '%s' !" % CfgDataFile)
     CfgBlobHeader.Attribute |= CCfgData.CDATA_BLOB_HEADER.ATTR_SIGNED
 
+    CfgBlobHeader.Svn = Args.svn
+
     TmpFile = Args.cfg_in_file + '.tmp'
     Fd      = open (TmpFile, 'wb')
     Fd.write (FileData)
@@ -926,6 +930,7 @@ def Main():
     SignParser.add_argument('-k', dest='cfg_pri_key', type=str, help='Key Id or Private key file (PEM format) used to sign configuration data', required=True)
     SignParser.add_argument('-a', dest='hash_alg', type=str, choices=['SHA2_256', 'SHA2_384', 'AUTO'], help='Hash Type for signing. For AUTO hash type will be choosen based on key length',  default = 'AUTO')
     SignParser.add_argument('-s', dest='sign_scheme', type=str, choices=['RSA_PKCS1', 'RSA_PSS'], help='Signing Scheme',   default = 'RSA_PSS')
+    SignParser.add_argument('-svn', dest='svn', type=int, required=True, help='Security version number for Config Data')
     SignParser.set_defaults(func=CmdSign)
 
     ExtractParser = SubParser.add_parser('extract', help='extract a single config data to a file')

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -276,6 +276,7 @@ class BaseBoard(object):
         self.PCI_MEM64_BASE        = 0
         self.BUILD_ARCH            = 'IA32'
         self.KEYH_SVN              = 0
+        self.CFGDATA_SVN           = 0
 
         for key, value in list(kwargs.items()):
             setattr(self, '%s' % key, value)
@@ -1187,11 +1188,12 @@ class Build(object):
 
         # create configuration data
         if self._board.CFGDATA_SIZE > 0:
+            svn = self._board.CFGDATA_SVN
             # create config data files
             gen_config_file (self._fv_dir, self._board.BOARD_PKG_NAME, self._board._PLATFORM_ID,
                              self._board._CFGDATA_PRIVATE_KEY, self._board.CFG_DATABASE_SIZE, self._board.CFGDATA_SIZE,
                              self._board._CFGDATA_INT_FILE, self._board._CFGDATA_EXT_FILE,
-                             self._board._SIGNING_SCHEME, HASH_VAL_STRING[self._board.SIGN_HASH_TYPE])
+                             self._board._SIGNING_SCHEME, HASH_VAL_STRING[self._board.SIGN_HASH_TYPE], svn)
 
         # rebuild reset vector
         vtf_dir = os.path.join('BootloaderCorePkg', 'Stage1A', 'Ia32', 'Vtf0')


### PR DESCRIPTION
Add support for security version check for config data blob update.
Added an new data struct CDATA_BLOB_ON_FLASH to reference flash data.
Update cfgdatatool.py for svn support.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>