### PR TITLE
[APL] Fix the infinite reboot issue in firmware update

### DIFF
--- a/Silicon/ApollolakePkg/Library/MeChipsetLib/MeChipsetLib.c
+++ b/Silicon/ApollolakePkg/Library/MeChipsetLib/MeChipsetLib.c
@@ -274,7 +274,7 @@ PrepareCseForFirmwareUpdate (
   Request->MkhiHeader.Fields.Command = IFWI_PREPARE_FOR_UPDATE_CMD_ID;
   Request->ResetType = 1;
 
-  HeciSendLength = sizeof (HECI_REQ_IFWI_PREPARE_FOR_UPDATE) - 3;
+  HeciSendLength = sizeof (HECI_REQ_IFWI_PREPARE_FOR_UPDATE);
   HeciRecvLength = sizeof (HECI_RES_IFWI_PREPARE_FOR_UPDATE);
 
   Status = HeciSendwAck (


### PR DESCRIPTION
This will fix an invalid data size of HECI_REQ_IFWI_PREPARE_FOR_UPDATE
command. Due to the invalid data sent, CSE rejected the IFWI prepare
update request and it caused infinite reboot issue.

The Issue #925 will be addressed with this patch.

Signed-off-by: Aiden Park <aiden.park@intel.com>