### PR TITLE
Update get_openssl_path to return absoulte path

### DIFF
--- a/BootloaderCorePkg/Tools/CommonUtility.py
+++ b/BootloaderCorePkg/Tools/CommonUtility.py
@@ -201,7 +201,11 @@ def get_openssl_path ():
                     openssl_cfg = "C:\\Openssl\\openssl.cfg"
                     if os.path.exists(openssl_cfg):
                         os.environ['OPENSSL_CONF'] = openssl_cfg
-    openssl = os.path.join(os.environ.get ('OPENSSL_PATH', ''), 'openssl')
+        openssl = os.path.join(os.environ.get ('OPENSSL_PATH', ''), 'openssl.exe')
+    else:
+        # Get openssl path for Linux cases
+        openssl = shutil.which('openssl')
+
     return openssl
 
 def run_process (arg_list, print_cmd = False, capture_out = False):

--- a/BootloaderCorePkg/Tools/SingleSign.py
+++ b/BootloaderCorePkg/Tools/SingleSign.py
@@ -72,7 +72,11 @@ def get_openssl_path ():
                     openssl_cfg = "C:\\Openssl\\openssl.cfg"
                     if os.path.exists(openssl_cfg):
                         os.environ['OPENSSL_CONF'] = openssl_cfg
-    openssl = os.path.join(os.environ.get ('OPENSSL_PATH', ''), 'openssl')
+        openssl = os.path.join(os.environ.get ('OPENSSL_PATH', ''), 'openssl.exe')
+    else:
+        # Get openssl path for Linux cases
+        openssl = shutil.which('openssl')
+
     return openssl
 
 def run_process (arg_list, print_cmd = False, capture_out = False):

--- a/Platform/CometlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/CometlakeBoardPkg/Script/StitchIfwi.py
@@ -108,10 +108,7 @@ def gen_sign_oem_key_manifest(stitch_dir, stitch_cfg_file):
     oem_bin_input  = os.path.join (stitch_dir, 'Input', 'OemExtInputFile.bin')
     oem_bin_sign   = os.path.join (output_dir, 'OemExtInputFile.bin')
 
-    if os.name == 'nt':
-        openssl_path = get_openssl_path() + '.exe'
-    else:
-        openssl_path = get_openssl_path()
+    openssl_path = get_openssl_path()
 
     bpm_gen2dir = os.path.join (stitch_dir, 'bpmgen2')
     bpm_key_dir = os.path.join (bpm_gen2dir, 'keys')

--- a/Platform/CometlakevBoardPkg/Script/StitchIfwi.py
+++ b/Platform/CometlakevBoardPkg/Script/StitchIfwi.py
@@ -108,10 +108,7 @@ def gen_sign_oem_key_manifest(stitch_dir, stitch_cfg_file):
     oem_bin_input  = os.path.join (stitch_dir, 'Input', 'OemExtInputFile.bin')
     oem_bin_sign   = os.path.join (output_dir, 'OemExtInputFile.bin')
 
-    if os.name == 'nt':
-        openssl_path = get_openssl_path() + '.exe'
-    else:
-        openssl_path = get_openssl_path()
+    openssl_path = get_openssl_path()
 
     bpm_gen2dir = os.path.join (stitch_dir, 'bpmgen2')
     bpm_key_dir = os.path.join (bpm_gen2dir, 'keys')

--- a/Platform/TigerlakeBoardPkg/Script/BtgSign.py
+++ b/Platform/TigerlakeBoardPkg/Script/BtgSign.py
@@ -106,10 +106,7 @@ def gen_sign_oem_key_manifest(meu_path, oem_bin_input, key_dir, key_sz, output_d
     oem_bin_sign   = oem_bin_output
     oem_priv_key = SIGNING_KEY['KEY_ID_PRIV_OEM_RSA' + key_sz]
 
-    if os.name == 'nt':
-        openssl_path = get_openssl_path() + '.exe'
-    else:
-        openssl_path = get_openssl_path()
+    openssl_path = get_openssl_path()
 
     if not os.path.exists(oem_bin_input):
 


### PR DESCRIPTION
Tools as MEU used for signing and generating key manifests
expects to pass abosulte openssl paths. Updating
get_openssl_path to return paths for linux cases.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>