### PR TITLE
Add Multiboot image support to PreOsChecker flow

### DIFF
--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -611,7 +611,7 @@ StartBooting (
   if ((LoadedImage->Flags & LOADED_IMAGE_LINUX) != 0) {
     if (FeaturePcdGet (PcdPreOsCheckerEnabled) && IsPreOsCheckerLoaded ()) {
       BeforeOSJump ("Starting Pre-OS Checker ...");
-      StartPreOsChecker (GetLinuxBootParams ());
+      StartPreOsChecker ((VOID *)GetLinuxBootParams (), LoadedImage->Flags);
     } else {
       BeforeOSJump ("Starting Kernel ...");
       LinuxBoot ((VOID *)(UINTN)PcdGet32 (PcdPayloadHobList), NULL);
@@ -624,8 +624,13 @@ StartBooting (
       DEBUG ((DEBUG_ERROR, "EntryPoint is not found\n"));
       return RETURN_INVALID_PARAMETER;
     }
-    BeforeOSJump ("Starting MB Kernel ...");
-    JumpToMultibootOs((IA32_BOOT_STATE*)&MultiBoot->BootState);
+    if (FeaturePcdGet (PcdPreOsCheckerEnabled) && IsPreOsCheckerLoaded ()) {
+      BeforeOSJump ("Starting Pre-OS Checker ...");
+      StartPreOsChecker ((VOID *)&MultiBoot->BootState, LoadedImage->Flags);
+    } else {
+      BeforeOSJump ("Starting MB Kernel ...");
+      JumpToMultibootOs((IA32_BOOT_STATE*)&MultiBoot->BootState);
+    }
     Status = EFI_DEVICE_ERROR;
 
   } else if ((LoadedImage->Flags & (LOADED_IMAGE_PE32 | LOADED_IMAGE_FV)) != 0) {

--- a/PayloadPkg/OsLoader/PreOsChecker.h
+++ b/PayloadPkg/OsLoader/PreOsChecker.h
@@ -1,6 +1,6 @@
 /** @file
 
-Copyright (c) 2019, Intel Corporation. All rights reserved.
+Copyright (c) 2019 - 2020, Intel Corporation. All rights reserved.
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -42,7 +42,8 @@ LoadPreOsChecker (
 /**
   Start PreOsChecker with OS information
 
-  @param[in] OsBootParam          Pointer of OS BOOT_PARAMS
+  @param[in] BootParam            Pointer of OS BOOT_PARAMS or IA32_BOOT_STATE
+  @param[in] ImageFlags           Flags of the loaded image
 
   @retval EFI_NOT_FOUND           PreOsChecker not found
   @retval EFI_INVALID_PARAMETER   Invalid OS BOOT_PARAMS found
@@ -51,7 +52,8 @@ LoadPreOsChecker (
 EFI_STATUS
 EFIAPI
 StartPreOsChecker (
-  IN  BOOT_PARAMS   *OsBootParam
+  IN  VOID   *OsBootParam,
+  IN  UINT8  ImageFlags
   );
 
 #endif /* __PRE_OS_CHECKER_H__ */


### PR DESCRIPTION
The pre-OS checker/payload flow can support more than
just Linux image type launching; there are use cases
for adding multiboot image support to this flow and
there may be others in the future.

Signed-off-by: James Gutbub <james.gutbub@intel.com>