### PR TITLE
[CFL]Fix payload selection issue

### DIFF
--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -894,7 +894,7 @@ UpdatePayloadId (
     Status = GpioGetInputValue (PayloadSelGpioPad, &PayloadSelGpioData);
     if (!EFI_ERROR (Status)) {
       if (PayloadSelGpioData == 1) {
-        PayloadId = UEFI_PAYLOAD_ID_SIGNATURE;
+        PayloadId = 0;
       } else {
         if ((GenericCfgData != NULL) && (GenericCfgData->PayloadId == AUTO_PAYLOAD_ID_SIGNATURE)) {
           PayloadId = UEFI_PAYLOAD_ID_SIGNATURE;


### PR DESCRIPTION
WHL CRB board is configured to boot different payload based on GPIO pin
status, which is not working currenly.
this patch ensures to boot to Osloader payload when PayloadSelGpioData=1
otherwise boot to UEFI payload.

TEST= Boot test on WHL CRB and verified board able to switch between
OSloader & UEFI payload based on DIP switch R4H1B_4 status.

Signed-off-by: Praveen Hp <praveen.hodagatta.pranesh@intel.com>