### PR TITLE
Fix firmware update failure during sbl svn check

### DIFF
--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.c
@@ -18,7 +18,243 @@
 #include <Library/ContainerLib.h>
 #include <Library/DecompressLib.h>
 #include <Library/ConfigDataLib.h>
+#include <Library/LiteFvLib.h>
 #include "FirmwareUpdateHelper.h"
+#include <Service/SpiFlashService.h>
+
+SPI_FLASH_SERVICE   *mFwuSpiService = NULL;
+
+/**
+  This function initialized boot media.
+
+  It initializes SPI services and SPI Flash size information.
+
+**/
+VOID
+EFIAPI
+InitializeBootMedia(
+  VOID
+  )
+{
+  mFwuSpiService = (SPI_FLASH_SERVICE *)GetServiceBySignature (SPI_FLASH_SERVICE_SIGNATURE);
+  if (mFwuSpiService == NULL) {
+    return;
+  }
+
+  mFwuSpiService->SpiInit ();
+}
+
+/**
+  Get the SPI region base and size, based on the enum type
+
+  @param[in] FlashRegionType      The Flash Region type for for the base address which is listed in the Descriptor.
+  @param[out] BaseAddress         The Flash Linear Address for the Region 'n' Base
+  @param[out] RegionSize          The size for the Region 'n'
+
+  @retval EFI_SUCCESS             Read success
+  @retval EFI_INVALID_PARAMETER   Invalid region type given
+  @retval EFI_DEVICE_ERROR        The region is not used
+**/
+EFI_STATUS
+EFIAPI
+BootMediaGetRegion (
+  IN     FLASH_REGION_TYPE  FlashRegionType,
+  OUT    UINT32             *BaseAddress, OPTIONAL
+  OUT    UINT32             *RegionSize OPTIONAL
+  )
+{
+  return mFwuSpiService->SpiGetRegion (FlashRegionType, BaseAddress, RegionSize);
+}
+
+/**
+  This function reads blocks from the SPI device.
+
+  @param[in]  Address             The block address in the FlashRegionAll to read from on the SPI.
+  @param[in]  ByteCount           Size of the Buffer in bytes.
+  @param[out] Buffer              Pointer to caller-allocated buffer containing the data received during the SPI cycle.
+
+  @retval EFI_SUCCESS             Read completes successfully.
+  @retval others                  Device error, the command aborts abnormally.
+
+**/
+EFI_STATUS
+EFIAPI
+BootMediaRead (
+  IN     UINT64   Address,
+  IN     UINT32   ByteCount,
+  OUT    UINT8    *Buffer
+  )
+{
+  return mFwuSpiService->SpiRead (FlashRegionBios, (UINT32)Address, ByteCount, Buffer);
+}
+
+/**
+  This function reads blocks from the SPI device.
+
+  @param[in] FlashRegionType      The Flash Region type for flash cycle which is listed in the Descriptor.
+  @param[in]  Address             The block address in the FlashRegionAll to read from on the SPI.
+  @param[in]  ByteCount           Size of the Buffer in bytes.
+  @param[out] Buffer              Pointer to caller-allocated buffer containing the data received during the SPI cycle.
+
+  @retval EFI_SUCCESS             Read completes successfully.
+  @retval others                  Device error, the command aborts abnormally.
+
+**/
+EFI_STATUS
+EFIAPI
+BootMediaReadByType (
+  IN     FLASH_REGION_TYPE  FlashRegionType,
+  IN     UINT64             Address,
+  IN     UINT32             ByteCount,
+  OUT    UINT8              *Buffer
+  )
+{
+  return mFwuSpiService->SpiRead (FlashRegionType, (UINT32)Address, ByteCount, Buffer);
+}
+
+/**
+  This function writes blocks from the SPI device.
+
+  @param[in]   Address            The block address in the FlashRegionAll to read from on the SPI.
+  @param[in]   ByteCount          Size of the Buffer in bytes.
+  @param[out]  Buffer             Pointer to the data to write.
+
+  @retval EFI_SUCCESS             Write completes successfully.
+  @retval others                  Device error, the command aborts abnormally.
+
+**/
+EFI_STATUS
+EFIAPI
+BootMediaWrite (
+  IN     UINT64   Address,
+  IN     UINT32   ByteCount,
+  OUT    UINT8    *Buffer
+  )
+{
+  return mFwuSpiService->SpiWrite (FlashRegionBios, (UINT32)Address, ByteCount, Buffer);
+}
+
+/**
+  This function erases blocks from the SPI device.
+
+  @param[in]  Address             The block address in the FlashRegionAll to read from on the SPI.
+  @param[in]  ByteCount           Size of the region to erase in bytes.
+
+  @retval EFI_SUCCESS             Erase completes successfully.
+  @retval others                  Device error, the command aborts abnormally.
+
+**/
+EFI_STATUS
+EFIAPI
+BootMediaErase (
+  IN     UINT64   Address,
+  IN     UINT32   ByteCount
+  )
+{
+  return mFwuSpiService->SpiErase (FlashRegionBios, (UINT32)Address, ByteCount);
+}
+
+/**
+  Get SVN from existing firmware
+
+  This routine get SPI base address and read first four bytes
+  to get STAGE1A FV base address, using this base address
+  this routine can calculate the offset to the SVN structure.
+
+  @param[in]  Stage1AFvPointer    Pointer to Stage1A fv base.
+  @param[out] BlVersion           Pointer to SBL version struct.
+
+  @retval EFI_SUCCESS             Read SVN success
+  @retval EFI_INVALID_PARAMETER   Invalid parameter
+**/
+EFI_STATUS
+EFIAPI
+GetSvn (
+  IN  UINT32                Stage1AFvPointer,
+  OUT BOOT_LOADER_VERSION   **BlVersion
+  )
+{
+  UINT32                Stage1AFvBase;
+  UINT32                TopSwapRegionSize;
+  EFI_STATUS            Status;
+
+  //
+  // When updating BP1 - read version from backup partition
+  // When updatint BP0 - since top swap bit is set, we need
+  //                     to substract the top swap region size
+  //                     because when top swap bit is set
+  //                     address lines will be inverted and point
+  //                     to stage 1A from primary partition.
+  //
+  Status = GetRegionInfo (&TopSwapRegionSize, NULL, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG((DEBUG_ERROR, "Error getting top swap region size, failed with status: %r\n", Status));
+    return Status;
+  }
+  Stage1AFvPointer = Stage1AFvPointer - TopSwapRegionSize;
+
+  Stage1AFvBase = (UINT32)(*(UINT32 *)(UINTN)Stage1AFvPointer);
+  Stage1AFvBase = Stage1AFvPointer - (~Stage1AFvBase + 1) + sizeof(UINT32);
+
+  Status = GetVersionfromFv (Stage1AFvBase, FALSE, BlVersion);
+  if (EFI_ERROR (Status)) {
+    DEBUG((DEBUG_ERROR, "Getting firmware version failed with status: %r\n", Status));
+    return Status;
+  }
+
+  return Status;
+}
+
+/**
+  Verify the firmware version to make sure it is no less than current firmware version.
+
+  @param[in]  Stage1ABase   Stage 1A base address.
+  @param[in]  IsFd          Does Stage1ABase point to Stage1A FD
+                            or SBL Stage1A FV ?
+  @param[out] Version       Pointer to version of the firmware
+
+  @retval  EFI_SUCCESS        The operation completed successfully.
+  @retval  others             There is error happening.
+**/
+EFI_STATUS
+GetVersionfromFv (
+  IN  UINT32              Stage1ABase,
+  IN  BOOLEAN             IsFd,
+  OUT BOOT_LOADER_VERSION **Version
+  )
+{
+  EFI_STATUS                  Status;
+  EFI_FFS_FILE_HEADER         *FfsFile;
+  EFI_FIRMWARE_VOLUME_HEADER  *FvHeader;
+
+  FvHeader = (EFI_FIRMWARE_VOLUME_HEADER *)(UINTN)Stage1ABase;
+  //
+  // Stage 1A FD has FSPT FV first, so move on to the next FV
+  //
+  if (IsFd) {
+    FvHeader = (EFI_FIRMWARE_VOLUME_HEADER *)((UINTN)FvHeader + (UINTN)FvHeader->FvLength);
+  }
+
+  //
+  // Get version info FFS from FV
+  //
+  Status = GetFfsFileByName (FvHeader, &gBootLoaderVersionFileGuid, &FfsFile);
+  if (EFI_ERROR (Status)) {
+    DEBUG((DEBUG_ERROR, "GetFfsFileByName: %r\n", Status));
+    return Status;
+  }
+
+  //
+  // Raw section in version info FFS has version information
+  //
+  Status = GetSectionByType (FfsFile, EFI_SECTION_RAW, 0, (VOID *)Version);
+  if (EFI_ERROR (Status)) {
+    DEBUG((DEBUG_ERROR, "GetSectionByType: %r\n", Status));
+    return Status;
+  }
+
+  return EFI_SUCCESS;
+}
 
 /**
   Update a region block.

--- a/Silicon/ApollolakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/ApollolakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -36,92 +36,6 @@
 
 #define FLASH_MAP_IN_FV_OFFSET   0xA4
 
-SPI_FLASH_SERVICE   *mFwuSpiService = NULL;
-
-/**
-  This function initialized boot media.
-
-  It initializes SPI services and SPI Flash size information.
-
-**/
-VOID
-EFIAPI
-InitializeBootMedia (
-  VOID
-  )
-{
-  mFwuSpiService = (SPI_FLASH_SERVICE *)GetServiceBySignature (SPI_FLASH_SERVICE_SIGNATURE);
-  if (mFwuSpiService == NULL) {
-    return;
-  }
-
-  mFwuSpiService->SpiInit ();
-}
-
-/**
-  This function reads blocks from the SPI device.
-
-  @param[in]  Address             The block address in the FlashRegionAll to read from on the SPI.
-  @param[in]  ByteCount           Size of the Buffer in bytes.
-  @param[out] Buffer              Pointer to caller-allocated buffer containing the data received during the SPI cycle.
-
-  @retval EFI_SUCCESS             Read completes successfully.
-  @retval others                  Device error, the command aborts abnormally.
-
-**/
-EFI_STATUS
-EFIAPI
-BootMediaRead (
-  IN     UINT64                  Address,
-  IN     UINT32                  ByteCount,
-  OUT    UINT8                   *Buffer
-  )
-{
-  return mFwuSpiService->SpiRead (FlashRegionBios, (UINT32)Address, ByteCount, Buffer);
-}
-
-/**
-  This function writes blocks from the SPI device.
-
-  @param[in]   Address            The block address in the FlashRegionAll to read from on the SPI.
-  @param[in]   ByteCount          Size of the Buffer in bytes.
-  @param[out]  Buffer             Pointer to the data to write.
-
-  @retval EFI_SUCCESS             Write completes successfully.
-  @retval others                  Device error, the command aborts abnormally.
-
-**/
-EFI_STATUS
-EFIAPI
-BootMediaWrite (
-  IN     UINT64                  Address,
-  IN     UINT32                  ByteCount,
-  OUT    UINT8                   *Buffer
-  )
-{
-  return mFwuSpiService->SpiWrite (FlashRegionBios, (UINT32)Address, ByteCount, Buffer);
-}
-
-/**
-  This function erases blocks from the SPI device.
-
-  @param[in]  Address             The block address in the FlashRegionAll to read from on the SPI.
-  @param[in]  ByteCount           Size of the region to erase in bytes.
-
-  @retval EFI_SUCCESS             Erase completes successfully.
-  @retval others                  Device error, the command aborts abnormally.
-
-**/
-EFI_STATUS
-EFIAPI
-BootMediaErase (
-  IN     UINT64                  Address,
-  IN     UINT32                  ByteCount
-  )
-{
-  return mFwuSpiService->SpiErase (FlashRegionBios, (UINT32)Address, ByteCount);
-}
-
 /**
   Initializes input structure for csme update driver.
 
@@ -224,7 +138,7 @@ PlatformGetStage1AOffset (
     return EFI_INVALID_PARAMETER;
   }
 
-  Status = mFwuSpiService->SpiGetRegion (FlashRegionBios, &RgnBase, &RgnSize);
+  Status = BootMediaGetRegion (FlashRegionBios, &RgnBase, &RgnSize);
   if (EFI_ERROR (Status)) {
     return EFI_NOT_AVAILABLE_YET;
   }
@@ -310,7 +224,7 @@ GetFirmwareUpdateInfo (
 
   UpdatePartition->RegionCount   = 2;
 
-  Status = mFwuSpiService->SpiGetRegion (FlashRegionBios, &RgnBase, &RgnSize);
+  Status = BootMediaGetRegion (FlashRegionBios, &RgnBase, &RgnSize);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "GetPartitionSize Status = 0x%x\n", Status));
     return Status;

--- a/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -15,7 +15,6 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/TimerLib.h>
-#include <Service/SpiFlashService.h>
 #include <Service/HeciService.h>
 #include <Library/FirmwareUpdateLib.h>
 #include <Library/BootloaderCommonLib.h>
@@ -24,94 +23,8 @@
 #include <Library/HeciLib.h>
 #include <CsmeUpdateDriver.h>
 
-SPI_FLASH_SERVICE   *mFwuSpiService = NULL;
-
 #define FWU_BOOT_MODE_OFFSET   0x40
 #define FWU_BOOT_MODE_VALUE    0x5A
-
-/**
-  This function initialized boot media.
-
-  It initializes SPI services and SPI Flash size information.
-
-**/
-VOID
-EFIAPI
-InitializeBootMedia(
-  VOID
-  )
-{
-  mFwuSpiService = (SPI_FLASH_SERVICE *)GetServiceBySignature (SPI_FLASH_SERVICE_SIGNATURE);
-  if (mFwuSpiService == NULL) {
-    return;
-  }
-
-  mFwuSpiService->SpiInit ();
-}
-
-/**
-  This function reads blocks from the SPI device.
-
-  @param[in]  Address             The block address in the FlashRegionAll to read from on the SPI.
-  @param[in]  ByteCount           Size of the Buffer in bytes.
-  @param[out] Buffer              Pointer to caller-allocated buffer containing the data received during the SPI cycle.
-
-  @retval EFI_SUCCESS             Read completes successfully.
-  @retval others                  Device error, the command aborts abnormally.
-
-**/
-EFI_STATUS
-EFIAPI
-BootMediaRead (
-  IN     UINT64   Address,
-  IN     UINT32   ByteCount,
-  OUT    UINT8    *Buffer
-  )
-{
-  return mFwuSpiService->SpiRead (FlashRegionBios, (UINT32)Address, ByteCount, Buffer);
-}
-
-/**
-  This function writes blocks from the SPI device.
-
-  @param[in]   Address            The block address in the FlashRegionAll to read from on the SPI.
-  @param[in]   ByteCount          Size of the Buffer in bytes.
-  @param[out]  Buffer             Pointer to the data to write.
-
-  @retval EFI_SUCCESS             Write completes successfully.
-  @retval others                  Device error, the command aborts abnormally.
-
-**/
-EFI_STATUS
-EFIAPI
-BootMediaWrite (
-  IN     UINT64   Address,
-  IN     UINT32   ByteCount,
-  OUT    UINT8    *Buffer
-  )
-{
-  return mFwuSpiService->SpiWrite (FlashRegionBios, (UINT32)Address, ByteCount, Buffer);
-}
-
-/**
-  This function erases blocks from the SPI device.
-
-  @param[in]  Address             The block address in the FlashRegionAll to read from on the SPI.
-  @param[in]  ByteCount           Size of the region to erase in bytes.
-
-  @retval EFI_SUCCESS             Erase completes successfully.
-  @retval others                  Device error, the command aborts abnormally.
-
-**/
-EFI_STATUS
-EFIAPI
-BootMediaErase (
-  IN     UINT64   Address,
-  IN     UINT32   ByteCount
-  )
-{
-  return mFwuSpiService->SpiErase (FlashRegionBios, (UINT32)Address, ByteCount);
-}
 
 /**
   Initializes input structure for csme update driver.

--- a/Silicon/CometlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/CometlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -15,7 +15,6 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/TimerLib.h>
-#include <Service/SpiFlashService.h>
 #include <Library/FirmwareUpdateLib.h>
 #include <Library/BootloaderCommonLib.h>
 #include <Library/PchSbiAccessLib.h>
@@ -23,94 +22,8 @@
 #include <Library/HeciLib.h>
 #include <CsmeUpdateDriver.h>
 
-SPI_FLASH_SERVICE   *mFwuSpiService = NULL;
-
 #define FWU_BOOT_MODE_OFFSET   0x40
 #define FWU_BOOT_MODE_VALUE    0x5A
-
-/**
-  This function initialized boot media.
-
-  It initializes SPI services and SPI Flash size information.
-
-**/
-VOID
-EFIAPI
-InitializeBootMedia(
-  VOID
-  )
-{
-  mFwuSpiService = (SPI_FLASH_SERVICE *)GetServiceBySignature (SPI_FLASH_SERVICE_SIGNATURE);
-  if (mFwuSpiService == NULL) {
-    return;
-  }
-
-  mFwuSpiService->SpiInit ();
-}
-
-/**
-  This function reads blocks from the SPI device.
-
-  @param[in]  Address             The block address in the FlashRegionAll to read from on the SPI.
-  @param[in]  ByteCount           Size of the Buffer in bytes.
-  @param[out] Buffer              Pointer to caller-allocated buffer containing the data received during the SPI cycle.
-
-  @retval EFI_SUCCESS             Read completes successfully.
-  @retval others                  Device error, the command aborts abnormally.
-
-**/
-EFI_STATUS
-EFIAPI
-BootMediaRead (
-  IN     UINT64   Address,
-  IN     UINT32   ByteCount,
-  OUT    UINT8    *Buffer
-  )
-{
-  return mFwuSpiService->SpiRead (FlashRegionBios, (UINT32)Address, ByteCount, Buffer);
-}
-
-/**
-  This function writes blocks from the SPI device.
-
-  @param[in]   Address            The block address in the FlashRegionAll to read from on the SPI.
-  @param[in]   ByteCount          Size of the Buffer in bytes.
-  @param[out]  Buffer             Pointer to the data to write.
-
-  @retval EFI_SUCCESS             Write completes successfully.
-  @retval others                  Device error, the command aborts abnormally.
-
-**/
-EFI_STATUS
-EFIAPI
-BootMediaWrite (
-  IN     UINT64   Address,
-  IN     UINT32   ByteCount,
-  OUT    UINT8    *Buffer
-  )
-{
-  return mFwuSpiService->SpiWrite (FlashRegionBios, (UINT32)Address, ByteCount, Buffer);
-}
-
-/**
-  This function erases blocks from the SPI device.
-
-  @param[in]  Address             The block address in the FlashRegionAll to read from on the SPI.
-  @param[in]  ByteCount           Size of the region to erase in bytes.
-
-  @retval EFI_SUCCESS             Erase completes successfully.
-  @retval others                  Device error, the command aborts abnormally.
-
-**/
-EFI_STATUS
-EFIAPI
-BootMediaErase (
-  IN     UINT64   Address,
-  IN     UINT32   ByteCount
-  )
-{
-  return mFwuSpiService->SpiErase (FlashRegionBios, (UINT32)Address, ByteCount);
-}
 
 /**
   Initializes input structure for csme update driver.

--- a/Silicon/CometlakevPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/CometlakevPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -15,7 +15,6 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/TimerLib.h>
-#include <Service/SpiFlashService.h>
 #include <Library/FirmwareUpdateLib.h>
 #include <Library/BootloaderCommonLib.h>
 #include <Library/PchSbiAccessLib.h>
@@ -23,94 +22,8 @@
 #include <Library/HeciLib.h>
 #include <CsmeUpdateDriver.h>
 
-SPI_FLASH_SERVICE   *mFwuSpiService = NULL;
-
 #define FWU_BOOT_MODE_OFFSET   0x40
 #define FWU_BOOT_MODE_VALUE    0x5A
-
-/**
-  This function initialized boot media.
-
-  It initializes SPI services and SPI Flash size information.
-
-**/
-VOID
-EFIAPI
-InitializeBootMedia(
-  VOID
-  )
-{
-  mFwuSpiService = (SPI_FLASH_SERVICE *)GetServiceBySignature (SPI_FLASH_SERVICE_SIGNATURE);
-  if (mFwuSpiService == NULL) {
-    return;
-  }
-
-  mFwuSpiService->SpiInit ();
-}
-
-/**
-  This function reads blocks from the SPI device.
-
-  @param[in]  Address             The block address in the FlashRegionAll to read from on the SPI.
-  @param[in]  ByteCount           Size of the Buffer in bytes.
-  @param[out] Buffer              Pointer to caller-allocated buffer containing the data received during the SPI cycle.
-
-  @retval EFI_SUCCESS             Read completes successfully.
-  @retval others                  Device error, the command aborts abnormally.
-
-**/
-EFI_STATUS
-EFIAPI
-BootMediaRead (
-  IN     UINT64   Address,
-  IN     UINT32   ByteCount,
-  OUT    UINT8    *Buffer
-  )
-{
-  return mFwuSpiService->SpiRead (FlashRegionBios, (UINT32)Address, ByteCount, Buffer);
-}
-
-/**
-  This function writes blocks from the SPI device.
-
-  @param[in]   Address            The block address in the FlashRegionAll to read from on the SPI.
-  @param[in]   ByteCount          Size of the Buffer in bytes.
-  @param[out]  Buffer             Pointer to the data to write.
-
-  @retval EFI_SUCCESS             Write completes successfully.
-  @retval others                  Device error, the command aborts abnormally.
-
-**/
-EFI_STATUS
-EFIAPI
-BootMediaWrite (
-  IN     UINT64   Address,
-  IN     UINT32   ByteCount,
-  OUT    UINT8    *Buffer
-  )
-{
-  return mFwuSpiService->SpiWrite (FlashRegionBios, (UINT32)Address, ByteCount, Buffer);
-}
-
-/**
-  This function erases blocks from the SPI device.
-
-  @param[in]  Address             The block address in the FlashRegionAll to read from on the SPI.
-  @param[in]  ByteCount           Size of the region to erase in bytes.
-
-  @retval EFI_SUCCESS             Erase completes successfully.
-  @retval others                  Device error, the command aborts abnormally.
-
-**/
-EFI_STATUS
-EFIAPI
-BootMediaErase (
-  IN     UINT64   Address,
-  IN     UINT32   ByteCount
-  )
-{
-  return mFwuSpiService->SpiErase (FlashRegionBios, (UINT32)Address, ByteCount);
-}
 
 /**
   Initializes input structure for csme update driver.

--- a/Silicon/ElkhartlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/ElkhartlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -15,7 +15,6 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/TimerLib.h>
-#include <Service/SpiFlashService.h>
 #include <Library/FirmwareUpdateLib.h>
 #include <Library/BootloaderCommonLib.h>
 #include <Library/PchSbiAccessLib.h>
@@ -24,95 +23,8 @@
 #include <CsmeUpdateDriver.h>
 #include "SpiRegionAccess.h"
 
-
-SPI_FLASH_SERVICE   *mFwuSpiService = NULL;
-
 #define FWU_BOOT_MODE_OFFSET   0x40
 #define FWU_BOOT_MODE_VALUE    0x5A
-
-/**
-  This function initialized boot media.
-
-  It initializes SPI services and SPI Flash size information.
-
-**/
-VOID
-EFIAPI
-InitializeBootMedia(
-  VOID
-  )
-{
-  mFwuSpiService = (SPI_FLASH_SERVICE *)GetServiceBySignature (SPI_FLASH_SERVICE_SIGNATURE);
-  if (mFwuSpiService == NULL) {
-    return;
-  }
-
-  mFwuSpiService->SpiInit ();
-}
-
-/**
-  This function reads blocks from the SPI device.
-
-  @param[in]  Address             The block address in the FlashRegionAll to read from on the SPI.
-  @param[in]  ByteCount           Size of the Buffer in bytes.
-  @param[out] Buffer              Pointer to caller-allocated buffer containing the data received during the SPI cycle.
-
-  @retval EFI_SUCCESS             Read completes successfully.
-  @retval others                  Device error, the command aborts abnormally.
-
-**/
-EFI_STATUS
-EFIAPI
-BootMediaRead (
-  IN     UINT64   Address,
-  IN     UINT32   ByteCount,
-  OUT    UINT8    *Buffer
-  )
-{
-  return mFwuSpiService->SpiRead (FlashRegionBios, (UINT32)Address, ByteCount, Buffer);
-}
-
-/**
-  This function writes blocks from the SPI device.
-
-  @param[in]   Address            The block address in the FlashRegionAll to read from on the SPI.
-  @param[in]   ByteCount          Size of the Buffer in bytes.
-  @param[out]  Buffer             Pointer to the data to write.
-
-  @retval EFI_SUCCESS             Write completes successfully.
-  @retval others                  Device error, the command aborts abnormally.
-
-**/
-EFI_STATUS
-EFIAPI
-BootMediaWrite (
-  IN     UINT64   Address,
-  IN     UINT32   ByteCount,
-  OUT    UINT8    *Buffer
-  )
-{
-  return mFwuSpiService->SpiWrite (FlashRegionBios, (UINT32)Address, ByteCount, Buffer);
-}
-
-/**
-  This function erases blocks from the SPI device.
-
-  @param[in]  Address             The block address in the FlashRegionAll to read from on the SPI.
-  @param[in]  ByteCount           Size of the region to erase in bytes.
-
-  @retval EFI_SUCCESS             Erase completes successfully.
-  @retval others                  Device error, the command aborts abnormally.
-
-**/
-EFI_STATUS
-EFIAPI
-BootMediaErase (
-  IN     UINT64   Address,
-  IN     UINT32   ByteCount
-  )
-{
-  return mFwuSpiService->SpiErase (FlashRegionBios, (UINT32)Address, ByteCount);
-}
 
 /**
   Initializes input structure for csme update driver.
@@ -177,7 +89,6 @@ SetBootPartition (
   // Get Top swap register Bit0 in PCH Private Configuration Space.
   //
   P2sbBase   = MmPciBase (0, PCI_DEVICE_NUMBER_PCH_LPC, 1); // P2SB device base
-  DEBUG ((DEBUG_ERROR, "p2sbbase: %x\n", P2sbBase));
   P2sbIsHidden = FALSE;
 
   if (MmioRead16 (P2sbBase) == 0xFFFF) {
@@ -190,7 +101,6 @@ SetBootPartition (
   }
 
   P2sbBar    = MmioRead32 (P2sbBase + 0x10);
-  DEBUG ((DEBUG_ERROR, "P2sbBar: %x\n", P2sbBar));
   P2sbBar  &= 0xFFFFFFF0;
   ASSERT (P2sbBar != 0xFFFFFFF0);
 
@@ -504,15 +414,10 @@ SetFlashDescriptorLock (
 
   if (SpiProtectionMode == 0) {
 
-    if (mFwuSpiService == NULL) {
-      DEBUG((DEBUG_ERROR, "SPI flash service is not initialized!!"));
-      return EFI_NO_MEDIA;
-    }
-
     //
     // Read from the flash descriptor master access region
     //
-    Status = mFwuSpiService->SpiRead (FlashRegionDescriptor, (UINT32) B_FLASH_FMBA, sizeof(FlashDescMasterAccess), (UINT8 *) FlashDescMasterAccess);
+    Status = BootMediaReadByType (FlashRegionDescriptor, (UINT32) B_FLASH_FMBA, sizeof(FlashDescMasterAccess), (UINT8 *) FlashDescMasterAccess);
     if (EFI_ERROR (Status)) {
       DEBUG((DEBUG_ERROR, "SPI read failed 0x%x\n", Status));
       return Status;
@@ -543,7 +448,7 @@ SetFlashDescriptorLock (
     //
     // Write to flash descriptor master access region
     //
-    Status = mFwuSpiService->SpiWrite (FlashRegionDescriptor, (UINT32) B_FLASH_FMBA, sizeof(FlashDescMasterAccess), (UINT8 *) FlashDescMasterAccess);
+    Status = BootMediaReadByType (FlashRegionDescriptor, (UINT32) B_FLASH_FMBA, sizeof(FlashDescMasterAccess), (UINT8 *) FlashDescMasterAccess);
     if (EFI_ERROR (Status)) {
       DEBUG((DEBUG_ERROR, "SPI Lock write failed 0x%x\n", Status));
     }

--- a/Silicon/QemuSocPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/QemuSocPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -15,7 +15,6 @@
 #include <Library/HobLib.h>
 #include <Library/SpiFlashLib.h>
 #include <Library/IoLib.h>
-#include <Library/SpiFlashLib.h>
 #include <Library/PcdLib.h>
 #include <Library/BootloaderCommonLib.h>
 #include <Library/BootloaderCoreLib.h>
@@ -24,8 +23,7 @@
 #include <Library/GpioLib.h>
 #include <Library/FirmwareUpdateLib.h>
 
-SPI_FLASH_SERVICE             *mFwuSpiService = NULL;
-UINT32                         mFlashSize;
+UINT32  mFlashSize = 0;
 
 /**
   Platform code to get capsule image for firmware update.
@@ -46,101 +44,6 @@ PlatformGetCapsuleImage (
   )
 {
   return EFI_UNSUPPORTED;
-}
-
-/**
-  This function initialized boot media.
-
-  It initializes SPI services and SPI Flash size information.
-
-**/
-VOID
-EFIAPI
-InitializeBootMedia (
-  VOID
-  )
-{
-  mFwuSpiService = (SPI_FLASH_SERVICE *)GetServiceBySignature (SPI_FLASH_SERVICE_SIGNATURE);
-  if (mFwuSpiService != NULL) {
-    mFwuSpiService->SpiGetRegion (FlashRegionAll, NULL, &mFlashSize);
-  }
-  ASSERT ((mFwuSpiService != NULL) && (mFlashSize > 0));
-}
-
-/**
-  This function reads blocks from the SPI device.
-
-  @param[in]  Address             The block address in the FlashRegionAll to read from on the SPI.
-  @param[in]  ByteCount           Size of the Buffer in bytes.
-  @param[out] Buffer              Pointer to caller-allocated buffer containing the data received during the SPI cycle.
-
-  @retval EFI_SUCCESS             Read completes successfully.
-  @retval others                  Device error, the command aborts abnormally.
-
-**/
-EFI_STATUS
-EFIAPI
-BootMediaRead (
-  IN     UINT64                  Address,
-  IN     UINT32                  ByteCount,
-  OUT    UINT8                   *Buffer
-  )
-{
-  EFI_STATUS                     Status;
-
-  Status = mFwuSpiService->SpiRead (FlashRegionAll, (UINT32)Address, ByteCount, Buffer);
-
-  return Status;
-}
-
-/**
-  This function writes blocks from the SPI device.
-
-  @param[in]  Address             The block address in the FlashRegionAll to read from on the SPI.
-  @param[in]  ByteCount           Size of the Buffer in bytes.
-  @param[in]  Buffer              Pointer to the data to write.
-
-  @retval EFI_SUCCESS             Write completes successfully.
-  @retval others                  Device error, the command aborts abnormally.
-
-**/
-EFI_STATUS
-EFIAPI
-BootMediaWrite (
-  IN     UINT64                  Address,
-  IN     UINT32                  ByteCount,
-  IN     UINT8                   *Buffer
-  )
-{
-  EFI_STATUS                     Status;
-
-  Status = mFwuSpiService->SpiWrite (FlashRegionAll, (UINT32)Address, ByteCount, Buffer);
-
-  return Status;
-}
-
-/**
-  This function erases blocks from the SPI device.
-
-  @param[in]  Address             The block address in the FlashRegionAll to read from on the SPI.
-  @param[in]  ByteCount           Size of the region to erase in bytes.
-
-  @retval EFI_SUCCESS             Erase completes successfully.
-  @retval others                  Device error, the command aborts abnormally.
-
-**/
-EFI_STATUS
-EFIAPI
-BootMediaErase (
-  IN     UINT64                  Address,
-  IN     UINT32                  ByteCount
-  )
-{
-  EFI_STATUS                     Status;
-
-  Status = mFwuSpiService->SpiErase (FlashRegionAll, (UINT32)Address, ByteCount);
-
-  return Status;
 }
 
 /**
@@ -394,7 +297,15 @@ SetBootPartition (
   IN BOOT_PARTITION  Partition
   )
 {
-  UINT8                   Data;
+  UINT8       Data;
+  EFI_STATUS  Status;
+
+  if (mFlashSize == 0) {
+    Status = BootMediaGetRegion (FlashRegionAll, NULL, &mFlashSize);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  }
 
   //
   // Flip the boot partition.
@@ -440,9 +351,17 @@ PlatformEndFirmwareUpdate (
   VOID
   )
 {
-  UINT8    Data;
+  UINT8       Data;
+  EFI_STATUS  Status;
 
   DEBUG ((DEBUG_INIT, "Firmware update Done! clear FWU flag to normal boot mode.\n"));
+
+  if (mFlashSize == 0) {
+    Status = BootMediaGetRegion (FlashRegionAll, NULL, &mFlashSize);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  }
 
   //
   // This is platform specific method.


### PR DESCRIPTION
This patch fixed a failure in firmware update that
occur during SBL version check. Current code assume
that the SBL layout does not change between the existing
firmware and the capsule, when the layout change, stage1A
address change and this is causing error while obtaining
the firmware version.

Code is modified to use the last 4 bytes of the SBL region
which contain Stage1A FV address and this is used to obtain
the version information.

Signed-off-by: Raghava <raghava.gudla@intel.com>