### PR TITLE
Enable python3 in windows travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ before_install:
       docker build -t sbl .
       chmod -R a+w .
     else
+      choco install python3 --version 3.8 --params "/InstallDir:C:\Python3"
       choco install nasm --version 2.14 --params "/InstallDir:C:\Nasm"
       choco install openssl.light --version 1.1.1 --params "/InstallDir:C:\Openssl"
       wget --no-check-certificate https://acpica.org/sites/acpica/files/iasl-win-20160831_0.zip -P "C:\Asl"
@@ -74,6 +75,6 @@ script:
     else
       git config --global user.email "travis@travis-ci.org"
       git config --global user.name  "Travis CI"
-      python BootloaderCorePkg/Tools/GenerateKeys.py -k ${SBL_KEY_DIR} && python BuildLoader.py build ${BUILD_REL} ${BUILD_TARGET} ${BUILD_ARCH}
+      C:/Python3/python BootloaderCorePkg/Tools/GenerateKeys.py -k ${SBL_KEY_DIR} && C:/Python3/python BuildLoader.py build ${BUILD_REL} ${BUILD_TARGET} ${BUILD_ARCH}
     fi
 


### PR DESCRIPTION
This patch switched to use python3 for Windows travis build.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>