### PR TITLE
Removed deprecated python imp module usage

### DIFF
--- a/BootloaderCorePkg/Tools/CommonUtility.py
+++ b/BootloaderCorePkg/Tools/CommonUtility.py
@@ -18,8 +18,9 @@ import subprocess
 import struct
 import hashlib
 import string
-from   functools import reduce
 from   ctypes import *
+from   functools import reduce
+from   importlib.machinery import SourceFileLoader
 from   SingleSign import *
 
 
@@ -183,6 +184,10 @@ def check_files_exist (base_name_list, dir = '', ext = ''):
         if not os.path.exists (os.path.join (dir, each + ext)):
             return False
     return True
+
+def load_source (name, filepath):
+    mod = SourceFileLoader (name, filepath).load_module()
+    return  mod
 
 def get_openssl_path ():
     if os.name == 'nt':

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -16,7 +16,6 @@ sys.dont_write_bytecode = True
 sys.path.append (tool_dir)
 
 import re
-import imp
 import errno
 import shutil
 import argparse
@@ -1389,9 +1388,8 @@ def main():
         get_board_config_file (os.path.join (search_dir, pkg), board_cfgs)
 
     for cfgfile in board_cfgs:
-        brdcfg = imp.load_source('BoardConfig', cfgfile)
+        brdcfg = load_source ('BoardConfig', cfgfile)
         board_names.append(brdcfg.Board().BOARD_NAME)
-
 
     ap = argparse.ArgumentParser()
     sp = ap.add_subparsers(help='command')
@@ -1399,7 +1397,7 @@ def main():
     def cmd_build(args):
         for index, name in enumerate(board_names):
             if args.board == name:
