### PR TITLE
Change PCI resource PCD to patchable type

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -87,8 +87,6 @@
   gPlatformModuleTokenSpaceGuid.PcdVariableRegionBase     | 0x00000000 | UINT32 | 0x2000008E
   gPlatformModuleTokenSpaceGuid.PcdVariableRegionSize     | 0x00000000 | UINT32 | 0x2000008F
 
-  gPlatformModuleTokenSpaceGuid.PcdPciResourceIoBase      | 0x00000000 | UINT32 | 0x200000A0
-  gPlatformModuleTokenSpaceGuid.PcdPciResourceMem32Base   | 0x00000000 | UINT32 | 0x200000A1
   gPlatformModuleTokenSpaceGuid.PcdMemoryMapEntryNumber   | 0x00000020 | UINT32 | 0x200000A2
   gPlatformModuleTokenSpaceGuid.PcdOsBootOptionNumber     | 0x00000008 | UINT32 | 0x200000A3
   gPlatformModuleTokenSpaceGuid.PcdServiceNumber          | 0x00000004 | UINT32 | 0x200000A4
@@ -117,7 +115,6 @@
   # self._PCI_ENUM_BUS_SCAN_TYPE    = 1
   # self._PCI_ENUM_BUS_SCAN_ITEMS   = '0,0xff'
   gPlatformModuleTokenSpaceGuid.PcdPciEnumPolicyInfo      | {0x00}     | VOID*  | 0x200000A5
-  gPlatformModuleTokenSpaceGuid.PcdPciResourceMem64Base   | 0x0000000000000000  | UINT64     | 0x200000A6
 
   gPlatformModuleTokenSpaceGuid.PcdLoaderHobStackSize     | 0x00040000 | UINT32 | 0x200000B0
   gPlatformModuleTokenSpaceGuid.PcdEarlyLogBufferSize     | 0x00000400 | UINT32 | 0x200000B1
@@ -180,7 +177,11 @@
   gPlatformModuleTokenSpaceGuid.PcdFuncCpuInitHook        | 0x00000000 | UINT32 | 0x2000019A
   gPlatformModuleTokenSpaceGuid.PcdFspsUpdPtr             | 0x00000000 | UINT32 | 0x2000019B
 
-  gPlatformModuleTokenSpaceGuid.PcdPciResAllocTableBase   | 0x00000000 | UINT32 | 0x2000019C
+  gPlatformModuleTokenSpaceGuid.PcdPciResAllocTableBase   | 0x00000000 | UINT32 | 0x200001A0
+  gPlatformModuleTokenSpaceGuid.PcdPciResourceIoBase      | 0x00000000 | UINT32 | 0x200001A1
+  gPlatformModuleTokenSpaceGuid.PcdPciResourceMem32Base   | 0x00000000 | UINT32 | 0x200001A2
+  gPlatformModuleTokenSpaceGuid.PcdPciResourceMem64Base   | 0x0000000000000000  | UINT64     | 0x200001A3
+
 
 [PcdsFeatureFlag]
   # Determine if the Intel GFX device should be enabled or not in system

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -153,10 +153,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdDebugPortNumber      | $(DEBUG_PORT_NUMBER)
 
   gPlatformModuleTokenSpaceGuid.PcdPciMmcfgBase           | $(PCI_EXPRESS_BASE)
-  gPlatformModuleTokenSpaceGuid.PcdPciResourceIoBase      | $(PCI_IO_BASE)
-  gPlatformModuleTokenSpaceGuid.PcdPciResourceMem32Base   | $(PCI_MEM32_BASE)
   gPlatformModuleTokenSpaceGuid.PcdPciEnumPolicyInfo      | $(PCI_ENUM_POLICY_INFO)
-  gPlatformModuleTokenSpaceGuid.PcdPciResourceMem64Base   | $(PCI_MEM64_BASE)
 
   gPlatformModuleTokenSpaceGuid.PcdLoaderReservedMemSize  | $(LOADER_RSVD_MEM_SIZE)
   gPlatformModuleTokenSpaceGuid.PcdLoaderAcpiNvsSize      | $(LOADER_ACPI_NVS_MEM_SIZE)
@@ -291,6 +288,10 @@
   gPlatformCommonLibTokenSpaceGuid.PcdSerialBaudRate       | 0
   gPlatformCommonLibTokenSpaceGuid.PcdSerialRegisterStride | 0
   gPlatformCommonLibTokenSpaceGuid.PcdSerialClockRate      | 0
+
+  gPlatformModuleTokenSpaceGuid.PcdPciResourceIoBase      | $(PCI_IO_BASE)
+  gPlatformModuleTokenSpaceGuid.PcdPciResourceMem32Base   | $(PCI_MEM32_BASE)
+  gPlatformModuleTokenSpaceGuid.PcdPciResourceMem64Base   | $(PCI_MEM64_BASE)
 
 [PcdsFeatureFlag]
   gPlatformCommonLibTokenSpaceGuid.PcdMinDecompression    | FALSE

--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
@@ -26,17 +26,16 @@ STATIC PCI_RES_ALLOC_TABLE  *mResAllocTablePtr;
 //
 // Default PCI Resource Allocation Range
 //
-STATIC CONST PCI_RES_ALLOC_RANGE mDefaultResRange = {
+STATIC PCI_RES_ALLOC_RANGE mDefaultResRange = {
   .BusBase      = 0,
   .BusLimit     = 0xFF,
   .Reserved     = 0,
-  .IoBase       = FixedPcdGet32 (PcdPciResourceIoBase),
+  .IoBase       = 0x1000,
   .IoLimit      = 0xFFFF,
-  .Mmio32Base   = FixedPcdGet32 (PcdPciResourceMem32Base),
+  .Mmio32Base   = 0x80000000,
   .Mmio32Limit  = 0xFFFFFFFF,
-  .Mmio64Base   = FixedPcdGet64 (PcdPciResourceMem64Base),
-  .Mmio64Limit  = FixedPcdGet64 (PcdPciResourceMem64Base) +
-                  (FixedPcdGet64 (PcdPciResourceMem64Base) >> 1)
+  .Mmio64Base   = 0x400000000ULL,
+  .Mmio64Limit  = 0xFFFFFFFFFULL
 };
 
 /**
@@ -1763,6 +1762,12 @@ PciEnumeration (
   EFI_STATUS                  Status;
 
   SetAllocationPool (MemPool);
+
+  // Update PCI default resource ranges
+  mDefaultResRange.IoBase       = PcdGet32 (PcdPciResourceIoBase);
+  mDefaultResRange.Mmio32Base   = PcdGet32 (PcdPciResourceMem32Base);
+  mDefaultResRange.Mmio64Base   = PcdGet64 (PcdPciResourceMem64Base);
+  mDefaultResRange.Mmio64Limit  = PcdGet64 (PcdPciResourceMem64Base) + (PcdGet64 (PcdPciResourceMem64Base) >> 1);
 
   EnumPolicy = (PCI_ENUM_POLICY_INFO *)PcdGetPtr (PcdPciEnumPolicyInfo);
   RootBridgeCount = 0;


### PR DESCRIPTION
Current PCI resource PCD bases are defined as fixed type. It
makes it impossible to dynamically adjust the base at runtime.
This patch changed it to be module patchable so that platform
can update when required.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>