### PR TITLE
[BoardConfig] Support Inherited BoardConfig

### DIFF
--- a/Platform/QemuBoardPkg/BoardConfigOverride.py
+++ b/Platform/QemuBoardPkg/BoardConfigOverride.py
@@ -1,0 +1,18 @@
+#  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+# This import module name is generated from BuildLoader.py.
+#   Directory name w/o 'BoardPkg' + parent 'BoardConfig.py' w/o '.py'
+#   ex) QemuBoardPkg/BoardConfig.py -> QemuBoardConfig
+#       QemuBoardPkg/BoardConfigParent.py -> QemuBoardConfigParent
+import QemuBoardConfig
+
+class Board(QemuBoardConfig.Board):
+    def __init__(self, *args, **kwargs):
+        super(Board, self).__init__(*args, **kwargs)
+
+        self.VERINFO_IMAGE_ID         = 'QEMUOVRD'
+        self.BOARD_NAME               = 'qemuovrd'
+        self.PCI_MEM32_BASE           = 0xA0000000


### PR DESCRIPTION
This will allow inherited BoardConfig from the existing one
in the same BoardPkg. It will be useful when a new BoardConfig
has very minimum difference from the existing one.

See Platform/QemuBoardPkg/BoardConfigOverride.py as a reference.

Signed-off-by: Aiden Park <aiden.park@intel.com>