### PR TITLE
Enhance PreOS support

### DIFF
--- a/BootloaderCommonPkg/Include/Guid/OsBootOptionGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/OsBootOptionGuid.h
@@ -17,7 +17,7 @@
 
 #define BOOT_FLAGS_MISC            BIT0
 #define BOOT_FLAGS_CRASH_OS        BIT1
-#define BOOT_FLAGS_TRUSTY          BIT2
+#define BOOT_FLAGS_PREOS           BIT2
 #define BOOT_FLAGS_EXTRA           BIT3
 #define BOOT_FLAGS_MENDER          BIT4
 
@@ -26,7 +26,7 @@
 
 typedef enum {
   LoadImageTypeNormal              = 0x0,
-  LoadImageTypeTrusty,
+  LoadImageTypePreOs,
   LoadImageTypeMisc,
   LoadImageTypeExtra0,
   LoadImageTypeExtra1,
@@ -82,6 +82,12 @@ typedef enum  {
   EnumImageTypeMax
 } BOOT_IMAGE_TYPE;
 
+typedef enum  {
+  EnumPreOsTypeDefault     = 0x0,
+  EnumPreOsTypeTrustyOs,
+  EnumPreOsTypeMax
+} PREOS_IMAGE_TYPE;
+
 typedef struct {
   //
   // Indicate this entry is invalid or not
@@ -101,8 +107,39 @@ typedef struct {
   UINT32               LbaAddr;
 } LBA_IMAGE_LOCATION;
 
-
+///
+/// Only used to load image from firmware boot media (e.g. SPI flash)
+///
 typedef struct {
+  ///
+  /// Should be '!'
+  ///
+  UINT8                Indicate;
+  ///
+  /// The signature of the container
+  ///
+  UINT32               ContainerSig;
+  ///
+  /// should be '/'
+  ///
+  UINT8                BackSlash;
+  ///
+  /// The component name
+  ///
+  UINT32               ComponentName;
+  ///
+  /// Optional, should set to ':' if Parameter field exists.
+  ///
+  UINT8                Colon;
+  ///
+  /// The parameter to component image
+  /// Available only on Colon == ':'
+  ///
+  UINT32               Parameter;
+} CONTAINER_IMAGE;
+
+
+typedef union {
   ///
   /// Used for image from file system, Ascii file name
   /// If FileName[0] is zero, means this entry is invalid
@@ -112,6 +149,10 @@ typedef struct {
   /// Used for image from raw partition
   ///
   LBA_IMAGE_LOCATION   LbaImage;
+  ///
+  ///
+  ///
+  CONTAINER_IMAGE      ContainerImage;
 } BOOT_IMAGE;
 
 typedef struct {
@@ -119,7 +160,12 @@ typedef struct {
   ///
   /// Image type for Image[0]. Refer BOOT_IMAGE_TYPE
   ///
-  UINT8                ImageType;
+  UINT8                ImageType:5;
+
+  ///
+  /// Image type for Image[1]. Refer PREOS_IMAGE_TYPE
+  ///
+  UINT8                PreOsImageType:3;
 
   ///
   /// Zero means normal boot.
@@ -155,7 +201,7 @@ typedef struct {
   UINT8                FsType;
 
   // Image[0] is for normal boot OS
-  // Image[1] is for trusty OS
+  // Image[1] is for Pre OS
   // Image[2] is for misc image
   // Image[3-6] is for extra Images
   BOOT_IMAGE           Image[LoadImageTypeMax];

--- a/BootloaderCommonPkg/Library/ShellLib/CmdBoot.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdBoot.c
@@ -170,7 +170,7 @@ GetBootDeviceInfo (
   }
 
   do {
-    ShellPrint (L"Enter BootFlags (MISC 0x1, CRASH_OS 0x2, TRUSTY 0x4, EXTRA 0x8, MENDER 0x10)\n");
+    ShellPrint (L"Enter BootFlags (MISC 0x1, CRASH_OS 0x2, PREOS 0x4, EXTRA 0x8, MENDER 0x10)\n");
     ShellPrint (L"(default 0x%X) ", CurrOption->BootFlags);
     Status = ShellReadUintn (Shell, Buffer, BufferSize, &IsHex);
     if (EFI_ERROR (Status)) {
@@ -181,7 +181,7 @@ GetBootDeviceInfo (
       break;
     }
     BootOption->BootFlags = (OS_FILE_SYSTEM_TYPE) ((IsHex) ? StrHexToUintn (Buffer) : StrDecimalToUintn (Buffer));
-    if (((UINT8)BootOption->BootFlags) <= ((UINT8)BOOT_FLAGS_MISC | BOOT_FLAGS_CRASH_OS | BOOT_FLAGS_TRUSTY | BOOT_FLAGS_EXTRA | BOOT_FLAGS_MENDER)) {
+    if (((UINT8)BootOption->BootFlags) <= ((UINT8)BOOT_FLAGS_MISC | BOOT_FLAGS_CRASH_OS | BOOT_FLAGS_PREOS | BOOT_FLAGS_EXTRA | BOOT_FLAGS_MENDER)) {
       break;
     }
     ShellPrint (L"Invalid value '%s', please re-enter\n", Buffer);

--- a/PayloadPkg/Include/PreOsHeader.h
+++ b/PayloadPkg/Include/PreOsHeader.h
@@ -1,0 +1,38 @@
+/** @file
+
+Copyright (c) 2020, Intel Corporation. All rights reserved.
+
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __PRE_OS_H__
+#define __PRE_OS_H__
+
+
+typedef struct {
+  UINT32 Eax;
+  UINT32 Ebx;
+  UINT32 Ecx;
+  UINT32 Edx;
+  UINT32 Esi;
+  UINT32 Edi;
+  UINT32 Ebp;
+  UINT32 Eip;
+  UINT32 Eflags;
+} OS_BOOT_INFO;
+
+
+typedef struct {
+  UINT32        Version;
+  UINT32        HeapSize;
+  UINT32        HeapAddr;
+  OS_BOOT_INFO  OsBootState;
+  UINT32        HobListPtr;
+} PRE_OS_PARAM;
+
+typedef VOID (*PRE_OS_ENTRYPOINT) (VOID *Params);
+
+
+
+#endif

--- a/PayloadPkg/OsLoader/BootParameters.c
+++ b/PayloadPkg/OsLoader/BootParameters.c
@@ -214,7 +214,7 @@ DEBUG_CODE_END ();
 
   @param[in]     CurrentBootOption Current boot option
   @param[in,out] LoadedImage       Normal OS boot image
-  @param[in,out] LoadedTrustyImage Trusty OS image
+  @param[in,out] LoadedPreOsImage  Pre-OS image
   @param[in,out] LoadedExtraImages Extra OS images
 
   @retval   RETURN_SUCCESS         If update OS parameter success
@@ -224,7 +224,7 @@ EFI_STATUS
 UpdateOsParameters (
   IN     OS_BOOT_OPTION      *CurrentBootOption,
   IN OUT LOADED_IMAGE        *LoadedImage,
-  IN OUT LOADED_IMAGE        *LoadedTrustyImage,
+  IN OUT LOADED_IMAGE        *LoadedPreOsImage,
   IN OUT LOADED_IMAGE        *LoadedExtraImages
   )
 {
@@ -282,24 +282,21 @@ UpdateOsParameters (
   }
 
   //
-  // Update Trusty image if it is loaded.
+  // Update PreOS image if it is loaded.
   //
-  if ((CurrentBootOption->BootFlags & BOOT_FLAGS_TRUSTY) != 0) {
+  if (((CurrentBootOption->BootFlags & BOOT_FLAGS_PREOS) != 0) && (LoadedPreOsImage != NULL)) {
     LoadedImage->Image.MultiBoot.CmdBufferSize       = CMDLINE_LENGTH_MAX;
-    if (LoadedTrustyImage != NULL) {
-      LoadedTrustyImage->Image.MultiBoot.CmdBufferSize = CMDLINE_LENGTH_MAX;
-      Status = SetupTrustyBoot (&LoadedTrustyImage->Image.MultiBoot, &LoadedImage->Image.MultiBoot);
+    if ((CurrentBootOption->PreOsImageType & EnumPreOsTypeTrustyOs) != 0) {
+      LoadedPreOsImage->Image.MultiBoot.CmdBufferSize = CMDLINE_LENGTH_MAX;
+      Status = SetupTrustyBoot (&LoadedPreOsImage->Image.MultiBoot, &LoadedImage->Image.MultiBoot);
       if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_ERROR, "ERROR Setting up Trusty Boot!\n"));
+        DEBUG ((DEBUG_ERROR, "ERROR Setting up preOS Boot!\n"));
         return Status;
       }
-    } else {
-      DEBUG ((DEBUG_ERROR, "ERROR Setting up Trusty Boot!\n"));
-      return Status;
     }
-    UpdateOsMemMap (LoadedTrustyImage);
-    DEBUG ((DEBUG_INFO, "\nDump trusty image info:\n"));
-    DisplayInfo (LoadedTrustyImage);
+    UpdateOsMemMap (LoadedPreOsImage);
+    DEBUG ((DEBUG_INFO, "\nDump PreOs image info:\n"));
+    DisplayInfo (LoadedPreOsImage);
   }
 
   if ((CurrentBootOption->BootFlags & BOOT_FLAGS_EXTRA) != 0) {

--- a/PayloadPkg/OsLoader/KeyManagement.c
+++ b/PayloadPkg/OsLoader/KeyManagement.c
@@ -127,11 +127,11 @@ SeedSanityCheck (
   // Get OStype/ Trusty Flag from Osbootoptionlist for index: 0
   // as its assumed that target OS should always be at index:0
   OsImageType = OsBootOptionList->OsBootOption[0].ImageType;
-  TrustyFlag  = (OsBootOptionList->OsBootOption[0].BootFlags & BOOT_FLAGS_TRUSTY) >> 2;
+  TrustyFlag  = (OsBootOptionList->OsBootOption[0].BootFlags & BOOT_FLAGS_PREOS) >> 2;
 
   // Get Os type/Trusty flag from current boot option
   CurrentOsImageType = CurrentBootOption->ImageType;
-  CurrentTrustyFlag = (CurrentBootOption->BootFlags & BOOT_FLAGS_TRUSTY) >> 2;
+  CurrentTrustyFlag = (CurrentBootOption->BootFlags & BOOT_FLAGS_PREOS) >> 2;
 
   // Compare OS type/Trusty flags of current bootoption with bootoption index 0
   if((OsImageType == CurrentOsImageType) && (TrustyFlag == CurrentTrustyFlag)) {

--- a/PayloadPkg/OsLoader/OsLoader.h
+++ b/PayloadPkg/OsLoader/OsLoader.h
@@ -64,6 +64,7 @@
 #include <Register/Intel/Msr/ArchitecturalMsr.h>
 #include "PreOsChecker.h"
 #include <Library/StringSupportLib.h>
+#include <PreOsHeader.h>
 
 
 #define MKHI_BOOTLOADER_SEED_LEN       64
@@ -322,7 +323,7 @@ GetFromConfigFile (
 
   @param[in]     BootOption        Current boot option
   @param[in,out] LoadedImage       Normal OS boot image
-  @param[in,out] LoadedTrustyImage Trusty OS image
+  @param[in,out] LoadedPreOsImage  Pre OS image
   @param[in,out] LoadedExtraImages Extra OS images
 
   @retval   RETURN_SUCCESS         If update OS parameter success
@@ -332,7 +333,7 @@ EFI_STATUS
 UpdateOsParameters (
   IN     OS_BOOT_OPTION      *BootOption,
   IN OUT LOADED_IMAGE        *LoadedImage,
-  IN OUT LOADED_IMAGE        *LoadedTrustyImage,
+  IN OUT LOADED_IMAGE        *LoadedPreOsImage,
   IN OUT LOADED_IMAGE        *LoadedExtraImages
   );
 
@@ -514,4 +515,30 @@ PayloadModuleInit (
   IN  CHAR8               *ModuleName
   );
 
+/**
+  Print the stack/HOB and heap usage information.
+
+**/
+VOID
+EFIAPI
+PrintStackHeapInfo (
+  VOID
+  );
+
+/**
+  Start preOS boot image
+
+  This function will call into preOS entry point with OS information as parameter.
+
+  @param[in]  LoadedPreOsImage  Loaded PreOS image information.
+  @param[in]  LoadedImage       Loaded OS image information.
+
+  @retval  RETURN_SUCCESS       boot image is return after boot
+  @retval  Others               There is error when checking boot image
+**/
+EFI_STATUS
+StartPreOsBooting (
+  IN LOADED_IMAGE            *LoadedPreOsImage,
+  IN LOADED_IMAGE            *LoadedImage
+  );
 #endif

--- a/PayloadPkg/OsLoader/OsLoader.inf
+++ b/PayloadPkg/OsLoader/OsLoader.inf
@@ -36,6 +36,7 @@
   BootParameters.c
   BlockIoTest.c
   KeyManagement.c
+  PreOsSupport.c
   PreOsChecker.c
   ModService.c
 

--- a/PayloadPkg/OsLoader/PreOsSupport.c
+++ b/PayloadPkg/OsLoader/PreOsSupport.c
@@ -1,0 +1,124 @@
+/** @file
+
+  Copyright (c) 2019 - 2020, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/DebugLib.h>
+#include <Library/ContainerLib.h>
+#include <Library/ElfLib.h>
+#include <Library/LinuxLib.h>
+#include <Library/MultibootLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/BootloaderCommonLib.h>
+#include "OsLoader.h"
+
+
+/**
+  Get required information from loaded OS image.
+
+  @param[in]  LoadedImage         Loaded OS image information.
+  @param[out] PreOsParams         Pointer of PRE_OS_PARAM
+
+  @retval EFI_INVALID_PARAMETER   Invalid parameter is given or loaded image flag is not set.
+  @retval EFI_SUCCESS             Get required information success.
+
+**/
+EFI_STATUS
+EFIAPI
+GetNormalOsInfo (
+  IN   LOADED_IMAGE           *LoadedImage,
+  OUT  PRE_OS_PARAM           *PreOsParams
+  )
+{
+  BOOT_PARAMS                *OsBootParam;
+  IA32_BOOT_STATE            *BootState;
+
+  if (PreOsParams == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (PreOsParams, sizeof (PRE_OS_PARAM));
+
+  PreOsParams->Version     = 0x1;
+  PreOsParams->HeapSize    = EFI_SIZE_TO_PAGES (0);
+  PreOsParams->HeapAddr    = (UINT32)(UINTN)AllocatePages (PreOsParams->HeapSize);
+  PreOsParams->HobListPtr  = PcdGet32 (PcdPayloadHobList);
+
+  if ((LoadedImage->Flags & LOADED_IMAGE_LINUX) != 0) {
+    OsBootParam = GetLinuxBootParams();
+    UpdateLinuxBootParams (OsBootParam);
+    PreOsParams->OsBootState.Esi     = (UINT32)(UINTN)OsBootParam;
+    PreOsParams->OsBootState.Eip     = OsBootParam->Hdr.Code32Start;
+  } else if ((LoadedImage->Flags & LOADED_IMAGE_MULTIBOOT) != 0) {
+    BootState = &LoadedImage->Image.MultiBoot.BootState;
+    PreOsParams->OsBootState.Eax     = BootState->Eax;
+    PreOsParams->OsBootState.Ebx     = BootState->Ebx;
+    PreOsParams->OsBootState.Esi     = BootState->Esi;
+    PreOsParams->OsBootState.Edi     = BootState->Edi;
+    PreOsParams->OsBootState.Eip     = BootState->EntryPoint;
+  } else if ((LoadedImage->Flags & LOADED_IMAGE_PE32) != 0) {
+    BootState = &LoadedImage->Image.MultiBoot.BootState;
+    PreOsParams->OsBootState.Eip     = BootState->EntryPoint;
+  } else {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  PreOsParams->OsBootState.Eflags  = 0;
+
+  return EFI_SUCCESS;
+}
+
+
+/**
+  Start preOS boot image
+
+  This function will call into preOS entry point with OS information as parameter.
+
+  @param[in]  LoadedPreOsImage  Loaded PreOS image information.
+  @param[in]  LoadedImage       Loaded OS image information.
+
+  @retval  RETURN_SUCCESS       boot image is return after boot
+  @retval  Others               There is error when checking boot image
+**/
+EFI_STATUS
+StartPreOsBooting (
+  IN LOADED_IMAGE            *LoadedPreOsImage,
+  IN LOADED_IMAGE            *LoadedImage
+  )
+{
+  EFI_STATUS                 Status;
+  PRE_OS_PARAM               PreOsParams;
+  IA32_BOOT_STATE            *BootState;
+  PRE_OS_ENTRYPOINT          EntryPoint;
+
+  DEBUG ((DEBUG_INFO, "StartPreOsBooting...\n"));
+
+  DEBUG_CODE_BEGIN();
+  PrintStackHeapInfo ();
+  DEBUG_CODE_END();
+
+  DEBUG ((DEBUG_INFO, "GetNormalOsInfo...\n"));
+
+  Status = GetNormalOsInfo (LoadedImage, &PreOsParams);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+  DEBUG ((DEBUG_INFO, "GetNormalOsInfo...%r\n", Status));
+
+  BootState  = &LoadedPreOsImage->Image.MultiBoot.BootState;
+  EntryPoint = (PRE_OS_ENTRYPOINT)(UINTN)BootState->EntryPoint;
+  DEBUG ((DEBUG_INFO, "EntryPoint =...0x%p\n", EntryPoint));
+
+  EntryPoint (&PreOsParams);
+
+  //
+  // Should not reach here
+  //
+  CpuHalt ("Failed to launch Pre-OS image!");
+
+  return EFI_DEVICE_ERROR;
+}
+

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/SeedSupport.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/SeedSupport.c
@@ -302,7 +302,7 @@ SeedStatusBasedOnImageType (
     return FALSE;
   }
   // First boot option should be the target OS.
-  TrustyFlag  = (OsBootOptionList->OsBootOption[0].BootFlags & BOOT_FLAGS_TRUSTY) >> 2;
+  TrustyFlag  = (OsBootOptionList->OsBootOption[0].BootFlags & BOOT_FLAGS_PREOS) >> 2;
   OsImageType = OsBootOptionList->OsBootOption[0].ImageType;
 
   switch (SeedType) {


### PR DESCRIPTION
SBL support to load PreOS and normal OS in a single boot option.
This patch tries to standardize the PreOS support.
The PreOS could be TrustyOS, PreOsChecker or others.
As long as PreOS flag is set in boot option, SBL will load and
boot PreOS before normal OS. If the preOS has specific requirement,
it could be addressed using PreOS image type.

Signed-off-by: Guo Dong <guo.dong@intel.com>