### PR TITLE
IntelFsp2Pkg: Fix FSP binary rebasing issue for PE32+ image

### DIFF
--- a/IntelFsp2Pkg/Tools/SplitFspBin.py
+++ b/IntelFsp2Pkg/Tools/SplitFspBin.py
@@ -677,8 +677,12 @@ class PeTeImage:
         else:
             offset  = self.Offset + self.DosHdr.e_lfanew
             offset += EFI_IMAGE_NT_HEADERS32.OptionalHeader.offset
-            offset += EFI_IMAGE_OPTIONAL_HEADER32.ImageBase.offset
-            size    = EFI_IMAGE_OPTIONAL_HEADER32.ImageBase.size
+            if self.PeHdr.OptionalHeader.PePlusOptHdr.Magic == 0x20b: # PE32+ image
+                offset += EFI_IMAGE_OPTIONAL_HEADER32_PLUS.ImageBase.offset
+                size    = EFI_IMAGE_OPTIONAL_HEADER32_PLUS.ImageBase.size
+            else:
+                offset += EFI_IMAGE_OPTIONAL_HEADER32.ImageBase.offset
+                size    = EFI_IMAGE_OPTIONAL_HEADER32.ImageBase.size
 
         value  = Bytes2Val(fdbin[offset:offset+size]) + delta
         fdbin[offset:offset+size] = Val2Bytes(value, size)


### PR DESCRIPTION
Current FSP rebasing script SplitFspBin.py has support for both
PE32 and PE32+ image formats. However, while updating the ImageBase
field in the image header, it always assumed the ImageBase field is
32bit long. Since PE32+ image format defined ImageBase as 64bit,
the current script will only update the lower 32bit value and leave
the upper 32bit untouched. It does not work well for PE32+ image
that requires update in the upper 32bit ImageBase field. The
expected behavior is to update the full 64bit field. This patch
implemented this fix.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>