### PR TITLE
Enable mixed payload mode calling

### DIFF
--- a/BootloaderCommonPkg/Include/Library/LiteFvLib.h
+++ b/BootloaderCommonPkg/Include/Library/LiteFvLib.h
@@ -34,6 +34,7 @@ IsValidFvHeader (
   @param[in]  FvBase                   Point to the boot firmware volume.
   @param[in]  FvLength                 The actural length of FV.
   @param[out] EntryPoint               The pointer to receive SecCore entry point.
+  @param[out] Machine                  The pointer to receive machine type.
 
   @retval RETURN_SUCCESS               The FV is loaded successfully.
   @retval Others                       Failed to load the FV.
@@ -43,7 +44,8 @@ EFIAPI
 LoadFvImage (
   IN  UINT32                            *FvBase,
   IN  UINT32                             FvLength,
-  OUT VOID                             **EntryPoint
+  OUT VOID                             **EntryPoint,
+  OUT UINT16                            *Machine  OPTIONAL
   );
 
 /**

--- a/BootloaderCommonPkg/Include/Library/LitePeCoffLib.h
+++ b/BootloaderCommonPkg/Include/Library/LitePeCoffLib.h
@@ -89,4 +89,23 @@ PeCoffGetPreferredBase (
   OUT UINT32                           *Base       OPTIONAL
   );
 
+/**
+  Extract and return the machine type from the PE/COFF image.
+
+  @param  Pe32Data                  The pointer to the PE/COFF image that is loaded in system memory.
+  @param  MachinePtr                The pointer to machine type to return.
+
+  @retval RETURN_SUCCESS            Machine was returned successfully.
+  @retval RETURN_UNSUPPORTED        Unsupported image format.
+  @retval RETURN_INVALID_PARAMETER  The Pe32Data pointer is NULL.
+
+**/
+RETURN_STATUS
+EFIAPI
+PeCoffLoaderGetMachine (
+  IN  VOID     *Pe32Data,
+  OUT UINT16   *MachinePtr      OPTIONAL
+  );
+
 #endif
+

--- a/BootloaderCommonPkg/Include/Library/ThunkLib.h
+++ b/BootloaderCommonPkg/Include/Library/ThunkLib.h
@@ -32,4 +32,25 @@ Execute32BitCode (
   IN BOOLEAN     ExeInMem
   );
 
+/**
+  Jump into funciton in X64 mode.
+  This function will not return.
+
+  @param[in] Function     The 32bit code entry to be executed.
+  @param[in] Param1       The first parameter to pass to 32bit code.
+  @param[in] Param2       The second parameter to pass to 32bit code.
+  @param[in] ExeInMem     If thunk needs to be executed from memory copy.
+
+  @return EFI_SUCCESS.
+**/
+EFI_STATUS
+EFIAPI
+Execute64BitCode (
+  IN UINT64      Function,
+  IN UINT64      Param1,
+  IN UINT64      Param2,
+  IN BOOLEAN     ExeInMem
+  );
+
+
 #endif

--- a/BootloaderCommonPkg/Library/LiteFvLib/FvLib.c
+++ b/BootloaderCommonPkg/Library/LiteFvLib/FvLib.c
@@ -289,6 +289,7 @@ GetSectionByType (
   @param[in]  FvBase                   Point to the boot firmware volume.
   @param[in]  FvLength                 The actural length of FV.
   @param[out] EntryPoint               The pointer to receive SecCore entry point.
+  @param[out] Machine                  The pointer to receive machine type.
 
   @retval RETURN_SUCCESS               The FV is loaded successfully.
   @retval Others                       Failed to load the FV.
@@ -298,7 +299,8 @@ EFIAPI
 LoadFvImage (
   IN  UINT32                            *FvBase,
   IN  UINT32                             FvLength,
-  OUT VOID                             **EntryPoint
+  OUT VOID                             **EntryPoint,
+  OUT UINT16                            *Machine   OPTIONAL
   )
 {
   EFI_STATUS                            Status;
@@ -340,7 +342,11 @@ LoadFvImage (
     SecCoreImageBase += Gap;
   }
 
-  Status = PeCoffLoaderGetEntryPoint ((VOID *)(UINTN)SecCoreImageBase, EntryPoint);
+  Status = PeCoffLoaderGetMachine ((VOID *)(UINTN)SecCoreImageBase, Machine);
+  if (EFI_ERROR(Status)) {
+    return Status;
+  }
 
+  Status = PeCoffLoaderGetEntryPoint ((VOID *)(UINTN)SecCoreImageBase, EntryPoint);
   return Status;
 }

--- a/BootloaderCommonPkg/Library/LitePeCoffLib/LitePeCoffLib.c
+++ b/BootloaderCommonPkg/Library/LitePeCoffLib/LitePeCoffLib.c
@@ -320,3 +320,50 @@ PeCoffGetPreferredBase (
 
   return RETURN_SUCCESS;
 }
+
+/**
+  Extract and return the machine type from the PE/COFF image.
+
+  @param  Pe32Data                  The pointer to the PE/COFF image that is loaded in system memory.
+  @param  MachinePtr                The pointer to machine type to return.
+
+  @retval RETURN_SUCCESS            Machine was returned successfully.
+  @retval RETURN_UNSUPPORTED        Unsupported image format.
+  @retval RETURN_INVALID_PARAMETER  The Pe32Data pointer is NULL.
+
+**/
+RETURN_STATUS
+EFIAPI
+PeCoffLoaderGetMachine (
+  IN  VOID     *Pe32Data,
+  OUT UINT16   *MachinePtr      OPTIONAL
+  )
+{
+  EFI_IMAGE_OPTIONAL_HEADER_PTR_UNION   Hdr;
+  UINT16                                Machine;
+
+  if (Pe32Data == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  Machine = 0;
+  if (IsTePe32Image (Pe32Data, &Hdr)) {
+    if (Hdr.Te->Signature == EFI_TE_IMAGE_HEADER_SIGNATURE) {
+      Machine = Hdr.Te->Machine;
+    }
+
+    if (Hdr.Te->Signature == EFI_IMAGE_NT_SIGNATURE) {
+      Machine = Hdr.Pe32->FileHeader.Machine;
+    }
+  }
+
+  if (Machine == 0) {
+    return RETURN_UNSUPPORTED;
+  }
+
+  if (MachinePtr != NULL) {
+    *MachinePtr = Machine;
+  }
+
+  return RETURN_SUCCESS;
+}

--- a/BootloaderCommonPkg/Library/ThunkLib/Ia32/DispatchExecute.c
+++ b/BootloaderCommonPkg/Library/ThunkLib/Ia32/DispatchExecute.c
@@ -10,6 +10,7 @@
 
 #include <PiPei.h>
 #include <Library/BaseLib.h>
+#include <Library/PagingLib.h>
 
 typedef EFI_STATUS (EFIAPI *EXECUTE_32BIT_CODE) (UINT64 Param1, UINT64 Param2);
 
@@ -40,5 +41,36 @@ Execute32BitCode (
   Status = Func (Param1, Param2);
 
   return Status;
+}
+
+/**
+  Jump into funciton in X64 mode.
+  This function will not return.
+
+  @param[in] Function     The 32bit code entry to be executed.
+  @param[in] Param1       The first parameter to pass to 32bit code.
+  @param[in] Param2       The second parameter to pass to 32bit code.
+  @param[in] ExeInMem     If thunk needs to be executed from memory copy.
+
+  @return EFI_SUCCESS     Dummy return value.
+**/
+EFI_STATUS
+EFIAPI
+Execute64BitCode (
+  IN UINT64      Function,
+  IN UINT64      Param1,
+  IN UINT64      Param2,
+  IN BOOLEAN     ExeInMem
+  )
+{
+  UINTN          NewStack;
+
+  NewStack = 0;
+  JumpToLongMode ((UINT64)(UINTN)Function,
+                  (UINT64)(UINTN)Param1,
+                  (UINT64)(UINTN)Param2,
+                  (UINT64)(UINTN)&NewStack);
+
+  return EFI_SUCCESS;
 }
 

--- a/BootloaderCommonPkg/Library/ThunkLib/X64/DispatchExecute.c
+++ b/BootloaderCommonPkg/Library/ThunkLib/X64/DispatchExecute.c
@@ -13,6 +13,8 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/BlMemoryAllocationLib.h>
 
+typedef EFI_STATUS (EFIAPI *EXECUTE_64BIT_CODE) (UINT64 Param1, UINT64 Param2);
+
 #pragma pack(1)
 typedef union {
   struct {
@@ -117,6 +119,35 @@ Execute32BitCode (
   AsmWriteIdtr (&IdtrNul);
   Status = ExecuteCode (Function, Param1, Param2, &Gdtr);
   AsmWriteIdtr (&Idtr);
+
+  return Status;
+}
+
+
+/**
+  Call into funciton in X64 mode.
+
+  @param[in] Function     The 32bit code entry to be executed.
+  @param[in] Param1       The first parameter to pass to 32bit code.
+  @param[in] Param2       The second parameter to pass to 32bit code.
+  @param[in] ExeInMem     If thunk needs to be executed from memory copy.
+
+  @return EFI_STATUS.
+**/
+EFI_STATUS
+EFIAPI
+Execute64BitCode (
+  IN UINT64      Function,
+  IN UINT64      Param1,
+  IN UINT64      Param2,
+  IN BOOLEAN     ExeInMem
+  )
+{
+  EFI_STATUS            Status;
+  EXECUTE_64BIT_CODE    Func;
+
+  Func   = (EXECUTE_64BIT_CODE)(UINTN)Function;
+  Status = Func (Param1, Param2);
 
   return Status;
 }

--- a/BootloaderCorePkg/Stage2/Stage2.h
+++ b/BootloaderCorePkg/Stage2/Stage2.h
@@ -38,6 +38,7 @@
 #include <Library/LiteFvLib.h>
 #include <Library/SortLib.h>
 #include <Library/StageLib.h>
+#include <Library/ThunkLib.h>
 #include <Library/ContainerLib.h>
 #include <Guid/BootLoaderServiceGuid.h>
 #include <Guid/BootLoaderVersionGuid.h>

--- a/BootloaderCorePkg/Stage2/Stage2.inf
+++ b/BootloaderCorePkg/Stage2/Stage2.inf
@@ -66,6 +66,7 @@
   LinuxLib
   SortLib
   StageLib
+  ThunkLib
 
 [Guids]
   gFspReservedMemoryResourceHobGuid

--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -377,6 +377,7 @@ SetupBootImage (
   IMAGE_DATA                *BootFile;
   LINUX_IMAGE               *LinuxImage;
   UINT32                     Size;
+  UINT16                     Machine;
 
   //
   // Allocate a cmd line buffer and init it with config file or default value
@@ -432,7 +433,7 @@ SetupBootImage (
     }
   } else if ((LoadedImage->Flags & LOADED_IMAGE_FV) != 0) {
     DEBUG ((DEBUG_INFO, "Boot image is FV format\n"));
-    Status = LoadFvImage ((UINT32 *)BootFile->Addr, BootFile->Size, (VOID **)&EntryPoint);
+    Status = LoadFvImage ((UINT32 *)BootFile->Addr, BootFile->Size, (VOID **)&EntryPoint, &Machine);
     if (!EFI_ERROR (Status)) {
       // Reuse MultiBoot structure to store the FV entry point information
       MultiBoot->BootState.EntryPoint = (UINT32)(UINTN)EntryPoint;


### PR DESCRIPTION
Since SBL could be built into either x86 or x64 mode, and the payload
can also be x86 or x64 mode. When mixed modes are used, it is required
to switch to proper mode first before calling into payload entrypoint.
This patch added this check to switch to required mode before calling
into payload entry point.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>