### PR TITLE
Expand HECI service to add more API's

### DIFF
--- a/BootloaderCommonPkg/Include/Service/HeciService.h
+++ b/BootloaderCommonPkg/Include/Service/HeciService.h
@@ -49,6 +49,68 @@ EFI_STATUS
 );
 
 /**
+  Function sends one message (of any length) through the HECI circular buffer.
+
+  @param[in] HeciDev              The HECI device to be accessed.
+  @param[in] Message              Pointer to the message data to be sent.
+  @param[in] Length               Length of the message in bytes.
+  @param[in] HostAddress          The address of the Host processor.
+  @param[in] MeAddress            Address of the ME subsystem the message is being sent to.
+
+  @retval EFI_SUCCESS             One message packet sent.
+  @retval EFI_DEVICE_ERROR        Failed to initialize HECI
+  @retval EFI_TIMEOUT             HECI is not ready for communication
+  @retval EFI_UNSUPPORTED      Current ME mode doesn't support send this message through this HECI
+**/
+typedef
+EFI_STATUS
+(EFIAPI *HECI_SEND) (
+  IN UINT8        HeciDev,
+  IN UINT32      *Message,
+  IN UINT32       Length,
+  IN UINT8        HostAddress,
+  IN UINT8        MeAddress
+  );
+
+/**
+  Reads a message from the ME across HECI. This function can only be used after invoking HeciSend() first.
+
+  @param[in] HeciDev              The HECI device to be accessed.
+  @param[in] Blocking             Used to determine if the read is BLOCKING or NON_BLOCKING.
+  @param[out] MessageBody         Pointer to a buffer used to receive a message.
+  @param[in][out] Length          Pointer to the length of the buffer on input and the length
+                                  of the message on return. (in bytes)
+
+  @retval EFI_SUCCESS             One message packet read.
+  @retval EFI_DEVICE_ERROR        Failed to initialize HECI or zero-length message packet read
+  @retval EFI_TIMEOUT             HECI is not ready for communication
+  @retval EFI_BUFFER_TOO_SMALL    The caller's buffer was not large enough
+  @retval EFI_UNSUPPORTED         Current ME mode doesn't support this message through this HECI
+**/
+typedef
+EFI_STATUS
+(EFIAPI *HECI_RECEIVE) (
+  IN      UINT8        HeciDev,
+  IN      UINT32       Blocking,
+  OUT     UINT32      *MessageBody,
+  IN OUT  UINT32      *Length
+  );
+
+/**
+  Function forces a reinit of the heci interface by following the reset heci interface via Host algorithm
+
+  @param[in] HeciDev              The HECI device to be accessed.
+
+  @retval EFI_TIMEOUT             ME is not ready
+  @retval EFI_SUCCESS             Interface reset
+**/
+typedef
+EFI_STATUS
+(EFIAPI *HECI_RESET_INTERFACE) (
+  IN UINT8        HeciDev
+  );
+
+/**
   Dummy function
 
   @retval EFI_SUCCESS         The command runs success
@@ -65,7 +127,10 @@ typedef struct {
   SERVICE_COMMON_HEADER              Header;
   SIMPLE_HECI_CMD                    SimpleHeciCommand;
   HECI_USER_COMMAND                  HeciUserCommand;
-  DUMMY_FUNCTION                     Reserved[9];
+  HECI_SEND                          HeciSend;
+  HECI_RECEIVE                       HeciReceive;
+  HECI_RESET_INTERFACE               HeciResetInterface;
+  DUMMY_FUNCTION                     Reserved[6];
 } HECI_SERVICE;
 
 #endif

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -67,6 +67,7 @@
 #include "GpioTables.h"
 #include <Library/PchSpiLib.h>
 #include <Register/RegsSpi.h>
+#include <Library/HeciLib.h>
 
 #define DEFAULT_GPIO_IRQ_ROUTE                      14
 
@@ -1081,6 +1082,8 @@ BoardInit (
     }
     break;
   case EndOfStages:
+    // Register Heci Service
+    HeciRegisterHeciService ();
     // Lock down SPI for all other payload entry except FWUpdate and OSloader
     // as this phase is too early for them to lock it here
     SpiBaseAddress = GetDeviceAddr (OsBootDeviceSpi, 0);

--- a/Silicon/ApollolakePkg/Library/MeChipsetLib/MeChipsetLib.c
+++ b/Silicon/ApollolakePkg/Library/MeChipsetLib/MeChipsetLib.c
@@ -20,10 +20,13 @@
 #include <MeBiosPayloadData.h>
 
 STATIC CONST HECI_SERVICE   mHeciService = {
-  .Header.Signature  = HECI_SERVICE_SIGNATURE,
-  .Header.Version    = HECI_SERVICE_VERSION,
-  .SimpleHeciCommand = SimpleHeciCommand,
-  .HeciUserCommand   = HeciSendUserCommand,
+  .Header.Signature   = HECI_SERVICE_SIGNATURE,
+  .Header.Version     = HECI_SERVICE_VERSION,
+  .HeciSend           = HeciServiceSend,
+  .HeciReceive        = HeciServiceReceive,
+  .HeciResetInterface = HeciServiceResetInterface,
+  .SimpleHeciCommand  = SimpleHeciCommand,
+  .HeciUserCommand    = HeciSendUserCommand,
 };
 
 /**

--- a/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.inf
+++ b/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.inf
@@ -36,7 +36,6 @@
   MmcAccessLib
   PcdLib
   PartitionLib
-  HeciLib
   LitePeCoffLib
 
 [Guids]

--- a/Silicon/CommonSocPkg/Include/Library/HeciLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/HeciLib.h
@@ -82,6 +82,30 @@ HeciReceive (
   );
 
 /**
+  Heci Service API function wrapper to HeciReceive API
+
+  @param[in] HeciDev              The HECI device to be accessed.
+  @param[in] Blocking             Used to determine if the read is BLOCKING or NON_BLOCKING.
+  @param[out] MessageBody         Pointer to a buffer used to receive a message.
+  @param[in][out] Length          Pointer to the length of the buffer on input and the length
+                                  of the message on return. (in bytes)
+
+  @retval EFI_SUCCESS             One message packet read.
+  @retval EFI_DEVICE_ERROR        Failed to initialize HECI or zero-length message packet read
+  @retval EFI_TIMEOUT             HECI is not ready for communication
+  @retval EFI_BUFFER_TOO_SMALL    The caller's buffer was not large enough
+  @retval EFI_UNSUPPORTED         Current ME mode doesn't support this message through this HECI
+**/
+EFI_STATUS
+EFIAPI
+HeciServiceReceive (
+  IN      UINT8        HeciDev,
+  IN      UINT32       Blocking,
+  OUT     UINT32      *MessageBody,
+  IN OUT  UINT32      *Length
+  );
+
+/**
   Function sends one message (of any length) through the HECI circular buffer.
 
   @param[in] HeciDev              The HECI device to be accessed.
@@ -99,6 +123,30 @@ EFI_STATUS
 EFIAPI
 HeciSend (
   IN HECI_DEVICE  HeciDev,
+  IN UINT32      *Message,
+  IN UINT32       Length,
+  IN UINT8        HostAddress,
+  IN UINT8        MeAddress
+  );
+
+/**
+  Heci Service API function wrapper to HeciSend API
+
+  @param[in] HeciDev              The HECI device to be accessed.
+  @param[in] Message              Pointer to the message data to be sent.
+  @param[in] Length               Length of the message in bytes.
+  @param[in] HostAddress          The address of the Host processor.
+  @param[in] MeAddress            Address of the ME subsystem the message is being sent to.
+
+  @retval EFI_SUCCESS             One message packet sent.
+  @retval EFI_DEVICE_ERROR        Failed to initialize HECI
+  @retval EFI_TIMEOUT             HECI is not ready for communication
+  @retval EFI_UNSUPPORTED      Current ME mode doesn't support send this message through this HECI
+**/
+EFI_STATUS
+EFIAPI
+HeciServiceSend (
+  IN UINT8        HeciDev,
   IN UINT32      *Message,
   IN UINT32       Length,
   IN UINT8        HostAddress,
@@ -145,6 +193,20 @@ EFI_STATUS
 EFIAPI
 HeciResetInterface (
   IN  HECI_DEVICE             HeciDev
+  );
+
+/**
+  Heci Service API function wrapper to HeciResetInterface API
+
+  @param[in] HeciDev              The HECI device to be accessed.
+
+  @retval EFI_TIMEOUT             ME is not ready
+  @retval EFI_SUCCESS             Interface reset
+**/
+EFI_STATUS
+EFIAPI
+HeciServiceResetInterface (
+  IN  UINT8             HeciDev
   );
 
 /**

--- a/Silicon/CommonSocPkg/Library/HeciLib/HeciCore.c
+++ b/Silicon/CommonSocPkg/Library/HeciLib/HeciCore.c
@@ -669,6 +669,32 @@ HeciReceive (
   return Status;
 }
 
+/**
+  Heci Service API function wrapper to HeciReceive API
+
+  @param[in] HeciDev              The HECI device to be accessed.
+  @param[in] Blocking             Used to determine if the read is BLOCKING or NON_BLOCKING.
+  @param[out] MessageBody         Pointer to a buffer used to receive a message.
+  @param[in][out] Length          Pointer to the length of the buffer on input and the length
+                                  of the message on return. (in bytes)
+
+  @retval EFI_SUCCESS             One message packet read.
+  @retval EFI_DEVICE_ERROR        Failed to initialize HECI or zero-length message packet read
+  @retval EFI_TIMEOUT             HECI is not ready for communication
+  @retval EFI_BUFFER_TOO_SMALL    The caller's buffer was not large enough
+  @retval EFI_UNSUPPORTED         Current ME mode doesn't support this message through this HECI
+**/
+EFI_STATUS
+EFIAPI
+HeciServiceReceive (
+  IN      UINT8        HeciDev,
+  IN      UINT32       Blocking,
+  OUT     UINT32      *MessageBody,
+  IN OUT  UINT32      *Length
+  )
+{
+  return HeciReceive((HECI_DEVICE)HeciDev, Blocking, MessageBody, Length);
+}
 
 /**
   Function sends one message (of any length) through the HECI circular buffer.
@@ -782,6 +808,32 @@ HeciSend (
   return EFI_SUCCESS;
 }
 
+/**
+  Heci Service API function wrapper to HeciSend API
+
+  @param[in] HeciDev              The HECI device to be accessed.
+  @param[in] Message              Pointer to the message data to be sent.
+  @param[in] Length               Length of the message in bytes.
+  @param[in] HostAddress          The address of the Host processor.
+  @param[in] MeAddress            Address of the ME subsystem the message is being sent to.
+
+  @retval EFI_SUCCESS             One message packet sent.
+  @retval EFI_DEVICE_ERROR        Failed to initialize HECI
+  @retval EFI_TIMEOUT             HECI is not ready for communication
+  @retval EFI_UNSUPPORTED      Current ME mode doesn't support send this message through this HECI
+**/
+EFI_STATUS
+EFIAPI
+HeciServiceSend (
+  IN UINT8        HeciDev,
+  IN UINT32      *Message,
+  IN UINT32       Length,
+  IN UINT8        HostAddress,
+  IN UINT8        MeAddress
+  )
+{
+  return HeciSend((HECI_DEVICE)HeciDev, Message, Length, HostAddress, MeAddress);
+}
 
 /**
   Function sends one message through the HECI circular buffer and waits
@@ -918,4 +970,21 @@ HeciResetInterface (
   MmioWrite32 (HeciMemBar + H_CSR, HeciCsrHost.Data);
 
   return EFI_SUCCESS;
+}
+
+/**
+  Heci Service API function wrapper to HeciResetInterface API
+
+  @param[in] HeciDev              The HECI device to be accessed.
+
+  @retval EFI_TIMEOUT             ME is not ready
+  @retval EFI_SUCCESS             Interface reset
+**/
+EFI_STATUS
+EFIAPI
+HeciServiceResetInterface (
+  IN  UINT8             HeciDev
+  )
+{
+  return HeciResetInterface((HECI_DEVICE)HeciDev);
 }

--- a/Silicon/CommonSocPkg/Library/MeChipsetLib/MeChipsetLib.c
+++ b/Silicon/CommonSocPkg/Library/MeChipsetLib/MeChipsetLib.c
@@ -18,10 +18,13 @@
 #include <MeBiosPayloadDataCommon.h>
 
 STATIC CONST HECI_SERVICE mHeciService = {
-  .Header.Signature  = HECI_SERVICE_SIGNATURE,
-  .Header.Version    = HECI_SERVICE_VERSION,
-  .SimpleHeciCommand = NULL,
-  .HeciUserCommand   = NULL,
+  .Header.Signature   = HECI_SERVICE_SIGNATURE,
+  .Header.Version     = HECI_SERVICE_VERSION,
+  .HeciSend           = HeciServiceSend,
+  .HeciReceive        = HeciServiceReceive,
+  .HeciResetInterface = HeciServiceResetInterface,
+  .SimpleHeciCommand  = NULL,
+  .HeciUserCommand    = NULL,
 };
 
 /**


### PR DESCRIPTION
This patch expanded HECI service to include send, receive and
reset interface functions. This helps in making firmwareupdatelib.c
and PSDlib common across platforms.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>