### PR TITLE
Fix failure during csme firmware update

### DIFF
--- a/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
+++ b/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
@@ -495,6 +495,38 @@ UpdateCsme (
   );
 
 /**
+  Reads a range of PCI configuration registers into a caller supplied buffer.
+
+  Reads the range of PCI configuration registers specified by StartAddress and
+  Size into the buffer specified by Buffer. This function only allows the PCI
+  configuration registers from a single PCI function to be read. Size is
+  returned. When possible 32-bit PCI configuration read cycles are used to read
+  from StartAddress to StartAddress + Size. Due to alignment restrictions, 8-bit
+  and 16-bit PCI configuration read cycles may be used at the beginning and the
+  end of the range.
+
+  If StartAddress > 0x0FFFFFFF, then ASSERT().
+  If ((StartAddress & 0xFFF) + Size) > 0x1000, then ASSERT().
+  If Size > 0 and Buffer is NULL, then ASSERT().
+
+  @param  StartAddress  The starting address that encodes the PCI Bus, Device,
+                        Function and Register.
+  @param  Size          The size in bytes of the transfer.
+  @param  Buffer        The pointer to a buffer receiving the data read.
+
+  @return EFI_SUCCESS        if data is read into buffer
+  @return EFI_NOT_FOUND      if data is NOT read into buffer
+  @return EFI_INVALID_PARAMETER  Invalid parameter
+**/
+EFI_STATUS
+EFIAPI
+CsmePciReadBuffer (
+  IN      UINTN     StartAddress,
+  IN      UINTN     Size,
+  OUT     VOID      *Buffer
+  );
+
+/**
   Platform hook point to clear firmware update trigger.
 
   This function is responsible for clearing firmware update trigger.

--- a/PayloadPkg/FirmwareUpdate/CsmeFwUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/CsmeFwUpdate.c
@@ -8,6 +8,7 @@
 #include <Base.h>
 #include <PiPei.h>
 #include <Uefi/UefiBaseType.h>
+#include <Library/PciLib.h>
 #include <Library/DebugLib.h>
 #include <Library/TimerLib.h>
 #include <Library/BaseMemoryLib.h>
@@ -77,6 +78,77 @@ DisplaySendStatus (
   );
 
 /**
+  Reads a range of PCI configuration registers into a caller supplied buffer.
+
+  Reads the range of PCI configuration registers specified by StartAddress and
+  Size into the buffer specified by Buffer. This function only allows the PCI
+  configuration registers from a single PCI function to be read. Size is
+  returned. When possible 32-bit PCI configuration read cycles are used to read
+  from StartAddress to StartAddress + Size. Due to alignment restrictions, 8-bit
+  and 16-bit PCI configuration read cycles may be used at the beginning and the
+  end of the range.
+
+  If StartAddress > 0x0FFFFFFF, then ASSERT().
+  If ((StartAddress & 0xFFF) + Size) > 0x1000, then ASSERT().
+  If Size > 0 and Buffer is NULL, then ASSERT().
+
+  @param  StartAddress  The starting address that encodes the PCI Bus, Device,
+                        Function and Register.
+  @param  Size          The size in bytes of the transfer.
+  @param  Buffer        The pointer to a buffer receiving the data read.
+
+  @return EFI_SUCCESS        if data is read into buffer
+  @return EFI_NOT_FOUND      if data is NOT read into buffer
+  @return EFI_INVALID_PARAMETER  Invalid parameter
+**/
+EFI_STATUS
+EFIAPI
+CsmePciReadBuffer (
+  IN      UINTN     StartAddress,
+  IN      UINTN     Size,
+  OUT     VOID      *Buffer
+  )
+{
+  UINT8   Bus;
+  UINT8   Device;
+  UINT8   Function;
+  UINT8   Register;
+  UINTN   ReadCount;
+
+  if ((Buffer == NULL) || (Size == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // A valid PCI address should contain 1's only in the low 28 bits.
+  //
+  if (((StartAddress) & (~0xfffffff)) != 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (((StartAddress & 0xFFF) + Size) > 0x1000) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Bus = (UINT8)((StartAddress >> 24) & 0xFF);
+  Device = (UINT8)((StartAddress >> 16) & 0xFF);
+  Function = (UINT8)((StartAddress >> 8) & 0xFF);
+  Register = (UINT8)(StartAddress & 0xFF);
+
+  ReadCount = PciReadBuffer (
+                PCI_LIB_ADDRESS(Bus, Device, Function, Register),
+                Size * sizeof(UINT32),
+                Buffer
+                );
+
+  if (ReadCount != 0) {
+    return EFI_SUCCESS;
+  }
+
+  return EFI_NOT_FOUND;
+}
+
+/**
   Check if the update image has the same version as the flash image.
 
   @param[in]  buffer         Buffer of Update Image.
@@ -112,12 +184,26 @@ IsUpdateToSameVersion(
 
   *IsSameVersion = FALSE;
 
-  Status = UpdateApi->FwuPartitionVersionFromFlash(FPT_PARTITION_NAME_FTPR, &flashMajor, &flashMinor, &flashHotfix, &flashBuild);
+  Status = UpdateApi->FwuPartitionVersionFromFlash(
+                        FPT_PARTITION_NAME_FTPR,
+                        &flashMajor,
+                        &flashMinor,
+                        &flashHotfix,
+                        &flashBuild
+                        );
   if (Status != SUCCESS) {
     return Status;
   }
 
-  Status = UpdateApi->FwuPartitionVersionFromBuffer(Buffer, BufferLength, FPT_PARTITION_NAME_FTPR, &bufferMajor, &bufferMinor, &bufferHotfix, &bufferBuild);
+  Status = UpdateApi->FwuPartitionVersionFromBuffer(
+                        Buffer,
+                        BufferLength,
+                        FPT_PARTITION_NAME_FTPR,
+                        &bufferMajor,
+                        &bufferMinor,
+                        &bufferHotfix,
+                        &bufferBuild
+                        );
   if (Status != SUCCESS) {
     return Status;
   }
@@ -227,7 +313,12 @@ StartCsmeUpdate (
   //
   // For full update, check if update to the same version
   //
-  UpdateStatus = IsUpdateToSameVersion(Buffer, (UINT32)BufferLength, UpdateApi, &IsSameVersion);
+  UpdateStatus = IsUpdateToSameVersion(
+                  Buffer,
+                  (UINT32)BufferLength,
+                  UpdateApi,
+                  &IsSameVersion
+                  );
   if (UpdateStatus != SUCCESS) {
     goto End;
   }

--- a/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -12,7 +12,6 @@
 #include <Uefi/UefiBaseType.h>
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
-#include <Library/PciLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/TimerLib.h>
@@ -146,7 +145,7 @@ InitCsmeUpdInputData (
     CsmeUpdDriverInput->SetMem           = (VOID *)((UINTN)SetMem);
     CsmeUpdDriverInput->CompareMem       = (VOID *)((UINTN)CompareMem);
     CsmeUpdDriverInput->Stall            = (VOID *)((UINTN)MicroSecondDelay);
-    CsmeUpdDriverInput->PciRead          = (VOID *)((UINTN)PciReadBuffer);
+    CsmeUpdDriverInput->PciRead          = (VOID *)((UINTN)CsmePciReadBuffer);
     if (HeciService != NULL) {
       CsmeUpdDriverInput->HeciReadMessage  = (VOID *)((UINTN)HeciService->HeciReceive);
       CsmeUpdDriverInput->HeciSendMessage  = (VOID *)((UINTN)HeciService->HeciSend);

--- a/Silicon/CometlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/CometlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -12,7 +12,6 @@
 #include <Uefi/UefiBaseType.h>
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
-#include <Library/PciLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/TimerLib.h>
@@ -144,7 +143,7 @@ InitCsmeUpdInputData (
   CsmeUpdDriverInput->SetMem           = (VOID *)((UINTN)SetMem);
   CsmeUpdDriverInput->CompareMem       = (VOID *)((UINTN)CompareMem);
   CsmeUpdDriverInput->Stall            = (VOID *)((UINTN)MicroSecondDelay);
-  CsmeUpdDriverInput->PciRead          = (VOID *)((UINTN)PciReadBuffer);
+  CsmeUpdDriverInput->PciRead          = (VOID *)((UINTN)CsmePciReadBuffer);
   CsmeUpdDriverInput->HeciReadMessage  = (VOID *)((UINTN)HeciReceive);
   CsmeUpdDriverInput->HeciSendMessage  = (VOID *)((UINTN)HeciSend);
   CsmeUpdDriverInput->HeciReset        = (VOID *)((UINTN)ResetHeciInterface);

--- a/Silicon/CometlakevPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/CometlakevPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -12,7 +12,6 @@
 #include <Uefi/UefiBaseType.h>
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
-#include <Library/PciLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/TimerLib.h>
@@ -144,7 +143,7 @@ InitCsmeUpdInputData (
   CsmeUpdDriverInput->SetMem           = (VOID *)((UINTN)SetMem);
   CsmeUpdDriverInput->CompareMem       = (VOID *)((UINTN)CompareMem);
   CsmeUpdDriverInput->Stall            = (VOID *)((UINTN)MicroSecondDelay);
-  CsmeUpdDriverInput->PciRead          = (VOID *)((UINTN)PciReadBuffer);
+  CsmeUpdDriverInput->PciRead          = (VOID *)((UINTN)CsmePciReadBuffer);
   CsmeUpdDriverInput->HeciReadMessage  = (VOID *)((UINTN)HeciReceive);
   CsmeUpdDriverInput->HeciSendMessage  = (VOID *)((UINTN)HeciSend);
   CsmeUpdDriverInput->HeciReset        = (VOID *)((UINTN)ResetHeciInterface);

--- a/Silicon/ElkhartlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/ElkhartlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -12,7 +12,6 @@
 #include <Uefi/UefiBaseType.h>
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
-#include <Library/PciLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/TimerLib.h>
@@ -143,7 +142,7 @@ InitCsmeUpdInputData (
     CsmeUpdDriverInput->SetMem           = (VOID *)((UINTN)SetMem);
     CsmeUpdDriverInput->CompareMem       = (VOID *)((UINTN)CompareMem);
     CsmeUpdDriverInput->Stall            = (VOID *)((UINTN)MicroSecondDelay);
-    CsmeUpdDriverInput->PciRead          = (VOID *)((UINTN)PciReadBuffer);
+    CsmeUpdDriverInput->PciRead          = (VOID *)((UINTN)CsmePciReadBuffer);
     CsmeUpdDriverInput->HeciReadMessage  = (VOID *)((UINTN)HeciReceive);
     CsmeUpdDriverInput->HeciSendMessage  = (VOID *)((UINTN)HeciSend);
     CsmeUpdDriverInput->HeciReset        = (VOID *)((UINTN)ResetHeciInterface);

--- a/Silicon/TigerlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/TigerlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -12,7 +12,6 @@
 #include <Uefi/UefiBaseType.h>
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
-#include <Library/PciLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/TimerLib.h>
@@ -145,7 +144,7 @@ InitCsmeUpdInputData (
     CsmeUpdDriverInput->SetMem           = (VOID *)((UINTN)SetMem);
     CsmeUpdDriverInput->CompareMem       = (VOID *)((UINTN)CompareMem);
     CsmeUpdDriverInput->Stall            = (VOID *)((UINTN)MicroSecondDelay);
-    CsmeUpdDriverInput->PciRead          = (VOID *)((UINTN)PciReadBuffer);
+    CsmeUpdDriverInput->PciRead          = (VOID *)((UINTN)CsmePciReadBuffer);
     CsmeUpdDriverInput->HeciReadMessage  = (VOID *)((UINTN)HeciReceive);
     CsmeUpdDriverInput->HeciSendMessage  = (VOID *)((UINTN)HeciSend);
     CsmeUpdDriverInput->HeciReset        = (VOID *)((UINTN)ResetHeciInterface);


### PR DESCRIPTION
This patch fixed a failure occured during CSME firmware
update. CSME firmware update library expects PCI read buffer
with a specific format, there is mismatch with input and output
parameter with the current code. Added a wrapper function
with the expected format to fix the failure.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>