### PR TITLE
Fix Klocwork issue reported in Osloader

### DIFF
--- a/BootloaderCommonPkg/Library/PartitionLib/PartitionLib.c
+++ b/BootloaderCommonPkg/Library/PartitionLib/PartitionLib.c
@@ -485,7 +485,7 @@ GetLogicalPartitionInfo (
     return EFI_INVALID_PARAMETER;
   }
 
-  if (SwPart >= PartBlockDev->BlockDeviceCount) {
+  if ((SwPart >= PartBlockDev->BlockDeviceCount) || (SwPart > PART_MAX_BLOCK_DEVICE)) {
     return EFI_INVALID_PARAMETER;
   }
 


### PR DESCRIPTION
Buffer Overflow - Local Array Index Out of Bounds
Issue reported is Array 'PartBlockDev->BlockDevice' of size 64
may use index value(s) 64..254

Signed-off-by: Sindhura Grandhi <sindhura.grandhi@intel.com>