### PR TITLE
Fix P2P bridge alignement issue

### DIFF
--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
@@ -1057,11 +1057,12 @@ CalculateResource (
     if (Alignment < 0xFFF) {
       Alignment = 0xFFF;
     }
-    Base = ALIGN (Base,  Alignment);
+    Base = ALIGN (Base,  0xFFF);
   } else {
     if (Alignment < 0xFFFFF) {
       Alignment = 0xFFFFF;
     }
+    Base = ALIGN (Base,  0xFFFFF);
   }
 
   Parent->PciBar[BarType - 1].Alignment = Alignment;


### PR DESCRIPTION
The following commit 9fcb3a6be1ff5482c3062fc10f17a9e8879d0500
caused a regression on PCI bridge resource allocation. At minimum
the PCI bridge needs to have IO apperture aligned at 4KB and MMIO
apperture aligned at 1MB. The new code did not adjust the
alignment for P2P bridge following this rule.  This patch fixed
this issue.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>