### PR TITLE
Update correct BarType field for VF Bar program

### DIFF
--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciIov.c
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciIov.c
@@ -206,6 +206,8 @@ PciIovParseVfBar (
     PciIoDevice->VfPciBar[BarIndex].BarType     = PciBarTypeUnknown;
     PciIoDevice->VfPciBar[BarIndex].BaseAddress = 0;
     PciIoDevice->VfPciBar[BarIndex].Alignment   = 0;
+  } else {
+    PciIoDevice->VfPciBar[BarIndex].OrgBarType = PciIoDevice->VfPciBar[BarIndex].BarType;
   }
 
   //


### PR DESCRIPTION
ProgramBar() routine uses 'OrgBarType' field to
determine BarType. So, if a BarType is valid, copy
it to OrgBarType for VF also.

Signed-off-by: Talamudupula <stalamudupula@gmail.com>