### PR TITLE
Revert "[CMLV] Fix PMC register offset value (#887)"

### DIFF
--- a/Silicon/CometlakevPkg/Include/Register/PchRegsPmc.h
+++ b/Silicon/CometlakevPkg/Include/Register/PchRegsPmc.h
@@ -69,7 +69,7 @@
 
 #define R_PMC_PWRM_CFG4                          0x18E8
 
-#define R_PMC_PWRM_GPIO_CFG                      0x1920
+#define R_PMC_PWRM_GPIO_CFG                      0x120
 #define B_PMC_PWRM_GPIO_CFG_GPE0_DW2             (BIT11 | BIT10 | BIT9 | BIT8)
 #define N_PMC_PWRM_GPIO_CFG_GPE0_DW2             8
 #define B_PMC_PWRM_GPIO_CFG_GPE0_DW1             (BIT7 | BIT6 | BIT5 | BIT4)


### PR DESCRIPTION
This reverts commit b53de73b5304e89c161dd37f2e9ee374ab832150.
Revert the particular commit to solve Gpio error.

Signed-off-by: jinjhuli <jin.jhu.lim@intel.com>