### PR TITLE
Klocwork: Validate fit entry ptr

### DIFF
--- a/Silicon/CommonSocPkg/Library/BootGuardLibCBnT/BootGuardTpmEventLogLib.c
+++ b/Silicon/CommonSocPkg/Library/BootGuardLibCBnT/BootGuardTpmEventLogLib.c
@@ -513,16 +513,18 @@ FindFitEntryData (
 
   FitTableOffset = *(UINT64 *)(UINTN)(BASE_4GB - 0x40);
   FitEntry = (FIRMWARE_INTERFACE_TABLE_ENTRY *)(UINTN)FitTableOffset;
-  if (FitEntry[0].Address != *(UINT64 *)"_FIT_   ") {
-    return NULL;
-  }
-  if (FitEntry[0].Type != FIT_TABLE_TYPE_HEADER) {
-    return NULL;
-  }
-  EntryNum = *(UINT32 *)(&FitEntry[0].Size[0]) & 0xFFFFFF;
-  for (Index = 0; Index < EntryNum; Index++) {
-    if (FitEntry[Index].Type == Type) {
-      return (VOID *)(UINTN)FitEntry[Index].Address;
+  if (FitEntry != NULL) {
+    if (FitEntry[0].Address != *(UINT64 *)"_FIT_   ") {
+      return NULL;
+    }
+    if (FitEntry[0].Type != FIT_TABLE_TYPE_HEADER) {
+      return NULL;
+    }
+    EntryNum = *(UINT32 *)(&FitEntry[0].Size[0]) & 0xFFFFFF;
+    for (Index = 0; Index < EntryNum; Index++) {
+      if (FitEntry[Index].Type == Type) {
+        return (VOID *)(UINTN)FitEntry[Index].Address;
+      }
     }
   }
 


### PR DESCRIPTION
Check fit entry read from fit entry offset before
its dereferenced.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>