### PR TITLE
[CommonSocPkg]: Remove ME BIOS Payload (MBP) handling from HeciLib

### DIFF
--- a/Silicon/ApollolakePkg/Library/PsdLib/PsdLib.c
+++ b/Silicon/ApollolakePkg/Library/PsdLib/PsdLib.c
@@ -112,7 +112,6 @@ GetSecCapability (
   )
 {
   EFI_STATUS               Status;
-  GEN_GET_FW_CAPSKU        MsgGenGetFwCapsSku;
   GEN_GET_FW_CAPS_SKU_ACK  MsgGenGetFwCapsSkuAck;
   if(SecCapability == NULL) {
     DEBUG ((DEBUG_ERROR, "GetSecCapability Failed Status=0x%x\n",EFI_INVALID_PARAMETER));
@@ -120,7 +119,7 @@ GetSecCapability (
   }
 
 
-  Status = HeciGetFwCapsSkuMsg ( (UINT8 *)&MsgGenGetFwCapsSku, (UINT8 *)&MsgGenGetFwCapsSkuAck);
+  Status = HeciGetFwCapsSkuMsg ((UINT8 *)&MsgGenGetFwCapsSkuAck);
   if (EFI_ERROR(Status)) {
     return Status;
   }

--- a/Silicon/CoffeelakePkg/Library/PsdLib/PsdLib.c
+++ b/Silicon/CoffeelakePkg/Library/PsdLib/PsdLib.c
@@ -235,7 +235,6 @@ GetSecCapability (
   )
 {
   EFI_STATUS               Status;
-  GEN_GET_FW_CAPSKU        MsgGenGetFwCapsSku;
   GEN_GET_FW_CAPS_SKU_ACK  MsgGenGetFwCapsSkuAck;
   if(SecCapability == NULL) {
     DEBUG ((DEBUG_ERROR, "GetSecCapability Failed Status=0x%x\n",EFI_INVALID_PARAMETER));
@@ -243,7 +242,7 @@ GetSecCapability (
   }
 
 
-  Status = HeciGetFwCapsSkuMsg ( (UINT8 *)&MsgGenGetFwCapsSku, (UINT8 *)&MsgGenGetFwCapsSkuAck);
+  Status = HeciGetFwCapsSkuMsg ((UINT8 *)&MsgGenGetFwCapsSkuAck);
   if (EFI_ERROR(Status)) {
     return Status;
   }

--- a/Silicon/CommonSocPkg/Include/Library/HeciLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/HeciLib.h
@@ -271,7 +271,6 @@ HeciGetFwVersionMsg (
 /**
   Send Get Firmware SKU Request
 
-  @param[in]  MsgGetFwCaps        Send  message for Get Firmware Capability SKU
   @param[out] MsgGetFwCapsAck     Return message for Get Firmware Capability SKU ACK
 
   @exception EFI_UNSUPPORTED      Current Sec mode doesn't support this function
@@ -283,7 +282,6 @@ HeciGetFwVersionMsg (
 EFI_STATUS
 EFIAPI
 HeciGetFwCapsSkuMsg (
-  IN  UINT8                      *MsgGetFwCaps,
   OUT UINT8                      *MsgGetFwCapsAck
   );
 

--- a/Silicon/CommonSocPkg/Include/MeBiosPayloadDataCommon.h
+++ b/Silicon/CommonSocPkg/Include/MeBiosPayloadDataCommon.h
@@ -159,23 +159,6 @@ typedef struct {
   UINT8                       Reserved[3];
 } MBP_MEASURED_BOOT_SUPPORT;
 
-///
-/// ME BIOS Payload structure containing insensitive data only
-///
-typedef struct {
-  MBP_FW_VERSION_NAME        FwVersionName;
-  MBP_FW_CAPS_SKU            FwCapsSku;
-  MBP_FW_FEATURES_STATE      FwFeaturesState;
-  MBP_PLAT_TYPE              FwPlatType;
-  MBP_HWA_REQ                HwaRequest;
-  MBP_ME_UNCONF_ON_RTC_STATE UnconfigOnRtcClearState;
-  MBP_ARB_SVN_STATE          ArbSvnState;
-  MBP_MPHY_DATA              MphyData;
-  MBP_IFWI_DNX_REQUEST       IfwiDnxRequest;
-  MBP_ICC_PROFILE            IccProfile;
-  MBP_MEASURED_BOOT_SUPPORT  MeasuredBootSupport;
-} ME_BIOS_PAYLOAD;
-
 #pragma pack(pop)
 
 #endif // _MBP_DATA_COMMON_H_

--- a/Silicon/CommonSocPkg/Library/HeciLib/HeciLib.inf
+++ b/Silicon/CommonSocPkg/Library/HeciLib/HeciLib.inf
@@ -35,6 +35,3 @@
   IoLib
   TimerLib
   MeChipsetLib
-
-[Guids]
-  gMeBiosPayloadHobGuid


### PR DESCRIPTION
o MBP is platform specific data which may be different for derivative
  platforms, so, the handling is moved back to platform code

Signed-off-by: Divneil Rai Wadhawan <divneil.r.wadhawan@intel.com>