### PR TITLE
PayloadPkg: Build paging table to cover high MMIO region

### DIFF
--- a/BootloaderCommonPkg/Include/Library/PagingLib.h
+++ b/BootloaderCommonPkg/Include/Library/PagingLib.h
@@ -107,17 +107,18 @@ UnmapMemoryRange (
   Allocates and fills in the Page Directory and Page Table Entries to
   establish a 1:1 Virtual to Physical mapping.
 
-  @param [in] Ranges
-  @param [in] PageTableMem
+  @param[in] RequestedAddressBits   If RequestedAddressBits is in valid range
+                                    (MIN_ADDR_BITS < RequestedAddressBits < PhysicalAddressBits),
+                                    paging table will cover the requested physical address range only.
 
-  @retval The address of 4 level page map.
+  @retval    EFI_SUCCESS            Page table was created successfully.
+  @retval    EFI_OUT_OF_RESOURCES   Failed to allocate page buffer
 
 **/
-UINT32
+EFI_STATUS
 EFIAPI
-Create4GbPageTablesAndRemapRange (
-  IN MAP_RANGE   Ranges[1],
-  IN VOID       *PageTableMem
+CreateIdentityMappingPageTables (
+  IN  UINT8         RequestedAddressBits
   );
 
 /**

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -252,7 +252,7 @@ class BaseBoard(object):
         self.FWUPDATE_LOAD_BASE    = 0
 
         # OS Loader FD/FV sizes
-        self.OS_LOADER_FD_SIZE     = 0x0004B000
+        self.OS_LOADER_FD_SIZE     = 0x0004C000
         self.OS_LOADER_FD_NUMBLK   = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.PLD_HEAP_SIZE         = 0x02000000

--- a/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.inf
+++ b/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.inf
@@ -39,12 +39,14 @@
   SerialPortLib
   DebugLogBufferLib
   DebugPrintErrorLevelLib
+  PagingLib
 
 [Guids]
   gLoaderLibraryDataGuid
   gLoaderPlatformDataGuid
   gBootLoaderServiceGuid
   gBootLoaderVersionGuid
+  gLoaderPciRootBridgeInfoGuid
 
 [Pcd]
   gPlatformCommonLibTokenSpaceGuid.PcdMaxLibraryDataEntry


### PR DESCRIPTION
A device in boot options can have a BAR greater than 4GB depending on PCI
64Mem/PMem resource policy.
This will allow Payload to build a paging table to cover high MMIO area.

Signed-off-by: Aiden Park <aiden.park@intel.com>