### PR TITLE
Add PCI resource downgrade option for all Bus-0 devices

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -93,21 +93,27 @@
   gPlatformModuleTokenSpaceGuid.PcdOsBootOptionNumber     | 0x00000008 | UINT32 | 0x200000A3
   gPlatformModuleTokenSpaceGuid.PcdServiceNumber          | 0x00000004 | UINT32 | 0x200000A4
 
+  # typedef struct {
+  #   UINT16            Io32      : 1;  // default:1
+  #   UINT16            Mem64     : 1;  // default:1
+  #   UINT16            PMem64    : 1;  // default:1
+  #   UINT16            Bus0      : 1;  // default:1, Downgrade all Io32/Mem64/PMem64 for all Bus-0 devices
+  #   UINT16            Reserved  : 12; // 0 initialized
+  # } PCI_RES_DOWNGRADE;
   #
   # typedef struct {
-  #   UINT8           DowngradeIo32;  // default: 1
-  #   UINT8           DowngradeMem64; // default: 1
-  #   UINT8           DowngradePMem64;// default: 1
-  #   UINT8           Reserved;
-  #   UINT8           BusScanType;    // default:0 (0: list, 1: range)
-  #   UINT8           NumOfBus;       // the number of BusScanItems
-  #   UINT8           BusScanItems[0];
+  #   PCI_RES_DOWNGRADE Downgrade;
+  #   UINT16            Reserved;
+  #   UINT8             BusScanType;    // default:0 (0: list, 1: range)
+  #   UINT8             NumOfBus;       // the number of BusScanItems
+  #   UINT8             BusScanItems[0];
   # } PCI_ENUM_POLICY_INFO;
   #
   # Update BoardConfig.py if necessary
   # self._PCI_ENUM_DOWNGRADE_IO32   = 0
   # self._PCI_ENUM_DOWNGRADE_MEM64  = 0
   # self._PCI_ENUM_DOWNGRADE_PMEM64 = 0
+  # self._PCI_ENUM_DOWNGRADE_BUS0   = 0
   # self._PCI_ENUM_BUS_SCAN_TYPE    = 1
   # self._PCI_ENUM_BUS_SCAN_ITEMS   = '0,0xff'
   gPlatformModuleTokenSpaceGuid.PcdPciEnumPolicyInfo      | {0x00}     | VOID*  | 0x200000A5

--- a/BootloaderCorePkg/Library/PciEnumerationLib/InternalPciEnumerationLib.h
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/InternalPciEnumerationLib.h
@@ -61,13 +61,19 @@ typedef enum {
 } BUS_SCAN_TYPE;
 
 typedef struct {
-  UINT8           DowngradeIo32;
-  UINT8           DowngradeMem64;
-  UINT8           DowngradePMem64;
-  UINT8           Reserved;
-  UINT8           BusScanType;
-  UINT8           NumOfBus;
-  UINT8           BusScanItems[0];
+  UINT16            Io32            : 1;
+  UINT16            Mem64           : 1;
+  UINT16            PMem64          : 1;
+  UINT16            Bus0            : 1;
+  UINT16            Reserved        : 12;
+} PCI_RES_DOWNGRADE;
+
+typedef struct {
+  PCI_RES_DOWNGRADE Downgrade;
+  UINT16            Reserved;
+  UINT8             BusScanType;
+  UINT8             NumOfBus;
+  UINT8             BusScanItems[0];
 } PCI_ENUM_POLICY_INFO;
 
 //

--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -179,22 +179,26 @@ class VariableRegionHeader(Structure):
 class PciEnumPolicyInfo(Structure):
     _pack_ = 1
     _fields_ = [
-        ('DowngradeIo32',   c_uint8),
-        ('DowngradeMem64',  c_uint8),
-        ('DowngradePMem64', c_uint8),
-        ('Reserved',        c_uint8),
-        ('BusScanType',     c_uint8), # 0: list, 1: range
-        ('NumOfBus',        c_uint8),
-        ('BusScanItems',    ARRAY(c_uint8, 0))
+        ('DowngradeIo32',           c_uint16, 1),
+        ('DowngradeMem64',          c_uint16, 1),
+        ('DowngradePMem64',         c_uint16, 1),
+        ('DowngradeBus0',           c_uint16, 1),
+        ('DowngradeReserved',       c_uint16, 12),
+        ('Reserved',                c_uint16),
+        ('BusScanType',             c_uint8), # 0: list, 1: range
+        ('NumOfBus',                c_uint8),
+        ('BusScanItems',            ARRAY(c_uint8, 0))
     ]
 
     def __init__(self):
-        self.DowngradeIo32    = 1
-        self.DowngradeMem64   = 1
-        self.DowngradePMem64  = 1
-        self.Reserved         = 0
-        self.BusScanType      = 0
-        self.NumOfBus         = 0
+        self.DowngradeIo32      = 1
+        self.DowngradeMem64     = 1
+        self.DowngradePMem64    = 1
+        self.DowngradeBus0      = 1
+        self.DowngradeReserved  = 0
+        self.Reserved           = 0
+        self.BusScanType        = 0
+        self.NumOfBus           = 0
 
 def get_visual_studio_info ():
 
@@ -1057,6 +1061,7 @@ def gen_pci_enum_policy_info (policy_dict):
         policy_info.DowngradeIo32   = policy_dict['DOWNGRADE_IO32']
         policy_info.DowngradeMem64  = policy_dict['DOWNGRADE_MEM64']
         policy_info.DowngradePMem64 = policy_dict['DOWNGRADE_PMEM64']
+        policy_info.DowngradeBus0   = policy_dict['DOWNGRADE_BUS0']
         policy_info.BusScanType     = policy_dict['BUS_SCAN_TYPE']
         bus_scan_items              = policy_dict['BUS_SCAN_ITEMS']
 

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -882,7 +882,14 @@ class Build(object):
                 raise Exception ('Diagnostic ACM base[FSP-T+CAR:0x%x] must be 4KB aligned!' % diagnosticacm_base)
 
         # Generate Pci Enum Policy Info
-        pci_enum_policy_list = ['DOWNGRADE_IO32', 'DOWNGRADE_MEM64', 'DOWNGRADE_PMEM64', 'BUS_SCAN_TYPE', 'BUS_SCAN_ITEMS']
+        pci_enum_policy_list = [
+            'DOWNGRADE_IO32',
+            'DOWNGRADE_MEM64',
+            'DOWNGRADE_PMEM64',
+            'DOWNGRADE_BUS0',
+            'BUS_SCAN_TYPE',
+            'BUS_SCAN_ITEMS'
+        ]
         pci_enum_policy_dict = {}
         for policy_list in pci_enum_policy_list:
             policy_name = '_PCI_ENUM_%s' % policy_list


### PR DESCRIPTION
In 64-bit operation, some PCI devices have high mmio BARs,
but 32-bit FSP can only access 32-bit memory space.
This introduces and additional PCI resource downgrade option
to downgrade all PCI devices under Bus-0.
- self._PCI_ENUM_DOWNGRADE_BUS0 = 1
  Force to have 32-bit BAR for all Bus-0 devices

Signed-off-by: Aiden Park <aiden.park@intel.com>