### PR TITLE
Use Python lz4 module for LZ4

### DIFF
--- a/.azurepipelines/azure-pipelines.yml
+++ b/.azurepipelines/azure-pipelines.yml
@@ -44,6 +44,7 @@ jobs:
     displayName: Install required tools
 
   - script: |
+      python -m pip install lz4
       python BuildLoader.py build qemu -k
     displayName: 'Run QEMU build'
 
@@ -98,6 +99,7 @@ jobs:
     displayName: Install required tools
 
   - script: |
+      python -m pip install lz4
       python BuildLoader.py build $(Build.Name) $(Build.Arch) $(Build.Target) -k
     displayName: 'Run $(Build.Name) build'
 
@@ -166,6 +168,7 @@ jobs:
     displayName: Environment configuration
 
   - script: |
+      python -m pip install lz4
       python BuildLoader.py build $(Build.Name) $(Build.Arch) $(Build.Target) -k
     displayName: 'Run $(Build.Name) build'
 


### PR DESCRIPTION
To make SBL scripts/tools more OS-agnostic the
lz4 (de)compression module can be used instead of
relying on the BaseTools LZ4 package/executable.

Need to update the azure pipeline to install
the python lz4 module before running the builds.

TEST=Confirmed that the python lz4.block.compress
     routine is compatible with Lz4DecompressLib
     during SBL runtime to decompress LZ4 binaries.

Signed-off-by: James Gutbub <james.gutbub@intel.com>