### PR TITLE
[EHL] Fix yocto hang issue and s0ix enable

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/AcpiTables/AcpiTables.inf
+++ b/Platform/ElkhartlakeBoardPkg/AcpiTables/AcpiTables.inf
@@ -34,6 +34,7 @@
   Platform/CommonBoardPkg/AcpiTables/Fpdt/Fpdt.aslc
   Ssdt/SaSsdt.asl
   SsdtRtd3/EhlCrbRtd3.asl
+  Lpit/Lpit.act
   Dmar/Dmar.aslc
   CpuSsdt/Cpu0Cst.asl
   CpuSsdt/Cpu0Ist.asl

--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Power.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Power.yaml
@@ -18,28 +18,28 @@
       help         : >
                      1-Core Ratio Limit- For XE part- LFM to 255, For overclocking part- LFM to Fused 1-Core Ratio Limit + OC Bins.This 1-Core Ratio Limit Must be greater than or equal to 2-Core Ratio Limit, 3-Core Ratio Limit, 4-Core Ratio Limit. Range is 0 to 83
       length       : 0x01
-      value        : 0x1E
+      value        : 0x13
   - TwoCoreRatioLimit :
       name         : 2-Core Ratio Limit
       type         : EditNum, HEX, (0x00, 0x53)
       help         : >
                      2-Core Ratio Limit- For XE part- LFM to 255, For overclocking part- LFM to Fused 2-Core Ratio Limit + OC Bins.This 2-Core Ratio Limit Must be Less than or equal to 1-Core Ratio Limit.Range is 0 to 83
       length       : 0x01
-      value        : 0x1E
+      value        : 0x13
   - ThreeCoreRatioLimit :
       name         : 3-Core Ratio Limit
       type         : EditNum, HEX, (0x00, 0x53)
       help         : >
                      3-Core Ratio Limit- For XE part- LFM to 255, For overclocking part- LFM to Fused 3-Core Ratio Limit + OC Bins.This 3-Core Ratio Limit Must be Less than or equal to 1-Core Ratio Limit.Range is 0 to 83
       length       : 0x01
-      value        : 0x1B
+      value        : 0x13
   - FourCoreRatioLimit :
       name         : 4-Core Ratio Limit
       type         : EditNum, HEX, (0x00, 0x53)
       help         : >
                      4-Core Ratio Limit- For XE part- LFM to 255, For overclocking part- LFM to Fused 4-Core Ratio Limit + OC Bins.This 4-Core Ratio Limit Must be Less than or equal to 1-Core Ratio Limit.Range is 0 to 83
       length       : 0x01
-      value        : 0x1B
+      value        : 0x13
   - Hwp          :
       name         : Enable or Disable HWP
       type         : Combo
@@ -713,28 +713,28 @@
       help         : >
                      5-Core Ratio Limit- For XE part- LFM to 255, For overclocking part- LFM to Fused 5-Core Ratio Limit + OC Bins.This 5-Core Ratio Limit Must be Less than or equal to 1-Core Ratio Limit.Range is 0 to 83
       length       : 0x01
-      value        : 0x1B
+      value        : 0x13
   - SixCoreRatioLimit :
       name         : 6-Core Ratio Limit
       type         : EditNum, HEX, (0x00, 0x53)
       help         : >
                      6-Core Ratio Limit- For XE part- LFM to 255, For overclocking part- LFM to Fused 6-Core Ratio Limit + OC Bins.This 6-Core Ratio Limit Must be Less than or equal to 1-Core Ratio Limit.Range is 0 to 83
       length       : 0x01
-      value        : 0x1B
+      value        : 0x13
   - SevenCoreRatioLimit :
       name         : 7-Core Ratio Limit
       type         : EditNum, HEX, (0x00, 0x53)
       help         : >
                      7-Core Ratio Limit- For XE part- LFM to 255, For overclocking part- LFM to Fused 7-Core Ratio Limit + OC Bins.This 7-Core Ratio Limit Must be Less than or equal to 1-Core Ratio Limit.Range is 0 to 83
       length       : 0x01
