### PR TITLE
[CFL] Use Latest FSP and microcode release

### DIFF
--- a/Platform/CoffeelakeBoardPkg/BoardConfig.py
+++ b/Platform/CoffeelakeBoardPkg/BoardConfig.py
@@ -75,11 +75,14 @@ class Board(BaseBoard):
         self.ENABLE_SMBIOS        = 1
 
         # Verify required minimum FSP version
-        self.MIN_FSP_REVISION     = 0x07006440
+        self.MIN_FSP_REVISION     = 0x07006550
         # Verify FSP image ID. Empty string means skipping verification
         self.FSP_IMAGE_ID         = '$CFLFSP$'
 
         self.STAGE1B_XIP          = 1
+
+        # Stack settings to run FspMemoryInit
+        self.FSP_M_STACK_TOP      = 0xFEF3FF00
 
         self.STAGE2_FD_BASE       = 0x01000000
         self.STAGE2_FD_SIZE       = 0x000E0000

--- a/Silicon/CoffeelakePkg/FspBin/FspBin.inf
+++ b/Silicon/CoffeelakePkg/FspBin/FspBin.inf
@@ -11,11 +11,11 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = 59964173e18950debcc6b8856c5c928935ce0b4f
+  COMMIT  = eb25f19ef7fbe88fb207c6896a37a2035bba9bc5
 
 [UserExtensions.SBL."CopyList"]
-  CoffeeLakeFspBinPkg/FSP.fd                 : Silicon/CoffeelakePkg/FspBin/FspDbg.bin
-  CoffeeLakeFspBinPkg/FSP.fd                 : Silicon/CoffeelakePkg/FspBin/FspRel.bin
+  CoffeeLakeFspBinPkg/Fsp.fd                 : Silicon/CoffeelakePkg/FspBin/FspDbg.bin
+  CoffeeLakeFspBinPkg/Fsp.fd                 : Silicon/CoffeelakePkg/FspBin/FspRel.bin
   CoffeeLakeFspBinPkg/Fsp.bsf                : Silicon/CoffeelakePkg/FspBin/Fsp.bsf
   CoffeeLakeFspBinPkg/Include/FspInfoHob.h   : Silicon/CoffeelakePkg/Include/FspInfoHob.h
   CoffeeLakeFspBinPkg/Include/FspUpd.h       : Silicon/CoffeelakePkg/Include/FspUpd.h

--- a/Silicon/CoffeelakePkg/Microcode/Microcode.inf
+++ b/Silicon/CoffeelakePkg/Microcode/Microcode.inf
@@ -22,7 +22,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO  = https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files.git
-  TAG   = microcode-20190514a
+  TAG   = microcode-20200616
 
 [UserExtensions.SBL."CopyList"]
   intel-ucode/06-8e-0c  : Silicon/CoffeelakePkg/Microcode/06-8e-0c.mcb


### PR DESCRIPTION
This patch adds following chnages,

- Revise FSP github commit id to use latest FSP 7.0.74.20.
- Add latest Microcode Release Tag.

- starting from FSP 7.0.65.50 FSP shares same stack with Bootloader
  to run FSP-M, hence adjust stack using  FSP_M_STACK_TOP variable in
  BoardConfig.py file.

Test: Build and Boot test on CFL,WHL platforms and verified successfull
      boot till yocto OS.

Signed-off-by: Praveen Hp <praveen.hodagatta.pranesh@intel.com>