### PR TITLE
Add HelloWorld payload example

### DIFF
--- a/BootloaderCommonPkg/Library/BootloaderCommonLib/BootloaderCommonLib.inf
+++ b/BootloaderCommonPkg/Library/BootloaderCommonLib/BootloaderCommonLib.inf
@@ -35,4 +35,3 @@
   DebugLib
   BootloaderLib
   HobLib
-  TpmLib

--- a/BootloaderCommonPkg/Library/UsbKbLib/UsbKbLibNull.c
+++ b/BootloaderCommonPkg/Library/UsbKbLib/UsbKbLibNull.c
@@ -1,0 +1,45 @@
+/** @file
+  USB keyboard library implementation.
+
+  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+
+/**
+  Polls a keyboard to see if there is any data waiting to be read.
+
+  @retval TRUE             Data is waiting to be read from the device.
+  @retval FALSE            There is no data waiting to be read from the device.
+
+**/
+BOOLEAN
+EFIAPI
+KeyboardPoll (
+  VOID
+  )
+{
+  return FALSE;
+}
+
+/**
+  Reads data from a USB keyboard into a buffer.
+  This function will wait till specified number of bytes are filled.
+
+  @param  Buffer           Pointer to the data buffer to store the data read from the device.
+  @param  NumberOfBytes    Number of bytes to read from the device.
+
+  @retval                  The number of bytes read from the device.
+
+**/
+UINTN
+EFIAPI
+KeyboardRead (
+  OUT UINT8   *Buffer,
+  IN  UINTN   NumberOfBytes
+  )
+{
+  return 0;
+}

--- a/BootloaderCommonPkg/Library/UsbKbLib/UsbKbLibNull.inf
+++ b/BootloaderCommonPkg/Library/UsbKbLib/UsbKbLibNull.inf
@@ -1,0 +1,36 @@
+## @file
+# Description file for the USB keyboard library.
+#
+# Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = UsbKbLib
+  FILE_GUID                      = DED53C0B-1EA9-4b29-9780-45A6A6C6BC36
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = UsbKbLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 IPF EBC
+#
+[Sources]
+  UsbKbLibNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+
+[LibraryClasses]
+  DebugLib
+
+[Pcd]
+
+

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -283,6 +283,12 @@
   gPlatformModuleTokenSpaceGuid.PcdFuncCpuInitHook   | 0x00000000
   gPlatformModuleTokenSpaceGuid.PcdFspsUpdPtr        | 0x00000000
 
+  gPlatformCommonLibTokenSpaceGuid.PcdSerialUseMmio        | 0
+  gPlatformCommonLibTokenSpaceGuid.PcdSerialRegisterBase   | 0
+  gPlatformCommonLibTokenSpaceGuid.PcdSerialBaudRate       | 0
+  gPlatformCommonLibTokenSpaceGuid.PcdSerialRegisterStride | 0
+  gPlatformCommonLibTokenSpaceGuid.PcdSerialClockRate      | 0
+
 [PcdsFeatureFlag]
   gPlatformCommonLibTokenSpaceGuid.PcdMinDecompression    | FALSE
   gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootEnabled | $(HAVE_MEASURED_BOOT)
@@ -377,6 +383,7 @@
       PayloadEntryLib     | PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.inf
       PayloadSupportLib   | PayloadPkg/Library/PayloadSupportLib/PayloadSupportLib.inf
       BootloaderLib       | PayloadPkg/Library/PayloadLib/PayloadLib.inf
+      PlatformHookLib     | PayloadPkg/Library/PlatformHookLib/PlatformHookLib.inf
       AbSupportLib        | PayloadPkg/Library/AbSupportLib/AbSupportLib.inf
       SblParameterLib     | PayloadPkg/Library/SblParameterLib/SblParameterLib.inf
       TrustyBootLib       | PayloadPkg/Library/TrustyBootLib/TrustyBootLib.inf
@@ -391,6 +398,7 @@
       PayloadEntryLib         | PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.inf
       PayloadSupportLib       | PayloadPkg/Library/PayloadSupportLib/PayloadSupportLib.inf
       BootloaderLib           | PayloadPkg/Library/PayloadLib/PayloadLib.inf
