### PR TITLE
[APL] Fix compiler intrinsics link error for NOOPT build

### DIFF
--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1121,7 +1121,7 @@ UpdateFspConfig (
     PciBase  = (UINT32)PcdGet64(PcdPciExpressBaseAddress);
     Stepping = MmioRead8 (PciBase + 8);
     Value64  = AsmReadMsr64 (MSR_IA32_PLATFORM_ID);
-    PlatformId = (Value64 >> 50) & 7;
+    PlatformId = RShiftU64 (Value64, 50) & 7;
     if (Stepping <= 0xB && PlatformId == 0) {
       FspsConfig->IpuEn   = 0;
     }

--- a/Silicon/ApollolakePkg/Library/GpioLib/GpioLib.c
+++ b/Silicon/ApollolakePkg/Library/GpioLib/GpioLib.c
@@ -292,9 +292,9 @@ ConfigureDirectIrqWakeEvent (
 
   // program Event Trigger Mapping
   d64 = (LShiftU64((UINT64)GpioRead(Community, EVMAP_0 + 4), 32)) | GpioRead(Community, EVMAP_0);
-  d64 |= LShiftU64((UINT64)Index / EVENT_MUX_SIZE, ((Index % EVENT_MUX_SIZE) << 2));
+  d64 |= LShiftU64((UINT64)(Index / EVENT_MUX_SIZE), ((Index % EVENT_MUX_SIZE) << 2));
   GpioWrite(Community, EVMAP_0, (UINT32)(d64 & 0xFFFFFFFF));
-  GpioWrite(Community, EVMAP_0 + 4, (UINT32)(d64 >> 32));
+  GpioWrite(Community, EVMAP_0 + 4, (UINT32)(RShiftU64 (d64, 32)));
 
   // program Event Trigger Output Enable
   d32 = GpioRead(Community, EVOUTEN_0);

--- a/Silicon/ApollolakePkg/Library/SocInfoLib/SocInfoLib.c
+++ b/Silicon/ApollolakePkg/Library/SocInfoLib/SocInfoLib.c
@@ -60,7 +60,7 @@ GetCpuMaxNbFrequency (
 {
   UINT64 MsrValue;
   MsrValue = AsmReadMsr64 (MSR_PLATFORM_INFO);
-  return (100 * ((MsrValue >> 8) & 0xff));
+  return (100 * (((UINT32)MsrValue >> 8) & 0xff));
 }
 
 /**
@@ -96,7 +96,7 @@ GetCpuUCodeRev (
   AsmWriteMsr64 (MSR_IA32_BIOS_SIGN_ID, 0LL);
   AsmCpuid (0, NULL, NULL, NULL, NULL);
   MsrValue = AsmReadMsr64 (MSR_IA32_BIOS_SIGN_ID);
-  UcodeRev = (MsrValue >> 32) & 0xffffffff;
+  UcodeRev = RShiftU64 (MsrValue, 32) & 0xffffffff;
 
   return UcodeRev;
 }
@@ -124,7 +124,7 @@ GetPchDeviceName (
   PciBase = (UINT32)PcdGet64(PcdPciExpressBaseAddress);
   Stepping = MmioRead8 (PciBase + 8);
   MsrValue = AsmReadMsr64 (MSR_IA32_PLATFORM_ID);
-  PlatformId = (MsrValue >> 50) & 7;
+  PlatformId = RShiftU64 (MsrValue, 50) & 7;
 
   //
   // Lookup silicon stepping in the dictionary
@@ -160,7 +160,7 @@ GetPchSteppingName (
   PciBase = (UINT32)PcdGet64(PcdPciExpressBaseAddress);
   Stepping = MmioRead8 (PciBase + 8);
   MsrValue = AsmReadMsr64 (0x17);
-  PlatformId = (MsrValue >> 50) & 7;
+  PlatformId = RShiftU64 (MsrValue, 50) & 7;
 
   //
   // Lookup silicon stepping in the dictionary


### PR DESCRIPTION
This patch fixed link error for APL NOOPT build due to compiler
intrinsics functions. However, due to APL hardware requirements,
it is not feasible to fit NOOPT build into real flash. This
patch will not fix the NOOPT build error caused by code size issue.

For example, the following error might still occur for APL NOOPT
build:
  Invalid the required fv image size 0xe3b0 exceeds the set fv image
  size 0x6000
The APL SOC requires Stage1A to fit into 32KB. Since FSP-T will take
8KB, it only gives 24KB for SBL Stage1A code. NOOPT build will create
about 56KB for Stage1A, and it is impossible to fit into the layout.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>