### PR TITLE
Handle TPMStartup error during S3 resume

### DIFF
--- a/BootloaderCommonPkg/Library/TpmLib/TpmLib.c
+++ b/BootloaderCommonPkg/Library/TpmLib/TpmLib.c
@@ -18,6 +18,7 @@
 #include <Pi/PiBootMode.h>
 #include <IndustryStandard/Tpm2Acpi.h>
 #include <Library/SecureBootLib.h>
+#include <Library/ResetSystemLib.h>
 #include "Tpm2CommandLib.h"
 #include "Tpm2DeviceLib.h"
 #include "TpmLibInternal.h"
@@ -461,8 +462,9 @@ TpmInit(
       DEBUG ((DEBUG_INFO, "Attempting TPM_Startup with TPM_SU_STATE. \n"));
       Status = Tpm2Startup (TPM_SU_STATE);
       if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_WARN, "TPM_Startup(TPM_SU_STATE) failed !!. Attempting TPM_Startup(TPM_SU_CLEAR).\n"));
-        Status = Tpm2Startup (TPM_SU_CLEAR);
+        //  As per PC Client spec, SRTM should perform a host platform reset.
+        ResetSystem(EfiResetCold);
+        CpuDeadLoop ();
       }
     } else {
       Status = Tpm2Startup (TPM_SU_CLEAR);

--- a/BootloaderCommonPkg/Library/TpmLib/TpmLib.inf
+++ b/BootloaderCommonPkg/Library/TpmLib/TpmLib.inf
@@ -51,3 +51,4 @@
   CryptoLib
   BootloaderCommonLib
   BootloaderLib
+  ResetSystemLib

--- a/Platform/CometlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CometlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -542,6 +542,12 @@ TpmInitialize (
   if ((PlatformData != NULL) && (PlatformData->BtGuardInfo.MeasuredBoot == 1) &&
       (PlatformData->BtGuardInfo.DisconnectAllTpms == 0) &&
       ((PlatformData->BtGuardInfo.TpmType == dTpm20) || (PlatformData->BtGuardInfo.TpmType == Ptt))) {
+
+    //  As per PC Client spec, SRTM should perform a host platform reset
+    if (PlatformData->BtGuardInfo.TpmStartupFailureOnS3 == TRUE) {
+      ResetSystem(EfiResetCold);
+      CpuDeadLoop ();
+    }
     // Initialize TPM if it has not already been initialized by BootGuard component (i.e. ACM)
     Status = TpmInit(PlatformData->BtGuardInfo.BypassTpmInit, BootMode);
 

--- a/Platform/CometlakevBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CometlakevBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -538,6 +538,12 @@ TpmInitialize (
   if ((PlatformData != NULL) && (PlatformData->BtGuardInfo.MeasuredBoot == 1) &&
       (PlatformData->BtGuardInfo.DisconnectAllTpms == 0) &&
       ((PlatformData->BtGuardInfo.TpmType == dTpm20) || (PlatformData->BtGuardInfo.TpmType == Ptt))) {
+
+    //  As per PC Client spec, SRTM should perform a host platform reset
+    if (PlatformData->BtGuardInfo.TpmStartupFailureOnS3 == TRUE) {
+      ResetSystem(EfiResetCold);
+      CpuDeadLoop ();
+    }
     // Initialize TPM if it has not already been initialized by BootGuard component (i.e. ACM)
     Status = TpmInit(PlatformData->BtGuardInfo.BypassTpmInit, BootMode);
 

--- a/Silicon/CommonSocPkg/Include/Library/BootGuardLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/BootGuardLib.h
@@ -56,6 +56,12 @@ typedef struct {
   - 1: Bypass TPM Event Log if Sx Resume Type is identified.
   **/
   BOOLEAN  ByPassTpmEventLog;
+  /**
+  This field indicates that the ACM's Tpm2Startup (State) command failed during S3 resume.
+  - 0: Successful Tpm2Startup (State)
+  - 1: Failure during Tpm2Startup (State). BIOS will need to perform a cold reset to handle the error.
+  **/
+  BOOLEAN  TpmStartupFailureOnS3;
 } BOOT_GUARD_INFO;
 
 /**

--- a/Silicon/CommonSocPkg/Library/BootGuardLibCBnT/BootGuardLibrary.c
+++ b/Silicon/CommonSocPkg/Library/BootGuardLibCBnT/BootGuardLibrary.c
@@ -64,7 +64,7 @@ GetBootGuardInfo (
   UINT32                  MsrValue;
   UINT32                  MeFwSts4;
   UINT32                  BootGuardAcmStatus;
-  UINT32                  BootGuardBootStatus;
+  UINT64                  BootGuardBootStatus;
 
   ///
   /// Check if System Supports Boot Guard
@@ -75,8 +75,8 @@ GetBootGuardInfo (
     BootGuardAcmStatus  = *(UINT32 *) (UINTN) (TXT_PUBLIC_BASE + R_CPU_BOOT_GUARD_ACM_STATUS);
     DEBUG ((DEBUG_INFO, "Boot Guard ACM Status = %x\n", BootGuardAcmStatus));
 
-    BootGuardBootStatus  = *(UINT32 *) (UINTN) (TXT_PUBLIC_BASE + R_CPU_BOOT_GUARD_BOOTSTATUS);
-    DEBUG ((DEBUG_INFO, "Boot Guard Boot Status = %x\n", BootGuardBootStatus));
+    BootGuardBootStatus  = *(UINT64 *) (UINTN) (TXT_PUBLIC_BASE + R_CPU_BOOT_GUARD_BOOTSTATUS);
+    DEBUG ((DEBUG_INFO, "Boot Guard Boot Status = %llx\n", BootGuardBootStatus));
 
     ///
     /// Read ME FWS Registers
@@ -98,6 +98,13 @@ GetBootGuardInfo (
     BootGuardInfo->MeasuredBoot = FALSE;
     BootGuardInfo->VerifiedBoot = FALSE;
 
+    ///
+    /// Check Bit 46 in BootGuardBootStatus to handle Tpm2Startup(Restore) errors.
+    ///
+    if ((BootGuardBootStatus & B_CPU_BOOT_GUARD_BOOTSTATUS_S3_TPM_STARTUP_FAILED) != 0) {
+      BootGuardInfo->TpmStartupFailureOnS3 = TRUE;
+      DEBUG ((DEBUG_INFO, "ACM Tpm2Startup (State) failure detected during S3 flow.\n"));
+    }
     if ((MeFwSts4 & BIT10) != 0) {
       DEBUG ((DEBUG_INFO, "Sx Resume Type Identified - TPM Event Log not required for ACM Measurements\n"));
       BootGuardInfo->ByPassTpmEventLog = TRUE;

--- a/Silicon/CommonSocPkg/Library/BootGuardLibCBnT/BootGuardRegister.h
+++ b/Silicon/CommonSocPkg/Library/BootGuardLibCBnT/BootGuardRegister.h
@@ -33,6 +33,7 @@
 #define TXT_PUBLIC_BASE                                               0xFED30000
 #define R_CPU_BOOT_GUARD_ERRORCODE                                    0x30
 #define R_CPU_BOOT_GUARD_BOOTSTATUS                                   0xA0
+#define B_CPU_BOOT_GUARD_BOOTSTATUS_S3_TPM_STARTUP_FAILED             BIT46
 
 #define R_CPU_BOOT_GUARD_ACM_STATUS                                   0x328
 #define MMIO_ACM_STATUS                                               (TXT_PUBLIC_BASE + R_CPU_BOOT_GUARD_ACM_STATUS)


### PR DESCRIPTION
As per TCG spec, if a Tpm2Startup(TPM_SU_STATE) fails during
S3 resume, a host reset should be done.

When BootGuard is enabled, ACM will notify of this failure via Bit46 in
BootGuardBootStatus register.


Signed-off-by: Sachin Agrawal <sachin.agrawal@intel.com>