### PR TITLE
Allow platform to override SOC or board specific inf files

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -356,8 +356,8 @@
     <LibraryClasses>
       FspApiLib    | BootloaderCorePkg/Library/FspApiLib/FsptApiLib.inf
       BaseMemoryLib| MdePkg/Library/BaseMemoryLibRepStr/BaseMemoryLibRepStr.inf
-      SocInitLib   | Silicon/$(SILICON_PKG_NAME)/Library/Stage1ASocInitLib/Stage1ASocInitLib.inf
-      BoardInitLib | Platform/$(BOARD_PKG_NAME)/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.inf
+      SocInitLib   | $(SOC_INIT_STAGE1A_LIB_INF_FILE)
+      BoardInitLib | $(BRD_INIT_STAGE1A_LIB_INF_FILE)
 !if $(SKIP_STAGE1A_SOURCE_DEBUG)
       DebugAgentLib| BootloaderCommonPkg/Library/DebugAgentLib/DebugAgentLibNull.inf
 !endif
@@ -367,15 +367,15 @@
     <LibraryClasses>
       FspApiLib    | BootloaderCorePkg/Library/FspApiLib/FspmApiLib.inf
       BaseMemoryLib| MdePkg/Library/BaseMemoryLibRepStr/BaseMemoryLibRepStr.inf
-      SocInitLib   | Silicon/$(SILICON_PKG_NAME)/Library/Stage1BSocInitLib/Stage1BSocInitLib.inf
-      BoardInitLib | Platform/$(BOARD_PKG_NAME)/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
+      SocInitLib   | $(SOC_INIT_STAGE1B_LIB_INF_FILE)
+      BoardInitLib | $(BRD_INIT_STAGE1B_LIB_INF_FILE)
   }
 
   BootloaderCorePkg/Stage2/Stage2.inf {
     <LibraryClasses>
       FspApiLib    | BootloaderCorePkg/Library/FspApiLib/FspsApiLib.inf
-      SocInitLib   | Silicon/$(SILICON_PKG_NAME)/Library/Stage2SocInitLib/Stage2SocInitLib.inf
-      BoardInitLib | Platform/$(BOARD_PKG_NAME)/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+      SocInitLib   | $(SOC_INIT_STAGE2_LIB_INF_FILE)
+      BoardInitLib | $(BRD_INIT_STAGE2_LIB_INF_FILE)
   }
 
   PayloadPkg/OsLoader/OsLoader.inf {
@@ -402,7 +402,7 @@
       PayloadSupportLib       | PayloadPkg/Library/PayloadSupportLib/PayloadSupportLib.inf
       BootloaderLib           | PayloadPkg/Library/PayloadLib/PayloadLib.inf
       PlatformHookLib         | PayloadPkg/Library/PlatformHookLib/PlatformHookLib.inf
-      FirmwareUpdateLib       | Silicon/$(SILICON_PKG_NAME)/Library/FirmwareUpdateLib/FirmwareUpdateLib.inf
+      FirmwareUpdateLib       | $(SOC_FWU_LIB_INF_FILE)
   }
 !endif
 
@@ -411,7 +411,7 @@
 !endif
 
 !if $(HAVE_ACPI_TABLE)
-  Platform/$(BOARD_PKG_NAME)/AcpiTables/AcpiTables.inf
+  $(ACPI_TABLE_INF_FILE)
 !endif
 
 !if $(UCODE_SIZE) > 0

--- a/BootloaderCorePkg/BootloaderCorePkg.fdf
+++ b/BootloaderCorePkg/BootloaderCorePkg.fdf
@@ -185,7 +185,7 @@ FV = OsLoader
   INF BootloaderCorePkg/Stage2/Stage2.inf
 
 !if $(HAVE_ACPI_TABLE)
-  INF RuleOverride = ACPITABLE Platform/$(BOARD_PKG_NAME)/AcpiTables/AcpiTables.inf
+  INF RuleOverride = ACPITABLE $(ACPI_TABLE_INF_FILE)
 !endif
 
 !if $(HAVE_VBT_BIN)

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -323,7 +323,22 @@ class Build(object):
             self._board.ENABLE_PAYLOD_MODULE = 1
 
         if not hasattr(self._board, 'MICROCODE_INF_FILE'):
-            self._board.MICROCODE_INF_FILE = os.path.join('Silicon', self._board.SILICON_PKG_NAME, "Microcode", "Microcode.inf")
+            self._board.MICROCODE_INF_FILE  = 'Silicon/%s/Microcode/Microcode.inf' % self._board.SILICON_PKG_NAME
+        if not hasattr(self._board, 'ACPI_TABLE_INF_FILE'):
+            self._board.ACPI_TABLE_INF_FILE = 'Platform/%s/AcpiTables/AcpiTables.inf' % self._board.BOARD_PKG_NAME
+
+        for stage in ['1A', '1B', '2']:
+            soc_inf = 'SOC_INIT_STAGE%s_LIB_INF_FILE' % stage
+            if not hasattr(self._board, soc_inf):
+                soc_init_lib = 'Silicon/%s/Library/Stage%sSocInitLib/Stage%sSocInitLib.inf' % (self._board.SILICON_PKG_NAME, stage, stage)
+                setattr(self._board, 'SOC_INIT_STAGE%s_LIB_INF_FILE' % stage, soc_init_lib)
+            brd_inf = 'BRD_INIT_STAGE%s_LIB_INF_FILE' % stage
+            if not hasattr(self._board, brd_inf):
+                brd_init_lib = 'Platform/%s/Library/Stage%sBoardInitLib/Stage%sBoardInitLib.inf' % (self._board.BOARD_PKG_NAME, stage, stage)
+                setattr(self._board, 'BRD_INIT_STAGE%s_LIB_INF_FILE' % stage, brd_init_lib)
+
+        if not hasattr(self._board, 'SOC_FWU_LIB_INF_FILE'):
+            self._board.SOC_FWU_LIB_INF_FILE = 'Silicon/%s/Library/FirmwareUpdateLib/FirmwareUpdateLib.inf' % self._board.SILICON_PKG_NAME
 
     def board_build_hook (self, phase):
         if getattr(self._board, "PlatformBuildHook", None):


### PR DESCRIPTION
In current SBL BootloaderCorePkg dsc and fdf files, it contains
hard-coded INF file path for SOC or board, such as ACPI INF
file and SOC/Board init library INF file. It makes it hard for
platform to provide its own overriding using different path.
This patch addressed this issue by allowing platform to override
the default paths in BoardConfig.py.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>