### PR TITLE
Fix default value change issue in ConfigEditor

### DIFF
--- a/BootloaderCorePkg/Tools/ConfigEditor.py
+++ b/BootloaderCorePkg/Tools/ConfigEditor.py
@@ -882,6 +882,7 @@ class application(tkinter.Frame):
 
             widget = ttk.Combobox(parent, value=option_list, state="readonly")
             widget.bind("<<ComboboxSelected>>", self.combo_select_changed)
+            widget.unbind_class("TCombobox", "<MouseWheel>")
 
             if current is None:
                 print('WARNING: Value "%s" is an invalid option for "%s" !' %


### PR DESCRIPTION
In ConfigEditor, while scrolling page using mouse middle wheel,
the Combo configuration items will change its default value. It
is because Combo control will bind MouseWheel event by default.
To address it, added code to unbind it explicitly.

It fixed #878.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>