### PR TITLE
Enhance FSP build path support

### DIFF
--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -1089,10 +1089,15 @@ class Build(object):
             raise Exception  ('IPP_HASH_LIB_SUPPORTED_MASK is not set correctly!!')
 
         # check if FSP binary exists
-        fsp_dir  = os.path.join(plt_dir, 'Silicon', self._board.SILICON_PKG_NAME, "FspBin", self._board._FSP_PATH_NAME)
+        if self._board._FSP_PATH_NAME != '':
+            fsp_path_name = self._board._FSP_PATH_NAME
+        else:
+            fsp_path_name = os.path.join('Silicon', self._board.SILICON_PKG_NAME, "FspBin")
+
+        fsp_dir  = os.path.join(plt_dir,  fsp_path_name)
         work_dir = plt_dir
         if not os.path.exists(fsp_dir):
-            fsp_dir  = os.path.join(sbl_dir, 'Silicon', self._board.SILICON_PKG_NAME, "FspBin", self._board._FSP_PATH_NAME)
+            fsp_dir  = os.path.join(sbl_dir, fsp_path_name)
             work_dir = sbl_dir
         fsp_path = os.path.join(fsp_dir, self._fsp_basename + '.bin')
 


### PR DESCRIPTION
Currently the build tool will always find FSP binaries from
Silicon'\self._board.SILICON_PKG_NAME\FspBin folder.
This patch enhance the build tool to support to get FSP from
_FSP_PATH_NAME. If _FSP_PATH_NAME is not specified, the default
behavior is same with current build.

If user wants to use a different one, they could override it
in BoardConfig.py as below:
self._FSP_PATH_NAME  = 'Silicon/Fsp'

Signed-off-by: Guo Dong <guo.dong@intel.com>