### PR TITLE
commonSocPkg: SpiFlashLib: Permissions bit read per read/write

### DIFF
--- a/Silicon/CommonSocPkg/Library/SpiFlashLib/SpiFlashLib.c
+++ b/Silicon/CommonSocPkg/Library/SpiFlashLib/SpiFlashLib.c
@@ -627,6 +627,7 @@ SendSpiCmd (
   SpiBaseAddress = SpiInstance->PchSpiBase;
   ScSpiBar0      = AcquireSpiBar0 (SpiBaseAddress);
   BiosCtlSave    = 0;
+  SpiInstance->RegionPermission = MmioRead16 (ScSpiBar0 + R_SPI_FRAP);
 
   ///
   /// If it's write cycle, disable Prefetching, Caching and disable BIOS Write Protect


### PR DESCRIPTION
The RegionPermission doesn't usually represent the current state of
the Region. There is a need to re-read the permission bit for each
read/write. There by making the variable accurately represents the
HW status.

Signed-off-by: Adithya Baglody <adithya.nagaraj.baglody@intel.com>