-      value        : 0x1B
+      value        : 0x13
   - EightCoreRatioLimit :
       name         : 8-Core Ratio Limit
       type         : EditNum, HEX, (0x00, 0x53)
       help         : >
                      8-Core Ratio Limit- For XE part- LFM to 255, For overclocking part- LFM to Fused 8-Core Ratio Limit + OC Bins.This 8-Core Ratio Limit Must be Less than or equal to 1-Core Ratio Limit.Range is 0 to 83
       length       : 0x01
-      value        : 0x1B
+      value        : 0x13
   - EnableItbm   :
       name         : Intel Turbo Boost Max Technology 3.0
       type         : Combo
@@ -742,7 +742,7 @@
       help         : >
                      Intel Turbo Boost Max Technology 3.0. 0- Disabled; <b>1- Enabled</b>
       length       : 0x01
-      value        : 0x0
+      value        : 0x01
   - EnableItbmDriver :
       name         : Intel Turbo Boost Max Technology 3.0 Driver
       type         : Combo
@@ -851,7 +851,7 @@
       help         : >
                      PCODE MMIO Mailbox- Imon slope correction. Specified in 1/100 increment values. Range is 0-200. 125 = 1.25. <b>0- Auto</b>.For all VR Indexes
       length       : 0x0A
-      value        : {0:0W, 0x00, 0x00, 0x00, 0x00, 0x00}
+      value        : {0:0W, 0x64, 0x00, 0x00, 0x00, 0x00}
   - ImoniOffset  :
       name         : Imon offset correction
       type         : EditNum, HEX, (0x00,0xFFFFFFFFFFFFFFFFFFFF)
@@ -880,7 +880,7 @@
       help         : >
                      PCODE MMIO Mailbox- Thermal Design Current time window. Defined in milli seconds. Valid Values 1 - 1ms , 2 - 2ms , 3 - 3ms , 4 - 4ms , 5 - 5ms , 6 - 6ms , 7 - 7ms , 8 - 8ms , 10 - 10ms.For all VR Indexe
       length       : 0x05
-      value        : {0x00, 0x01, 0x01, 0x01, 0x01}
+      value        : {0x01, 0x01, 0x01, 0x01, 0x01}
   - TdcLock      :
       name         : Thermal Design Current Lock
       type         : EditNum, HEX, (0x00,0xFFFFFFFFFF)

--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -1522,28 +1522,28 @@
       help         : >
                      SLP_S3 Minimum Assertion Width Policy. Default is PchSlpS350ms.
       length       : 0x01
-      value        : 0x03
+      value        : 0x01
   - PchPmSlpS4MinAssert :
       name         : PCH Pm Slp S4 Min Assert
       type         : EditNum, HEX, (0x0,0xFF)
       help         : >
                      SLP_S4 Minimum Assertion Width Policy. Default is PchSlpS44s.
       length       : 0x01
-      value        : 0x01
+      value        : 0x0
   - PchPmSlpSusMinAssert :
       name         : PCH Pm Slp Sus Min Assert
       type         : EditNum, HEX, (0x0,0xFF)
       help         : >
                      SLP_SUS Minimum Assertion Width Policy. Default is PchSlpSus4s.
       length       : 0x01
-      value        : 0x04
+      value        : 0x01
   - PchPmSlpAMinAssert :
       name         : PCH Pm Slp A Min Assert
       type         : EditNum, HEX, (0x0,0xFF)
       help         : >
                      SLP_A Minimum Assertion Width Policy. Default is PchSlpA2s.
       length       : 0x01
