### PR TITLE
Check for '.exe' in run_process routine

### DIFF
--- a/BootloaderCorePkg/Tools/CommonUtility.py
+++ b/BootloaderCorePkg/Tools/CommonUtility.py
@@ -206,6 +206,10 @@ def get_openssl_path ():
 
 def run_process (arg_list, print_cmd = False, capture_out = False):
     sys.stdout.flush()
+
+    if os.name == 'nt' and os.path.splitext(arg_list[0])[1] == '':
+        arg_list[0] += '.exe'
+
     if print_cmd:
         print (' '.join(arg_list))
 

--- a/BootloaderCorePkg/Tools/GenerateKeys.py
+++ b/BootloaderCorePkg/Tools/GenerateKeys.py
@@ -96,8 +96,10 @@ def generate_rsa_priv_keys (openssl_path, key_dir, key_size):
                         replace_all = 'yes'
 
                 print("Generating private key %s" % priv_key_name)
-                cmd = '%s genrsa -F4 -out %s %s' % (openssl_path, priv_key_name, key_sz)
-                run_process (cmd.split())
+                cmd = 'genrsa -F4 -out %s %s' % (priv_key_name, key_sz)
+                cmd = cmd.split()
+                cmd.insert(0, '%s' % (openssl_path))
+                run_process (cmd)
                 print('\n' * 3)
 
         # Generate test public keys
@@ -120,14 +122,18 @@ def generate_rsa_pub_keys (openssl_path, key_dir, key_size, replace_key):
                     continue
 
             print("Generating OS Private Key %s" % priv_key_name)
-            cmd = '%s genrsa -F4 -out %s %s' % (openssl_path, priv_key_name, key_size)
-            run_process (cmd.split())
+            cmd = 'genrsa -F4 -out %s %s' % (priv_key_name, key_size)
+            cmd = cmd.split()
+            cmd.insert(0, '%s' % (openssl_path))
+            run_process (cmd)
 
             # Extract public key from private key
             pub_key_name = '%s/%s_Pub_RSA%s.pem' % (key_dir, key_file_name, key_size)
             print("Generating OS Public Key %s" % pub_key_name)
-            cmd = '%s rsa -pubout -in %s -out %s' % (openssl_path, priv_key_name, pub_key_name)
-            run_process (cmd.split())
+            cmd = 'rsa -pubout -in %s -out %s' % (priv_key_name, pub_key_name)
+            cmd = cmd.split()
+            cmd.insert(0, '%s' % (openssl_path))
+            run_process (cmd)
     return
 
 def main():


### PR DESCRIPTION
run_process is used in stitching scripts
and other places and when the command being
called might also have a similarly named
command in the same folder (ex. fit and fit.exe)
where one command is meant to be ran in Linux
and the other is meant to be ran in Windows, there
can be issues that require to check for which
OS the stitching script is running in to append
'.exe' if Windows is detected. Rather than change
it every where else we can change it in the
run_process routine to check for Windows and if
'.exe' is not already included in the command we
can append it.

Signed-off-by: James Gutbub <james.gutbub@intel.com>