### PR TITLE
Fix an issue in firmware update

### DIFF
--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -623,7 +623,7 @@ AuthenticateCapsule (
   //
   if (*(UINT32 *)(FwUpdStatus.CapsuleSig) != 0xFFFFFFFF) {
 
-    CopyMem((VOID *)&FwUpdStatus.CapsuleSig, (VOID *)SignatureHdr, sizeof(FW_UPDATE_SIG_LENGTH));
+    CopyMem((VOID *)&FwUpdStatus.CapsuleSig, (VOID *)SignatureHdr, FW_UPDATE_SIG_LENGTH);
 
     Status = BootMediaWrite (FwUpdStatusOffset, sizeof(FW_UPDATE_STATUS), (UINT8 *)&FwUpdStatus);
     if (EFI_ERROR (Status)) {


### PR DESCRIPTION
This patch fixed an issue in firmware update. During the saved capsule
signature verification against the capsule signature to make sure
that the capsule did not change during the reboot, instead of using
length of the signature, used the size of the macro that indicate the
length of the signature.

Verified that firmware update is able to pass on WHL.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>