### PR TITLE
[APL] Fix reference to DSC file in output image

### DIFF
--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -236,7 +236,7 @@ class Board(BaseBoard):
         # define extra images that will be copied to output folder
         img_list = ['SlimBootloader.txt',
                     'CfgDataStitch.py',
-                    'CfgDataDef.dsc',
+                    'CfgDataDef.yaml',
                     'CfgDataInt.bin'
                     ]
         return img_list


### PR DESCRIPTION
Since SBL moved to use YAML rather than DSC. The refrence needs to
be fixed to use yaml files too.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>