### PR TITLE
[CFL] Add CSME FWU driver build support

### DIFF
--- a/Silicon/CoffeelakePkg/Library/MeFwUpdateLib/MeFwUpdateLib.inf
+++ b/Silicon/CoffeelakePkg/Library/MeFwUpdateLib/MeFwUpdateLib.inf
@@ -1,0 +1,20 @@
+### @file
+#
+#  Copyright (c) 2017-2021, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+###
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MeFwUpdateLib
+  FILE_GUID                      = 946C899C-BE23-48CF-B75F-9F6F4212037F
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MeFwUpdateLib
+
+[Binaries]
+  LIB|MeFwUpdateLib.lib
+
+[LibraryClasses]
+


### PR DESCRIPTION
This patch adds support to build CSME firmware update driver.

BUILD_CSME_UPDATE_DRIVER in BoardConfig.py must set 1 to build csme FWU
driver.

Signed-off-by: Praveen Hp <praveen.hodagatta.pranesh@intel.com>