### PR TITLE
Check for dummy data in the Component Entry

### DIFF
--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
@@ -798,9 +798,15 @@ LoadComponentWithCallback (
 
   if (IS_COMPRESSED (CompressHdr)) {
     SignedDataLen = sizeof (LOADER_COMPRESSED_HEADER) + CompressHdr->CompressedSize;
-    if (SignedDataLen <= CompLen) {
-      Status = DecompressGetInfo (CompressHdr->Signature, CompressHdr->Data,
-                                  CompressHdr->CompressedSize, &DstLen, &ScrLen);
+    if (CompressHdr->Size == 0) {
+      Status = EFI_SUCCESS;
+      DstLen = 0;
+      ScrLen = 0;
+    } else {
+      if (SignedDataLen <= CompLen) {
+        Status = DecompressGetInfo (CompressHdr->Signature, CompressHdr->Data,
+                                    CompressHdr->CompressedSize, &DstLen, &ScrLen);
+      }
     }
   }
   if (EFI_ERROR (Status)) {
@@ -865,6 +871,7 @@ LoadComponentWithCallback (
     } else {
       CompBase = ReqCompBase;
     }
+
     if (CompBase != NULL) {
       Status = Decompress (CompressHdr->Signature, CompressHdr->Data, CompressHdr->CompressedSize,
                            CompBase, ScrBuf);
@@ -877,7 +884,11 @@ LoadComponentWithCallback (
         }
       }
     } else {
-      Status = EFI_OUT_OF_RESOURCES;
+      if (CompressHdr->Size == 0) {
+        Status = EFI_SUCCESS;
+      } else {
+        Status = EFI_OUT_OF_RESOURCES;
+      }
     }
 
   } else {

--- a/BootloaderCorePkg/Tools/CommonUtility.py
+++ b/BootloaderCorePkg/Tools/CommonUtility.py
@@ -368,18 +368,23 @@ def compress (in_file, alg, svn=0, out_path = '', tool_dir = ''):
         sig = "LZDM"
     else:
         raise Exception ("Unsupported compression '%s' !" % alg)
-    if sig == "LZDM":
-        shutil.copy(in_file, out_file)
-    else:
-        compress_tool = "%sCompress" % alg
-        cmdline = [
-            os.path.join (tool_dir, compress_tool),
-            "-e",
-            "-o", out_file,
-            in_file]
-        run_process (cmdline, False, True)
 
-    compress_data = get_file_data(out_file)
+    in_len = os.path.getsize(in_file)
+    if in_len > 0:
+        if sig == "LZDM":
+            shutil.copy(in_file, out_file)
+        else:
+            compress_tool = "%sCompress" % alg
+            cmdline = [
+                os.path.join (tool_dir, compress_tool),
+                "-e",
+                "-o", out_file,
+                in_file]
+            run_process (cmdline, False, True)
+        compress_data = get_file_data(out_file)
+    else:
+        compress_data = bytearray()
+
     lz_hdr = LZ_HEADER ()
     lz_hdr.signature = sig.encode()
     lz_hdr.svn = svn

--- a/BootloaderCorePkg/Tools/GenContainer.py
+++ b/BootloaderCorePkg/Tools/GenContainer.py
@@ -475,7 +475,7 @@ class CONTAINER ():
                     raise Exception ("Component file path '%s' is invalid !" % file)
             else:
                 in_file = os.path.join(self.out_dir, component.name.decode() + '.bin')
-                gen_file_with_size (in_file, 0x10)
+                gen_file_with_size (in_file, 0)
                 if component.name == mono_sig.encode():
                     component.attribute = COMPONENT_ENTRY._attr['RESERVED']
                     compress_alg        = 'Dummy'


### PR DESCRIPTION
Generate zero size dummy data in the Component Entry

This patch generate a component binary of zero size if not
already present.

Signed-off-by: Sindhura Grandhi <sindhura.grandhi@intel.com>