### PR TITLE
Fix Linux Framebuffer

### DIFF
--- a/BootloaderCommonPkg/Include/Library/LinuxLib.h
+++ b/BootloaderCommonPkg/Include/Library/LinuxLib.h
@@ -25,6 +25,9 @@
 #define VIDEO_TYPE_EFI        0x70
 #define GET_POS_FROM_MASK(mask)   (mask & 0x0FF)?0:((mask & 0x0FF00)?8:((mask & 0x0FF0000)?16:24))
 
+#define VIDEO_CAPABILITY_SKIP_QUIRKS  (1 << 0)
+#define VIDEO_CAPABILITY_64BIT_BASE   (1 << 1)  /* Frame buffer base is 64-bit */
+
 #pragma pack(1)
 
 typedef struct {
@@ -122,7 +125,8 @@ typedef struct {
   UINT16    Pages;             /* 0x32 */
   UINT16    VesaAttributes;    /* 0x34 */
   UINT32    Capabilities;      /* 0x36 */
-  UINT8     Reserved[6];       /* 0x3a */
+  UINT32    ExtLfbBase;        /* 0x3a */
+  UINT8     Reserved[2];       /* 0x3e */
 } SCREEN_INFO;
 
 typedef struct {

--- a/BootloaderCommonPkg/Library/LinuxLib/LinuxLib.c
+++ b/BootloaderCommonPkg/Library/LinuxLib/LinuxLib.c
@@ -297,6 +297,8 @@ UpdateLinuxBootParams (
       Bp->ScreenInfo.LfbLinelength   = (UINT16) (GfxMode->PixelsPerScanLine * 4);
       Bp->ScreenInfo.LfbDepth        = 32;
       Bp->ScreenInfo.LfbBase         = (UINT32)(UINTN)GfxInfoHob->FrameBufferBase;
+      Bp->ScreenInfo.ExtLfbBase      = (UINT32)RShiftU64 (GfxInfoHob->FrameBufferBase, 32);
+      Bp->ScreenInfo.Capabilities   |= VIDEO_CAPABILITY_64BIT_BASE;
       Bp->ScreenInfo.LfbWidth        = (UINT16)GfxMode->HorizontalResolution;
       Bp->ScreenInfo.LfbHeight       = (UINT16)GfxMode->VerticalResolution;
       Bp->ScreenInfo.Pages           = 1;


### PR DESCRIPTION
Linux framebuffer screen_info has been extended to support 64bit
address. This patch added extra fields and set the upper 32 bit
for the framebuffer base.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>