### PR TITLE
Fix hang at STAGE1B when compile with MSVC 2017 for IA32 Debug

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -1622,7 +1622,7 @@ NOOPT_VS2015x86_X64_DLINK_FLAGS    = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /OPT:REF
 *_VS2017_IA32_ASM_PATH     = DEF(VS2017_BIN_IA32)\ml.exe
 
       *_VS2017_IA32_MAKE_FLAGS  = /nologo
-  DEBUG_VS2017_IA32_CC_FLAGS    = /nologo /arch:IA32 /c /WX /GS- /W4 /Gs32768 /D UNICODE /O1 /GL /FIAutoGen.h /EHs-c- /GR- /GF /Gy /Zi /Gw /Oy-
+  DEBUG_VS2017_IA32_CC_FLAGS    = /nologo /arch:IA32 /c /WX /GS- /W4 /Gs32768 /D UNICODE /O1 /GL /FIAutoGen.h /EHs-c- /GR- /GF /Gy /Zi /Gw
 RELEASE_VS2017_IA32_CC_FLAGS    = /nologo /arch:IA32 /c /WX /GS- /W4 /Gs32768 /D UNICODE /O1 /GL /FIAutoGen.h /EHs-c- /GR- /GF /Gw
 NOOPT_VS2017_IA32_CC_FLAGS      = /nologo /arch:IA32 /c /WX /GS- /W4 /Gs32768 /D UNICODE /FIAutoGen.h /EHs-c- /GR- /GF /Gy /Zi /Od
 


### PR DESCRIPTION
Removed the Oy- flag for DEBUG_VS2017_IA32_CC_FLAGS
which was introduced recently in commit 9f3d2b5fc39b45f34ce22d462b25d24c1d559ed8
it causes hang when calculating SHA384 by CryptoLib call by SecureBootLib driver

Signed-off-by: Chin Keong Ang <chin.keong.ang@intel.com>