### PR TITLE
Delay MP init done for OsLoader payload

### DIFF
--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
@@ -293,6 +293,8 @@ MpInit (
     if (mMpInitPhase != EnumMpInitNull) {
       Status = EFI_UNSUPPORTED;
     } else {
+      DEBUG ((DEBUG_INIT, "MP Init%a\n", DebugCodeEnabled() ? " (Wakeup)" : ""));
+
       // Init structure for lock
       mMpDataStruct.SmmRebaseDoneCounter = 0;
       InitializeSpinLock (&mMpDataStruct.SpinLock);
@@ -393,6 +395,8 @@ MpInit (
     if (mMpInitPhase != EnumMpInitWakeup) {
       Status = EFI_UNSUPPORTED;
     } else {
+      DEBUG ((DEBUG_INFO, "MP Init (Run)\n"));
+
       //
       // Wait for task done
       //
@@ -442,9 +446,12 @@ MpInit (
   }
 
   if (Phase == EnumMpInitDone) {
-    if (mMpInitPhase != EnumMpInitRun) {
+    if (mMpInitPhase == EnumMpInitDone) {
+      Status = EFI_UNSUPPORTED;
+    } else if (mMpInitPhase != EnumMpInitRun) {
       Status = EFI_UNSUPPORTED;
     } else {
+      DEBUG ((DEBUG_INFO, "MP Init (Done)\n"));
       //
       // All APs should be in EnumCpuReady now
       //
@@ -465,7 +472,6 @@ MpInit (
   }
 
   return Status;
-
 }
 
 

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -227,12 +227,6 @@ NormalBootPath (
   AddMeasurePoint (0x31B0);
   ASSERT_EFI_ERROR (Status);
 
-  if (FixedPcdGetBool (PcdSmpEnabled)) {
-    DEBUG ((DEBUG_INIT, "MP Init%a\n", DebugCodeEnabled() ? " (Done)" : ""));
-    Status = MpInit (EnumMpInitDone);
-    AddMeasurePoint (0x31C0);
-  }
-
   BoardInit (EndOfStages);
 
   PayloadId = GetPayloadId ();
@@ -248,6 +242,14 @@ NormalBootPath (
     CallBoardNotify = FALSE;
   } else {
     CallBoardNotify = TRUE;
+  }
+
+  if (FixedPcdGetBool (PcdSmpEnabled)) {
+    // Only delay MpInitDone for OsLoader
+    if ((PayloadId != 0) || (GetBootMode() == BOOT_ON_FLASH_UPDATE)) {
+      Status = MpInit (EnumMpInitDone);
+      AddMeasurePoint (0x31C0);
+    }
   }
 
   if (CallBoardNotify) {
@@ -310,7 +312,6 @@ S3ResumePath (
   S3Data    = (S3_DATA *)LdrGlobal->S3DataPtr;
 
   if (FixedPcdGetBool (PcdSmpEnabled)) {
-    DEBUG ((DEBUG_INFO, "MP Init (Done)\n"));
     MpInit (EnumMpInitDone);
     AddMeasurePoint (0x31C0);
   }
@@ -446,7 +447,6 @@ SecStartup (
 
   // MP Init phase 1
   if (FixedPcdGetBool (PcdSmpEnabled)) {
-    DEBUG ((DEBUG_INFO, "MP Init (Wakeup)\n"));
     Status = MpInit (EnumMpInitWakeup);
   } else {
     DEBUG ((DEBUG_INIT, "BSP Init\n"));
@@ -456,7 +456,6 @@ SecStartup (
 
   // MP Init phase 2
   if (FixedPcdGetBool (PcdSmpEnabled) && !EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "MP Init (Run)\n"));
     Status = MpInit (EnumMpInitRun);
     AddMeasurePoint (0x3080);
   }

--- a/BootloaderCorePkg/Stage2/Stage2Support.c
+++ b/BootloaderCorePkg/Stage2/Stage2Support.c
@@ -47,6 +47,12 @@ BoardNotifyPhase (
   }
 
   if (FspPhaseMask != 0) {
+
+    if (FspPhaseMask & BIT1) {
+      // Sigal MP to stop
+      MpInit (EnumMpInitDone);
+    }
+
     if ((FspPhaseMask & mFspPhaseMask) == 0) {
       // Only call FSP notify once
       Status = CallFspNotifyPhase (FspPhase);


### PR DESCRIPTION
There is request to utilize MP in OsLoader. To support it, it is
desired to delay MP init done signal to the end of the OsLoader.
This patch moved the MP init done signal into board ReadyToBoot
notification so that MP is still alive in OsLoader phase.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>