### PR TITLE
[CFL] Fix CSME firmware update failure

### DIFF
--- a/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -21,6 +21,7 @@
 #include <Library/BootloaderCommonLib.h>
 #include <Library/PchSbiAccessLib.h>
 #include <Library/PchPcrLib.h>
+#include <Library/PciLib.h>
 #include <Library/HeciLib.h>
 #include <CsmeUpdateDriver.h>
 
@@ -145,7 +146,7 @@ InitCsmeUpdInputData (
     CsmeUpdDriverInput->SetMem           = (VOID *)((UINTN)SetMem);
     CsmeUpdDriverInput->CompareMem       = (VOID *)((UINTN)CompareMem);
     CsmeUpdDriverInput->Stall            = (VOID *)((UINTN)MicroSecondDelay);
-    CsmeUpdDriverInput->PciRead          = (VOID *)((UINTN)CsmePciReadBuffer);
+    CsmeUpdDriverInput->PciRead          = (VOID *)((UINTN)PciReadBuffer);
     if (HeciService != NULL) {
       CsmeUpdDriverInput->HeciReadMessage  = (VOID *)((UINTN)HeciService->HeciReceive);
       CsmeUpdDriverInput->HeciSendMessage  = (VOID *)((UINTN)HeciService->HeciSend);


### PR DESCRIPTION
during CSME firmware update process, CSME update library throw error
"Could not access PCI device".this patch fixes this issue by adding
back "PciReadBuffer".

TEST=Verified CSME FWU on CFL-H & WHL platforms.

Signed-off-by: Praveen Hp <praveen.hodagatta.pranesh@intel.com>