### PR TITLE
[PCI] Add an option to allocate PCI PMEM resource first

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -100,8 +100,13 @@
   # } PCI_RES_DOWNGRADE;
   #
   # typedef struct {
+  #   UINT16            AllocPmemFirst  : 1;  // default:0 (Mem32->Pmem32->Mem64->Pmem64), 1 (Pmem64->Mem64->Pmem32->Mem32)
+  #   UINT16            Reserved        : 15; // 0 initialized
+  # } PCI_ENUM_FLAG;
+  #
+  # typedef struct {
   #   PCI_RES_DOWNGRADE Downgrade;
-  #   UINT16            Reserved;
+  #   PCI_ENUM_FLAG     Flag;
   #   UINT8             BusScanType;    // default:0 (0: list, 1: range)
   #   UINT8             NumOfBus;       // the number of BusScanItems
   #   UINT8             BusScanItems[0];
@@ -112,6 +117,7 @@
   # self._PCI_ENUM_DOWNGRADE_MEM64  = 0
   # self._PCI_ENUM_DOWNGRADE_PMEM64 = 0
   # self._PCI_ENUM_DOWNGRADE_BUS0   = 0
+  # self._PCI_ENUM_FLAG_ALLOC_PMEM_FIRST = 1
   # self._PCI_ENUM_BUS_SCAN_TYPE    = 1
   # self._PCI_ENUM_BUS_SCAN_ITEMS   = '0,0xff'
   gPlatformModuleTokenSpaceGuid.PcdPciEnumPolicyInfo      | {0x00}     | VOID*  | 0x200000A5

--- a/BootloaderCorePkg/Library/PciEnumerationLib/InternalPciEnumerationLib.h
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/InternalPciEnumerationLib.h
@@ -69,8 +69,13 @@ typedef struct {
 } PCI_RES_DOWNGRADE;
 
 typedef struct {
+  UINT16            AllocPmemFirst  : 1;
+  UINT16            Reserved        : 15;
+} PCI_ENUM_FLAG;
+
+typedef struct {
   PCI_RES_DOWNGRADE Downgrade;
-  UINT16            Reserved;
+  PCI_ENUM_FLAG     Flag;
   UINT8             BusScanType;
   UINT8             NumOfBus;
   UINT8             BusScanItems[0];

--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
@@ -1479,6 +1479,9 @@ PciProgramResources (
   CONST PCI_RES_ALLOC_RANGE *ResRange;
   UINT64                     Address;
   PCI_BAR_TYPE               BarType;
+  PCI_BAR_TYPE               BarTypeStart;
+  PCI_BAR_TYPE               BarTypeEnd;
+  INT8                       BarTypeStep;
   UINT64                     ResBase[3];
   UINT64                     ResLimit[3];
   UINT8                      Index;
@@ -1495,7 +1498,17 @@ PciProgramResources (
     ResBase[2]  = ResRange->Mmio64Base;
     ResLimit[2] = ResRange->Mmio64Limit;
 
-    for (BarType = PciBarTypeIo16; BarType <= PciBarTypePMem64; BarType++) {
+    if (EnumPolicy->Flag.AllocPmemFirst != 0) {
+      BarTypeStart = PciBarTypePMem64;
+      BarTypeEnd   = PciBarTypeIo16 - 1;
+      BarTypeStep  = -1;
+    } else {
+      BarTypeStart = PciBarTypeIo16;
+      BarTypeEnd   = PciBarTypePMem64 + 1;
+      BarTypeStep  = 1;
+    }
+
+    for (BarType = BarTypeStart; BarType != BarTypeEnd; BarType += BarTypeStep) {
       if (((BarType == PciBarTypeIo32) && (EnumPolicy->Downgrade.Io32 != 0)) ||
           ((BarType == PciBarTypeMem64) && (EnumPolicy->Downgrade.Mem64 != 0)) ||
           ((BarType == PciBarTypePMem64) && (EnumPolicy->Downgrade.PMem64 != 0))) {

--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -184,7 +184,8 @@ class PciEnumPolicyInfo(Structure):
         ('DowngradePMem64',         c_uint16, 1),
         ('DowngradeBus0',           c_uint16, 1),
         ('DowngradeReserved',       c_uint16, 12),
-        ('Reserved',                c_uint16),
+        ('FlagAllocPmemFirst',      c_uint16, 1),
+        ('FlagReserved',            c_uint16, 15),
         ('BusScanType',             c_uint8), # 0: list, 1: range
         ('NumOfBus',                c_uint8),
         ('BusScanItems',            ARRAY(c_uint8, 0))
@@ -196,6 +197,8 @@ class PciEnumPolicyInfo(Structure):
         self.DowngradePMem64    = 1
         self.DowngradeBus0      = 1
         self.DowngradeReserved  = 0
+        self.FlagAllocPmemFirst = 0
+        self.FlagReserved       = 0
         self.Reserved           = 0
         self.BusScanType        = 0
         self.NumOfBus           = 0
@@ -1062,6 +1065,7 @@ def gen_pci_enum_policy_info (policy_dict):
         policy_info.DowngradeMem64  = policy_dict['DOWNGRADE_MEM64']
         policy_info.DowngradePMem64 = policy_dict['DOWNGRADE_PMEM64']
         policy_info.DowngradeBus0   = policy_dict['DOWNGRADE_BUS0']
+        policy_info.FlagAllocPmemFirst  = policy_dict['FLAG_ALLOC_PMEM_FIRST']
         policy_info.BusScanType     = policy_dict['BUS_SCAN_TYPE']
         bus_scan_items              = policy_dict['BUS_SCAN_ITEMS']
 

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -903,6 +903,7 @@ class Build(object):
             'DOWNGRADE_MEM64',
             'DOWNGRADE_PMEM64',
             'DOWNGRADE_BUS0',
+            'FLAG_ALLOC_PMEM_FIRST',
             'BUS_SCAN_TYPE',
             'BUS_SCAN_ITEMS'
         ]
@@ -911,12 +912,12 @@ class Build(object):
             policy_name = '_PCI_ENUM_%s' % policy_list
             policy_value = None
             if not hasattr(self._board, policy_name):
-                if policy_list == 'BUS_SCAN_TYPE':
-                    policy_value = 0
-                elif policy_list == 'BUS_SCAN_ITEMS':
+                if policy_list == 'BUS_SCAN_ITEMS':
                     policy_value = '0'
-                else:
+                elif 'DOWNGRADE' in policy_list:
                     policy_value = 1
+                else:
+                    policy_value = 0
             else:
                 policy_value = getattr(self._board, policy_name)
             pci_enum_policy_dict[policy_list] = policy_value


### PR DESCRIPTION
This introduces an additional PCI Enumeration option.
- self._PCI_ENUM_FLAG_ALLOC_PMEM_FIRST

By deafult, the option will allocate PCI resource by ascending order
(MEM32->PMEM32->MEM64->PMEM64). If it's set to 1, by reversed order.

Signed-off-by: Aiden Park <aiden.park@intel.com>