### PR TITLE
Fix the MP hang issue

### DIFF
--- a/BootloaderCommonPkg/Include/Guid/MpCpuTaskInfoHob.h
+++ b/BootloaderCommonPkg/Include/Guid/MpCpuTaskInfoHob.h
@@ -22,7 +22,9 @@ typedef enum {
   EnumCpuEnd,
 } CPU_STATE;
 
-typedef UINT64 (*CPU_TASK_PROC)          (UINT64 Arg);
+typedef UINT64 (*CPU_TASK_FUNC)          (UINT64 Arg);
+
+#pragma pack(1)
 
 typedef struct {
   // Refer CPU_STATE
@@ -30,8 +32,8 @@ typedef struct {
 
   UINT8           Reserved[7];
 
-  // CPU task function CPU_TASK_PROC
-  UINT64          CProcedure;
+  // CPU task function CPU_TASK_FUNC
+  UINT64          TaskFunc;
 
   // Argument for the CPU task function
   UINT64          Argument;
@@ -48,5 +50,7 @@ typedef struct {
 typedef struct {
   SYS_CPU_TASK     *SysCpuTask;
 } SYS_CPU_TASK_HOB;
+
+#pragma pack()
 
 #endif

--- a/BootloaderCorePkg/Include/Library/MpInitLib.h
+++ b/BootloaderCorePkg/Include/Library/MpInitLib.h
@@ -83,7 +83,7 @@ MpGetTask (
   Run a task function for a specific processor.
 
   @param[in]  Index       CPU index
-  @param[in]  TaskProc    Task function pointer
+  @param[in]  TaskFunc    Task function pointer
   @param[in]  Argument    Argument for the task function
 
   @retval EFI_INVALID_PARAMETER   Invalid Index parameter.
@@ -95,7 +95,7 @@ EFI_STATUS
 EFIAPI
 MpRunTask (
   IN  UINT32         Index,
-  IN  CPU_TASK_PROC  TaskProc,
+  IN  CPU_TASK_FUNC  TaskFunc,
   IN  UINT64         Argument
   );
 

--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
@@ -181,7 +181,7 @@ ApFunc (
   )
 {
   BOOLEAN            WaitTask;
-  CPU_TASK_PROC      ApRunTask;
+  CPU_TASK_FUNC      ApRunTask;
   volatile UINT8     *State;
 
   // Enable more CPU featurs
@@ -214,7 +214,7 @@ ApFunc (
 
     case EnumCpuStart:
       *State = EnumCpuBusy;
-      ApRunTask = (CPU_TASK_PROC)(UINTN)mSysCpuTask.CpuTask[Index].CProcedure;
+      ApRunTask = (CPU_TASK_FUNC)(UINTN)mSysCpuTask.CpuTask[Index].TaskFunc;
       if (ApRunTask != NULL) {
         mSysCpuTask.CpuTask[Index].Result = ApRunTask (mSysCpuTask.CpuTask[Index].Argument);
       }
@@ -347,7 +347,7 @@ MpInit (
       //
       // Patch the C Procedure variable
       //
-      ApDataPtr->CProcedure   = (UINT64)(UINTN)ApFunc;
+      ApDataPtr->CProcedure   = (UINT32)(UINTN)ApFunc;
 
       //
       // Patch the mMpDataStructure Pointer variable
@@ -511,7 +511,7 @@ MpGetTask (
   Run a task function for a specific processor.
 
   @param[in]  Index       CPU index
-  @param[in]  TaskProc    Task function pointer
+  @param[in]  TaskFunc    Task function pointer
   @param[in]  Argument    Argument for the task function
 
   @retval EFI_INVALID_PARAMETER   Invalid Index parameter.
@@ -523,7 +523,7 @@ EFI_STATUS
 EFIAPI
 MpRunTask (
   IN  UINT32         Index,
-  IN  CPU_TASK_PROC  TaskProc,
+  IN  CPU_TASK_FUNC  TaskFunc,
   IN  UINT64         Argument
   )
 {
@@ -535,7 +535,7 @@ MpRunTask (
     return EFI_NOT_READY;
   }
 
-  mSysCpuTask.CpuTask[Index].CProcedure = (UINT64)(UINTN)TaskProc;
+  mSysCpuTask.CpuTask[Index].TaskFunc = (UINT64)(UINTN)TaskFunc;
   mSysCpuTask.CpuTask[Index].Argument   = Argument;
   mSysCpuTask.CpuTask[Index].State      = EnumCpuStart;
 
@@ -563,7 +563,7 @@ MpDumpTask (
     DEBUG ((DEBUG_INFO, "CPU%02X: %02X %010lX %010lX %010lX\n",
             Index,
             mSysCpuTask.CpuTask[Index].State,
-            mSysCpuTask.CpuTask[Index].CProcedure,
+            mSysCpuTask.CpuTask[Index].TaskFunc,
             mSysCpuTask.CpuTask[Index].Argument,
             mSysCpuTask.CpuTask[Index].Result));
   }

--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLibInternal.h
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLibInternal.h
@@ -54,7 +54,7 @@ typedef struct {
   UINT32            Reserved;
   MP_BSP_SELECTORS  BspSelector;
   UINT32            StackStart;
-  UINT64            CProcedure;
+  UINT32            CProcedure;
   UINT32            SpinLock;
   UINT32            ApCounter;
   UINT32            ApStackSize;


### PR DESCRIPTION
The ApDataPtr->CProcedure was wrongly updated in previous patch.
This patch fixed it and CPU task name from CProcedure to TaskFunc
to avoid confusion.

Signed-off-by: Guo Dong <guo.dong@intel.com>