### PR TITLE
Fix PCI enumeration issue with mulitple PCI bridges

### DIFF
--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
@@ -645,12 +645,18 @@ PciGetMaxBusNumber (
   )
 {
   UINT8             MaxBusNumber;
+  PCI_IO_DEVICE    *CurrBridge;
 
   //
   // No Bridge type check here. A caller must guarantee IS_PCI_BRIDGE(Bridge)
   //
   if (Bridge != NULL) {
-    MaxBusNumber = Bridge->BusNumberRanges.BusLimit;
+    // Find the root bridge to get the bus limit
+    CurrBridge = Bridge;
+    while (CurrBridge->Parent != NULL) {
+      CurrBridge = CurrBridge->Parent;
+    }
+    MaxBusNumber = CurrBridge->BusNumberRanges.BusLimit;
   } else {
     MaxBusNumber = PCI_MAX_BUS;
   }


### PR DESCRIPTION
When multiple level of PCI bridges exists on a platform, current
SBL PCI bus library could not find all devices. This issue was
caused by incorrect root bridge bus limit got from the data
structure. This patch fixed this issue.
It also fixed #800.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>