### PR TITLE
DEBUG() macro with a smaller code footprint

### DIFF
--- a/BootloaderCommonPkg/Library/BootloaderDebugLib/DebugLib.c
+++ b/BootloaderCommonPkg/Library/BootloaderDebugLib/DebugLib.c
@@ -57,6 +57,13 @@ DebugPrint (
   ASSERT (Format != NULL);
 
   //
+  // Check that debug print is enabled at all
+  //
+  if (!DebugPrintEnabled ()) {
+    return;
+  }
+
+  //
   // Check driver debug mask value and global mask
   //
   if ((ErrorLevel & GetDebugPrintErrorLevel ()) == 0) {

--- a/MdePkg/Include/Library/DebugLib.h
+++ b/MdePkg/Include/Library/DebugLib.h
@@ -367,12 +367,7 @@ DebugPrintLevelEnabled (
 
 **/
 #if !defined(MDEPKG_NDEBUG)
-  #define DEBUG(Expression)        \
-    do {                           \
-      if (DebugPrintEnabled ()) {  \
-        _DEBUG (Expression);       \
-      }                            \
-    } while (FALSE)
+  #define DEBUG(Expression) DebugPrint Expression
 #else
   #define DEBUG(Expression)
 #endif


### PR DESCRIPTION
The original DEBUG() macro expanded to three function calls. And there
are around 3000 calls of this macro in the SBL code base. So this is
clearly a waste of .text section space and thus FV space. The code
footprint of the original macro forces the use of aggressive compiler
flags to meet the size requirements, flags which hurt the debugging
experience.

The solution is to reduce the DEBUG() macro to a single function call.
This might result in some performance impact (only on debug builds)
because of possible "useless" calls that quickly return, but this
performance impact is negligible compared to the impact of the serial
output. Even more important than that: this smaller DEBUG() paves the
way for less aggressive compiler optimizations which in turn lead to a
better source-level debugging experience.

Signed-off-by: Mircea Gherzan <mircea.gherzan@intel.com>