### PR TITLE
Fix Secureboot status in PSD

### DIFF
--- a/Silicon/CoffeelakePkg/Library/PsdLib/PsdLib.c
+++ b/Silicon/CoffeelakePkg/Library/PsdLib/PsdLib.c
@@ -338,8 +338,8 @@ UpdateAcpiPsdTable (
     return  EFI_UNSUPPORTED;
   }
 
-  //00 - Secure boot is Disabled; 01 - Verified boot is enabled; 11 - Secure boot (verified + PcdVerifiedBootEnabled) enabled.
-  mPsdt->SecureBoot = (UINT8)(((PlatformData->BtGuardInfo.VerifiedBoot) << 1)| FeaturePcdGet (PcdVerifiedBootEnabled));
+  //000 - Secure boot is Disabled; 010 - Boot Guard Enabled; 100 - Bootloader Verified boot Enabled.
+  mPsdt->SecureBoot = (UINT8)(((PlatformData->BtGuardInfo.VerifiedBoot) << 1)| (FeaturePcdGet (PcdVerifiedBootEnabled)) << 2);
   //Measured boot enabled.
   mPsdt->MeasuredBoot = (UINT8)((PlatformData->BtGuardInfo.MeasuredBoot));
 

--- a/Silicon/CometlakePkg/Library/PsdLib/PsdLib.c
+++ b/Silicon/CometlakePkg/Library/PsdLib/PsdLib.c
@@ -338,8 +338,8 @@ UpdateAcpiPsdTable (
     return  EFI_UNSUPPORTED;
   }
 
-  //00 - Secure boot is Disabled; 01 - Verified boot is enabled; 11 - Secure boot (verified + PcdVerifiedBootEnabled) enabled.
-  mPsdt->SecureBoot = (UINT8)(((PlatformData->BtGuardInfo.VerifiedBoot) << 1)| FeaturePcdGet (PcdVerifiedBootEnabled));
+  //000 - Secure boot is Disabled; 010 - Boot Guard Enabled; 100 - Bootloader Verified boot Enabled.
+  mPsdt->SecureBoot = (UINT8)(((PlatformData->BtGuardInfo.VerifiedBoot) << 1)| (FeaturePcdGet (PcdVerifiedBootEnabled)) << 2);
   //Measured boot enabled.
   mPsdt->MeasuredBoot = (UINT8)((PlatformData->BtGuardInfo.MeasuredBoot));
 

--- a/Silicon/CometlakevPkg/Library/PsdLib/PsdLib.c
+++ b/Silicon/CometlakevPkg/Library/PsdLib/PsdLib.c
@@ -339,8 +339,8 @@ UpdateAcpiPsdTable (
     return  EFI_UNSUPPORTED;
   }
 
-  //00 - Secure boot is Disabled; 01 - Verified boot is enabled; 11 - Secure boot (verified + PcdVerifiedBootEnabled) enabled.
-  mPsdt->SecureBoot = (UINT8)(((PlatformData->BtGuardInfo.VerifiedBoot) << 1)| FeaturePcdGet (PcdVerifiedBootEnabled));
+  //000 - Secure boot is Disabled; 010 - Boot Guard Enabled; 100 - Bootloader Verified boot Enabled.
+  mPsdt->SecureBoot = (UINT8)(((PlatformData->BtGuardInfo.VerifiedBoot) << 1)| (FeaturePcdGet (PcdVerifiedBootEnabled)) << 2);
   //Measured boot enabled.
   mPsdt->MeasuredBoot = (UINT8)((PlatformData->BtGuardInfo.MeasuredBoot));
 

--- a/Silicon/ElkhartlakePkg/Library/PsdLib/PsdLib.c
+++ b/Silicon/ElkhartlakePkg/Library/PsdLib/PsdLib.c
@@ -204,8 +204,8 @@ UpdateAcpiPsdTable (
     return  EFI_UNSUPPORTED;
   }
 
-  //00 - Secure boot is Disabled; 01 - Verified boot is enabled; 11 - Secure boot (verified + PcdVerifiedBootEnabled) enabled.
-  mPsdt->SecureBoot = (UINT8)(((PlatformData->BtGuardInfo.VerifiedBoot) << 1)| FeaturePcdGet (PcdVerifiedBootEnabled));
+  //000 - Secure boot is Disabled; 010 - Boot Guard Enabled; 100 - Bootloader Verified boot Enabled.
+  mPsdt->SecureBoot = (UINT8)(((PlatformData->BtGuardInfo.VerifiedBoot) << 1)| (FeaturePcdGet (PcdVerifiedBootEnabled)) << 2);
   //Measured boot enabled.
   mPsdt->MeasuredBoot = (UINT8)((PlatformData->BtGuardInfo.MeasuredBoot));
 

--- a/Silicon/TigerlakePkg/Library/PsdLib/PsdLib.c
+++ b/Silicon/TigerlakePkg/Library/PsdLib/PsdLib.c
@@ -203,8 +203,8 @@ UpdateAcpiPsdTable (
     return  EFI_UNSUPPORTED;
   }
 
-  //00 - Secure boot is Disabled; 01 - Verified boot is enabled; 11 - Secure boot (verified + PcdVerifiedBootEnabled) enabled.
-  mPsdt->SecureBoot = (UINT8)(((PlatformData->BtGuardInfo.VerifiedBoot) << 1)| FeaturePcdGet (PcdVerifiedBootEnabled));
+  //000 - Secure boot is Disabled; 010 - Boot Guard Enabled; 100 - Bootloader Verified boot Enabled.
+  mPsdt->SecureBoot = (UINT8)(((PlatformData->BtGuardInfo.VerifiedBoot) << 1)| (FeaturePcdGet (PcdVerifiedBootEnabled)) << 2);
   //Measured boot enabled.
   mPsdt->MeasuredBoot = (UINT8)((PlatformData->BtGuardInfo.MeasuredBoot));
 


### PR DESCRIPTION
CFL, CML, EHL, TGL platforms are using PSD version 0.3.
as per PSD Spec v0.3 secureboot status indication as ber below,

000 – Secure boot is Disabled
001 – UEFI Secure boot is enabled
010 – Boot Guard is Enabled
100 – Bootloader Verified boot is Enabled

Signed-off-by: Praveen Hp <praveen.hodagatta.pranesh@intel.com>