### PR TITLE
Check PPB decode space and assign BAR accordingly

### DIFF
--- a/BootloaderCorePkg/Library/PciEnumerationLib/InternalPciEnumerationLib.h
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/InternalPciEnumerationLib.h
@@ -11,6 +11,14 @@
 #include <IndustryStandard/Pci.h>
 #include <Guid/PciRootBridgeInfoGuid.h>
 
+#define EFI_BRIDGE_IO32_DECODE_SUPPORTED      0x0001
+#define EFI_BRIDGE_PMEM32_DECODE_SUPPORTED    0x0002
+#define EFI_BRIDGE_PMEM64_DECODE_SUPPORTED    0x0004
+#define EFI_BRIDGE_IO16_DECODE_SUPPORTED      0x0008
+#define EFI_BRIDGE_PMEM_MEM_COMBINE_SUPPORTED 0x0010
+#define EFI_BRIDGE_MEM64_DECODE_SUPPORTED     0x0020
+#define EFI_BRIDGE_MEM32_DECODE_SUPPORTED     0x0040
+
 //
 // The PCI Command register bits owned by PCI Bus driver.
 //
@@ -105,6 +113,11 @@ struct _PCI_IO_DEVICE {
   // BAR for this PCI Device
   //
   PCI_BAR                                   PciBar[PCI_MAX_BAR];
+
+  //
+  // The resource decode the bridge supports
+  //
+  UINT32                                    Decodes;
 
   //
   // Bus number ranges for a PCI Root Bridge device

--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciIov.c
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciIov.c
@@ -32,11 +32,10 @@ PciIovParseVfBar (
   IN UINTN          BarIndex
   )
 {
-  UINT32      Value;
-  UINT32      OriginalValue;
-  UINT32      Mask;
-  EFI_STATUS  Status;
-  PCI_ENUM_POLICY_INFO  *EnumPolicy;
+  UINT32                Value;
+  UINT32                OriginalValue;
+  UINT32                Mask;
+  EFI_STATUS            Status;
 
   //
   // Ensure it is called properly
@@ -68,7 +67,6 @@ PciIovParseVfBar (
     return Offset + 4;
   }
 
-  EnumPolicy = (PCI_ENUM_POLICY_INFO *)PcdGetPtr (PcdPciEnumPolicyInfo);
   PciIoDevice->VfPciBar[BarIndex].Offset = (UINT16) Offset;
   if ((Value & 0x01) != 0) {
     //
@@ -115,13 +113,13 @@ PciIovParseVfBar (
     //
     case 0x04:
       if ((Value & 0x08) != 0) {
-        if ((EnumPolicy != NULL) && (EnumPolicy->DowngradePMem64 == 0)) {
+        if ((PciIoDevice->Decodes & EFI_BRIDGE_PMEM64_DECODE_SUPPORTED) != 0) {
           PciIoDevice->VfPciBar[BarIndex].BarType = PciBarTypePMem64;
         } else {
           PciIoDevice->VfPciBar[BarIndex].BarType = PciBarTypePMem32;
         }
       } else {
-        if ((EnumPolicy != NULL) && (EnumPolicy->DowngradeMem64 == 0)) {
+        if ((PciIoDevice->Decodes & EFI_BRIDGE_MEM64_DECODE_SUPPORTED) != 0) {
           PciIoDevice->VfPciBar[BarIndex].BarType = PciBarTypeMem64;
         } else {
           PciIoDevice->VfPciBar[BarIndex].BarType = PciBarTypeMem32;


### PR DESCRIPTION
All child devices under a PPB must be in scope of its PPB's decode space.
Therefore, all PPB checks the decode capability and downgrades its child
devices' resources accordingly.

Signed-off-by: Aiden Park <aiden.park@intel.com>