### PR TITLE
Check LocateComponentEntry outputs before its consumed

### DIFF
--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
@@ -670,12 +670,16 @@ LocateComponent (
     return Status;
   }
 
-  ContainerHdr = (CONTAINER_HDR *)(UINTN)ContainerEntry->HeaderCache;
-  if (Buffer != NULL) {
-    *Buffer = (VOID *)(UINTN)(ContainerEntry->Base + ContainerHdr->DataOffset + CompEntry->Offset);
-  }
-  if (Length != NULL) {
-    *Length = CompEntry->Size;
+  if ((ContainerEntry != NULL) && (CompEntry != NULL)) {
+    ContainerHdr = (CONTAINER_HDR *)(UINTN)ContainerEntry->HeaderCache;
+    if (Buffer != NULL) {
+      *Buffer = (VOID *)(UINTN)(ContainerEntry->Base + ContainerHdr->DataOffset + CompEntry->Offset);
+    }
+    if (Length != NULL) {
+      *Length = CompEntry->Size;
+    }
+  } else {
+    Status = EFI_NOT_FOUND;
   }
 
   return Status;
@@ -762,6 +766,10 @@ LoadComponentWithCallback (
     Status = LocateComponentEntry (ContainerSig, ComponentName, &ContainerEntry, &CompEntry);
     if (EFI_ERROR (Status)) {
       return Status;
+    }
+
+    if ((ContainerEntry == NULL) || (CompEntry == NULL)) {
+      return EFI_NOT_FOUND;
     }
 
     if ((CompEntry->Attribute & COMPONENT_ENTRY_ATTR_RESERVED) != 0) {

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.c
@@ -426,6 +426,10 @@ UpdateContainerComp (
     return Status;
   }
 
+  if ((ContainerEntryPtr == NULL) || (ComponentEntryPtr == NULL)) {
+    return EFI_NOT_FOUND;
+  }
+
   //
   // Update the component
   //


### PR DESCRIPTION
LocateComponentEntry is modified to locate only container
entry. Additional checks are required at consumer end
for Container entry and CompEntry.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>