### PR TITLE
[CML] Fix StitchIfwi script error

### DIFF
--- a/Platform/CometlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/CometlakeBoardPkg/Script/StitchIfwi.py
@@ -16,8 +16,8 @@ import shutil
 import glob
 import shlex
 import subprocess # nosec
-import defusedxml.ElementTree as ET
-from   defusedxml import minidom
+import xml.etree.ElementTree as ET
+from   xml.dom import minidom
 from   ctypes  import *
 from   subprocess   import call #nosec
 from   StitchLoader import *

--- a/Platform/CometlakevBoardPkg/Script/StitchIfwi.py
+++ b/Platform/CometlakevBoardPkg/Script/StitchIfwi.py
@@ -16,8 +16,8 @@ import shutil
 import glob
 import shlex
 import subprocess # nosec
-import defusedxml.ElementTree as ET
-from   defusedxml import minidom
+import xml.etree.ElementTree as ET
+from   xml.dom import minidom
 from   ctypes  import *
 from   subprocess   import call # nosec
 from   StitchLoader import *


### PR DESCRIPTION
This Patch fixes below error,
"ModuleNotFoundError: No module named 'defusedxml'"

Signed-off-by: Praveen Hp <praveen.hodagatta.pranesh@intel.com>