### PR TITLE
Fix path issue for WORKSPACE variable

### DIFF
--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -63,7 +63,7 @@ def prep_env ():
     os.environ['PYTHON_COMMAND'] = '"' + sys.executable + '"'
     print_tool_version_info(os.environ['PYTHON_COMMAND'], version.strip())
 
-    sblsource = os.path.dirname(os.path.realpath(__file__))
+    sblsource = os.path.dirname(os.path.abspath(__file__))
     os.chdir(sblsource)
     if sys.platform == 'darwin':
         toolchain = 'XCODE5'


### PR DESCRIPTION
This patch fixed one issue on the WORKSPACE path. The current
script used "realpath" instead of "abspath".  It will cause issue
if "subst" is used for the drive path since it returns the real
path before "subst".  The expected behavior is to use the
path after "subst".

Signed-off-by: Maurice Ma <maurice.ma@intel.com>