### PR TITLE
[CFL] Fix the ucode checkout issue

### DIFF
--- a/BootloaderCorePkg/Tools/PrepareBuildComponentBin.py
+++ b/BootloaderCorePkg/Tools/PrepareBuildComponentBin.py
@@ -30,7 +30,7 @@ def CloneRepo (clone_dir, driver_inf):
         print ('Done\n')
     else:
         print ('Update the repo ...')
-        cmd = 'git fetch origin master'
+        cmd = 'git fetch origin'
         ret = subprocess.call(cmd.split(' '), cwd=clone_dir)
         if ret:
             Fatal ('Failed to update repo in directory %s !' % clone_dir)


### PR DESCRIPTION
This will fix the ucode repo checkout issue on 'cfl' target.

FYI, here are simple steps to reproduce.
1) Build 'apl' target first
2) Build 'cfl' target -> fails to checkout ucode repo

Signed-off-by: Aiden Park <aiden.park@intel.com>