### PR TITLE
Add EXT4 to print in 'boot' command

### DIFF
--- a/BootloaderCommonPkg/Library/ShellLib/CmdBoot.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdBoot.c
@@ -200,7 +200,7 @@ GetBootDeviceInfo (
   }
 
   do {
-    ShellPrint (L"Enter FsType (FAT (0x%X), EXT2/3 (0x%X), Auto (0x%X), RAW (0x%X))\n",
+    ShellPrint (L"Enter FsType (FAT (0x%X), EXT2/3/4 (0x%X), Auto (0x%X), RAW (0x%X))\n",
                 EnumFileSystemTypeFat, EnumFileSystemTypeExt2, EnumFileSystemTypeAuto,
                 EnumFileSystemMax);
     ShellPrint (L"(default 0x%X) ", CurrOption->FsType);


### PR DESCRIPTION
Since the EXT library we have in OS Loader
supports 2, 3, and 4 it will help to reduce
confusion for users who have noticed that
only 2 and 3 are currently printed.

Signed-off-by: James Gutbub <james.gutbub@intel.com>