### PR TITLE
Configdata firmware update svn check

### DIFF
--- a/BootloaderCommonPkg/Include/Library/ConfigDataLib.h
+++ b/BootloaderCommonPkg/Include/Library/ConfigDataLib.h
@@ -59,11 +59,18 @@ typedef struct {
   //
   UINT8   HeaderLength;
   UINT8   Attribute;
-  //
-  // Internal configuration data offset in DWORD from the start of data blob.
-  // This value is only valid in runtime.
-  //
-  UINT16  InternalDataOffset;
+  union {
+    //
+    // Internal configuration data offset in DWORD from the start of data blob.
+    // This value is only valid in runtime.
+    //
+    UINT16  InternalDataOffset;
+    //
+    // Security version number
+    // This is available only in flash. It would be overwritten by CDATA_BLOB.InternalDataOffset in runtime
+    //
+    UINT8   Svn;
+  } ExtraInfo;
   //
   // The total valid configuration data length including this header.
   //

--- a/BootloaderCommonPkg/Library/ConfigDataLib/ConfigDataLib.c
+++ b/BootloaderCommonPkg/Library/ConfigDataLib/ConfigDataLib.c
@@ -37,7 +37,7 @@ FindConfigHdrByPidMaskTag (
   UINT32               Offset;
 
   CdataBlob = (CDATA_BLOB *) GetConfigDataPtr ();
-  Offset    = IsInternal > 0 ? (CdataBlob->InternalDataOffset * 4) : CdataBlob->HeaderLength;
+  Offset    = IsInternal > 0 ? (CdataBlob->ExtraInfo.InternalDataOffset * 4) : CdataBlob->HeaderLength;
 
   while (Offset < CdataBlob->UsedLength) {
     CdataHdr = (CDATA_HEADER *) ((UINT8 *)CdataBlob + Offset);
@@ -183,7 +183,7 @@ AddConfigData (
     return EFI_OUT_OF_RESOURCES;
   }
 
-  if (LdrCfgBlob->InternalDataOffset == 0) {
+  if (LdrCfgBlob->ExtraInfo.InternalDataOffset == 0) {
     // Append new config data before internal config data is available.
     CopyMem ((UINT8 *)LdrCfgBlob + LdrCfgBlob->UsedLength,
              (UINT8 *)CfgAddBlob + CfgAddBlob->HeaderLength,
@@ -201,7 +201,7 @@ AddConfigData (
     CopyMem ((UINT8 *)LdrCfgBlob + LdrCfgBlob->HeaderLength,
              (UINT8 *)CfgAddBlob + CfgAddBlob->HeaderLength,
              CfgAddSize);
-    LdrCfgBlob->InternalDataOffset += (UINT16) (CfgAddSize >> 2);
+    LdrCfgBlob->ExtraInfo.InternalDataOffset += (UINT16) (CfgAddSize >> 2);
   }
   LdrCfgBlob->UsedLength += CfgAddSize;
 

--- a/BootloaderCommonPkg/Library/ShellLib/CmdCdata.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdCdata.c
@@ -56,7 +56,7 @@ PrintBlobheader (
   ShellPrint (L"    Signature   :%x\n", CdataBlob->Signature);
   ShellPrint (L"    HeaderLength:%x\n", CdataBlob->HeaderLength);
   ShellPrint (L"    Attribute   :%x\n", CdataBlob->Attribute);
-  ShellPrint (L"    IntCfgOffset:%x\n", CdataBlob->InternalDataOffset * 4);
+  ShellPrint (L"    IntCfgOffset:%x\n", CdataBlob->ExtraInfo.InternalDataOffset * 4);
   ShellPrint (L"    UsedLength  :%x\n", CdataBlob->UsedLength);
   ShellPrint (L"    TotalLength :%x\n", CdataBlob->TotalLength);
 }

--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -13,7 +13,7 @@ CONST CDATA_BLOB mCfgBlobTmpl = {
   CFG_DATA_SIGNATURE,
   sizeof (CDATA_BLOB),
   0,
-  0,
+  {0},
   sizeof (CDATA_BLOB),
   FixedPcdGet32 (PcdCfgDatabaseSize)
 };

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -271,7 +271,7 @@ CreateConfigDatabase (
         CfgBlob       = (CDATA_BLOB *) IntCfgAddPtr;
         CfgDataLength = CfgBlob->UsedLength - CfgBlob->HeaderLength;
         CfgBlob       = (CDATA_BLOB *) LdrGlobal->CfgDataPtr;
-        CfgBlob->InternalDataOffset = (UINT16) ((CfgBlob->UsedLength - CfgDataLength) >> 2);
+        CfgBlob->ExtraInfo.InternalDataOffset = (UINT16) ((CfgBlob->UsedLength - CfgDataLength) >> 2);
       } else {
         DEBUG ((DEBUG_INFO, "Append Built-In CFG Data ... %r\n", Status));
       }

--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -429,7 +429,7 @@ def gen_flash_map_bin (flash_map_file, comp_list):
 def copy_expanded_file (src, dst):
     gen_cfg_data ("GENDLT", src, dst)
 
-def gen_config_file (fv_dir, brd_name, platform_id, pri_key, cfg_db_size, cfg_size, cfg_int, cfg_ext, sign_scheme, hash_type):
+def gen_config_file (fv_dir, brd_name, platform_id, pri_key, cfg_db_size, cfg_size, cfg_int, cfg_ext, sign_scheme, hash_type, svn):
     # Remove previous generated files
     for file in glob.glob(os.path.join(fv_dir, "CfgData*.*")):
             os.remove(file)
@@ -512,7 +512,7 @@ def gen_config_file (fv_dir, brd_name, platform_id, pri_key, cfg_db_size, cfg_si
 
     cfg_final_file = os.path.join(fv_dir, "CFGDATA.bin")
     if pri_key:
-        cfg_data_tool ('sign', ['-k', pri_key, '-a', hash_type, '-s', sign_scheme, cfg_merged_bin_file], cfg_final_file)
+        cfg_data_tool ('sign', ['-k', pri_key, '-a', hash_type, '-s', sign_scheme, '-svn', str(svn), cfg_merged_bin_file], cfg_final_file)
     else:
         shutil.copy(cfg_merged_bin_file, cfg_final_file)
 

--- a/BootloaderCorePkg/Tools/CfgDataTool.py
+++ b/BootloaderCorePkg/Tools/CfgDataTool.py
@@ -13,19 +13,6 @@ from   CommonUtility import *
 
 CFGDATA_INT_GUID = b'\xD0\x6C\x6E\x01\x34\x48\x7E\x4C\xBC\xFE\x41\xDF\xB8\x8A\x6A\x6D'
 
-class CDATA_BLOB_HEADER(Structure):
-    ATTR_EXTERN = 1 << 0
-    ATTR_MERGED = 1 << 7
-    _pack_ = 1
-    _fields_ = [
-        ('Signature', ARRAY(c_char, 4)),
-        ('HeaderLength', c_uint8),
-        ('Attribute', c_uint8),
-        ('Reserved', ARRAY(c_char, 2)),
-        ('UsedLength', c_uint32),
-        ('TotalLength', c_uint32),
-    ]
-
 class CCfgData:
 
     DEBUG_FLAG_PARSE  = (1 << 0)
@@ -42,7 +29,8 @@ class CCfgData:
             ('Signature', ARRAY(c_char, 4)),
             ('HeaderLength', c_uint8),
             ('Attribute', c_uint8),
-            ('Reserved', ARRAY(c_char, 2)),
+            ('Svn', c_uint8),
+            ('Reserved', ARRAY(c_char, 1)),
             ('UsedLength', c_uint32),
             ('TotalLength', c_uint32),
         ]
@@ -758,12 +746,14 @@ def CmdSign(Args):
         raise Exception("Invalid config binary file '%s' !" % CfgDataFile)
     CfgBlobHeader.Attribute |= CCfgData.CDATA_BLOB_HEADER.ATTR_SIGNED
 
+    CfgBlobHeader.Svn = Args.svn
+
     TmpFile = Args.cfg_in_file + '.tmp'
     Fd      = open (TmpFile, 'wb')
     Fd.write (FileData)
     Fd.close ()
 
-    if Args.hash_alg is 'AUTO':
+    if Args.hash_alg == 'AUTO':
         Args.hash_alg = adjust_hash_type(Args.cfg_pri_key)
 
     rsa_sign_file (Args.cfg_pri_key, None, Args.hash_alg, Args.sign_scheme, TmpFile, Args.cfg_out_file, True, True)
@@ -817,11 +807,11 @@ def CmdReplace(Args):
     CfgBins = bytearray(Fh.read())
     Fh.close()
 
-    CfgHdr = CDATA_BLOB_HEADER.from_buffer(CfgBins)
+    CfgHdr = CCfgData.CDATA_BLOB_HEADER.from_buffer(CfgBins)
     if CfgHdr.Signature != b'CFGD':
         raise Exception("Invalid CFGDATA image file '%s'" % CfgFile)
 
-    if not CfgHdr.Attribute & CDATA_BLOB_HEADER.ATTR_MERGED:
+    if not CfgHdr.Attribute & CCfgData.CDATA_BLOB_HEADER.ATTR_MERGED:
         raise Exception("CFGDATA image file '%s' is not merged yet!" % CfgFile)
 
     # Get flash image
@@ -926,6 +916,7 @@ def Main():
     SignParser.add_argument('-k', dest='cfg_pri_key', type=str, help='Key Id or Private key file (PEM format) used to sign configuration data', required=True)
     SignParser.add_argument('-a', dest='hash_alg', type=str, choices=['SHA2_256', 'SHA2_384', 'AUTO'], help='Hash Type for signing. For AUTO hash type will be choosen based on key length',  default = 'AUTO')
     SignParser.add_argument('-s', dest='sign_scheme', type=str, choices=['RSA_PKCS1', 'RSA_PSS'], help='Signing Scheme',   default = 'RSA_PSS')
+    SignParser.add_argument('-svn', dest='svn', type=int, help='Security version number for Config Data', default = 0)
     SignParser.set_defaults(func=CmdSign)
 
     ExtractParser = SubParser.add_parser('extract', help='extract a single config data to a file')

--- a/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
+++ b/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
@@ -416,7 +416,7 @@ def SignImage(RawData, OutFile, HashType, SignScheme, PrivKey):
     elif key_type ==  'RSA3072':
         key_size = 384
 
-    if HashType is 'AUTO':
+    if HashType == 'AUTO':
         HashType = adjust_hash_type(PrivKey)
 
     header.FileGuid         = (c_ubyte *16).from_buffer_copy(FIRMWARE_UPDATE_IMAGE_FILE_GUID.bytes_le)

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -276,6 +276,7 @@ class BaseBoard(object):
         self.PCI_MEM64_BASE        = 0
         self.BUILD_ARCH            = 'IA32'
         self.KEYH_SVN              = 0
+        self.CFGDATA_SVN           = 0
 
         for key, value in list(kwargs.items()):
             setattr(self, '%s' % key, value)
@@ -1187,11 +1188,12 @@ class Build(object):
 
         # create configuration data
         if self._board.CFGDATA_SIZE > 0:
+            svn = self._board.CFGDATA_SVN
             # create config data files
             gen_config_file (self._fv_dir, self._board.BOARD_PKG_NAME, self._board._PLATFORM_ID,
                              self._board._CFGDATA_PRIVATE_KEY, self._board.CFG_DATABASE_SIZE, self._board.CFGDATA_SIZE,
                              self._board._CFGDATA_INT_FILE, self._board._CFGDATA_EXT_FILE,
-                             self._board._SIGNING_SCHEME, HASH_VAL_STRING[self._board.SIGN_HASH_TYPE])
+                             self._board._SIGNING_SCHEME, HASH_VAL_STRING[self._board.SIGN_HASH_TYPE], svn)
 
         # rebuild reset vector
         vtf_dir = os.path.join('BootloaderCorePkg', 'Stage1A', 'Ia32', 'Vtf0')

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
@@ -173,7 +173,7 @@ UpdateSblComponent (
 
   This function has the logic to perform CMD  update.
 
-  @param[in] CapImageHdr    The pointer to the firmware update capsule image.
+  @param[in] CapImageHdr    The pointer to the firmware update capsule image
 
   @retval  EFI_SUCCESS      Update successful
   @retval  other            error status from the update routine
@@ -181,5 +181,25 @@ UpdateSblComponent (
 EFI_STATUS
 FwCmdUpdateProcess (
   EFI_FW_MGMT_CAP_IMAGE_HEADER  *CapImageHdr
+  );
+
+/**
+  Perform Config data svn check
+
+  This function will perform svn checks for cfgdata in flash and
+  config data in capsule.
+
+  @param[in]  ImageHdr       Pointer to fw mgmt capsule Image header
+  @param[in]  FwPolicy       Firmware update policy
+  @param[out] SvnStatus      Svn compare status
+
+  @retval  EFI_SUCCESS      SVN check successful
+  @retval  other            error occurred during firmware update
+**/
+EFI_STATUS
+CheckSblConfigDataSvn (
+  IN   EFI_FW_MGMT_CAP_IMAGE_HEADER  *ImageHdr,
+  IN   FIRMWARE_UPDATE_POLICY         FwPolicy,
+  OUT  UINT8                         *SvnStatus
   );
 #endif


### PR DESCRIPTION
Add support for security version check for
config data blob update. SVN is checked
for redundant region which would be updated.

Fixed python warnings in CfgDataTool and GenCapsuleFirmware.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>