+      PlatformHookLib         | PayloadPkg/Library/PlatformHookLib/PlatformHookLib.inf
       FirmwareUpdateLib       | Silicon/$(SILICON_PKG_NAME)/Library/FirmwareUpdateLib/FirmwareUpdateLib.inf
   }
 !endif

--- a/PayloadPkg/HelloWorld/HelloWorld.c
+++ b/PayloadPkg/HelloWorld/HelloWorld.c
@@ -1,0 +1,44 @@
+/** @file
+
+  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "HelloWorld.h"
+
+/**
+  Payload main entry.
+
+  @param  Param           parameter passed from SwitchStack().
+  @param  PldBase         payload base passed from SwitchStack().
+
+**/
+VOID
+EFIAPI
+PayloadMain (
+  IN  VOID             *Param,
+  IN  VOID             *PldBase
+  )
+{
+  UINT8      Key;
+  CHAR8      Message[64];
+  UINTN      Len;
+
+  DEBUG ((DEBUG_INFO, "\n\n==================== Hello World ====================\n\n"));
+
+  Key = 0;
+  while (Key != 0x1B) {
+    if (ConsolePoll ()) {
+      if (ConsoleRead (&Key, 1) > 0) {
+        if ((Key >= 0x20) && (Key < 0x7F)) {
+          Len = AsciiSPrint (Message, sizeof (Message), "Key '%c' pressed !\n", Key);
+          ConsoleWrite (Message, Len);
+        }
+      }
+    }
+  }
+
+  DEBUG ((DEBUG_INFO, "\nExit\n"));
+  CpuDeadLoop ();
+}

