### PR TITLE
Allow PatchCheck only in PR condition

### DIFF
--- a/.azurepipelines/azure-pipelines.yml
+++ b/.azurepipelines/azure-pipelines.yml
@@ -37,6 +37,7 @@ jobs:
       git fetch origin $(System.PullRequest.TargetBranch):$(System.PullRequest.TargetBranch)
       python BaseTools/Scripts/PatchCheck.py $(System.PullRequest.TargetBranch)..$(System.PullRequest.SourceCommitId)
     displayName: Check patch format
+    condition: eq(variables['Build.Reason'], 'PullRequest')
 
   - bash: |
       sudo apt-get install -y nasm uuid-dev iasl qemu


### PR DESCRIPTION
The master build trigger does not have PullRequest variable.
This will allow PatchCheck to be run only in PR condition.

Signed-off-by: Aiden Park <aiden.park@intel.com>