### PR TITLE
Add common GpioLib

### DIFF
--- a/BootloaderCorePkg/Include/Library/GpioLib.h
+++ b/BootloaderCorePkg/Include/Library/GpioLib.h
@@ -21,4 +21,20 @@ GpioPadConfigTable (
   IN VOID               *Gpio_Conf_Data
   );
 
+
+/**
+  Configure the GPIO pins, available as part of platform specific GPIO CFG DATA.
+  If the pins are not part of GPIO CFG DATA, call GpioPadConfigTable() directly
+  with the appropriate arguments.
+
+  @retval EFI_SUCCESS                   The function completed successfully
+  @retval EFI_NOT_FOUND                 If Gpio Config Data cant be found
+**/
+EFI_STATUS
+EFIAPI
+ConfigureGpio (
+  VOID
+  );
+
+
 #endif /* __GPIO_LIB_H__ */

--- a/Silicon/CommonSocPkg/Include/GpioLibConfig.h
+++ b/Silicon/CommonSocPkg/Include/GpioLibConfig.h
@@ -1,0 +1,505 @@
+/** @file
+  Header file for GpioConfig structure used by GPIO library.
+
+  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _GPIO_CONFIG_H_
+#define _GPIO_CONFIG_H_
+
+#pragma pack(push, 1)
+
+///
+/// For any GpioPad usage in code use GPIO_PAD type
+///
+typedef UINT32 GPIO_PAD;
+
+///
+/// GpioPad with additional native function information.
+/// This type is used to represent signal muxing alternatives. Platform will provide such value to
+/// identify muxing selection for given signal on a specific SOC.
+/// Please refer to the board layout
+///
+typedef UINT32 GPIO_NATIVE_PAD;
+
+///
+/// For any GpioGroup usage in code use GPIO_GROUP type
+///
+typedef UINT32 GPIO_GROUP;
+
+/**
+  GPIO configuration structure used for pin programming.
+  Structure contains fields that can be used to configure pad.
+**/
+typedef struct {
+  /**
+  Pad Mode
+  Pad can be set as GPIO or one of its native functions.
+  When in native mode setting Direction (except Inversion), OutputState,
+  InterruptConfig, Host Software Pad Ownership and OutputStateLock are unnecessary.
+  Refer to definition of GPIO_PAD_MODE.
+  Refer to EDS for each native mode according to the pad.
+  **/
+  UINT32 PadMode            : 5;
+  /**
+  Host Software Pad Ownership
+  Set pad to ACPI mode or GPIO Driver Mode.
+  Refer to definition of GPIO_HOSTSW_OWN.
+  **/
+  UINT32 HostSoftPadOwn     : 2;
+  /**
+  GPIO Direction
+  Can choose between In, In with inversion, Out, both In and Out, both In with inversion and out or disabling both.
+  Refer to definition of GPIO_DIRECTION for supported settings.
+  **/
+  UINT32 Direction           : 6;
+  /**
+  Output State
+  Set Pad output value.
+  Refer to definition of GPIO_OUTPUT_STATE for supported settings.
+  This setting takes place when output is enabled.
+  **/
+  UINT32 OutputState         : 2;
+  /**
+  GPIO Interrupt Configuration
+  Set Pad to cause one of interrupts (IOxAPIC/SCI/SMI/NMI).
+  This setting is applicable only if GPIO is in GpioMode with input enabled.
+  Refer to definition of GPIO_INT_CONFIG for supported settings.
+  **/
+  UINT32 InterruptConfig     : 9;
+  /**
+  GPIO Power Configuration.
+  This setting controls Pad Reset Configuration.
+  Refer to definition of GPIO_RESET_CONFIG for supported settings.
+  **/
+  UINT32 PowerConfig        : 8;
+  /**
+  GPIO Electrical Configuration
+  This setting controls pads termination.
+  Refer to definition of GPIO_ELECTRICAL_CONFIG for supported settings.
+  **/
+  UINT32 ElectricalConfig   : 9;
+  /**
+  GPIO Lock Configuration
+  This setting controls pads lock.
+  Refer to definition of GPIO_LOCK_CONFIG for supported settings.
+  **/
+  UINT32 LockConfig         : 4;
+  /**
+  Additional GPIO configuration
+  Refer to definition of GPIO_OTHER_CONFIG for supported settings.
+  **/
+  UINT32 OtherSettings     :  9;
+  UINT32 RsvdBits          : 10;    ///< Reserved bits for future extension
+} GPIO_CONFIG;
+
+typedef enum {
+  GpioHardwareDefault        = 0x0    ///< Leave setting unmodified
+} GPIO_HARDWARE_DEFAULT;
+
+/**
+  GPIO Pad Mode
+  Refer to GPIO documentation on native functions available for certain pad.
+  If GPIO is set to one of NativeX modes then following settings are not applicable
+  and can be skipped:
+  - Interrupt related settings
+  - Host Software Ownership
+  - Output/Input enabling/disabling
+  - Output lock
+**/
+typedef enum {
+  GpioPadModeGpio     = 0x1,
+  GpioPadModeNative1  = 0x3,
+  GpioPadModeNative2  = 0x5,
+  GpioPadModeNative3  = 0x7,
+  GpioPadModeNative4  = 0x9,
+  GpioPadModeNative5  = 0xB,
+  GpioPadModeNative6  = 0xD,
+  GpioPadModeNative7  = 0xF,
+  GpioPadModeNative8  = 0x11
+} GPIO_PAD_MODE;
+
+/**
+  Host Software Pad Ownership modes
+  This setting affects GPIO interrupt status registers. Depending on chosen ownership
+  some GPIO Interrupt status register get updated and other masked.
+  Please refer to EDS for HOSTSW_OWN register description.
+**/
+typedef enum {
+  GpioHostOwnDefault = 0x0,   ///< Leave ownership value unmodified
+  /**
+  Set HOST ownership to ACPI.
+  Use this setting if pad is not going to be used by GPIO OS driver.
+  If GPIO is configured to generate SCI/SMI/NMI then this setting must be
+  used for interrupts to work
+  **/
+  GpioHostOwnAcpi    = 0x1,
+  /**
+  Set HOST ownership to GPIO Driver mode.
+  Use this setting only if GPIO pad should be controlled by GPIO OS Driver.
+  GPIO OS Driver will be able to control the pad if appropriate entry in
+  ACPI exists (refer to ACPI specification for GpioIo and GpioInt descriptors)
+  **/
+  GpioHostOwnGpio    = 0x3
+} GPIO_HOSTSW_OWN;
+
+///
+/// GPIO Direction
+///
+typedef enum {
+  GpioDirDefault         = 0x0,                ///< Leave pad direction setting unmodified
+  GpioDirInOut           = (0x1 | (0x1 << 3)), ///< Set pad for both output and input
+  GpioDirInInvOut        = (0x1 | (0x3 << 3)), ///< Set pad for both output and input with inversion
+  GpioDirIn              = (0x3 | (0x1 << 3)), ///< Set pad for input only
+  GpioDirInInv           = (0x3 | (0x3 << 3)), ///< Set pad for input with inversion
+  GpioDirOut             = 0x5,                ///< Set pad for output only
+  GpioDirNone            = 0x7                 ///< Disable both output and input
+} GPIO_DIRECTION;
+
+/**
+  GPIO Output State
+  This field is relevant only if output is enabled
+**/
+typedef enum {
+  GpioOutDefault         = 0x0,  ///< Leave output value unmodified
+  GpioOutLow             = 0x1,  ///< Set output to low
+  GpioOutHigh            = 0x3   ///< Set output to high
+} GPIO_OUTPUT_STATE;
+
+/**
+  GPIO interrupt configuration
+  This setting is applicable only if pad is in GPIO mode and has input enabled.
+  GPIO_INT_CONFIG allows to choose which interrupt is generated (IOxAPIC/SCI/SMI/NMI)
+  and how it is triggered (edge or level). Refer to PADCFG_DW0 register description in
+  EDS for details on this settings.
+  Field from GpioIntNmi to GpioIntApic can be OR'ed with GpioIntLevel to GpioIntBothEdge
+  to describe an interrupt e.g. GpioIntApic | GpioIntLevel
+  If GPIO is set to cause an SCI then also GPI_GPE_EN is enabled for this pad.
+  If GPIO is set to cause an NMI then also GPI_NMI_EN is enabled for this pad.
+  Not all GPIO are capable of generating an SMI or NMI interrupt.
+  When routing GPIO to cause an IOxAPIC interrupt care must be taken, as this
+  interrupt cannot be shared and its IRQn number is not configurable.
+  Refer to EDS for GPIO pads IRQ numbers (PADCFG_DW1.IntSel)
+  If GPIO is under GPIO OS driver control and appropriate ACPI GpioInt descriptor
+  exist then use only trigger type setting (from GpioIntLevel to GpioIntBothEdge).
+  This type of GPIO Driver interrupt doesn't have any additional routing setting
+  required to be set by BIOS. Interrupt is handled by GPIO OS Driver.
+**/
+
+typedef enum {
+  GpioIntDefault           = 0x0,  ///< Leave value of interrupt routing unmodified
+  GpioIntDis               = 0x1,  ///< Disable IOxAPIC/SCI/SMI/NMI interrupt generation
+  GpioIntNmi               = 0x3,  ///< Enable NMI interrupt only
+  GpioIntSmi               = 0x5,  ///< Enable SMI interrupt only
+  GpioIntSci               = 0x9,  ///< Enable SCI interrupt only
+  GpioIntApic              = 0x11, ///< Enable IOxAPIC interrupt only
+  GpioIntLevel       = (0x1 << 5), ///< Set interrupt as level triggered
+  GpioIntEdge        = (0x3 << 5), ///< Set interrupt as edge triggered (type of edge depends on input inversion)
+  GpioIntLvlEdgDis   = (0x5 << 5), ///< Disable interrupt trigger
+  GpioIntBothEdge    = (0x7 << 5)  ///< Set interrupt as both edge triggered
+} GPIO_INT_CONFIG;
+
+#define B_GPIO_INT_CONFIG_INT_SOURCE_MASK  0x1F ///< Mask for GPIO_INT_CONFIG for interrupt source
+#define B_GPIO_INT_CONFIG_INT_TYPE_MASK    0xE0 ///< Mask for GPIO_INT_CONFIG for interrupt type
+
+/**
+  GPIO Power Configuration
+  GPIO_RESET_CONFIG allows to set GPIO Reset type (PADCFG_DW0.PadRstCfg) which will
+  be used to reset certain GPIO settings.
+  Refer to EDS for settings that are controllable by PadRstCfg.
+**/
+typedef enum {
+  GpioResetDefault   = 0x00,        ///< Leave value of pad reset unmodified
+  ///
+  /// Deprecated settings. Maintained only for compatibility.
+  ///
+  GpioResetPwrGood   = 0x09,        ///< GPP: RSMRST; GPD: DSW_PWROK; (PadRstCfg = 00b = "Powergood")
+  GpioResetDeep      = 0x0B,        ///< Deep GPIO Reset (PadRstCfg = 01b = "Deep GPIO Reset")
+  GpioResetNormal    = 0x0D,        ///< GPIO Reset (PadRstCfg = 10b = "GPIO Reset" )
+  GpioResetResume    = 0x0F,        ///< GPP: Reserved; GPD: RSMRST; (PadRstCfg = 11b = "Resume Reset" )
+
+  ///
+  /// New GPIO reset configuration options
+  ///
+  /**
+  Resume Reset (RSMRST)
+    GPP: PadRstCfg = 00b = "Powergood"
+    GPD: PadRstCfg = 11b = "Resume Reset"
+  Pad setting will reset on:
+  - DeepSx transition
+  - G3
+  Pad settings will not reset on:
+  - S3/S4/S5 transition
+  - Warm/Cold/Global reset
+  **/
+  GpioResumeReset      = 0x01,
+  /**
+  Host Deep Reset
+    PadRstCfg = 01b = "Deep GPIO Reset"
+  Pad settings will reset on:
+  - Warm/Cold/Global reset
+  - DeepSx transition
+  - G3
+  Pad settings will not reset on:
+  - S3/S4/S5 transition
+  **/
+  GpioHostDeepReset    = 0x03,
+  /**
+  Platform Reset (PLTRST)
+    PadRstCfg = 10b = "GPIO Reset"
+  Pad settings will reset on:
+  - S3/S4/S5 transition
+  - Warm/Cold/Global reset
+  - DeepSx transition
+  - G3
+  **/
+  GpioPlatformReset    = 0x05,
+  /**
+  Deep Sleep Well Reset (DSW_PWROK)
+    GPP: not applicable
+    GPD: PadRstCfg = 00b = "Powergood"
+  Pad settings will reset on:
+  - G3
+  Pad settings will not reset on:
+  - S3/S4/S5 transition
+  - Warm/Cold/Global reset
+  - DeepSx transition
+  **/
+  GpioDswReset         = 0x07
+} GPIO_RESET_CONFIG;
+
+/**
+  GPIO Electrical Configuration
+  Configuration options for GPIO termination setting
+**/
+typedef enum {
+  GpioTermDefault          = 0x0,  ///< Leave termination setting unmodified
+  GpioTermNone             = 0x1,  ///< none
+  GpioTermWpd5K            = 0x5,  ///< 5kOhm weak pull-down
+  GpioTermWpd20K           = 0x9,  ///< 20kOhm weak pull-down
+  GpioTermWpu1K            = 0x13, ///< 1kOhm weak pull-up
+  GpioTermWpu2K            = 0x17, ///< 2kOhm weak pull-up
+  GpioTermWpu5K            = 0x15, ///< 5kOhm weak pull-up
+  GpioTermWpu20K           = 0x19, ///< 20kOhm weak pull-up
+  GpioTermWpu1K2K          = 0x1B, ///< 1kOhm & 2kOhm weak pull-up
+  /**
+  Native function controls pads termination
+  This setting is applicable only to some native modes.
+  Please check EDS to determine which native functionality
+  can control pads termination
+  **/
+  GpioTermNative     = 0x1F,
+  GpioNoTolerance1v8 = (0x1 << 5),   ///< Disable 1.8V pad tolerance
+  GpioTolerance1v8   = (0x3 << 5)    ///< Enable 1.8V pad tolerance
+} GPIO_ELECTRICAL_CONFIG;
+
+#define B_GPIO_ELECTRICAL_CONFIG_TERMINATION_MASK    0x1F   ///< Mask for GPIO_ELECTRICAL_CONFIG for termination value
+
+/**
+  GPIO LockConfiguration
+  Set GPIO configuration lock and output state lock.
+  GpioPadConfigUnlock/Lock and GpioOutputStateUnlock can be OR'ed.
+  By default GPIO pads will be locked unless GPIO lib is explicitly
+  informed that certain pad is to be left unlocked.
+  Lock settings reset is in Powergood domain. Care must be taken when using this setting
+  as fields it locks may be reset by a different signal and can be controlled
+  by what is in GPIO_RESET_CONFIG (PADCFG_DW0.PadRstCfg). GPIO library provides
+  functions which allow to unlock a GPIO pad. If possible each GPIO lib function will try to unlock
+  an already locked pad upon request for reconfiguration
+**/
+typedef enum {
+  /**
+  Perform default action
+   - if pad is an GPO, lock configuration but leave output unlocked
+   - if pad is an GPI, lock everything
+   - if pad is in native, lock everything
+**/
+  GpioLockDefault       = 0x0,
+  GpioPadConfigUnlock   = 0x3,  ///< Leave Pad configuration unlocked
+  GpioPadConfigLock     = 0x1,  ///< Lock Pad configuration
+  GpioOutputStateUnlock = 0xC,  ///< Leave Pad output control unlocked
+  GpioPadUnlock         = 0xF,  ///< Leave both Pad configuration and output control unlocked
+  GpioPadLock           = 0x5   ///< Lock both Pad configuration and output control
+} GPIO_LOCK_CONFIG;
+
+#define B_GPIO_LOCK_CONFIG_PAD_CONF_LOCK_MASK  0x3  ///< Mask for GPIO_LOCK_CONFIG for Pad Configuration Lock
+#define B_GPIO_LOCK_CONFIG_OUTPUT_LOCK_MASK    0xC  ///< Mask for GPIO_LOCK_CONFIG for Pad Output Lock
+
+/**
+  Other GPIO Configuration
+  GPIO_OTHER_CONFIG is used for less often settings and for future extensions
+  Supported settings:
+   - RX raw override to '1' - allows to override input value to '1'
+      This setting is applicable only if in input mode (both in GPIO and native usage).
+      The override takes place at the internal pad state directly from buffer and before the RXINV.
+**/
+typedef enum {
+  GpioRxRaw1Default           = 0x0,  ///< Use default input override value
+  GpioRxRaw1Dis               = 0x1,  ///< Don't override input
+  GpioRxRaw1En                = 0x3   ///< Override input to '1'
+} GPIO_OTHER_CONFIG;
+
+#define B_GPIO_OTHER_CONFIG_RXRAW_MASK           0x3   ///< Mask for GPIO_OTHER_CONFIG for RxRaw1 setting
+
+typedef UINT8    GPIO_PCH_SBI_PID;
+
+/**
+  PCH SBI opcode definitions
+**/
+typedef enum {
+  GpioMemoryRead             = 0x0,
+  GpioMemoryWrite            = 0x1,
+  GpioPciConfigRead          = 0x4,
+  GpioPciConfigWrite         = 0x5,
+  GpioPrivateControlRead     = 0x6,
+  GpioPrivateControlWrite    = 0x7,
+  GpioLibGpioLockUnlock      = 0x13
+} GPIO_PCH_SBI_OPCODE;
+
+typedef struct {
+  GPIO_PAD           GpioPad;
+  GPIO_CONFIG        GpioConfig;
+} GPIO_INIT_CONFIG;
+
+//
+// Structure for native pin data
+//
+typedef struct {
+  GPIO_PAD       Pad;
+  GPIO_PAD_MODE  Mode;
+} GPIO_PAD_NATIVE_FUNCTION;
+
+//
+// Below defines are based on GPIO_CONFIG structure fields
+//
+#define B_GPIO_PAD_MODE_MASK                            0xF
+#define N_GPIO_PAD_MODE_BIT_POS                         0
+#define B_GPIO_HOSTSW_OWN_MASK                          0x3
+#define N_GPIO_HOSTSW_OWN_BIT_POS                       0
+#define B_GPIO_DIRECTION_MASK                           0x1F
+#define B_GPIO_DIRECTION_DIR_MASK                       0x7
+#define N_GPIO_DIRECTION_DIR_BIT_POS                    0
+#define B_GPIO_DIRECTION_INV_MASK                       0x18
+#define N_GPIO_DIRECTION_INV_BIT_POS                    3
+#define B_GPIO_OUTPUT_MASK                              0x3
+#define N_GPIO_OUTPUT_BIT_POS                           0
+#define N_GPIO_INT_CONFIG_INT_SOURCE_BIT_POS            0
+#define N_GPIO_INT_CONFIG_INT_TYPE_BIT_POS              5
+#define B_GPIO_RESET_CONFIG_RESET_MASK                  0x3F
+#define N_GPIO_RESET_CONFIG_OLD_RESET_TYPE              BIT1
+#define B_GPIO_RESET_CONFIG_OLD_RESET_MASK              0xF
+#define N_GPIO_RESET_CONFIG_RESET_BIT_POS               0
+#define B_GPIO_RESET_CONFIG_GPD_RESET_MASK              (BIT5 | BIT4)
+#define B_GPIO_RESET_CONFIG_GPP_RESET_MASK              (BIT3 | BIT2)
+#define N_GPIO_ELECTRICAL_CONFIG_TERMINATION_BIT_POS    0
+#define N_GPIO_OTHER_CONFIG_RXRAW_BIT_POS               0
+
+//#define GPIO_PCR_PADCFG               0x10
+#define GPIO_PCR_PADCFG                 GpioGetPcrPadCfgOffset()
+
+#define B_GPIO_PCR_RST_CONF             (BIT31 | BIT30)
+#define N_GPIO_PCR_RST_CONF             30
+#define V_GPIO_PCR_RST_CONF_POW_GOOD    0x00
+#define V_GPIO_PCR_RST_CONF_DEEP_RST    0x01
+#define V_GPIO_PCR_RST_CONF_GPIO_RST    0x02
+#define V_GPIO_PCR_RST_CONF_RESUME_RST  0x03
+#define B_GPIO_PCR_RX_RAW1              BIT28
+#define N_GPIO_PCR_RX_RAW1              28
+#define B_GPIO_PCR_RX_LVL_EDG           (BIT26 | BIT25)
+#define N_GPIO_PCR_RX_LVL_EDG           25
+#define B_GPIO_PCR_RXINV                BIT23
+#define N_GPIO_PCR_RXINV                23
+#define B_GPIO_PCR_RX_APIC_ROUTE        BIT20
+#define B_GPIO_PCR_RX_SCI_ROUTE         BIT19
+#define B_GPIO_PCR_RX_SMI_ROUTE         BIT18
+#define B_GPIO_PCR_RX_NMI_ROUTE         BIT17
+#define N_GPIO_PCR_RX_NMI_ROUTE         17
+#define B_GPIO_PCR_TERM                 (BIT13 | BIT12 | BIT11 | BIT10)
+#define N_GPIO_PCR_TERM                 10
+#define B_GPIO_PCR_PAD_MODE             (BIT12 | BIT11 | BIT10)
+#define N_GPIO_PCR_PAD_MODE             10
+#define B_GPIO_PCR_RXDIS                BIT9
+#define B_GPIO_PCR_TXDIS                BIT8
+#define N_GPIO_PCR_TXDIS                8
+#define B_GPIO_PCR_INTSEL               0x7F
+#define N_GPIO_PCR_INTSEL               0
+#define B_GPIO_PCR_RX_STATE             BIT1
+#define N_GPIO_PCR_RX_STATE             1
+#define B_GPIO_PCR_TX_STATE             BIT0
+#define N_GPIO_PCR_TX_STATE             0
+
+///
+/// Groups mapped to 2-tier General Purpose Event will all be under
+/// one master GPE_111 (0x6F)
+///
+#define PCH_GPIO_2_TIER_MASTER_GPE_NUMBER  0x6F
+
+//
+// Structure for storing information about registers offset, community,
+// maximal pad number for available groups
+//
+typedef struct {
+  GPIO_PCH_SBI_PID Community;
+  UINT16       PadOwnOffset;
+  UINT16       HostOwnOffset;
+  UINT16       GpiIsOffset;
+  UINT16       GpiIeOffset;
+  UINT16       GpiGpeStsOffset;
+  UINT16       GpiGpeEnOffset;
+  UINT16       SmiStsOffset;
+  UINT16       SmiEnOffset;
+  UINT16       NmiStsOffset;
+  UINT16       NmiEnOffset;
+  UINT16       PadCfgLockOffset;
+  UINT16       PadCfgLockTxOffset;
+  UINT16       PadCfgOffset;
+  UINT16       PadPerGroup;
+} GPIO_GROUP_INFO;
+
+//
+// If in GPIO_GROUP_INFO structure certain register doesn't exist
+// it will have value equal to NO_REGISTER_FOR_PROPERTY
+//
+#define NO_REGISTER_FOR_PROPERTY 0xFFFF
+
+/*#define GPIO_PAD_DEF(Group,Pad)                (UINT32)(((Group) << 16) + (Pad))
+#define GPIO_GROUP_DEF(GroupIndex,ChipsetId)   ((GroupIndex) | ((ChipsetId) << 8))
+#define GPIO_GET_GROUP_INDEX(Group)            ((Group) & 0x1F)
+#define GPIO_GET_GROUP_FROM_PAD(GpioPad)       (((GpioPad) & 0x0F1F0000) >> 16)
+#define GPIO_GET_GROUP_INDEX_FROM_PAD(GpioPad) GPIO_GET_GROUP_INDEX (GPIO_GET_GROUP_FROM_PAD(GpioPad))
+#define GPIO_GET_PAD_NUMBER(GpioPad)           ((GpioPad) & 0x1FF)
+#define GPIO_GET_CHIPSET_ID(GpioPad)           (((GpioPad) >> 24) & 0xF)
+*/
+#define GPIO_GET_PAD_POSITION(PadNumber)       ((PadNumber) % 32)
+#define GPIO_GET_DW_NUM(PadNumber)             ((PadNumber) / 32u)
+
+//
+// Structure which stores information needed to map GPIO Group
+// to 1-Tier GPE. Configuration is needed both in PMC and GPIO IP.
+// Because GPE_DWx can handle only 32 pins only single double word can
+// be mapped at a time. Each DW for a group has different configuration in PMC and GPIO
+//
+typedef struct {
+  GPIO_GROUP  Group;
+  UINT8       GroupDw;
+  UINT8       PmcGpeDwxVal;
+  UINT8       GpioGpeDwxVal;
+} GPIO_GROUP_TO_GPE_MAPPING;
+
+//
+// Access necessary info from GPIO CFG DATA
+//
+typedef struct {
+  UINT8       BaseTableId;
+  UINT16      ItemSize;
+  UINT16      ItemCount;
+  UINT8      *BaseTableBitMask;
+  UINT8      *TableData;
+} GPIO_CFG_HDR_INFO;
+
+#pragma pack(pop)
+
+#endif //_GPIO_CONFIG_H_
+

