### PR TITLE
Openssl 1.1.1i tool support

### DIFF
--- a/BootloaderCorePkg/Tools/CommonUtility.py
+++ b/BootloaderCorePkg/Tools/CommonUtility.py
@@ -187,11 +187,15 @@ def check_files_exist (base_name_list, dir = '', ext = ''):
 def get_openssl_path ():
     if os.name == 'nt':
         if 'OPENSSL_PATH' not in os.environ:
-            os.environ['OPENSSL_PATH'] = "C:\\Openssl\\"
-        if 'OPENSSL_CONF' not in os.environ:
-            openssl_cfg = "C:\\Openssl\\openssl.cfg"
-            if os.path.exists(openssl_cfg):
-                os.environ['OPENSSL_CONF'] = openssl_cfg
+            openssl_dir = "C:\\Openssl\\bin\\"
+            if os.path.exists (openssl_dir):
+                os.environ['OPENSSL_PATH'] = openssl_dir
+            else:
+                os.environ['OPENSSL_PATH'] = "C:\\Openssl\\"
+                if 'OPENSSL_CONF' not in os.environ:
+                    openssl_cfg = "C:\\Openssl\\openssl.cfg"
+                    if os.path.exists(openssl_cfg):
+                        os.environ['OPENSSL_CONF'] = openssl_cfg
     openssl = os.path.join(os.environ.get ('OPENSSL_PATH', ''), 'openssl')
     return openssl
 

--- a/BootloaderCorePkg/Tools/SingleSign.py
+++ b/BootloaderCorePkg/Tools/SingleSign.py
@@ -63,11 +63,15 @@ MESSAGE_SBL_KEY_DIR = (
 def get_openssl_path ():
     if os.name == 'nt':
         if 'OPENSSL_PATH' not in os.environ:
-            os.environ['OPENSSL_PATH'] = "C:\\Openssl\\"
-        if 'OPENSSL_CONF' not in os.environ:
-            openssl_cfg = "C:\\Openssl\\openssl.cfg"
-            if os.path.exists(openssl_cfg):
-                os.environ['OPENSSL_CONF'] = openssl_cfg
+            openssl_dir = "C:\\Openssl\\bin\\"
+            if os.path.exists (openssl_dir):
+                os.environ['OPENSSL_PATH'] = openssl_dir
+            else:
+                os.environ['OPENSSL_PATH'] = "C:\\Openssl\\"
+                if 'OPENSSL_CONF' not in os.environ:
+                    openssl_cfg = "C:\\Openssl\\openssl.cfg"
+                    if os.path.exists(openssl_cfg):
+                        os.environ['OPENSSL_CONF'] = openssl_cfg
     openssl = os.path.join(os.environ.get ('OPENSSL_PATH', ''), 'openssl')
     return openssl
 

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -92,8 +92,6 @@ def prep_env ():
             sys.exit(1)
         if 'NASM_PREFIX' not in os.environ:
             os.environ['NASM_PREFIX'] = "C:\\Nasm\\"
-        if 'OPENSSL_PATH' not in os.environ:
-            os.environ['OPENSSL_PATH'] = "C:\\Openssl\\"
         if 'IASL_PREFIX' not in os.environ:
             os.environ['IASL_PREFIX'] = "C:\\ASL\\"
     else:


### PR DESCRIPTION
Openssl 1.1.1 is an installable and it creates
openssl.exe in a bin folder.
default slimboot path: c:\Openssl\bin\openssl.exe
Download location: https://slproweb.com/products/Win32OpenSSL.html

Added support to populate OPENSSL_PATH
from bin dir incase its available.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>