-      value        : 0x04
+      value        : 0x01
   - PchPmPwrBtnOverridePeriod :
       name         : PCH Pm Pwr Btn Override Period
       type         : EditNum, HEX, (0x0,0xFF)

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1441,7 +1441,11 @@ UpdateFspConfig (
     Fspscfg->PchFivrVccinAuxRetToHighCurModeVolTranTime  = 0x36;
     Fspscfg->PchFivrVccinAuxRetToLowCurModeVolTranTime   = 0x2B;
     Fspscfg->PchFivrVccinAuxOffToHighCurModeVolTranTime  = 0x0096;
-    Fspscfg->PchFivrDynPm                                = 0x00;
+    Fspscfg->PchFivrDynPm                                = 0x01;
+    Fspscfg->PchFivrExtVnnRailIccMaximum                 = 0xC8;
+    Fspscfg->PchFivrExtV1p05RailIccMaximum               = 0x64;
+    Fspscfg->PchFivrExtVnnRailSxIccMaximum               = 0xC8;
+    Fspscfg->PchFivrExtV1p05RailCtrlRampTmr              = 0x0;
 
     // PCH_PM_CONFIG
     Fspscfg->PchPmSlpS3MinAssert                         = SiCfgData->PchPmSlpS3MinAssert;
@@ -1453,6 +1457,12 @@ UpdateFspConfig (
     Fspscfg->PmcLpmS0ixSubStateEnableMask                = SiCfgData->PmcLpmS0ixSubStateEnableMask;
     Fspscfg->PmcV1p05PhyExtFetControlEn                  = 1;
     Fspscfg->PmcV1p05IsExtFetControlEn                   = 1;
+    Fspscfg->PmcModPhySusPgEnable = 0x1;
+    Fspscfg->PchPwrOptEnable = 0x1;
+    Fspscfg->PmcUsb2PhySusPgEnable      = 0x1;
+    Fspscfg->PmcCpuC10GatePinEnable     = 0x1;
+    Fspscfg->PchPmMeWakeSts             = 0x1;
+    Fspscfg->PchPmWolOvrWkSts           = 0x1;
 
     Fspscfg->SerialIoUartRxPinMuxPolicy[0]               = GPIO_VER3_MUXING_SERIALIO_UART0_RXD_GPP_F1;
     Fspscfg->SerialIoUartTxPinMuxPolicy[0]               = GPIO_VER3_MUXING_SERIALIO_UART0_TXD_GPP_F2;
@@ -1633,7 +1643,7 @@ UpdateFspConfig (
     CopyMem (Fspscfg->Psi3Enable,          PowerCfgData->Psi3Enable,            sizeof(PowerCfgData->Psi3Enable));
     CopyMem (Fspscfg->Psi4Enable,          PowerCfgData->Psi4Enable,            sizeof(PowerCfgData->Psi4Enable));
     CopyMem (Fspscfg->ImonSlope,           PowerCfgData->ImonSlope,             sizeof(PowerCfgData->ImonSlope));
-    CopyMem (Fspscfg->ImonSlope,           PowerCfgData->ImonSlope,             sizeof(PowerCfgData->ImonSlope));
+    CopyMem (Fspscfg->ImonOffset,          PowerCfgData->ImoniOffset,           sizeof(PowerCfgData->ImoniOffset));
     CopyMem (Fspscfg->IccMax,              PowerCfgData->IccMax,                sizeof(PowerCfgData->IccMax));
     //Removed due to fsp 2233
     //CopyMem (Fspscfg->VrVoltageLimit,      PowerCfgData->VrVoltageLimit,        sizeof(PowerCfgData->VrVoltageLimit));
@@ -1641,6 +1651,8 @@ UpdateFspConfig (
     CopyMem (Fspscfg->TdcTimeWindow,       PowerCfgData->TdcTimeWindow,         sizeof(PowerCfgData->TdcTimeWindow));
 
     Fspscfg->PsysPmax                      = PowerCfgData->PsysPmax;
+    Fspscfg->AcousticNoiseMitigation       = 0x1;
+    Fspscfg->FivrSpreadSpectrum            = 0xF;
 
     //CPU Power Management Custom Config
     Fspscfg->MaxRatio                      = PowerCfgData->MaxRatio;

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/UpdateAcpiGnvs.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/UpdateAcpiGnvs.c
@@ -671,7 +671,7 @@ PlatformUpdateAcpiGnvs (
 
   PlatformNvs->ApicEnable                       = 1;
   PlatformNvs->EcAvailable                      = 0;
-  PlatformNvs->LowPowerS0Idle                   = 0;
+  PlatformNvs->LowPowerS0Idle                   = 1;
 
   PlatformNvs->TenSecondPowerButtonEnable       = 8;
 
@@ -769,7 +769,10 @@ PlatformUpdateAcpiGnvs (
                                                             (mSystemConfiguration.PepPse                                                  << 29);  // Bit[29]  - En/Dis PSE
   DEBUG((DEBUG_INFO, "ACPI NVS, LowPowerS0IdleConstraint(Micro-pep constraints) = 0x%X \n", mPlatformNvsAreaProtocol.Area->LowPowerS0IdleConstraint )); //0x1F6FFBD
 **/
-  PlatformNvs->LowPowerS0IdleConstraint = 0x1F6FFBD;
+  PlatformNvs->LowPowerS0IdleConstraint = 0x11E2FFBC;
+  DEBUG((DEBUG_INFO, "ACPI NVS, LowPowerS0IdleConstraint(Micro-pep constraints) = 0x%X \n", PlatformNvs->LowPowerS0IdleConstraint ));
+  PlatformNvs->LowPowerS0IdleConstraint2 = 1;
+  DEBUG((DEBUG_INFO, "ACPI NVS, LowPowerS0IdleConstraint(Micro-pep constraints 2) = 0x%X \n", PlatformNvs->LowPowerS0IdleConstraint2 ));
 
   PlatformNvs->TsnEnabled                       = IsTsnPresent();
   PlatformNvs->PseTsn0Enabled                   = IsPseGbe0Enabled();

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/UpdateAcpiTable.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/UpdateAcpiTable.c
@@ -447,11 +447,9 @@ PlatformUpdateAcpiTable (
           //
           // Read PWRM Base Address to fill in Residency counter Address Space
           //
-          SetResidencyCounter[0].Address = (UINT64)PCH_PWRM_BASE_ADDRESS + R_PMC_PWRM_SLP_S0_RESIDENCY_COUNTER;
+          SetResidencyCounter[0].Address = (UINT64)PCH_PWRM_BASE_ADDRESS + R_PMC_PWRM_BIOS_SCRATCHPAD_2;
           ResidencyCounterFrequency = 32678; //Counter runs at 100us granularity which implies 10KHz frequency (10000Hz)
-          if (IsPchLp ()) {
-            ResidencyCounterFrequency = 8197;  //Counter runs at 122us granularity which implies 10KHz frequency (8197Hz)
-          }
+
         (((ACPI_LOW_POWER_IDLE_TABLE *)Table)->LpiStates[LpitStateEntries - 1].ResidencyCounter) = SetResidencyCounter[0];
         (((ACPI_LOW_POWER_IDLE_TABLE *)Table)->LpiStates[LpitStateEntries - 1].ResidencyCounterFrequency) = ResidencyCounterFrequency;
       }

--- a/Silicon/ElkhartlakePkg/Include/Register/PmcRegs.h
+++ b/Silicon/ElkhartlakePkg/Include/Register/PmcRegs.h
@@ -174,5 +174,6 @@
 
 #define R_PMC_PWRM_NST_PG_FDIS_1                            0x1E28
 
+#define R_PMC_PWRM_BIOS_SCRATCHPAD_2                        0x1098 ///< Aggregated SLPS0 Residency counter will be saved by PMC FW
 
 #endif


### PR DESCRIPTION
Resolved yocto hang issue after booted into OS
for non Fusa sku.
Enabled s0ix for yocto and windows.

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>