### PR TITLE
Use Python lz4 module for LZ4 compression

### DIFF
--- a/.azurepipelines/azure-pipelines.yml
+++ b/.azurepipelines/azure-pipelines.yml
@@ -44,6 +44,7 @@ jobs:
     displayName: Install required tools
 
   - script: |
+      python -m pip install lz4
       python BuildLoader.py build qemu -k
     displayName: 'Run QEMU build'
 
@@ -98,6 +99,7 @@ jobs:
     displayName: Install required tools
 
   - script: |
+      python -m pip install lz4
       python BuildLoader.py build $(Build.Name) $(Build.Arch) $(Build.Target) -k
     displayName: 'Run $(Build.Name) build'
 
@@ -166,6 +168,7 @@ jobs:
     displayName: Environment configuration
 
   - script: |
+      python -m pip install lz4
       python BuildLoader.py build $(Build.Name) $(Build.Arch) $(Build.Target) -k
     displayName: 'Run $(Build.Name) build'
 

--- a/BootloaderCorePkg/Tools/CommonUtility.py
+++ b/BootloaderCorePkg/Tools/CommonUtility.py
@@ -377,7 +377,15 @@ def compress (in_file, alg, svn=0, out_path = '', tool_dir = ''):
     if in_len > 0:
         if sig == "LZDM":
             shutil.copy(in_file, out_file)
-        else:
+            compress_data = get_file_data(out_file)
+        elif sig == "LZ4 ":
+            try:
+                import lz4.block
+                compress_data = lz4.block.compress(get_file_data(in_file), mode='high_compression')
+            except ImportError:
+                print("Could not import lz4, use 'python -m pip install lz4' to install it.")
+                exit(1)
+        elif sig == "LZMA":
             compress_tool = "%sCompress" % alg
             cmdline = [
                 os.path.join (tool_dir, compress_tool),
@@ -385,7 +393,7 @@ def compress (in_file, alg, svn=0, out_path = '', tool_dir = ''):
                 "-o", out_file,
                 in_file]
             run_process (cmdline, False, True)
-        compress_data = get_file_data(out_file)
+            compress_data = get_file_data(out_file)
     else:
         compress_data = bytearray()
 


### PR DESCRIPTION
To make SBL scripts/tools more OS-agnostic the
lz4 compression module can be used instead of
relying on the BaseTools LZ4 package/executable.

TEST=Confirmed that the python lz4.block.compress
     routine is compatible with Lz4DecompressLib
     during SBL runtime to decompress LZ4 binaries.

Signed-off-by: James Gutbub <james.gutbub@intel.com>