### PR TITLE
Represent data in required format in ConfigEditor

### DIFF
--- a/BootloaderCorePkg/Tools/ConfigEditor.py
+++ b/BootloaderCorePkg/Tools/ConfigEditor.py
@@ -544,7 +544,7 @@ class application(tkinter.Frame):
                 pass
 
             text = item['value'].strip('{').strip('}').strip()
-            widget.delete(0, END)
+            widget.delete(0, tkinter.END)
             widget.insert(0, text)
 
         self.update_widgets_visibility_on_page()

--- a/BootloaderCorePkg/Tools/GenCfgData.py
+++ b/BootloaderCorePkg/Tools/GenCfgData.py
@@ -1071,6 +1071,19 @@ class CGenCfgData:
             line = line_after
         return line_after
 
+    def reformat_number_per_type (self, itype, value):
+        if check_quote(value) or value.startswith('{'):
+            return value
+        parts = itype.split(',')
+        if len(parts) > 3 and parts[0] == 'EditNum':
+            num_fmt = parts[1].strip()
+        else:
+            num_fmt = ''
+        if num_fmt == 'HEX' and not value.startswith('0x'):
+            value = '0x%X' % int(value, 10)
+        elif num_fmt == 'DEC' and value.startswith('0x'):
+            value = '%d' % int(value, 16)
+        return value
 
     def add_cfg_item(self, name, item, offset, path):
 
@@ -1110,10 +1123,12 @@ class CGenCfgData:
 
         itype = str(item.get('type', 'Reserved'))
         value = str(item.get('value', ''))
-        if value and ((value[0] == "'" and  value[-1] == "'") or (value[0] == '"' and  value[-1] == '"')):
-            pass
-        elif (',' in value) and (not value.startswith('{')):
-            value = '{ %s }' % value
+        if value:
+            if not (check_quote(value) or value.startswith('{')):
+                if ',' in value:
+                    value = '{ %s }' % value
+                else:
+                    value = self.reformat_number_per_type (itype, value)
 
         help = str(item.get('help', ''))
         if '\n' in help:
@@ -1224,7 +1239,11 @@ class CGenCfgData:
             act_cfg = self.get_item_by_index (cfgs['indx'])
             if force or act_cfg['value'] == '':
                 value = get_bits_from_bytes (full_bytes, act_cfg['offset'] - struct_info['offset'], act_cfg['length'])
-                act_cfg['value'] = self.format_value_to_str (value, act_cfg['length'], act_cfg['value'])
+                act_val = act_cfg['value']
+                if act_val == '':
+                    act_val = '%d' % value
+                act_val = self.reformat_number_per_type (act_cfg['type'], act_val)
+                act_cfg['value'] = self.format_value_to_str (value, act_cfg['length'], act_val)
 
         if 'indx' in top:
             # it is config option

--- a/Platform/ApollolakeBoardPkg/CfgData/CfgData_CapsuleInformation.yaml
+++ b/Platform/ApollolakeBoardPkg/CfgData/CfgData_CapsuleInformation.yaml
@@ -46,7 +46,7 @@
       value        : 0
   - SwPart       :
       name         : Software Partition
-      type         : EditNum, INT, (0,127)
+      type         : EditNum, DEC, (0,127)
       help         : >
                      Specify software partition number
       length       : 0x01

--- a/Platform/ApollolakeBoardPkg/CfgData/Template_PcieRp.yaml
+++ b/Platform/ApollolakeBoardPkg/CfgData/Template_PcieRp.yaml
@@ -81,7 +81,7 @@ PCIERP_CTRL_PIN_TMPL: >
         length       : 8b
     - PadNum       :
         name         : Power Pad Number
-        type         : EditNum, INT, (0,4095)
+        type         : EditNum, DEC, (0,4095)
         help         : >
                        Specify Pad Number
         condition    : $(COND_PCIE_RP_PWR_PIN_SKIP)
@@ -135,7 +135,7 @@ PCIERP_CTRL_PIN_TMPL: >
         length       : 8b
     - PadNum       :
         name         : Reset Pad Number
-        type         : EditNum, INT, (0,4095)
+        type         : EditNum, DEC, (0,4095)
         help         : >
                        Specify Pad Number
         condition    : $(COND_PCIE_RP_RST_PIN_SKIP)

--- a/Platform/CoffeelakeBoardPkg/CfgData/CfgData_CapsuleInformation.yaml
+++ b/Platform/CoffeelakeBoardPkg/CfgData/CfgData_CapsuleInformation.yaml
@@ -42,7 +42,7 @@
       value        : 0
   - SwPart       :
       name         : Software Partition
-      type         : EditNum, INT, (0,127)
+      type         : EditNum, DEC, (0,127)
       help         : >
                      Specify software partition number
       length       : 0x01

