### PR TITLE
[CFL] Fix klockwork issue

### DIFF
--- a/Silicon/CoffeelakePkg/Library/BootGuardLib/BootGuardTpmEventLogLib.c
+++ b/Silicon/CoffeelakePkg/Library/BootGuardLib/BootGuardTpmEventLogLib.c
@@ -266,16 +266,18 @@ FindFitEntryData (
 
   FitTableOffset = *(UINT64 *)(UINTN)(BASE_4GB - 0x40);
   FitEntry = (FIRMWARE_INTERFACE_TABLE_ENTRY *)(UINTN)FitTableOffset;
-  if (FitEntry[0].Address != *(UINT64 *)"_FIT_   ") {
-    return NULL;
-  }
-  if (FitEntry[0].Type != FIT_TABLE_TYPE_HEADER) {
-    return NULL;
-  }
-  EntryNum = *(UINT32 *)(&FitEntry[0].Size[0]) & 0xFFFFFF;
-  for (Index = 0; Index < EntryNum; Index++) {
-    if (FitEntry[Index].Type == Type) {
-      return (VOID *)(UINTN)FitEntry[Index].Address;
+  if (FitEntry != NULL) {
+    if (FitEntry[0].Address != *(UINT64 *)"_FIT_   ") {
+      return NULL;
+    }
+    if (FitEntry[0].Type != FIT_TABLE_TYPE_HEADER) {
+      return NULL;
+    }
+    EntryNum = *(UINT32 *)(&FitEntry[0].Size[0]) & 0xFFFFFF;
+    for (Index = 0; Index < EntryNum; Index++) {
+      if (FitEntry[Index].Type == Type) {
+        return (VOID *)(UINTN)FitEntry[Index].Address;
+      }
     }
   }
 


### PR DESCRIPTION
This patch adds code to check FitEntry for NULL to avoid null pointer
dereference.

Signed-off-by: Praveen <praveen.hodagatta.pranesh@intel.com>