### PR TITLE
[QEMU] Fix NOOPT build failure

### DIFF
--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/owncp.h
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/owncp.h
@@ -91,11 +91,19 @@ typedef int cpSize;
 
 /* WORD and DWORD manipulators */
 #define IPP_LODWORD(x)    ((Ipp32u)(x))
-#define IPP_HIDWORD(x)    ((Ipp32u)(((Ipp64u)(x) >>32) & 0xFFFFFFFF))
+#if defined(_SLIMBOOT_OPT)
+  #define IPP_HIDWORD(x)    ((Ipp32u)((RShiftU64(x, 32)) & 0xFFFFFFFF))
+#else
+  #define IPP_HIDWORD(x)    ((Ipp32u)(((Ipp64u)(x) >>32) & 0xFFFFFFFF))
+#endif
 
 #define IPP_MAKEHWORD(bLo,bHi) ((Ipp16u)(((Ipp8u)(bLo))  | ((Ipp16u)((Ipp8u)(bHi))) << 8))
 #define IPP_MAKEWORD(hLo,hHi)  ((Ipp32u)(((Ipp16u)(hLo)) | ((Ipp32u)((Ipp16u)(hHi))) << 16))
-#define IPP_MAKEDWORD(wLo,wHi) ((Ipp64u)(((Ipp32u)(wLo)) | ((Ipp64u)((Ipp32u)(wHi))) << 32))
+#if defined(_SLIMBOOT_OPT)
+  #define IPP_MAKEDWORD(wLo,wHi) ((Ipp64u)(((Ipp32u)(wLo)) | LShiftU64 (wHi, 32)))
+#else
+  #define IPP_MAKEDWORD(wLo,wHi) ((Ipp64u)(((Ipp32u)(wLo)) | ((Ipp64u)((Ipp32u)(wHi))) << 32))
+#endif
 
 /* extract byte */
 #define EBYTE(w,n) ((Ipp8u)((w) >> (8 * (n))))

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpsha256ca.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpsha256ca.c
@@ -236,7 +236,12 @@ void sha224_hashOctString(Ipp8u* pMD, void* pHashVal)
 void sha256_msgRep(Ipp8u* pDst, Ipp64u lenLo, Ipp64u lenHi)
 {
    IPP_UNREFERENCED_PARAMETER(lenHi);
+#ifdef _SLIMBOOT_OPT
+   lenLo = ENDIANNESS64(LShiftU64 (lenLo, 3));
+#else
    lenLo = ENDIANNESS64(lenLo<<3);
+#endif
+
    ((Ipp64u*)(pDst))[0] = lenLo;
 }
 
