### PR TITLE
Enhance BGRT BMP support for logo display

### DIFF
--- a/BootloaderCommonPkg/Include/Library/GraphicsLib.h
+++ b/BootloaderCommonPkg/Include/Library/GraphicsLib.h
@@ -96,29 +96,28 @@ GetBmpDisplayPos (
 
 
 /**
-  Display a *.BMP graphics image to the frame buffer. If a NULL GopBlt buffer
-  is passed in a GopBlt buffer will be allocated by this routine. If a GopBlt
-  buffer is passed in it will be used if it is big enough.
+  Display a *.BMP graphics image to the frame buffer or BLT buffer. If a NULL
+  GopBlt buffer is passed in, the BMP image will be displayed into BLT memory
+  buffer. Otherwise, it will be dispalyed into the actual frame buffer.
 
   @param  BmpImage      Pointer to BMP file
-  @param  GopBlt        Buffer for transferring BmpImage to the frame buffer.
+  @param  GopBlt        Buffer for transferring BmpImage to the BLT memory buffer.
   @param  GopBltSize    Size of GopBlt in bytes.
   @param  GfxInfoHob    Pointer to graphics info HOB.
 
   @retval EFI_SUCCESS           GopBlt and GopBltSize are returned.
   @retval EFI_UNSUPPORTED       BmpImage is not a valid *.BMP image
   @retval EFI_BUFFER_TOO_SMALL  The passed in GopBlt buffer is not big enough.
-                                GopBltSize will contain the required size.
   @retval EFI_OUT_OF_RESOURCES  No enough buffer to allocate.
 
 **/
 EFI_STATUS
 EFIAPI
 DisplayBmpToFrameBuffer (
-  IN     VOID      *BmpImage,
-  IN OUT VOID      **GopBlt,
-  IN OUT UINTN     *GopBltSize,
-  IN     EFI_PEI_GRAPHICS_INFO_HOB *GfxInfoHob
+  IN  VOID      *BmpImage,
+  IN  VOID      *GopBlt,
+  IN  UINTN      GopBltSize,
+  IN  EFI_PEI_GRAPHICS_INFO_HOB *GfxInfoHob
   );
 
 /**

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
@@ -43,6 +43,7 @@
   DebugDataLib
   MpInitLib
   TimeStampLib
+  MemoryAllocationLib
 
 [Guids]
   gEsrtSystemFirmwareGuid

--- a/BootloaderCorePkg/Stage2/Stage2Support.c
+++ b/BootloaderCorePkg/Stage2/Stage2Support.c
@@ -82,14 +82,9 @@ DisplaySplash (
   VOID
   )
 {
-  EFI_STATUS                          Status;
+  EFI_STATUS                           Status;
   VOID                                *SplashLogoBmp;
   EFI_PEI_GRAPHICS_INFO_HOB           *GfxInfoHob;
-  EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION *GopBlt;
-  UINTN                               GopBltSize;
-
-  GopBlt = NULL;
-  GopBltSize = 0;
 
   // Get framebuffer info
   GfxInfoHob = (EFI_PEI_GRAPHICS_INFO_HOB *)GetGuidHobData (NULL, NULL, &gEfiGraphicsInfoHobGuid);
@@ -98,10 +93,9 @@ DisplaySplash (
   }
 
   // Convert image from BMP format and write to frame buffer
-  GopBlt = NULL;
   SplashLogoBmp = (VOID *)(UINTN)PCD_GET32_WITH_ADJUST (PcdSplashLogoAddress);
   ASSERT (SplashLogoBmp != NULL);
-  Status = DisplayBmpToFrameBuffer (SplashLogoBmp, (VOID **)&GopBlt, &GopBltSize, GfxInfoHob);
+  Status = DisplayBmpToFrameBuffer (SplashLogoBmp, NULL, 0, GfxInfoHob);
 
   return Status;
 }


### PR DESCRIPTION
BGRT can be used by bootloader to pass logo to OS. But BGRT can
only support 24bit or 32bit BMP format. If the bootloader uses
other bit format or indexed color format, the image has to be
converted before passing it to BGRT. This patch added support
to convert other BMP image format into 32bit format required by
BGRT.

This has been tested with Windows on Leafhill board. The SBL
logo was dispalyed properly while booting Windows.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>