### PR TITLE
Add splash support post PCI enumeration

### DIFF
--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -367,6 +367,7 @@ SecStartup (
   S3_DATA                        *S3Data;
   PLATFORM_SERVICE               *PlatformService;
   VOID                           *SmbiosEntry;
+  BOOLEAN                         SplashPostPci;
 
   // Initialize HOB
   LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer();
@@ -434,9 +435,13 @@ SecStartup (
   BuildBaseInfoHob (Stage2Param);
 
   // Display splash
+  SplashPostPci = FALSE;
   if (FixedPcdGetBool (PcdSplashEnabled)) {
-    DisplaySplash ();
+    Status = DisplaySplash ();
     AddMeasurePoint (0x3050);
+    if (Status == EFI_NOT_FOUND) {
+      SplashPostPci = TRUE;
+    }
   }
 
   // MP Init phase 1
@@ -476,8 +481,13 @@ SecStartup (
         AddMeasurePoint (0x30C0);
       }
     }
-
     ASSERT_EFI_ERROR (Status);
+
+    if (FixedPcdGetBool (PcdSplashEnabled)) {
+      if (SplashPostPci) {
+        DisplaySplash ();
+      }
+    }
   }
 
   // ACPI Initialization

--- a/BootloaderCorePkg/Stage2/Stage2.h
+++ b/BootloaderCorePkg/Stage2/Stage2.h
@@ -98,7 +98,7 @@ BuildExtraInfoHob (
   Display graphical splash screen
 
   @retval EFI_SUCCESS     Splash screen was successfully displayed
-  @retval EFI_UNSUPPORTED Frame buffer access not supported
+  @retval EFI_NOT_FOUND   Frame buffer hob not found
   @retval EFI_UNSUPPORTED BmpImage is not a valid *.BMP image
 
 **/

--- a/BootloaderCorePkg/Stage2/Stage2Support.c
+++ b/BootloaderCorePkg/Stage2/Stage2Support.c
@@ -72,7 +72,7 @@ BoardNotifyPhase (
   Display graphical splash screen
 
   @retval EFI_SUCCESS     Splash screen was successfully displayed
-  @retval EFI_UNSUPPORTED Frame buffer access not supported
+  @retval EFI_NOT_FOUND   Frame buffer hob not found
   @retval EFI_UNSUPPORTED BmpImage is not a valid *.BMP image
 
 **/
@@ -89,7 +89,7 @@ DisplaySplash (
   // Get framebuffer info
   GfxInfoHob = (EFI_PEI_GRAPHICS_INFO_HOB *)GetGuidHobData (NULL, NULL, &gEfiGraphicsInfoHobGuid);
   if (GfxInfoHob == NULL) {
-    return EFI_UNSUPPORTED;
+    return EFI_NOT_FOUND;
   }
 
   // Convert image from BMP format and write to frame buffer


### PR DESCRIPTION
In some cases FSP does not support GFX and does not produce
GFX hob. But platform will be able to initialize its GFX after
PCI enumeration. This patch allows splash to be displayed post
PCI if the splash has not been displayed yet.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>