--- a/Platform/CoffeelakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/CoffeelakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -57,7 +57,7 @@
         length       : 4bW
     - PinNum       :
         name         : Pin Number
-        type         : EditNum, INT, (0,24)
+        type         : EditNum, DEC, (0,24)
         help         : >
                        Specify Pin Number
         length       : 5bW

--- a/Platform/CommonBoardPkg/CfgData/Template_BootOption.yaml
+++ b/Platform/CommonBoardPkg/CfgData/Template_BootOption.yaml
@@ -69,7 +69,7 @@ BOOT_OPTION_TMPL: >
         value        : $(6)
     - SwPart_$(1)  :
         name         : Software Partition
-        type         : EditNum, INT, (0,127)
+        type         : EditNum, DEC, (0,127)
         help         : >
                        Specify software partition number
         condition    : $BOOT_OPTION_CFG_DATA_$(1).ImageType_$(1) < 0xFF
@@ -148,7 +148,7 @@ OS_TMPL: >
       value        : $(6)
   - SwPart_$(1)  :
       name         : Software Partition
-      type         : EditNum, INT, (0,127)
+      type         : EditNum, DEC, (0,127)
       help         : >
                      Specify software partition number
       length       : 0x01
@@ -175,7 +175,7 @@ OS_TMPL: >
   - SwPart_0_$(1) :
       name         : Software partition for normal OS Image)
       condition    : $FsType_$(1) == 3
-      type         : EditNum, INT, (0,127)
+      type         : EditNum, DEC, (0,127)
       help         : >
                      Specify software partition number
       length       : 0x01
@@ -186,7 +186,7 @@ OS_TMPL: >
   - LbaAddr_0_$(1) :
       name         : LBA address for normal OS Image)
       condition    : $FsType_$(1) == 3
-      type         : EditNum, INT, (0,0xFFFFFFFF)
+      type         : EditNum, DEC, (0,0xFFFFFFFF)
       help         : >
                      Specify LBA address where to find normal OS image
       length       : 0x04
@@ -205,7 +205,7 @@ OS_TMPL: >
   - SwPart_1_$(1) :
       name         : Software partition for trusty OS
       condition    : ($BootFlags_$(1) & 0x4 == 0x4) and ($FsType_$(1) == 3)
-      type         : EditNum, INT, (0,127)
+      type         : EditNum, DEC, (0,127)
       help         : >
                      Specify software partition number
       length       : 0x01
@@ -216,7 +216,7 @@ OS_TMPL: >
   - LbaAddr_1_$(1) :
       name         : LBA address for trusty OS
       condition    : ($BootFlags_$(1) & 0x4 == 0x4) and ($FsType_$(1) != 3)
-      type         : EditNum, INT, (0,0xFFFFFFFF)
+      type         : EditNum, DEC, (0,0xFFFFFFFF)
       help         : >
                      Specify LBA address where to find trusty OS image
       length       : 0x04
@@ -235,7 +235,7 @@ OS_TMPL: >
   - SwPart_2_$(1) :
       name         : Software partition for misc Image
       condition    : ($BootFlags_$(1) & 0x1 == 0x1) and ($FsType_$(1) == 3)
-      type         : EditNum, INT, (0,127)
+      type         : EditNum, DEC, (0,127)
       help         : >
                      Specify software partition number for OS A/B support
       length       : 0x01
@@ -246,7 +246,7 @@ OS_TMPL: >
   - LbaAddr_2_$(1) :
       name         : LBA address for misc image
       condition    : ($BootFlags_$(1) & 0x1 == 0x1) and ($FsType_$(1) == 3)
-      type         : EditNum, INT, (0,0xFFFFFFFF)
+      type         : EditNum, DEC, (0,0xFFFFFFFF)
       help         : >
                      Specify LBA address where to find misc image to support OS A/B
       length       : 0x04

--- a/Platform/QemuBoardPkg/CfgData/CfgData_CapsuleInformation.yaml
+++ b/Platform/QemuBoardPkg/CfgData/CfgData_CapsuleInformation.yaml
@@ -42,7 +42,7 @@
       value        : 5
   - SwPart       :
       name         : Software Partition
-      type         : EditNum, INT, (0,127)
+      type         : EditNum, DEC, (0,127)
       help         : >
                      Specify software partition number
       length       : 0x01


### PR DESCRIPTION
Current ConfigEditor relies on the original input data format in YAML
to determine how to represent data in GUI. For example, if the data
value is HEX in YAML, then the data will be displayed in HEX format.
This patch switched to use the specified format type to reformat the
value string so that the display is always consistent with the required
format type.

It fixed #844.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>