### PR TITLE
Revert "Reserve Pcie config space region as a reserved memory"

### DIFF
--- a/BootloaderCorePkg/Stage2/Stage2Support.c
+++ b/BootloaderCorePkg/Stage2/Stage2Support.c
@@ -262,12 +262,6 @@ SplitMemroyMap (
     }
   }
 
-  MemoryMapInfo->Entry[NewIdx].Base = PcdGet64 (PcdPciExpressBaseAddress);
-  MemoryMapInfo->Entry[NewIdx].Size = SIZE_256MB;
-  MemoryMapInfo->Entry[NewIdx].Type = MEM_MAP_TYPE_RESERVED;
-  MemoryMapInfo->Entry[NewIdx].Flag = 0;
-  NewIdx++;
-
   MemoryMapInfo->Entry[NewIdx].Base = PcdGet32(PcdFlashBaseAddress);
   MemoryMapInfo->Entry[NewIdx].Size = PcdGet32(PcdFlashSize);
   MemoryMapInfo->Entry[NewIdx].Type = MEM_MAP_TYPE_RESERVED;


### PR DESCRIPTION
Reverts slimbootloader/slimbootloader#885

Some platform may have a regression with this PR, so this PR will be reverted
and the PCI config space will be reserved in ACPI table.