--- a/Silicon/CommonSocPkg/Include/Library/GpioPlatformLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/GpioPlatformLib.h
@@ -1,0 +1,321 @@
+/** @file
+
+  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _GPIO_INFO_LIB_H_
+#define _GPIO_INFO_LIB_H_
+
+#include <Uefi/UefiBaseType.h>
+#include <GpioLibConfig.h>
+
+/**
+  This function gets Group to GPE0 configuration
+
+  @param[out] GpeDw0Value       GPIO Group to GPE_DW0 assignment
+  @param[out] GpeDw1Value       GPIO Group to GPE_DW1 assignment
+  @param[out] GpeDw2Value       GPIO Group to GPE_DW2 assignment
+**/
+VOID
+EFIAPI
+PmcGetGpioGpe (
+  OUT UINT32    *GpeDw0Value,
+  OUT UINT32    *GpeDw1Value,
+  OUT UINT32    *GpeDw2Value
+  );
+
+
+/**
+  This internal procedure will check if group is within DeepSleepWell.
+
+  @param[in]  Group               GPIO Group
+
+  @retval GroupWell               TRUE:  This is DSW Group
+                                  FALSE: This is not DSW Group
+**/
+BOOLEAN
+EFIAPI
+GpioIsDswGroup (
+  IN  GPIO_GROUP         Group
+  );
+
+
+/**
+  This procedure will retrieve address and length of GPIO info table
+
+  @param[out]  GpioGroupInfoTableLength   Length of GPIO group table
+
+  @retval Pointer to GPIO group table
+
+**/
+CONST GPIO_GROUP_INFO*
+EFIAPI
+GpioGetGroupInfoTable (
+  OUT UINT32              *GpioGroupInfoTableLength
+  );
+
+
+/**
+  Get GPIO Chipset ID specific to PCH generation and series
+
+  @retval PCH Chipset ID
+**/
+UINT32
+EFIAPI
+GpioGetThisChipsetId (
+  VOID
+  );
+
+
+/**
+  Get information for GPIO Group required to program GPIO and PMC for desired 1-Tier GPE mapping
+
+  @param[out] GpioGroupToGpeMapping        Table with GPIO Group to GPE mapping
+  @param[out] GpioGroupToGpeMappingLength  GPIO Group to GPE mapping table length
+**/
+VOID
+EFIAPI
+GpioGetGroupToGpeMapping (
+  OUT GPIO_GROUP_TO_GPE_MAPPING  **GpioGroupToGpeMapping,
+  OUT UINT32                     *GpioGroupToGpeMappingLength
+  );
+
+
+/**
+  This function provides GPIO Community PortIDs
+
+  @param[out] NativePinsTable                Table with GPIO COMMx SBI PortIDs
+
+  @retval     Number of communities
+**/
+UINT32
+EFIAPI
+GpioGetComSbiPortIds (
+  OUT GPIO_PCH_SBI_PID    **GpioComSbiIds
+  );
+
+
+/**
+  Wrapper to full function for executing PCH SBI message
+
+  @param[in] Pid                        Port ID of the SBI message
+  @param[in] Offset                     Offset of the SBI message
+  @param[in] Opcode                     Opcode
+  @param[in] Posted                     Posted message
+  @param[in] Fbe                        First byte enable
+  @param[in] Bar                        Bar
+  @param[in] Fid                        Function ID
+  @param[in, out] Data32                Read/Write data
+  @param[out] Response                  Response
+
+  @retval EFI_SUCCESS                   Successfully completed.
+  @retval EFI_DEVICE_ERROR              Transaction fail
+  @retval EFI_INVALID_PARAMETER         Invalid parameter
+  @retval EFI_TIMEOUT                   Timeout while waiting for response
+**/
+EFI_STATUS
+EFIAPI
+GpioPchSbiExecutionEx (
+  IN     GPIO_PCH_SBI_PID               Pid,
+  IN     UINT64                         Offset,
+  IN     GPIO_PCH_SBI_OPCODE            Opcode,
+  IN     BOOLEAN                        Posted,
+  IN     UINT16                         Fbe,
+  IN     UINT16                         Bar,
+  IN     UINT16                         Fid,
+  IN OUT UINT32                         *Data32,
+  OUT    UINT8                          *Response
+  );
+
+
+/**
+  Get PCH PCR Address for this Register
+
+  @param[in] Pid                        Port ID of the SBI message
+  @param[in] Offset                     Offset of the Cfg Regsiter
+
+  @retval UINT32                        Pch Pcr Address to access this register
+**/
+UINT32
+EFIAPI
+GetPchPcrAddress (
+  IN     GPIO_PCH_SBI_PID                 Pid,
+  IN     UINT32                         Offset
+  );
+
+
+/**
+  Get TypeC SBU Gpio Pad table
+
+  @param[out] TableLength       Length of the TypeC SBU Gpio Pad table
+
+  @retval Pointer to TypeC SBU Gpio Pad table
+**/
+GPIO_PAD*
+EFIAPI
+GpioGetTypeCSbuGpioPad (
+  IN OUT   UINT32      *TableLength
+  );
+
+
+/**
+  Get GPIO PCR Pad Cfg Offset
+
+  @retval PAD CFG Offset
+**/
+UINT8
+EFIAPI
+GpioGetPcrPadCfgOffset(
+  VOID
+  );
+
+
+/**
+  This procedure will return GpioPad from Group and PadNumber
+
+  @param[in] Group              GPIO group
+  @param[in] PadNumber          GPIO PadNumber
+
+  @retval GpioPad               GpioPad
+**/
+GPIO_PAD
+EFIAPI
+GpioGetGpioPadFromGroupAndPadNumber (
+  IN GPIO_GROUP      Group,
+  IN UINT32          PadNumber
+  );
+
+
+/**
+  This procedure will return GpioPad from GroupIndex and PadNumber
+
+  @param[in] GroupIndex         GPIO GroupIndex
+  @param[in] PadNumber          GPIO PadNumber
+
+  @retval GpioPad               GpioPad
+**/
+GPIO_PAD
+EFIAPI
+GpioGetGpioPadFromGroupIndexAndPadNumber (
+  IN UINT32          GroupIndex,
+  IN UINT32          PadNumber
+  );
+
+
+/**
+  This procedure will get group from group index (0 based)
+
+  @param[in] GroupIndex        Group Index
+
+  @retval GpioGroup            Gpio Group
+**/
+GPIO_GROUP
+EFIAPI
+GpioGetGroupFromGroupIndex (
+  IN UINT32        GroupIndex
+  );
+
+
+/**
+  This procedure will get group index (0 based) from group
+
+  @param[in] GpioGroup        Gpio Group
+
+  @retval Value               Group Index
+**/
+UINT32
+EFIAPI
+GpioGetGroupIndexFromGroup (
+  IN GPIO_GROUP        GpioGroup
+  );
+
+
+/**
+  This procedure will get group number
+
+  @param[in] GpioPad          Gpio Pad
+
+  @retval Value               Group number
+**/
+GPIO_GROUP
+EFIAPI
+GpioGetGroupFromGpioPad (
+  IN GPIO_PAD         GpioPad
+  );
+
+
+/**
+  This procedure will get group index (0 based)
+
+  @param[in] GpioPad          Gpio Pad
+
+  @retval Value               Group Index
+**/
+UINT32
+EFIAPI
+GpioGetGroupIndexFromGpioPad (
+  IN GPIO_PAD        GpioPad
+  );
+
+
+/**
+  This procedure will get pad number (0 based) from Gpio Pad
+
+  @param[in] GpioPad          Gpio Pad
+
+  @retval Value               Pad Number
+**/
+UINT32
+EFIAPI
+GpioGetPadNumberFromGpioPad (
+  IN GPIO_PAD        GpioPad
+  );
+
+
+/**
+  This procedure will get Chipset ID from Gpio Pad
+
+  @param[in] GpioPad          Gpio Pad
+
+  @retval Value               PCH Chipset ID
+**/
+UINT32
+EFIAPI
+GpioGetChipsetIdFromGpioPad (
+  IN GPIO_PAD        GpioPad
+  );
+
+
+/**
+  This procedure will get Gpio Pad from Cfg Dword
+
+  @param[in]  GpioItem         Pointer to the Gpio Cfg Data Item
+  @param[out] GpioPad          Gpio Pad
+**/
+VOID
+EFIAPI
+GpioGetGpioPadFromCfgDw (
+  IN  UINT32        *GpioItem,
+  OUT GPIO_PAD      *GpioPad
+  );
+
+
+/**
+  This procedure will get GPIO CFG INFO based on BaseTable Id
+
+  @param[in]  BaseTableId         BaseTableId value; if 0xFF, get ByTag; else get ByPidTag
+  @param[out] CfgHdrInfo          Pointer to the GPIO_CFG_HDR_INFO struct
+
+  @retval Status                  EFI_SUCCESS, if executed successfully
+                                  EFI_NOT_FOUND, if failed to find the GPIO CFG DATA Tag
+**/
+EFI_STATUS
+EFIAPI
+GpioGetCfgHdrInfo (
+  OUT GPIO_CFG_HDR_INFO  *CfgHdrInfo,
+  IN  UINT8               BaseTableId
+  );
+
+#endif // _GPIO_INFO_LIB_H_

--- a/Silicon/CommonSocPkg/Include/Library/GpioSocLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/GpioSocLib.h
@@ -1,0 +1,324 @@
+/** @file
+  The platform GPIO library header.
+
+  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _GPIO_LIBRARY_H_
+#define _GPIO_LIBRARY_H_
+
+#include <Base.h>
+#include <Uefi/UefiBaseType.h>
+#include <Library/IoLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/GpioPlatformLib.h>
+
+/**
+  This procedure is used to lock all GPIO pads except the ones
+  which were requested during their configuration to be left unlocked.
+  This function must be called before BIOS_DONE - before POSTBOOT_SAI is enabled.
+    FSP - call this function from wrapper before transition to FSP-S
+    UEFI/EDK - call this function before EndOfPei event
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+GpioLockPads (
+  VOID
+  );
+
+
+/**
+  This procedure is used to clear GPE STS for a specified GpioPad
+
+  @param[in]  GpioPad             GPIO pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioClearGpiGpeSts (
+  IN GPIO_PAD                  GpioPad
+  );
+
+
+/**
+  This procedure will get Group to GPE mapping. If group has more than 32 bits
+  it is possible to map only single DW of pins (e.g. 0-31, 32-63) because
+  ACPI GPE_DWx register is 32 bits large.
+
+  @param[out]  GroupToGpeDw0       GPIO group mapped to GPE_DW0
+  @param[out]  GroupDwForGpeDw0    DW of pins mapped to GPE_DW0
+  @param[out]  GroupToGpeDw1       GPIO group mapped to GPE_DW1
+  @param[out]  GroupDwForGpeDw1    DW of pins mapped to GPE_DW1
+  @param[out]  GroupToGpeDw2       GPIO group mapped to GPE_DW2
+  @param[out]  GroupDwForGpeDw2    DW of pins mapped to GPE_DW2
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+GpioGetGroupDwToGpeDwX (
+  OUT GPIO_GROUP                *GroupToGpeDw0,
+  OUT UINT32                    *GroupDwForGpeDw0,
+  OUT GPIO_GROUP                *GroupToGpeDw1,
+  OUT UINT32                    *GroupDwForGpeDw1,
+  OUT GPIO_GROUP                *GroupToGpeDw2,
+  OUT UINT32                    *GroupDwForGpeDw2
+  );
+
+
+/**
+  This procedure will set PadCfgLock for selected pad
+
+  @param[in] GpioPad              GPIO pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioLockPadCfg (
+  IN GPIO_PAD                   GpioPad
+  );
+
+
+/**
+  This procedure will check state of Pad Config Lock for selected pad
+
+  @param[in]  GpioPad             GPIO pad
+  @param[out] PadCfgLock          PadCfgLock for selected pad
+                                  0: NotLocked, 1: Locked
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioGetPadCfgLock (
+  IN GPIO_PAD                   GpioPad,
+  OUT UINT32                    *PadCfgLock
+  );
+
+
+/**
+  This procedure will clear PadCfgLock for selected pad.
+  Unlocking a pad will cause an SMI (if enabled)
+
+  @param[in] GpioPad              GPIO pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioUnlockPadCfg (
+  IN GPIO_PAD                   GpioPad
+  );
+
+
+/**
+  This procedure will set GPIO output level
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Value                Output value
+                                  0: OutputLow, 1: OutputHigh
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioSetOutputValue (
+  IN GPIO_PAD                  GpioPad,
+  IN UINT32                    Value
+  );
+
+
+/**
+  This procedure will get GPIO output level
+
+  @param[in]  GpioPad             GPIO pad
+  @param[out] OutputVal           GPIO Output value
+                                  0: OutputLow, 1: OutputHigh
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioGetOutputValue (
+  IN GPIO_PAD                  GpioPad,
+  OUT UINT32                   *OutputVal
+  );
+
+
+/**
+  This procedure will get GPIO input level
+
+  @param[in]  GpioPad             GPIO pad
+  @param[out] InputVal            GPIO Input value
+                                  0: InputLow, 1: InputHigh
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioGetInputValue (
+  IN GPIO_PAD                  GpioPad,
+  OUT UINT32                   *InputVal
+  );
+
+
+/**
+  This procedure will configure GPIO input inversion
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Value                Value for GPIO input inversion
+                                  0: No input inversion, 1: Invert input
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioSetInputInversion (
+  IN GPIO_PAD                  GpioPad,
+  IN UINT32                    Value
+  );
+
+
+/**
+  This procedure will get GPIO pad input inversion value
+
+  @param[in] GpioPad              GPIO pad
+  @param[out] InvertState         GPIO inversion state
+                                  0: No input inversion, 1: Inverted input
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioGetInputInversion (
+  IN GPIO_PAD                  GpioPad,
+  OUT UINT32                   *InvertState
+  );
+
+
+/**
+  This procedure will set GPIO interrupt settings
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Value                Value of Level/Edge
+                                  use GPIO_INT_CONFIG as argument
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioSetPadInterruptConfig (
+  IN GPIO_PAD                 GpioPad,
+  IN GPIO_INT_CONFIG          Value
+  );
+
+
+/**
+  This procedure will set GPIO electrical settings
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Value                Value of termination
+                                  use GPIO_ELECTRICAL_CONFIG as argument
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioSetPadElectricalConfig (
+  IN GPIO_PAD                  GpioPad,
+  IN GPIO_ELECTRICAL_CONFIG    Value
+  );
+
+
+/**
+  This procedure will set GPIO Reset settings
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Value                Value for Pad Reset Configuration
+                                  use GPIO_RESET_CONFIG as argument
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioSetPadResetConfig (
+  IN GPIO_PAD                  GpioPad,
+  IN GPIO_RESET_CONFIG         Value
+  );
+
+
+/**
+  This procedure will get GPIO Reset settings
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Value                Value of Pad Reset Configuration
+                                  based on GPIO_RESET_CONFIG
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioGetPadResetConfig (
+  IN GPIO_PAD                  GpioPad,
+  IN GPIO_RESET_CONFIG         *Value
+  );
+
+
+/**
+  This procedure will read GPIO Pad Configuration register
+
+  @param[in] GpioPad          GPIO pad
+  @param[in] DwReg            Choose PADCFG register: 0:DW0, 1:DW1
+
+  @retval PadCfgRegValue      PADCFG_DWx value
+**/
+UINT32
+GpioReadPadCfgReg (
+  IN GPIO_PAD             GpioPad,
+  IN UINT8                DwReg
+  );
+
+
+/**
+  This procedure will write or read GPIO Pad Configuration register
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] DwReg                Choose PADCFG register: 0:DW0, 1:DW1
+  @param[in] PadCfgAndMask        Mask to be AND'ed with PADCFG reg value
+  @param[in] PadCfgOrMask         Mask to be OR'ed with PADCFG reg value
+
+  @retval none
+**/
+VOID
+GpioWritePadCfgReg (
+  IN GPIO_PAD             GpioPad,
+  IN UINT8                DwReg,
+  IN UINT32               PadCfgAndMask,
+  IN UINT32               PadCfgOrMask
+  );
+
+
+/**
+  This procedure will read multiple GPIO settings
+
+  @param[in]  GpioPad                   GPIO Pad
+  @param[out] GpioData                  GPIO data structure
+
+  @retval EFI_SUCCESS                   The function completed successfully
+  @retval EFI_INVALID_PARAMETER         Invalid GpioPad
+**/
+EFI_STATUS
+GpioGetPadConfig (
+  IN  GPIO_PAD               GpioPad,
+  OUT GPIO_CONFIG            *GpioData
+  );
+
+#endif // _GPIO_LIBRARY_H_
+

