### PR TITLE
[PCI] Platform builds PCI Resource Allocation Table

### DIFF
--- a/BootloaderCommonPkg/Include/Guid/PciRootBridgeInfoGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/PciRootBridgeInfoGuid.h
@@ -51,4 +51,22 @@ typedef struct {
   PCI_ROOT_BRIDGE_ENTRY     Entry[0];
 } PCI_ROOT_BRIDGE_INFO_HOB;
 
+typedef struct {
+  UINT8                     BusBase;
+  UINT8                     BusLimit;
+  UINT16                    Reserved;
+  UINT32                    IoBase;
+  UINT32                    IoLimit;
+  UINT32                    Mmio32Base;
+  UINT32                    Mmio32Limit;
+  UINT64                    Mmio64Base;
+  UINT64                    Mmio64Limit;
+} PCI_RES_ALLOC_RANGE;
+
+typedef struct {
+  UINT8                     NumOfEntries;
+  UINT8                     Reserved[3];
+  PCI_RES_ALLOC_RANGE       ResourceRange[0];
+} PCI_RES_ALLOC_TABLE;
+
 #endif // __PCI_ROOT_BRIDGE_INFO_GUID_H__

--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -180,6 +180,8 @@
   gPlatformModuleTokenSpaceGuid.PcdFuncCpuInitHook        | 0x00000000 | UINT32 | 0x2000019A
   gPlatformModuleTokenSpaceGuid.PcdFspsUpdPtr             | 0x00000000 | UINT32 | 0x2000019B
 
+  gPlatformModuleTokenSpaceGuid.PcdPciResAllocTableBase   | 0x00000000 | UINT32 | 0x2000019C
+
 [PcdsFeatureFlag]
   # Determine if the Intel GFX device should be enabled or not in system
   gPlatformModuleTokenSpaceGuid.PcdIntelGfxEnabled        | TRUE       | BOOLEAN | 0x20000200

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -284,6 +284,8 @@
   gPlatformModuleTokenSpaceGuid.PcdFuncCpuInitHook   | 0x00000000
   gPlatformModuleTokenSpaceGuid.PcdFspsUpdPtr        | 0x00000000
 
+  gPlatformModuleTokenSpaceGuid.PcdPciResAllocTableBase    | 0x00000000
+
   gPlatformCommonLibTokenSpaceGuid.PcdSerialUseMmio        | 0
   gPlatformCommonLibTokenSpaceGuid.PcdSerialRegisterBase   | 0
   gPlatformCommonLibTokenSpaceGuid.PcdSerialBaudRate       | 0

--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.inf
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.inf
@@ -55,3 +55,4 @@
   gPlatformModuleTokenSpaceGuid.PcdPciResourceMem64Base
   gPlatformModuleTokenSpaceGuid.PcdAriSupport
   gPlatformModuleTokenSpaceGuid.PcdSrIovSupport
+  gPlatformModuleTokenSpaceGuid.PcdPciResAllocTableBase


### PR DESCRIPTION
This introduces a new PCD 'PcdPciResAllocTableBase' to allow a platform
to provide its specific PCI resource allocation pool at runtime.
PCI Enumerator will allocate required resources in the range.
If the PCD is not provided, a default range will be used.

Signed-off-by: Aiden Park <aiden.park@intel.com>