### PR TITLE
Fix InitRd image alignment issue

### DIFF
--- a/PayloadPkg/OsLoader/LoadImage.c
+++ b/PayloadPkg/OsLoader/LoadImage.c
@@ -355,7 +355,7 @@ LoadLinuxFile (
     goto Done;
   }
 
-  FileBuffer = AllocatePool (FileSize);
+  FileBuffer = AllocatePages (EFI_SIZE_TO_PAGES(FileSize));
   if (FileBuffer == NULL) {
     Status = EFI_OUT_OF_RESOURCES;
     goto Done;
@@ -369,9 +369,10 @@ LoadLinuxFile (
     // Re-assign new memory
     ImageData->Addr = FileBuffer;
     ImageData->Size = (UINT32)FileSize;
+    ImageData->AllocType = ImageAllocateTypePage;
   } else {
     if (FileBuffer != NULL) {
-      FreePool (FileBuffer);
+      FreePages (FileBuffer, EFI_SIZE_TO_PAGES(FileSize));
     }
   }
 


### PR DESCRIPTION
Current SBL used AllocatePool to allocae space for Linux files
including Kernel and InitRd. However, since InitRd is required to
be aligned at page boundary, it needs to use AllocatePages instead.
This patch addressed this issue. It fixed #908.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>