-                brdcfg = imp.load_source('BoardConfig', board_cfgs[index])
+                brdcfg = load_source('BoardConfig', board_cfgs[index])
                 board  = brdcfg.Board(
                                         BUILD_ARCH        = args.arch.upper(), \
                                         RELEASE_MODE      = args.release,     \

--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -15,7 +15,7 @@ import sys
 sys.dont_write_bytecode = True
 sys.path.append (os.path.join('..', '..'))
 from BuildLoader import FLASH_MAP, BaseBoard, STITCH_OPS
-from BuildLoader import IPP_CRYPTO_OPTIMIZATION_MASK, IPP_CRYPTO_ALG_MASK
+from BuildLoader import IPP_CRYPTO_OPTIMIZATION_MASK, IPP_CRYPTO_ALG_MASK, HASH_USAGE
 
 #
 #    Temporary Memory Layout for APL

--- a/Platform/CoffeelakeBoardPkg/BoardConfig.py
+++ b/Platform/CoffeelakeBoardPkg/BoardConfig.py
@@ -17,6 +17,7 @@ import time
 sys.dont_write_bytecode = True
 sys.path.append (os.path.join('..', '..'))
 from BuildLoader import BaseBoard, STITCH_OPS, FLASH_REGION_TYPE
+from BuildLoader import HASH_USAGE
 
 class Board(BaseBoard):
     def __init__(self, *args, **kwargs):

--- a/Platform/CoffeelakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/CoffeelakeBoardPkg/Script/StitchIfwi.py
@@ -9,7 +9,6 @@
 import sys
 import os
 import re
-import imp
 import struct
 import argparse
 import zipfile
@@ -504,7 +503,7 @@ def main():
 
     args = ap.parse_args()
 
-    stitch_cfg_file = imp.load_source('StitchIfwiConfig', args.config_file)
+    stitch_cfg_file = load_source('StitchIfwiConfig', args.config_file)
     if args.stitch_dir == '':
         print ("Please specify stitch work directory")
         print ('%s' % stitch_cfg_file.extra_usage_txt)

--- a/Platform/CometlakeBoardPkg/BoardConfig.py
+++ b/Platform/CometlakeBoardPkg/BoardConfig.py
@@ -17,6 +17,7 @@ import time
 sys.dont_write_bytecode = True
 sys.path.append (os.path.join('..', '..'))
 from BuildLoader import BaseBoard, STITCH_OPS, FLASH_REGION_TYPE
+from BuildLoader import HASH_USAGE
 
 class Board(BaseBoard):
     def __init__(self, *args, **kwargs):

--- a/Platform/CometlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/CometlakeBoardPkg/Script/StitchIfwi.py
@@ -9,7 +9,6 @@
 import sys
 import os
 import re
-import imp
 import struct
 import argparse
 import zipfile
@@ -441,7 +440,7 @@ def main():
     ap.add_argument('-fusa', dest='fusa', action = "store_true", default = False, help = "Patch IFWI to generate Fusa ifwi")
     args = ap.parse_args()
 
-    stitch_cfg_file = imp.load_source('StitchIfwiConfig', args.config_file)
+    stitch_cfg_file = load_source('StitchIfwiConfig', args.config_file)
     if args.work_dir == '':
         print ("Please specify stitch work directory")
         print ('%s' % stitch_cfg_file.extra_usage_txt)

--- a/Platform/CometlakevBoardPkg/BoardConfig.py
+++ b/Platform/CometlakevBoardPkg/BoardConfig.py
@@ -17,6 +17,7 @@ import time
 sys.dont_write_bytecode = True
 sys.path.append (os.path.join('..', '..'))
 from BuildLoader import BaseBoard, STITCH_OPS, FLASH_REGION_TYPE
+from BuildLoader import HASH_USAGE
 
 class Board(BaseBoard):
     def __init__(self, *args, **kwargs):

--- a/Platform/CometlakevBoardPkg/Script/StitchIfwi.py
+++ b/Platform/CometlakevBoardPkg/Script/StitchIfwi.py
@@ -9,7 +9,6 @@
 import sys
 import os
 import re
-import imp
 import struct
 import argparse
 import zipfile
@@ -441,7 +440,7 @@ def main():
     ap.add_argument('-fusa', dest='fusa', action = "store_true", default = False, help = "Patch IFWI to generate Fusa ifwi")
     args = ap.parse_args()
 
-    stitch_cfg_file = imp.load_source('StitchIfwiConfig', args.config_file)
+    stitch_cfg_file = load_source('StitchIfwiConfig', args.config_file)
     if args.work_dir == '':
         print ("Please specify stitch work directory")
         print ('%s' % stitch_cfg_file.extra_usage_txt)

--- a/Platform/CommonBoardPkg/Tools/GpioDataConvert.py
+++ b/Platform/CommonBoardPkg/Tools/GpioDataConvert.py
@@ -11,7 +11,7 @@ import os
 import sys
 import argparse
 import re
-import imp
+from   importlib.machinery import SourceFileLoader
 from   ctypes import *
 
 YML_LINE_HDR = "- !expand { GPIO_TMPL : [ "
@@ -569,7 +569,7 @@ def get_sbl_dws (inp_fmt, cfg_file, parts):
     if not pad_name.startswith('GPP_'):
         return '', 0x0, 0x0
 
-    gpio_cfg_file = imp.load_source('GenGpioDataConfig', cfg_file)
+    gpio_cfg_file = SourceFileLoader ('GenGpioDataConfig', cfg_file).load_module()
 
     if inp_fmt.endswith ('.h') or inp_fmt.endswith ('.csv'):
         get_sbl_dws_from_h_csv (parts, pad_name, sbl_dw0, sbl_dw1, gpio_cfg_file)
@@ -696,7 +696,7 @@ def parse_sbl_dws (inp_fmt, out_fmt, cfg_file, parts):
     if not pad_name.startswith('GPP_'):
         return '', ''
 
-    gpio_cfg_file = imp.load_source('GenGpioDataConfig', cfg_file)
+    gpio_cfg_file = SourceFileLoader ('GenGpioDataConfig', cfg_file).load_module()
 
     if out_fmt == 'h' or out_fmt == 'csv':
         out_line = get_h_csv_from_sbl_dws (sbl_dw0, sbl_dw1, gpio_cfg_file)
@@ -835,7 +835,7 @@ if __name__ == '__main__':
 
     args = ap.parse_args()
 
-    gpio_cfg_file = imp.load_source('GenGpioDataConfig', args.cfg_file)
+    gpio_cfg_file = SourceFileLoader ('GenGpioDataConfig', args.cfg_file).load_module()
     if (gpio_cfg_file.plat_name() == 'apl'):
         raise Exception ('Platform unsupported')
 

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -14,8 +14,8 @@ import sys
 
 sys.dont_write_bytecode = True
 sys.path.append (os.path.join('..', '..'))
-from BuildLoader import BaseBoard, STITCH_OPS, HASH_USAGE
-from BuildLoader import IPP_CRYPTO_OPTIMIZATION_MASK, IPP_CRYPTO_ALG_MASK, HASH_TYPE_VALUE
+from BuildLoader import BaseBoard, STITCH_OPS
+from BuildLoader import IPP_CRYPTO_OPTIMIZATION_MASK, IPP_CRYPTO_ALG_MASK, HASH_TYPE_VALUE, HASH_USAGE
 
 class Board(BaseBoard):
 


### PR DESCRIPTION
Python 3.4 and above have deprecated imp module in favor of
importlib.  This patch removed imp module usage from SBL, and
used importlib instead.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>