### PR TITLE
Enable ACPI BGRT table support

### DIFF
--- a/BootloaderCommonPkg/Include/Library/GraphicsLib.h
+++ b/BootloaderCommonPkg/Include/Library/GraphicsLib.h
@@ -72,6 +72,29 @@ typedef struct {
   EFI_GRAPHICS_OUTPUT_BLT_PIXEL BackgroundColor;
 } FRAME_BUFFER_CONSOLE;
 
+
+/**
+  Verify a BMP image header and determine its centralized display location
+  on screen.
+
+  @param  BmpImage      Pointer to BMP file
+  @param  OffX          Pointer to receive X offset for BMP display position.
+  @param  OffY          Pointer to receive Y offset for BMP display position.
+  @param  GfxInfoHob    Pointer to graphics info HOB.
+
+  @retval EFI_SUCCESS           GopBlt and GopBltSize are returned.
+  @retval EFI_UNSUPPORTED       BmpImage is not a valid *.BMP image
+**/
+EFI_STATUS
+EFIAPI
+GetBmpDisplayPos (
+  IN     VOID    *BmpImage,
+  OUT  UINT32    *OffX,          OPTIONAL
+  OUT  UINT32    *OffY,          OPTIONAL
+  IN   EFI_PEI_GRAPHICS_INFO_HOB *GfxInfoHob
+);
+
+
 /**
   Display a *.BMP graphics image to the frame buffer. If a NULL GopBlt buffer
   is passed in a GopBlt buffer will be allocated by this routine. If a GopBlt
@@ -90,6 +113,7 @@ typedef struct {
 
 **/
 EFI_STATUS
