### PR TITLE
Fix MicroCode path

### DIFF
--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -322,7 +322,8 @@ class Build(object):
         if self._board.ENABLE_SBL_SETUP:
             self._board.ENABLE_PAYLOD_MODULE = 1
 
-        self._board.MICROCODE_INF_FILE     = os.path.join('Silicon', self._board.SILICON_PKG_NAME, "Microcode", "Microcode.inf")
+        if not hasattr(self._board, 'MICROCODE_INF_FILE'):
+            self._board.MICROCODE_INF_FILE = os.path.join('Silicon', self._board.SILICON_PKG_NAME, "Microcode", "Microcode.inf")
 
     def board_build_hook (self, phase):
         if getattr(self._board, "PlatformBuildHook", None):


### PR DESCRIPTION
Use the default path only when MICROCODE_INF_FILE
is not defined in platform board. Currently it will
override the one defined in platform.

Signed-off-by: Guo Dong <guo.dong@intel.com>