### PR TITLE
Fix paging issue when PCI PMEM64 resource exists

### DIFF
--- a/BootloaderCommonPkg/Library/PagingLib/PagingLib.c
+++ b/BootloaderCommonPkg/Library/PagingLib/PagingLib.c
@@ -373,6 +373,7 @@ CreateIdentityMappingPageTables (
   if (PageBuffer == NULL) {
     return EFI_OUT_OF_RESOURCES;
   }
+  ZeroMem (PageBuffer, EFI_PAGES_TO_SIZE (TotalPagesNum));
 
   Address   = 0;
   Attribute = IA32_PG_P | IA32_PG_RW;

--- a/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
+++ b/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
@@ -220,7 +220,8 @@ SecStartup (
       }
     }
 
-    if (MaxResLimit > BASE_4GB) {
+    // Only create paging in X64 mode
+    if (IS_X64 && (MaxResLimit > BASE_4GB)) {
       Index = (UINT8)HighBitSet64 (MaxResLimit);
       CreateIdentityMappingPageTables (Index + 1);
     }


### PR DESCRIPTION
In 32 bit SBL, when PCI PMEM64 exists, the OsLoader will hang
during boot in CreateIdentityMappingPageTables().  The function
is inteneded to be used in X64 mode only, and cannot handle
32bit well. So OsLoader should not call it for 32 bit build.

This patch also zeroed the allcated memory to ensure the unused
entries are all 0.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>