### PR TITLE
Add EndOfStage callback in S3 flow

### DIFF
--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -292,6 +292,9 @@ S3ResumePath (
     AddMeasurePoint (0x31C0);
   }
 
+  // Call the board notification
+  BoardInit (EndOfStages);
+
   // Call board and FSP Notify ReadyToBoot
   BoardNotifyPhase (ReadyToBoot);
   AddMeasurePoint (0x31D0);


### PR DESCRIPTION
EndOfStage callback is missing in S3 boot flow.
so just add it in case platform need do something.

Signed-off-by: Guo Dong <guo.dong@intel.com>