### PR TITLE
Naming convention update for secureboot and IppLibs

### DIFF
--- a/BootloaderCommonPkg/Include/Library/CryptoLib.h
+++ b/BootloaderCommonPkg/Include/Library/CryptoLib.h
@@ -124,6 +124,7 @@ typedef struct {
   @retval                  A pointer to SHA-256 digest value
 **/
 UINT8 *
+EFIAPI
 Sha256 (
   IN  CONST UINT8          *Data,
   IN        UINT32          Length,
@@ -145,6 +146,7 @@ Sha256 (
   @retval                  A pointer to SHA-384 digest value
 **/
 UINT8 *
+EFIAPI
 Sha384 (
   IN  CONST UINT8          *Data,
   IN        UINT32          Length,
@@ -165,6 +167,7 @@ Sha384 (
   @retval                  A pointer to SM3 digest value
 **/
 UINT8 *
+EFIAPI
 Sm3 (
   IN  CONST UINT8          *Data,
   IN        UINT32          Length,
@@ -234,6 +237,7 @@ RsaVerify_PSS (
   @retval   EFI_PROTOCOL_ERROR          Error caused while calculating HMAC SHA256
 **/
 EFI_STATUS
+EFIAPI
 HmacSha256 (
   IN  CONST UINT8          *Msg,
   IN        UINT32          MsgLen,
@@ -284,6 +288,7 @@ HkdfExtractExpand (
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
+EFIAPI
 Sha256Init (
   IN      HASH_CTX   *HashCtx,
   IN      UINT32      HashCtxSize
@@ -301,6 +306,7 @@ Sha256Init (
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
+EFIAPI
 Sha256Update (
   IN        HASH_CTX   *HashCtx,
   IN CONST  UINT8      *Msg,
@@ -317,6 +323,7 @@ Sha256Update (
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
+EFIAPI
 Sha256Final (
   IN       HASH_CTX   *HashCtx,
   OUT      UINT8      *Hash
@@ -334,6 +341,7 @@ Sha256Final (
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
+EFIAPI
 Sha384Init (
   IN      HASH_CTX   *HashCtx,
   IN      UINT32      HashCtxSize
@@ -351,6 +359,7 @@ Sha384Init (
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
+EFIAPI
 Sha384Update (
   IN        HASH_CTX   *HashCtx,
   IN CONST  UINT8      *Msg,
@@ -367,6 +376,7 @@ Sha384Update (
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
+EFIAPI
 Sha384Final (
   IN       HASH_CTX   *HashCtx,
   OUT      UINT8      *Hash
@@ -383,6 +393,7 @@ Sha384Final (
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
+EFIAPI
 Sm3Init (
   IN      HASH_CTX   *HashCtx,
   IN      UINT32      HashCtxSize
@@ -400,6 +411,7 @@ Sm3Init (
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
+EFIAPI
 Sm3Update (
   IN        HASH_CTX   *HashCtx,
   IN CONST  UINT8      *Msg,
@@ -416,6 +428,7 @@ Sm3Update (
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
+EFIAPI
 Sm3Final (
   IN       HASH_CTX   *HashCtx,
   OUT      UINT8      *Hash

--- a/BootloaderCommonPkg/Include/Library/SecureBootLib.h
+++ b/BootloaderCommonPkg/Include/Library/SecureBootLib.h
@@ -30,6 +30,7 @@
   @retval Others              Unable to calcuate hash.
 **/
 RETURN_STATUS
+EFIAPI
 GetHashToExtend (
   IN       UINT8            ComponentType,
   IN       HASH_ALG_TYPE    HashType,
@@ -53,6 +54,7 @@ GetHashToExtend (
 
 **/
 RETURN_STATUS
+EFIAPI
 CalculateHash  (
   IN CONST UINT8          *Data,
   IN       UINT32          Length,
@@ -78,6 +80,7 @@ CalculateHash  (
 
 **/
 RETURN_STATUS
+EFIAPI
 DoHashVerify (
   IN CONST UINT8           *Data,
   IN       UINT32           Length,
@@ -107,6 +110,7 @@ DoHashVerify (
 
 **/
 RETURN_STATUS
+EFIAPI
 DoRsaVerify (
   IN CONST UINT8           *Data,
   IN       UINT32           Length,

--- a/BootloaderCommonPkg/Library/IppCryptoLib/sha256.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/sha256.c
@@ -28,7 +28,9 @@
 
   @retval                  A pointer to SHA-256 digest value
 **/
-Ipp8u* Sha256 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
+Ipp8u*
+EFIAPI
+Sha256 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
 {
   if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_256) {
 
@@ -52,6 +54,7 @@ Ipp8u* Sha256 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
+EFIAPI
 Sha256Init (
   IN      HASH_CTX   *HashCtx,
   IN      Ipp32u      HashCtxSize
@@ -85,6 +88,7 @@ Sha256Init (
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
+EFIAPI
 Sha256Update (
   IN        HASH_CTX   *HashCtx,
   IN CONST  Ipp8u      *Msg,
@@ -114,6 +118,7 @@ Sha256Update (
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
+EFIAPI
 Sha256Final (
   IN       HASH_CTX   *HashCtx,
   OUT      Ipp8u      *Hash

--- a/BootloaderCommonPkg/Library/IppCryptoLib/sha384.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/sha384.c
@@ -29,7 +29,9 @@
 
   @retval                  A pointer to SHA-384 digest value
 **/
-Ipp8u* Sha384 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
+Ipp8u*
+EFIAPI
+Sha384 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
 {
   if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_384) {
     ippsHashMessage_rmf(pMsg, msgLen, pMD, ippsHashMethod_SHA384 ());
@@ -52,6 +54,7 @@ Ipp8u* Sha384 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
+EFIAPI
 Sha384Init (
   IN      HASH_CTX   *HashCtx,
   IN      Ipp32u      HashCtxSize
@@ -85,6 +88,7 @@ Sha384Init (
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
+EFIAPI
 Sha384Update (
   IN        HASH_CTX   *HashCtx,
   IN CONST  Ipp8u      *Msg,
@@ -114,6 +118,7 @@ Sha384Update (
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
+EFIAPI
 Sha384Final (
   IN       HASH_CTX   *HashCtx,
   OUT      Ipp8u      *Hash

--- a/BootloaderCommonPkg/Library/IppCryptoLib/sm3.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/sm3.c
@@ -27,7 +27,9 @@
 
   @retval                  A pointer to SM3 digest value
 **/
-Ipp8u* Sm3 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
+Ipp8u*
+EFIAPI
+Sm3 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
 {
   if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SM3_256) {
     ippsHashMessage_rmf(pMsg, msgLen, pMD, ippsHashMethod_SM3 ());
@@ -51,6 +53,7 @@ Ipp8u* Sm3 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
+EFIAPI
 Sm3Init (
   IN      HASH_CTX   *HashCtx,
   IN      Ipp32u      HashCtxSize
@@ -84,6 +87,7 @@ Sm3Init (
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
+EFIAPI
 Sm3Update (
   IN        HASH_CTX   *HashCtx,
   IN CONST  Ipp8u      *Msg,
@@ -113,6 +117,7 @@ Sm3Update (
   @retval  RETURN_SECURITY_VIOLATION  All other errors.
 **/
 RETURN_STATUS
+EFIAPI
 Sm3Final (
   IN       HASH_CTX   *HashCtx,
   OUT      Ipp8u      *Hash

--- a/BootloaderCommonPkg/Library/SecureBootLib/SecureBootHash.c
+++ b/BootloaderCommonPkg/Library/SecureBootLib/SecureBootHash.c
@@ -29,6 +29,7 @@
   @retval Others              Unable to calcuate hash.
 **/
 RETURN_STATUS
+EFIAPI
 GetHashToExtend (
   IN       UINT8            ComponentType,
   IN       HASH_ALG_TYPE    HashType,
@@ -95,6 +96,7 @@ GetHashToExtend (
 
 **/
 RETURN_STATUS
+EFIAPI
 CalculateHash  (
   IN CONST UINT8          *Data,
   IN       UINT32          Length,
@@ -149,6 +151,7 @@ CalculateHash  (
 
 **/
 RETURN_STATUS
+EFIAPI
 DoHashVerify (
   IN CONST UINT8           *Data,
   IN       UINT32           Length,

--- a/BootloaderCommonPkg/Library/SecureBootLib/SecureBootRsa.c
+++ b/BootloaderCommonPkg/Library/SecureBootLib/SecureBootRsa.c
@@ -34,6 +34,7 @@
 
 **/
 RETURN_STATUS
+EFIAPI
 DoRsaVerify (
   IN CONST UINT8           *Data,
   IN       UINT32           Length,


### PR DESCRIPTION
Added EFIAPI to missing APIs in Secureboot library interfaces.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>