--- a/Silicon/CommonSocPkg/Library/GpioLib/GpioHelpersLib.c
+++ b/Silicon/CommonSocPkg/Library/GpioLib/GpioHelpersLib.c
@@ -1,0 +1,524 @@
+/** @file
+  This file contains routines for GPIO native and chipset specific usage
+
+  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/GpioSocLib.h>
+#include <Library/DebugLib.h>
+#include <Library/GpioPlatformLib.h>
+#include <GpioLibConfig.h>
+#include <Library/MemoryAllocationLib.h>
+#include <GpioLibInternal.h>
+
+//
+//  GPIO Lock HOB
+//  Stores information on GPIO pads that should be left unlocked
+//
+typedef struct {
+  //
+  // GPIO PadConfig unlock data
+  //
+  UINT32  PadConfig;
+  //
+  // GPIO Output unlock data
+  //
+  UINT32  OutputState;
+} GPIO_UNLOCK_HOB_DATA;
+
+GLOBAL_REMOVE_IF_UNREFERENCED GPIO_UNLOCK_HOB_DATA *mGpioUnlockData = NULL;
+GLOBAL_REMOVE_IF_UNREFERENCED UINT32 mGpioUnlockDataRecords = 0;
+
+/**
+  This procedure will get index of GPIO Unlock HOB structure for selected GroupIndex and DwNum.
+
+  @param[in]  GroupIndex          GPIO group index
+  @param[in]  DwNum               DWORD index for a group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+
+  @retval GpioUnlockHobIndex
+**/
+STATIC
+UINT32
+GpioUnlockDataIndex (
+  IN UINT32                       GroupIndex,
+  IN UINT32                       DwNum
+  )
+{
+  UINT32         GpioUnlockDataIndex;
+  UINT32         Index;
+
+  GpioUnlockDataIndex = 0;
+
+  for (Index = 0; Index < GroupIndex; Index++) {
+    GpioUnlockDataIndex += GPIO_GET_DW_NUM (GpioGetPadPerGroup (GpioGetGroupFromGroupIndex (Index))) + 1;
+  }
+
+  GpioUnlockDataIndex += DwNum;
+  return GpioUnlockDataIndex;
+}
+
+/**
+  This procedure will create GPIO HOB for storing unlock data
+
+  @retval Pointer to GPIO Unlock data structure
+**/
+STATIC
+GPIO_UNLOCK_HOB_DATA*
+GpioCreateUnlockData (
+  VOID
+  )
+{
+  GPIO_GROUP     Group;
+  GPIO_GROUP     GroupMin;
+  GPIO_GROUP     GroupMax;
+  UINT32         GpioUnlockDataRecords;
+
+  if (mGpioUnlockData == NULL) {
+    GroupMin = GpioGetLowestGroup ();
+    GroupMax = GpioGetHighestGroup ();
+    GpioUnlockDataRecords = 0;
+
+    for (Group = GroupMin; Group <= GroupMax; Group++) {
+      GpioUnlockDataRecords += GPIO_GET_DW_NUM (GpioGetPadPerGroup (Group)) + 1;
+    }
+
+    mGpioUnlockData = (GPIO_UNLOCK_HOB_DATA *)AllocatePool (GpioUnlockDataRecords * sizeof (GPIO_UNLOCK_HOB_DATA));
+    if (mGpioUnlockData != NULL) {
+      mGpioUnlockDataRecords = GpioUnlockDataRecords;
+      ZeroMem (mGpioUnlockData, mGpioUnlockDataRecords * sizeof (GPIO_UNLOCK_HOB_DATA));
+    }
+  }
+
+  return (GPIO_UNLOCK_HOB_DATA*)mGpioUnlockData;
+}
+
+/**
+  This procedure will Get GPIO Unlock data structure for storing unlock data.
+  If HOB doesn't exist it will be created.
+
+  @param[out] GpioUnlockData          pointer to GPIO Unlock data structure
+
+  @retval Length                      number of GPIO unlock data records
+**/
+STATIC
+UINT32
+GpioGetUnlockData (
+  GPIO_UNLOCK_HOB_DATA  **GpioUnlockData
+  )
+{
+  if (mGpioUnlockData == NULL) {
+    //
+    // It is the first time this function is used so create the HOB
+    //
+    *GpioUnlockData = GpioCreateUnlockData ();
+    if (*GpioUnlockData == NULL) {
+      return 0;
+    }
+  } else {
+    *GpioUnlockData = mGpioUnlockData;
+  }
+  return mGpioUnlockDataRecords;
+}
+
+/**
+  This procedure will get pointer to GPIO Unlock data structure.
+
+  @param[out] GpioUnlockData          pointer to GPIO Unlock data structure
+
+  @retval Length                      number of GPIO unlock data records
+**/
+STATIC
+UINT32
+GpioLocateUnlockData (
+  GPIO_UNLOCK_HOB_DATA  **GpioUnlockData
+  )
+{
+  if (mGpioUnlockData == NULL) {
+    *GpioUnlockData = NULL;
+    return 0;
+  }
+
+  *GpioUnlockData = (GPIO_UNLOCK_HOB_DATA *) mGpioUnlockData;
+  return mGpioUnlockDataRecords;
+}
+
+/**
+  This procedure stores GPIO pad unlock information
+
+  @param[in] GpioPad         GPIO pad
+  @param[in] GpioLockConfig  GPIO Lock Configuration
+
+  @retval Status
+**/
+EFI_STATUS
+GpioStoreUnlockData (
+  IN GPIO_PAD             GpioPad,
+  IN GPIO_LOCK_CONFIG     GpioLockConfig
+  )
+{
+  GPIO_UNLOCK_HOB_DATA *GpioUnlockData;
+  UINT32               Length;
+  UINT32               GroupIndex;
+  UINT32               PadNumber;
+  UINT32               Index;
+
+  if (GpioLockConfig == GpioLockDefault) {
+    return EFI_SUCCESS;
+  }
+
+  Length = GpioGetUnlockData (&GpioUnlockData);
+  if (Length == 0) {
+    return EFI_NOT_FOUND;
+  }
+
+  GroupIndex = GpioGetGroupIndexFromGpioPad (GpioPad);
+  PadNumber = GpioGetPadNumberFromGpioPad (GpioPad);
+  Index = GpioUnlockDataIndex (GroupIndex, GPIO_GET_DW_NUM (PadNumber));
+
+  if (Index >= Length) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((GpioLockConfig & B_GPIO_LOCK_CONFIG_PAD_CONF_LOCK_MASK) == GpioPadConfigUnlock) {
+    GpioUnlockData[Index].PadConfig |= 1 << (GpioGetPadNumberFromGpioPad (GpioPad) % 32);
+  }
+
+  if ((GpioLockConfig & B_GPIO_LOCK_CONFIG_OUTPUT_LOCK_MASK) == GpioOutputStateUnlock) {
+    GpioUnlockData[Index].OutputState |= 1 << (GpioGetPadNumberFromGpioPad (GpioPad) % 32);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure stores GPIO group data about pads which PadConfig needs to be unlocked.
+
+  @param[in]  GroupIndex          GPIO group index
+  @param[in]  DwNum               DWORD index for a group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[in]  UnlockedPads        DWORD bitmask for pads which are going to be left unlocked
+                                  Bit position - PadNumber
+                                  Bit value - 0: Skip, 1: Leave unlocked
+
+  @retval Status
+**/
+EFI_STATUS
+GpioStoreGroupDwUnlockPadConfigData (
+  IN UINT32                       GroupIndex,
+  IN UINT32                       DwNum,
+  IN UINT32                       UnlockedPads
+  )
+{
+  GPIO_UNLOCK_HOB_DATA *GpioUnlockData;
+  UINT32               Length;
+  UINT32               Index;
+
+  if (UnlockedPads == 0) {
+    //
+    // No pads to be left unlocked
+    //
+    return EFI_SUCCESS;
+  }
+
+  Length = GpioGetUnlockData (&GpioUnlockData);
+  if (Length == 0) {
+    return EFI_NOT_FOUND;
+  }
+
+  Index = GpioUnlockDataIndex (GroupIndex, DwNum);
+  if (Index >= Length) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  GpioUnlockData[Index].PadConfig |= UnlockedPads;
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure stores GPIO group data about pads which Output state needs to be unlocked.
+
+  @param[in]  GroupIndex          GPIO group index
+  @param[in]  DwNum               DWORD index for a group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[in]  UnlockedPads        DWORD bitmask for pads which are going to be left unlocked
+                                  Bit position - PadNumber
+                                  Bit value - 0: Skip, 1: Leave unlocked
+  @retval Status
+**/
+EFI_STATUS
+GpioStoreGroupDwUnlockOutputData (
+  IN UINT32                       GroupIndex,
+  IN UINT32                       DwNum,
+  IN UINT32                       UnlockedPads
+  )
+{
+  GPIO_UNLOCK_HOB_DATA *GpioUnlockData;
+  UINT32               Length;
+  UINT32               Index;
+
+  if (UnlockedPads == 0) {
+    //
+    // No pads to be left unlocked
+    //
+    return EFI_SUCCESS;
+  }
+
+  Length = GpioGetUnlockData (&GpioUnlockData);
+  if (Length == 0) {
+    return EFI_NOT_FOUND;
+  }
+
+  Index = GpioUnlockDataIndex (GroupIndex, DwNum);
+  if (Index >= Length) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  GpioUnlockData[Index].OutputState |= UnlockedPads;
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will get GPIO group data with pads, which PadConfig is supposed to be left unlock
+
+  @param[in]  GroupIndex          GPIO group index
+  @param[in]  DwNum               DWORD index for a group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @retval     UnlockedPads        DWORD bitmask for pads which are going to be left unlocked
+                                  Bit position - PadNumber
+                                  Bit value - 0: to be locked, 1: Leave unlocked
+**/
+UINT32
+GpioGetGroupDwUnlockPadConfigMask (
+  IN UINT32                       GroupIndex,
+  IN UINT32                       DwNum
+  )
+{
+  GPIO_UNLOCK_HOB_DATA *GpioUnlockData;
+  UINT32               Length;
+  UINT32               Index;
+
+  Length = GpioLocateUnlockData (&GpioUnlockData);
+  if (Length == 0) {
+    return 0;
+  }
+
+  Index = GpioUnlockDataIndex (GroupIndex, DwNum);
+  if (Index >= Length) {
+    return 0;
+  }
+
+  return GpioUnlockData[Index].PadConfig;
+}
+
+/**
+  This procedure will get GPIO group data with pads, which Output is supposed to be left unlock
+
+  @param[in]  GroupIndex          GPIO group index
+  @param[in]  DwNum               DWORD index for a group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @retval     UnlockedPads        DWORD bitmask for pads which are going to be left unlocked
+                                  Bit position - PadNumber
+                                  Bit value - 0: to be locked, 1: Leave unlocked
+**/
+UINT32
+GpioGetGroupDwUnlockOutputMask (
+  IN UINT32                       GroupIndex,
+  IN UINT32                       DwNum
+  )
+{
+  GPIO_UNLOCK_HOB_DATA *GpioUnlockData;
+  UINT32               Length;
+  UINT32               Index;
+
+  Length = GpioLocateUnlockData (&GpioUnlockData);
+  if (Length == 0) {
+    return 0;
+  }
+
+  Index = GpioUnlockDataIndex (GroupIndex, DwNum);
+  if (Index >= Length) {
+    return 0;
+  }
+
+  return GpioUnlockData[Index].OutputState;
+}
+
+
+/**
+  This procedure is used to check if GpioPad is valid for certain chipset
+
+  @param[in]  GpioPad             GPIO pad
+
+  @retval TRUE                    This pin is valid on this chipset
+          FALSE                   Incorrect pin
+**/
+BOOLEAN
+GpioIsCorrectPadForThisChipset (
+  IN  GPIO_PAD        GpioPad
+  )
+{
+  return ((GpioGetChipsetIdFromGpioPad (GpioPad) == GpioGetThisChipsetId ()) &&
+         (GpioGetGroupIndexFromGpioPad (GpioPad) < GpioGetNumberOfGroups ()));
+}
+
+
+
+/**
+  This procedure will get number of pads for certain GPIO group
+
+  @param[in] Group            GPIO group number
+
+  @retval Value               Pad number for group
+                              If illegal group number then return 0
+**/
+UINT32
+GpioGetPadPerGroup (
+  IN GPIO_GROUP      Group
+  )
+{
+  CONST GPIO_GROUP_INFO  *GpioGroupInfo;
+  UINT32                 GpioGroupInfoLength;
+  UINT32                 GroupIndex;
+  //
+  // Check if group argument exceeds GPIO GROUP INFO array
+  //
+  GpioGroupInfo = GpioGetGroupInfoTable (&GpioGroupInfoLength);
+  GroupIndex = GpioGetGroupIndexFromGroup (Group);
+
+  if ((UINTN) GroupIndex >= GpioGroupInfoLength) {
+    return 0;
+  } else {
+    return GpioGroupInfo[GroupIndex].PadPerGroup;
+  }
+}
+
+/**
+  This procedure will get number of groups
+
+  @param[in] none
+
+  @retval Value               Group number
+**/
+UINT32
+GpioGetNumberOfGroups (
+  VOID
+  )
+{
+  UINT32                 GpioGroupInfoLength;
+
+  GpioGetGroupInfoTable (&GpioGroupInfoLength);
+  return GpioGroupInfoLength;
+}
+/**
+  This procedure will get lowest group
+
+  @param[in] none
+
+  @retval Value               Lowest Group
+**/
+GPIO_GROUP
+GpioGetLowestGroup (
+  VOID
+  )
+{
+  return GpioGetGroupFromGroupIndex (0);
+}
+
+/**
+  This procedure will get highest group
+
+  @param[in] none
+
+  @retval Value               Highest Group
+**/
+GPIO_GROUP
+GpioGetHighestGroup (
+  VOID
+  )
+{
+  return GpioGetGroupFromGroupIndex (GpioGetNumberOfGroups () - 1);
+}
+
+
+/**
+  This function is to be used In GpioLockPads() to override a lock request by SOC code.
+
+  @param[in]  Group               GPIO group
+  @param[in]  DwNum               Register number for current group (parameter applicable in accessing whole register).
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[out] *UnlockCfgPad       DWORD bitmask for pads which are going to be left unlocked
+                                  Bit position - PadNumber
+                                  Bit value - 0: to be locked, 1: Leave unlocked
+  @param[out] *UnlockTxPad        DWORD bitmask for pads which are going to be left unlocked
+                                  Bit position - PadNumber
+                                  Bit value - 0: to be locked, 1: Leave unlocked
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid input parameter
+**/
+EFI_STATUS
+GpioUnlockOverride (
+  IN  GPIO_GROUP  Group,
+  IN  UINT32      DwNum,
+  OUT UINT32      *UnlockCfgPad,
+  OUT UINT32      *UnlockTxPad
+  )
+{
+  GPIO_PAD            *GpioSbuPadTable;
+  UINT32              SbuPadNum;
+  UINT32              MaxIndex;
+  GPIO_CONFIG         PadConfig;
+  UINT32              Index;
+  UINT32              SbuUnlockedPads;
+  EFI_STATUS          Status;
+
+  if ((UnlockCfgPad == NULL) || (UnlockTxPad == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  MaxIndex = 0;
+  // SBU (Sideband use) pins are used as auxiliary signals for Type C connector,
+  // which are hard-wired to BSSB_LS natively for debug function.
+  // when USB-C needed, don't lock pins that control by PMC at runtime,
+  GpioSbuPadTable = GpioGetTypeCSbuGpioPad(&MaxIndex);
+  if (GpioSbuPadTable == NULL || MaxIndex == 0) {
+    *UnlockCfgPad = 0;
+    *UnlockTxPad = 0;
+    return EFI_SUCCESS;
+  }
+  SbuUnlockedPads = 0;
+
+  for (Index = 0; Index < MaxIndex; Index++) {
+
+    SbuPadNum = GpioGetPadNumberFromGpioPad (GpioSbuPadTable[Index]);
+
+    if (Group != GpioGetGroupFromGpioPad (GpioSbuPadTable[Index])) {
+      continue;
+    }
+
+    if (DwNum != GPIO_GET_DW_NUM (SbuPadNum)) {
+      continue;
+    }
+
+    Status = GpioGetPadConfig (GpioSbuPadTable[Index], &PadConfig);
+    if (EFI_ERROR(Status)) {
+      continue;
+    }
+
+    //
+    // GPIO, Native3, Native4 and Native5 control by PMC at runtime
+    //
+    if ((PadConfig.PadMode == GpioPadModeNative1) || (PadConfig.PadMode == GpioPadModeNative2)) {
+      continue;
+    }
+
+    SbuUnlockedPads |= (1 << GPIO_GET_PAD_POSITION (SbuPadNum));
+  }
+
+  *UnlockCfgPad = SbuUnlockedPads;
+  *UnlockTxPad = SbuUnlockedPads;
+  return EFI_SUCCESS;
+}

--- a/Silicon/CommonSocPkg/Library/GpioLib/GpioInit.c
+++ b/Silicon/CommonSocPkg/Library/GpioLib/GpioInit.c
@@ -1,0 +1,737 @@
+/** @file
+  This file contains routines for GPIO
+
+  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi/UefiBaseType.h>
+#include <Library/DebugLib.h>
+#include <Library/GpioSocLib.h>
+#include <Library/GpioPlatformLib.h>
+#include <GpioLibInternal.h>
+
+//
+// GPIO_GROUP_DW_DATA structure is used by GpioConfigurePch function
+// to cache values which will be programmed into respective GPIO registers
+// after all GpioPads are processed. This way MMIO accesses are decreased
+// and instead of doing one programming for one GpioPad there is only
+// one access for whole register.
+//
+typedef struct {
+  UINT32             HostSoftOwnReg;
+  UINT32             HostSoftOwnRegMask;
+  UINT32             GpiGpeEnReg;
+  UINT32             GpiGpeEnRegMask;
+  UINT32             GpiNmiEnReg;
+  UINT32             GpiNmiEnRegMask;
+  UINT32             GpiSmiEnReg;
+  UINT32             GpiSmiEnRegMask;
+  UINT32             ConfigUnlockMask;
+  UINT32             OutputUnlockMask;
+} GPIO_GROUP_DW_DATA;
+
+//
+// GPIO_GROUP_DW_NUMBER contains number of DWords required to
+// store Pad data for all groups. Each pad uses one bit.
+//
+
+#define GPIO_GROUP_DW_NUMBER  1
+
+/**
+  Get GPIO DW Register values (HOSTSW_OWN, GPE_EN, NMI_EN, Lock).
+
+  @param[in]     PadNumber      GPIO pad number
+  @param[in]     GpioConfig     GPIO Config data
+  @param[in out] DwRegsValues   Values for GPIO DW Registers
+
+  @retval None
+**/
+STATIC
+VOID
+GpioDwRegValueFromGpioConfig (
+  IN UINT32                 PadNumber,
+  IN CONST GPIO_CONFIG      *GpioConfig,
+  IN OUT GPIO_GROUP_DW_DATA *GroupDwData
+  )
+{
+  UINT32  PadBitPosition;
+  UINT32  DwNum;
+
+  PadBitPosition = GPIO_GET_PAD_POSITION (PadNumber);
+  DwNum = GPIO_GET_DW_NUM (PadNumber);
+
+  if (DwNum >= GPIO_GROUP_DW_NUMBER) {
+    ASSERT (FALSE);
+    return;
+  }
+  //
+  // Update value to be programmed in HOSTSW_OWN register
+  //
+  GroupDwData[DwNum].HostSoftOwnRegMask |= (GpioConfig->HostSoftPadOwn & 0x1) << PadBitPosition;
+  GroupDwData[DwNum].HostSoftOwnReg |= (GpioConfig->HostSoftPadOwn >> 0x1) << PadBitPosition;
+
+  //
+  // Update value to be programmed in GPI_GPE_EN register
+  //
+  GroupDwData[DwNum].GpiGpeEnRegMask |= (GpioConfig->InterruptConfig & 0x1) << PadBitPosition;
+  GroupDwData[DwNum].GpiGpeEnReg |= ((GpioConfig->InterruptConfig & GpioIntSci) >> 3) << PadBitPosition;
+
+  //
+  // Update value to be programmed in GPI_NMI_EN register
+  //
+  GroupDwData[DwNum].GpiNmiEnRegMask |= (GpioConfig->InterruptConfig & 0x1) << PadBitPosition;
+  GroupDwData[DwNum].GpiNmiEnReg |= ((GpioConfig->InterruptConfig & GpioIntNmi) >> 1) << PadBitPosition;
+
+  //
+  // Update value to be programmed in GPI_SMI_EN register
+  //
+  GroupDwData[DwNum].GpiSmiEnRegMask |= (GpioConfig->InterruptConfig & 0x1) << PadBitPosition;
+  GroupDwData[DwNum].GpiSmiEnReg |= ((GpioConfig->InterruptConfig & GpioIntSmi) >> 2) << PadBitPosition;
+  if ((GpioConfig->InterruptConfig & GpioIntSmi) == GpioIntSmi) {
+    GroupDwData[DwNum].HostSoftOwnRegMask |= 1 << PadBitPosition;
+    GroupDwData[DwNum].HostSoftOwnReg |= 1 << PadBitPosition;
+  }
+
+  //
+  // Update information on Pad Configuration Lock
+  //
+  GroupDwData[DwNum].ConfigUnlockMask |= ((GpioConfig->LockConfig >> 1) & 0x1) << PadBitPosition;
+
+  //
+  // Update information on Pad Configuration Lock Tx
+  //
+  GroupDwData[DwNum].OutputUnlockMask |= ((GpioConfig->LockConfig >> 3) & 0x1) << PadBitPosition;
+
+  //
+  // if pad in GpioMode is an output default action should be to leave output unlocked
+  //
+  if ((GpioConfig->PadMode == GpioPadModeGpio) &&
+      (GpioConfig->Direction == GpioDirOut) &&
+      ((GpioConfig->LockConfig & B_GPIO_LOCK_CONFIG_OUTPUT_LOCK_MASK) == GpioLockDefault)) {
+    GroupDwData[DwNum].OutputUnlockMask |= 0x1 << PadBitPosition;
+  }
+}
+
+/**
+  This internal procedure will scan GPIO initialization table and unlock
+  all pads present in it
+
+  @param[in] NumberOfItem               Number of GPIO pad records in table
+  @param[in] GpioInitTableAddress       GPIO initialization table
+  @param[in] Index                      Index of GPIO Initialization table record
+
+  @retval EFI_SUCCESS                   The function completed successfully
+  @retval EFI_INVALID_PARAMETER         Invalid group or pad number
+**/
+STATIC
+EFI_STATUS
+GpioUnlockPadsForAGroup (
+  IN UINT32                    NumberOfItems,
+  IN GPIO_INIT_CONFIG          *GpioInitTableAddress,
+  IN UINT32                    Index
+  )
+{
+  UINT32                 PadsToUnlock[GPIO_GROUP_DW_NUMBER];
+  UINT32                 DwNum;
+  UINT32                 PadBitPosition;
+  CONST GPIO_GROUP_INFO  *GpioGroupInfo;
+  UINT32                 GpioGroupInfoLength;
+  CONST GPIO_INIT_CONFIG *GpioData;
+  GPIO_GROUP             Group;
+  UINT32                 GroupIndex;
+  UINT32                 PadNumber;
+
+  GpioGroupInfo = GpioGetGroupInfoTable (&GpioGroupInfoLength);
+
+  GpioData   = &GpioInitTableAddress[Index];
+  Group      = GpioGetGroupFromGpioPad (GpioData->GpioPad);
+  GroupIndex = GpioGetGroupIndexFromGpioPad (GpioData->GpioPad);
+
+  ZeroMem (PadsToUnlock, sizeof (PadsToUnlock));
+  //
+  // Loop through pads for one group. If pad belongs to a different group then
+  // break and move to register programming.
+  //
+  while (Index < NumberOfItems) {
+
+    GpioData   = &GpioInitTableAddress[Index];
+    if (GroupIndex != GpioGetGroupIndexFromGpioPad (GpioData->GpioPad)) {
+      //if next pad is from different group then break loop
+      break;
+    }
+
+    PadNumber  = GpioGetPadNumberFromGpioPad (GpioData->GpioPad);
+    //
+    // Check if legal pin number
+    //
+    if (PadNumber >= GpioGroupInfo[GroupIndex].PadPerGroup) {
+      DEBUG ((DEBUG_ERROR, "GPIO ERROR: Pin number (%d) exceeds possible range for group %d\n", PadNumber, GroupIndex));
+      return EFI_INVALID_PARAMETER;
+    }
+
+    PadBitPosition = GPIO_GET_PAD_POSITION (PadNumber);
+    DwNum = GPIO_GET_DW_NUM (PadNumber);
+
+    if (DwNum >= GPIO_GROUP_DW_NUMBER) {
+      ASSERT (FALSE);
+      return EFI_UNSUPPORTED;
+    }
+    //
+    // Update pads which need to be unlocked
+    //
+    PadsToUnlock[DwNum] |= 0x1 << PadBitPosition;
+
+    //Move to next item
+    Index++;
+  }
+
+  for (DwNum = 0; DwNum <= GPIO_GET_DW_NUM (GpioGroupInfo[GroupIndex].PadPerGroup); DwNum++) {
+    //
+    // Unlock pads
+    //
+    if (PadsToUnlock[DwNum] != 0) {
+      GpioUnlockPadCfgForGroupDw (Group, DwNum, PadsToUnlock[DwNum]);
+      GpioUnlockPadCfgTxForGroupDw (Group, DwNum, PadsToUnlock[DwNum]);
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will initialize multiple PCH GPIO pins
+
+  @param[in] NumberofItem               Number of GPIO pads to be updated
+  @param[in] GpioInitTableAddress       GPIO initialization table
+
+  @retval EFI_SUCCESS                   The function completed successfully
+  @retval EFI_INVALID_PARAMETER         Invalid group or pad number
+**/
+STATIC
+EFI_STATUS
+GpioConfigurePch (
+  IN UINT32                    NumberOfItems,
+  IN GPIO_INIT_CONFIG          *GpioInitTableAddress
+  )
+{
+  UINT32                 Index;
+  UINT32                 PadCfgDwReg[GPIO_PADCFG_DW_REG_NUMBER];
+  UINT32                 PadCfgDwRegMask[GPIO_PADCFG_DW_REG_NUMBER];
+  UINT32                 PadCfgReg;
+  GPIO_GROUP_DW_DATA     GroupDwData[GPIO_GROUP_DW_NUMBER];
+  UINT32                 DwNum;
+  CONST GPIO_GROUP_INFO  *GpioGroupInfo;
+  UINT32                 GpioGroupInfoLength;
+  GPIO_PAD_OWN           PadOwnVal;
+  CONST GPIO_INIT_CONFIG *GpioData;
+  UINT32                 GroupIndex;
+  UINT32                 PadNumber;
+  GPIO_PCH_SBI_PID       GpioCom;
+
+  PadOwnVal = GpioPadOwnHost;
+
+  GpioGroupInfo = GpioGetGroupInfoTable (&GpioGroupInfoLength);
+
+  Index = 0;
+  while (Index < NumberOfItems) {
+
+    GpioData   = &GpioInitTableAddress[Index];
+    GroupIndex = GpioGetGroupIndexFromGpioPad (GpioData->GpioPad);
+    GpioCom    = GpioGroupInfo[GroupIndex].Community;
+
+    DEBUG_CODE_BEGIN();
+    if (!GpioIsCorrectPadForThisChipset (GpioData->GpioPad)) {
+      DEBUG ((DEBUG_ERROR, "GPIO ERROR: Incorrect GpioPad (0x%08x) used on this chipset!\n", GpioData->GpioPad));
+      ASSERT (FALSE);
+      return EFI_UNSUPPORTED;
+    }
+    DEBUG_CODE_END ();
+
+    //
+    // Unlock pads for a given group which are going to be reconfigured
+    //
+    //
+    // Because PADCFGLOCK/LOCKTX register reset domain is Powergood, lock settings
+    // will get back to default only after G3 or DeepSx transition. On the other hand GpioPads
+    // configuration is controlled by a configurable type of reset - PadRstCfg. This means that if
+    // PadRstCfg != Powergood GpioPad will have its configuration locked despite it being not the
+    // one desired by BIOS. Before reconfiguring all pads they will get unlocked.
+    //
+    GpioUnlockPadsForAGroup (NumberOfItems, GpioInitTableAddress, Index);
+
+    ZeroMem (GroupDwData, sizeof (GroupDwData));
+    //
+    // Loop through pads for one group. If pad belongs to a different group then
+    // break and move to register programming.
+    //
+    while (Index < NumberOfItems) {
+
+      GpioData   = &GpioInitTableAddress[Index];
+      if (GroupIndex != GpioGetGroupIndexFromGpioPad (GpioData->GpioPad)) {
+        //if next pad is from different group then break loop
+        break;
+      }
+
+      PadNumber  = GpioGetPadNumberFromGpioPad (GpioData->GpioPad);
+
+      DEBUG_CODE_BEGIN ();
+      //
+      // Check if legal pin number
+      //
+      if (PadNumber >= GpioGroupInfo[GroupIndex].PadPerGroup) {
+        DEBUG ((DEBUG_ERROR, "GPIO ERROR: Pin number (%d) exceeds possible range for group %d\n", PadNumber, GroupIndex));
+        return EFI_INVALID_PARAMETER;
+      }
+
+      //
+      // Check if selected GPIO Pad is not owned by CSME/ISH
+      //
+      GpioGetPadOwnership (GpioData->GpioPad, &PadOwnVal);
+
+      if (PadOwnVal != GpioPadOwnHost) {
+        DEBUG ((DEBUG_ERROR, "GPIO ERROR: Accessing pad not owned by host (Group=%d, Pad=%d)!\n", GroupIndex, PadNumber));
+        DEBUG ((DEBUG_ERROR, "** Please make sure the GPIO usage in sync between CSME and BIOS configuration. \n"));
+        DEBUG ((DEBUG_ERROR, "** All the GPIO occupied by CSME should not do any configuration by BIOS.\n"));
+        Index++;
+        continue;
+      }
+
+      //
+      // Check if Pad enabled for SCI is to be in unlocked state
+      //
+      if (((GpioData->GpioConfig.InterruptConfig & GpioIntSci) == GpioIntSci) &&
+          ((GpioData->GpioConfig.LockConfig & B_GPIO_LOCK_CONFIG_PAD_CONF_LOCK_MASK) != GpioPadConfigUnlock)){
+        DEBUG ((DEBUG_ERROR, "GPIO ERROR: Gpio pad for SCI is not unlocked (Group=%d, Pad=%d)!\n", GroupIndex, PadNumber));
+        ASSERT (FALSE);
+        return EFI_INVALID_PARAMETER;
+      }
+      DEBUG_CODE_END ();
+
+      ZeroMem (PadCfgDwReg, sizeof (PadCfgDwReg));
+      ZeroMem (PadCfgDwRegMask, sizeof (PadCfgDwRegMask));
+      //
+      // Get GPIO PADCFG register value from GPIO config data
+      //
+      GpioPadCfgRegValueFromGpioConfig (
+        GpioData->GpioPad,
+        &GpioData->GpioConfig,
+        PadCfgDwReg,
+        PadCfgDwRegMask
+        );
+
+      //
+      // Create PADCFG register offset using group and pad number
+      //
+      PadCfgReg = GPIO_PCR_PADCFG * PadNumber + GpioGroupInfo[GroupIndex].PadCfgOffset;
+
+      //
+      // Write PADCFG DW0 register
+      //
+      MmioAndThenOr32 (
+        GetPchPcrAddress (GpioCom, PadCfgReg),
+        ~PadCfgDwRegMask[0],
+        PadCfgDwReg[0]
+        );
+
+      //
+      // Write PADCFG DW1 register
+      //
+      MmioAndThenOr32 (
+        GetPchPcrAddress (GpioCom, PadCfgReg + 0x4),
+        ~PadCfgDwRegMask[1],
+        PadCfgDwReg[1]
+        );
+
+      //
+      // Write PADCFG DW2 register
+      //
+      MmioAndThenOr32 (
+        GetPchPcrAddress (GpioCom, PadCfgReg + 0x8),
+        ~PadCfgDwRegMask[2],
+        PadCfgDwReg[2]
+        );
+
+      //
+      // Get GPIO DW register values from GPIO config data
+      //
+      GpioDwRegValueFromGpioConfig (
+        PadNumber,
+        &GpioData->GpioConfig,
+        GroupDwData
+        );
+
+      //Move to next item
+      Index++;
+    }
+
+    for (DwNum = 0; DwNum <= GPIO_GET_DW_NUM (GpioGroupInfo[GroupIndex].PadPerGroup); DwNum++) {
+      //
+      // Write HOSTSW_OWN registers
+      //
+      if (GpioGroupInfo[GroupIndex].HostOwnOffset != NO_REGISTER_FOR_PROPERTY) {
+        MmioAndThenOr32 (
+          GetPchPcrAddress (GpioCom, GpioGroupInfo[GroupIndex].HostOwnOffset + DwNum * 0x4),
+          ~GroupDwData[DwNum].HostSoftOwnRegMask,
+          GroupDwData[DwNum].HostSoftOwnReg
+          );
+      }
+
+      //
+      // Write GPI_GPE_EN registers
+      //
+      if (GpioGroupInfo[GroupIndex].GpiGpeEnOffset != NO_REGISTER_FOR_PROPERTY) {
+        MmioAndThenOr32 (
+          GetPchPcrAddress (GpioCom, GpioGroupInfo[GroupIndex].GpiGpeEnOffset + DwNum * 0x4),
+          ~GroupDwData[DwNum].GpiGpeEnRegMask,
+          GroupDwData[DwNum].GpiGpeEnReg
+          );
+      }
+
+      //
+      // Write GPI_NMI_EN registers
+      //
+      if (GpioGroupInfo[GroupIndex].NmiEnOffset != NO_REGISTER_FOR_PROPERTY) {
+        MmioAndThenOr32 (
+          GetPchPcrAddress (GpioCom, GpioGroupInfo[GroupIndex].NmiEnOffset + DwNum * 0x4),
+          ~GroupDwData[DwNum].GpiNmiEnRegMask,
+          GroupDwData[DwNum].GpiNmiEnReg
+          );
+      } else if (GroupDwData[DwNum].GpiNmiEnReg != 0x0) {
+        DEBUG ((DEBUG_ERROR, "GPIO ERROR: Group %d has no pads supporting NMI\n", GroupIndex));
+        ASSERT_EFI_ERROR (EFI_UNSUPPORTED);
+      }
+
+      //
+      // Write GPI_SMI_EN registers
+      //
+      if (GpioGroupInfo[GroupIndex].SmiEnOffset != NO_REGISTER_FOR_PROPERTY) {
+        MmioAndThenOr32 (
+          GetPchPcrAddress (GpioCom, GpioGroupInfo[GroupIndex].SmiEnOffset + DwNum * 0x4),
+          ~GroupDwData[DwNum].GpiSmiEnRegMask,
+          GroupDwData[DwNum].GpiSmiEnReg
+          );
+      } else if (GroupDwData[DwNum].GpiSmiEnReg != 0x0) {
+        DEBUG ((DEBUG_ERROR, "GPIO ERROR: Group %d has no pads supporting SMI\n", GroupIndex));
+        ASSERT_EFI_ERROR (EFI_UNSUPPORTED);
+      }
+
+      //
+      // Update Pad Configuration unlock data
+      //
+      if (GroupDwData[DwNum].ConfigUnlockMask) {
+        GpioStoreGroupDwUnlockPadConfigData (GroupIndex, DwNum, GroupDwData[DwNum].ConfigUnlockMask);
+      }
+
+      //
+      // Update Pad Output unlock data
+      //
+      if (GroupDwData[DwNum].OutputUnlockMask) {
+        GpioStoreGroupDwUnlockOutputData (GroupIndex, DwNum, GroupDwData[DwNum].OutputUnlockMask);
+      }
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will clear all status bits of any GPIO interrupts.
+
+  @param[in] none
+
+  @retval EFI_SUCCESS                   The function completed successfully
+  @retval EFI_INVALID_PARAMETER         Invalid group or pad number
+**/
+STATIC
+EFI_STATUS
+GpioClearAllGpioInterrupts (
+  VOID
+  )
+{
+  GPIO_GROUP             Group;
+  CONST GPIO_GROUP_INFO  *GpioGroupInfo;
+  GPIO_GROUP             GpioGroupLowest;
+  GPIO_GROUP             GpioGroupHighest;
+  UINT32                 GroupIndex;
+  UINT32                 GpioGroupInfoLength;
+  UINT32                 DwNum;
+
+  GpioGroupInfo = GpioGetGroupInfoTable (&GpioGroupInfoLength);
+
+  GpioGroupLowest = GpioGetLowestGroup ();
+  GpioGroupHighest = GpioGetHighestGroup ();
+
+  for (Group = GpioGroupLowest; Group <= GpioGroupHighest; Group++) {
+    GroupIndex = GpioGetGroupIndexFromGroup (Group);
+    //
+    // Check if group has GPI IS register
+    //
+    if (GpioGroupInfo[GroupIndex].GpiIsOffset != NO_REGISTER_FOR_PROPERTY) {
+      //
+      // Clear all GPI_IS Status bits by writing '1'
+      //
+      for (DwNum = 0; DwNum <= GPIO_GET_DW_NUM (GpioGroupInfo[GroupIndex].PadPerGroup); DwNum++) {
+        MmioWrite32 (
+          GetPchPcrAddress (GpioGroupInfo[GroupIndex].Community, GpioGroupInfo[GroupIndex].GpiIsOffset + DwNum * 0x4),
+          0xFFFFFFFF
+          );
+      }
+    }
+
+    //
+    // Check if group has GPI_GPE_STS register
+    //
+    if (GpioGroupInfo[GroupIndex].GpiGpeStsOffset != NO_REGISTER_FOR_PROPERTY) {
+      //
+      // Clear all GPI_GPE_STS Status bits by writing '1'
+      //
+      for (DwNum = 0; DwNum <= GPIO_GET_DW_NUM (GpioGroupInfo[GroupIndex].PadPerGroup); DwNum++) {
+        MmioWrite32 (
+          GetPchPcrAddress (GpioGroupInfo[GroupIndex].Community, GpioGroupInfo[GroupIndex].GpiGpeStsOffset + DwNum * 0x4),
+          0xFFFFFFFF
+          );
+      }
+    }
+
+    //
+    // Check if group has SMI_STS register
+    //
+    if (GpioGroupInfo[GroupIndex].SmiStsOffset != NO_REGISTER_FOR_PROPERTY) {
+      //
+      // Clear all SMI_STS Status bits by writing '1'
+      //
+      for (DwNum = 0; DwNum <= GPIO_GET_DW_NUM (GpioGroupInfo[GroupIndex].PadPerGroup); DwNum++) {
+        MmioWrite32 (
+          GetPchPcrAddress (GpioGroupInfo[GroupIndex].Community, GpioGroupInfo[GroupIndex].SmiStsOffset + DwNum * 4),
+          0xFFFFFFFF
+          );
+      }
+    }
+
+    //
+    // Check if group has NMI_STS register
+    //
+    if (GpioGroupInfo[GroupIndex].NmiStsOffset != NO_REGISTER_FOR_PROPERTY) {
+      //
+      // Clear all NMI_STS Status bits by writing '1'
+      //
+      for (DwNum = 0; DwNum <= GPIO_GET_DW_NUM (GpioGroupInfo[GroupIndex].PadPerGroup); DwNum++) {
+        MmioWrite32 (
+          GetPchPcrAddress (GpioGroupInfo[GroupIndex].Community, GpioGroupInfo[GroupIndex].NmiStsOffset + DwNum * 4),
+          0xFFFFFFFF
+          );
+      }
+    }
+
+  }
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will initialize multiple GPIO pins. Use GPIO_INIT_CONFIG structure.
+  Structure contains fields that can be used to configure each pad.
+  Pad not configured using GPIO_INIT_CONFIG will be left with hardware default values.
+  Separate fields could be set to hardware default if it does not matter, except
+  GpioPad and PadMode.
+  Function will work in most efficient way if pads which belong to the same group are
+  placed in adjacent records of the table.
+  Although function can enable pads for Native mode, such programming is done
+  by reference code when enabling related silicon feature.
+
+  @param[in] NumberofItem               Number of GPIO pads to be updated
+  @param[in] GpioInitTableAddress       GPIO initialization table
+
+  @retval EFI_SUCCESS                   The function completed successfully
+  @retval EFI_INVALID_PARAMETER         Invalid group or pad number
+**/
+EFI_STATUS
+GpioConfigurePads (
+  IN UINT32                    NumberOfItems,
+  IN GPIO_INIT_CONFIG          *GpioInitTableAddress
+  )
+{
+  EFI_STATUS   Status;
+  Status =  GpioConfigurePch (NumberOfItems, GpioInitTableAddress);
+  GpioClearAllGpioInterrupts ();
+  return Status;
+}
+
+/**
+  This procedure will initialize multiple GPIO pins. Use GPIO_INIT_CONFIG structure.
+  Structure contains fields that can be used to configure each pad.
+  Pad not configured using GPIO_INIT_CONFIG will be left with hardware default values.
+  Separate fields could be set to hardware default if it does not matter, except
+  GpioPad and PadMode.
+  Some GpioPads are configured and switched to native mode by RC, those include:
+  SerialIo pins, ISH pins, ClkReq Pins
+
+  @param[in] NumberofItem               Number of GPIO pads to be updated
+  @param[in] GpioInitTableAddress       GPIO initialization table
+
+  @retval EFI_SUCCESS                   The function completed successfully
+  @retval EFI_INVALID_PARAMETER         Invalid group or pad number
+**/
+VOID
+GpioPadConfigTable (
+  IN UINT32                    NumberOfItems,
+  IN VOID                     *GpioInitTableAddress
+  )
+{
+  GpioConfigurePads (NumberOfItems, (GPIO_INIT_CONFIG *)GpioInitTableAddress);
+}
+
+
+/**
+  Print the output of the GPIO Config table that was read from CfgData.
+
+  @param GpioPinNum           Number of GPIO entries in the table.
+
+  @param GpioConfData         GPIO Config Data that was read from the Configuration region either from internal or external source.
+
+**/
+STATIC
+VOID
+PrintGpioConfigTable (
+  IN UINT32              GpioPinNum,
+  IN VOID*               GpioConfData
+)
+{
+  GPIO_INIT_CONFIG  *GpioInitConf;
+  UINT32            *PadDataPtr;
+  UINT32             Index;
+
+  GpioInitConf = (GPIO_INIT_CONFIG *)GpioConfData;
+  for (Index  = 0; Index < GpioPinNum; Index++) {
+    PadDataPtr = (UINT32 *)&GpioInitConf->GpioConfig;
+    DEBUG ((DEBUG_INFO, "GPIO PAD: 0x%08X   DATA: 0x%08X 0x%08X\n", GpioInitConf->GpioPad, PadDataPtr[0], PadDataPtr[1]));
+    GpioInitConf++;
+  }
+}
+
+
+/**
+  Retreive PadInfo embedded inside DW of GPIO CFG DATA.
+  Prepare a PadInfo DWORD first, add into the GpioTable,
+  followed by DW0 and DW1 directly from GPIO CFG DATA.
+  This format of GpioTable is what the Gpio library expects.
+
+  @param    GpioTable   Pointer to the GpioTable to be updated
+  @param    GpioCfg     Pointer to the cfg data
+  @param    Offset      Index of a particulr pin's DW0, DW1 in GpioCfg
+
+  @retval   GpioTable   Pointer to fill the next gpio item
+**/
+STATIC
+UINT8 *
+FillGpioTable (
+  IN  UINT8              *GpioTable,
+  IN  GPIO_CFG_HDR_INFO  *GpioCfgHdrInfo,
+  IN  UINT32              Offset
+
+)
+{
+  UINT32             *GpioItem;
+  GPIO_PAD            GpioPad;
+
+  //
+  // Get the DW and extract PadInfo
+  //
+  GpioItem = (UINT32 *) (GpioCfgHdrInfo->TableData + Offset);
+  GpioGetGpioPadFromCfgDw (GpioItem, &GpioPad);
+
+  //
+  // Copy PadInfo(PinOffset), DW0, DW1
+  //
+  CopyMem (GpioTable, (VOID *)&GpioPad, sizeof(GPIO_PAD));
+  GpioTable += sizeof(GPIO_PAD);
+  CopyMem (GpioTable, GpioItem, GpioCfgHdrInfo->ItemSize);
+  GpioTable += GpioCfgHdrInfo->ItemSize;
+
+  return GpioTable;
+}
+
+
+/**
+  Configure the GPIO pins, available as part of platform specific GPIO CFG DATA.
+  If the pins are not part of GPIO CFG DATA, call GpioPadConfigTable() directly
+  with the appropriate arguments.
+
+  @retval EFI_SUCCESS                   The function completed successfully
+  @retval EFI_NOT_FOUND                 If Gpio Config Data cant be found
+**/
+EFI_STATUS
+EFIAPI
+ConfigureGpio (
+  VOID
+  )
+{
+  GPIO_CFG_HDR_INFO       GpioCfgCurrHdrInfo;
+  GPIO_CFG_HDR_INFO       GpioCfgBaseHdrInfo;
+  GPIO_CFG_HDR_INFO      *GpioCfgHdrInfo;
+  UINT32                  GpioEntries;
+  UINT32                  Index;
+  UINT32                  Offset;
+  UINT8                  *GpioCfgDataBuffer;
+  UINT8                  *GpioTable;
+  EFI_STATUS              Status;
+
+  GpioEntries    = 0;
+
+  //
+  // Find the GPIO CFG HDR INFO
+  //
+  Status = GpioGetCfgHdrInfo (&GpioCfgCurrHdrInfo, 0xFF);
+  if (Status != EFI_SUCCESS) {
+    return Status;
+  }
+
+  //
+  // Find the GPIO CFG HDR INFO based on Platform ID
+  //
+  if (GpioCfgCurrHdrInfo.BaseTableId < 16) {
+    Status = GpioGetCfgHdrInfo (&GpioCfgBaseHdrInfo, GpioCfgCurrHdrInfo.BaseTableId);
+    if (Status != EFI_SUCCESS) {
+      DEBUG ((DEBUG_ERROR, "Cannot find base GPIO table for platform ID %d\n", GpioCfgCurrHdrInfo.BaseTableId));
+      return Status;
+    }
+    if (GpioCfgCurrHdrInfo.ItemSize != GpioCfgBaseHdrInfo.ItemSize) {
+      DEBUG ((DEBUG_ERROR, "Inconsistent GPIO item size\n"));
+      return Status;
+    }
+    GpioCfgHdrInfo = &GpioCfgBaseHdrInfo;
+  } else {
+    GpioCfgHdrInfo = &GpioCfgCurrHdrInfo;
+  }
+
+  Offset     = 0;
+  GpioTable  = (UINT8 *)AllocateTemporaryMemory (0);  //allocate new buffer
+  GpioCfgDataBuffer = GpioTable;
+
+  for (Index = 0; Index  < GpioCfgHdrInfo->ItemCount; Index++) {
+    if (GpioCfgCurrHdrInfo.BaseTableBitMask[Index >> 3] & (1 << (Index & 7))) {
+      GpioTable = FillGpioTable (GpioTable, GpioCfgHdrInfo, Offset);
+      GpioEntries++;
+    }
+    Offset += GpioCfgHdrInfo->ItemSize;
+  }
+
+  Offset = 0;
+  if (GpioCfgBaseHdrInfo.ItemCount != 0) {
+    for (Index = 0; Index  < GpioCfgCurrHdrInfo.ItemCount; Index++) {
+      GpioTable = FillGpioTable (GpioTable, &GpioCfgCurrHdrInfo, Offset);
+      GpioEntries++;
+      Offset += GpioCfgCurrHdrInfo.ItemSize;
+    }
+  }
+
+  DEBUG_CODE_BEGIN ();
+  PrintGpioConfigTable (GpioEntries, GpioCfgDataBuffer);
+  DEBUG_CODE_END ();
+
+  GpioPadConfigTable (GpioEntries, (VOID *)GpioCfgDataBuffer);
+
+  DEBUG ((DEBUG_INFO, "GpioInit(0x%p:%d) Done\n", GpioCfgDataBuffer, GpioEntries));
+  return EFI_SUCCESS;
+}

--- a/Silicon/CommonSocPkg/Library/GpioLib/GpioLib.c
+++ b/Silicon/CommonSocPkg/Library/GpioLib/GpioLib.c
@@ -1,0 +1,2244 @@
+/** @file
+  This file contains routines for GPIO
+
+  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi/UefiBaseType.h>
+#include <GpioLibConfig.h>
+#include <Library/GpioSocLib.h>
+#include <Library/GpioPlatformLib.h>
+#include <GpioLibInternal.h>
+
+/**
+  This procedure will check if GpioPad is owned by host.
+
+  @param[in] GpioPad       GPIO pad
+
+  @retval TRUE             GPIO pad is owned by host
+  @retval FALSE            GPIO pad is not owned by host and should not be used with GPIO lib API
+**/
+BOOLEAN
+GpioIsPadHostOwned (
+  IN GPIO_PAD             GpioPad
+  )
+{
+  UINT32               GroupIndex;
+  UINT32               PadNumber;
+  GPIO_PAD_OWN         PadOwnVal;
+
+  //
+  // Check if selected GPIO Pad is not owned by CSME/ISH
+  // If GPIO is not owned by Host all access to PadCfg will be dropped
+  //
+  GpioGetPadOwnership (GpioPad, &PadOwnVal);
+  if (PadOwnVal != GpioPadOwnHost) {
+    GroupIndex = GpioGetGroupIndexFromGpioPad (GpioPad);
+    PadNumber = GpioGetPadNumberFromGpioPad (GpioPad);
+    DEBUG ((DEBUG_ERROR, "GPIO ERROR: Gpio pad not owned by host (Group=%d, Pad=%d)!\n", GroupIndex, PadNumber));
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+  This procedure will check if GpioPad argument is valid.
+  Function will check below conditions:
+   - GpioPad represents a pad for current PCH
+   - GpioPad belongs to valid GpioGroup
+   - GPIO PadNumber is not greater than number of pads for this group
+
+  @param[in] GpioPad       GPIO pad
+
+  @retval TRUE             GPIO pad is valid and can be used with GPIO lib API
+  @retval FALSE            GPIO pad is invalid and cannot be used with GPIO lib API
+**/
+BOOLEAN
+GpioIsPadValid (
+  IN GPIO_PAD             GpioPad
+  )
+{
+  CONST GPIO_GROUP_INFO  *GpioGroupInfo;
+  UINT32                 GpioGroupInfoLength;
+  UINT32                 PadNumber;
+  UINT32                 GroupIndex;
+
+  if (!GpioIsCorrectPadForThisChipset (GpioPad)) {
+    DEBUG ((DEBUG_ERROR, "GPIO ERROR: Incorrect GpioPad (0x%08x) used on this chipset!\n", GpioPad));
+    goto Error;
+  }
+
+  GpioGroupInfo = GpioGetGroupInfoTable (&GpioGroupInfoLength);
+
+  //
+  // Check if legal pin number
+  //
+  GroupIndex = GpioGetGroupIndexFromGpioPad (GpioPad);
+  PadNumber = GpioGetPadNumberFromGpioPad (GpioPad);
+  if (PadNumber >= GpioGroupInfo[GroupIndex].PadPerGroup) {
+    DEBUG ((DEBUG_ERROR, "GPIO ERROR: Pin number (%d) exceeds possible range for this group\n", PadNumber));
+    goto Error;
+  }
+
+  return TRUE;
+Error:
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  This procedure will check if GpioGroup argument is correct and
+  supplied DW reg number can be used for this group to access DW registers.
+  Function will check below conditions:
+   - Valid GpioGroup
+   - DwNum is has valid value for this group
+
+  @param[in] Group        GPIO group
+  @param[in] DwNum        Register number for current group (parameter applicable in accessing whole register).
+                          For group which has less then 32 pads per group DwNum must be 0.
+
+  @retval TRUE             DW Reg number and GpioGroup is valid
+  @retval FALSE            DW Reg number and GpioGroup is invalid
+**/
+STATIC
+BOOLEAN
+GpioIsGroupAndDwNumValid (
+  IN GPIO_GROUP             Group,
+  IN UINT32                 DwNum
+  )
+{
+  UINT32                 GroupIndex;
+  CONST GPIO_GROUP_INFO  *GpioGroupInfo;
+  UINT32                 GpioGroupInfoLength;
+
+  GpioGroupInfo = GpioGetGroupInfoTable (&GpioGroupInfoLength);
+
+  GroupIndex = GpioGetGroupIndexFromGroup (Group);
+
+  if ((Group < GpioGetLowestGroup ()) || (Group > GpioGetHighestGroup ()) || (GroupIndex >= GpioGroupInfoLength)) {
+    DEBUG ((DEBUG_ERROR, "GPIO ERROR: Group argument (%d) is not within range of possible groups for this PCH\n", GroupIndex));
+    goto Error;
+  }
+
+  //
+  // Check if DwNum argument does not exceed number of DWord registers
+  // resulting from available pads for certain group
+  //
+  if (DwNum > GPIO_GET_DW_NUM (GpioGroupInfo[GroupIndex].PadPerGroup - 1)){
+    goto Error;
+  }
+
+  return TRUE;
+Error:
+  ASSERT (FALSE);
+  return FALSE;
+}
+
+/**
+  This procedure will read GPIO Pad Configuration register
+
+  @param[in] GpioPad          GPIO pad
+  @param[in] DwReg            Choose PADCFG register: 0:DW0, 1:DW1
+
+  @retval PadCfgRegValue      PADCFG_DWx value
+**/
+UINT32
+GpioReadPadCfgReg (
+  IN GPIO_PAD             GpioPad,
+  IN UINT8                DwReg
+  )
+{
+  UINT32                 PadCfgReg;
+  CONST GPIO_GROUP_INFO  *GpioGroupInfo;
+  UINT32                 GpioGroupInfoLength;
+  UINT32                 GroupIndex;
+  UINT32                 PadNumber;
+
+  GroupIndex = GpioGetGroupIndexFromGpioPad (GpioPad);
+  PadNumber = GpioGetPadNumberFromGpioPad (GpioPad);
+
+  GpioGroupInfo = GpioGetGroupInfoTable (&GpioGroupInfoLength);
+
+  //
+  // Create Pad Configuration register offset
+  //
+  PadCfgReg = GpioGroupInfo[GroupIndex].PadCfgOffset + GPIO_PCR_PADCFG * PadNumber + 0x4 * DwReg;
+
+  return MmioRead32 (GetPchPcrAddress (GpioGroupInfo[GroupIndex].Community, PadCfgReg));
+}
+
+/**
+  This procedure will write or read GPIO Pad Configuration register
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] DwReg                Choose PADCFG register: 0:DW0, 1:DW1
+  @param[in] PadCfgAndMask        Mask to be AND'ed with PADCFG reg value
+  @param[in] PadCfgOrMask         Mask to be OR'ed with PADCFG reg value
+
+  @retval none
+**/
+VOID
+GpioWritePadCfgReg (
+  IN GPIO_PAD             GpioPad,
+  IN UINT8                DwReg,
+  IN UINT32               PadCfgAndMask,
+  IN UINT32               PadCfgOrMask
+  )
+{
+  UINT32                 PadCfgReg;
+  CONST GPIO_GROUP_INFO  *GpioGroupInfo;
+  UINT32                 GpioGroupInfoLength;
+  UINT32                 GroupIndex;
+  UINT32                 PadNumber;
+  UINT32                 PadCfgLock;
+  UINT32                 PadCfgLockTx;
+
+  PadCfgLock = 0;
+  PadCfgLockTx = 0;
+
+  //
+  // Check if Pad Configuration (except output state) is to be changed.
+  // If AND and OR masks will indicate that configuration fields (other than output control)
+  // are to be modified it means that there is a need to perform an unlock (if set)
+  //
+  if ((~PadCfgAndMask | PadCfgOrMask) & (UINT32)~B_GPIO_PCR_TX_STATE) {
+    GpioGetPadCfgLock (GpioPad, &PadCfgLock);
+    if (PadCfgLock) {
+      GpioUnlockPadCfg (GpioPad);
+    }
+  }
+
+  //
+  // Check if Pad Output state is to be changed
+  // If AND and OR masks will indicate that output control
+  // is to be modified it means that there is a need to perform an unlock (if set)
+  //
+  if ((~PadCfgAndMask | PadCfgOrMask) & B_GPIO_PCR_TX_STATE) {
+    GpioGetPadCfgLockTx (GpioPad, &PadCfgLockTx);
+    if (PadCfgLockTx) {
+      GpioUnlockPadCfgTx (GpioPad);
+    }
+  }
+
+  GroupIndex = GpioGetGroupIndexFromGpioPad (GpioPad);
+  PadNumber = GpioGetPadNumberFromGpioPad (GpioPad);
+
+  GpioGroupInfo = GpioGetGroupInfoTable (&GpioGroupInfoLength);
+
+  //
+  // Create Pad Configuration register offset
+  //
+  PadCfgReg = GpioGroupInfo[GroupIndex].PadCfgOffset + GPIO_PCR_PADCFG * PadNumber + 0x4 * DwReg;
+
+  MmioAndThenOr32 (
+    GetPchPcrAddress (GpioGroupInfo[GroupIndex].Community, PadCfgReg),
+    PadCfgAndMask,
+    PadCfgOrMask
+    );
+  DEBUG((DEBUG_INFO, "GPIO Address: 0x%08x, PadCfgAndMask = 0x%08x, PadCfgOrMask = 0x%08x\n", GetPchPcrAddress(GpioGroupInfo[GroupIndex].Community, PadCfgReg), PadCfgAndMask, PadCfgOrMask));
+  if (PadCfgLock) {
+    GpioLockPadCfg (GpioPad);
+  }
+  if (PadCfgLockTx) {
+    GpioLockPadCfgTx (GpioPad);
+  }
+}
+
+//
+// Possible registers to be accessed using GpioReadReg()/GpioWriteReg() functions
+//
+typedef enum {
+  GpioHostOwnershipRegister = 0,
+  GpioGpeEnableRegister,
+  GpioGpeStatusRegister,
+  GpioSmiEnableRegister,
+  GpioSmiStatusRegister,
+  GpioNmiEnableRegister,
+  GpioPadConfigLockRegister,
+  GpioPadLockOutputRegister
+} GPIO_REG;
+
+/**
+  This procedure will read GPIO register
+
+  @param[in] RegType              GPIO register type
+  @param[in] Group                GPIO group
+  @param[in] DwNum                Register number for current group (parameter applicable in accessing whole register).
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[out] ReadVal             Read data
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_UNSUPPORTED         Feature is not supported for this group or pad
+**/
+STATIC
+EFI_STATUS
+GpioReadReg (
+  IN GPIO_REG               RegType,
+  IN GPIO_GROUP             Group,
+  IN UINT32                 DwNum,
+  OUT UINT32                *ReadVal
+  )
+{
+  UINT32                 RegOffset;
+  UINT32                 GroupIndex;
+  CONST GPIO_GROUP_INFO  *GpioGroupInfo;
+  UINT32                 GpioGroupInfoLength;
+
+  RegOffset = NO_REGISTER_FOR_PROPERTY;
+  GroupIndex = GpioGetGroupIndexFromGroup (Group);
+
+  GpioGroupInfo = GpioGetGroupInfoTable (&GpioGroupInfoLength);
+
+  switch (RegType) {
+    case GpioHostOwnershipRegister:
+      RegOffset = GpioGroupInfo[GroupIndex].HostOwnOffset;
+      break;
+    case GpioGpeEnableRegister:
+      RegOffset = GpioGroupInfo[GroupIndex].GpiGpeEnOffset;
+      break;
+    case GpioGpeStatusRegister:
+      RegOffset = GpioGroupInfo[GroupIndex].GpiGpeStsOffset;
+      break;
+    case GpioSmiEnableRegister:
+      RegOffset = GpioGroupInfo[GroupIndex].SmiEnOffset;
+      break;
+    case GpioSmiStatusRegister:
+      RegOffset = GpioGroupInfo[GroupIndex].SmiStsOffset;
+      break;
+    case GpioNmiEnableRegister:
+      RegOffset = GpioGroupInfo[GroupIndex].NmiEnOffset;
+      break;
+    case GpioPadConfigLockRegister:
+      RegOffset = GpioGroupInfo[GroupIndex].PadCfgLockOffset;
+      break;
+    case GpioPadLockOutputRegister:
+      RegOffset = GpioGroupInfo[GroupIndex].PadCfgLockTxOffset;
+      break;
+    default:
+      break;
+  }
+
+  //
+  // Check if selected register exists
+  //
+  if (RegOffset == NO_REGISTER_FOR_PROPERTY) {
+    return EFI_UNSUPPORTED;
+  }
+
+  //
+  // If there are more then 32 pads per group then certain
+  // group information would be split into more then one DWord register.
+  //
+  if ((RegType == GpioPadConfigLockRegister) || (RegType == GpioPadLockOutputRegister)) {
+    //
+    // PadConfigLock and OutputLock registers when used for group containing more than 32 pads
+    // are not placed in a continuous way, e.g:
+    // 0x0 - PadConfigLock_DW0
+    // 0x4 - OutputLock_DW0
+    // 0x8 - PadConfigLock_DW1
+    // 0xC - OutputLock_DW1
+    //
+    RegOffset += DwNum * 0x8;
+  } else {
+    RegOffset += DwNum * 0x4;
+  }
+
+  *ReadVal = MmioRead32 (GetPchPcrAddress (GpioGroupInfo[GroupIndex].Community, RegOffset));
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will write GPIO register
+
+  @param[in] RegType              GPIO register type
+  @param[in] Group                GPIO group
+  @param[in] DwNum                Register number for current group (parameter applicable in accessing whole register).
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[in] RegAndMask           Mask which will be AND'ed with register value
+  @param[in] RegOrMask            Mask which will be OR'ed with register value
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_UNSUPPORTED         Feature is not supported for this group or pad
+**/
+STATIC
+EFI_STATUS
+GpioWriteReg (
+  IN GPIO_REG               RegType,
+  IN GPIO_GROUP             Group,
+  IN UINT32                 DwNum,
+  IN UINT32                 RegAndMask,
+  IN UINT32                 RegOrMask
+  )
+{
+  UINT32                 RegOffset;
+  UINT32                 GroupIndex;
+  CONST GPIO_GROUP_INFO  *GpioGroupInfo;
+  UINT32                 GpioGroupInfoLength;
+  UINT32                 PadCfgLock;
+  BOOLEAN                Lockable;
+  EFI_STATUS             Status;
+
+  Lockable = FALSE;
+  PadCfgLock = 0;
+  RegOffset = NO_REGISTER_FOR_PROPERTY;
+  GroupIndex = GpioGetGroupIndexFromGroup (Group);
+
+  GpioGroupInfo = GpioGetGroupInfoTable (&GpioGroupInfoLength);
+
+  switch (RegType) {
+    case GpioHostOwnershipRegister:
+      RegOffset = GpioGroupInfo[GroupIndex].HostOwnOffset;
+      break;
+    case GpioGpeEnableRegister:
+      RegOffset = GpioGroupInfo[GroupIndex].GpiGpeEnOffset;
+      Lockable = TRUE;
+      break;
+    case GpioGpeStatusRegister:
+      RegOffset = GpioGroupInfo[GroupIndex].GpiGpeStsOffset;
+      break;
+    case GpioSmiEnableRegister:
+      RegOffset = GpioGroupInfo[GroupIndex].SmiEnOffset;
+      Lockable = TRUE;
+      break;
+    case GpioSmiStatusRegister:
+      RegOffset = GpioGroupInfo[GroupIndex].SmiStsOffset;
+      break;
+    case GpioNmiEnableRegister:
+      RegOffset = GpioGroupInfo[GroupIndex].NmiEnOffset;
+      Lockable = TRUE;
+      break;
+    case GpioPadConfigLockRegister:
+    case GpioPadLockOutputRegister:
+    default:
+      break;
+  }
+
+  //
+  // Check if selected register exists
+  //
+  if (RegOffset == NO_REGISTER_FOR_PROPERTY) {
+    return EFI_UNSUPPORTED;
+  }
+
+  if (Lockable) {
+    GpioGetPadCfgLockForGroupDw (Group, DwNum, &PadCfgLock);
+    if (PadCfgLock) {
+      //
+      // Check if for pads which are going to be reconfigured lock is set.
+      //
+      if ((~RegAndMask | RegOrMask) & PadCfgLock) {
+        //
+        // Unlock all pads for this Group DW reg for simplicity
+        // even if not all of those pads will have their settings reprogrammed
+        //
+        Status = GpioUnlockPadCfgForGroupDw (Group, DwNum, PadCfgLock);
+        if (EFI_ERROR (Status)) {
+          ASSERT (FALSE);
+          return Status;
+        }
+      } else {
+        //
+        // No need to perform an unlock as pads which are going to be reconfigured
+        // are not in locked state
+        //
+        PadCfgLock = 0;
+      }
+    }
+  }
+
+  //
+  // If there are more then 32 pads per group then certain
+  // group information would be split into more then one DWord register.
+  //
+  RegOffset += DwNum * 0x4;
+
+  MmioAndThenOr32 (
+    GetPchPcrAddress (GpioGroupInfo[GroupIndex].Community, RegOffset),
+    RegAndMask,
+    RegOrMask
+    );
+
+  if (Lockable && PadCfgLock) {
+    //
+    // Lock previously unlocked pads
+    //
+    Status = GpioLockPadCfgForGroupDw (Group, DwNum, PadCfgLock);
+    if (EFI_ERROR (Status)) {
+      ASSERT (FALSE);
+      return Status;
+    }
+  }
+}
+
+/**
+  This procedure will write GPIO Lock/LockTx register using SBI.
+
+  @param[in] RegType              GPIO register (Lock or LockTx)
+  @param[in] Group                GPIO group number
+  @param[in] DwNum                Register number for current group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[in] LockRegAndMask       Mask which will be AND'ed with Lock register value
+  @param[in] LockRegOrMask        Mask which will be Or'ed with Lock register value
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_UNSUPPORTED         Feature is not supported for this group or pad
+**/
+STATIC
+EFI_STATUS
+GpioWriteLockReg (
+  IN GPIO_REG                  RegType,
+  IN GPIO_GROUP                Group,
+  IN UINT32                    DwNum,
+  IN UINT32                    LockRegAndMask,
+  IN UINT32                    LockRegOrMask
+  )
+{
+  UINT8                  Response;
+  CONST GPIO_GROUP_INFO  *GpioGroupInfo;
+  UINT32                 GpioGroupInfoLength;
+  UINT32                 RegOffset;
+  UINT32                 OldLockVal;
+  UINT32                 NewLockVal;
+  UINT32                 GroupIndex;
+  EFI_STATUS             Status;
+
+  OldLockVal = 0;
+  NewLockVal = 0;
+
+  RegOffset = NO_REGISTER_FOR_PROPERTY;
+  GroupIndex = GpioGetGroupIndexFromGroup (Group);
+
+  GpioGroupInfo = GpioGetGroupInfoTable (&GpioGroupInfoLength);
+
+  switch (RegType) {
+    case GpioPadConfigLockRegister:
+      RegOffset = GpioGroupInfo[GroupIndex].PadCfgLockOffset;
+      GpioGetPadCfgLockForGroupDw (Group, DwNum, &OldLockVal);
+      break;
+    case GpioPadLockOutputRegister:
+      RegOffset = GpioGroupInfo[GroupIndex].PadCfgLockTxOffset;
+      GpioGetPadCfgLockTxForGroupDw (Group, DwNum, &OldLockVal);
+      break;
+    default:
+      break;
+  }
+
+  //
+  // Check if selected register exists
+  //
+  if (RegOffset == NO_REGISTER_FOR_PROPERTY) {
+    return EFI_UNSUPPORTED;
+  }
+
+  //
+  // If there are more then 32 pads per group then certain
+  // group information would be split into more then one DWord register.
+  // PadConfigLock and OutputLock registers when used for group containing more than 32 pads
+  // are not placed in a continuous way, e.g:
+  // 0x0 - PadConfigLock_DW0
+  // 0x4 - OutputLock_DW0
+  // 0x8 - PadConfigLock_DW1
+  // 0xC - OutputLock_DW1
+  //
+  RegOffset += DwNum *0x8;
+
+  NewLockVal = (OldLockVal & LockRegAndMask) | LockRegOrMask;
+
+  Status = GpioPchSbiExecutionEx (
+             GpioGroupInfo[GroupIndex].Community,
+             RegOffset,
+             GpioLibGpioLockUnlock,
+             FALSE,
+             0x000F,
+             0x0000,
+             0x0000,
+             &NewLockVal,
+             &Response
+             );
+  ASSERT_EFI_ERROR (Status);
+  return Status;
+}
+
+/**
+  This internal procedure will calculate GPIO_RESET_CONFIG value  (new type)
+  based on provided PadRstCfg for a specific GPIO Pad.
+
+  @param[in]  GpioPad               GPIO Pad
+  @param[in]  PadRstCfg             GPIO PadRstCfg value
+
+  @retval GpioResetConfig           GPIO Reset configuration (new type)
+**/
+GPIO_RESET_CONFIG
+GpioResetConfigFromPadRstCfg (
+  IN  GPIO_PAD           GpioPad,
+  IN  UINT32             PadRstCfg
+  )
+{
+  GPIO_GROUP           Group;
+
+  static GPIO_RESET_CONFIG  GppPadRstCfgToGpioResetConfigMap[] = {
+                              GpioResumeReset,
+                              GpioHostDeepReset,
+                              GpioPlatformReset};
+  static GPIO_RESET_CONFIG  GpdPadRstCfgToGpioResetConfigMap[] = {
+                              GpioDswReset,
+                              GpioHostDeepReset,
+                              GpioPlatformReset,
+                              GpioResumeReset};
+
+  Group = GpioGetGroupFromGpioPad (GpioPad);
+
+  if (GpioIsDswGroup (Group) && PadRstCfg < 4) {
+    return GpdPadRstCfgToGpioResetConfigMap[PadRstCfg];
+  } else if (PadRstCfg < 3) {
+    return GppPadRstCfgToGpioResetConfigMap[PadRstCfg];
+  } else {
+    ASSERT (FALSE);
+    return GpioResetDefault;
+  }
+}
+
+/**
+  This internal procedure will calculate PadRstCfg register value based
+  on provided GPIO Reset configuration for a certain pad.
+
+  @param[in]  GpioPad                   GPIO Pad
+  @param[in]  GpioResetConfig           GPIO Reset configuration
+  @param[out] PadRstCfg                 GPIO PadRstCfg value
+
+  @retval EFI_SUCCESS                   The function completed successfully
+  @retval EFI_INVALID_PARAMETER         Invalid configuration
+**/
+EFI_STATUS
+GpioPadRstCfgFromResetConfig (
+  IN  GPIO_PAD           GpioPad,
+  IN  GPIO_RESET_CONFIG  GpioResetConfig,
+  OUT UINT32             *PadRstCfg
+  )
+{
+  GPIO_GROUP           Group;
+
+  Group = GpioGetGroupFromGpioPad (GpioPad);
+
+  switch (GpioResetConfig) {
+    case GpioResetDefault:
+      *PadRstCfg = 0x0;
+      break;
+    case GpioHostDeepReset:
+      *PadRstCfg = V_GPIO_PCR_RST_CONF_DEEP_RST;
+      break;
+    case GpioPlatformReset:
+      *PadRstCfg = V_GPIO_PCR_RST_CONF_GPIO_RST;
+      break;
+    case GpioResumeReset:
+      if (GpioIsDswGroup (Group)) {
+        *PadRstCfg = V_GPIO_PCR_RST_CONF_RESUME_RST;
+      } else {
+        *PadRstCfg = V_GPIO_PCR_RST_CONF_POW_GOOD;
+      }
+      break;
+    case GpioDswReset:
+      if (GpioIsDswGroup (Group)) {
+        *PadRstCfg = V_GPIO_PCR_RST_CONF_POW_GOOD;
+      } else {
+        DEBUG ((DEBUG_ERROR, "GPIO ERROR: Only GPD group pads can use GpioDswReset (Group=%d, Pad=%d)!\n", GpioGetGroupIndexFromGpioPad (GpioPad), GpioGetPadNumberFromGpioPad (GpioPad)));
+        goto Error;
+      }
+      break;
+    default:
+      goto Error;
+  }
+
+  return EFI_SUCCESS;
+Error:
+  ASSERT (FALSE);
+  return EFI_INVALID_PARAMETER;
+}
+
+/**
+  This internal procedure will get GPIO_CONFIG data from PADCFG registers value
+
+  @param[in]  GpioPad                   GPIO Pad
+  @param[in]  PadCfgDwReg               PADCFG DWx register values
+  @param[out] GpioData                  GPIO Configuration data
+
+  @retval Status
+**/
+STATIC
+VOID
+GpioConfigFromPadCfgRegValue (
+  IN GPIO_PAD      GpioPad,
+  IN CONST UINT32  *PadCfgDwReg,
+  OUT GPIO_CONFIG  *GpioConfig
+  )
+{
+  UINT32               PadRstCfg;
+
+  //
+  // Get Reset Type (PadRstCfg)
+  //
+  PadRstCfg = (PadCfgDwReg[0] & B_GPIO_PCR_RST_CONF) >> N_GPIO_PCR_RST_CONF;
+
+  GpioConfig->PowerConfig = GpioResetConfigFromPadRstCfg (
+                              GpioPad,
+                              PadRstCfg
+                              );
+
+  //
+  // Get how interrupt is triggered (RxEvCfg)
+  //
+  GpioConfig->InterruptConfig = ((PadCfgDwReg[0] & B_GPIO_PCR_RX_LVL_EDG) >> (N_GPIO_PCR_RX_LVL_EDG - (N_GPIO_INT_CONFIG_INT_TYPE_BIT_POS + 1))) | (0x1 << N_GPIO_INT_CONFIG_INT_TYPE_BIT_POS);
+
+  //
+  // Get interrupt generation (GPIRoutIOxAPIC/SCI/SMI/NMI)
+  //
+  GpioConfig->InterruptConfig |= ((PadCfgDwReg[0] & (B_GPIO_PCR_RX_NMI_ROUTE | B_GPIO_PCR_RX_SCI_ROUTE | B_GPIO_PCR_RX_SMI_ROUTE | B_GPIO_PCR_RX_APIC_ROUTE)) >> (N_GPIO_PCR_RX_NMI_ROUTE - (N_GPIO_INT_CONFIG_INT_SOURCE_BIT_POS + 1))) | (0x1 << N_GPIO_INT_CONFIG_INT_SOURCE_BIT_POS);
+
+  //
+  // Get GPIO direction (GPIORxDis and GPIOTxDis)
+  //
+  GpioConfig->Direction = ((PadCfgDwReg[0] & (B_GPIO_PCR_RXDIS | B_GPIO_PCR_TXDIS)) >> (N_GPIO_PCR_TXDIS - (N_GPIO_DIRECTION_DIR_BIT_POS + 1))) | (0x1 << N_GPIO_DIRECTION_DIR_BIT_POS);
+
+  //
+  // Get GPIO input inversion (RXINV)
+  // (Only meaningful if input enabled)
+  //
+  if((PadCfgDwReg[0] & B_GPIO_PCR_RXDIS) == 0) {
+    GpioConfig->Direction |= ((PadCfgDwReg[0] & B_GPIO_PCR_RXINV) >> (N_GPIO_PCR_RXINV - (N_GPIO_DIRECTION_INV_BIT_POS + 1))) | (0x1 << N_GPIO_DIRECTION_INV_BIT_POS);
+  }
+
+  //
+  // Get GPIO output state (GPIOTxState)
+  //
+  GpioConfig->OutputState = ((PadCfgDwReg[0] & B_GPIO_PCR_TX_STATE) << (N_GPIO_PCR_TX_STATE + (N_GPIO_OUTPUT_BIT_POS + 1))) | (0x1 << N_GPIO_OUTPUT_BIT_POS);
+
+  //
+  // Configure GPIO RX raw override to '1' (RXRAW1)
+  //
+  GpioConfig->OtherSettings = ((PadCfgDwReg[0] & B_GPIO_PCR_RX_RAW1) >> (N_GPIO_PCR_RX_RAW1 - (N_GPIO_OTHER_CONFIG_RXRAW_BIT_POS + 1))) | (0x1 << N_GPIO_OTHER_CONFIG_RXRAW_BIT_POS);
+
+  //
+  // Get GPIO Pad Mode (PMode)
+  //
+  GpioConfig->PadMode = ((PadCfgDwReg[0] & B_GPIO_PCR_PAD_MODE) >> (N_GPIO_PCR_PAD_MODE - (N_GPIO_PAD_MODE_BIT_POS + 1))) | (0x1 << N_GPIO_PAD_MODE_BIT_POS);
+
+  //
+  // Get GPIO termination (Term)
+  //
+  GpioConfig->ElectricalConfig = ((PadCfgDwReg[1] & B_GPIO_PCR_TERM) >> (N_GPIO_PCR_TERM - (N_GPIO_ELECTRICAL_CONFIG_TERMINATION_BIT_POS + 1))) | (0x1 << N_GPIO_ELECTRICAL_CONFIG_TERMINATION_BIT_POS);
+}
+
+/**
+  This procedure will read multiple GPIO settings
+
+  @param[in]  GpioPad                   GPIO Pad
+  @param[out] GpioData                  GPIO data structure
+
+  @retval EFI_SUCCESS                   The function completed successfully
+  @retval EFI_INVALID_PARAMETER         Invalid group or pad number
+**/
+EFI_STATUS
+GpioGetPadConfig (
+  IN  GPIO_PAD               GpioPad,
+  OUT GPIO_CONFIG            *GpioData
+  )
+{
+  UINT32               PadCfgDwReg[GPIO_PADCFG_DW_REG_NUMBER];
+  UINT32               RegVal;
+  GPIO_GROUP           Group;
+  UINT32               PadNumber;
+  UINT32               PadBitPosition;
+
+  Group = GpioGetGroupFromGpioPad (GpioPad);
+  PadNumber = GpioGetPadNumberFromGpioPad (GpioPad);
+  PadBitPosition = GPIO_GET_PAD_POSITION (PadNumber);
+
+  if (!GpioIsPadValid (GpioPad)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  if (!GpioIsPadHostOwned (GpioPad)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  //
+  // Read PADCFG DW0 register
+  //
+  PadCfgDwReg[0] = GpioReadPadCfgReg (GpioPad, 0);
+
+  //
+  // Read PADCFG DW1 register
+  //
+  PadCfgDwReg[1] = GpioReadPadCfgReg (GpioPad, 1);
+
+  //
+  // Read PADCFG DW2 register
+  //
+  PadCfgDwReg[2] = GpioReadPadCfgReg (GpioPad, 2);
+
+  GpioConfigFromPadCfgRegValue (
+    GpioPad,
+    PadCfgDwReg,
+    GpioData
+    );
+
+  //
+  // Read HOSTSW_OWN registers
+  //
+  GpioReadReg (
+    GpioHostOwnershipRegister,
+    Group,
+    GPIO_GET_DW_NUM (PadNumber),
+    &RegVal
+    );
+
+  //
+  // Get Host Software Ownership
+  //
+  GpioData->HostSoftPadOwn = (((RegVal >> PadBitPosition) & 0x1) << (N_GPIO_HOSTSW_OWN_BIT_POS + 1)) | (0x1 << N_GPIO_HOSTSW_OWN_BIT_POS);
+
+  //
+  // Read PADCFGLOCK register
+  //
+  GpioReadReg (
+    GpioPadConfigLockRegister,
+    Group,
+    GPIO_GET_DW_NUM (PadNumber),
+    &RegVal
+    );
+
+  //
+  // Get Pad Configuration Lock state
+  //
+  GpioData->LockConfig = ((!((RegVal >> PadBitPosition) & 0x1)) << 1) | 0x1;
+
+  //
+  // Read PADCFGLOCKTX register
+  //
+  GpioReadReg (
+    GpioPadLockOutputRegister,
+    Group,
+    GPIO_GET_DW_NUM (PadNumber),
+    &RegVal
+    );
+
+  //
+  // Get Pad Configuration Lock Tx state
+  //
+  GpioData->LockConfig |= ((!((RegVal >> PadBitPosition) & 0x1)) << 2) | 0x1;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will calculate PADCFG register value based on GpioConfig data
+
+  @param[in]  GpioPad                   GPIO Pad
+  @param[in]  GpioConfig                GPIO Configuration data
+  @param[out] PadCfgDwReg               PADCFG DWx register value
+  @param[out] PadCfgDwRegMask           Mask with PADCFG DWx register bits to be modified
+
+  @retval Status
+**/
+EFI_STATUS
+GpioPadCfgRegValueFromGpioConfig (
+  IN  GPIO_PAD           GpioPad,
+  IN  CONST GPIO_CONFIG  *GpioConfig,
+  OUT UINT32             *PadCfgDwReg,
+  OUT UINT32             *PadCfgDwRegMask
+  )
+{
+  UINT32               PadRstCfg;
+
+  //
+  // Configure Reset Type (PadRstCfg)
+  // Reset configuration depends on group type.
+  // This field requires support for new and deprecated settings.
+  //
+  GpioPadRstCfgFromResetConfig (
+    GpioPad,
+    GpioConfig->PowerConfig,
+    &PadRstCfg
+    );
+
+  PadCfgDwRegMask[0] |= ((((GpioConfig->PowerConfig & B_GPIO_RESET_CONFIG_RESET_MASK) >> N_GPIO_RESET_CONFIG_RESET_BIT_POS) == GpioHardwareDefault) ? 0x0 : B_GPIO_PCR_RST_CONF);
+  PadCfgDwReg[0] |= PadRstCfg << N_GPIO_PCR_RST_CONF;
+
+  //
+  // Configure how interrupt is triggered (RxEvCfg)
+  //
+  PadCfgDwRegMask[0] |= ((((GpioConfig->InterruptConfig & B_GPIO_INT_CONFIG_INT_TYPE_MASK) >> N_GPIO_INT_CONFIG_INT_TYPE_BIT_POS) == GpioHardwareDefault) ? 0x0 : B_GPIO_PCR_RX_LVL_EDG);
+  PadCfgDwReg[0] |= (((GpioConfig->InterruptConfig & B_GPIO_INT_CONFIG_INT_TYPE_MASK) >> (N_GPIO_INT_CONFIG_INT_TYPE_BIT_POS + 1)) << N_GPIO_PCR_RX_LVL_EDG);
+
+  //
+  // Configure interrupt generation (GPIRoutIOxAPIC/SCI/SMI/NMI)
+  //
+  PadCfgDwRegMask[0] |= ((((GpioConfig->InterruptConfig & B_GPIO_INT_CONFIG_INT_SOURCE_MASK) >> N_GPIO_INT_CONFIG_INT_SOURCE_BIT_POS) == GpioHardwareDefault)  ? 0x0 : (B_GPIO_PCR_RX_NMI_ROUTE | B_GPIO_PCR_RX_SCI_ROUTE | B_GPIO_PCR_RX_SMI_ROUTE | B_GPIO_PCR_RX_APIC_ROUTE));
+  PadCfgDwReg[0] |= (((GpioConfig->InterruptConfig & B_GPIO_INT_CONFIG_INT_SOURCE_MASK) >> (N_GPIO_INT_CONFIG_INT_SOURCE_BIT_POS + 1)) << N_GPIO_PCR_RX_NMI_ROUTE);
+
+  //
+  // Configure GPIO direction (GPIORxDis and GPIOTxDis)
+  //
+  PadCfgDwRegMask[0] |= ((((GpioConfig->Direction & B_GPIO_DIRECTION_DIR_MASK) >> N_GPIO_DIRECTION_DIR_BIT_POS) == GpioHardwareDefault) ? 0x0 : (B_GPIO_PCR_RXDIS | B_GPIO_PCR_TXDIS));
+  PadCfgDwReg[0] |= (((GpioConfig->Direction & B_GPIO_DIRECTION_DIR_MASK) >> (N_GPIO_DIRECTION_DIR_BIT_POS + 1)) << N_GPIO_PCR_TXDIS);
+
+  //
+  // Configure GPIO input inversion (RXINV)
+  //
+  PadCfgDwRegMask[0] |= ((((GpioConfig->Direction & B_GPIO_DIRECTION_INV_MASK) >> N_GPIO_DIRECTION_INV_BIT_POS) == GpioHardwareDefault) ?  0x0 : B_GPIO_PCR_RXINV);
+  PadCfgDwReg[0] |= (((GpioConfig->Direction & B_GPIO_DIRECTION_INV_MASK) >> (N_GPIO_DIRECTION_INV_BIT_POS + 1)) << N_GPIO_PCR_RXINV);
+
+  //
+  // Configure GPIO output state (GPIOTxState)
+  //
+  PadCfgDwRegMask[0] |= ((((GpioConfig->OutputState & B_GPIO_OUTPUT_MASK) >> N_GPIO_OUTPUT_BIT_POS) == GpioHardwareDefault) ? 0x0 : B_GPIO_PCR_TX_STATE);
+  PadCfgDwReg[0] |= (((GpioConfig->OutputState & B_GPIO_OUTPUT_MASK) >> (N_GPIO_OUTPUT_BIT_POS + 1)) << N_GPIO_PCR_TX_STATE);
+
+  //
+  // Configure GPIO RX raw override to '1' (RXRAW1)
+  //
+  PadCfgDwRegMask[0] |= ((((GpioConfig->OtherSettings & B_GPIO_OTHER_CONFIG_RXRAW_MASK) >> N_GPIO_OTHER_CONFIG_RXRAW_BIT_POS) == GpioHardwareDefault) ? 0x0 : B_GPIO_PCR_RX_RAW1);
+  PadCfgDwReg[0] |= (((GpioConfig->OtherSettings & B_GPIO_OTHER_CONFIG_RXRAW_MASK) >> (N_GPIO_OTHER_CONFIG_RXRAW_BIT_POS + 1)) << N_GPIO_PCR_RX_RAW1);
+
+  //
+  // Configure GPIO Pad Mode (PMode)
+  //
+  PadCfgDwRegMask[0] |= ((((GpioConfig->PadMode & B_GPIO_PAD_MODE_MASK) >> N_GPIO_PAD_MODE_BIT_POS) == GpioHardwareDefault) ? 0x0 : B_GPIO_PCR_PAD_MODE);
+  PadCfgDwReg[0] |= (((GpioConfig->PadMode & B_GPIO_PAD_MODE_MASK) >> (N_GPIO_PAD_MODE_BIT_POS + 1)) << N_GPIO_PCR_PAD_MODE);
+
+  //
+  // Configure GPIO termination (Term)
+  //
+  PadCfgDwRegMask[1] |= ((((GpioConfig->ElectricalConfig & B_GPIO_ELECTRICAL_CONFIG_TERMINATION_MASK) >> N_GPIO_ELECTRICAL_CONFIG_TERMINATION_BIT_POS) == GpioHardwareDefault) ? 0x0 : B_GPIO_PCR_TERM);
+  PadCfgDwReg[1] |= (((GpioConfig->ElectricalConfig & B_GPIO_ELECTRICAL_CONFIG_TERMINATION_MASK) >> (N_GPIO_ELECTRICAL_CONFIG_TERMINATION_BIT_POS + 1)) << N_GPIO_PCR_TERM);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will set GPIO output level
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Value                Output value
+                                  0: OutputLow, 1: OutputHigh
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioSetOutputValue (
+  IN GPIO_PAD                  GpioPad,
+  IN UINT32                    Value
+  )
+{
+  if (Value > 1) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!GpioIsPadValid (GpioPad)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!GpioIsPadHostOwned (GpioPad)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  GpioWritePadCfgReg (
+    GpioPad,
+    0,
+    (UINT32)~B_GPIO_PCR_TX_STATE,
+    Value << N_GPIO_PCR_TX_STATE
+    );
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will get GPIO output level
+
+  @param[in]  GpioPad             GPIO pad
+  @param[out] OutputVal           GPIO Output value
+                                  0: OutputLow, 1: OutputHigh
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioGetOutputValue (
+  IN GPIO_PAD                  GpioPad,
+  OUT UINT32                   *OutputVal
+  )
+{
+  UINT32      PadCfgReg;
+
+  if (!GpioIsPadValid (GpioPad)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!GpioIsPadHostOwned (GpioPad)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  PadCfgReg = GpioReadPadCfgReg (GpioPad, 0);
+
+  *OutputVal = (PadCfgReg & B_GPIO_PCR_TX_STATE) >> N_GPIO_PCR_TX_STATE;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will get GPIO input level
+
+  @param[in] GpioPad              GPIO pad
+  @param[out] InputVal            GPIO Input value
+                                  0: InputLow, 1: InpuHigh
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioGetInputValue (
+  IN GPIO_PAD                  GpioPad,
+  OUT UINT32                   *InputVal
+  )
+{
+  UINT32      PadCfgReg;
+
+  if (!GpioIsPadValid (GpioPad)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!GpioIsPadHostOwned (GpioPad)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  PadCfgReg = GpioReadPadCfgReg (GpioPad, 0);
+
+  *InputVal = (PadCfgReg & B_GPIO_PCR_RX_STATE) >> N_GPIO_PCR_RX_STATE;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will get GPIO IOxAPIC interrupt number
+
+  @param[in]  GpioPad             GPIO pad
+  @param[out] IrqNum              IRQ number
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioGetPadIoApicIrqNumber (
+  IN GPIO_PAD                  GpioPad,
+  OUT UINT32                   *IrqNum
+  )
+{
+  UINT32      PadCfgReg;
+
+  if (!GpioIsPadValid (GpioPad)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!GpioIsPadHostOwned (GpioPad)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  PadCfgReg = GpioReadPadCfgReg (GpioPad, 1);
+
+  *IrqNum = (PadCfgReg & B_GPIO_PCR_INTSEL) >> N_GPIO_PCR_INTSEL;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will configure GPIO input inversion
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Value                Value for GPIO input inversion
+                                  0: No input inversion, 1: Invert input
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioSetInputInversion (
+  IN GPIO_PAD                  GpioPad,
+  IN UINT32                    Value
+  )
+{
+  if (Value > 1) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!GpioIsPadValid (GpioPad)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!GpioIsPadHostOwned (GpioPad)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  GpioWritePadCfgReg (
+    GpioPad,
+    0,
+    (UINT32)~B_GPIO_PCR_RXINV,
+    Value << N_GPIO_PCR_RXINV
+    );
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will get GPIO pad input inversion value
+
+  @param[in]  GpioPad             GPIO pad
+  @param[out] InvertState         GPIO inversion state
+                                  0: No input inversion, 1: Inverted input
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioGetInputInversion (
+  IN  GPIO_PAD                 GpioPad,
+  OUT UINT32                   *InvertState
+  )
+{
+  UINT32      PadCfgReg;
+
+  if (!GpioIsPadValid (GpioPad)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!GpioIsPadHostOwned (GpioPad)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  PadCfgReg = GpioReadPadCfgReg (GpioPad, 0);
+
+  *InvertState = (PadCfgReg & B_GPIO_PCR_RXINV) >> N_GPIO_PCR_RXINV;
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will set GPIO interrupt settings
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Value                Value of Level/Edge
+                                  use GPIO_INT_CONFIG as argument
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioSetPadInterruptConfig (
+  IN GPIO_PAD                 GpioPad,
+  IN GPIO_INT_CONFIG          Value
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      RxLvlEdgeValue;
+  UINT32      IntRouteValue;
+  UINT32      PadNumber;
+  UINT32      GpeEnable;
+  UINT32      NmiEnable;
+
+  if (!GpioIsPadValid (GpioPad)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!GpioIsPadHostOwned (GpioPad)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  Status = EFI_SUCCESS;
+
+  if (((Value & B_GPIO_INT_CONFIG_INT_TYPE_MASK) >> N_GPIO_INT_CONFIG_INT_TYPE_BIT_POS) != GpioHardwareDefault) {
+    RxLvlEdgeValue = ((Value & B_GPIO_INT_CONFIG_INT_TYPE_MASK) >> (N_GPIO_INT_CONFIG_INT_TYPE_BIT_POS + 1)) << N_GPIO_PCR_RX_LVL_EDG;
+
+    GpioWritePadCfgReg (
+      GpioPad,
+      0,
+      (UINT32)~B_GPIO_PCR_RX_LVL_EDG,
+      RxLvlEdgeValue
+      );
+  }
+
+  if (((Value & B_GPIO_INT_CONFIG_INT_SOURCE_MASK) >> N_GPIO_INT_CONFIG_INT_SOURCE_BIT_POS) != GpioHardwareDefault) {
+
+    IntRouteValue = ((Value & B_GPIO_INT_CONFIG_INT_SOURCE_MASK) >> (N_GPIO_INT_CONFIG_INT_SOURCE_BIT_POS + 1)) << N_GPIO_PCR_RX_NMI_ROUTE;
+
+    GpioWritePadCfgReg (
+      GpioPad,
+      0,
+      (UINT32)~(B_GPIO_PCR_RX_NMI_ROUTE | B_GPIO_PCR_RX_SCI_ROUTE | B_GPIO_PCR_RX_SMI_ROUTE | B_GPIO_PCR_RX_APIC_ROUTE),
+      IntRouteValue
+      );
+
+    if ((Value & GpioIntSci) == GpioIntSci) {
+      GpeEnable = 0x1;
+    } else {
+      GpeEnable = 0x0;
+    }
+
+    PadNumber = GpioGetPadNumberFromGpioPad (GpioPad);
+
+    GpioWriteReg (
+      GpioGpeEnableRegister,
+      GpioGetGroupFromGpioPad (GpioPad),
+      GPIO_GET_DW_NUM (PadNumber),
+      ~(1 << GPIO_GET_PAD_POSITION (PadNumber)),
+      GpeEnable << GPIO_GET_PAD_POSITION (PadNumber)
+      );
+
+    if ((Value & GpioIntNmi) == GpioIntNmi) {
+      NmiEnable = 0x1;
+    } else {
+      NmiEnable = 0x0;
+    }
+
+    Status = GpioWriteReg (
+               GpioNmiEnableRegister,
+               GpioGetGroupFromGpioPad (GpioPad),
+               GPIO_GET_DW_NUM (PadNumber),
+               ~(1 << GPIO_GET_PAD_POSITION (PadNumber)),
+               NmiEnable << GPIO_GET_PAD_POSITION (PadNumber)
+               );
+    if (Status == EFI_UNSUPPORTED) {
+      if (NmiEnable == 0) {
+        //
+        // Not all GPIO have NMI capabilities. Since we always try to program this register,
+        // even when not enabling NMI for a pad so do not report such access as an error
+        //
+        return EFI_SUCCESS;
+      } else {
+        DEBUG ((DEBUG_ERROR, "GPIO ERROR: Group %d has no pads supporting NMI\n", GpioGetGroupIndexFromGpioPad (GpioPad)));
+      }
+    }
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  return Status;
+}
+
+/**
+  This procedure will set GPIO electrical settings
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Value                Value of termination
+                                  use GPIO_ELECTRICAL_CONFIG as argument
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioSetPadElectricalConfig (
+  IN GPIO_PAD                  GpioPad,
+  IN GPIO_ELECTRICAL_CONFIG    Value
+  )
+{
+  UINT32      TermValue;
+
+  if (!GpioIsPadValid (GpioPad)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!GpioIsPadHostOwned (GpioPad)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  if (((Value & B_GPIO_ELECTRICAL_CONFIG_TERMINATION_MASK) >> N_GPIO_ELECTRICAL_CONFIG_TERMINATION_BIT_POS) != GpioHardwareDefault) {
+    TermValue = ((Value & B_GPIO_ELECTRICAL_CONFIG_TERMINATION_MASK) >> (N_GPIO_ELECTRICAL_CONFIG_TERMINATION_BIT_POS + 1)) << N_GPIO_PCR_TERM;
+
+    GpioWritePadCfgReg (
+      GpioPad,
+      1,
+      (UINT32)~B_GPIO_PCR_TERM,
+      TermValue
+      );
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will set GPIO Reset settings
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Value                Value for Pad Reset Configuration
+                                  use GPIO_RESET_CONFIG as argument
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioSetPadResetConfig (
+  IN GPIO_PAD                  GpioPad,
+  IN GPIO_RESET_CONFIG         Value
+  )
+{
+  UINT32      PadRstCfg;
+  EFI_STATUS  Status;
+
+  if (!GpioIsPadValid (GpioPad)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!GpioIsPadHostOwned (GpioPad)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  if (((Value & B_GPIO_RESET_CONFIG_RESET_MASK) >> N_GPIO_RESET_CONFIG_RESET_BIT_POS) != GpioHardwareDefault) {
+
+    //
+    // Reset configuration depends on group type.
+    // This field requires support for new and deprecated settings.
+    //
+    Status = GpioPadRstCfgFromResetConfig (
+               GpioPad,
+               Value,
+               &PadRstCfg
+               );
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+    GpioWritePadCfgReg (
+      GpioPad,
+      0,
+      (UINT32)~B_GPIO_PCR_RST_CONF,
+      PadRstCfg << N_GPIO_PCR_RST_CONF
+      );
+  }
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will get GPIO Reset settings
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Value                Value of Pad Reset Configuration
+                                  based on GPIO_RESET_CONFIG
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioGetPadResetConfig (
+  IN GPIO_PAD                  GpioPad,
+  IN GPIO_RESET_CONFIG         *Value
+  )
+{
+  UINT32      PadRstCfg;
+  UINT32      PadCfgDw0Reg;
+
+  if (!GpioIsPadValid (GpioPad)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!GpioIsPadHostOwned (GpioPad)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  PadCfgDw0Reg = GpioReadPadCfgReg (GpioPad, 0);
+
+  //
+  // Get Reset Type (PadRstCfg)
+  //
+  PadRstCfg = (PadCfgDw0Reg & B_GPIO_PCR_RST_CONF) >> N_GPIO_PCR_RST_CONF;
+
+  *Value = GpioResetConfigFromPadRstCfg (
+             GpioPad,
+             PadRstCfg
+             );
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will get GPIO Host Software Pad Ownership for certain group
+
+  @param[in]  Group               GPIO group
+  @param[in]  DwNum               Host Ownership register number for current group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[out] HostSwRegVal        Value of Host Software Pad Ownership register
+                                  Bit position - PadNumber
+                                  Bit value - 0: ACPI Mode, 1: GPIO Driver mode
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or DwNum parameter number
+**/
+EFI_STATUS
+GpioGetHostSwOwnershipForGroupDw (
+  IN  GPIO_GROUP                  Group,
+  IN  UINT32                      DwNum,
+  OUT UINT32                      *HostSwRegVal
+  )
+{
+  if (!GpioIsGroupAndDwNumValid (Group, DwNum)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  return GpioReadReg (
+           GpioHostOwnershipRegister,
+           Group,
+           DwNum,
+           HostSwRegVal
+           );
+}
+
+/**
+  This procedure will get GPIO Host Software Pad Ownership for certain group
+
+  @param[in]  Group               GPIO group
+  @param[in]  DwNum               Host Ownership register number for current group
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[in]  HostSwRegVal        Value of Host Software Pad Ownership register
+                                  Bit position - PadNumber
+                                  Bit value - 0: ACPI Mode, 1: GPIO Driver mode
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or DwNum parameter number
+**/
+EFI_STATUS
+GpioSetHostSwOwnershipForGroupDw (
+  IN GPIO_GROUP                   Group,
+  IN UINT32                       DwNum,
+  IN UINT32                       HostSwRegVal
+  )
+{
+  if (!GpioIsGroupAndDwNumValid (Group, DwNum)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  return GpioWriteReg (
+           GpioHostOwnershipRegister,
+           Group,
+           DwNum,
+           0,
+           HostSwRegVal
+           );
+}
+
+/**
+  This procedure will get Gpio Pad Host Software Ownership
+
+  @param[in]  GpioPad             GPIO pad
+  @param[out] PadHostSwOwn        Value of Host Software Pad Owner
+                                  0: ACPI Mode, 1: GPIO Driver mode
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioGetHostSwOwnershipForPad (
+  IN GPIO_PAD                 GpioPad,
+  OUT UINT32                  *PadHostSwOwn
+  )
+{
+  UINT32      PadNumber;
+  UINT32      HostSwRegVal;
+
+  if (!GpioIsPadValid (GpioPad)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  PadNumber = GpioGetPadNumberFromGpioPad (GpioPad);
+
+  GpioReadReg (
+    GpioHostOwnershipRegister,
+    GpioGetGroupFromGpioPad (GpioPad),
+    GPIO_GET_DW_NUM (PadNumber),
+    &HostSwRegVal
+    );
+
+  *PadHostSwOwn = (HostSwRegVal >> GPIO_GET_PAD_POSITION (PadNumber)) & 0x1;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will set Gpio Pad Host Software Ownership
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] PadHostSwOwn         Pad Host Software Owner
+                                  0: ACPI Mode, 1: GPIO Driver mode
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioSetHostSwOwnershipForPad (
+  IN GPIO_PAD                  GpioPad,
+  IN UINT32                    PadHostSwOwn
+  )
+{
+  UINT32      PadNumber;
+
+  if (!GpioIsPadValid (GpioPad) || (PadHostSwOwn > 1)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  PadNumber = GpioGetPadNumberFromGpioPad (GpioPad);
+
+  return GpioWriteReg (
+           GpioHostOwnershipRegister,
+           GpioGetGroupFromGpioPad (GpioPad),
+           GPIO_GET_DW_NUM (PadNumber),
+           (UINT32)~(1 << GPIO_GET_PAD_POSITION (PadNumber)),
+           PadHostSwOwn << GPIO_GET_PAD_POSITION (PadNumber)
+           );
+}
+
+/**
+  This procedure will get Gpio Pad Ownership
+
+  @param[in] GpioPad              GPIO pad
+  @param[out] PadOwnVal           Value of Pad Ownership
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+GpioGetPadOwnership (
+  IN  GPIO_PAD                GpioPad,
+  OUT GPIO_PAD_OWN            *PadOwnVal
+  )
+{
+  UINT32                 Mask;
+  UINT32                 RegOffset;
+  UINT32                 GroupIndex;
+  UINT32                 PadNumber;
+  CONST GPIO_GROUP_INFO  *GpioGroupInfo;
+  UINT32                 GpioGroupInfoLength;
+  UINT32                 PadOwnRegValue;
+
+  if (!GpioIsPadValid (GpioPad)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  GroupIndex = GpioGetGroupIndexFromGpioPad (GpioPad);
+  PadNumber = GpioGetPadNumberFromGpioPad (GpioPad);
+
+  GpioGroupInfo = GpioGetGroupInfoTable (&GpioGroupInfoLength);
+
+  //
+  // Calculate RegOffset using Pad Ownership offset and GPIO Pad number.
+  // One DWord register contains information for 8 pads.
+  //
+  RegOffset = GpioGroupInfo[GroupIndex].PadOwnOffset + (PadNumber >> 3) * 0x4;
+
+  //
+  // Calculate pad bit position within DWord register
+  //
+  PadNumber %= 8;
+  Mask = (BIT1 | BIT0) << (PadNumber * 4);
+
+  PadOwnRegValue = MmioRead32 (GetPchPcrAddress (GpioGroupInfo[GroupIndex].Community, RegOffset));
+
+  *PadOwnVal = (GPIO_PAD_OWN) ((PadOwnRegValue & Mask) >> (PadNumber * 4));
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will check state of Pad Config Lock for pads within one group
+
+  @param[in]  Group               GPIO group
+  @param[in]  DwNum               PadCfgLock register number for current group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[out] PadCfgLockRegVal    Value of PadCfgLock register
+                                  Bit position - PadNumber
+                                  Bit value - 0: NotLocked, 1: Locked
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or DwNum parameter number
+**/
+EFI_STATUS
+GpioGetPadCfgLockForGroupDw (
+  IN  GPIO_GROUP                  Group,
+  IN  UINT32                      DwNum,
+  OUT UINT32                      *PadCfgLockRegVal
+  )
+{
+  if (!GpioIsGroupAndDwNumValid (Group, DwNum)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  return GpioReadReg (
+           GpioPadConfigLockRegister,
+           Group,
+           DwNum,
+           PadCfgLockRegVal
+           );
+}
+
+/**
+  This procedure will check state of Pad Config Lock for selected pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[out] PadCfgLock          PadCfgLock for selected pad
+                                  0: NotLocked, 1: Locked
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioGetPadCfgLock (
+  IN GPIO_PAD                   GpioPad,
+  OUT UINT32                    *PadCfgLock
+  )
+{
+  UINT32      PadNumber;
+  UINT32      PadCfgLockRegVal;
+
+  if (!GpioIsPadValid (GpioPad)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  PadNumber = GpioGetPadNumberFromGpioPad (GpioPad);
+
+  GpioReadReg (
+    GpioPadConfigLockRegister,
+    GpioGetGroupFromGpioPad (GpioPad),
+    GPIO_GET_DW_NUM (PadNumber),
+    &PadCfgLockRegVal
+    );
+
+  *PadCfgLock = (PadCfgLockRegVal >> GPIO_GET_PAD_POSITION (PadNumber)) & 0x1;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will check state of Pad Config Tx Lock for pads within one group
+
+  @param[in]  Group               GPIO group
+  @param[in]  DwNum               PadCfgLockTx register number for current group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[out] PadCfgLockTxRegVal  Value of PadCfgLockTx register
+                                  Bit position - PadNumber
+                                  Bit value - 0: NotLockedTx, 1: LockedTx
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or DwNum parameter number
+**/
+EFI_STATUS
+GpioGetPadCfgLockTxForGroupDw (
+  IN  GPIO_GROUP                  Group,
+  IN  UINT32                      DwNum,
+  OUT UINT32                      *PadCfgLockTxRegVal
+  )
+{
+  if (!GpioIsGroupAndDwNumValid (Group, DwNum)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  return GpioReadReg (
+           GpioPadLockOutputRegister,
+           Group,
+           DwNum,
+           PadCfgLockTxRegVal
+           );
+}
+
+/**
+  This procedure will check state of Pad Config Tx Lock for selected pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[out] PadCfgLock          PadCfgLockTx for selected pad
+                                  0: NotLockedTx, 1: LockedTx
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioGetPadCfgLockTx (
+  IN GPIO_PAD                   GpioPad,
+  OUT UINT32                    *PadCfgLockTx
+  )
+{
+  UINT32      PadNumber;
+  UINT32      PadCfgLockTxRegVal;
+
+  if (!GpioIsPadValid (GpioPad)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  PadNumber = GpioGetPadNumberFromGpioPad (GpioPad);
+
+  GpioReadReg (
+    GpioPadLockOutputRegister,
+    GpioGetGroupFromGpioPad (GpioPad),
+    GPIO_GET_DW_NUM (PadNumber),
+    &PadCfgLockTxRegVal
+    );
+
+  *PadCfgLockTx = (PadCfgLockTxRegVal >> GPIO_GET_PAD_POSITION (PadNumber)) & 0x1;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will clear PadCfgLock for selected pads within one group.
+  This function should be used only inside SMI.
+
+  @param[in]  Group               GPIO group
+  @param[in]  DwNum               PadCfgLock register number for current group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[in]  PadsToUnlock        Bitmask for pads which are going to be unlocked,
+                                  Bit position - PadNumber
+                                  Bit value - 0: DoNotUnlock, 1: Unlock
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+GpioUnlockPadCfgForGroupDw (
+  IN GPIO_GROUP                Group,
+  IN UINT32                    DwNum,
+  IN UINT32                    PadsToUnlock
+  )
+{
+  if (!GpioIsGroupAndDwNumValid (Group, DwNum)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  return GpioWriteLockReg (
+           GpioPadConfigLockRegister,
+           Group,
+           DwNum,
+           ~PadsToUnlock,
+           0
+           );
+}
+
+/**
+  This procedure will clear PadCfgLock for selected pad.
+  This function should be used only inside SMI.
+
+  @param[in] GpioPad              GPIO pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+GpioUnlockPadCfg (
+  IN GPIO_PAD                   GpioPad
+  )
+{
+  GPIO_GROUP   Group;
+  UINT32       PadNumber;
+
+  Group = GpioGetGroupFromGpioPad (GpioPad);
+  PadNumber = GpioGetPadNumberFromGpioPad (GpioPad);
+
+  return GpioUnlockPadCfgForGroupDw (
+           Group,
+           GPIO_GET_DW_NUM (PadNumber),
+           1 << GPIO_GET_PAD_POSITION (PadNumber)
+           );
+}
+
+/**
+  This procedure will set PadCfgLock for selected pads within one group
+
+  @param[in]  Group               GPIO group
+  @param[in]  DwNum               PadCfgLock register number for current group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[in]  PadsToLock          Bitmask for pads which are going to be locked
+                                  Bit position - PadNumber
+                                  Bit value - 0: DoNotLock, 1: Lock
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or DwNum parameter number
+**/
+EFI_STATUS
+GpioLockPadCfgForGroupDw (
+  IN GPIO_GROUP                   Group,
+  IN UINT32                       DwNum,
+  IN UINT32                       PadsToLock
+  )
+{
+  if (!GpioIsGroupAndDwNumValid (Group, DwNum)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  return GpioWriteLockReg (
+           GpioPadConfigLockRegister,
+           Group,
+           DwNum,
+           ~0u,
+           PadsToLock
+           );
+}
+
+/**
+  This procedure will set PadCfgLock for selected pad
+
+  @param[in] GpioPad              GPIO pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+GpioLockPadCfg (
+  IN GPIO_PAD                   GpioPad
+  )
+{
+  GPIO_GROUP   Group;
+  UINT32       PadNumber;
+
+  Group = GpioGetGroupFromGpioPad (GpioPad);
+  PadNumber = GpioGetPadNumberFromGpioPad (GpioPad);
+
+  return GpioLockPadCfgForGroupDw (
+           Group,
+           GPIO_GET_DW_NUM (PadNumber),
+           1 << GPIO_GET_PAD_POSITION (PadNumber)
+           );
+}
+
+/**
+  This procedure will clear PadCfgLockTx for selected pads within one group.
+  This function should be used only inside SMI.
+
+  @param[in]  Group               GPIO group
+  @param[in]  DwNum               PadCfgLockTx register number for current group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[in]  PadsToUnlockTx      Bitmask for pads which are going to be unlocked,
+                                  Bit position - PadNumber
+                                  Bit value - 0: DoNotUnLockTx, 1: LockTx
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+GpioUnlockPadCfgTxForGroupDw (
+  IN GPIO_GROUP                Group,
+  IN UINT32                    DwNum,
+  IN UINT32                    PadsToUnlockTx
+  )
+{
+  if (!GpioIsGroupAndDwNumValid (Group, DwNum)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  return GpioWriteLockReg (
+           GpioPadLockOutputRegister,
+           Group,
+           DwNum,
+           ~PadsToUnlockTx,
+           0
+           );
+}
+
+/**
+  This procedure will clear PadCfgLockTx for selected pad.
+  This function should be used only inside SMI.
+
+  @param[in] GpioPad              GPIO pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+GpioUnlockPadCfgTx (
+  IN GPIO_PAD                   GpioPad
+  )
+{
+  GPIO_GROUP   Group;
+  UINT32       PadNumber;
+
+  Group = GpioGetGroupFromGpioPad (GpioPad);
+  PadNumber = GpioGetPadNumberFromGpioPad (GpioPad);
+
+  return GpioUnlockPadCfgTxForGroupDw (
+           Group,
+           GPIO_GET_DW_NUM (PadNumber),
+           1 << GPIO_GET_PAD_POSITION (PadNumber)
+           );
+}
+
+/**
+  This procedure will set PadCfgLockTx for selected pads within one group
+
+  @param[in]  Group               GPIO group
+  @param[in]  DwNum               PadCfgLock register number for current group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[in]  PadsToLockTx        Bitmask for pads which are going to be locked,
+                                  Bit position - PadNumber
+                                  Bit value - 0: DoNotLockTx, 1: LockTx
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or DwNum parameter number
+**/
+EFI_STATUS
+GpioLockPadCfgTxForGroupDw (
+  IN GPIO_GROUP                   Group,
+  IN UINT32                       DwNum,
+  IN UINT32                       PadsToLockTx
+  )
+{
+  if (!GpioIsGroupAndDwNumValid (Group, DwNum)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  return GpioWriteLockReg (
+           GpioPadLockOutputRegister,
+           Group,
+           DwNum,
+           ~0u,
+           PadsToLockTx
+           );
+}
+
+/**
+  This procedure will set PadCfgLockTx for selected pad
+
+  @param[in] GpioPad              GPIO pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+GpioLockPadCfgTx (
+  IN GPIO_PAD                   GpioPad
+  )
+{
+  GPIO_GROUP   Group;
+  UINT32       PadNumber;
+
+  Group = GpioGetGroupFromGpioPad (GpioPad);
+  PadNumber = GpioGetPadNumberFromGpioPad (GpioPad);
+
+  return GpioLockPadCfgTxForGroupDw (
+           Group,
+           GPIO_GET_DW_NUM (PadNumber),
+           1 << GPIO_GET_PAD_POSITION (PadNumber)
+           );
+}
+
+/**
+  This procedure will get Group to GPE mapping.
+  It will assume that only first 32 pads can be mapped to GPE.
+  To handle cases where groups have more than 32 pads and higher part of group
+  can be mapped please refer to GpioGetGroupDwToGpeDwX()
+
+  @param[out] GroupToGpeDw0       GPIO group to be mapped to GPE_DW0
+  @param[out] GroupToGpeDw1       GPIO group to be mapped to GPE_DW1
+  @param[out] GroupToGpeDw2       GPIO group to be mapped to GPE_DW2
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+GpioGetGroupToGpeDwX (
+  IN GPIO_GROUP               *GroupToGpeDw0,
+  IN GPIO_GROUP               *GroupToGpeDw1,
+  IN GPIO_GROUP               *GroupToGpeDw2
+  )
+{
+  UINT32     GroupDw[3];
+  UINT32     Index;
+  EFI_STATUS Status;
+
+  Status = GpioGetGroupDwToGpeDwX (
+             GroupToGpeDw0,
+             &GroupDw[0],
+             GroupToGpeDw1,
+             &GroupDw[1],
+             GroupToGpeDw2,
+             &GroupDw[2]
+             );
+
+  for (Index = 0; Index < ARRAY_SIZE (GroupDw); Index++) {
+    if (GroupDw[Index] != 0) {
+      Status = EFI_UNSUPPORTED;
+      ASSERT (FALSE);
+    }
+  }
+  return Status;
+}
+
+
+/**
+  This procedure will get Group to GPE mapping. If group has more than 32 bits
+  it is possible to map only single DW of pins (e.g. 0-31, 32-63) because
+  ACPI GPE_DWx register is 32 bits large.
+
+  @param[out]  GroupToGpeDw0       GPIO group mapped to GPE_DW0
+  @param[out]  GroupDwForGpeDw0    DW of pins mapped to GPE_DW0
+  @param[out]  GroupToGpeDw1       GPIO group mapped to GPE_DW1
+  @param[out]  GroupDwForGpeDw1    DW of pins mapped to GPE_DW1
+  @param[out]  GroupToGpeDw2       GPIO group mapped to GPE_DW2
+  @param[out]  GroupDwForGpeDw2    DW of pins mapped to GPE_DW2
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+GpioGetGroupDwToGpeDwX (
+  OUT GPIO_GROUP                *GroupToGpeDw0,
+  OUT UINT32                    *GroupDwForGpeDw0,
+  OUT GPIO_GROUP                *GroupToGpeDw1,
+  OUT UINT32                    *GroupDwForGpeDw1,
+  OUT GPIO_GROUP                *GroupToGpeDw2,
+  OUT UINT32                    *GroupDwForGpeDw2
+  )
+{
+  UINT32                     PmcGpeDwXValue[3];
+  GPIO_GROUP                 GroupToGpeDwX[3];
+  UINT32                     GroupDwForGpeDwX[3];
+  UINT8                      GpeDwXIndex;
+  UINT32                     Index;
+  GPIO_GROUP_TO_GPE_MAPPING  *GpioGpeMap;
+  UINT32                     GpioGpeMapLength;
+
+  ZeroMem (GroupToGpeDwX, sizeof (GroupToGpeDwX));
+  ZeroMem (GroupDwForGpeDwX, sizeof (GroupDwForGpeDwX));
+
+  PmcGetGpioGpe (&PmcGpeDwXValue[0], &PmcGpeDwXValue[1], &PmcGpeDwXValue[2]);
+
+  GpioGetGroupToGpeMapping (&GpioGpeMap, &GpioGpeMapLength);
+
+  for (GpeDwXIndex = 0; GpeDwXIndex < 3; GpeDwXIndex++) {
+    for (Index = 0; Index < GpioGpeMapLength; Index++) {
+
+      if (GpioGpeMap[Index].PmcGpeDwxVal == PmcGpeDwXValue[GpeDwXIndex]) {
+        GroupToGpeDwX[GpeDwXIndex] = GpioGpeMap[Index].Group;
+        GroupDwForGpeDwX[GpeDwXIndex] = GpioGpeMap[Index].GroupDw;
+        break;
+      }
+    }
+  }
+
+  if ((GroupToGpeDwX[0] == 0) ||
+      (GroupToGpeDwX[1] == 0) ||
+      (GroupToGpeDwX[2] == 0)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  *GroupToGpeDw0 = GroupToGpeDwX[0];
+  *GroupDwForGpeDw0 = GroupDwForGpeDwX[0];
+  *GroupToGpeDw1 = GroupToGpeDwX[1];
+  *GroupDwForGpeDw1 = GroupDwForGpeDwX[1];
+  *GroupToGpeDw2 = GroupToGpeDwX[2];
+  *GroupDwForGpeDw2 = GroupDwForGpeDwX[2];
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will get GPE number for provided GpioPad.
+  PCH allows to configure mapping between GPIO groups and related GPE (GpioSetGroupToGpeDwX())
+  what results in the fact that certain Pad can cause different General Purpose Event. Only three
+  GPIO groups can be mapped to cause unique GPE (1-tier), all others groups will be under one common
+  event (GPE_111 for 2-tier).
+
+  1-tier:
+  Returned GpeNumber is in range <0,95>. GpioGetGpeNumber() can be used
+  to determine what _LXX ACPI method would be called on event on selected GPIO pad
+
+  2-tier:
+  Returned GpeNumber is 0x6F (111). All GPIO pads which are not mapped to 1-tier GPE
+  will be under one master GPE_111 which is linked to _L6F ACPI method. If it is needed to determine
+  what Pad from 2-tier has caused the event, _L6F method should check GPI_GPE_STS and GPI_GPE_EN
+  registers for all GPIO groups not mapped to 1-tier GPE.
+
+  @param[in]  GpioPad             GPIO pad
+  @param[out] GpeNumber           GPE number
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioGetGpeNumber (
+  IN  GPIO_PAD                  GpioPad,
+  OUT UINT32                    *GpeNumber
+  )
+{
+  GPIO_GROUP           GroupToGpeDwX[3];
+  UINT32               GroupDw[3];
+  GPIO_GROUP           Group;
+  UINT32               PadNumber;
+  UINT32               Index;
+  EFI_STATUS           Status;
+
+  Group = GpioGetGroupFromGpioPad (GpioPad);
+  PadNumber = GpioGetPadNumberFromGpioPad (GpioPad);
+
+  if (!GpioIsPadValid (GpioPad)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Get GPIO groups mapping to 1-tier GPE
+  // This mapping is dependent on GPIO IP implementation
+  // and may change between chipset generations
+  //
+  Status = GpioGetGroupDwToGpeDwX (
+             &GroupToGpeDwX[0], &GroupDw[0],
+             &GroupToGpeDwX[1], &GroupDw[1],
+             &GroupToGpeDwX[2], &GroupDw[2]
+             );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Check if pad is routed to 1-Tier GPE
+  //
+  for (Index = 0; Index < 3; Index++) {
+    if ((Group == GroupToGpeDwX[Index]) && (PadNumber >= (32 * GroupDw[Index])) && (PadNumber < (32 * (GroupDw[Index] + 1)))) {
+      *GpeNumber = PadNumber + (32 * Index) - (32 * GroupDw[Index]);
+      return EFI_SUCCESS;
+    }
+  }
+
+  //
+  // If Group number doesn't match any of above then
+  // it means that the pad is routed to 2-tier GPE
+  // which corresponds to  GPE_111 (0x6F)
+  //
+  *GpeNumber = PCH_GPIO_2_TIER_MASTER_GPE_NUMBER;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure is used to check GPIO inputs belongs to 2 tier or 1 tier architecture
+
+  @param[in]  GpioPad             GPIO pad
+
+  @retval     Data                0 means 1-tier, 1 means 2-tier
+**/
+BOOLEAN
+GpioCheckFor2Tier (
+  IN GPIO_PAD                  GpioPad
+  )
+{
+  UINT32               Data32;
+  EFI_STATUS           Status;
+
+  Status = GpioGetGpeNumber (GpioPad, &Data32);
+  if (EFI_ERROR (Status)) {
+    DEBUG (( DEBUG_ERROR, "GpioCheckFor2Tier: Failed to get GPE number. Status: %r\n", Status ));
+    return FALSE;
+  }
+
+  if (Data32 == PCH_GPIO_2_TIER_MASTER_GPE_NUMBER) {
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+/**
+  This procedure is used to clear GPE STS for a specified GpioPad
+
+  @param[in]  GpioPad             GPIO pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioClearGpiGpeSts (
+  IN GPIO_PAD                  GpioPad
+  )
+{
+  GPIO_GROUP           Group;
+  UINT32               PadNumber;
+  UINT32               DwNum;
+  UINT32               PadBitPosition;
+
+  if (!GpioIsPadValid (GpioPad)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  //
+  // Check for 2-tier
+  //
+  if (!(GpioCheckFor2Tier (GpioPad))) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Group = GpioGetGroupFromGpioPad (GpioPad);
+  PadNumber = GpioGetPadNumberFromGpioPad (GpioPad);
+  DwNum = GPIO_GET_DW_NUM (PadNumber);
+  PadBitPosition = GPIO_GET_PAD_POSITION (PadNumber);
+
+  //
+  // Clear GPI GPE Status bit by writing '1'
+  //
+  return GpioWriteReg (
+           GpioGpeStatusRegister,
+           Group,
+           DwNum,
+           0u,
+           (UINT32) (BIT0 << PadBitPosition)
+           );
+}
+
+
+/**
+  This procedure is used to lock all GPIO pads except the ones
+  which were requested during their configuration to be left unlocked.
+  This function must be called before BIOS_DONE - before POSTBOOT_SAI is enabled.
+    FSP - call this function from wrapper before transition to FSP-S
+    UEFI/EDK - call this function before EndOfPei event
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+GpioLockPads (
+  VOID
+  )
+{
+  UINT32         DwNum;
+  GPIO_GROUP     Group;
+  GPIO_GROUP     GroupMin;
+  GPIO_GROUP     GroupMax;
+  UINT32         UnlockedPads;
+  UINT32         OverrideCfgPads;
+  UINT32         OverrideTxPads;
+  EFI_STATUS     Status;
+
+  GroupMin = GpioGetLowestGroup ();
+  GroupMax = GpioGetHighestGroup ();
+
+  for (Group = GroupMin; Group <= GroupMax; Group++) {
+    for (DwNum = 0; DwNum <= GPIO_GET_DW_NUM (GpioGetPadPerGroup (Group)); DwNum++) {
+
+      OverrideCfgPads = 0;
+      OverrideTxPads = 0;
+      Status = GpioUnlockOverride (Group, DwNum, &OverrideCfgPads, &OverrideTxPads);
+      if (EFI_ERROR (Status)) {
+        ASSERT (FALSE);
+        return Status;
+      }
+
+      UnlockedPads = GpioGetGroupDwUnlockPadConfigMask (GpioGetGroupIndexFromGroup (Group), DwNum);
+
+      Status = GpioLockPadCfgForGroupDw (Group, DwNum, (UINT32)~(UnlockedPads | OverrideCfgPads));
+      if (EFI_ERROR (Status)) {
+        ASSERT (FALSE);
+        return Status;
+      }
+
+      UnlockedPads = GpioGetGroupDwUnlockOutputMask (GpioGetGroupIndexFromGroup (Group), DwNum);
+
+      Status = GpioLockPadCfgTxForGroupDw (Group, DwNum, (UINT32)~(UnlockedPads | OverrideTxPads));
+      if (EFI_ERROR (Status)) {
+        ASSERT (FALSE);
+        return Status;
+      }
+    }
+  }
+  return EFI_SUCCESS;
+}

--- a/Silicon/CommonSocPkg/Library/GpioLib/GpioLib.inf
+++ b/Silicon/CommonSocPkg/Library/GpioLib/GpioLib.inf
@@ -1,0 +1,40 @@
+## @file
+#
+#  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = GpioLib
+  FILE_GUID                      = 421461F4-5508-4a1a-8F6C-BC1034D3CBC2
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = GpioLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 IPF
+#
+
+[Sources]
+  GpioLib.c
+  GpioInit.c
+  GpioHelpersLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCorePkg/BootloaderCorePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+  Silicon/CommonSocPkg/CommonSocPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  IoLib
+  MemoryAllocationLib
+  GpioPlatformLib
+
+[Pcd]
+

--- a/Silicon/CommonSocPkg/Library/GpioLib/GpioLibInternal.h
+++ b/Silicon/CommonSocPkg/Library/GpioLib/GpioLibInternal.h
@@ -1,0 +1,612 @@
+/** @file
+  The platform GPIO library header.
+
+  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _GPIO_LIB_INTERNAL_H_
+#define _GPIO_LIB_INTERNAL_H_
+
+#include <Base.h>
+#include <Uefi/UefiBaseType.h>
+#include <Library/IoLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/GpioPlatformLib.h>
+#include <Library/BlMemoryAllocationLib.h>
+
+#define GPIO_NAME_LENGTH_MAX  32
+
+//
+// Number of PADCFG_DW registers
+//
+#define GPIO_PADCFG_DW_REG_NUMBER  4
+
+/**
+  This internal procedure will calculate GPIO_RESET_CONFIG value  (new type)
+  based on provided PadRstCfg for a specific GPIO Pad.
+
+  @param[in]  GpioPad               GPIO Pad
+  @param[in]  PadRstCfg             GPIO PadRstCfg value
+
+  @retval GpioResetConfig           GPIO Reset configuration (new type)
+**/
+GPIO_RESET_CONFIG
+GpioResetConfigFromPadRstCfg (
+  IN  GPIO_PAD           GpioPad,
+  IN  UINT32             PadRstCfg
+  );
+
+/**
+  This internal procedure will calculate PadRstCfg register value based
+  on provided GPIO Reset configuration for a certain pad.
+
+  @param[in]  GpioPad                   GPIO Pad
+  @param[in]  GpioResetConfig           GPIO Reset configuration
+  @param[out] PadRstCfg                 GPIO PadRstCfg value
+
+  @retval EFI_SUCCESS                   The function completed successfully
+  @retval EFI_INVALID_PARAMETER         Invalid configuration
+**/
+EFI_STATUS
+GpioPadRstCfgFromResetConfig (
+  IN  GPIO_PAD           GpioPad,
+  IN  GPIO_RESET_CONFIG  GpioResetConfig,
+  OUT UINT32             *PadRstCfg
+  );
+
+/**
+  This procedure will calculate PADCFG register value based on GpioConfig data
+
+  @param[in]  GpioPad                   GPIO Pad
+  @param[in]  GpioConfig                GPIO Configuration data
+  @param[out] PadCfgDwReg               PADCFG DWx register value
+  @param[out] PadCfgDwRegMask           Mask with PADCFG DWx register bits to be modified
+
+  @retval Status
+**/
+EFI_STATUS
+GpioPadCfgRegValueFromGpioConfig (
+  IN  GPIO_PAD           GpioPad,
+  IN  CONST GPIO_CONFIG  *GpioConfig,
+  OUT UINT32             *PadCfgDwReg,
+  OUT UINT32             *PadCfgDwRegMask
+  );
+
+/**
+  This procedure will initialize multiple GPIO pins. Use GPIO_INIT_CONFIG structure.
+  Structure contains fields that can be used to configure each pad.
+  Pad not configured using GPIO_INIT_CONFIG will be left with hardware default values.
+  Separate fields could be set to hardware default if it does not matter, except
+  GpioPad and PadMode.
+  Function will work in most efficient way if pads which belong to the same group are
+  placed in adjacent records of the table.
+  Although function can enable pads for Native mode, such programming is done
+  by reference code when enabling related silicon feature.
+
+  @param[in] NumberofItem               Number of GPIO pads to be updated
+  @param[in] GpioInitTableAddress       GPIO initialization table
+
+  @retval EFI_SUCCESS                   The function completed successfully
+  @retval EFI_INVALID_PARAMETER         Invalid group or pad number
+**/
+EFI_STATUS
+GpioConfigurePads (
+  IN UINT32                    NumberOfItems,
+  IN GPIO_INIT_CONFIG          *GpioInitTableAddress
+  );
+
+//
+// Functions for setting/getting multiple GpioPad settings
+//
+
+/**
+  This procedure is used to check GPIO inputs belongs to 2 tier or 1 tier architecture
+
+  @param[in]  GpioPad             GPIO pad
+
+  @retval     Data                0 means 1-tier, 1 means 2-tier
+**/
+BOOLEAN
+GpioCheckFor2Tier (
+  IN GPIO_PAD                  GpioPad
+  );
+
+/**
+  This procedure will get GPE number for provided GpioPad.
+  PCH allows to configure mapping between GPIO groups and related GPE (GpioSetGroupToGpeDwX())
+  what results in the fact that certain Pad can cause different General Purpose Event. Only three
+  GPIO groups can be mapped to cause unique GPE (1-tier), all others groups will be under one common
+  event (GPE_111 for 2-tier).
+
+  1-tier:
+  Returned GpeNumber is in range <0,95>. GpioGetGpeNumber() can be used
+  to determine what _LXX ACPI method would be called on event on selected GPIO pad
+
+  2-tier:
+  Returned GpeNumber is 0x6F (111). All GPIO pads which are not mapped to 1-tier GPE
+  will be under one master GPE_111 which is linked to _L6F ACPI method. If it is needed to determine
+  what Pad from 2-tier has caused the event, _L6F method should check GPI_GPE_STS and GPI_GPE_EN
+  registers for all GPIO groups not mapped to 1-tier GPE.
+
+  @param[in]  GpioPad             GPIO pad
+  @param[out] GpeNumber           GPE number
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioGetGpeNumber (
+  IN GPIO_PAD                   GpioPad,
+  OUT UINT32                    *GpeNumber
+  );
+
+/**
+  This procedure will get Group to GPE mapping.
+  It will assume that only first 32 pads can be mapped to GPE.
+  To handle cases where groups have more than 32 pads and higher part of group
+  can be mapped please refer to GpioGetGroupDwToGpeDwX()
+
+  @param[out] GroupToGpeDw0       GPIO group to be mapped to GPE_DW0
+  @param[out] GroupToGpeDw1       GPIO group to be mapped to GPE_DW1
+  @param[out] GroupToGpeDw2       GPIO group to be mapped to GPE_DW2
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+GpioGetGroupToGpeDwX (
+  IN GPIO_GROUP               *GroupToGpeDw0,
+  IN GPIO_GROUP               *GroupToGpeDw1,
+  IN GPIO_GROUP               *GroupToGpeDw2
+  );
+
+/**
+  This procedure will clear PadCfgLockTx for selected pad.
+  Unlocking a pad will cause an SMI (if enabled)
+
+  @param[in] GpioPad              GPIO pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioUnlockPadCfgTx (
+  IN GPIO_PAD                   GpioPad
+  );
+
+/**
+  This procedure will set PadCfgLockTx for selected pads within one group
+
+  @param[in]  Group               GPIO group
+  @param[in]  DwNum               PadCfgLock register number for current group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[in]  PadsToLockTx        Bitmask for pads which are going to be locked,
+                                  Bit position - PadNumber
+                                  Bit value - 0: DoNotLockTx, 1: LockTx
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or DwNum parameter number
+**/
+EFI_STATUS
+GpioLockPadCfgTxForGroupDw (
+  IN GPIO_GROUP                   Group,
+  IN UINT32                       DwNum,
+  IN UINT32                       PadsToLockTx
+  );
+
+/**
+  This procedure will set PadCfgLockTx for selected pad
+
+  @param[in] GpioPad              GPIO pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioLockPadCfgTx (
+  IN GPIO_PAD                   GpioPad
+  );
+
+/**
+  This procedure will set PadCfgLock for selected pads within one group
+
+  @param[in]  Group               GPIO group
+  @param[in]  DwNum               PadCfgLock register number for current group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[in]  PadsToLock          Bitmask for pads which are going to be locked,
+                                  Bit position - PadNumber
+                                  Bit value - 0: DoNotLock, 1: Lock
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or DwNum parameter number
+**/
+EFI_STATUS
+GpioLockPadCfgForGroupDw (
+  IN GPIO_GROUP                   Group,
+  IN UINT32                       DwNum,
+  IN UINT32                       PadsToLock
+  );
+
+/**
+  This procedure will clear PadCfgLockTx for selected pads within one group.
+  Unlocking a pad will cause an SMI (if enabled)
+
+  @param[in]  Group               GPIO group
+  @param[in]  DwNum               PadCfgLockTx register number for current group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[in]  PadsToUnlockTx      Bitmask for pads which are going to be unlocked,
+                                  Bit position - PadNumber
+                                  Bit value - 0: DoNotUnLockTx, 1: LockTx
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+GpioUnlockPadCfgTxForGroupDw (
+  IN GPIO_GROUP                Group,
+  IN UINT32                    DwNum,
+  IN UINT32                    PadsToUnlockTx
+  );
+
+///
+/// Possible values of Pad Ownership
+/// If Pad is not under Host ownership then GPIO registers
+/// are not accessible by host (e.g. BIOS) and reading them
+/// will return 0xFFs.
+///
+typedef enum {
+  GpioPadOwnHost = 0x0,
+  GpioPadOwnCsme = 0x1,
+  GpioPadOwnIsh  = 0x2,
+} GPIO_PAD_OWN;
+
+/**
+  This procedure will get Gpio Pad Ownership
+
+  @param[in] GpioPad              GPIO pad
+  @param[out] PadOwnVal           Value of Pad Ownership
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioGetPadOwnership (
+  IN  GPIO_PAD                GpioPad,
+  OUT GPIO_PAD_OWN            *PadOwnVal
+  );
+
+/**
+  This procedure will check state of Pad Config Lock for pads within one group
+
+  @param[in]  Group               GPIO group
+  @param[in]  DwNum               PadCfgLock register number for current group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[out] PadCfgLockRegVal    Value of PadCfgLock register
+                                  Bit position - PadNumber
+                                  Bit value - 0: NotLocked, 1: Locked
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or DwNum parameter number
+**/
+EFI_STATUS
+GpioGetPadCfgLockForGroupDw (
+  IN  GPIO_GROUP                  Group,
+  IN  UINT32                      DwNum,
+  OUT UINT32                      *PadCfgLockRegVal
+  );
+
+/**
+  This procedure will check state of Pad Config Tx Lock for pads within one group
+
+  @param[in]  Group               GPIO group
+  @param[in]  DwNum               PadCfgLockTx register number for current group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[out] PadCfgLockTxRegVal  Value of PadCfgLockTx register
+                                  Bit position - PadNumber
+                                  Bit value - 0: NotLockedTx, 1: LockedTx
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or DwNum parameter number
+**/
+EFI_STATUS
+GpioGetPadCfgLockTxForGroupDw (
+  IN  GPIO_GROUP                  Group,
+  IN  UINT32                      DwNum,
+  OUT UINT32                      *PadCfgLockTxRegVal
+  );
+
+/**
+  This procedure will check state of Pad Config Tx Lock for selected pad
+
+  @param[in]  GpioPad             GPIO pad
+  @param[out] PadCfgLock          PadCfgLockTx for selected pad
+                                  0: NotLockedTx, 1: LockedTx
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioGetPadCfgLockTx (
+  IN GPIO_PAD                   GpioPad,
+  OUT UINT32                    *PadCfgLockTx
+  );
+
+/**
+  This procedure will clear PadCfgLock for selected pads within one group.
+  Unlocking a pad will cause an SMI (if enabled)
+
+  @param[in]  Group               GPIO group
+  @param[in]  DwNum               PadCfgLock register number for current group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[in]  PadsToUnlock        Bitmask for pads which are going to be unlocked,
+                                  Bit position - PadNumber
+                                  Bit value - 0: DoNotUnlock, 1: Unlock
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+GpioUnlockPadCfgForGroupDw (
+  IN GPIO_GROUP                Group,
+  IN UINT32                    DwNum,
+  IN UINT32                    PadsToUnlock
+  );
+
+//
+// Functions for setting/getting single GpioPad properties
+//
+
+/**
+  This procedure will get GPIO IOxAPIC interrupt number
+
+  @param[in]  GpioPad             GPIO pad
+  @param[out] IrqNum              IRQ number
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioGetPadIoApicIrqNumber (
+  IN GPIO_PAD                  GpioPad,
+  OUT UINT32                   *IrqNum
+  );
+
+/**
+  This procedure will get GPIO Host Software Pad Ownership for certain group
+
+  @param[in]  Group               GPIO group
+  @param[in]  DwNum               Host Ownership register number for current group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[out] HostSwRegVal        Value of Host Software Pad Ownership register
+                                  Bit position - PadNumber
+                                  Bit value - 0: ACPI Mode, 1: GPIO Driver mode
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or DwNum parameter number
+**/
+EFI_STATUS
+GpioGetHostSwOwnershipForGroupDw (
+  IN  GPIO_GROUP                  Group,
+  IN  UINT32                      DwNum,
+  OUT UINT32                      *HostSwRegVal
+  );
+
+/**
+  This procedure will get GPIO Host Software Pad Ownership for certain group
+
+  @param[in]  Group               GPIO group
+  @param[in]  DwNum               Host Ownership register number for current group
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[in]  HostSwRegVal        Value of Host Software Pad Ownership register
+                                  Bit position - PadNumber
+                                  Bit value - 0: ACPI Mode, 1: GPIO Driver mode
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or DwNum parameter number
+**/
+EFI_STATUS
+GpioSetHostSwOwnershipForGroupDw (
+  IN GPIO_GROUP                   Group,
+  IN UINT32                       DwNum,
+  IN UINT32                       HostSwRegVal
+  );
+
+/**
+  This procedure will get Gpio Pad Host Software Ownership
+
+  @param[in] GpioPad              GPIO pad
+  @param[out] PadHostSwOwn        Value of Host Software Pad Owner
+                                  0: ACPI Mode, 1: GPIO Driver mode
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioGetHostSwOwnershipForPad (
+  IN GPIO_PAD                 GpioPad,
+  OUT UINT32                  *PadHostSwOwn
+  );
+
+/**
+  This procedure will set Gpio Pad Host Software Ownership
+
+  @param[in] GpioPad              GPIO pad
+  @param[in]  PadHostSwOwn        Pad Host Software Owner
+                                  0: ACPI Mode, 1: GPIO Driver mode
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+GpioSetHostSwOwnershipForPad (
+  IN GPIO_PAD                  GpioPad,
+  IN UINT32                    PadHostSwOwn
+  );
+
+
+/**
+  This procedure will get number of pads for certain GPIO group
+
+  @param[in] Group            GPIO group number
+
+  @retval Value               Pad number for group
+                              If illegal group number then return 0
+**/
+UINT32
+GpioGetPadPerGroup (
+  IN GPIO_GROUP        Group
+  );
+
+
+/**
+  This procedure will get lowest group
+
+  @param[in] none
+
+  @retval Value               Lowest Group
+**/
+GPIO_GROUP
+GpioGetLowestGroup (
+  VOID
+  );
+
+
+/**
+  This procedure will get highest group
+
+  @param[in] none
+
+  @retval Value               Highest Group
+**/
+GPIO_GROUP
+GpioGetHighestGroup (
+  VOID
+  );
+
+
+/**
+  This procedure will get number of groups
+
+  @param[in] none
+
+  @retval Value               Group number
+**/
+UINT32
+GpioGetNumberOfGroups (
+  VOID
+  );
+
+
+/**
+  This procedure will get GPIO group data with pads, which PadConfig is supposed to be left unlock
+
+  @param[in]  GroupIndex          GPIO group index
+  @param[in]  DwNum               DWORD index for a group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @retval     UnlockedPads        DWORD bitmask for pads which are going to be left unlocked
+                                  Bit position - PadNumber
+                                  Bit value - 0: to be locked, 1: Leave unlocked
+**/
+UINT32
+GpioGetGroupDwUnlockPadConfigMask (
+  IN UINT32                       GroupIndex,
+  IN UINT32                       DwNum
+  );
+
+
+/**
+  This procedure will get GPIO group data with pads, which Output is supposed to be left unlock
+
+  @param[in]  GroupIndex          GPIO group index
+  @param[in]  DwNum               DWORD index for a group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @retval     UnlockedPads        DWORD bitmask for pads which are going to be left unlocked
+                                  Bit position - PadNumber
+                                  Bit value - 0: to be locked, 1: Leave unlocked
+**/
+UINT32
+GpioGetGroupDwUnlockOutputMask (
+  IN UINT32                       GroupIndex,
+  IN UINT32                       DwNum
+  );
+
+
+/**
+  This procedure stores GPIO group data about pads which PadConfig needs to be unlocked.
+
+  @param[in]  GroupIndex          GPIO group index
+  @param[in]  DwNum               DWORD index for a group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[in]  PadsToLock          DWORD bitmask for pads which are going to be left unlocked
+                                  Bit position - PadNumber
+                                  Bit value - 0: Skip, 1: Leave unlocked
+
+  @retval Status
+**/
+EFI_STATUS
+GpioStoreGroupDwUnlockPadConfigData (
+  IN UINT32                       GroupIndex,
+  IN UINT32                       DwNum,
+  IN UINT32                       UnlockedPads
+  );
+
+/**
+  This procedure stores GPIO group data about pads which Output state needs to be unlocked.
+
+  @param[in]  GroupIndex          GPIO group index
+  @param[in]  DwNum               DWORD index for a group.
+                                  For group which has less then 32 pads per group DwNum must be 0.
+  @param[in]  PadsToLock          DWORD bitmask for pads which are going to be left unlocked
+                                  Bit position - PadNumber
+                                  Bit value - 0: Skip, 1: Leave unlocked
+
+  @retval Status
+**/
+EFI_STATUS
+GpioStoreGroupDwUnlockOutputData (
+  IN UINT32                       GroupIndex,
+  IN UINT32                       DwNum,
+  IN UINT32                       UnlockedPads
+  );
+
+/**
+  This function is to be used In GpioLockPads() to override a lock request by SOC code.
+
+  @param[in]  Group          GPIO group
+  @param[in]  DwNum          Register number for current group (parameter applicable in accessing whole register).
+                             For group which has less then 32 pads per group DwNum must be 0.
+  @param[out] *UnlockCfgPad  DWORD bitmask for pads which are going to be left unlocked
+                             Bit position - PadNumber
+                             Bit value - 0: to be locked, 1: Leave unlocked
+  @param[out] *UnlockTxPad   DWORD bitmask for pads which are going to be left unlocked
+                             Bit position - PadNumber
+                             Bit value - 0: to be locked, 1: Leave unlocked
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid input parameter
+**/
+EFI_STATUS
+GpioUnlockOverride (
+  IN  GPIO_GROUP  Group,
+  IN  UINT32      DwNum,
+  OUT UINT32      *UnlockCfgPad,
+  OUT UINT32      *UnlockTxPad
+  );
+
+/**
+  This procedure is used to check if GpioPad is valid for certain chipset
+
+  @param[in]  GpioPad             GPIO pad
+
+  @retval TRUE                    This pin is valid on this chipset
+          FALSE                   Incorrect pin
+**/
+BOOLEAN
+GpioIsCorrectPadForThisChipset (
+  IN  GPIO_PAD        GpioPad
+  );
+
+#endif // _GPIO_LIB_INTERNAL_H_
+


### PR DESCRIPTION
This patch adds a common GpioLib that all platforms
can link to. Common GpioLib requires platforms to
implement the GpioInfoLib to provide platform-specific
information like GroupInfo etc.

Signed-off-by: Sai Talamudupula <sai.kiran.talamudupula@intel.com>