### PR TITLE
Always allocate framebuffer resource

### DIFF
--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -982,10 +982,9 @@ BoardInit (
     BuildOsConfigDataHob ();
     break;
   case PostPciEnumeration:
-    if (PcdGetBool (PcdFramebufferInitEnabled)) {
-      // Enable framebuffer as WC for performance
-      SetFrameBufferWriteCombining ();
-    }
+    // Enable framebuffer as WC for performance
+    SetFrameBufferWriteCombining ();
+
     if (PcdGetBool (PcdSeedListEnabled)) {
       Status = GenerateSeeds ();
       if (EFI_ERROR (Status)) {


### PR DESCRIPTION
- Allocate framebuffer resource even if  ENABLE_FRAMEBUFFER_INIT=0

Signed-off-by: Andrey Vinokurtsev <avinok@gmail.com>