### PR TITLE
Fix permission check during Spi access

### DIFF
--- a/Silicon/CommonSocPkg/Library/SpiFlashLib/SpiFlashLib.c
+++ b/Silicon/CommonSocPkg/Library/SpiFlashLib/SpiFlashLib.c
@@ -656,7 +656,7 @@ SendSpiCmd (
       if (FlashCycleType == FlashCycleRead) {
         PermissionBit = B_SPI_FRAP_BRRA_FLASHD;
       } else {
-        PermissionBit = B_SPI_FRAP_BRRA_FLASHD;
+        PermissionBit = B_SPI_FRAP_BRWA_FLASHD;
       }
       HardwareSpiAddr += (MmioRead32 (ScSpiBar0 + R_SPI_FREG0_FLASHD) &
                           B_SPI_FREG0_BASE_MASK) << N_SPI_FREG0_BASE;
@@ -667,7 +667,7 @@ SendSpiCmd (
       if (FlashCycleType == FlashCycleRead) {
         PermissionBit = B_SPI_FRAP_BRRA_BIOS;
       } else {
-        PermissionBit = B_SPI_FRAP_BRRA_BIOS;
+        PermissionBit = B_SPI_FRAP_BRWA_BIOS;
       }
       HardwareSpiAddr += (MmioRead32 (ScSpiBar0 + R_SPI_FREG1_BIOS) &
                           B_SPI_FREG1_BASE_MASK) << N_SPI_FREG1_BASE;


### PR DESCRIPTION
Check for Write access permission during
Write/Erase Flash cycles for BIOS/FLAHD regions.

Signed-off-by: Sai Talamudupula <sai.kiran.talamudupula@intel.com>