### PR TITLE
Fix klockwork scanning issue

### DIFF
--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -675,6 +675,9 @@ StartBooting (
 
     if (FeaturePcdGet (PcdPayloadModuleEnabled)) {
       OsBootOptionList = GetBootOptionList ();
+      if (OsBootOptionList == NULL) {
+        return EFI_NOT_FOUND;
+      }
       CurrIdx = GetCurrentBootOption (OsBootOptionList, mCurrentBoot);
       PathPtr = (CHAR8 *)OsBootOptionList->OsBootOption[CurrIdx].Image[0].FileName;
       ModCmdLineBuf[0] = 0;


### PR DESCRIPTION
This patch add code to check OsBootOptionList for NULL to avoid
NULL pointer dereference.

Signed-off-by: Praveen Hp <praveen.hodagatta.pranesh@intel.com>