@@ -556,7 +561,11 @@ static void cpFinalizeSHA256(DigestSHA256 pHash, const Ipp8u* inpBuffer, int inp
    PadBlock(0, buffer+inpLen, (cpSize)(bufferLen-inpLen-(int)MLR_SHA256));
 
    /* put processed message length in bits */
+#ifdef _SLIMBOOT_OPT
+   processedMsgLen = ENDIANNESS64(LShiftU64 (processedMsgLen, 3));
+#else
    processedMsgLen = ENDIANNESS64(processedMsgLen<<3);
+#endif
    ((Ipp64u*)(buffer+bufferLen))[-1] = processedMsgLen;
 
    /* copmplete hash computation */

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpsm3ca.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpsm3ca.c
@@ -85,7 +85,11 @@ static void sm3_hashOctString(Ipp8u* pMD, void* pHashVal)
 static void sm3_msgRep(Ipp8u* pDst, Ipp64u lenLo, Ipp64u lenHi)
 {
    IPP_UNREFERENCED_PARAMETER(lenHi);
+#ifdef _SLIMBOOT_OPT
+   lenLo = ENDIANNESS64(LShiftU64 (lenLo, 3));
+#else
    lenLo = ENDIANNESS64(lenLo<<3);
+#endif
    ((Ipp64u*)(pDst))[0] = lenLo;
 }
 
@@ -110,7 +114,11 @@ void cpFinalizeSM3(DigestSHA1 pHash, const Ipp8u* inpBuffer, int inpLen, Ipp64u 
    PadBlock(0, buffer+inpLen, (cpSize)(bufferLen-inpLen-(int)MLR_SM3));
 
    /* put processed message length in bits */
+#ifdef _SLIMBOOT_OPT
+   processedMsgLen = ENDIANNESS64(LShiftU64 (processedMsgLen, 3));
+#else
    processedMsgLen = ENDIANNESS64(processedMsgLen<<3);
+#endif
    ((Ipp64u*)(buffer+bufferLen))[-1] = processedMsgLen;
 
    /* copmplete hash computation */

--- a/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressPassthru.c
+++ b/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressPassthru.c
@@ -619,7 +619,7 @@ NvmExpressPassThru (
 
   // Wait for completion queue to get filled in. 100ns unit by EFI spec
   //
-  TimeCount = (Packet->CommandTimeout) >> 7; //times = 128ns unit
+  TimeCount = RShiftU64 (Packet->CommandTimeout, 7); //times = 128ns unit
   Status = EFI_TIMEOUT;
   while ((TimeCount--) != 0 ) {
     if (Cq->Pt != Private->Pt[QueueId]) {

--- a/BootloaderCommonPkg/Library/ShellLib/CmdPerf.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdPerf.c
@@ -59,7 +59,7 @@ PrintPerformanceInfo (
   ShellPrint (L"------+------------+------------\n");
   for (Idx = 0; Idx < PerfData->Count; Idx++) {
     Tsc  = PerfData->TimeStamp[Idx] & 0x0000FFFFFFFFFFFFULL;
-    Id   = (PerfData->TimeStamp[Idx] >> 48) & 0xFFFF;
+    Id   = (RShiftU64 (PerfData->TimeStamp[Idx], 48)) & 0xFFFF;
     Time = (UINT32)DivU64x32 (Tsc, PerfData->Frequency);
     ShellPrint (L" %4x | %7d ms | %7d ms\n", Id, Time, Time - PrevTime);
     PrevTime = Time;

--- a/BootloaderCommonPkg/Library/TimeStampLib/TimeStampLib.c
+++ b/BootloaderCommonPkg/Library/TimeStampLib/TimeStampLib.c
@@ -36,7 +36,7 @@ GetTimeStampFrequency (
 {
   UINT8  Ratio;
 
-  Ratio = (UINT8)(AsmReadMsr64 (0xCE) >> 8);
+  Ratio = (UINT8)((UINT32)AsmReadMsr64 (0xCE) >> 8);
   if (Ratio == 0) {
     // This might be QEMU case
     Ratio = 8;

--- a/BootloaderCorePkg/Library/DebugDataLib/DebugDataLib.c
+++ b/BootloaderCorePkg/Library/DebugDataLib/DebugDataLib.c
@@ -108,18 +108,14 @@ S3DebugCalculateCRC32 (
   UINT32                      CrcRegionIdx;
 
   CrcRegionIdx = *S3CrcRegionIdx;
-  if ( CrcRegionIdx >= (S3CrcTableSize / sizeof (S3_CRC_DATA)) ) {
+  if ( CrcRegionIdx >= DivU64x32 (S3CrcTableSize, sizeof (S3_CRC_DATA)) ) {
     DEBUG ((DEBUG_INFO, "S3CrcTable to over-flow! Returning\n"));
     return;
   }
 
   SubRegionBase = (UINT32)MemoryMapEntry->Base;
   SubRegionSize = S3_DEBUG_CRC32_REGION_SIZE;
-  if (MemoryMapEntry->Size % S3_DEBUG_CRC32_REGION_SIZE == 0) {
-    SubRegionCount = (UINT32) (MemoryMapEntry->Size / S3_DEBUG_CRC32_REGION_SIZE);
-  } else {
-    SubRegionCount = (UINT32) ((MemoryMapEntry->Size / S3_DEBUG_CRC32_REGION_SIZE) + 1);
-  }
+  SubRegionCount = (UINT32) DivU64x32 (MemoryMapEntry->Size + S3_DEBUG_CRC32_REGION_SIZE - 1, S3_DEBUG_CRC32_REGION_SIZE);
 
   for (SubRegionIndex = 0; SubRegionIndex < SubRegionCount; SubRegionIndex++) {
     S3CrcTable[CrcRegionIdx].RegionBase   = SubRegionBase;

--- a/PayloadPkg/OsLoader/BootParameters.c
+++ b/PayloadPkg/OsLoader/BootParameters.c
@@ -101,8 +101,9 @@ UpdateOsMemSize (
   }
 
   if ((MemLowerSize != 0) || (MemUpperSize != 0)) {
-    MbInfo->MemLower = (UINT32) (MemLowerSize / KB_ (1));
-    MbInfo->MemUpper = (UINT32) (MemUpperSize / KB_ (1));
+    // Convert to KB in size
+    MbInfo->MemLower = (UINT32) (RShiftU64 (MemLowerSize, 10));
+    MbInfo->MemUpper = (UINT32) (RShiftU64 (MemUpperSize, 10));
     MbInfo->Flags   |= MULTIBOOT_INFO_HAS_MEMORY;
   }
 

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -139,9 +139,9 @@ class Board(BaseBoard):
         if not self.STAGE1B_XIP:
             # For Stage1B, it can be compressed if STAGE1B_XIP is 0
             # If so, STAGE1B_FD_BASE/STAGE1B_FD_SIZE need to be defined
-            self.STAGE1B_FD_SIZE    = 0x30000
+            self.STAGE1B_FD_SIZE      = 0x30000
             if self.NO_OPT_MODE:
-                self.STAGE1B_FD_SIZE += 0x2000
+                self.STAGE1B_FD_SIZE += 0xE000
             self.STAGE1B_FD_BASE    = FREE_TEMP_RAM_TOP - self.STAGE1B_FD_SIZE
 
         # For Stage2, it is always compressed.
@@ -150,7 +150,10 @@ class Board(BaseBoard):
         self.STAGE2_FD_SIZE       = 0x00060000
 
         if self.NO_OPT_MODE:
-            self.OS_LOADER_FD_SIZE   += 0x00010000
+            self.STAGE2_SIZE         += 0x2000
+            self.PAYLOAD_SIZE        += 0xA000
+            self.OS_LOADER_FD_SIZE   += 0x22000
+            self.FWUPDATE_SIZE       += 0x8000
             self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.STAGE1_STACK_SIZE    = 0x00002000


### PR DESCRIPTION
This patch fixed NOOPT build failure for QEMU.
It fixed #871.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>