### PR TITLE
Add legacy EF segment memory config

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -202,3 +202,4 @@
   gPlatformModuleTokenSpaceGuid.PcdAriSupport             | FALSE      | BOOLEAN | 0x20000211
   gPlatformModuleTokenSpaceGuid.PcdSrIovSupport           | FALSE      | BOOLEAN | 0x20000212
   gPlatformModuleTokenSpaceGuid.PcdEnableSetup            | FALSE      | BOOLEAN | 0x20000213
+  gPlatformModuleTokenSpaceGuid.PcdLegacyEfSegmentEnabled | TRUE       | BOOLEAN | 0x20000214

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -310,6 +310,7 @@
   gPlatformModuleTokenSpaceGuid.PcdLinuxPayloadEnabled    | $(ENABLE_LINUX_PAYLOAD)
   gPlatformCommonLibTokenSpaceGuid.PcdContainerBootEnabled| $(ENABLE_CONTAINER_BOOT)
   gPayloadTokenSpaceGuid.PcdCsmeUpdateEnabled             | $(ENABLE_CSME_UPDATE)
+  gPlatformModuleTokenSpaceGuid.PcdLegacyEfSegmentEnabled | $(ENABLE_LEGACY_EF_SEG)
   gPlatformCommonLibTokenSpaceGuid.PcdEmmcHs400SupportEnabled | $(ENABLE_EMMC_HS400)
   gPlatformCommonLibTokenSpaceGuid.PcdPreOsCheckerEnabled | $(ENABLE_PRE_OS_CHECKER)
   gPlatformCommonLibTokenSpaceGuid.PcdDmaProtectionEnabled | $(ENABLE_DMA_PROTECTION)

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
@@ -676,11 +676,14 @@ AcpiInit (
   Rsdp->ExtendedChecksum = CalculateCheckSum8 ((UINT8 *)Rsdp, Rsdp->Length);
   *AcpiMemBase = (UINT32)(UINTN)Current;
 
+  Status = PcdSet32S (PcdAcpiTablesRsdp, (UINT32)(UINTN)Rsdp);
+
   //
   // Keep a copy at F segment so that non-UEFI OS will find ACPI tables
   //
-  Status = PcdSet32S (PcdAcpiTablesRsdp, (UINT32)(UINTN)Rsdp);
-  CopyMem ((VOID *)0xFFF80, Rsdp, sizeof (RsdpTmp));
+  if (FeaturePcdGet (PcdLegacyEfSegmentEnabled)) {
+    CopyMem ((VOID *)0xFFF80, Rsdp, sizeof (RsdpTmp));
+  }
 
   // Update ACPI update service so that payload can have opportunity to update ACPI tables
   PlatformService = (PLATFORM_SERVICE *) GetServiceBySignature (PLATFORM_SERVICE_SIGNATURE);

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
@@ -56,3 +56,4 @@
   gPlatformModuleTokenSpaceGuid.PcdAcpiGnvsAddress
   gPlatformModuleTokenSpaceGuid.PcdLoaderAcpiReclaimSize
   gPlatformCommonLibTokenSpaceGuid.PcdLowestSupportedFwVer
+  gPlatformModuleTokenSpaceGuid.PcdLegacyEfSegmentEnabled

--- a/BootloaderCorePkg/Library/SmbiosInitLib/SmbiosInitLib.c
+++ b/BootloaderCorePkg/Library/SmbiosInitLib/SmbiosInitLib.c
@@ -186,7 +186,9 @@ FinalizeSmbios (
   //
   // Keep a copy in legacy F segment so that non-UEFI can locate it
   //
-  CopyMem ((VOID *)0xFFF60, SmbiosEntry, sizeof (SMBIOS_TABLE_ENTRY_POINT));
+  if (FeaturePcdGet (PcdLegacyEfSegmentEnabled)) {
+    CopyMem ((VOID *)0xFFF60, SmbiosEntry, sizeof (SMBIOS_TABLE_ENTRY_POINT));
+  }
 
   return Status;
 }

--- a/BootloaderCorePkg/Library/SmbiosInitLib/SmbiosInitLib.inf
+++ b/BootloaderCorePkg/Library/SmbiosInitLib/SmbiosInitLib.inf
@@ -42,6 +42,6 @@
   gPlatformModuleTokenSpaceGuid.PcdSmbiosTablesSize
   gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsPtr
   gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsCnt
+  gPlatformModuleTokenSpaceGuid.PcdLegacyEfSegmentEnabled
 
-[Pcd]
 

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -216,6 +216,7 @@ class BaseBoard(object):
         self.ENABLE_SBL_SETUP      = 0
         self.ENABLE_PAYLOD_MODULE  = 0
         self.ENABLE_FAST_BOOT      = 0
+        self.ENABLE_LEGACY_EF_SEG  = 1
 
         self.SUPPORT_ARI           = 0
         self.SUPPORT_SR_IOV        = 0


### PR DESCRIPTION
Current SBL code will build pointers in E/F segment for ACPI
and SMBIOS table. On some platforms, E/F segment is not supported.
So a new configuration ENABLE_LEGACY_EF_SEG is added.  When
it is enabled, SBL will not use legacy E/F segment memory.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>