### PR TITLE
Add '.exe' extension if missing for windows build

### DIFF
--- a/BootloaderCorePkg/Tools/CommonUtility.py
+++ b/BootloaderCorePkg/Tools/CommonUtility.py
@@ -206,6 +206,9 @@ def get_openssl_path ():
 
 def run_process (arg_list, print_cmd = False, capture_out = False):
     sys.stdout.flush()
+    if os.name == 'nt' and os.path.splitext(arg_list[0])[1] == '' and \
+       os.path.exists (arg_list[0] + '.exe'):
+        arg_list[0] += '.exe'
     if print_cmd:
         print (' '.join(arg_list))
 


### PR DESCRIPTION
run_process is used several places. Sometime
the extension name is not given for windows build.
In this case, if same file without file extension
exist (e.g. fit and fit.exe), then fit will be used
for windows build. It is not expected, so this patch
will add the missing .exe extension for this case.

Signed-off-by: Guo Dong <guo.dong@intel.com>