### PR TITLE
Update Microcode path to support customization

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -415,7 +415,7 @@
 !endif
 
 !if $(UCODE_SIZE) > 0
-  Silicon/$(SILICON_PKG_NAME)/Microcode/Microcode.inf
+  $(MICROCODE_INF_FILE)
 !endif
 
 [BuildOptions.Common.EDKII]

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -322,6 +322,7 @@ class Build(object):
         if self._board.ENABLE_SBL_SETUP:
             self._board.ENABLE_PAYLOD_MODULE = 1
 
+        self._board.MICROCODE_INF_FILE     = os.path.join('Silicon', self._board.SILICON_PKG_NAME, "Microcode", "Microcode.inf")
 
     def board_build_hook (self, phase):
         if getattr(self._board, "PlatformBuildHook", None):


### PR DESCRIPTION
Microcode module locates in different place.
so each platform could specify the path by
MICROCODE_INF_FILE in BoardConfig.py.
By default, it uses the same path if there
is no MICROCODE_INF_FILE defined in platform.

Signed-off-by: Guo Dong <guo.dong@intel.com>