### PR TITLE
Get SVN ver from capsule during firmware update

### DIFF
--- a/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -232,42 +232,7 @@ PlatformGetStage1AOffset (
   OUT UINT32     *Size
   )
 {
-  EFI_STATUS                Status;
-  FLASH_MAP                 *FlashMap;
-
-  if ((Base == NULL) || (Size == NULL)) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  FlashMap = GetFlashMapPtr();
-  if (FlashMap == NULL) {
-    return EFI_NOT_FOUND;
-  }
-
-  //
-  // Get stage 1A base and size
-  //
-  Status = GetComponentInfoByPartition (FLASH_MAP_SIG_STAGE1A, IsBackupPartition, Base, Size);
-  if (IsBackupPartition && (Status == EFI_NOT_FOUND)) {
-    Status = GetComponentInfoByPartition (FLASH_MAP_SIG_STAGE1A, FALSE, Base, Size);
-  }
-  if (EFI_ERROR(Status)) {
-    DEBUG((DEBUG_ERROR, "Could not get component information from flash map \n"));
-    return Status;
-  }
-
-  //
-  // Convert base address to offset in the BIOS region
-  //
-  *Base = (UINT32)(FlashMap->RomSize - (0x100000000ULL - *Base));
-
-  //
-  // Calculate base address of the component in the capsule image
-  // Capsule image address + bios region offset + offset of the component
-  //
-  *Base  = (UINT32)((UINTN)ImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER) + *Base);
-
-  return EFI_SUCCESS;
+  return EFI_UNSUPPORTED;
 }
 
 /**

--- a/Silicon/CometlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/CometlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -199,42 +199,7 @@ PlatformGetStage1AOffset (
   OUT UINT32     *Size
   )
 {
-  EFI_STATUS                Status;
-  FLASH_MAP                 *FlashMap;
-
-  if ((Base == NULL) || (Size == NULL)) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  FlashMap = GetFlashMapPtr();
-  if (FlashMap == NULL) {
-    return EFI_NOT_FOUND;
-  }
-
-  //
-  // Get stage 1A base and size
-  //
-  Status = GetComponentInfoByPartition (FLASH_MAP_SIG_STAGE1A, IsBackupPartition, Base, Size);
-  if (IsBackupPartition && (Status == EFI_NOT_FOUND)) {
-    Status = GetComponentInfoByPartition (FLASH_MAP_SIG_STAGE1A, FALSE, Base, Size);
-  }
-  if (EFI_ERROR(Status)) {
-    DEBUG((DEBUG_ERROR, "Could not get component information from flash map \n"));
-    return Status;
-  }
-
-  //
-  // Convert base address to offset in the BIOS region
-  //
-  *Base = (UINT32)(FlashMap->RomSize - (0x100000000ULL - *Base));
-
-  //
-  // Calculate base address of the component in the capsule image
-  // Capsule image address + bios region offset + offset of the component
-  //
-  *Base  = (UINT32)((UINTN)ImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER) + *Base);
-
-  return EFI_SUCCESS;
+  return EFI_UNSUPPORTED;
 }
 
 /**

--- a/Silicon/CometlakevPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/CometlakevPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -199,42 +199,7 @@ PlatformGetStage1AOffset (
   OUT UINT32     *Size
   )
 {
-  EFI_STATUS                Status;
-  FLASH_MAP                 *FlashMap;
-
-  if ((Base == NULL) || (Size == NULL)) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  FlashMap = GetFlashMapPtr();
-  if (FlashMap == NULL) {
-    return EFI_NOT_FOUND;
-  }
-
-  //
-  // Get stage 1A base and size
-  //
-  Status = GetComponentInfoByPartition (FLASH_MAP_SIG_STAGE1A, IsBackupPartition, Base, Size);
-  if (IsBackupPartition && (Status == EFI_NOT_FOUND)) {
-    Status = GetComponentInfoByPartition (FLASH_MAP_SIG_STAGE1A, FALSE, Base, Size);
-  }
-  if (EFI_ERROR(Status)) {
-    DEBUG((DEBUG_ERROR, "Could not get component information from flash map \n"));
-    return Status;
-  }
-
-  //
-  // Convert base address to offset in the BIOS region
-  //
-  *Base = (UINT32)(FlashMap->RomSize - (0x100000000ULL - *Base));
-
-  //
-  // Calculate base address of the component in the capsule image
-  // Capsule image address + bios region offset + offset of the component
-  //
-  *Base  = (UINT32)((UINTN)ImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER) + *Base);
-
-  return EFI_SUCCESS;
+  return EFI_UNSUPPORTED;
 }
 
 /**

--- a/Silicon/QemuSocPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/QemuSocPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -187,43 +187,7 @@ PlatformGetStage1AOffset (
   OUT UINT32     *Size
   )
 {
-  EFI_STATUS                Status;
-  FLASH_MAP                 *FlashMap;
-
-  if ((Base == NULL) || (Size == NULL)) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  FlashMap = GetFlashMapPtr();
-  if (FlashMap == NULL) {
-    return EFI_NOT_FOUND;
-  }
-
-  //
-  // Get stage 1A base and size
-  //
-  Status = GetComponentInfoByPartition (FLASH_MAP_SIG_STAGE1A, IsBackupPartition, Base, Size);
-  if (IsBackupPartition && (Status == EFI_NOT_FOUND)) {
-    Status = GetComponentInfoByPartition (FLASH_MAP_SIG_STAGE1A, FALSE, Base, Size);
-  }
-
-  if (EFI_ERROR(Status)) {
-    DEBUG((DEBUG_ERROR, "Could not get component information from flash map \n"));
-    return Status;
-  }
-
-  //
-  // Convert base address to offset in the BIOS region
-  //
-  *Base = (UINT32)(FlashMap->RomSize - (0x100000000ULL - *Base));
-
-  //
-  // Calculate base address of the component in the capsule image
-  // Capsule image address + bios region offset + offset of the component
-  //
-  *Base  = (UINT32)((UINTN)ImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER) + *Base);
-
-  return EFI_SUCCESS;
+  return EFI_UNSUPPORTED;
 }
 
 /**

--- a/Silicon/TigerlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/TigerlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -255,42 +255,7 @@ PlatformGetStage1AOffset (
   OUT UINT32     *Size
   )
 {
-  EFI_STATUS                Status;
-  FLASH_MAP                 *FlashMap;
-
-  if ((Base == NULL) || (Size == NULL)) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  FlashMap = GetFlashMapPtr();
-  if (FlashMap == NULL) {
-    return EFI_NOT_FOUND;
-  }
-
-  //
-  // Get stage 1A base and size
-  //
-  Status = GetComponentInfoByPartition (FLASH_MAP_SIG_STAGE1A, IsBackupPartition, Base, Size);
-  if (IsBackupPartition && (Status == EFI_NOT_FOUND)) {
-    Status = GetComponentInfoByPartition (FLASH_MAP_SIG_STAGE1A, FALSE, Base, Size);
-  }
-  if (EFI_ERROR(Status)) {
-    DEBUG((DEBUG_ERROR, "Could not get component information from flash map \n"));
-    return Status;
-  }
-
-  //
-  // Convert base address to offset in the BIOS region
-  //
-  *Base = (UINT32)(FlashMap->RomSize - (0x100000000ULL - *Base));
-
-  //
-  // Calculate base address of the component in the capsule image
-  // Capsule image address + bios region offset + offset of the component
-  //
-  *Base  = (UINT32)((UINTN)ImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER) + *Base);
-
-  return EFI_SUCCESS;
+  return EFI_UNSUPPORTED;
 }
 
 /**


### PR DESCRIPTION
During firmware update svn check for SBL region, Current code
assumes that Stage1A base does not change, because of this when
Stage1A base changed in capsule image, getting svn version from
the capsule fails and firmware update is failing.

This patch addressed above issue by reading stage1A base from
capsule image, this way even if stage1A base changes, code will
be able to read it and get svn version from capsule.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>