### PR TITLE
Make Python lz4 module optional

### DIFF
--- a/.azurepipelines/azure-pipelines.yml
+++ b/.azurepipelines/azure-pipelines.yml
@@ -44,7 +44,6 @@ jobs:
     displayName: Install required tools
 
   - script: |
-      python -m pip install lz4
       python BuildLoader.py build qemu -k
     displayName: 'Run QEMU build'
 
@@ -99,7 +98,6 @@ jobs:
     displayName: Install required tools
 
   - script: |
-      python -m pip install lz4
       python BuildLoader.py build $(Build.Name) $(Build.Arch) $(Build.Target) -k
     displayName: 'Run $(Build.Name) build'
 
@@ -168,7 +166,6 @@ jobs:
     displayName: Environment configuration
 
   - script: |
-      python -m pip install lz4
       python BuildLoader.py build $(Build.Name) $(Build.Arch) $(Build.Target) -k
     displayName: 'Run $(Build.Name) build'
 


### PR DESCRIPTION
To avoid any dependency on non-standard python modules
it is preferred to make the binary Lz4 compression the
default flow and try the python module as a backup. Also
recommend to use a known working version of the lz4
python module, 3.1.1.

Signed-off-by: James Gutbub <james.gutbub@intel.com>