--- a/PayloadPkg/HelloWorld/HelloWorld.h
+++ b/PayloadPkg/HelloWorld/HelloWorld.h
@@ -1,0 +1,20 @@
+/** @file
+
+  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __HELLO_WORLD_H__
+#define __HELLO_WORLD_H__
+
+#include <PiPei.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/BootloaderCommonLib.h>
+#include <Library/PrintLib.h>
+#include <Library/ConsoleInLib.h>
+#include <Library/ConsoleOutLib.h>
+
+#endif

--- a/PayloadPkg/HelloWorld/HelloWorld.inf
+++ b/PayloadPkg/HelloWorld/HelloWorld.inf
@@ -1,0 +1,43 @@
+## @file
+#  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = HelloWorld
+  FILE_GUID                      = DDFC7348-FD07-4E41-B744-F7E133B07BF2
+  MODULE_TYPE                    = PEIM
+  VERSION_STRING                 = 1.0
+
+[Sources]
+  HelloWorld.h
+  HelloWorld.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+  PayloadPkg/PayloadPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  BootloaderCommonLib
+  PayloadEntryLib
+  SerialPortLib
+  ConsoleInLib
+  ConsoleOutLib
+  PrintLib
+  DebugLib
+  PcdLib
+
+
+[Guids]
+
+[Pcd]
+
+[Depex]
+  TRUE

--- a/PayloadPkg/Library/DebugPrintErrorLevelLib/DebugPrintErrorLevelLib.c
+++ b/PayloadPkg/Library/DebugPrintErrorLevelLib/DebugPrintErrorLevelLib.c
@@ -45,12 +45,10 @@ SetDebugPrintErrorLevel (
   UINT32  ErrorLevel
   )
 {
-  EFI_STATUS Status;
-
   //
   // This library uinstance does not support setting the global debug print error
   // level mask.
   //
-  Status = PcdSet32S (PcdDebugPrintErrorLevel, ErrorLevel);
+  (VOID) PcdSet32S (PcdDebugPrintErrorLevel, ErrorLevel);
   return TRUE;
 }

--- a/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
+++ b/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
@@ -17,6 +17,7 @@
 #include <Library/LoaderPerformanceLib.h>
 #include <Library/PayloadMemoryAllocationLib.h>
 #include <Library/SerialPortLib.h>
+#include <Library/PlatformHookLib.h>
 #include <Library/DebugLogBufferLib.h>
 #include <Library/DebugPrintErrorLevelLib.h>
 #include <Library/ContainerLib.h>
@@ -144,6 +145,7 @@ PayloadInit (
 
   }
 
+  PlatformHookSerialPortInitialize ();
   SerialPortInitialize ();
 
   if (PldHeapBase != NULL) {

--- a/PayloadPkg/Library/PlatformHookLib/PlatformHookLib.c
+++ b/PayloadPkg/Library/PlatformHookLib/PlatformHookLib.c
@@ -14,6 +14,36 @@
 #include <Guid/SerialPortInfoGuid.h>
 
 /**
+  Get serial port stride register size.
+
+  @retval  The serial port register stride size.
+
+**/
+UINT8
+EFIAPI
+GetSerialPortStrideSize (
+  VOID
+  )
+{
+  return (UINT8) PcdGet32 (PcdSerialRegisterStride);
+}
+
+/**
+  Get serial port register base address.
+
+  @retval  The serial port register base address.
+
+**/
+UINT32
+EFIAPI
+GetSerialPortBase (
+  VOID
+  )
+{
+  return (UINT32) PcdGet64 (PcdSerialRegisterBase);
+}
+
+/**
   Performs platform specific initialization required for the CPU to access
   the hardware associated with a SerialPortLib instance.  This function does
   not intiailzie the serial port hardware itself.  Instead, it initializes
@@ -34,7 +64,7 @@ PlatformHookSerialPortInitialize (
   EFI_HOB_GUID_TYPE             *GuidHob;
   SERIAL_PORT_INFO              *PldSerialInfo;
 
-  GuidHob = GetNextGuidHob (&gLoaderSerialPortInfoGuid, (VOID *)PcdGet32 (PcdPayloadHobList));
+  GuidHob = GetNextGuidHob (&gLoaderSerialPortInfoGuid, (VOID *)(UINTN)PcdGet32 (PcdPayloadHobList));
   if (GuidHob == NULL) {
     ASSERT (FALSE);
     return RETURN_NOT_FOUND;

--- a/PayloadPkg/PayloadPkg.dsc
+++ b/PayloadPkg/PayloadPkg.dsc
@@ -1,0 +1,115 @@
+## @file
+# Provides driver and definitions to build payload module.
+#
+# Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+################################################################################
+#
+# Defines Section - statements that will be processed to create a Makefile.
+#
+################################################################################
+[Defines]
+  PLATFORM_NAME                       = PayloadPkg
+  PLATFORM_GUID                       = 5BCB969A-9151-45E0-BE14-048954BD2E8E
+  PLATFORM_VERSION                    = 0.1
+  DSC_SPECIFICATION                   = 0x00010005
+  OUTPUT_DIRECTORY                    = Build/PayloadPkg
+  SUPPORTED_ARCHITECTURES             = IA32|X64
+  BUILD_TARGETS                       = DEBUG|RELEASE|NOOPT
+  SKUID_IDENTIFIER                    = DEFAULT
+
+################################################################################
+#
+# SKU Identification section - list of all SKU IDs supported by this Platform.
+#
+################################################################################
+[SkuIds]
+  0|DEFAULT              # The entry: 0|DEFAULT is reserved and always required.
+
+################################################################################
+#
+# Library Class section - list of all Library Classes needed by this Platform.
+#
+################################################################################
+[LibraryClasses]
+  BaseLib | MdePkg/Library/BaseLib/BaseLib.inf
+  BaseMemoryLib | MdePkg/Library/BaseMemoryLibSse2/BaseMemoryLibSse2.inf
+  IoLib | MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
+  PrintLib | MdePkg/Library/BasePrintLib/BasePrintLib.inf
+  HobLib | BootloaderCommonPkg/Library/HobLib/HobLib.inf
+  DebugLogBufferLib | BootloaderCommonPkg/Library/DebugLogBufferLib/DebugLogBufferLib.inf
+  SerialPortLib | BootloaderCommonPkg/Library/SerialPortLib/SerialPortLib.inf
+  DebugLib | BootloaderCommonPkg/Library/BootloaderDebugLib/BootloaderDebugLib.inf
+  PcdLib | BootloaderCommonPkg/Library/PcdLib/PcdLib.inf
+  ConsoleInLib | BootloaderCommonPkg/Library/ConsoleInLib/ConsoleInLib.inf
+  ConsoleOutLib | BootloaderCommonPkg/Library/ConsoleOutLib/ConsoleOutLib.inf
+  GraphicsLib | BootloaderCommonPkg/Library/GraphicsLib/GraphicsLib.inf
+  MemoryAllocationLib | BootloaderCommonPkg/Library/FullMemoryAllocationLib/FullMemoryAllocationLib.inf
+  ModuleEntryLib | BootloaderCommonPkg/Library/ModuleEntryLib/ModuleEntryLib.inf
+  TimeStampLib | BootloaderCommonPkg/Library/TimeStampLib/TimeStampLib.inf
+  LoaderPerformanceLib | BootloaderCommonPkg/Library/LoaderPerformanceLib/LoaderPerformanceLib.inf
+  BootloaderCommonLib | BootloaderCommonPkg/Library/BootloaderCommonLib/BootloaderCommonLib.inf
+  UsbKbLib | BootloaderCommonPkg/Library/UsbKbLib/UsbKbLibNull.inf
+  PayloadSupportLib | PayloadPkg/Library/PayloadSupportLib/PayloadSupportLib.inf
+  DebugPrintErrorLevelLib | PayloadPkg/Library/DebugPrintErrorLevelLib/DebugPrintErrorLevelLib.inf
+  BootloaderLib | PayloadPkg/Library/PayloadLib/PayloadLib.inf
+  PayloadEntryLib | PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.inf
+  PlatformHookLib | PayloadPkg/Library/PlatformHookLib/PlatformHookLib.inf
+
+
+[PcdsPatchableInModule]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel         | 0x8000004F
+  # Following will be initialized at runtime
+  gPayloadTokenSpaceGuid.PcdGlobalDataAddress              | 0
+  gPayloadTokenSpaceGuid.PcdPayloadHobList                 | 0
+  gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress        | 0
+  gPlatformCommonLibTokenSpaceGuid.PcdAcpiPmTimerBase      | 0
+  gPlatformCommonLibTokenSpaceGuid.PcdSerialUseMmio        | 0
+  gPlatformCommonLibTokenSpaceGuid.PcdSerialRegisterBase   | 0
+  gPlatformCommonLibTokenSpaceGuid.PcdSerialBaudRate       | 0
+  gPlatformCommonLibTokenSpaceGuid.PcdSerialRegisterStride | 0
+  gPlatformCommonLibTokenSpaceGuid.PcdSerialClockRate      | 0
+
+[PcdsFixedAtBuild]
+!if $(TARGET) == RELEASE
+  # Use this PCD to control the debug message that goes into binary image
+  gEfiMdePkgTokenSpaceGuid.PcdFixedDebugPrintErrorLevel    | 0x80080003
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask            | 0x23
+!else
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask            | 0x27
+!endif
+
+  gPayloadTokenSpaceGuid.PcdPayloadHeapSize                | 0x02000000
+  gPayloadTokenSpaceGuid.PcdPayloadStackSize               | 0x00010000
+
+
+[Components]
+  PayloadPkg/HelloWorld/HelloWorld.inf
+
+
+[BuildOptions.Common.EDKII]
+  # Enable link-time optimization when building with GCC49
+  *_GCC49_IA32_CC_FLAGS = -flto
+  *_GCC49_IA32_DLINK_FLAGS = -flto
+  *_GCC5_IA32_CC_FLAGS = -fno-pic
+  *_GCC5_IA32_DLINK_FLAGS = -no-pie
+  *_GCC5_IA32_ASLCC_FLAGS = -fno-pic
+  *_GCC5_IA32_ASLDLINK_FLAGS = -no-pie
+  # Force synchronous PDB writes for parallel builds
+  *_VS2015x86_IA32_CC_FLAGS = /FS
+  *_XCODE5_IA32_CC_FLAGS = -flto
+
+  *_*_*_CC_FLAGS = -DDISABLE_NEW_DEPRECATED_INTERFACES
+
+!if $(TARGET) == NOOPT
+  # GCC: -O0 results in too big size. Override it to -O1 with lto
+  *_GCC49_*_CC_FLAGS = -O1
+  *_GCC49_*_DLINK_FLAGS = -O1
+  *_GCC5_*_CC_FLAGS = -flto -O1
+  *_GCC5_*_DLINK_FLAGS = -flto -O1
+  # VS: Use default /Od for now
+!endif
+


### PR DESCRIPTION
This patch added an example on how to build a HelloWorld payload
from separate DSC file.

To build a standalone HelloWorld payload, use the following command:
  BuildLoader.py build_dsc -p PayloadPkg\PayloadPkg.dsc

Signed-off-by: Maurice Ma <maurice.ma@intel.com>