### PR TITLE
Enable Azure Pipelines with Ubuntu-20.04

### DIFF
--- a/.azurepipelines/azure-pipelines.yml
+++ b/.azurepipelines/azure-pipelines.yml
@@ -18,12 +18,12 @@ jobs:
 - job: QEMU
 
   pool:
-    vmImage: 'ubuntu-latest'
+    vmImage: 'ubuntu-20.04'
 
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.6.x'
+      versionSpec: '3.8.x'
       architecture: 'x64'
     displayName: Set Python version
 
@@ -40,7 +40,7 @@ jobs:
     condition: eq(variables['Build.Reason'], 'PullRequest')
 
   - bash: |
-      sudo apt-get install -y nasm uuid-dev iasl qemu
+      sudo apt-get install -y nasm uuid-dev iasl qemu-system-x86
     displayName: Install required tools
 
   - script: |
@@ -65,25 +65,25 @@ jobs:
         Build.Name:   "apl"
         Build.Arch:   "-a x64"
         Build.Target: ""
-      # CFL_X64_RELEASE:
-      #   Build.Name:   "cfl"
-      #   Build.Arch:   "-a x64"
-      #   Build.Target: "-r"
-      # CML_X86_DEBUG:
-      #   Build.Name:   "cml"
-      #   Build.Arch:   ""
-      #   Build.Target: ""
-      # CMLV_X64_DEBUG:
-      #   Build.Name:   "cmlv"
-      #   Build.Arch:   "-a x64"
-      #   Build.Target: ""
-      # TGL_X86_DEBUG:
-      #   Build.Name:   "tgl"
-      #   Build.Arch:   ""
-      #   Build.Target: ""
+      CFL_X64_RELEASE:
+        Build.Name:   "cfl"
+        Build.Arch:   "-a x64"
+        Build.Target: "-r"
+      CML_X86_DEBUG:
+        Build.Name:   "cml"
+        Build.Arch:   ""
+        Build.Target: ""
+      CMLV_X64_DEBUG:
+        Build.Name:   "cmlv"
+        Build.Arch:   "-a x64"
+        Build.Target: ""
+      TGL_X86_DEBUG:
+        Build.Name:   "tgl"
+        Build.Arch:   ""
+        Build.Target: ""
 
   pool:
-    vmImage: 'ubuntu-latest'
+    vmImage: 'ubuntu-20.04'
 
   steps:
   - task: UsePythonVersion@0
@@ -97,8 +97,8 @@ jobs:
       git config --global user.name  "Your Name"
       sudo apt-get update
       sudo apt-get install -y nasm uuid-dev
-      wget --no-check-certificate http://archive.ubuntu.com/ubuntu/pool/universe/a/acpica-unix/acpica-tools_20180105-1_amd64.deb -P ~/asl/
-      sudo dpkg -i ~/asl/acpica-tools_20180105-1_amd64.deb
+      wget --no-check-certificate http://archive.ubuntu.com/ubuntu/pool/universe/a/acpica-unix/acpica-tools_20200925-1_amd64.deb -P ~/asl/
+      sudo dpkg -i ~/asl/acpica-tools_20200925-1_amd64.deb
     displayName: Install required tools
 
   - script: |


### PR DESCRIPTION
This patch moves the Linux build environment into latest Ubuntu
20.04 and updated to use latest ACPICA. All GCC build now is
enabled.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>