### PR TITLE
Add MultiBoot support for X64 build

### DIFF
--- a/BootloaderCommonPkg/Include/Library/ThunkLib.h
+++ b/BootloaderCommonPkg/Include/Library/ThunkLib.h
@@ -1,17 +1,16 @@
 /** @file
-  Execute 32-bit code in Long Mode.
-  Provide a thunk function to transition from long mode to compatibility mode to execute 32-bit code and then transit
-  back to long mode.
+  Thunk to 32 bit mode for execution from Long Mode.
 
-  Copyright (c) 2014 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
+#ifndef _THUNK_LIB_H_
+#define _THUNK_LIB_H_
+
 #include <PiPei.h>
 #include <Library/BaseLib.h>
-#include <FspEas.h>
-
 
 /**
   Wrapper for a thunk  to transition from long mode to compatibility mode to execute 32-bit code and then transit back to
@@ -31,9 +30,6 @@ Execute32BitCode (
   IN UINT64      Param1,
   IN UINT64      Param2,
   IN BOOLEAN     ExeInMem
-  )
-{
-  // 32 bit mode should not call this interface.
-  return EFI_UNSUPPORTED;
-}
+  );
 
+#endif

--- a/BootloaderCommonPkg/Library/MultibootLib/MultibootLib.inf
+++ b/BootloaderCommonPkg/Library/MultibootLib/MultibootLib.inf
@@ -30,6 +30,7 @@
   Ia32/MultibootJump.nasm
 
 [Sources.X64]
+  X64/BootJump.c
   X64/MultibootJump.nasm
 
 [Packages]
@@ -42,6 +43,7 @@
   DebugLib
   MemoryAllocationLib
   ElfLib
+  ThunkLib
 
 [Guids]
 

--- a/BootloaderCommonPkg/Library/MultibootLib/X64/BootJump.c
+++ b/BootloaderCommonPkg/Library/MultibootLib/X64/BootJump.c
@@ -1,0 +1,40 @@
+/** @file
+  This file provids APi to call into Multiboot entry.
+
+  Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+#include <Library/BaseLib.h>
+#include <Library/MultibootLib.h>
+#include <Library/ThunkLib.h>
+
+/**
+  ASM code to jump into MultiBoot image entry point.
+
+  @param[in]     State  Pointer to boot state buffer defined by MultiBoot spec.
+
+**/
+VOID
+EFIAPI
+AsmJumpToMultibootOs (
+  IN IA32_BOOT_STATE  *State
+);
+
+
+/**
+  Jump into 32bit MultiBoot image entry point by thunking.
+
+  @param[in]     State  Pointer to boot state buffer defined by MultiBoot spec.
+
+**/
+VOID
+EFIAPI
+JumpToMultibootOs (
+  IN IA32_BOOT_STATE    *State
+  )
+{
+  Execute32BitCode ((UINT64)&AsmJumpToMultibootOs, (UINT64)State, (UINT64)NULL, FALSE);
+}

--- a/BootloaderCommonPkg/Library/MultibootLib/X64/MultibootJump.nasm
+++ b/BootloaderCommonPkg/Library/MultibootLib/X64/MultibootJump.nasm
@@ -12,18 +12,24 @@
 ;  This is the code that goes from payload to a Multiboot enabled OS.
 ;
 ;------------------------------------------------------------------------------
-
+DEFAULT  REL
 SECTION .text
 
 ;------------------------------------------------------------------------------
 ; VOID
 ; EFIAPI
