### PR TITLE
[CFL] Fix BOM ID detection for Upx platform.

### DIFF
--- a/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -327,7 +327,7 @@ PlatformIdInitialize (
       if (EFI_ERROR(Status)) {
         break;
       }
-      BomId = (BomId << 1) + ((GpioData & BIT1) >> 1);
+      BomId = (BomId << 1) + (GpioData & BIT0);
     }
 
     if (Idx == ARRAY_SIZE(mUpxGpioBomPad)) {


### PR DESCRIPTION
This patch addressed an issue while detecting the
BOM ID for Upx platform which is causing the MRC
to fail.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>