### PR TITLE
Enable Azure Pipeline build for TGL

### DIFF
--- a/.azurepipelines/azure-pipelines.yml
+++ b/.azurepipelines/azure-pipelines.yml
@@ -77,6 +77,10 @@ jobs:
       #   Build.Name:   "cmlv"
       #   Build.Arch:   "-a x64"
       #   Build.Target: ""
+      # TGL_X86_DEBUG:
+      #   Build.Name:   "tgl"
+      #   Build.Arch:   ""
+      #   Build.Target: ""
 
   pool:
     vmImage: 'ubuntu-latest'
@@ -136,6 +140,14 @@ jobs:
         Build.Target: "-r"
       CMLV_X64_DEBUG:
         Build.Name:   "cmlv"
+        Build.Arch:   "-a x64"
+        Build.Target: ""
+      TGL_X86_RELEASE:
+        Build.Name:   "tgl"
+        Build.Arch:   ""
+        Build.Target: "-r"
+      TGL_X64_DEBUG:
+        Build.Name:   "tgl"
         Build.Arch:   "-a x64"
         Build.Target: ""
 

--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -15,7 +15,7 @@ import time
 
 sys.dont_write_bytecode = True
 sys.path.append (os.path.join('..', '..'))
-from BuildLoader import BaseBoard, STITCH_OPS, FLASH_REGION_TYPE
+from BuildLoader import BaseBoard, STITCH_OPS, FLASH_REGION_TYPE, HASH_USAGE
 from BuildLoader import IPP_CRYPTO_OPTIMIZATION_MASK, IPP_CRYPTO_ALG_MASK, HASH_TYPE_VALUE
 
 class Board(BaseBoard):


### PR DESCRIPTION
This patch enabled auto build for TGL Azure Pipelines.
Only Windows build is enabled. GCC build has IASL issue.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>