+EFIAPI
 DisplayBmpToFrameBuffer (
   IN     VOID      *BmpImage,
   IN OUT VOID      **GopBlt,

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiBgrt.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiBgrt.c
@@ -1,0 +1,91 @@
+/** @file
+
+  Copyright (c) 2019 - 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/GraphicsLib.h>
+#include <Library/PcdLib.h>
+#include "AcpiInitLibInternal.h"
+
+
+//
+// ACPI Boot Graphics Resource Table template
+//
+CONST
+EFI_ACPI_5_0_BOOT_GRAPHICS_RESOURCE_TABLE mBootGraphicsResourceTableTemplate = {
+  {
+    EFI_ACPI_5_0_BOOT_GRAPHICS_RESOURCE_TABLE_SIGNATURE,
+    sizeof (EFI_ACPI_5_0_BOOT_GRAPHICS_RESOURCE_TABLE),
+    EFI_ACPI_5_0_BOOT_GRAPHICS_RESOURCE_TABLE_REVISION,     // Revision
+    0x00,  // Checksum will be updated at runtime
+    //
+    // It is expected that these values will be updated at EntryPoint.
+    //
+    EFI_ACPI_OEM_ID,                 // OEM ID is a 6 bytes long field
+    EFI_ACPI_OEM_TABLE_ID,           // OEM Table ID(8 bytes long)
+    EFI_ACPI_OEM_REVISION,           // OEM Revision
+    EFI_ACPI_CREATOR_ID,             // Creator ID
+    EFI_ACPI_CREATOR_REVISION        // Creator Revision
+  },
+  EFI_ACPI_5_0_BGRT_VERSION,         // Version
+  EFI_ACPI_5_0_BGRT_STATUS_VALID,    // Status
+  EFI_ACPI_5_0_BGRT_IMAGE_TYPE_BMP,  // Image Type
+  0,                                 // Image Address
+  0,                                 // Image Offset X
+  0                                  // Image Offset Y
+};
+
+
+/**
+  Update Boot Graphics Resource Table (BGRT).
+
+  @param[in] Table          Pointer of ACPI BGRT Table.
+
+  @retval EFI_SUCCESS       Update ACPI BGRT table successfully.
+  @retval Others            Failed to update FPDT table.
+ **/
+EFI_STATUS
+UpdateBgrt (
+  IN  UINT8                           *Table
+  )
+{
+  UINT32       BmpBase;
+  UINT32       OffX;
+  UINT32       OffY;
+  EFI_STATUS   Status;
+  EFI_ACPI_5_0_BOOT_GRAPHICS_RESOURCE_TABLE  *Bgrt;
+  EFI_PEI_GRAPHICS_INFO_HOB                  *GfxInfoHob;
+
+  if (PcdGet32 (PcdSplashLogoAddress) == 0) {
+    return EFI_UNSUPPORTED;
+  }
+
+  // Get framebuffer info
+  GfxInfoHob = (EFI_PEI_GRAPHICS_INFO_HOB *)GetGuidHobData (NULL, NULL, &gEfiGraphicsInfoHobGuid);
+  if (GfxInfoHob == NULL) {
+    return EFI_UNSUPPORTED;
+  }
+
+  BmpBase = PCD_GET32_WITH_ADJUST (PcdSplashLogoAddress);
+  Status = GetBmpDisplayPos ((VOID *)(UINTN)BmpBase, &OffX, &OffY, GfxInfoHob);
+  if (EFI_ERROR(Status)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  Bgrt = (EFI_ACPI_5_0_BOOT_GRAPHICS_RESOURCE_TABLE *)Table;
+  Bgrt->ImageAddress = (UINTN)BmpBase;
+  Bgrt->ImageOffsetX = OffX;
+  Bgrt->ImageOffsetY = OffY;
+
+  if (!FeaturePcdGet (PcdSplashEnabled)) {
+    Bgrt->Status = 0;
+  }
+
+  return EFI_SUCCESS;
+}

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
@@ -25,8 +25,10 @@
   X64/S3Wake.nasm
 
 [Sources]
+  AcpiInitLibInternal.h
   AcpiInitLib.c
   AcpiFpdt.c
+  AcpiBgrt.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -57,3 +59,5 @@
   gPlatformModuleTokenSpaceGuid.PcdLoaderAcpiReclaimSize
   gPlatformCommonLibTokenSpaceGuid.PcdLowestSupportedFwVer
   gPlatformModuleTokenSpaceGuid.PcdLegacyEfSegmentEnabled
+  gPlatformModuleTokenSpaceGuid.PcdSplashLogoAddress
+  gPlatformModuleTokenSpaceGuid.PcdSplashEnabled

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLibInternal.h
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLibInternal.h
@@ -1,0 +1,74 @@
+/** @file
+
+  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _ACPI_INIT_LIB_INTERNAL_H_
+#define _ACPI_INIT_LIB_INTERNAL_H_
+
+
+#include <PiPei.h>
+#include <Library/PcdLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/AcpiInitLib.h>
+#include <Library/BootloaderCoreLib.h>
+#include <IndustryStandard/Acpi.h>
+
+
+#define  ACPI_ALIGN()       (Current = (UINT8 *)ALIGN_POINTER (Current, 0x10))
+#define  ACPI_ALIGN_PAGE()  (Current = (UINT8 *)ALIGN_POINTER (Current, 0x1000))
+
+#define  EFI_ACPI_OEM_ID           {'O','E','M','I','D',' '}   // OEMID 6 bytes long
+#define  EFI_ACPI_OEM_TABLE_ID     SIGNATURE_64('O','E','M','T','A','B','L','E') // OEM table id 8 bytes long
+#define  EFI_ACPI_OEM_REVISION     0x00000005
+#define  EFI_ACPI_CREATOR_ID       SIGNATURE_32('C','R','E','A')
+#define  EFI_ACPI_CREATOR_REVISION 0x0100000D
+
+#define  ACPI_SKIP             0
+#define  ACPI_APPEND           1
+#define  ACPI_REPLACE          2
+
+extern  UINT32          WakeUpBuffer;
+extern  CHAR8           WakeUp;
+extern  UINT32          WakeUpSize;
+
+extern  CONST EFI_ACPI_5_0_BOOT_GRAPHICS_RESOURCE_TABLE mBootGraphicsResourceTableTemplate;
+
+typedef struct {
+  UINT8   Type;
+  UINT8   Length;
+} EFI_ACPI_MADT_ENTRY_COMMON_HEADER;
+
+/**
+  Update Boot Graphics Resource Table (BGRT).
+
+  @param[in] Table          Pointer of ACPI BGRT Table.
+
+  @retval EFI_SUCCESS       Update ACPI BGRT table successfully.
+  @retval Others            Failed to update FPDT table.
+ **/
+EFI_STATUS
+UpdateBgrt (
+  IN  UINT8                           *Table
+  );
+
+/**
+  Update Firmware Performance Data Table (FPDT).
+
+  @param[in]  Table         Pointer of ACPI FPDT Table.
+  @param[out] ExtraSize     Extra size the table needed.
+
+  @retval EFI_SUCCESS       Update ACPI FPDT table successfully.
+  @retval Others            Failed to update FPDT table.
+ **/
+EFI_STATUS
+UpdateFpdt (
+  IN  UINT8                             *Table,
+  OUT UINT32                            *ExtraSize
+  );
+
+#endif


### PR DESCRIPTION
This patch enabled ACPI BGRT support. It is used to pass splash
display information from bootloader to payload and OS.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>