### PR TITLE
Enhance grub.cfg to support CentOS

### DIFF
--- a/PayloadPkg/OsLoader/LoadImage.c
+++ b/PayloadPkg/OsLoader/LoadImage.c
@@ -14,9 +14,10 @@ typedef struct {
   LOADED_IMAGE           *LoadedImageList[LoadImageTypeMax];
 } LOADED_IMAGES_INFO;
 
-STATIC CONST CHAR16  *mConfigFileName[2] = {
+STATIC CONST CHAR16  *mConfigFileName[3] = {
   L"config.cfg",
-  L"boot/grub/grub.cfg"
+  L"boot/grub/grub.cfg",
+  L"EFI/BOOT/grub.cfg"
 };
 
 /**
@@ -421,7 +422,7 @@ GetTraditionalLinux (
 
   DEBUG ((DEBUG_INFO, "Try booting Linux from config file ...\n"));
 
-  for (Index = 0; Index < (UINTN)(FeaturePcdGet (PcdGrubBootCfgEnabled) ? 2 : 1); Index++) {
+  for (Index = 0; Index < (UINTN)(FeaturePcdGet (PcdGrubBootCfgEnabled) ? 3 : 1); Index++) {
     DEBUG ((DEBUG_INFO, "Checking %s\n",mConfigFileName[Index]));
     ConfigFile     = NULL;
     ConfigFileSize = 0;


### PR DESCRIPTION
CentOS live CD iso image has different path for grub.cfg file. It
also used "linuxefi" and "initrdefi" for keywords. This patch added
support for it. With this patch, verified it can boot to CentOS
live-cd on APL platform.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>