### PR TITLE
Add ACPI RSDP to Linux BOOT_PARAMS

### DIFF
--- a/BootloaderCommonPkg/Include/Library/LinuxLib.h
+++ b/BootloaderCommonPkg/Include/Library/LinuxLib.h
@@ -135,7 +135,8 @@ typedef struct {
   UINT8         Pad2[4];
   UINT64        TbootAddr;
   UINT8         IstInfo[0x10];
-  UINT8         Pad3[16];
+  UINT64        AcpiRsdpAddr;
+  UINT8         Pad3[8];
   UINT8         Hd0Info[16];
   UINT8         Hd1Info[16];
   UINT8         SysDescTable[0x10];

--- a/BootloaderCommonPkg/Library/LinuxLib/LinuxLib.c
+++ b/BootloaderCommonPkg/Library/LinuxLib/LinuxLib.c
@@ -329,15 +329,15 @@ UpdateLinuxBootParams (
   // To check the existence, simply search for "acpi_rsdp=" string since it's
   // case-sensitive with the immediate '=' trailing according to kernel spec.
   //
-  if (AsciiStrStr ((CHAR8 *)(UINTN)Bp->Hdr.CmdLinePtr,(CHAR8 *)ACPI_RSDP_CMDLINE_STR) == NULL) {
-    GuidHob = GetFirstGuidHob (&gLoaderSystemTableInfoGuid);
-    if (GuidHob != NULL) {
-      SystemTableInfo = (SYSTEM_TABLE_INFO *)GET_GUID_HOB_DATA (GuidHob);
-
+  GuidHob = GetFirstGuidHob (&gLoaderSystemTableInfoGuid);
+  if (GuidHob != NULL) {
+    SystemTableInfo = (SYSTEM_TABLE_INFO *)GET_GUID_HOB_DATA (GuidHob);
+    if (AsciiStrStr ((CHAR8 *)(UINTN)Bp->Hdr.CmdLinePtr, (CHAR8 *)ACPI_RSDP_CMDLINE_STR) == NULL) {
       AsciiSPrint (ParamValue, sizeof (ParamValue), " %a0x%lx", ACPI_RSDP_CMDLINE_STR, SystemTableInfo->AcpiTableBase);
       AsciiStrCatS ((CHAR8 *)(UINTN)Bp->Hdr.CmdLinePtr, CMDLINE_LENGTH_MAX, ParamValue);
       Bp->Hdr.CmdlineSize = (UINT32)AsciiStrLen ((CHAR8 *)(UINTN)Bp->Hdr.CmdLinePtr);
     }
+    Bp->AcpiRsdpAddr = SystemTableInfo->AcpiTableBase;
   }
 }
 


### PR DESCRIPTION
For UEFI Linux boot, a new parameter was added into BOOT_PARAMS.
This patch added this parameter support so that ACPI base can
be passed directly to kernel.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>