### PR TITLE
Reserve Pcie config space region as a reserved memory

### DIFF
--- a/BootloaderCorePkg/Stage2/Stage2Support.c
+++ b/BootloaderCorePkg/Stage2/Stage2Support.c
@@ -262,6 +262,12 @@ SplitMemroyMap (
     }
   }
 
+  MemoryMapInfo->Entry[NewIdx].Base = PcdGet64 (PcdPciExpressBaseAddress);
+  MemoryMapInfo->Entry[NewIdx].Size = SIZE_256MB;
+  MemoryMapInfo->Entry[NewIdx].Type = MEM_MAP_TYPE_RESERVED;
+  MemoryMapInfo->Entry[NewIdx].Flag = 0;
+  NewIdx++;
+
   MemoryMapInfo->Entry[NewIdx].Base = PcdGet32(PcdFlashBaseAddress);
   MemoryMapInfo->Entry[NewIdx].Size = PcdGet32(PcdFlashSize);
   MemoryMapInfo->Entry[NewIdx].Type = MEM_MAP_TYPE_RESERVED;


### PR DESCRIPTION
This will report pcie config space region as a reserved memory in e820
and let Linux use the PCI MMCONFIG which has bus range information.
If it is not reserved, the pcie config space region will be freed/available
for PCI devices.

Signed-off-by: Aiden Park <aiden.park@intel.com>