-; JumpToMultibootOs (
-;   IA32_BOOT_STATE state
+; AsmJumpToMultibootOs (
+;   IA32_BOOT_STATE  *State
 ;   );
 ;------------------------------------------------------------------------------
-global ASM_PFX(JumpToMultibootOs)
-ASM_PFX(JumpToMultibootOs):
-    ; TBD: Need porting
-    jmp    $
+global ASM_PFX(AsmJumpToMultibootOs)
+ASM_PFX(AsmJumpToMultibootOs):
+BITS 32
+    mov    ecx, DWORD [esp + 4]
+    mov    eax, DWORD [ecx + 4]
+    mov    ebx, DWORD [ecx + 8]
+    mov    esi, DWORD [ecx + 12]
+    mov    edi, DWORD [ecx + 16]
+    cli
+    jmp    DWORD [ecx]
     ret

--- a/BootloaderCommonPkg/Library/ThunkLib/Ia32/DispatchExecute.c
+++ b/BootloaderCommonPkg/Library/ThunkLib/Ia32/DispatchExecute.c
@@ -1,0 +1,44 @@
+/** @file
+  Execute 32-bit code in Long Mode.
+  Provide a thunk function to transition from long mode to compatibility mode to execute 32-bit code and then transit
+  back to long mode.
+
+  Copyright (c) 2014 - 2018, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+#include <Library/BaseLib.h>
+
+typedef EFI_STATUS (EFIAPI *EXECUTE_32BIT_CODE) (UINT64 Param1, UINT64 Param2);
+
+/**
+  Wrapper for a thunk  to transition from long mode to compatibility mode to execute 32-bit code and then transit back to
+  long mode.
+
+  @param[in] Function     The 32bit code entry to be executed.
+  @param[in] Param1       The first parameter to pass to 32bit code.
+  @param[in] Param2       The second parameter to pass to 32bit code.
+  @param[in] ExeInMem     If thunk needs to be executed from memory copy.
+
+  @return Status.         Status returned from the calling function.
+**/
+EFI_STATUS
+EFIAPI
+Execute32BitCode (
+  IN UINT64      Function,
+  IN UINT64      Param1,
+  IN UINT64      Param2,
+  IN BOOLEAN     ExeInMem
+  )
+{
+  EFI_STATUS            Status;
+  EXECUTE_32BIT_CODE    Func;
+
+  Func   = (EXECUTE_32BIT_CODE)(UINTN)Function;
+  Status = Func (Param1, Param2);
+
+  return Status;
+}
+

--- a/BootloaderCommonPkg/Library/ThunkLib/ThunkLib.inf
+++ b/BootloaderCommonPkg/Library/ThunkLib/ThunkLib.inf
@@ -1,0 +1,42 @@
+## @file
+#
+#  Copyright (c) 2019 - 2020, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = ThunkLib
+  FILE_GUID                      = F3B030C8-CACA-4E83-BEB8-CAE6981DE960
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = ThunkLib
+
+[Sources]
+
+
+[Sources.IA32]
+  Ia32/DispatchExecute.c
+
+[Sources.X64]
+  X64/DispatchExecute.c
+  X64/Thunk64To32.nasm
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  PagingLib
+  PrintLib
+
+[Guids]
+  gEfiGraphicsInfoHobGuid
+  gLoaderMemoryMapInfoGuid
+  gLoaderSystemTableInfoGuid
+
+[Pcd]

--- a/BootloaderCommonPkg/Library/ThunkLib/X64/DispatchExecute.c
+++ b/BootloaderCommonPkg/Library/ThunkLib/X64/DispatchExecute.c
@@ -12,7 +12,6 @@
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/BlMemoryAllocationLib.h>
-#include <FspEas.h>
 
 #pragma pack(1)
 typedef union {
@@ -37,15 +36,15 @@ typedef union {
 
 
 /**
-  Assembly function to transition from long mode to compatibility mode to execute 32-bit code and then transit back to
-  long mode.
+  Wrapper for a thunk  to transition from long mode to compatibility mode to
+  execute 32-bit code and then transit back to long mode.
 
   @param[in] Function     The 32bit code entry to be executed.
-  @param[in] Param1       The first parameter to pass to 32bit code
-  @param[in] Param2       The second parameter to pass to 32bit code
-  @param[in] InternalGdtr The GDT and GDT descriptor used by this library
+  @param[in] Param1       The first parameter to pass to 32bit code.
+  @param[in] Param2       The second parameter to pass to 32bit code.
+  @param[in] ExeInMem     If thunk needs to be executed from memory copy.
 
-  @return status.
+  @return Status.         Status returned from the calling function.
 **/
 UINT32
 EFIAPI

--- a/BootloaderCommonPkg/Library/ThunkLib/X64/Thunk64To32.nasm
+++ b/BootloaderCommonPkg/Library/ThunkLib/X64/Thunk64To32.nasm
@@ -130,6 +130,13 @@ Compatible:
     btc     eax, 8
     wrmsr
 
+    ;
+    ; clear CR4 PAE
+    ;
+    mov     rax, cr4
+    btc     eax, 5
+    mov     cr4, rax
+
 ; Now we are in protected mode
     ;
     ; Call 32-bit function. Assume the function entry address and parameter value is less than 4G
@@ -146,7 +153,7 @@ ReturnBack:
     pop   rcx                  ; drop param2
 
     ;
-    ; restore CR4
+    ; restore CR4 PAE
     ;
     mov     rax, cr4
     bts     eax, 5

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -119,7 +119,7 @@
   IoMmuLib|BootloaderCommonPkg/Library/IoMmuLib/IoMmuLib.inf
   MtrrLib|BootloaderCommonPkg/Library/MtrrLib/MtrrLib.inf
   StringSupportLib|BootloaderCommonPkg/Library/StringSupportLib/StringSupportLib.inf
-
+  ThunkLib|BootloaderCommonPkg/Library/ThunkLib/ThunkLib.inf
 
 !if $(ENABLE_SOURCE_DEBUG)
   DebugAgentLib|BootloaderCommonPkg/Library/DebugAgentLib/DebugAgentLib.inf

--- a/BootloaderCorePkg/Library/FspApiLib/FspApiLibInternal.h
+++ b/BootloaderCorePkg/Library/FspApiLib/FspApiLibInternal.h
@@ -15,6 +15,7 @@
 #include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/BootloaderCommonLib.h>
+#include <Library/ThunkLib.h>
 
 /**
   Switch to new stack and then call specified function with arguments.
@@ -33,26 +34,6 @@ FspmSwitchStack (
   IN VOID        *Context1,   OPTIONAL
   IN VOID        *Context2,   OPTIONAL
   IN VOID        *NewStack
-  );
-
-/**
-  Wrapper for a thunk  to transition from long mode to compatibility mode to execute 32-bit code and then transit back to
-  long mode.
-
-  @param[in] Function     The 32bit code entry to be executed.
-  @param[in] Param1       The first parameter to pass to 32bit code.
-  @param[in] Param2       The second parameter to pass to 32bit code.
-  @param[in] ExeInMem     If thunk needs to be executed from memory copy.
-
-  @return EFI_STATUS.
-**/
-EFI_STATUS
-EFIAPI
-Execute32BitCode (
-  IN UINT64      Function,
-  IN UINT64      Param1,
-  IN UINT64      Param2,
-  IN BOOLEAN     ExeInMem
   );
 
 #endif

--- a/BootloaderCorePkg/Library/FspApiLib/FspmApiLib.inf
+++ b/BootloaderCorePkg/Library/FspApiLib/FspmApiLib.inf
@@ -21,12 +21,9 @@
 #
 
 [Sources.X64]
-  X64/DispatchExecute.c
-  X64/Thunk64To32.nasm
   X64/FspSwitchStack.nasm
 
 [Sources.IA32]
-  Ia32/DispatchExecute.c
   Ia32/FspSwitchStack.nasm
 
 [Sources]
@@ -46,6 +43,7 @@
   DebugLib
   BaseMemoryLib
   ResetSystemLib
+  ThunkLib
 
 [Pcd]
   gPlatformModuleTokenSpaceGuid.PcdFSPMBase

--- a/BootloaderCorePkg/Library/FspApiLib/FspsApiLib.inf
+++ b/BootloaderCorePkg/Library/FspApiLib/FspsApiLib.inf
@@ -20,13 +20,6 @@
 #  VALID_ARCHITECTURES           = IA32 X64 IPF EBC
 #
 
-[Sources.X64]
-  X64/DispatchExecute.c
-  X64/Thunk64To32.nasm
-
-[Sources.IA32]
-  Ia32/DispatchExecute.c
-
 [Sources]
   FspApiLibInternal.h
   FspSiliconInit.c
@@ -44,6 +37,7 @@
   DebugLib
   BaseMemoryLib
   ResetSystemLib
+  ThunkLib
 
 [Pcd]
   gPlatformModuleTokenSpaceGuid.PcdFSPSBase


### PR DESCRIPTION
During X64 enabling, there was a pending task to enable 32bit
MultiBoot support. It is not implemented.  This patch added the
support to allow X64 SBL to boot a 32bit MB image through thunking.
As part of this patch, the ThunkLib is separated from the FspApiLib
so that it can be shared by other component.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>