### PR TITLE
Capsule update command for SVN commit

### DIFF
--- a/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
+++ b/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
@@ -526,4 +526,21 @@ SetFlashDescriptorLock (
    IN  CHAR8     *CmdDataBuf,
    IN  UINTN     CmdDataSize
    );
+
+/**
+  Anti Rollback Svn Commit
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      ARB Svn commit is successful.
+  @retval  others           Error happened while doing commit.
+
+**/
+EFI_STATUS
+EFIAPI
+SetArbSvnCommit (
+   IN  CHAR8     *CmdDataBuf,
+   IN  UINTN     CmdDataSize
+   );
 #endif

--- a/PayloadPkg/FirmwareUpdate/CmdFwUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/CmdFwUpdate.c
@@ -18,10 +18,11 @@
 
 
 #define FLASH_DESCRIPTOR_LOCK_STR     "FLASHDESCLOCK"
+#define ARB_SVN_COMMIT_STR            "ARBSVNCOMMIT"
 
 typedef UINT32 CMDI_TYPE;
 #define CMDI_TYPE_SPI_DESCRIPTOR_LOCK       BIT0
-
+#define CMDI_TYPE_ARB_SVN_COMMIT            BIT1
 
 /*
   Firmware update command handler
@@ -48,9 +49,12 @@ FwUpdateCmdHandler (
   Status = EFI_SUCCESS;
   *CmdProcessed = 0;
 
-  if(AsciiStrnCmp(CmdBuf, FLASH_DESCRIPTOR_LOCK_STR, AsciiStrLen(FLASH_DESCRIPTOR_LOCK_STR)) == 0) {
+  if (AsciiStrnCmp (CmdBuf, FLASH_DESCRIPTOR_LOCK_STR, AsciiStrLen(FLASH_DESCRIPTOR_LOCK_STR)) == 0) {
       *CmdProcessed  =  CMDI_TYPE_SPI_DESCRIPTOR_LOCK;
       Status = SetFlashDescriptorLock (CmdBuf, BufLen);
+  } else if (AsciiStrnCmp (CmdBuf, ARB_SVN_COMMIT_STR, AsciiStrLen(ARB_SVN_COMMIT_STR)) == 0) {
+      *CmdProcessed  =  CMDI_TYPE_ARB_SVN_COMMIT;
+      Status = SetArbSvnCommit (CmdBuf, BufLen);
   }
 
   return Status;
@@ -62,7 +66,8 @@ FwUpdateCmdHandler (
 
  Command format:
  {FLASHDESCLOCK}
- {Command2}
+ {ARBSVNCOMMIT}
+ {Command3}
 
   @param[in]  Buffer            Command buffer.
   @param[in]  BufLength         Command buffer length

--- a/Silicon/ApollolakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/ApollolakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -535,3 +535,23 @@ SetFlashDescriptorLock (
 {
   return EFI_UNSUPPORTED;
 }
+
+/**
+  Anti Rollback Svn Commit
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      Svn commit successfully.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+SetArbSvnCommit (
+   IN  CHAR8     *CmdDataBuf,
+   IN  UINTN     CmdDataSize
+   )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -504,3 +504,23 @@ SetFlashDescriptorLock (
 {
   return EFI_UNSUPPORTED;
 }
+
+/**
+  Anti Rollback Svn Commit
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      Svn commit successfully.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+SetArbSvnCommit (
+   IN  CHAR8     *CmdDataBuf,
+   IN  UINTN     CmdDataSize
+   )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/Silicon/QemuSocPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/QemuSocPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -534,3 +534,24 @@ SetFlashDescriptorLock (
 {
   return EFI_UNSUPPORTED;
 }
+
+
+/**
+  Anti Rollback Svn Commit
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      Svn commit successfully.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+SetArbSvnCommit (
+   IN  CHAR8     *CmdDataBuf,
+   IN  UINTN     CmdDataSize
+   )
+{
+  return EFI_UNSUPPORTED;
+}


### PR DESCRIPTION
Capsule Command support added for anti rollback
security version number. User can create command
in text file and create capsule with CMDI mode.

{ARBSVNCOMMIT}

Platform APIs would be invoked to do SVN
commit operations by useing HECI interfaces.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>