### PR TITLE
[QEMU] Add general setting CFG page

### DIFF
--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpvariant.h
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpvariant.h
@@ -19,7 +19,7 @@
 //               Intel(R) Integrated Performance Primitives
 //                   Cryptographic Primitives (ippcp)
 //
-//   Intel® Integrated Performance Primitives Cryptography (Intel® IPP Cryptography)
+//   Intel(R) Integrated Performance Primitives Cryptography (Intel(R) IPP Cryptography)
 //
 //   Purpose:
 //     Define ippCP variant

--- a/Platform/QemuBoardPkg/CfgData/CfgDataDef.yaml
+++ b/Platform/QemuBoardPkg/CfgData/CfgDataDef.yaml
@@ -89,7 +89,7 @@ template:
 
 configs:
   - $ACTION      :
-      page         : PLT::"Platform", MEM::"Memory Settings", SIL::"Silicon Settings", GIO::"GPIO Settings", OS::"OS Boot Options"
+      page         : PLT::"Platform", MEM::"Memory Settings", SIL::"Silicon Settings", GEN::"General Settings", GIO::"GPIO Settings", OS::"OS Boot Options"
   - Signature    :
       length       : 0x04
       value        : {'CFGD'}


### PR DESCRIPTION
This patch added the missing general configuration settings for
QEMU platform.  It also addressed a build issue due to non-ascii
chars in the IPP file.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>