### PR TITLE
Add FSP HOB print function

### DIFF
--- a/BootloaderCorePkg/Include/Library/FspSupportLib.h
+++ b/BootloaderCorePkg/Include/Library/FspSupportLib.h
@@ -62,4 +62,16 @@ TraverseMemoryResourceHob (
   IN  VOID                  *Param
   );
 
+/**
+  Dump FSP memory resource
+
+  @param  HobListPtr         A HOB list pointer.
+
+**/
+VOID
+EFIAPI
+DumpFspResourceHob (
+  IN  CONST VOID            *HobListPtr
+  );
+
 #endif

--- a/BootloaderCorePkg/Library/FspSupportLib/FspSupportLib.c
+++ b/BootloaderCorePkg/Library/FspSupportLib/FspSupportLib.c
@@ -114,3 +114,38 @@ TraverseMemoryResourceHob (
     Hob.Raw = GET_NEXT_HOB (Hob);
   }
 }
+
+/**
+  Dump FSP memory resource
+
+  @param  HobListPtr         A HOB list pointer.
+
+**/
+VOID
+EFIAPI
+DumpFspResourceHob (
+  IN  CONST VOID            *HobListPtr
+  )
+{
+  EFI_PEI_HOB_POINTERS    Hob;
+
+  // Get the HOB list for processing
+  Hob.Raw = (VOID *)HobListPtr;
+
+  DEBUG ((DEBUG_INFO, "    FSP Resource HOB Range        Type       Owner\n"));
+  DEBUG ((DEBUG_INFO, "================================= ==== ====================================\n"));
+
+  // Collect memory ranges
+  while (!END_OF_HOB_LIST (Hob)) {
+    if (Hob.Header->HobType == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+      DEBUG ((DEBUG_INFO, "%016lx-%016lx  %02x  %g\n",
+              Hob.ResourceDescriptor->PhysicalStart,
+              Hob.ResourceDescriptor->PhysicalStart + Hob.ResourceDescriptor->ResourceLength,
+              Hob.ResourceDescriptor->ResourceType,
+              &(Hob.ResourceDescriptor->Owner)
+              ));
+    }
+    Hob.Raw = GET_NEXT_HOB (Hob);
+  }
+  DEBUG ((DEBUG_INFO, "\n"));
+}

--- a/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -21,6 +21,7 @@
 #include <Library/ConfigDataLib.h>
 #include <Library/SpiFlashLib.h>
 #include <Library/VariableLib.h>
+#include <Library/FspSupportLib.h>
 #include <Library/BootloaderCoreLib.h>
 #include <Library/BoardSupportLib.h>
 #include <FspmUpd.h>
@@ -184,8 +185,9 @@ BoardInit (
   IN  BOARD_INIT_PHASE  InitPhase
 )
 {
-  EFI_STATUS            Status;
+  EFI_STATUS             Status;
   PLT_DEVICE_TABLE      *PltDeviceTable;
+  VOID                  *FspHob;
 
   switch (InitPhase) {
   case PreConfigInit:
@@ -205,8 +207,15 @@ BoardInit (
   case PostConfigInit:
     PlatformNameInit ();
     break;
-  case PreMemoryInit:
+
   case PostMemoryInit:
+    FspHob = GetFspHobListPtr ();
+    if (FspHob != NULL) {
+      DumpFspResourceHob (FspHob);
+    }
+    break;
+
+  case PreMemoryInit:
   case PreTempRamExit:
   case PostTempRamExit:
     break;


### PR DESCRIPTION
This patch will display FSP HOBs. It will help the debug when FSP
produce incomplete HOBs.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>