### PR TITLE
Provide HeciBaseAddr with GetBootGuardInfo

### DIFF
--- a/Silicon/CommonSocPkg/Include/Library/BootGuardLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/BootGuardLib.h
@@ -79,6 +79,7 @@ IsBootGuardSupported (
 VOID
 EFIAPI
 GetBootGuardInfo (
+  IN  UINTN            HeciBaseAddress,
   OUT BOOT_GUARD_INFO *BootGuardInfo
   );
 

--- a/Silicon/CommonSocPkg/Library/BootGuardLibCBnT/BootGuardLibrary.c
+++ b/Silicon/CommonSocPkg/Library/BootGuardLibCBnT/BootGuardLibrary.c
@@ -57,12 +57,12 @@ IsBootGuardSupported (
 VOID
 EFIAPI
 GetBootGuardInfo (
+  IN  UINTN            HeciBaseAddress,
   OUT BOOT_GUARD_INFO *BootGuardInfo
   )
 {
   UINT32                  MsrValue;
   UINT32                  MeFwSts4;
-  UINTN                   HeciBaseAddress;
   UINT32                  BootGuardAcmStatus;
   UINT32                  BootGuardBootStatus;
 
@@ -81,13 +81,6 @@ GetBootGuardInfo (
     ///
     /// Read ME FWS Registers
     ///
-    HeciBaseAddress = MM_PCI_ADDRESS (
-                      ME_BUS,
-                      ME_DEVICE_NUMBER,
-                      HECI_FUNCTION_NUMBER,
-                      0x0
-                      );
-
     MeFwSts4 = MmioRead32 (HeciBaseAddress + R_ME_HFS_4);
     DEBUG ((DEBUG_INFO, "ME FW STS 4 = %x\n", MeFwSts4));
 

--- a/Silicon/CommonSocPkg/Library/BootGuardLibCBnT/BootGuardRegister.h
+++ b/Silicon/CommonSocPkg/Library/BootGuardLibCBnT/BootGuardRegister.h
@@ -39,10 +39,6 @@
 #define R_CPU_ACM_POLICY_STATUS                                       0x378
 #define MMIO_ACM_POLICY_STATUS                                        (TXT_PUBLIC_BASE + R_CPU_ACM_POLICY_STATUS)
 
-#define ME_BUS                                                        0
-#define ME_DEVICE_NUMBER                                              22
-#define HECI_FUNCTION_NUMBER                                          0x00
-
 #define R_ME_HFS_3                                                    0x60
 #define R_ME_HFS_4                                                    0x64
 #define R_ME_HFS_5                                                    0x68


### PR DESCRIPTION
ME PCI device number is platform dependent and
heci base address is provided with common
CBnT GetBootGuardInfo.

For server platforms ME dev is 24.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>