### PR TITLE
use different workspace to prepare binaries

### DIFF
--- a/BootloaderCorePkg/Tools/PrepareBuildComponentBin.py
+++ b/BootloaderCorePkg/Tools/PrepareBuildComponentBin.py
@@ -236,7 +236,7 @@ def Main():
     sbl_dir          = sys.argv[1]
     silicon_pkg_name = sys.argv[2]
 
-    workspace_dir  = os.path.join(sbl_dir, '../Download')
+    workspace_dir  = os.path.join(sbl_dir, '../Download', silicon_pkg_name)
     fsp_repo_dir   = os.path.abspath (os.path.join(workspace_dir, 'IntelFsp'))
     qemu_repo_dir  = os.path.abspath (os.path.join(workspace_dir, 'QemuFsp'))
     ucode_repo_dir = os.path.abspath (os.path.join(workspace_dir, 'IntelUcode'))


### PR DESCRIPTION
Different projects might use different repo to get binaries.
or different project might be built at same time. so change
to use different workspace for different project to avoid
potential conflict.

Signed-off-by: Guo Dong <guo.dong@intel.com>