### PR TITLE
Resolve raw partition boot loading

### DIFF
--- a/PayloadPkg/OsLoader/LoadImage.c
+++ b/PayloadPkg/OsLoader/LoadImage.c
@@ -47,6 +47,7 @@ GetBootImageFromRawPartition (
   LOGICAL_BLOCK_DEVICE       LogicBlkDev;
   UINTN                      AlignedHeaderSize;
   UINTN                      AlignedImageSize;
+  UINTN                      AlignedHeaderBlkCnt;
   UINT32                     BlockSize;
   VOID                      *BlockData;
   EFI_LBA                    LbaAddr;
@@ -182,11 +183,11 @@ GetBootImageFromRawPartition (
     //
     // Read the rest of the IAS image into the buffer
     //
-
+    AlignedHeaderBlkCnt = AlignedHeaderSize / BlockSize;
     if ( BootOption->DevType == OsBootDeviceMemory ) {
-      Address =  LogicBlkDev.StartBlock + LbaAddr + AlignedHeaderSize;
+      Address =  LogicBlkDev.StartBlock + LbaAddr + AlignedHeaderBlkCnt;
     } else {
-      Address =  LbaAddr + AlignedHeaderSize;
+      Address =  LbaAddr + AlignedHeaderBlkCnt;
     }
 
     Status = MediaReadBlocks (


### PR DESCRIPTION
The calculation on where to start reading the
remainder of the boot image from is not being
calculated properly, the aligned header size
is given in bytes instead of in terms of block
size. This patch updates the calculation
accordingly.

Signed-off-by: James Gutbub <james.gutbub@intel.com>