### PR TITLE
Fix AHCI init failure when NumPort=0

### DIFF
--- a/BootloaderCommonPkg/Library/AhciLib/AhciBlkIo.c
+++ b/BootloaderCommonPkg/Library/AhciLib/AhciBlkIo.c
@@ -389,6 +389,13 @@ AhciInitialize (
   InitializeListHead (&AhciPrivateData->DeviceList);
 
   //
+  // Set RFis, CommandList, CommandTable to NULL as init
+  //
+  AhciPrivateData->AhciRegisters.AhciRFis         = NULL;
+  AhciPrivateData->AhciRegisters.AhciCmdList      = NULL;
+  AhciPrivateData->AhciRegisters.AhciCommandTable = NULL;
+
+  //
   // Enable AHCI controller
   //
   AhciPrivateData->AhciPciCfgAddr = (UINT32)AhciHcPciBase;


### PR DESCRIPTION
When a SATA controller has no Ports Implemented
behind it, AHCI mode init returns error even before
allocating buffers for RFis, CommandTable, CommandList.
So, AHCI de-init expects them to be NULL, else any
garbage value for these fields forces the code to do
a FreePool on non-allocated memory.

Signed-off-by: Sai Talamudupula <sai.kiran.talamudupula@intel.com>