### PR TITLE
Add CPU X2APIC support

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -281,5 +281,6 @@
   gPlatformCommonLibTokenSpaceGuid.PcdDmaProtectionEnabled    | FALSE      | BOOLEAN | 0x20000218
   # This PCD will enable multiple USB mass storage boot device support
   gPlatformCommonLibTokenSpaceGuid.PcdMultiUsbBootDeviceEnabled   | FALSE  | BOOLEAN | 0x20000219
-
+  # Control if X2APIC should be used or not
+  gPlatformCommonLibTokenSpaceGuid.PcdCpuX2ApicEnabled            | FALSE  | BOOLEAN | 0x20000220
 

--- a/BootloaderCommonPkg/Include/Library/LocalApicLib.h
+++ b/BootloaderCommonPkg/Include/Library/LocalApicLib.h
@@ -1,10 +1,10 @@
 /** @file
   Public include file for Local APIC library.
 
-  Local APIC library assumes local APIC is enabled. It does not handles cases
-  where local APIC is disabled.
+  Local APIC library assumes local APIC is enabled. It does not
+  handles cases where local APIC is disabled.
 
-  Copyright (c) 2010 - 2015, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -405,5 +405,53 @@ GetApicMsiValue (
   IN BOOLEAN  AssertionLevel
   );
 
+/**
+  Get Package ID/Core ID/Thread ID of a processor.
+
+  The algorithm assumes the target system has symmetry across physical
+  package  boundaries with respect to the number of logical processors
+  per package,  number of cores per package.
+
+  @param[in]  InitialApicId  Initial APIC ID of the target logical processor.
+  @param[out]  Package       Returns the processor package ID.
+  @param[out]  Core          Returns the processor core ID.
+  @param[out]  Thread        Returns the processor thread ID.
+**/
+VOID
+EFIAPI
+GetProcessorLocationByApicId (
+  IN  UINT32  InitialApicId,
+  OUT UINT32  *Package  OPTIONAL,
+  OUT UINT32  *Core    OPTIONAL,
+  OUT UINT32  *Thread  OPTIONAL
+  );
+
+/**
+  Get Package ID/Module ID/Tile ID/Die ID/Core ID/Thread ID of a processor.
+
+  The algorithm assumes the target system has symmetry across physical
+  package boundaries with respect to the number of threads per core, number of
+  cores per module, number of modules per tile, number of tiles per die, number
+  of dies per package.
+
+  @param[in]   InitialApicId Initial APIC ID of the target logical processor.
+  @param[out]  Package       Returns the processor package ID.
+  @param[out]  Die           Returns the processor die ID.
+  @param[out]  Tile          Returns the processor tile ID.
+  @param[out]  Module        Returns the processor module ID.
+  @param[out]  Core          Returns the processor core ID.
+  @param[out]  Thread        Returns the processor thread ID.
+**/
+VOID
+EFIAPI
+GetProcessorLocation2ByApicId (
+  IN  UINT32  InitialApicId,
+  OUT UINT32  *Package  OPTIONAL,
+  OUT UINT32  *Die      OPTIONAL,
+  OUT UINT32  *Tile     OPTIONAL,
+  OUT UINT32  *Module   OPTIONAL,
+  OUT UINT32  *Core     OPTIONAL,
+  OUT UINT32  *Thread   OPTIONAL
+  );
 #endif
 

--- a/BootloaderCommonPkg/Include/Register/Intel/ArchitecturalMsr.h
+++ b/BootloaderCommonPkg/Include/Register/Intel/ArchitecturalMsr.h
@@ -1,0 +1,6572 @@
+/** @file
+  Intel Architectural MSR Definitions.
+
+  Provides defines for Machine Specific Registers(MSR) indexes. Data structures
+  are provided for MSRs that contain one or more bit fields.  If the MSR value
+  returned is a single 32-bit or 64-bit value, then a data structure is not
+  provided for that MSR.
+
+  Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Specification Reference:
+  Intel(R) 64 and IA-32 Architectures Software Developer's Manual, Volume 4,
+  May 2018, Volume 4: Model-Specific-Registers (MSR)
+
+**/
+
+#ifndef __INTEL_ARCHITECTURAL_MSR_H__
+#define __INTEL_ARCHITECTURAL_MSR_H__
+
+/**
+  See Section 2.22, "MSRs in Pentium Processors.". Pentium Processor (05_01H).
+
+  @param  ECX  MSR_IA32_P5_MC_ADDR (0x00000000)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_P5_MC_ADDR);
+  AsmWriteMsr64 (MSR_IA32_P5_MC_ADDR, Msr);
+  @endcode
+  @note MSR_IA32_P5_MC_ADDR is defined as IA32_P5_MC_ADDR in SDM.
+**/
+#define MSR_IA32_P5_MC_ADDR                      0x00000000
+
+
+/**
+  See Section 2.22, "MSRs in Pentium Processors.". DF_DM = 05_01H.
+
+  @param  ECX  MSR_IA32_P5_MC_TYPE (0x00000001)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_P5_MC_TYPE);
+  AsmWriteMsr64 (MSR_IA32_P5_MC_TYPE, Msr);
+  @endcode
+  @note MSR_IA32_P5_MC_TYPE is defined as IA32_P5_MC_TYPE in SDM.
+**/
+#define MSR_IA32_P5_MC_TYPE                      0x00000001
+
+
+/**
+  See Section 8.10.5, "Monitor/Mwait Address Range Determination.". Introduced
+  at Display Family / Display Model 0F_03H.
+
+  @param  ECX  MSR_IA32_MONITOR_FILTER_SIZE (0x00000006)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_MONITOR_FILTER_SIZE);
+  AsmWriteMsr64 (MSR_IA32_MONITOR_FILTER_SIZE, Msr);
+  @endcode
+  @note MSR_IA32_MONITOR_FILTER_SIZE is defined as IA32_MONITOR_FILTER_SIZE in SDM.
+**/
+#define MSR_IA32_MONITOR_FILTER_SIZE             0x00000006
+
+
+/**
+  See Section 17.17, "Time-Stamp Counter.". Introduced at Display Family /
+  Display Model 05_01H.
+
+  @param  ECX  MSR_IA32_TIME_STAMP_COUNTER (0x00000010)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_TIME_STAMP_COUNTER);
+  AsmWriteMsr64 (MSR_IA32_TIME_STAMP_COUNTER, Msr);
+  @endcode
+  @note MSR_IA32_TIME_STAMP_COUNTER is defined as IA32_TIME_STAMP_COUNTER in SDM.
+**/
+#define MSR_IA32_TIME_STAMP_COUNTER              0x00000010
+
+
+/**
+  Platform ID (RO)  The operating system can use this MSR to determine "slot"
+  information for the processor and the proper microcode update to load.
+  Introduced at Display Family / Display Model 06_01H.
+
+  @param  ECX  MSR_IA32_PLATFORM_ID (0x00000017)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_PLATFORM_ID_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_PLATFORM_ID_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_PLATFORM_ID_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_PLATFORM_ID);
+  @endcode
+  @note MSR_IA32_PLATFORM_ID is defined as IA32_PLATFORM_ID in SDM.
+**/
+#define MSR_IA32_PLATFORM_ID                     0x00000017
+
+/**
+  MSR information returned for MSR index #MSR_IA32_PLATFORM_ID
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    UINT32  Reserved1:32;
+    UINT32  Reserved2:18;
+    ///
+    /// [Bits 52:50] Platform Id (RO)  Contains information concerning the
+    /// intended platform for the processor.
+    ///   52 51 50
+    ///   -- -- --
+    ///    0  0  0  Processor Flag 0.
+    ///    0  0  1  Processor Flag 1
+    ///    0  1  0  Processor Flag 2
+    ///    0  1  1  Processor Flag 3
+    ///    1  0  0  Processor Flag 4
+    ///    1  0  1  Processor Flag 5
+    ///    1  1  0  Processor Flag 6
+    ///    1  1  1  Processor Flag 7
+    ///
+    UINT32  PlatformId:3;
+    UINT32  Reserved3:11;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_PLATFORM_ID_REGISTER;
+
+
+/**
+  06_01H.
+
+  @param  ECX  MSR_IA32_APIC_BASE (0x0000001B)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_APIC_BASE_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_APIC_BASE_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_APIC_BASE_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_APIC_BASE);
+  AsmWriteMsr64 (MSR_IA32_APIC_BASE, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_APIC_BASE is defined as IA32_APIC_BASE in SDM.
+**/
+#define MSR_IA32_APIC_BASE                       0x0000001B
+
+/**
+  MSR information returned for MSR index #MSR_IA32_APIC_BASE
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    UINT32  Reserved1:8;
+    ///
+    /// [Bit 8] BSP flag (R/W).
+    ///
+    UINT32  BSP:1;
+    UINT32  Reserved2:1;
+    ///
+    /// [Bit 10] Enable x2APIC mode. Introduced at Display Family / Display
+    /// Model 06_1AH.
+    ///
+    UINT32  EXTD:1;
+    ///
+    /// [Bit 11] APIC Global Enable (R/W).
+    ///
+    UINT32  EN:1;
+    ///
+    /// [Bits 31:12] APIC Base (R/W).
+    ///
+    UINT32  ApicBase:20;
+    ///
+    /// [Bits 63:32] APIC Base (R/W).
+    ///
+    UINT32  ApicBaseHi:32;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_APIC_BASE_REGISTER;
+
+
+/**
+  Control Features in Intel 64 Processor (R/W). If any one enumeration
+  condition for defined bit field holds.
+
+  @param  ECX  MSR_IA32_FEATURE_CONTROL (0x0000003A)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_FEATURE_CONTROL_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_FEATURE_CONTROL_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_FEATURE_CONTROL_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_FEATURE_CONTROL);
+  AsmWriteMsr64 (MSR_IA32_FEATURE_CONTROL, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_FEATURE_CONTROL is defined as IA32_FEATURE_CONTROL in SDM.
+**/
+#define MSR_IA32_FEATURE_CONTROL                 0x0000003A
+
+/**
+  MSR information returned for MSR index #MSR_IA32_FEATURE_CONTROL
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Lock bit (R/WO): (1 = locked). When set, locks this MSR from
+    /// being written, writes to this bit will result in GP(0). Note: Once the
+    /// Lock bit is set, the contents of this register cannot be modified.
+    /// Therefore the lock bit must be set after configuring support for Intel
+    /// Virtualization Technology and prior to transferring control to an
+    /// option ROM or the OS. Hence, once the Lock bit is set, the entire
+    /// IA32_FEATURE_CONTROL contents are preserved across RESET when PWRGOOD
+    /// is not deasserted. If any one enumeration condition for defined bit
+    /// field position greater than bit 0 holds.
+    ///
+    UINT32  Lock:1;
+    ///
+    /// [Bit 1] Enable VMX inside SMX operation (R/WL): This bit enables a
+    /// system executive to use VMX in conjunction with SMX to support
+    /// Intel(R) Trusted Execution Technology. BIOS must set this bit only
+    /// when the CPUID function 1 returns VMX feature flag and SMX feature
+    /// flag set (ECX bits 5 and 6 respectively). If CPUID.01H:ECX[5] = 1 &&
+    /// CPUID.01H:ECX[6] = 1.
+    ///
+    UINT32  EnableVmxInsideSmx:1;
+    ///
+    /// [Bit 2] Enable VMX outside SMX operation (R/WL): This bit enables VMX
+    /// for system executive that do not require SMX. BIOS must set this bit
+    /// only when the CPUID function 1 returns VMX feature flag set (ECX bit
+    /// 5). If CPUID.01H:ECX[5] = 1.
+    ///
+    UINT32  EnableVmxOutsideSmx:1;
+    UINT32  Reserved1:5;
+    ///
+    /// [Bits 14:8] SENTER Local Function Enables (R/WL): When set, each bit
+    /// in the field represents an enable control for a corresponding SENTER
+    /// function. This bit is supported only if CPUID.1:ECX.[bit 6] is set. If
+    /// CPUID.01H:ECX[6] = 1.
+    ///
+    UINT32  SenterLocalFunctionEnables:7;
+    ///
+    /// [Bit 15] SENTER Global Enable (R/WL): This bit must be set to enable
+    /// SENTER leaf functions. This bit is supported only if CPUID.1:ECX.[bit
+    /// 6] is set. If CPUID.01H:ECX[6] = 1.
+    ///
+    UINT32  SenterGlobalEnable:1;
+    UINT32  Reserved2:1;
+    ///
+    /// [Bit 17] SGX Launch Control Enable (R/WL): This bit must be set to
+    /// enable runtime reconfiguration of SGX Launch Control via
+    /// IA32_SGXLEPUBKEYHASHn MSR. If CPUID.(EAX=07H, ECX=0H): ECX[30] = 1.
+    ///
+    UINT32  SgxLaunchControlEnable:1;
+    ///
+    /// [Bit 18] SGX Global Enable (R/WL): This bit must be set to enable SGX
+    /// leaf functions. If CPUID.(EAX=07H, ECX=0H): EBX[2] = 1.
+    ///
+    UINT32  SgxEnable:1;
+    UINT32  Reserved3:1;
+    ///
+    /// [Bit 20] LMCE On (R/WL): When set, system software can program the
+    /// MSRs associated with LMCE to configure delivery of some machine check
+    /// exceptions to a single logical processor. If IA32_MCG_CAP[27] = 1.
+    ///
+    UINT32  LmceOn:1;
+    UINT32  Reserved4:11;
+    UINT32  Reserved5:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_FEATURE_CONTROL_REGISTER;
+
+
+/**
+  Per Logical Processor TSC Adjust (R/Write to clear). If CPUID.(EAX=07H,
+  ECX=0H): EBX[1] = 1. THREAD_ADJUST:  Local offset value of the IA32_TSC for
+  a logical processor. Reset value is Zero. A write to IA32_TSC will modify
+  the local offset in IA32_TSC_ADJUST and the content of IA32_TSC, but does
+  not affect the internal invariant TSC hardware.
+
+  @param  ECX  MSR_IA32_TSC_ADJUST (0x0000003B)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_TSC_ADJUST);
+  AsmWriteMsr64 (MSR_IA32_TSC_ADJUST, Msr);
+  @endcode
+  @note MSR_IA32_TSC_ADJUST is defined as IA32_TSC_ADJUST in SDM.
+**/
+#define MSR_IA32_TSC_ADJUST                      0x0000003B
+
+
+/**
+  BIOS Update Trigger (W) Executing a WRMSR instruction to this MSR causes a
+  microcode update to be loaded into the processor. See Section 9.11.6,
+  "Microcode Update Loader." A processor may prevent writing to this MSR when
+  loading guest states on VM entries or saving guest states on VM exits.
+  Introduced at Display Family / Display Model 06_01H.
+
+  @param  ECX  MSR_IA32_BIOS_UPDT_TRIG (0x00000079)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = 0;
+  AsmWriteMsr64 (MSR_IA32_BIOS_UPDT_TRIG, Msr);
+  @endcode
+  @note MSR_IA32_BIOS_UPDT_TRIG is defined as IA32_BIOS_UPDT_TRIG in SDM.
+**/
+#define MSR_IA32_BIOS_UPDT_TRIG                  0x00000079
+
+
+/**
+  BIOS Update Signature (RO) Returns the microcode update signature following
+  the execution of CPUID.01H. A processor may prevent writing to this MSR when
+  loading guest states on VM entries or saving guest states on VM exits.
+  Introduced at Display Family / Display Model 06_01H.
+
+  @param  ECX  MSR_IA32_BIOS_SIGN_ID (0x0000008B)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_BIOS_SIGN_ID_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_BIOS_SIGN_ID_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_BIOS_SIGN_ID_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_BIOS_SIGN_ID);
+  @endcode
+  @note MSR_IA32_BIOS_SIGN_ID is defined as IA32_BIOS_SIGN_ID in SDM.
+**/
+#define MSR_IA32_BIOS_SIGN_ID                    0x0000008B
+
+/**
+  MSR information returned for MSR index #MSR_IA32_BIOS_SIGN_ID
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    UINT32  Reserved:32;
+    ///
+    /// [Bits 63:32] Microcode update signature. This field contains the
+    /// signature of the currently loaded microcode update when read following
+    /// the execution of the CPUID instruction, function 1. It is required
+    /// that this register field be pre-loaded with zero prior to executing
+    /// the CPUID, function 1. If the field remains equal to zero, then there
+    /// is no microcode update loaded. Another nonzero value will be the
+    /// signature.
+    ///
+    UINT32  MicrocodeUpdateSignature:32;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_BIOS_SIGN_ID_REGISTER;
+
+
+/**
+  IA32_SGXLEPUBKEYHASH[(64*n+63):(64*n)] (R/W) Bits (64*n+63):(64*n) of the
+  SHA256 digest of the SIGSTRUCT.MODULUS for SGX Launch Enclave. On reset, the
+  default value is the digest of Intel's signing key. Read permitted If
+  CPUID.(EAX=12H,ECX=0H):EAX[0]=1, Write permitted if CPUID.(EAX=12H,ECX=0H):
+  EAX[0]=1 && IA32_FEATURE_CONTROL[17] = 1 && IA32_FEATURE_CONTROL[0] = 1.
+
+  @param  ECX  MSR_IA32_SGXLEPUBKEYHASHn
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_SGXLEPUBKEYHASHn);
+  AsmWriteMsr64 (MSR_IA32_SGXLEPUBKEYHASHn, Msr);
+  @endcode
+  @note MSR_IA32_SGXLEPUBKEYHASH0 is defined as IA32_SGXLEPUBKEYHASH0 in SDM.
+        MSR_IA32_SGXLEPUBKEYHASH1 is defined as IA32_SGXLEPUBKEYHASH1 in SDM.
+        MSR_IA32_SGXLEPUBKEYHASH2 is defined as IA32_SGXLEPUBKEYHASH2 in SDM.
+        MSR_IA32_SGXLEPUBKEYHASH3 is defined as IA32_SGXLEPUBKEYHASH3 in SDM.
+  @{
+**/
+#define MSR_IA32_SGXLEPUBKEYHASH0                0x0000008C
+#define MSR_IA32_SGXLEPUBKEYHASH1                0x0000008D
+#define MSR_IA32_SGXLEPUBKEYHASH2                0x0000008E
+#define MSR_IA32_SGXLEPUBKEYHASH3                0x0000008F
+/// @}
+
+
+/**
+  SMM Monitor Configuration (R/W). If CPUID.01H: ECX[5]=1 or CPUID.01H: ECX[6] =
+  1.
+
+  @param  ECX  MSR_IA32_SMM_MONITOR_CTL (0x0000009B)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_SMM_MONITOR_CTL_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_SMM_MONITOR_CTL_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_SMM_MONITOR_CTL_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_SMM_MONITOR_CTL);
+  AsmWriteMsr64 (MSR_IA32_SMM_MONITOR_CTL, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_SMM_MONITOR_CTL is defined as IA32_SMM_MONITOR_CTL in SDM.
+**/
+#define MSR_IA32_SMM_MONITOR_CTL                 0x0000009B
+
+/**
+  MSR information returned for MSR index #MSR_IA32_SMM_MONITOR_CTL
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Valid (R/W).  The STM may be invoked using VMCALL only if this
+    /// bit is 1. Because VMCALL is used to activate the dual-monitor treatment
+    /// (see Section 34.15.6), the dual-monitor treatment cannot be activated
+    /// if the bit is 0. This bit is cleared when the logical processor is
+    /// reset.
+    ///
+    UINT32  Valid:1;
+    UINT32  Reserved1:1;
+    ///
+    /// [Bit 2] Controls SMI unblocking by VMXOFF (see Section 34.14.4). If
+    /// IA32_VMX_MISC[28].
+    ///
+    UINT32  BlockSmi:1;
+    UINT32  Reserved2:9;
+    ///
+    /// [Bits 31:12] MSEG Base (R/W).
+    ///
+    UINT32  MsegBase:20;
+    UINT32  Reserved3:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_SMM_MONITOR_CTL_REGISTER;
+
+/**
+  MSEG header that is located at the physical address specified by the MsegBase
+  field of #MSR_IA32_SMM_MONITOR_CTL_REGISTER.
+**/
+typedef struct {
+  ///
+  /// Different processors may use different MSEG revision identifiers. These
+  /// identifiers enable software to avoid using an MSEG header formatted for
+  /// one processor on a processor that uses a different format. Software can
+  /// discover the MSEG revision identifier that a processor uses by reading
+  /// the VMX capability MSR IA32_VMX_MISC.
+  //
+  UINT32  MsegHeaderRevision;
+  ///
+  /// Bits 31:1 of this field are reserved and must be zero. Bit 0 of the field
+  /// is the IA-32e mode SMM feature bit. It indicates whether the logical
+  /// processor will be in IA-32e mode after the STM is activated.
+  ///
+  UINT32  MonitorFeatures;
+  UINT32  GdtrLimit;
+  UINT32  GdtrBaseOffset;
+  UINT32  CsSelector;
+  UINT32  EipOffset;
+  UINT32  EspOffset;
+  UINT32  Cr3Offset;
+  ///
+  /// Pad header so total size is 2KB
+  ///
+  UINT8   Reserved[SIZE_2KB - 8 * sizeof (UINT32)];
+} MSEG_HEADER;
+
+///
+/// @{ Define values for the MonitorFeatures field of #MSEG_HEADER
+///
+#define STM_FEATURES_IA32E 0x1
+///
+/// @}
+///
+
+/**
+  Base address of the logical processor's SMRAM image (RO, SMM only). If
+  IA32_VMX_MISC[15].
+
+  @param  ECX  MSR_IA32_SMBASE (0x0000009E)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_SMBASE);
+  @endcode
+  @note MSR_IA32_SMBASE is defined as IA32_SMBASE in SDM.
+**/
+#define MSR_IA32_SMBASE                          0x0000009E
+
+
+/**
+  General Performance Counters (R/W).
+  MSR_IA32_PMCn is supported if CPUID.0AH: EAX[15:8] > n.
+
+  @param  ECX  MSR_IA32_PMCn
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_PMC0);
+  AsmWriteMsr64 (MSR_IA32_PMC0, Msr);
+  @endcode
+  @note MSR_IA32_PMC0 is defined as IA32_PMC0 in SDM.
+        MSR_IA32_PMC1 is defined as IA32_PMC1 in SDM.
+        MSR_IA32_PMC2 is defined as IA32_PMC2 in SDM.
+        MSR_IA32_PMC3 is defined as IA32_PMC3 in SDM.
+        MSR_IA32_PMC4 is defined as IA32_PMC4 in SDM.
+        MSR_IA32_PMC5 is defined as IA32_PMC5 in SDM.
+        MSR_IA32_PMC6 is defined as IA32_PMC6 in SDM.
+        MSR_IA32_PMC7 is defined as IA32_PMC7 in SDM.
+  @{
+**/
+#define MSR_IA32_PMC0                            0x000000C1
+#define MSR_IA32_PMC1                            0x000000C2
+#define MSR_IA32_PMC2                            0x000000C3
+#define MSR_IA32_PMC3                            0x000000C4
+#define MSR_IA32_PMC4                            0x000000C5
+#define MSR_IA32_PMC5                            0x000000C6
+#define MSR_IA32_PMC6                            0x000000C7
+#define MSR_IA32_PMC7                            0x000000C8
+/// @}
+
+
+/**
+  TSC Frequency Clock Counter (R/Write to clear). If CPUID.06H: ECX[0] = 1.
+  C0_MCNT: C0 TSC Frequency Clock Count Increments at fixed interval (relative
+  to TSC freq.) when the logical processor is in C0. Cleared upon overflow /
+  wrap-around of IA32_APERF.
+
+  @param  ECX  MSR_IA32_MPERF (0x000000E7)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_MPERF);
+  AsmWriteMsr64 (MSR_IA32_MPERF, Msr);
+  @endcode
+  @note MSR_IA32_MPERF is defined as IA32_MPERF in SDM.
+**/
+#define MSR_IA32_MPERF                           0x000000E7
+
+
+/**
+  Actual Performance Clock Counter (R/Write to clear). If CPUID.06H: ECX[0] =
+  1. C0_ACNT: C0 Actual Frequency Clock Count Accumulates core clock counts at
+  the coordinated clock frequency, when the logical processor is in C0.
+  Cleared upon overflow / wrap-around of IA32_MPERF.
+
+  @param  ECX  MSR_IA32_APERF (0x000000E8)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_APERF);
+  AsmWriteMsr64 (MSR_IA32_APERF, Msr);
+  @endcode
+  @note MSR_IA32_APERF is defined as IA32_APERF in SDM.
+**/
+#define MSR_IA32_APERF                           0x000000E8
+
+
+/**
+  MTRR Capability (RO) Section 11.11.2.1, "IA32_MTRR_DEF_TYPE MSR.".
+  Introduced at Display Family / Display Model 06_01H.
+
+  @param  ECX  MSR_IA32_MTRRCAP (0x000000FE)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_MTRRCAP_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_MTRRCAP_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_MTRRCAP_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_MTRRCAP);
+  @endcode
+  @note MSR_IA32_MTRRCAP is defined as IA32_MTRRCAP in SDM.
+**/
+#define MSR_IA32_MTRRCAP                         0x000000FE
+
+/**
+  MSR information returned for MSR index #MSR_IA32_MTRRCAP
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 7:0] VCNT: The number of variable memory type ranges in the
+    /// processor.
+    ///
+    UINT32  VCNT:8;
+    ///
+    /// [Bit 8] Fixed range MTRRs are supported when set.
+    ///
+    UINT32  FIX:1;
+    UINT32  Reserved1:1;
+    ///
+    /// [Bit 10] WC Supported when set.
+    ///
+    UINT32  WC:1;
+    ///
+    /// [Bit 11] SMRR Supported when set.
+    ///
+    UINT32  SMRR:1;
+    UINT32  Reserved2:20;
+    UINT32  Reserved3:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_MTRRCAP_REGISTER;
+
+
+/**
+  SYSENTER_CS_MSR (R/W). Introduced at Display Family / Display Model 06_01H.
+
+  @param  ECX  MSR_IA32_SYSENTER_CS (0x00000174)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_SYSENTER_CS_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_SYSENTER_CS_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_SYSENTER_CS_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_SYSENTER_CS);
+  AsmWriteMsr64 (MSR_IA32_SYSENTER_CS, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_SYSENTER_CS is defined as IA32_SYSENTER_CS in SDM.
+**/
+#define MSR_IA32_SYSENTER_CS                     0x00000174
+
+/**
+  MSR information returned for MSR index #MSR_IA32_SYSENTER_CS
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 15:0] CS Selector.
+    ///
+    UINT32  CS:16;
+    UINT32  Reserved1:16;
+    UINT32  Reserved2:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_SYSENTER_CS_REGISTER;
+
+
+/**
+  SYSENTER_ESP_MSR (R/W). Introduced at Display Family / Display Model 06_01H.
+
+  @param  ECX  MSR_IA32_SYSENTER_ESP (0x00000175)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_SYSENTER_ESP);
+  AsmWriteMsr64 (MSR_IA32_SYSENTER_ESP, Msr);
+  @endcode
+  @note MSR_IA32_SYSENTER_ESP is defined as IA32_SYSENTER_ESP in SDM.
+**/
+#define MSR_IA32_SYSENTER_ESP                    0x00000175
+
+
+/**
+  SYSENTER_EIP_MSR (R/W). Introduced at Display Family / Display Model 06_01H.
+
+  @param  ECX  MSR_IA32_SYSENTER_EIP (0x00000176)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_SYSENTER_EIP);
+  AsmWriteMsr64 (MSR_IA32_SYSENTER_EIP, Msr);
+  @endcode
+  @note MSR_IA32_SYSENTER_EIP is defined as IA32_SYSENTER_EIP in SDM.
+**/
+#define MSR_IA32_SYSENTER_EIP                    0x00000176
+
+
+/**
+  Global Machine Check Capability (RO). Introduced at Display Family / Display
+  Model 06_01H.
+
+  @param  ECX  MSR_IA32_MCG_CAP (0x00000179)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_MCG_CAP_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_MCG_CAP_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_MCG_CAP_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_MCG_CAP);
+  @endcode
+  @note MSR_IA32_MCG_CAP is defined as IA32_MCG_CAP in SDM.
+**/
+#define MSR_IA32_MCG_CAP                         0x00000179
+
+/**
+  MSR information returned for MSR index #MSR_IA32_MCG_CAP
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 7:0] Count: Number of reporting banks.
+    ///
+    UINT32  Count:8;
+    ///
+    /// [Bit 8] MCG_CTL_P: IA32_MCG_CTL is present if this bit is set.
+    ///
+    UINT32  MCG_CTL_P:1;
+    ///
+    /// [Bit 9] MCG_EXT_P: Extended machine check state registers are present
+    /// if this bit is set.
+    ///
+    UINT32  MCG_EXT_P:1;
+    ///
+    /// [Bit 10] MCP_CMCI_P: Support for corrected MC error event is present.
+    /// Introduced at Display Family / Display Model 06_01H.
+    ///
+    UINT32  MCP_CMCI_P:1;
+    ///
+    /// [Bit 11] MCG_TES_P: Threshold-based error status register are present
+    /// if this bit is set.
+    ///
+    UINT32  MCG_TES_P:1;
+    UINT32  Reserved1:4;
+    ///
+    /// [Bits 23:16] MCG_EXT_CNT: Number of extended machine check state
+    /// registers present.
+    ///
+    UINT32  MCG_EXT_CNT:8;
+    ///
+    /// [Bit 24] MCG_SER_P: The processor supports software error recovery if
+    /// this bit is set.
+    ///
+    UINT32  MCG_SER_P:1;
+    UINT32  Reserved2:1;
+    ///
+    /// [Bit 26] MCG_ELOG_P: Indicates that the processor allows platform
+    /// firmware to be invoked when an error is detected so that it may
+    /// provide additional platform specific information in an ACPI format
+    /// "Generic Error Data Entry" that augments the data included in machine
+    /// check bank registers. Introduced at Display Family / Display Model
+    /// 06_3EH.
+    ///
+    UINT32  MCG_ELOG_P:1;
+    ///
+    /// [Bit 27] MCG_LMCE_P: Indicates that the processor support extended
+    /// state in IA32_MCG_STATUS and associated MSR necessary to configure
+    /// Local Machine Check Exception (LMCE). Introduced at Display Family /
+    /// Display Model 06_3EH.
+    ///
+    UINT32  MCG_LMCE_P:1;
+    UINT32  Reserved3:4;
+    UINT32  Reserved4:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_MCG_CAP_REGISTER;
+
+
+/**
+  Global Machine Check Status (R/W0). Introduced at Display Family / Display
+  Model 06_01H.
+
+  @param  ECX  MSR_IA32_MCG_STATUS (0x0000017A)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_MCG_STATUS_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_MCG_STATUS_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_MCG_STATUS_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_MCG_STATUS);
+  AsmWriteMsr64 (MSR_IA32_MCG_STATUS, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_MCG_STATUS is defined as IA32_MCG_STATUS in SDM.
+**/
+#define MSR_IA32_MCG_STATUS                      0x0000017A
+
+/**
+  MSR information returned for MSR index #MSR_IA32_MCG_STATUS
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] RIPV. Restart IP valid. Introduced at Display Family / Display
+    /// Model 06_01H.
+    ///
+    UINT32  RIPV:1;
+    ///
+    /// [Bit 1] EIPV. Error IP valid. Introduced at Display Family / Display
+    /// Model 06_01H.
+    ///
+    UINT32  EIPV:1;
+    ///
+    /// [Bit 2] MCIP. Machine check in progress. Introduced at Display Family
+    /// / Display Model 06_01H.
+    ///
+    UINT32  MCIP:1;
+    ///
+    /// [Bit 3] LMCE_S. If IA32_MCG_CAP.LMCE_P[2 7] =1.
+    ///
+    UINT32  LMCE_S:1;
+    UINT32  Reserved1:28;
+    UINT32  Reserved2:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_MCG_STATUS_REGISTER;
+
+
+/**
+  Global Machine Check Control (R/W). If IA32_MCG_CAP.CTL_P[8] =1.
+
+  @param  ECX  MSR_IA32_MCG_CTL (0x0000017B)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_MCG_CTL);
+  AsmWriteMsr64 (MSR_IA32_MCG_CTL, Msr);
+  @endcode
+  @note MSR_IA32_MCG_CTL is defined as IA32_MCG_CTL in SDM.
+**/
+#define MSR_IA32_MCG_CTL                         0x0000017B
+
+
+/**
+  Performance Event Select Register n (R/W). If CPUID.0AH: EAX[15:8] > n.
+
+  @param  ECX  MSR_IA32_PERFEVTSELn
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_PERFEVTSEL_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_PERFEVTSEL_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_PERFEVTSEL_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_PERFEVTSEL0);
+  AsmWriteMsr64 (MSR_IA32_PERFEVTSEL0, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_PERFEVTSEL0 is defined as IA32_PERFEVTSEL0 in SDM.
+        MSR_IA32_PERFEVTSEL1 is defined as IA32_PERFEVTSEL1 in SDM.
+        MSR_IA32_PERFEVTSEL2 is defined as IA32_PERFEVTSEL2 in SDM.
+        MSR_IA32_PERFEVTSEL3 is defined as IA32_PERFEVTSEL3 in SDM.
+  @{
+**/
+#define MSR_IA32_PERFEVTSEL0                     0x00000186
+#define MSR_IA32_PERFEVTSEL1                     0x00000187
+#define MSR_IA32_PERFEVTSEL2                     0x00000188
+#define MSR_IA32_PERFEVTSEL3                     0x00000189
+/// @}
+
+/**
+  MSR information returned for MSR indexes #MSR_IA32_PERFEVTSEL0 to
+  #MSR_IA32_PERFEVTSEL3
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 7:0] Event Select: Selects a performance event logic unit.
+    ///
+    UINT32  EventSelect:8;
+    ///
+    /// [Bits 15:8] UMask: Qualifies the microarchitectural condition to
+    /// detect on the selected event logic.
+    ///
+    UINT32  UMASK:8;
+    ///
+    /// [Bit 16] USR: Counts while in privilege level is not ring 0.
+    ///
+    UINT32  USR:1;
+    ///
+    /// [Bit 17] OS: Counts while in privilege level is ring 0.
+    ///
+    UINT32  OS:1;
+    ///
+    /// [Bit 18] Edge: Enables edge detection if set.
+    ///
+    UINT32  E:1;
+    ///
+    /// [Bit 19] PC: enables pin control.
+    ///
+    UINT32  PC:1;
+    ///
+    /// [Bit 20] INT: enables interrupt on counter overflow.
+    ///
+    UINT32  INT:1;
+    ///
+    /// [Bit 21] AnyThread: When set to 1, it enables counting the associated
+    /// event conditions occurring across all logical processors sharing a
+    /// processor core. When set to 0, the counter only increments the
+    /// associated event conditions occurring in the logical processor which
+    /// programmed the MSR.
+    ///
+    UINT32  ANY:1;
+    ///
+    /// [Bit 22] EN: enables the corresponding performance counter to commence
+    /// counting when this bit is set.
+    ///
+    UINT32  EN:1;
+    ///
+    /// [Bit 23] INV: invert the CMASK.
+    ///
+    UINT32  INV:1;
+    ///
+    /// [Bits 31:24] CMASK: When CMASK is not zero, the corresponding
+    /// performance counter increments each cycle if the event count is
+    /// greater than or equal to the CMASK.
+    ///
+    UINT32  CMASK:8;
+    UINT32  Reserved:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_PERFEVTSEL_REGISTER;
+
+
+/**
+  Current performance state(P-State) operating point (RO). Introduced at
+  Display Family / Display Model 0F_03H.
+
+  @param  ECX  MSR_IA32_PERF_STATUS (0x00000198)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_PERF_STATUS_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_PERF_STATUS_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_PERF_STATUS_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_PERF_STATUS);
+  @endcode
+  @note MSR_IA32_PERF_STATUS is defined as IA32_PERF_STATUS in SDM.
+**/
+#define MSR_IA32_PERF_STATUS                     0x00000198
+
+/**
+  MSR information returned for MSR index #MSR_IA32_PERF_STATUS
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 15:0] Current performance State Value.
+    ///
+    UINT32  State:16;
+    UINT32  Reserved1:16;
+    UINT32  Reserved2:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_PERF_STATUS_REGISTER;
+
+
+/**
+  (R/W). Introduced at Display Family / Display Model 0F_03H.
+
+  @param  ECX  MSR_IA32_PERF_CTL (0x00000199)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_PERF_CTL_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_PERF_CTL_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_PERF_CTL_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_PERF_CTL);
+  AsmWriteMsr64 (MSR_IA32_PERF_CTL, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_PERF_CTL is defined as IA32_PERF_CTL in SDM.
+**/
+#define MSR_IA32_PERF_CTL                        0x00000199
+
+/**
+  MSR information returned for MSR index #MSR_IA32_PERF_CTL
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 15:0] Target performance State Value.
+    ///
+    UINT32  TargetState:16;
+    UINT32  Reserved1:16;
+    ///
+    /// [Bit 32] IDA Engage. (R/W) When set to 1: disengages IDA. 06_0FH
+    /// (Mobile only).
+    ///
+    UINT32  IDA:1;
+    UINT32  Reserved2:31;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_PERF_CTL_REGISTER;
+
+
+/**
+  Clock Modulation Control (R/W) See Section 14.7.3, "Software Controlled
+  Clock Modulation.". If CPUID.01H:EDX[22] = 1.
+
+  @param  ECX  MSR_IA32_CLOCK_MODULATION (0x0000019A)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_CLOCK_MODULATION_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_CLOCK_MODULATION_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_CLOCK_MODULATION_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_CLOCK_MODULATION);
+  AsmWriteMsr64 (MSR_IA32_CLOCK_MODULATION, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_CLOCK_MODULATION is defined as IA32_CLOCK_MODULATION in SDM.
+**/
+#define MSR_IA32_CLOCK_MODULATION                0x0000019A
+
+/**
+  MSR information returned for MSR index #MSR_IA32_CLOCK_MODULATION
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Extended On-Demand Clock Modulation Duty Cycle:. If
+    /// CPUID.06H:EAX[5] = 1.
+    ///
+    UINT32  ExtendedOnDemandClockModulationDutyCycle:1;
+    ///
+    /// [Bits 3:1] On-Demand Clock Modulation Duty Cycle: Specific encoded
+    /// values for target duty cycle modulation. If CPUID.01H:EDX[22] = 1.
+    ///
+    UINT32  OnDemandClockModulationDutyCycle:3;
+    ///
+    /// [Bit 4] On-Demand Clock Modulation Enable: Set 1 to enable modulation.
+    /// If CPUID.01H:EDX[22] = 1.
+    ///
+    UINT32  OnDemandClockModulationEnable:1;
+    UINT32  Reserved1:27;
+    UINT32  Reserved2:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_CLOCK_MODULATION_REGISTER;
+
+
+/**
+  Thermal Interrupt Control (R/W) Enables and disables the generation of an
+  interrupt on temperature transitions detected with the processor's thermal
+  sensors and thermal monitor. See Section 14.7.2, "Thermal Monitor.".
+  If CPUID.01H:EDX[22] = 1
+
+  @param  ECX  MSR_IA32_THERM_INTERRUPT (0x0000019B)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_THERM_INTERRUPT_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_THERM_INTERRUPT_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_THERM_INTERRUPT_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_THERM_INTERRUPT);
+  AsmWriteMsr64 (MSR_IA32_THERM_INTERRUPT, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_THERM_INTERRUPT is defined as IA32_THERM_INTERRUPT in SDM.
+**/
+#define MSR_IA32_THERM_INTERRUPT                 0x0000019B
+
+/**
+  MSR information returned for MSR index #MSR_IA32_THERM_INTERRUPT
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] High-Temperature Interrupt Enable. If CPUID.01H:EDX[22] = 1.
+    ///
+    UINT32  HighTempEnable:1;
+    ///
+    /// [Bit 1] Low-Temperature Interrupt Enable. If CPUID.01H:EDX[22] = 1.
+    ///
+    UINT32  LowTempEnable:1;
+    ///
+    /// [Bit 2] PROCHOT# Interrupt Enable. If CPUID.01H:EDX[22] = 1.
+    ///
+    UINT32  PROCHOT_Enable:1;
+    ///
+    /// [Bit 3] FORCEPR# Interrupt Enable. If CPUID.01H:EDX[22] = 1.
+    ///
+    UINT32  FORCEPR_Enable:1;
+    ///
+    /// [Bit 4] Critical Temperature Interrupt Enable.
+    /// If CPUID.01H:EDX[22] = 1.
+    ///
+    UINT32  CriticalTempEnable:1;
+    UINT32  Reserved1:3;
+    ///
+    /// [Bits 14:8] Threshold #1 Value. If CPUID.01H:EDX[22] = 1.
+    ///
+    UINT32  Threshold1:7;
+    ///
+    /// [Bit 15] Threshold #1 Interrupt Enable. If CPUID.01H:EDX[22] = 1.
+    ///
+    UINT32  Threshold1Enable:1;
+    ///
+    /// [Bits 22:16] Threshold #2 Value. If CPUID.01H:EDX[22] = 1.
+    ///
+    UINT32  Threshold2:7;
+    ///
+    /// [Bit 23] Threshold #2 Interrupt Enable. If CPUID.01H:EDX[22] = 1.
+    ///
+    UINT32  Threshold2Enable:1;
+    ///
+    /// [Bit 24] Power Limit Notification Enable. If CPUID.06H:EAX[4] = 1.
+    ///
+    UINT32  PowerLimitNotificationEnable:1;
+    UINT32  Reserved2:7;
+    UINT32  Reserved3:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_THERM_INTERRUPT_REGISTER;
+
+
+/**
+  Thermal Status Information (RO) Contains status information about the
+  processor's thermal sensor and automatic thermal monitoring facilities. See
+  Section 14.7.2, "Thermal Monitor". If CPUID.01H:EDX[22] = 1.
+
+  @param  ECX  MSR_IA32_THERM_STATUS (0x0000019C)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_THERM_STATUS_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_THERM_STATUS_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_THERM_STATUS_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_THERM_STATUS);
+  @endcode
+  @note MSR_IA32_THERM_STATUS is defined as IA32_THERM_STATUS in SDM.
+**/
+#define MSR_IA32_THERM_STATUS                    0x0000019C
+
+/**
+  MSR information returned for MSR index #MSR_IA32_THERM_STATUS
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Thermal Status (RO):. If CPUID.01H:EDX[22] = 1.
+    ///
+    UINT32  ThermalStatus:1;
+    ///
+    /// [Bit 1] Thermal Status Log (R/W):. If CPUID.01H:EDX[22] = 1.
+    ///
+    UINT32  ThermalStatusLog:1;
+    ///
+    /// [Bit 2] PROCHOT # or FORCEPR# event (RO). If CPUID.01H:EDX[22] = 1.
+    ///
+    UINT32  PROCHOT_FORCEPR_Event:1;
+    ///
+    /// [Bit 3] PROCHOT # or FORCEPR# log (R/WC0). If CPUID.01H:EDX[22] = 1.
+    ///
+    UINT32  PROCHOT_FORCEPR_Log:1;
+    ///
+    /// [Bit 4] Critical Temperature Status (RO). If CPUID.01H:EDX[22] = 1.
+    ///
+    UINT32  CriticalTempStatus:1;
+    ///
+    /// [Bit 5] Critical Temperature Status log (R/WC0).
+    /// If CPUID.01H:EDX[22] = 1.
+    ///
+    UINT32  CriticalTempStatusLog:1;
+    ///
+    /// [Bit 6] Thermal Threshold #1 Status (RO). If CPUID.01H:ECX[8] = 1.
+    ///
+    UINT32  ThermalThreshold1Status:1;
+    ///
+    /// [Bit 7] Thermal Threshold #1 log (R/WC0). If CPUID.01H:ECX[8] = 1.
+    ///
+    UINT32  ThermalThreshold1Log:1;
+    ///
+    /// [Bit 8] Thermal Threshold #2 Status (RO). If CPUID.01H:ECX[8] = 1.
+    ///
+    UINT32  ThermalThreshold2Status:1;
+    ///
+    /// [Bit 9] Thermal Threshold #2 log (R/WC0). If CPUID.01H:ECX[8] = 1.
+    ///
+    UINT32  ThermalThreshold2Log:1;
+    ///
+    /// [Bit 10] Power Limitation Status (RO). If CPUID.06H:EAX[4] = 1.
+    ///
+    UINT32  PowerLimitStatus:1;
+    ///
+    /// [Bit 11] Power Limitation log (R/WC0). If CPUID.06H:EAX[4] = 1.
+    ///
+    UINT32  PowerLimitLog:1;
+    ///
+    /// [Bit 12] Current Limit Status (RO). If CPUID.06H:EAX[7] = 1.
+    ///
+    UINT32  CurrentLimitStatus:1;
+    ///
+    /// [Bit 13] Current Limit log (R/WC0). If CPUID.06H:EAX[7] = 1.
+    ///
+    UINT32  CurrentLimitLog:1;
+    ///
+    /// [Bit 14] Cross Domain Limit Status (RO). If CPUID.06H:EAX[7] = 1.
+    ///
+    UINT32  CrossDomainLimitStatus:1;
+    ///
+    /// [Bit 15] Cross Domain Limit log (R/WC0). If CPUID.06H:EAX[7] = 1.
+    ///
+    UINT32  CrossDomainLimitLog:1;
+    ///
+    /// [Bits 22:16] Digital Readout (RO). If CPUID.06H:EAX[0] = 1.
+    ///
+    UINT32  DigitalReadout:7;
+    UINT32  Reserved1:4;
+    ///
+    /// [Bits 30:27] Resolution in Degrees Celsius (RO). If CPUID.06H:EAX[0] =
+    /// 1.
+    ///
+    UINT32  ResolutionInDegreesCelsius:4;
+    ///
+    /// [Bit 31] Reading Valid (RO). If CPUID.06H:EAX[0] = 1.
+    ///
+    UINT32  ReadingValid:1;
+    UINT32  Reserved2:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_THERM_STATUS_REGISTER;
+
+
+/**
+  Enable Misc. Processor Features (R/W)  Allows a variety of processor
+  functions to be enabled and disabled.
+
+  @param  ECX  MSR_IA32_MISC_ENABLE (0x000001A0)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_MISC_ENABLE_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_MISC_ENABLE_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_MISC_ENABLE_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_MISC_ENABLE);
+  AsmWriteMsr64 (MSR_IA32_MISC_ENABLE, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_MISC_ENABLE is defined as IA32_MISC_ENABLE in SDM.
+**/
+#define MSR_IA32_MISC_ENABLE                     0x000001A0
+
+/**
+  MSR information returned for MSR index #MSR_IA32_MISC_ENABLE
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Fast-Strings Enable When set, the fast-strings feature (for
+    /// REP MOVS and REP STORS) is enabled (default); when clear, fast-strings
+    /// are disabled. Introduced at Display Family / Display Model 0F_0H.
+    ///
+    UINT32  FastStrings:1;
+    UINT32  Reserved1:2;
+    ///
+    /// [Bit 3] Automatic Thermal Control Circuit Enable (R/W)  1 = Setting
+    /// this bit enables the thermal control circuit (TCC) portion of the
+    /// Intel Thermal Monitor feature. This allows the processor to
+    /// automatically reduce power consumption in response to TCC activation.
+    /// 0 = Disabled. Note: In some products clearing this bit might be
+    /// ignored in critical thermal conditions, and TM1, TM2 and adaptive
+    /// thermal throttling will still be activated. The default value of this
+    /// field varies with product. See respective tables where default value is
+    /// listed. Introduced at Display Family / Display Model 0F_0H.
+    ///
+    UINT32  AutomaticThermalControlCircuit:1;
+    UINT32  Reserved2:3;
+    ///
+    /// [Bit 7] Performance Monitoring Available (R)  1 = Performance
+    /// monitoring enabled 0 = Performance monitoring disabled. Introduced at
+    /// Display Family / Display Model 0F_0H.
+    ///
+    UINT32  PerformanceMonitoring:1;
+    UINT32  Reserved3:3;
+    ///
+    /// [Bit 11] Branch Trace Storage Unavailable (RO) 1 = Processor doesn't
+    /// support branch trace storage (BTS) 0 = BTS is supported. Introduced at
+    /// Display Family / Display Model 0F_0H.
+    ///
+    UINT32  BTS:1;
+    ///
+    /// [Bit 12] Processor Event Based Sampling (PEBS)  Unavailable (RO)  1 =
+    /// PEBS is not supported; 0 = PEBS is supported. Introduced at Display
+    /// Family / Display Model 06_0FH.
+    ///
+    UINT32  PEBS:1;
+    UINT32  Reserved4:3;
+    ///
+    /// [Bit 16] Enhanced Intel SpeedStep Technology  Enable (R/W) 0= Enhanced
+    /// Intel SpeedStep Technology disabled 1 = Enhanced Intel SpeedStep
+    /// Technology enabled. If CPUID.01H: ECX[7] =1.
+    ///
+    UINT32  EIST:1;
+    UINT32  Reserved5:1;
+    ///
+    /// [Bit 18] ENABLE MONITOR FSM (R/W) When this bit is set to 0, the
+    /// MONITOR feature flag is not set (CPUID.01H:ECX[bit 3] = 0). This
+    /// indicates that MONITOR/MWAIT are not supported. Software attempts to
+    /// execute MONITOR/MWAIT will cause #UD when this bit is 0. When this bit
+    /// is set to 1 (default), MONITOR/MWAIT are supported (CPUID.01H:ECX[bit
+    /// 3] = 1). If the SSE3 feature flag ECX[0] is not set (CPUID.01H:ECX[bit
+    /// 0] = 0), the OS must not attempt to alter this bit. BIOS must leave it
+    /// in the default state. Writing this bit when the SSE3 feature flag is
+    /// set to 0 may generate a #GP exception. Introduced at Display Family /
+    /// Display Model 0F_03H.
+    ///
+    UINT32  MONITOR:1;
+    UINT32  Reserved6:3;
+    ///
+    /// [Bit 22] Limit CPUID Maxval (R/W) When this bit is set to 1, CPUID.00H
+    /// returns a maximum value in EAX[7:0] of 2. BIOS should contain a setup
+    /// question that allows users to specify when the installed OS does not
+    /// support CPUID functions greater than 2. Before setting this bit, BIOS
+    /// must execute the CPUID.0H and examine the maximum value returned in
+    /// EAX[7:0]. If the maximum value is greater than 2, this bit is
+    /// supported. Otherwise, this bit is not supported. Setting this bit when
+    /// the maximum value is not greater than 2 may generate a #GP exception.
+    /// Setting this bit may cause unexpected behavior in software that
+    /// depends on the availability of CPUID leaves greater than 2. Introduced
+    /// at Display Family / Display Model 0F_03H.
+    ///
+    UINT32  LimitCpuidMaxval:1;
+    ///
+    /// [Bit 23] xTPR Message Disable (R/W) When set to 1, xTPR messages are
+    /// disabled. xTPR messages are optional messages that allow the processor
+    /// to inform the chipset of its priority. if CPUID.01H:ECX[14] = 1.
+    ///
+    UINT32  xTPR_Message_Disable:1;
+    UINT32  Reserved7:8;
+    UINT32  Reserved8:2;
+    ///
+    /// [Bit 34] XD Bit Disable (R/W) When set to 1, the Execute Disable Bit
+    /// feature (XD Bit) is disabled and the XD Bit extended feature flag will
+    /// be clear (CPUID.80000001H: EDX[20]=0). When set to a 0 (default), the
+    /// Execute Disable Bit feature (if available) allows the OS to enable PAE
+    /// paging and take advantage of data only pages. BIOS must not alter the
+    /// contents of this bit location, if XD bit is not supported. Writing
+    /// this bit to 1 when the XD Bit extended feature flag is set to 0 may
+    /// generate a #GP exception. if CPUID.80000001H:EDX[2 0] = 1.
+    ///
+    UINT32  XD:1;
+    UINT32  Reserved9:29;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_MISC_ENABLE_REGISTER;
+
+
+/**
+  Performance Energy Bias Hint (R/W). if CPUID.6H:ECX[3] = 1.
+
+  @param  ECX  MSR_IA32_ENERGY_PERF_BIAS (0x000001B0)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_ENERGY_PERF_BIAS_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_ENERGY_PERF_BIAS_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_ENERGY_PERF_BIAS_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_ENERGY_PERF_BIAS);
+  AsmWriteMsr64 (MSR_IA32_ENERGY_PERF_BIAS, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_ENERGY_PERF_BIAS is defined as IA32_ENERGY_PERF_BIAS in SDM.
+**/
+#define MSR_IA32_ENERGY_PERF_BIAS                0x000001B0
+
+/**
+  MSR information returned for MSR index #MSR_IA32_ENERGY_PERF_BIAS
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 3:0] Power Policy Preference: 0 indicates preference to highest
+    /// performance. 15 indicates preference to maximize energy saving.
+    ///
+    UINT32  PowerPolicyPreference:4;
+    UINT32  Reserved1:28;
+    UINT32  Reserved2:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_ENERGY_PERF_BIAS_REGISTER;
+
+
+/**
+  Package Thermal Status Information (RO) Contains status information about
+  the package's thermal sensor. See Section 14.8, "Package Level Thermal
+  Management.". If CPUID.06H: EAX[6] = 1.
+
+  @param  ECX  MSR_IA32_PACKAGE_THERM_STATUS (0x000001B1)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_PACKAGE_THERM_STATUS_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_PACKAGE_THERM_STATUS_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_PACKAGE_THERM_STATUS_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_PACKAGE_THERM_STATUS);
+  @endcode
+  @note MSR_IA32_PACKAGE_THERM_STATUS is defined as IA32_PACKAGE_THERM_STATUS in SDM.
+**/
+#define MSR_IA32_PACKAGE_THERM_STATUS            0x000001B1
+
+/**
+  MSR information returned for MSR index #MSR_IA32_PACKAGE_THERM_STATUS
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Pkg Thermal Status (RO):.
+    ///
+    UINT32  ThermalStatus:1;
+    ///
+    /// [Bit 1] Pkg Thermal Status Log (R/W):.
+    ///
+    UINT32  ThermalStatusLog:1;
+    ///
+    /// [Bit 2] Pkg PROCHOT # event (RO).
+    ///
+    UINT32  PROCHOT_Event:1;
+    ///
+    /// [Bit 3] Pkg PROCHOT # log (R/WC0).
+    ///
+    UINT32  PROCHOT_Log:1;
+    ///
+    /// [Bit 4] Pkg Critical Temperature Status (RO).
+    ///
+    UINT32  CriticalTempStatus:1;
+    ///
+    /// [Bit 5] Pkg Critical Temperature Status log (R/WC0).
+    ///
+    UINT32  CriticalTempStatusLog:1;
+    ///
+    /// [Bit 6] Pkg Thermal Threshold #1 Status (RO).
+    ///
+    UINT32  ThermalThreshold1Status:1;
+    ///
+    /// [Bit 7] Pkg Thermal Threshold #1 log (R/WC0).
+    ///
+    UINT32  ThermalThreshold1Log:1;
+    ///
+    /// [Bit 8] Pkg Thermal Threshold #2 Status (RO).
+    ///
+    UINT32  ThermalThreshold2Status:1;
+    ///
+    /// [Bit 9] Pkg Thermal Threshold #1 log (R/WC0).
+    ///
+    UINT32  ThermalThreshold2Log:1;
+    ///
+    /// [Bit 10] Pkg Power Limitation Status (RO).
+    ///
+    UINT32  PowerLimitStatus:1;
+    ///
+    /// [Bit 11] Pkg Power Limitation log (R/WC0).
+    ///
+    UINT32  PowerLimitLog:1;
+    UINT32  Reserved1:4;
+    ///
+    /// [Bits 22:16] Pkg Digital Readout (RO).
+    ///
+    UINT32  DigitalReadout:7;
+    UINT32  Reserved2:9;
+    UINT32  Reserved3:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_PACKAGE_THERM_STATUS_REGISTER;
+
+
+/**
+  Pkg Thermal Interrupt Control (R/W) Enables and disables the generation of
+  an interrupt on temperature transitions detected with the package's thermal
+  sensor. See Section 14.8, "Package Level Thermal Management.". If CPUID.06H:
+  EAX[6] = 1.
+
+  @param  ECX  MSR_IA32_PACKAGE_THERM_INTERRUPT (0x000001B2)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_PACKAGE_THERM_INTERRUPT_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_PACKAGE_THERM_INTERRUPT_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_PACKAGE_THERM_INTERRUPT_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_PACKAGE_THERM_INTERRUPT);
+  AsmWriteMsr64 (MSR_IA32_PACKAGE_THERM_INTERRUPT, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_PACKAGE_THERM_INTERRUPT is defined as IA32_PACKAGE_THERM_INTERRUPT in SDM.
+**/
+#define MSR_IA32_PACKAGE_THERM_INTERRUPT         0x000001B2
+
+/**
+  MSR information returned for MSR index #MSR_IA32_PACKAGE_THERM_INTERRUPT
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Pkg High-Temperature Interrupt Enable.
+    ///
+    UINT32  HighTempEnable:1;
+    ///
+    /// [Bit 1] Pkg Low-Temperature Interrupt Enable.
+    ///
+    UINT32  LowTempEnable:1;
+    ///
+    /// [Bit 2] Pkg PROCHOT# Interrupt Enable.
+    ///
+    UINT32  PROCHOT_Enable:1;
+    UINT32  Reserved1:1;
+    ///
+    /// [Bit 4] Pkg Overheat Interrupt Enable.
+    ///
+    UINT32  OverheatEnable:1;
+    UINT32  Reserved2:3;
+    ///
+    /// [Bits 14:8] Pkg Threshold #1 Value.
+    ///
+    UINT32  Threshold1:7;
+    ///
+    /// [Bit 15] Pkg Threshold #1 Interrupt Enable.
+    ///
+    UINT32  Threshold1Enable:1;
+    ///
+    /// [Bits 22:16] Pkg Threshold #2 Value.
+    ///
+    UINT32  Threshold2:7;
+    ///
+    /// [Bit 23] Pkg Threshold #2 Interrupt Enable.
+    ///
+    UINT32  Threshold2Enable:1;
+    ///
+    /// [Bit 24] Pkg Power Limit Notification Enable.
+    ///
+    UINT32  PowerLimitNotificationEnable:1;
+    UINT32  Reserved3:7;
+    UINT32  Reserved4:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_PACKAGE_THERM_INTERRUPT_REGISTER;
+
+
+/**
+  Trace/Profile Resource Control (R/W). Introduced at Display Family / Display
+  Model 06_0EH.
+
+  @param  ECX  MSR_IA32_DEBUGCTL (0x000001D9)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_DEBUGCTL_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_DEBUGCTL_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_DEBUGCTL_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_DEBUGCTL);
+  AsmWriteMsr64 (MSR_IA32_DEBUGCTL, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_DEBUGCTL is defined as IA32_DEBUGCTL in SDM.
+**/
+#define MSR_IA32_DEBUGCTL                        0x000001D9
+
+/**
+  MSR information returned for MSR index #MSR_IA32_DEBUGCTL
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] LBR: Setting this bit to 1 enables the processor to record a
+    /// running trace of the most recent branches taken by the processor in
+    /// the LBR stack. Introduced at Display Family / Display Model 06_01H.
+    ///
+    UINT32  LBR:1;
+    ///
+    /// [Bit 1] BTF: Setting this bit to 1 enables the processor to treat
+    /// EFLAGS.TF as single-step on branches instead of single-step on
+    /// instructions. Introduced at Display Family / Display Model 06_01H.
+    ///
+    UINT32  BTF:1;
+    UINT32  Reserved1:4;
+    ///
+    /// [Bit 6] TR: Setting this bit to 1 enables branch trace messages to be
+    /// sent. Introduced at Display Family / Display Model 06_0EH.
+    ///
+    UINT32  TR:1;
+    ///
+    /// [Bit 7] BTS: Setting this bit enables branch trace messages (BTMs) to
+    /// be logged in a BTS buffer. Introduced at Display Family / Display
+    /// Model 06_0EH.
+    ///
+    UINT32  BTS:1;
+    ///
+    /// [Bit 8] BTINT: When clear, BTMs are logged in a BTS buffer in circular
+    /// fashion. When this bit is set, an interrupt is generated by the BTS
+    /// facility when the BTS buffer is full. Introduced at Display Family /
+    /// Display Model 06_0EH.
+    ///
+    UINT32  BTINT:1;
+    ///
+    /// [Bit 9] BTS_OFF_OS: When set, BTS or BTM is skipped if CPL = 0.
+    /// Introduced at Display Family / Display Model 06_0FH.
+    ///
+    UINT32  BTS_OFF_OS:1;
+    ///
+    /// [Bit 10] BTS_OFF_USR: When set, BTS or BTM is skipped if CPL > 0.
+    /// Introduced at Display Family / Display Model 06_0FH.
+    ///
+    UINT32  BTS_OFF_USR:1;
+    ///
+    /// [Bit 11] FREEZE_LBRS_ON_PMI: When set, the LBR stack is frozen on a
+    /// PMI request. If CPUID.01H: ECX[15] = 1 && CPUID.0AH: EAX[7:0] > 1.
+    ///
+    UINT32  FREEZE_LBRS_ON_PMI:1;
+    ///
+    /// [Bit 12] FREEZE_PERFMON_ON_PMI: When set, each ENABLE bit of the
+    /// global counter control MSR are frozen (address 38FH) on a PMI request.
+    /// If CPUID.01H: ECX[15] = 1 && CPUID.0AH: EAX[7:0] > 1.
+    ///
+    UINT32  FREEZE_PERFMON_ON_PMI:1;
+    ///
+    /// [Bit 13] ENABLE_UNCORE_PMI: When set, enables the logical processor to
+    /// receive and generate PMI on behalf of the uncore. Introduced at
+    /// Display Family / Display Model 06_1AH.
+    ///
+    UINT32  ENABLE_UNCORE_PMI:1;
+    ///
+    /// [Bit 14] FREEZE_WHILE_SMM: When set, freezes perfmon and trace
+    /// messages while in SMM. If IA32_PERF_CAPABILITIES[ 12] = 1.
+    ///
+    UINT32  FREEZE_WHILE_SMM:1;
+    ///
+    /// [Bit 15] RTM_DEBUG: When set, enables DR7 debug bit on XBEGIN. If
+    /// (CPUID.(EAX=07H, ECX=0):EBX[11] = 1).
+    ///
+    UINT32  RTM_DEBUG:1;
+    UINT32  Reserved2:16;
+    UINT32  Reserved3:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_DEBUGCTL_REGISTER;
+
+
+/**
+  SMRR Base Address (Writeable only in SMM)  Base address of SMM memory range.
+  If IA32_MTRRCAP.SMRR[11] = 1.
+
+  @param  ECX  MSR_IA32_SMRR_PHYSBASE (0x000001F2)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_SMRR_PHYSBASE_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_SMRR_PHYSBASE_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_SMRR_PHYSBASE_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_SMRR_PHYSBASE);
+  AsmWriteMsr64 (MSR_IA32_SMRR_PHYSBASE, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_SMRR_PHYSBASE is defined as IA32_SMRR_PHYSBASE in SDM.
+**/
+#define MSR_IA32_SMRR_PHYSBASE                   0x000001F2
+
+/**
+  MSR information returned for MSR index #MSR_IA32_SMRR_PHYSBASE
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 7:0] Type. Specifies memory type of the range.
+    ///
+    UINT32  Type:8;
+    UINT32  Reserved1:4;
+    ///
+    /// [Bits 31:12] PhysBase.  SMRR physical Base Address.
+    ///
+    UINT32  PhysBase:20;
+    UINT32  Reserved2:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_SMRR_PHYSBASE_REGISTER;
+
+
+/**
+  SMRR Range Mask (Writeable only in SMM) Range Mask of SMM memory range. If
+  IA32_MTRRCAP[SMRR] = 1.
+
+  @param  ECX  MSR_IA32_SMRR_PHYSMASK (0x000001F3)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_SMRR_PHYSMASK_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_SMRR_PHYSMASK_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_SMRR_PHYSMASK_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_SMRR_PHYSMASK);
+  AsmWriteMsr64 (MSR_IA32_SMRR_PHYSMASK, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_SMRR_PHYSMASK is defined as IA32_SMRR_PHYSMASK in SDM.
+**/
+#define MSR_IA32_SMRR_PHYSMASK                   0x000001F3
+
+/**
+  MSR information returned for MSR index #MSR_IA32_SMRR_PHYSMASK
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    UINT32  Reserved1:11;
+    ///
+    /// [Bit 11] Valid Enable range mask.
+    ///
+    UINT32  Valid:1;
+    ///
+    /// [Bits 31:12] PhysMask SMRR address range mask.
+    ///
+    UINT32  PhysMask:20;
+    UINT32  Reserved2:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_SMRR_PHYSMASK_REGISTER;
+
+
+/**
+  DCA Capability (R). If CPUID.01H: ECX[18] = 1.
+
+  @param  ECX  MSR_IA32_PLATFORM_DCA_CAP (0x000001F8)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_PLATFORM_DCA_CAP);
+  @endcode
+  @note MSR_IA32_PLATFORM_DCA_CAP is defined as IA32_PLATFORM_DCA_CAP in SDM.
+**/
+#define MSR_IA32_PLATFORM_DCA_CAP                0x000001F8
+
+
+/**
+  If set, CPU supports Prefetch-Hint type. If CPUID.01H: ECX[18] = 1.
+
+  @param  ECX  MSR_IA32_CPU_DCA_CAP (0x000001F9)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_CPU_DCA_CAP);
+  AsmWriteMsr64 (MSR_IA32_CPU_DCA_CAP, Msr);
+  @endcode
+  @note MSR_IA32_CPU_DCA_CAP is defined as IA32_CPU_DCA_CAP in SDM.
+**/
+#define MSR_IA32_CPU_DCA_CAP                     0x000001F9
+
+
+/**
+  DCA type 0 Status and Control register. If CPUID.01H: ECX[18] = 1.
+
+  @param  ECX  MSR_IA32_DCA_0_CAP (0x000001FA)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_DCA_0_CAP_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_DCA_0_CAP_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_DCA_0_CAP_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_DCA_0_CAP);
+  AsmWriteMsr64 (MSR_IA32_DCA_0_CAP, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_DCA_0_CAP is defined as IA32_DCA_0_CAP in SDM.
+**/
+#define MSR_IA32_DCA_0_CAP                       0x000001FA
+
+/**
+  MSR information returned for MSR index #MSR_IA32_DCA_0_CAP
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] DCA_ACTIVE: Set by HW when DCA is fuseenabled and no
+    /// defeatures are set.
+    ///
+    UINT32  DCA_ACTIVE:1;
+    ///
+    /// [Bits 2:1] TRANSACTION.
+    ///
+    UINT32  TRANSACTION:2;
+    ///
+    /// [Bits 6:3] DCA_TYPE.
+    ///
+    UINT32  DCA_TYPE:4;
+    ///
+    /// [Bits 10:7] DCA_QUEUE_SIZE.
+    ///
+    UINT32  DCA_QUEUE_SIZE:4;
+    UINT32  Reserved1:2;
+    ///
+    /// [Bits 16:13] DCA_DELAY: Writes will update the register but have no HW
+    /// side-effect.
+    ///
+    UINT32  DCA_DELAY:4;
+    UINT32  Reserved2:7;
+    ///
+    /// [Bit 24] SW_BLOCK: SW can request DCA block by setting this bit.
+    ///
+    UINT32  SW_BLOCK:1;
+    UINT32  Reserved3:1;
+    ///
+    /// [Bit 26] HW_BLOCK: Set when DCA is blocked by HW (e.g. CR0.CD = 1).
+    ///
+    UINT32  HW_BLOCK:1;
+    UINT32  Reserved4:5;
+    UINT32  Reserved5:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_DCA_0_CAP_REGISTER;
+
+
+/**
+  MTRRphysBasen.  See Section 11.11.2.3, "Variable Range MTRRs".
+  If CPUID.01H: EDX.MTRR[12] = 1 and IA32_MTRRCAP[7:0] > n.
+
+  @param  ECX  MSR_IA32_MTRR_PHYSBASEn
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_MTRR_PHYSBASE_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_MTRR_PHYSBASE_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_MTRR_PHYSBASE_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_MTRR_PHYSBASE0);
+  AsmWriteMsr64 (MSR_IA32_MTRR_PHYSBASE0, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_MTRR_PHYSBASE0 is defined as IA32_MTRR_PHYSBASE0 in SDM.
+        MSR_IA32_MTRR_PHYSBASE1 is defined as IA32_MTRR_PHYSBASE1 in SDM.
+        MSR_IA32_MTRR_PHYSBASE2 is defined as IA32_MTRR_PHYSBASE2 in SDM.
+        MSR_IA32_MTRR_PHYSBASE3 is defined as IA32_MTRR_PHYSBASE3 in SDM.
+        MSR_IA32_MTRR_PHYSBASE4 is defined as IA32_MTRR_PHYSBASE4 in SDM.
+        MSR_IA32_MTRR_PHYSBASE5 is defined as IA32_MTRR_PHYSBASE5 in SDM.
+        MSR_IA32_MTRR_PHYSBASE6 is defined as IA32_MTRR_PHYSBASE6 in SDM.
+        MSR_IA32_MTRR_PHYSBASE7 is defined as IA32_MTRR_PHYSBASE7 in SDM.
+        MSR_IA32_MTRR_PHYSBASE8 is defined as IA32_MTRR_PHYSBASE8 in SDM.
+        MSR_IA32_MTRR_PHYSBASE9 is defined as IA32_MTRR_PHYSBASE9 in SDM.
+  @{
+**/
+#define MSR_IA32_MTRR_PHYSBASE0                  0x00000200
+#define MSR_IA32_MTRR_PHYSBASE1                  0x00000202
+#define MSR_IA32_MTRR_PHYSBASE2                  0x00000204
+#define MSR_IA32_MTRR_PHYSBASE3                  0x00000206
+#define MSR_IA32_MTRR_PHYSBASE4                  0x00000208
+#define MSR_IA32_MTRR_PHYSBASE5                  0x0000020A
+#define MSR_IA32_MTRR_PHYSBASE6                  0x0000020C
+#define MSR_IA32_MTRR_PHYSBASE7                  0x0000020E
+#define MSR_IA32_MTRR_PHYSBASE8                  0x00000210
+#define MSR_IA32_MTRR_PHYSBASE9                  0x00000212
+/// @}
+
+/**
+  MSR information returned for MSR indexes #MSR_IA32_MTRR_PHYSBASE0 to
+  #MSR_IA32_MTRR_PHYSBASE9
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 7:0] Type. Specifies memory type of the range.
+    ///
+    UINT32  Type:8;
+    UINT32  Reserved1:4;
+    ///
+    /// [Bits 31:12] PhysBase.  MTRR physical Base Address.
+    ///
+    UINT32  PhysBase:20;
+    ///
+    /// [Bits MAXPHYSADDR:32] PhysBase.  Upper bits of MTRR physical Base Address.
+    /// MAXPHYADDR: The bit position indicated by MAXPHYADDR depends on the
+    /// maximum physical address range supported by the processor. It is
+    /// reported by CPUID leaf function 80000008H. If CPUID does not support
+    /// leaf 80000008H, the processor supports 36-bit physical address size,
+    /// then bit PhysMask consists of bits 35:12, and bits 63:36 are reserved.
+    ///
+    UINT32  PhysBaseHi:32;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_MTRR_PHYSBASE_REGISTER;
+
+
+/**
+  MTRRphysMaskn.  See Section 11.11.2.3, "Variable Range MTRRs".
+  If CPUID.01H: EDX.MTRR[12] = 1 and IA32_MTRRCAP[7:0] > n.
+
+  @param  ECX  MSR_IA32_MTRR_PHYSMASKn
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_MTRR_PHYSMASK_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_MTRR_PHYSMASK_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_MTRR_PHYSMASK_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_MTRR_PHYSMASK0);
+  AsmWriteMsr64 (MSR_IA32_MTRR_PHYSMASK0, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_MTRR_PHYSMASK0 is defined as IA32_MTRR_PHYSMASK0 in SDM.
+        MSR_IA32_MTRR_PHYSMASK1 is defined as IA32_MTRR_PHYSMASK1 in SDM.
+        MSR_IA32_MTRR_PHYSMASK2 is defined as IA32_MTRR_PHYSMASK2 in SDM.
+        MSR_IA32_MTRR_PHYSMASK3 is defined as IA32_MTRR_PHYSMASK3 in SDM.
+        MSR_IA32_MTRR_PHYSMASK4 is defined as IA32_MTRR_PHYSMASK4 in SDM.
+        MSR_IA32_MTRR_PHYSMASK5 is defined as IA32_MTRR_PHYSMASK5 in SDM.
+        MSR_IA32_MTRR_PHYSMASK6 is defined as IA32_MTRR_PHYSMASK6 in SDM.
+        MSR_IA32_MTRR_PHYSMASK7 is defined as IA32_MTRR_PHYSMASK7 in SDM.
+        MSR_IA32_MTRR_PHYSMASK8 is defined as IA32_MTRR_PHYSMASK8 in SDM.
+        MSR_IA32_MTRR_PHYSMASK9 is defined as IA32_MTRR_PHYSMASK9 in SDM.
+  @{
+**/
+#define MSR_IA32_MTRR_PHYSMASK0                  0x00000201
+#define MSR_IA32_MTRR_PHYSMASK1                  0x00000203
+#define MSR_IA32_MTRR_PHYSMASK2                  0x00000205
+#define MSR_IA32_MTRR_PHYSMASK3                  0x00000207
+#define MSR_IA32_MTRR_PHYSMASK4                  0x00000209
+#define MSR_IA32_MTRR_PHYSMASK5                  0x0000020B
+#define MSR_IA32_MTRR_PHYSMASK6                  0x0000020D
+#define MSR_IA32_MTRR_PHYSMASK7                  0x0000020F
+#define MSR_IA32_MTRR_PHYSMASK8                  0x00000211
+#define MSR_IA32_MTRR_PHYSMASK9                  0x00000213
+/// @}
+
+/**
+  MSR information returned for MSR indexes #MSR_IA32_MTRR_PHYSMASK0 to
+  #MSR_IA32_MTRR_PHYSMASK9
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    UINT32  Reserved1:11;
+    ///
+    /// [Bit 11] Valid Enable range mask.
+    ///
+    UINT32  V:1;
+    ///
+    /// [Bits 31:12] PhysMask.  MTRR address range mask.
+    ///
+    UINT32  PhysMask:20;
+    ///
+    /// [Bits MAXPHYSADDR:32] PhysMask.  Upper bits of MTRR address range mask.
+    /// MAXPHYADDR: The bit position indicated by MAXPHYADDR depends on the
+    /// maximum physical address range supported by the processor. It is
+    /// reported by CPUID leaf function 80000008H. If CPUID does not support
+    /// leaf 80000008H, the processor supports 36-bit physical address size,
+    /// then bit PhysMask consists of bits 35:12, and bits 63:36 are reserved.
+    ///
+    UINT32  PhysMaskHi:32;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_MTRR_PHYSMASK_REGISTER;
+
+
+/**
+  MTRRfix64K_00000. If CPUID.01H: EDX.MTRR[12] =1.
+
+  @param  ECX  MSR_IA32_MTRR_FIX64K_00000 (0x00000250)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_MTRR_FIX64K_00000);
+  AsmWriteMsr64 (MSR_IA32_MTRR_FIX64K_00000, Msr);
+  @endcode
+  @note MSR_IA32_MTRR_FIX64K_00000 is defined as IA32_MTRR_FIX64K_00000 in SDM.
+**/
+#define MSR_IA32_MTRR_FIX64K_00000               0x00000250
+
+
+/**
+  MTRRfix16K_80000. If CPUID.01H: EDX.MTRR[12] =1.
+
+  @param  ECX  MSR_IA32_MTRR_FIX16K_80000 (0x00000258)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_MTRR_FIX16K_80000);
+  AsmWriteMsr64 (MSR_IA32_MTRR_FIX16K_80000, Msr);
+  @endcode
+  @note MSR_IA32_MTRR_FIX16K_80000 is defined as IA32_MTRR_FIX16K_80000 in SDM.
+**/
+#define MSR_IA32_MTRR_FIX16K_80000               0x00000258
+
+
+/**
+  MTRRfix16K_A0000. If CPUID.01H: EDX.MTRR[12] =1.
+
+  @param  ECX  MSR_IA32_MTRR_FIX16K_A0000 (0x00000259)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_MTRR_FIX16K_A0000);
+  AsmWriteMsr64 (MSR_IA32_MTRR_FIX16K_A0000, Msr);
+  @endcode
+  @note MSR_IA32_MTRR_FIX16K_A0000 is defined as IA32_MTRR_FIX16K_A0000 in SDM.
+**/
+#define MSR_IA32_MTRR_FIX16K_A0000               0x00000259
+
+
+/**
+  See Section 11.11.2.2, "Fixed Range MTRRs.". If CPUID.01H: EDX.MTRR[12] =1.
+
+  @param  ECX  MSR_IA32_MTRR_FIX4K_C0000 (0x00000268)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_MTRR_FIX4K_C0000);
+  AsmWriteMsr64 (MSR_IA32_MTRR_FIX4K_C0000, Msr);
+  @endcode
+  @note MSR_IA32_MTRR_FIX4K_C0000 is defined as IA32_MTRR_FIX4K_C0000 in SDM.
+**/
+#define MSR_IA32_MTRR_FIX4K_C0000                0x00000268
+
+
+/**
+  MTRRfix4K_C8000. If CPUID.01H: EDX.MTRR[12] =1.
+
+  @param  ECX  MSR_IA32_MTRR_FIX4K_C8000 (0x00000269)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_MTRR_FIX4K_C8000);
+  AsmWriteMsr64 (MSR_IA32_MTRR_FIX4K_C8000, Msr);
+  @endcode
+  @note MSR_IA32_MTRR_FIX4K_C8000 is defined as IA32_MTRR_FIX4K_C8000 in SDM.
+**/
+#define MSR_IA32_MTRR_FIX4K_C8000                0x00000269
+
+
+/**
+  MTRRfix4K_D0000. If CPUID.01H: EDX.MTRR[12] =1.
+
+  @param  ECX  MSR_IA32_MTRR_FIX4K_D0000 (0x0000026A)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_MTRR_FIX4K_D0000);
+  AsmWriteMsr64 (MSR_IA32_MTRR_FIX4K_D0000, Msr);
+  @endcode
+  @note MSR_IA32_MTRR_FIX4K_D0000 is defined as IA32_MTRR_FIX4K_D0000 in SDM.
+**/
+#define MSR_IA32_MTRR_FIX4K_D0000                0x0000026A
+
+
+/**
+  MTRRfix4K_D8000. If CPUID.01H: EDX.MTRR[12] =1.
+
+  @param  ECX  MSR_IA32_MTRR_FIX4K_D8000 (0x0000026B)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_MTRR_FIX4K_D8000);
+  AsmWriteMsr64 (MSR_IA32_MTRR_FIX4K_D8000, Msr);
+  @endcode
+  @note MSR_IA32_MTRR_FIX4K_D8000 is defined as IA32_MTRR_FIX4K_D8000 in SDM.
+**/
+#define MSR_IA32_MTRR_FIX4K_D8000                0x0000026B
+
+
+/**
+  MTRRfix4K_E0000. If CPUID.01H: EDX.MTRR[12] =1.
+
+  @param  ECX  MSR_IA32_MTRR_FIX4K_E0000 (0x0000026C)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_MTRR_FIX4K_E0000);
+  AsmWriteMsr64 (MSR_IA32_MTRR_FIX4K_E0000, Msr);
+  @endcode
+  @note MSR_IA32_MTRR_FIX4K_E0000 is defined as IA32_MTRR_FIX4K_E0000 in SDM.
+**/
+#define MSR_IA32_MTRR_FIX4K_E0000                0x0000026C
+
+
+/**
+  MTRRfix4K_E8000. If CPUID.01H: EDX.MTRR[12] =1.
+
+  @param  ECX  MSR_IA32_MTRR_FIX4K_E8000 (0x0000026D)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_MTRR_FIX4K_E8000);
+  AsmWriteMsr64 (MSR_IA32_MTRR_FIX4K_E8000, Msr);
+  @endcode
+  @note MSR_IA32_MTRR_FIX4K_E8000 is defined as IA32_MTRR_FIX4K_E8000 in SDM.
+**/
+#define MSR_IA32_MTRR_FIX4K_E8000                0x0000026D
+
+
+/**
+  MTRRfix4K_F0000. If CPUID.01H: EDX.MTRR[12] =1.
+
+  @param  ECX  MSR_IA32_MTRR_FIX4K_F0000 (0x0000026E)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_MTRR_FIX4K_F0000);
+  AsmWriteMsr64 (MSR_IA32_MTRR_FIX4K_F0000, Msr);
+  @endcode
+  @note MSR_IA32_MTRR_FIX4K_F0000 is defined as IA32_MTRR_FIX4K_F0000 in SDM.
+**/
+#define MSR_IA32_MTRR_FIX4K_F0000                0x0000026E
+
+
+/**
+  MTRRfix4K_F8000. If CPUID.01H: EDX.MTRR[12] =1.
+
+  @param  ECX  MSR_IA32_MTRR_FIX4K_F8000 (0x0000026F)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_MTRR_FIX4K_F8000);
+  AsmWriteMsr64 (MSR_IA32_MTRR_FIX4K_F8000, Msr);
+  @endcode
+  @note MSR_IA32_MTRR_FIX4K_F8000 is defined as IA32_MTRR_FIX4K_F8000 in SDM.
+**/
+#define MSR_IA32_MTRR_FIX4K_F8000                0x0000026F
+
+
+/**
+  IA32_PAT (R/W). If CPUID.01H: EDX.MTRR[16] =1.
+
+  @param  ECX  MSR_IA32_PAT (0x00000277)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_PAT_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_PAT_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_PAT_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_PAT);
+  AsmWriteMsr64 (MSR_IA32_PAT, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_PAT is defined as IA32_PAT in SDM.
+**/
+#define MSR_IA32_PAT                             0x00000277
+
+/**
+  MSR information returned for MSR index #MSR_IA32_PAT
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 2:0] PA0.
+    ///
+    UINT32  PA0:3;
+    UINT32  Reserved1:5;
+    ///
+    /// [Bits 10:8] PA1.
+    ///
+    UINT32  PA1:3;
+    UINT32  Reserved2:5;
+    ///
+    /// [Bits 18:16] PA2.
+    ///
+    UINT32  PA2:3;
+    UINT32  Reserved3:5;
+    ///
+    /// [Bits 26:24] PA3.
+    ///
+    UINT32  PA3:3;
+    UINT32  Reserved4:5;
+    ///
+    /// [Bits 34:32] PA4.
+    ///
+    UINT32  PA4:3;
+    UINT32  Reserved5:5;
+    ///
+    /// [Bits 42:40] PA5.
+    ///
+    UINT32  PA5:3;
+    UINT32  Reserved6:5;
+    ///
+    /// [Bits 50:48] PA6.
+    ///
+    UINT32  PA6:3;
+    UINT32  Reserved7:5;
+    ///
+    /// [Bits 58:56] PA7.
+    ///
+    UINT32  PA7:3;
+    UINT32  Reserved8:5;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_PAT_REGISTER;
+
+
+/**
+  Provides the programming interface to use corrected MC error signaling
+  capability (R/W). If IA32_MCG_CAP[10] = 1 && IA32_MCG_CAP[7:0] > n.
+
+  @param  ECX  MSR_IA32_MCn_CTL2
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_MC_CTL2_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_MC_CTL2_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_MC_CTL2_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_MC0_CTL2);
+  AsmWriteMsr64 (MSR_IA32_MC0_CTL2, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_MC0_CTL2  is defined as IA32_MC0_CTL2  in SDM.
+        MSR_IA32_MC1_CTL2  is defined as IA32_MC1_CTL2  in SDM.
+        MSR_IA32_MC2_CTL2  is defined as IA32_MC2_CTL2  in SDM.
+        MSR_IA32_MC3_CTL2  is defined as IA32_MC3_CTL2  in SDM.
+        MSR_IA32_MC4_CTL2  is defined as IA32_MC4_CTL2  in SDM.
+        MSR_IA32_MC5_CTL2  is defined as IA32_MC5_CTL2  in SDM.
+        MSR_IA32_MC6_CTL2  is defined as IA32_MC6_CTL2  in SDM.
+        MSR_IA32_MC7_CTL2  is defined as IA32_MC7_CTL2  in SDM.
+        MSR_IA32_MC8_CTL2  is defined as IA32_MC8_CTL2  in SDM.
+        MSR_IA32_MC9_CTL2  is defined as IA32_MC9_CTL2  in SDM.
+        MSR_IA32_MC10_CTL2 is defined as IA32_MC10_CTL2 in SDM.
+        MSR_IA32_MC11_CTL2 is defined as IA32_MC11_CTL2 in SDM.
+        MSR_IA32_MC12_CTL2 is defined as IA32_MC12_CTL2 in SDM.
+        MSR_IA32_MC13_CTL2 is defined as IA32_MC13_CTL2 in SDM.
+        MSR_IA32_MC14_CTL2 is defined as IA32_MC14_CTL2 in SDM.
+        MSR_IA32_MC15_CTL2 is defined as IA32_MC15_CTL2 in SDM.
+        MSR_IA32_MC16_CTL2 is defined as IA32_MC16_CTL2 in SDM.
+        MSR_IA32_MC17_CTL2 is defined as IA32_MC17_CTL2 in SDM.
+        MSR_IA32_MC18_CTL2 is defined as IA32_MC18_CTL2 in SDM.
+        MSR_IA32_MC19_CTL2 is defined as IA32_MC19_CTL2 in SDM.
+        MSR_IA32_MC20_CTL2 is defined as IA32_MC20_CTL2 in SDM.
+        MSR_IA32_MC21_CTL2 is defined as IA32_MC21_CTL2 in SDM.
+        MSR_IA32_MC22_CTL2 is defined as IA32_MC22_CTL2 in SDM.
+        MSR_IA32_MC23_CTL2 is defined as IA32_MC23_CTL2 in SDM.
+        MSR_IA32_MC24_CTL2 is defined as IA32_MC24_CTL2 in SDM.
+        MSR_IA32_MC25_CTL2 is defined as IA32_MC25_CTL2 in SDM.
+        MSR_IA32_MC26_CTL2 is defined as IA32_MC26_CTL2 in SDM.
+        MSR_IA32_MC27_CTL2 is defined as IA32_MC27_CTL2 in SDM.
+        MSR_IA32_MC28_CTL2 is defined as IA32_MC28_CTL2 in SDM.
+        MSR_IA32_MC29_CTL2 is defined as IA32_MC29_CTL2 in SDM.
+        MSR_IA32_MC30_CTL2 is defined as IA32_MC30_CTL2 in SDM.
+        MSR_IA32_MC31_CTL2 is defined as IA32_MC31_CTL2 in SDM.
+  @{
+**/
+#define MSR_IA32_MC0_CTL2                        0x00000280
+#define MSR_IA32_MC1_CTL2                        0x00000281
+#define MSR_IA32_MC2_CTL2                        0x00000282
+#define MSR_IA32_MC3_CTL2                        0x00000283
+#define MSR_IA32_MC4_CTL2                        0x00000284
+#define MSR_IA32_MC5_CTL2                        0x00000285
+#define MSR_IA32_MC6_CTL2                        0x00000286
+#define MSR_IA32_MC7_CTL2                        0x00000287
+#define MSR_IA32_MC8_CTL2                        0x00000288
+#define MSR_IA32_MC9_CTL2                        0x00000289
+#define MSR_IA32_MC10_CTL2                       0x0000028A
+#define MSR_IA32_MC11_CTL2                       0x0000028B
+#define MSR_IA32_MC12_CTL2                       0x0000028C
+#define MSR_IA32_MC13_CTL2                       0x0000028D
+#define MSR_IA32_MC14_CTL2                       0x0000028E
+#define MSR_IA32_MC15_CTL2                       0x0000028F
+#define MSR_IA32_MC16_CTL2                       0x00000290
+#define MSR_IA32_MC17_CTL2                       0x00000291
+#define MSR_IA32_MC18_CTL2                       0x00000292
+#define MSR_IA32_MC19_CTL2                       0x00000293
+#define MSR_IA32_MC20_CTL2                       0x00000294
+#define MSR_IA32_MC21_CTL2                       0x00000295
+#define MSR_IA32_MC22_CTL2                       0x00000296
+#define MSR_IA32_MC23_CTL2                       0x00000297
+#define MSR_IA32_MC24_CTL2                       0x00000298
+#define MSR_IA32_MC25_CTL2                       0x00000299
+#define MSR_IA32_MC26_CTL2                       0x0000029A
+#define MSR_IA32_MC27_CTL2                       0x0000029B
+#define MSR_IA32_MC28_CTL2                       0x0000029C
+#define MSR_IA32_MC29_CTL2                       0x0000029D
+#define MSR_IA32_MC30_CTL2                       0x0000029E
+#define MSR_IA32_MC31_CTL2                       0x0000029F
+/// @}
+
+/**
+  MSR information returned for MSR indexes #MSR_IA32_MC0_CTL2
+  to #MSR_IA32_MC31_CTL2
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 14:0] Corrected error count threshold.
+    ///
+    UINT32  CorrectedErrorCountThreshold:15;
+    UINT32  Reserved1:15;
+    ///
+    /// [Bit 30] CMCI_EN.
+    ///
+    UINT32  CMCI_EN:1;
+    UINT32  Reserved2:1;
+    UINT32  Reserved3:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_MC_CTL2_REGISTER;
+
+
+/**
+  MTRRdefType (R/W). If CPUID.01H: EDX.MTRR[12] =1.
+
+  @param  ECX  MSR_IA32_MTRR_DEF_TYPE (0x000002FF)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_MTRR_DEF_TYPE_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_MTRR_DEF_TYPE_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_MTRR_DEF_TYPE_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_MTRR_DEF_TYPE);
+  AsmWriteMsr64 (MSR_IA32_MTRR_DEF_TYPE, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_MTRR_DEF_TYPE is defined as IA32_MTRR_DEF_TYPE in SDM.
+**/
+#define MSR_IA32_MTRR_DEF_TYPE                   0x000002FF
+
+/**
+  MSR information returned for MSR index #MSR_IA32_MTRR_DEF_TYPE
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 2:0] Default Memory Type.
+    ///
+    UINT32  Type:3;
+    UINT32  Reserved1:7;
+    ///
+    /// [Bit 10] Fixed Range MTRR Enable.
+    ///
+    UINT32  FE:1;
+    ///
+    /// [Bit 11] MTRR Enable.
+    ///
+    UINT32  E:1;
+    UINT32  Reserved2:20;
+    UINT32  Reserved3:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_MTRR_DEF_TYPE_REGISTER;
+
+
+/**
+  Fixed-Function Performance Counter 0 (R/W): Counts Instr_Retired.Any. If
+  CPUID.0AH: EDX[4:0] > 0.
+
+  @param  ECX  MSR_IA32_FIXED_CTR0 (0x00000309)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_FIXED_CTR0);
+  AsmWriteMsr64 (MSR_IA32_FIXED_CTR0, Msr);
+  @endcode
+  @note MSR_IA32_FIXED_CTR0 is defined as IA32_FIXED_CTR0 in SDM.
+**/
+#define MSR_IA32_FIXED_CTR0                      0x00000309
+
+
+/**
+  Fixed-Function Performance Counter 1 (R/W): Counts CPU_CLK_Unhalted.Core. If
+  CPUID.0AH: EDX[4:0] > 1.
+
+  @param  ECX  MSR_IA32_FIXED_CTR1 (0x0000030A)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_FIXED_CTR1);
+  AsmWriteMsr64 (MSR_IA32_FIXED_CTR1, Msr);
+  @endcode
+  @note MSR_IA32_FIXED_CTR1 is defined as IA32_FIXED_CTR1 in SDM.
+**/
+#define MSR_IA32_FIXED_CTR1                      0x0000030A
+
+
+/**
+  Fixed-Function Performance Counter 2 (R/W): Counts CPU_CLK_Unhalted.Ref. If
+  CPUID.0AH: EDX[4:0] > 2.
+
+  @param  ECX  MSR_IA32_FIXED_CTR2 (0x0000030B)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_FIXED_CTR2);
+  AsmWriteMsr64 (MSR_IA32_FIXED_CTR2, Msr);
+  @endcode
+  @note MSR_IA32_FIXED_CTR2 is defined as IA32_FIXED_CTR2 in SDM.
+**/
+#define MSR_IA32_FIXED_CTR2                      0x0000030B
+
+
+/**
+  RO. If CPUID.01H: ECX[15] = 1.
+
+  @param  ECX  MSR_IA32_PERF_CAPABILITIES (0x00000345)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_PERF_CAPABILITIES_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_PERF_CAPABILITIES_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_PERF_CAPABILITIES_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_PERF_CAPABILITIES);
+  AsmWriteMsr64 (MSR_IA32_PERF_CAPABILITIES, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_PERF_CAPABILITIES is defined as IA32_PERF_CAPABILITIES in SDM.
+**/
+#define MSR_IA32_PERF_CAPABILITIES               0x00000345
+
+/**
+  MSR information returned for MSR index #MSR_IA32_PERF_CAPABILITIES
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 5:0] LBR format.
+    ///
+    UINT32  LBR_FMT:6;
+    ///
+    /// [Bit 6] PEBS Trap.
+    ///
+    UINT32  PEBS_TRAP:1;
+    ///
+    /// [Bit 7] PEBSSaveArchRegs.
+    ///
+    UINT32  PEBS_ARCH_REG:1;
+    ///
+    /// [Bits 11:8] PEBS Record Format.
+    ///
+    UINT32  PEBS_REC_FMT:4;
+    ///
+    /// [Bit 12] 1: Freeze while SMM is supported.
+    ///
+    UINT32  SMM_FREEZE:1;
+    ///
+    /// [Bit 13] 1: Full width of counter writable via IA32_A_PMCx.
+    ///
+    UINT32  FW_WRITE:1;
+    UINT32  Reserved1:18;
+    UINT32  Reserved2:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_PERF_CAPABILITIES_REGISTER;
+
+
+/**
+  Fixed-Function Performance Counter Control (R/W) Counter increments while
+  the results of ANDing respective enable bit in IA32_PERF_GLOBAL_CTRL with
+  the corresponding OS or USR bits in this MSR is true. If CPUID.0AH: EAX[7:0]
+  > 1.
+
+  @param  ECX  MSR_IA32_FIXED_CTR_CTRL (0x0000038D)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_FIXED_CTR_CTRL_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_FIXED_CTR_CTRL_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_FIXED_CTR_CTRL_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_FIXED_CTR_CTRL);
+  AsmWriteMsr64 (MSR_IA32_FIXED_CTR_CTRL, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_FIXED_CTR_CTRL is defined as IA32_FIXED_CTR_CTRL in SDM.
+**/
+#define MSR_IA32_FIXED_CTR_CTRL                  0x0000038D
+
+/**
+  MSR information returned for MSR index #MSR_IA32_FIXED_CTR_CTRL
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] EN0_OS: Enable Fixed Counter 0 to count while CPL = 0.
+    ///
+    UINT32  EN0_OS:1;
+    ///
+    /// [Bit 1] EN0_Usr: Enable Fixed Counter 0 to count while CPL > 0.
+    ///
+    UINT32  EN0_Usr:1;
+    ///
+    /// [Bit 2] AnyThread: When set to 1, it enables counting the associated
+    /// event conditions occurring across all logical processors sharing a
+    /// processor core. When set to 0, the counter only increments the
+    /// associated event conditions occurring in the logical processor which
+    /// programmed the MSR. If CPUID.0AH: EAX[7:0] > 2.
+    ///
+    UINT32  AnyThread0:1;
+    ///
+    /// [Bit 3] EN0_PMI: Enable PMI when fixed counter 0 overflows.
+    ///
+    UINT32  EN0_PMI:1;
+    ///
+    /// [Bit 4] EN1_OS: Enable Fixed Counter 1 to count while CPL = 0.
+    ///
+    UINT32  EN1_OS:1;
+    ///
+    /// [Bit 5] EN1_Usr: Enable Fixed Counter 1 to count while CPL > 0.
+    ///
+    UINT32  EN1_Usr:1;
+    ///
+    /// [Bit 6] AnyThread: When set to 1, it enables counting the associated
+    /// event conditions occurring across all logical processors sharing a
+    /// processor core. When set to 0, the counter only increments the
+    /// associated event conditions occurring in the logical processor which
+    /// programmed the MSR. If CPUID.0AH: EAX[7:0] > 2.
+    ///
+    UINT32  AnyThread1:1;
+    ///
+    /// [Bit 7] EN1_PMI: Enable PMI when fixed counter 1 overflows.
+    ///
+    UINT32  EN1_PMI:1;
+    ///
+    /// [Bit 8] EN2_OS: Enable Fixed Counter 2 to count while CPL = 0.
+    ///
+    UINT32  EN2_OS:1;
+    ///
+    /// [Bit 9] EN2_Usr: Enable Fixed Counter 2 to count while CPL > 0.
+    ///
+    UINT32  EN2_Usr:1;
+    ///
+    /// [Bit 10] AnyThread: When set to 1, it enables counting the associated
+    /// event conditions occurring across all logical processors sharing a
+    /// processor core. When set to 0, the counter only increments the
+    /// associated event conditions occurring in the logical processor which
+    /// programmed the MSR. If CPUID.0AH: EAX[7:0] > 2.
+    ///
+    UINT32  AnyThread2:1;
+    ///
+    /// [Bit 11] EN2_PMI: Enable PMI when fixed counter 2 overflows.
+    ///
+    UINT32  EN2_PMI:1;
+    UINT32  Reserved1:20;
+    UINT32  Reserved2:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_FIXED_CTR_CTRL_REGISTER;
+
+
+/**
+  Global Performance Counter Status (RO). If CPUID.0AH: EAX[7:0] > 0.
+
+  @param  ECX  MSR_IA32_PERF_GLOBAL_STATUS (0x0000038E)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_PERF_GLOBAL_STATUS_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_PERF_GLOBAL_STATUS_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_PERF_GLOBAL_STATUS_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_PERF_GLOBAL_STATUS);
+  @endcode
+  @note MSR_IA32_PERF_GLOBAL_STATUS is defined as IA32_PERF_GLOBAL_STATUS in SDM.
+**/
+#define MSR_IA32_PERF_GLOBAL_STATUS              0x0000038E
+
+/**
+  MSR information returned for MSR index #MSR_IA32_PERF_GLOBAL_STATUS
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Ovf_PMC0: Overflow status of IA32_PMC0. If CPUID.0AH:
+    /// EAX[15:8] > 0.
+    ///
+    UINT32  Ovf_PMC0:1;
+    ///
+    /// [Bit 1] Ovf_PMC1: Overflow status of IA32_PMC1. If CPUID.0AH:
+    /// EAX[15:8] > 1.
+    ///
+    UINT32  Ovf_PMC1:1;
+    ///
+    /// [Bit 2] Ovf_PMC2: Overflow status of IA32_PMC2. If CPUID.0AH:
+    /// EAX[15:8] > 2.
+    ///
+    UINT32  Ovf_PMC2:1;
+    ///
+    /// [Bit 3] Ovf_PMC3: Overflow status of IA32_PMC3. If CPUID.0AH:
+    /// EAX[15:8] > 3.
+    ///
+    UINT32  Ovf_PMC3:1;
+    UINT32  Reserved1:28;
+    ///
+    /// [Bit 32] Ovf_FixedCtr0: Overflow status of IA32_FIXED_CTR0. If
+    /// CPUID.0AH: EAX[7:0] > 1.
+    ///
+    UINT32  Ovf_FixedCtr0:1;
+    ///
+    /// [Bit 33] Ovf_FixedCtr1: Overflow status of IA32_FIXED_CTR1. If
+    /// CPUID.0AH: EAX[7:0] > 1.
+    ///
+    UINT32  Ovf_FixedCtr1:1;
+    ///
+    /// [Bit 34] Ovf_FixedCtr2: Overflow status of IA32_FIXED_CTR2. If
+    /// CPUID.0AH: EAX[7:0] > 1.
+    ///
+    UINT32  Ovf_FixedCtr2:1;
+    UINT32  Reserved2:20;
+    ///
+    /// [Bit 55] Trace_ToPA_PMI: A PMI occurred due to a ToPA entry memory
+    /// buffer was completely filled. If (CPUID.(EAX=07H, ECX=0):EBX[25] = 1)
+    /// && IA32_RTIT_CTL.ToPA = 1.
+    ///
+    UINT32  Trace_ToPA_PMI:1;
+    UINT32  Reserved3:2;
+    ///
+    /// [Bit 58] LBR_Frz: LBRs are frozen due to -
+    /// IA32_DEBUGCTL.FREEZE_LBR_ON_PMI=1, -  The LBR stack overflowed. If
+    /// CPUID.0AH: EAX[7:0] > 3.
+    ///
+    UINT32  LBR_Frz:1;
+    ///
+    /// [Bit 59] CTR_Frz: Performance counters in the core PMU are frozen due
+    /// to -  IA32_DEBUGCTL.FREEZE_PERFMON_ON_ PMI=1, -  one or more core PMU
+    /// counters overflowed. If CPUID.0AH: EAX[7:0] > 3.
+    ///
+    UINT32  CTR_Frz:1;
+    ///
+    /// [Bit 60] ASCI: Data in the performance counters in the core PMU may
+    /// include contributions from the direct or indirect operation intel SGX
+    /// to protect an enclave. If CPUID.(EAX=07H, ECX=0):EBX[2] = 1.
+    ///
+    UINT32  ASCI:1;
+    ///
+    /// [Bit 61] Ovf_Uncore: Uncore counter overflow status. If CPUID.0AH:
+    /// EAX[7:0] > 2.
+    ///
+    UINT32  Ovf_Uncore:1;
+    ///
+    /// [Bit 62] OvfBuf: DS SAVE area Buffer overflow status. If CPUID.0AH:
+    /// EAX[7:0] > 0.
+    ///
+    UINT32  OvfBuf:1;
+    ///
+    /// [Bit 63] CondChgd: status bits of this register has changed. If
+    /// CPUID.0AH: EAX[7:0] > 0.
+    ///
+    UINT32  CondChgd:1;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_PERF_GLOBAL_STATUS_REGISTER;
+
+
+/**
+  Global Performance Counter Control (R/W) Counter increments while the result
+  of ANDing respective enable bit in this MSR with the corresponding OS or USR
+  bits in the general-purpose or fixed counter control MSR is true. If
+  CPUID.0AH: EAX[7:0] > 0.
+
+  @param  ECX  MSR_IA32_PERF_GLOBAL_CTRL (0x0000038F)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_PERF_GLOBAL_CTRL_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_PERF_GLOBAL_CTRL_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_PERF_GLOBAL_CTRL_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_PERF_GLOBAL_CTRL);
+  AsmWriteMsr64 (MSR_IA32_PERF_GLOBAL_CTRL, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_PERF_GLOBAL_CTRL is defined as IA32_PERF_GLOBAL_CTRL in SDM.
+**/
+#define MSR_IA32_PERF_GLOBAL_CTRL                0x0000038F
+
+/**
+  MSR information returned for MSR index #MSR_IA32_PERF_GLOBAL_CTRL
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+///
+  struct {
+    ///
+    /// [Bits 31:0] EN_PMCn. If CPUID.0AH: EAX[15:8] > n.
+    /// Enable bitmask.  Only the first n-1 bits are valid.
+    /// Bits n..31 are reserved.
+    ///
+    UINT32  EN_PMCn:32;
+    ///
+    /// [Bits 63:32] EN_FIXED_CTRn. If CPUID.0AH: EDX[4:0] > n.
+    /// Enable bitmask.  Only the first n-1 bits are valid.
+    /// Bits 31:n are reserved.
+    ///
+    UINT32  EN_FIXED_CTRn:32;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_PERF_GLOBAL_CTRL_REGISTER;
+
+
+/**
+  Global Performance Counter Overflow Control (R/W). If CPUID.0AH: EAX[7:0] >
+  0 && CPUID.0AH: EAX[7:0] <= 3.
+
+  @param  ECX  MSR_IA32_PERF_GLOBAL_OVF_CTRL (0x00000390)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_PERF_GLOBAL_OVF_CTRL_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_PERF_GLOBAL_OVF_CTRL_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_PERF_GLOBAL_OVF_CTRL_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_PERF_GLOBAL_OVF_CTRL);
+  AsmWriteMsr64 (MSR_IA32_PERF_GLOBAL_OVF_CTRL, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_PERF_GLOBAL_OVF_CTRL is defined as IA32_PERF_GLOBAL_OVF_CTRL in SDM.
+**/
+#define MSR_IA32_PERF_GLOBAL_OVF_CTRL            0x00000390
+
+/**
+  MSR information returned for MSR index #MSR_IA32_PERF_GLOBAL_OVF_CTRL
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 31:0] Set 1 to Clear Ovf_PMC0 bit. If CPUID.0AH: EAX[15:8] > n.
+    /// Clear bitmask.  Only the first n-1 bits are valid.
+    /// Bits 31:n are reserved.
+    ///
+    UINT32  Ovf_PMCn:32;
+    ///
+    /// [Bits 54:32] Set 1 to Clear Ovf_FIXED_CTR0 bit.
+    /// If CPUID.0AH: EDX[4:0] > n.
+    /// Clear bitmask.  Only the first n-1 bits are valid.
+    /// Bits 22:n are reserved.
+    ///
+    UINT32  Ovf_FIXED_CTRn:23;
+    ///
+    /// [Bit 55] Set 1 to Clear Trace_ToPA_PMI bit. If (CPUID.(EAX=07H,
+    /// ECX=0):EBX[25] = 1) && IA32_RTIT_CTL.ToPA = 1.
+    ///
+    UINT32  Trace_ToPA_PMI:1;
+    UINT32  Reserved2:5;
+    ///
+    /// [Bit 61] Set 1 to Clear Ovf_Uncore bit. Introduced at Display Family /
+    /// Display Model 06_2EH.
+    ///
+    UINT32  Ovf_Uncore:1;
+    ///
+    /// [Bit 62] Set 1 to Clear OvfBuf: bit. If CPUID.0AH: EAX[7:0] > 0.
+    ///
+    UINT32  OvfBuf:1;
+    ///
+    /// [Bit 63] Set to 1to clear CondChgd: bit. If CPUID.0AH: EAX[7:0] > 0.
+    ///
+    UINT32  CondChgd:1;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_PERF_GLOBAL_OVF_CTRL_REGISTER;
+
+
+/**
+  Global Performance Counter Overflow Reset Control (R/W). If CPUID.0AH:
+  EAX[7:0] > 3.
+
+  @param  ECX  MSR_IA32_PERF_GLOBAL_STATUS_RESET (0x00000390)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_PERF_GLOBAL_STATUS_RESET_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_PERF_GLOBAL_STATUS_RESET_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_PERF_GLOBAL_STATUS_RESET_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_PERF_GLOBAL_STATUS_RESET);
+  AsmWriteMsr64 (MSR_IA32_PERF_GLOBAL_STATUS_RESET, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_PERF_GLOBAL_STATUS_RESET is defined as IA32_PERF_GLOBAL_STATUS_RESET in SDM.
+**/
+#define MSR_IA32_PERF_GLOBAL_STATUS_RESET        0x00000390
+
+/**
+  MSR information returned for MSR index #MSR_IA32_PERF_GLOBAL_STATUS_RESET
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 31:0] Set 1 to Clear Ovf_PMC0 bit. If CPUID.0AH: EAX[15:8] > n.
+    /// Clear bitmask.  Only the first n-1 bits are valid.
+    /// Bits 31:n are reserved.
+    ///
+    UINT32  Ovf_PMCn:32;
+    ///
+    /// [Bits 54:32] Set 1 to Clear Ovf_FIXED_CTR0 bit.
+    /// If CPUID.0AH: EDX[4:0] > n.
+    /// Clear bitmask.  Only the first n-1 bits are valid.
+    /// Bits 22:n are reserved.
+    ///
+    UINT32  Ovf_FIXED_CTRn:23;
+    ///
+    /// [Bit 55] Set 1 to Clear Trace_ToPA_PMI bit. If (CPUID.(EAX=07H,
+    /// ECX=0):EBX[25] = 1) && IA32_RTIT_CTL.ToPA[8] = 1.
+    ///
+    UINT32  Trace_ToPA_PMI:1;
+    UINT32  Reserved2:2;
+    ///
+    /// [Bit 58] Set 1 to Clear LBR_Frz bit. If CPUID.0AH: EAX[7:0] > 3.
+    ///
+    UINT32  LBR_Frz:1;
+    ///
+    /// [Bit 59] Set 1 to Clear CTR_Frz bit. If CPUID.0AH: EAX[7:0] > 3.
+    ///
+    UINT32  CTR_Frz:1;
+    ///
+    /// [Bit 60] Set 1 to Clear ASCI bit. If CPUID.0AH: EAX[7:0] > 3.
+    ///
+    UINT32  ASCI:1;
+    ///
+    /// [Bit 61] Set 1 to Clear Ovf_Uncore bit. Introduced at Display Family /
+    /// Display Model 06_2EH.
+    ///
+    UINT32  Ovf_Uncore:1;
+    ///
+    /// [Bit 62] Set 1 to Clear OvfBuf: bit. If CPUID.0AH: EAX[7:0] > 0.
+    ///
+    UINT32  OvfBuf:1;
+    ///
+    /// [Bit 63] Set to 1to clear CondChgd: bit. If CPUID.0AH: EAX[7:0] > 0.
+    ///
+    UINT32  CondChgd:1;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_PERF_GLOBAL_STATUS_RESET_REGISTER;
+
+
+/**
+  Global Performance Counter Overflow Set Control (R/W). If CPUID.0AH:
+  EAX[7:0] > 3.
+
+  @param  ECX  MSR_IA32_PERF_GLOBAL_STATUS_SET (0x00000391)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_PERF_GLOBAL_STATUS_SET_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_PERF_GLOBAL_STATUS_SET_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_PERF_GLOBAL_STATUS_SET_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_PERF_GLOBAL_STATUS_SET);
+  AsmWriteMsr64 (MSR_IA32_PERF_GLOBAL_STATUS_SET, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_PERF_GLOBAL_STATUS_SET is defined as IA32_PERF_GLOBAL_STATUS_SET in SDM.
+**/
+#define MSR_IA32_PERF_GLOBAL_STATUS_SET          0x00000391
+
+/**
+  MSR information returned for MSR index #MSR_IA32_PERF_GLOBAL_STATUS_SET
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 31:0] Set 1 to cause Ovf_PMCn = 1. If CPUID.0AH: EAX[7:0] > n.
+    /// Set bitmask.  Only the first n-1 bits are valid.
+    /// Bits 31:n are reserved.
+    ///
+    UINT32  Ovf_PMCn:32;
+    ///
+    /// [Bits 54:32] Set 1 to cause Ovf_FIXED_CTRn = 1.
+    /// If CPUID.0AH: EAX[7:0] > n.
+    /// Set bitmask.  Only the first n-1 bits are valid.
+    /// Bits 22:n are reserved.
+    ///
+    UINT32  Ovf_FIXED_CTRn:23;
+    ///
+    /// [Bit 55] Set 1 to cause Trace_ToPA_PMI = 1. If CPUID.0AH: EAX[7:0] > 3.
+    ///
+    UINT32  Trace_ToPA_PMI:1;
+    UINT32  Reserved2:2;
+    ///
+    /// [Bit 58] Set 1 to cause LBR_Frz = 1. If CPUID.0AH: EAX[7:0] > 3.
+    ///
+    UINT32  LBR_Frz:1;
+    ///
+    /// [Bit 59] Set 1 to cause CTR_Frz = 1. If CPUID.0AH: EAX[7:0] > 3.
+    ///
+    UINT32  CTR_Frz:1;
+    ///
+    /// [Bit 60] Set 1 to cause ASCI = 1. If CPUID.0AH: EAX[7:0] > 3.
+    ///
+    UINT32  ASCI:1;
+    ///
+    /// [Bit 61] Set 1 to cause Ovf_Uncore = 1. If CPUID.0AH: EAX[7:0] > 3.
+    ///
+    UINT32  Ovf_Uncore:1;
+    ///
+    /// [Bit 62] Set 1 to cause OvfBuf = 1. If CPUID.0AH: EAX[7:0] > 3.
+    ///
+    UINT32  OvfBuf:1;
+    UINT32  Reserved3:1;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_PERF_GLOBAL_STATUS_SET_REGISTER;
+
+
+/**
+  Indicator of core perfmon interface is in use (RO). If CPUID.0AH: EAX[7:0] >
+  3.
+
+  @param  ECX  MSR_IA32_PERF_GLOBAL_INUSE (0x00000392)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_PERF_GLOBAL_INUSE_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_PERF_GLOBAL_INUSE_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_PERF_GLOBAL_INUSE_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_PERF_GLOBAL_INUSE);
+  @endcode
+  @note MSR_IA32_PERF_GLOBAL_INUSE is defined as IA32_PERF_GLOBAL_INUSE in SDM.
+**/
+#define MSR_IA32_PERF_GLOBAL_INUSE               0x00000392
+
+/**
+  MSR information returned for MSR index #MSR_IA32_PERF_GLOBAL_INUSE
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 31:0] IA32_PERFEVTSELn in use.  If CPUID.0AH: EAX[7:0] > n.
+    /// Status bitmask.  Only the first n-1 bits are valid.
+    /// Bits 31:n are reserved.
+    ///
+    UINT32  IA32_PERFEVTSELn:32;
+    ///
+    /// [Bits 62:32] IA32_FIXED_CTRn in use.
+    /// If CPUID.0AH: EAX[7:0] > n.
+    /// Status bitmask.  Only the first n-1 bits are valid.
+    /// Bits 30:n are reserved.
+    ///
+    UINT32  IA32_FIXED_CTRn:31;
+    ///
+    /// [Bit 63] PMI in use.
+    ///
+    UINT32  PMI:1;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_PERF_GLOBAL_INUSE_REGISTER;
+
+
+/**
+  PEBS Control (R/W).
+
+  @param  ECX  MSR_IA32_PEBS_ENABLE (0x000003F1)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_PEBS_ENABLE_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_PEBS_ENABLE_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_PEBS_ENABLE_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_PEBS_ENABLE);
+  AsmWriteMsr64 (MSR_IA32_PEBS_ENABLE, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_PEBS_ENABLE is defined as IA32_PEBS_ENABLE in SDM.
+**/
+#define MSR_IA32_PEBS_ENABLE                     0x000003F1
+
+/**
+  MSR information returned for MSR index #MSR_IA32_PEBS_ENABLE
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Enable PEBS on IA32_PMC0. Introduced at Display Family /
+    /// Display Model 06_0FH.
+    ///
+    UINT32  Enable:1;
+    ///
+    /// [Bits 3:1] Reserved or Model specific.
+    ///
+    UINT32  Reserved1:3;
+    UINT32  Reserved2:28;
+    ///
+    /// [Bits 35:32] Reserved or Model specific.
+    ///
+    UINT32  Reserved3:4;
+    UINT32  Reserved4:28;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_PEBS_ENABLE_REGISTER;
+
+
+/**
+  MCn_CTL. If IA32_MCG_CAP.CNT > n.
+
+  @param  ECX  MSR_IA32_MCn_CTL
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_MC0_CTL);
+  AsmWriteMsr64 (MSR_IA32_MC0_CTL, Msr);
+  @endcode
+  @note MSR_IA32_MC0_CTL  is defined as IA32_MC0_CTL  in SDM.
+        MSR_IA32_MC1_CTL  is defined as IA32_MC1_CTL  in SDM.
+        MSR_IA32_MC2_CTL  is defined as IA32_MC2_CTL  in SDM.
+        MSR_IA32_MC3_CTL  is defined as IA32_MC3_CTL  in SDM.
+        MSR_IA32_MC4_CTL  is defined as IA32_MC4_CTL  in SDM.
+        MSR_IA32_MC5_CTL  is defined as IA32_MC5_CTL  in SDM.
+        MSR_IA32_MC6_CTL  is defined as IA32_MC6_CTL  in SDM.
+        MSR_IA32_MC7_CTL  is defined as IA32_MC7_CTL  in SDM.
+        MSR_IA32_MC8_CTL  is defined as IA32_MC8_CTL  in SDM.
+        MSR_IA32_MC9_CTL  is defined as IA32_MC9_CTL  in SDM.
+        MSR_IA32_MC10_CTL is defined as IA32_MC10_CTL in SDM.
+        MSR_IA32_MC11_CTL is defined as IA32_MC11_CTL in SDM.
+        MSR_IA32_MC12_CTL is defined as IA32_MC12_CTL in SDM.
+        MSR_IA32_MC13_CTL is defined as IA32_MC13_CTL in SDM.
+        MSR_IA32_MC14_CTL is defined as IA32_MC14_CTL in SDM.
+        MSR_IA32_MC15_CTL is defined as IA32_MC15_CTL in SDM.
+        MSR_IA32_MC16_CTL is defined as IA32_MC16_CTL in SDM.
+        MSR_IA32_MC17_CTL is defined as IA32_MC17_CTL in SDM.
+        MSR_IA32_MC18_CTL is defined as IA32_MC18_CTL in SDM.
+        MSR_IA32_MC19_CTL is defined as IA32_MC19_CTL in SDM.
+        MSR_IA32_MC20_CTL is defined as IA32_MC20_CTL in SDM.
+        MSR_IA32_MC21_CTL is defined as IA32_MC21_CTL in SDM.
+        MSR_IA32_MC22_CTL is defined as IA32_MC22_CTL in SDM.
+        MSR_IA32_MC23_CTL is defined as IA32_MC23_CTL in SDM.
+        MSR_IA32_MC24_CTL is defined as IA32_MC24_CTL in SDM.
+        MSR_IA32_MC25_CTL is defined as IA32_MC25_CTL in SDM.
+        MSR_IA32_MC26_CTL is defined as IA32_MC26_CTL in SDM.
+        MSR_IA32_MC27_CTL is defined as IA32_MC27_CTL in SDM.
+        MSR_IA32_MC28_CTL is defined as IA32_MC28_CTL in SDM.
+  @{
+**/
+#define MSR_IA32_MC0_CTL                         0x00000400
+#define MSR_IA32_MC1_CTL                         0x00000404
+#define MSR_IA32_MC2_CTL                         0x00000408
+#define MSR_IA32_MC3_CTL                         0x0000040C
+#define MSR_IA32_MC4_CTL                         0x00000410
+#define MSR_IA32_MC5_CTL                         0x00000414
+#define MSR_IA32_MC6_CTL                         0x00000418
+#define MSR_IA32_MC7_CTL                         0x0000041C
+#define MSR_IA32_MC8_CTL                         0x00000420
+#define MSR_IA32_MC9_CTL                         0x00000424
+#define MSR_IA32_MC10_CTL                        0x00000428
+#define MSR_IA32_MC11_CTL                        0x0000042C
+#define MSR_IA32_MC12_CTL                        0x00000430
+#define MSR_IA32_MC13_CTL                        0x00000434
+#define MSR_IA32_MC14_CTL                        0x00000438
+#define MSR_IA32_MC15_CTL                        0x0000043C
+#define MSR_IA32_MC16_CTL                        0x00000440
+#define MSR_IA32_MC17_CTL                        0x00000444
+#define MSR_IA32_MC18_CTL                        0x00000448
+#define MSR_IA32_MC19_CTL                        0x0000044C
+#define MSR_IA32_MC20_CTL                        0x00000450
+#define MSR_IA32_MC21_CTL                        0x00000454
+#define MSR_IA32_MC22_CTL                        0x00000458
+#define MSR_IA32_MC23_CTL                        0x0000045C
+#define MSR_IA32_MC24_CTL                        0x00000460
+#define MSR_IA32_MC25_CTL                        0x00000464
+#define MSR_IA32_MC26_CTL                        0x00000468
+#define MSR_IA32_MC27_CTL                        0x0000046C
+#define MSR_IA32_MC28_CTL                        0x00000470
+/// @}
+
+
+/**
+  MCn_STATUS. If IA32_MCG_CAP.CNT > n.
+
+  @param  ECX  MSR_IA32_MCn_STATUS
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_MC0_STATUS);
+  AsmWriteMsr64 (MSR_IA32_MC0_STATUS, Msr);
+  @endcode
+  @note MSR_IA32_MC0_STATUS  is defined as IA32_MC0_STATUS  in SDM.
+        MSR_IA32_MC1_STATUS  is defined as IA32_MC1_STATUS  in SDM.
+        MSR_IA32_MC2_STATUS  is defined as IA32_MC2_STATUS  in SDM.
+        MSR_IA32_MC3_STATUS  is defined as IA32_MC3_STATUS  in SDM.
+        MSR_IA32_MC4_STATUS  is defined as IA32_MC4_STATUS  in SDM.
+        MSR_IA32_MC5_STATUS  is defined as IA32_MC5_STATUS  in SDM.
+        MSR_IA32_MC6_STATUS  is defined as IA32_MC6_STATUS  in SDM.
+        MSR_IA32_MC7_STATUS  is defined as IA32_MC7_STATUS  in SDM.
+        MSR_IA32_MC8_STATUS  is defined as IA32_MC8_STATUS  in SDM.
+        MSR_IA32_MC9_STATUS  is defined as IA32_MC9_STATUS  in SDM.
+        MSR_IA32_MC10_STATUS is defined as IA32_MC10_STATUS in SDM.
+        MSR_IA32_MC11_STATUS is defined as IA32_MC11_STATUS in SDM.
+        MSR_IA32_MC12_STATUS is defined as IA32_MC12_STATUS in SDM.
+        MSR_IA32_MC13_STATUS is defined as IA32_MC13_STATUS in SDM.
+        MSR_IA32_MC14_STATUS is defined as IA32_MC14_STATUS in SDM.
+        MSR_IA32_MC15_STATUS is defined as IA32_MC15_STATUS in SDM.
+        MSR_IA32_MC16_STATUS is defined as IA32_MC16_STATUS in SDM.
+        MSR_IA32_MC17_STATUS is defined as IA32_MC17_STATUS in SDM.
+        MSR_IA32_MC18_STATUS is defined as IA32_MC18_STATUS in SDM.
+        MSR_IA32_MC19_STATUS is defined as IA32_MC19_STATUS in SDM.
+        MSR_IA32_MC20_STATUS is defined as IA32_MC20_STATUS in SDM.
+        MSR_IA32_MC21_STATUS is defined as IA32_MC21_STATUS in SDM.
+        MSR_IA32_MC22_STATUS is defined as IA32_MC22_STATUS in SDM.
+        MSR_IA32_MC23_STATUS is defined as IA32_MC23_STATUS in SDM.
+        MSR_IA32_MC24_STATUS is defined as IA32_MC24_STATUS in SDM.
+        MSR_IA32_MC25_STATUS is defined as IA32_MC25_STATUS in SDM.
+        MSR_IA32_MC26_STATUS is defined as IA32_MC26_STATUS in SDM.
+        MSR_IA32_MC27_STATUS is defined as IA32_MC27_STATUS in SDM.
+        MSR_IA32_MC28_STATUS is defined as IA32_MC28_STATUS in SDM.
+  @{
+**/
+#define MSR_IA32_MC0_STATUS                      0x00000401
+#define MSR_IA32_MC1_STATUS                      0x00000405
+#define MSR_IA32_MC2_STATUS                      0x00000409
+#define MSR_IA32_MC3_STATUS                      0x0000040D
+#define MSR_IA32_MC4_STATUS                      0x00000411
+#define MSR_IA32_MC5_STATUS                      0x00000415
+#define MSR_IA32_MC6_STATUS                      0x00000419
+#define MSR_IA32_MC7_STATUS                      0x0000041D
+#define MSR_IA32_MC8_STATUS                      0x00000421
+#define MSR_IA32_MC9_STATUS                      0x00000425
+#define MSR_IA32_MC10_STATUS                     0x00000429
+#define MSR_IA32_MC11_STATUS                     0x0000042D
+#define MSR_IA32_MC12_STATUS                     0x00000431
+#define MSR_IA32_MC13_STATUS                     0x00000435
+#define MSR_IA32_MC14_STATUS                     0x00000439
+#define MSR_IA32_MC15_STATUS                     0x0000043D
+#define MSR_IA32_MC16_STATUS                     0x00000441
+#define MSR_IA32_MC17_STATUS                     0x00000445
+#define MSR_IA32_MC18_STATUS                     0x00000449
+#define MSR_IA32_MC19_STATUS                     0x0000044D
+#define MSR_IA32_MC20_STATUS                     0x00000451
+#define MSR_IA32_MC21_STATUS                     0x00000455
+#define MSR_IA32_MC22_STATUS                     0x00000459
+#define MSR_IA32_MC23_STATUS                     0x0000045D
+#define MSR_IA32_MC24_STATUS                     0x00000461
+#define MSR_IA32_MC25_STATUS                     0x00000465
+#define MSR_IA32_MC26_STATUS                     0x00000469
+#define MSR_IA32_MC27_STATUS                     0x0000046D
+#define MSR_IA32_MC28_STATUS                     0x00000471
+/// @}
+
+
+/**
+  MCn_ADDR. If IA32_MCG_CAP.CNT > n.
+
+  @param  ECX  MSR_IA32_MCn_ADDR
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_MC0_ADDR);
+  AsmWriteMsr64 (MSR_IA32_MC0_ADDR, Msr);
+  @endcode
+  @note MSR_IA32_MC0_ADDR  is defined as IA32_MC0_ADDR  in SDM.
+        MSR_IA32_MC1_ADDR  is defined as IA32_MC1_ADDR  in SDM.
+        MSR_IA32_MC2_ADDR  is defined as IA32_MC2_ADDR  in SDM.
+        MSR_IA32_MC3_ADDR  is defined as IA32_MC3_ADDR  in SDM.
+        MSR_IA32_MC4_ADDR  is defined as IA32_MC4_ADDR  in SDM.
+        MSR_IA32_MC5_ADDR  is defined as IA32_MC5_ADDR  in SDM.
+        MSR_IA32_MC6_ADDR  is defined as IA32_MC6_ADDR  in SDM.
+        MSR_IA32_MC7_ADDR  is defined as IA32_MC7_ADDR  in SDM.
+        MSR_IA32_MC8_ADDR  is defined as IA32_MC8_ADDR  in SDM.
+        MSR_IA32_MC9_ADDR  is defined as IA32_MC9_ADDR  in SDM.
+        MSR_IA32_MC10_ADDR is defined as IA32_MC10_ADDR in SDM.
+        MSR_IA32_MC11_ADDR is defined as IA32_MC11_ADDR in SDM.
+        MSR_IA32_MC12_ADDR is defined as IA32_MC12_ADDR in SDM.
+        MSR_IA32_MC13_ADDR is defined as IA32_MC13_ADDR in SDM.
+        MSR_IA32_MC14_ADDR is defined as IA32_MC14_ADDR in SDM.
+        MSR_IA32_MC15_ADDR is defined as IA32_MC15_ADDR in SDM.
+        MSR_IA32_MC16_ADDR is defined as IA32_MC16_ADDR in SDM.
+        MSR_IA32_MC17_ADDR is defined as IA32_MC17_ADDR in SDM.
+        MSR_IA32_MC18_ADDR is defined as IA32_MC18_ADDR in SDM.
+        MSR_IA32_MC19_ADDR is defined as IA32_MC19_ADDR in SDM.
+        MSR_IA32_MC20_ADDR is defined as IA32_MC20_ADDR in SDM.
+        MSR_IA32_MC21_ADDR is defined as IA32_MC21_ADDR in SDM.
+        MSR_IA32_MC22_ADDR is defined as IA32_MC22_ADDR in SDM.
+        MSR_IA32_MC23_ADDR is defined as IA32_MC23_ADDR in SDM.
+        MSR_IA32_MC24_ADDR is defined as IA32_MC24_ADDR in SDM.
+        MSR_IA32_MC25_ADDR is defined as IA32_MC25_ADDR in SDM.
+        MSR_IA32_MC26_ADDR is defined as IA32_MC26_ADDR in SDM.
+        MSR_IA32_MC27_ADDR is defined as IA32_MC27_ADDR in SDM.
+        MSR_IA32_MC28_ADDR is defined as IA32_MC28_ADDR in SDM.
+  @{
+**/
+#define MSR_IA32_MC0_ADDR                        0x00000402
+#define MSR_IA32_MC1_ADDR                        0x00000406
+#define MSR_IA32_MC2_ADDR                        0x0000040A
+#define MSR_IA32_MC3_ADDR                        0x0000040E
+#define MSR_IA32_MC4_ADDR                        0x00000412
+#define MSR_IA32_MC5_ADDR                        0x00000416
+#define MSR_IA32_MC6_ADDR                        0x0000041A
+#define MSR_IA32_MC7_ADDR                        0x0000041E
+#define MSR_IA32_MC8_ADDR                        0x00000422
+#define MSR_IA32_MC9_ADDR                        0x00000426
+#define MSR_IA32_MC10_ADDR                       0x0000042A
+#define MSR_IA32_MC11_ADDR                       0x0000042E
+#define MSR_IA32_MC12_ADDR                       0x00000432
+#define MSR_IA32_MC13_ADDR                       0x00000436
+#define MSR_IA32_MC14_ADDR                       0x0000043A
+#define MSR_IA32_MC15_ADDR                       0x0000043E
+#define MSR_IA32_MC16_ADDR                       0x00000442
+#define MSR_IA32_MC17_ADDR                       0x00000446
+#define MSR_IA32_MC18_ADDR                       0x0000044A
+#define MSR_IA32_MC19_ADDR                       0x0000044E
+#define MSR_IA32_MC20_ADDR                       0x00000452
+#define MSR_IA32_MC21_ADDR                       0x00000456
+#define MSR_IA32_MC22_ADDR                       0x0000045A
+#define MSR_IA32_MC23_ADDR                       0x0000045E
+#define MSR_IA32_MC24_ADDR                       0x00000462
+#define MSR_IA32_MC25_ADDR                       0x00000466
+#define MSR_IA32_MC26_ADDR                       0x0000046A
+#define MSR_IA32_MC27_ADDR                       0x0000046E
+#define MSR_IA32_MC28_ADDR                       0x00000472
+/// @}
+
+
+/**
+  MCn_MISC. If IA32_MCG_CAP.CNT > n.
+
+  @param  ECX  MSR_IA32_MCn_MISC
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_MC0_MISC);
+  AsmWriteMsr64 (MSR_IA32_MC0_MISC, Msr);
+  @endcode
+  @note MSR_IA32_MC0_MISC  is defined as IA32_MC0_MISC  in SDM.
+        MSR_IA32_MC1_MISC  is defined as IA32_MC1_MISC  in SDM.
+        MSR_IA32_MC2_MISC  is defined as IA32_MC2_MISC  in SDM.
+        MSR_IA32_MC3_MISC  is defined as IA32_MC3_MISC  in SDM.
+        MSR_IA32_MC4_MISC  is defined as IA32_MC4_MISC  in SDM.
+        MSR_IA32_MC5_MISC  is defined as IA32_MC5_MISC  in SDM.
+        MSR_IA32_MC6_MISC  is defined as IA32_MC6_MISC  in SDM.
+        MSR_IA32_MC7_MISC  is defined as IA32_MC7_MISC  in SDM.
+        MSR_IA32_MC8_MISC  is defined as IA32_MC8_MISC  in SDM.
+        MSR_IA32_MC9_MISC  is defined as IA32_MC9_MISC  in SDM.
+        MSR_IA32_MC10_MISC is defined as IA32_MC10_MISC in SDM.
+        MSR_IA32_MC11_MISC is defined as IA32_MC11_MISC in SDM.
+        MSR_IA32_MC12_MISC is defined as IA32_MC12_MISC in SDM.
+        MSR_IA32_MC13_MISC is defined as IA32_MC13_MISC in SDM.
+        MSR_IA32_MC14_MISC is defined as IA32_MC14_MISC in SDM.
+        MSR_IA32_MC15_MISC is defined as IA32_MC15_MISC in SDM.
+        MSR_IA32_MC16_MISC is defined as IA32_MC16_MISC in SDM.
+        MSR_IA32_MC17_MISC is defined as IA32_MC17_MISC in SDM.
+        MSR_IA32_MC18_MISC is defined as IA32_MC18_MISC in SDM.
+        MSR_IA32_MC19_MISC is defined as IA32_MC19_MISC in SDM.
+        MSR_IA32_MC20_MISC is defined as IA32_MC20_MISC in SDM.
+        MSR_IA32_MC21_MISC is defined as IA32_MC21_MISC in SDM.
+        MSR_IA32_MC22_MISC is defined as IA32_MC22_MISC in SDM.
+        MSR_IA32_MC23_MISC is defined as IA32_MC23_MISC in SDM.
+        MSR_IA32_MC24_MISC is defined as IA32_MC24_MISC in SDM.
+        MSR_IA32_MC25_MISC is defined as IA32_MC25_MISC in SDM.
+        MSR_IA32_MC26_MISC is defined as IA32_MC26_MISC in SDM.
+        MSR_IA32_MC27_MISC is defined as IA32_MC27_MISC in SDM.
+        MSR_IA32_MC28_MISC is defined as IA32_MC28_MISC in SDM.
+  @{
+**/
+#define MSR_IA32_MC0_MISC                        0x00000403
+#define MSR_IA32_MC1_MISC                        0x00000407
+#define MSR_IA32_MC2_MISC                        0x0000040B
+#define MSR_IA32_MC3_MISC                        0x0000040F
+#define MSR_IA32_MC4_MISC                        0x00000413
+#define MSR_IA32_MC5_MISC                        0x00000417
+#define MSR_IA32_MC6_MISC                        0x0000041B
+#define MSR_IA32_MC7_MISC                        0x0000041F
+#define MSR_IA32_MC8_MISC                        0x00000423
+#define MSR_IA32_MC9_MISC                        0x00000427
+#define MSR_IA32_MC10_MISC                       0x0000042B
+#define MSR_IA32_MC11_MISC                       0x0000042F
+#define MSR_IA32_MC12_MISC                       0x00000433
+#define MSR_IA32_MC13_MISC                       0x00000437
+#define MSR_IA32_MC14_MISC                       0x0000043B
+#define MSR_IA32_MC15_MISC                       0x0000043F
+#define MSR_IA32_MC16_MISC                       0x00000443
+#define MSR_IA32_MC17_MISC                       0x00000447
+#define MSR_IA32_MC18_MISC                       0x0000044B
+#define MSR_IA32_MC19_MISC                       0x0000044F
+#define MSR_IA32_MC20_MISC                       0x00000453
+#define MSR_IA32_MC21_MISC                       0x00000457
+#define MSR_IA32_MC22_MISC                       0x0000045B
+#define MSR_IA32_MC23_MISC                       0x0000045F
+#define MSR_IA32_MC24_MISC                       0x00000463
+#define MSR_IA32_MC25_MISC                       0x00000467
+#define MSR_IA32_MC26_MISC                       0x0000046B
+#define MSR_IA32_MC27_MISC                       0x0000046F
+#define MSR_IA32_MC28_MISC                       0x00000473
+/// @}
+
+
+/**
+  Reporting Register of Basic VMX  Capabilities (R/O) See Appendix A.1, "Basic
+  VMX Information.". If CPUID.01H:ECX.[5] = 1.
+
+  @param  ECX  MSR_IA32_VMX_BASIC (0x00000480)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_VMX_BASIC_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_VMX_BASIC);
+  @endcode
+  @note MSR_IA32_VMX_BASIC is defined as IA32_VMX_BASIC in SDM.
+**/
+#define MSR_IA32_VMX_BASIC                       0x00000480
+
+/**
+  MSR information returned for MSR index #MSR_IA32_VMX_BASIC
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 30:0] VMCS revision identifier used by the processor.  Processors
+    /// that use the same VMCS revision identifier use the same size for VMCS
+    /// regions (see subsequent item on bits 44:32).
+    ///
+    /// @note Earlier versions of this manual specified that the VMCS revision
+    /// identifier was a 32-bit field in bits 31:0 of this MSR. For all
+    /// processors produced prior to this change, bit 31 of this MSR was read
+    /// as 0.
+    ///
+    UINT32  VmcsRevisonId:31;
+    UINT32  MustBeZero:1;
+    ///
+    /// [Bit 44:32] Reports the number of bytes that software should allocate
+    /// for the VMXON region and any VMCS region.  It is a value greater than
+    /// 0 and at most 4096(bit 44 is set if and only if bits 43:32 are clear).
+    ///
+    UINT32  VmcsSize:13;
+    UINT32  Reserved1:3;
+    ///
+    /// [Bit 48] Indicates the width of the physical addresses that may be used
+    /// for the VMXON region, each VMCS, and data structures referenced by
+    /// pointers in a VMCS (I/O bitmaps, virtual-APIC page, MSR areas for VMX
+    /// transitions).  If the bit is 0, these addresses are limited to the
+    /// processor's physical-address width.  If the bit is 1, these addresses
+    /// are limited to 32 bits. This bit is always 0 for processors that
+    /// support Intel 64 architecture.
+    ///
+    /// @note On processors that support Intel 64 architecture, the pointer
+    /// must not set bits beyond the processor's physical address width.
+    ///
+    UINT32  VmcsAddressWidth:1;
+    ///
+    /// [Bit 49] If bit 49 is read as 1, the logical processor supports the
+    /// dual-monitor treatment of system-management interrupts and
+    /// system-management mode. See Section 34.15 for details of this treatment.
+    ///
+    UINT32  DualMonitor:1;
+    ///
+    /// [Bit 53:50] report the memory type that should be used for the VMCS,
+    /// for data structures referenced by pointers in the VMCS (I/O bitmaps,
+    /// virtual-APIC page, MSR areas for VMX transitions), and for the MSEG
+    /// header. If software needs to access these data structures (e.g., to
+    /// modify the contents of the MSR bitmaps), it can configure the paging
+    /// structures to map them into the linear-address space. If it does so,
+    /// it should establish mappings that use the memory type reported bits
+    /// 53:50 in this MSR.
+    ///
+    /// As of this writing, all processors that support VMX operation indicate
+    /// the write-back type.
+    ///
+    /// If software needs to access these data structures (e.g., to modify
+    /// the contents of the MSR bitmaps), it can configure the paging
+    /// structures to map them into the linear-address space. If it does so,
+    /// it should establish mappings that use the memory type reported in this
+    /// MSR.
+    ///
+    /// @note Alternatively, software may map any of these regions or
+    /// structures with the UC memory type. (This may be necessary for the MSEG
+    /// header.) Doing so is discouraged unless necessary as it will cause the
+    /// performance of software accesses to those structures to suffer.
+    ///
+    ///
+    UINT32  MemoryType:4;
+    ///
+    /// [Bit 54] If bit 54 is read as 1, the processor reports information in
+    /// the VM-exit instruction-information field on VM exitsdue to execution
+    /// of the INS and OUTS instructions (see Section 27.2.4). This reporting
+    /// is done only if this bit is read as 1.
+    ///
+    UINT32  InsOutsReporting:1;
+    ///
+    /// [Bit 55] Bit 55 is read as 1 if any VMX controls that default to 1 may
+    /// be cleared to 0. See Appendix A.2 for details. It also reports support
+    /// for the VMX capability MSRs IA32_VMX_TRUE_PINBASED_CTLS,
+    /// IA32_VMX_TRUE_PROCBASED_CTLS, IA32_VMX_TRUE_EXIT_CTLS, and
+    /// IA32_VMX_TRUE_ENTRY_CTLS. See Appendix A.3.1, Appendix A.3.2,
+    /// Appendix A.4, and Appendix A.5 for details.
+    ///
+    UINT32  VmxControls:1;
+    UINT32  Reserved2:8;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_VMX_BASIC_REGISTER;
+
+///
+/// @{ Define value for bit field MSR_IA32_VMX_BASIC_REGISTER.MemoryType
+///
+#define MSR_IA32_VMX_BASIC_REGISTER_MEMORY_TYPE_UNCACHEABLE  0x00
+#define MSR_IA32_VMX_BASIC_REGISTER_MEMORY_TYPE_WRITE_BACK   0x06
+///
+/// @}
+///
+
+
+/**
+  Capability Reporting Register of Pinbased VM-execution Controls (R/O) See
+  Appendix A.3.1, "Pin-Based VMExecution Controls.". If CPUID.01H:ECX.[5] = 1.
+
+  @param  ECX  MSR_IA32_VMX_PINBASED_CTLS (0x00000481)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_VMX_PINBASED_CTLS);
+  @endcode
+  @note MSR_IA32_VMX_PINBASED_CTLS is defined as IA32_VMX_PINBASED_CTLS in SDM.
+**/
+#define MSR_IA32_VMX_PINBASED_CTLS               0x00000481
+
+
+/**
+  Capability Reporting Register of Primary  Processor-based VM-execution
+  Controls (R/O) See Appendix A.3.2, "Primary Processor- Based VM-Execution
+  Controls.". If CPUID.01H:ECX.[5] = 1.
+
+  @param  ECX  MSR_IA32_VMX_PROCBASED_CTLS (0x00000482)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_VMX_PROCBASED_CTLS);
+  @endcode
+  @note MSR_IA32_VMX_PROCBASED_CTLS is defined as IA32_VMX_PROCBASED_CTLS in SDM.
+**/
+#define MSR_IA32_VMX_PROCBASED_CTLS              0x00000482
+
+
+/**
+  Capability Reporting Register of VM-exit  Controls (R/O) See Appendix A.4,
+  "VM-Exit Controls.". If CPUID.01H:ECX.[5] = 1.
+
+  @param  ECX  MSR_IA32_VMX_EXIT_CTLS (0x00000483)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_VMX_EXIT_CTLS);
+  @endcode
+  @note MSR_IA32_VMX_EXIT_CTLS is defined as IA32_VMX_EXIT_CTLS in SDM.
+**/
+#define MSR_IA32_VMX_EXIT_CTLS                   0x00000483
+
+
+/**
+  Capability Reporting Register of VMentry Controls (R/O) See Appendix A.5,
+  "VM-Entry Controls.". If CPUID.01H:ECX.[5] = 1.
+
+  @param  ECX  MSR_IA32_VMX_ENTRY_CTLS (0x00000484)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_VMX_ENTRY_CTLS);
+  @endcode
+  @note MSR_IA32_VMX_ENTRY_CTLS is defined as IA32_VMX_ENTRY_CTLS in SDM.
+**/
+#define MSR_IA32_VMX_ENTRY_CTLS                  0x00000484
+
+
+/**
+  Reporting Register of Miscellaneous VMX Capabilities (R/O) See Appendix A.6,
+  "Miscellaneous Data.". If CPUID.01H:ECX.[5] = 1.
+
+  @param  ECX  MSR_IA32_VMX_MISC (0x00000485)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  IA32_VMX_MISC_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_VMX_MISC);
+  @endcode
+  @note MSR_IA32_VMX_MISC is defined as IA32_VMX_MISC in SDM.
+**/
+#define MSR_IA32_VMX_MISC                        0x00000485
+
+/**
+  MSR information returned for MSR index #IA32_VMX_MISC
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 4:0] Reports a value X that specifies the relationship between the
+    /// rate of the VMX-preemption timer and that of the timestamp counter (TSC).
+    /// Specifically, the VMX-preemption timer (if it is active) counts down by
+    /// 1 every time bit X in the TSC changes due to a TSC increment.
+    ///
+    UINT32  VmxTimerRatio:5;
+    ///
+    /// [Bit 5] If bit 5 is read as 1, VM exits store the value of IA32_EFER.LMA
+    /// into the "IA-32e mode guest" VM-entry control;see Section 27.2 for more
+    /// details. This bit is read as 1 on any logical processor that supports
+    /// the 1-setting of the "unrestricted guest" VM-execution control.
+    ///
+    UINT32  VmExitEferLma:1;
+    ///
+    /// [Bit 6] reports (if set) the support for activity state 1 (HLT).
+    ///
+    UINT32  HltActivityStateSupported:1;
+    ///
+    /// [Bit 7] reports (if set) the support for activity state 2 (shutdown).
+    ///
+    UINT32  ShutdownActivityStateSupported:1;
+    ///
+    /// [Bit 8] reports (if set) the support for activity state 3 (wait-for-SIPI).
+    ///
+    UINT32  WaitForSipiActivityStateSupported:1;
+    UINT32  Reserved1:5;
+    ///
+    /// [Bit 14] If read as 1, Intel(R) Processor Trace (Intel PT) can be used
+    /// in VMX operation. If the processor supports Intel PT but does not allow
+    /// it to be used in VMX operation, execution of VMXON clears
+    /// IA32_RTIT_CTL.TraceEn (see "VMXON-Enter VMX Operation" in Chapter 30);
+    /// any attempt to set that bit while in VMX operation (including VMX root
+    /// operation) using the WRMSR instruction causes a general-protection
+    /// exception.
+    ///
+    UINT32  ProcessorTraceSupported:1;
+    ///
+    /// [Bit 15] If read as 1, the RDMSR instruction can be used in system-
+    /// management mode (SMM) to read the IA32_SMBASE MSR (MSR address 9EH).
+    /// See Section 34.15.6.3.
+    ///
+    UINT32  SmBaseMsrSupported:1;
+    ///
+    /// [Bits 24:16] Indicate the number of CR3-target values supported by the
+    /// processor. This number is a value between 0 and 256, inclusive (bit 24
+    /// is set if and only if bits 23:16 are clear).
+    ///
+    UINT32  NumberOfCr3TargetValues:9;
+    ///
+    /// [Bit 27:25] Bits 27:25 is used to compute the recommended maximum
+    /// number of MSRs that should appear in the VM-exit MSR-store list, the
+    /// VM-exit MSR-load list, or the VM-entry MSR-load list. Specifically, if
+    /// the value bits 27:25 of IA32_VMX_MISC is N, then 512 * (N + 1) is the
+    /// recommended maximum number of MSRs to be included in each list. If the
+    /// limit is exceeded, undefined processor behavior may result (including a
+    /// machine check during the VMX transition).
+    ///
+    UINT32  MsrStoreListMaximum:3;
+    ///
+    /// [Bit 28] If read as 1, bit 2 of the IA32_SMM_MONITOR_CTL can be set
+    /// to 1. VMXOFF unblocks SMIs unless IA32_SMM_MONITOR_CTL[bit 2] is 1
+    /// (see Section 34.14.4).
+    ///
+    UINT32  BlockSmiSupported:1;
+    ///
+    /// [Bit 29] read as 1, software can use VMWRITE to write to any supported
+    /// field in the VMCS; otherwise, VMWRITE cannot be used to modify VM-exit
+    /// information fields.
+    ///
+    UINT32  VmWriteSupported:1;
+    ///
+    /// [Bit 30] If read as 1, VM entry allows injection of a software
+    /// interrupt, software exception, or privileged software exception with an
+    /// instruction length of 0.
+    ///
+    UINT32  VmInjectSupported:1;
+    UINT32  Reserved2:1;
+    ///
+    /// [Bits 63:32] Reports the 32-bit MSEG revision identifier used by the
+    /// processor.
+    ///
+    UINT32  MsegRevisionIdentifier:32;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} IA32_VMX_MISC_REGISTER;
+
+
+/**
+  Capability Reporting Register of CR0 Bits Fixed to 0 (R/O) See Appendix A.7,
+  "VMX-Fixed Bits in CR0.". If CPUID.01H:ECX.[5] = 1.
+
+  @param  ECX  MSR_IA32_VMX_CR0_FIXED0 (0x00000486)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_VMX_CR0_FIXED0);
+  @endcode
+  @note MSR_IA32_VMX_CR0_FIXED0 is defined as IA32_VMX_CR0_FIXED0 in SDM.
+**/
+#define MSR_IA32_VMX_CR0_FIXED0                  0x00000486
+
+
+/**
+  Capability Reporting Register of CR0 Bits Fixed to 1 (R/O) See Appendix A.7,
+  "VMX-Fixed Bits in CR0.". If CPUID.01H:ECX.[5] = 1.
+
+  @param  ECX  MSR_IA32_VMX_CR0_FIXED1 (0x00000487)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_VMX_CR0_FIXED1);
+  @endcode
+  @note MSR_IA32_VMX_CR0_FIXED1 is defined as IA32_VMX_CR0_FIXED1 in SDM.
+**/
+#define MSR_IA32_VMX_CR0_FIXED1                  0x00000487
+
+
+/**
+  Capability Reporting Register of CR4 Bits Fixed to 0 (R/O) See Appendix A.8,
+  "VMX-Fixed Bits in CR4.". If CPUID.01H:ECX.[5] = 1.
+
+  @param  ECX  MSR_IA32_VMX_CR4_FIXED0 (0x00000488)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_VMX_CR4_FIXED0);
+  @endcode
+  @note MSR_IA32_VMX_CR4_FIXED0 is defined as IA32_VMX_CR4_FIXED0 in SDM.
+**/
+#define MSR_IA32_VMX_CR4_FIXED0                  0x00000488
+
+
+/**
+  Capability Reporting Register of CR4 Bits Fixed to 1 (R/O) See Appendix A.8,
+  "VMX-Fixed Bits in CR4.". If CPUID.01H:ECX.[5] = 1.
+
+  @param  ECX  MSR_IA32_VMX_CR4_FIXED1 (0x00000489)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_VMX_CR4_FIXED1);
+  @endcode
+  @note MSR_IA32_VMX_CR4_FIXED1 is defined as IA32_VMX_CR4_FIXED1 in SDM.
+**/
+#define MSR_IA32_VMX_CR4_FIXED1                  0x00000489
+
+
+/**
+  Capability Reporting Register of VMCS Field Enumeration (R/O) See Appendix
+  A.9, "VMCS Enumeration.". If CPUID.01H:ECX.[5] = 1.
+
+  @param  ECX  MSR_IA32_VMX_VMCS_ENUM (0x0000048A)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_VMX_VMCS_ENUM);
+  @endcode
+  @note MSR_IA32_VMX_VMCS_ENUM is defined as IA32_VMX_VMCS_ENUM in SDM.
+**/
+#define MSR_IA32_VMX_VMCS_ENUM                   0x0000048A
+
+
+/**
+  Capability Reporting Register of  Secondary Processor-based  VM-execution
+  Controls (R/O) See Appendix A.3.3, "Secondary Processor- Based VM-Execution
+  Controls.". If ( CPUID.01H:ECX.[5] && IA32_VMX_PROCBASED_C TLS[63]).
+
+  @param  ECX  MSR_IA32_VMX_PROCBASED_CTLS2 (0x0000048B)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_VMX_PROCBASED_CTLS2);
+  @endcode
+  @note MSR_IA32_VMX_PROCBASED_CTLS2 is defined as IA32_VMX_PROCBASED_CTLS2 in SDM.
+**/
+#define MSR_IA32_VMX_PROCBASED_CTLS2             0x0000048B
+
+
+/**
+  Capability Reporting Register of EPT and  VPID (R/O) See Appendix A.10,
+  "VPID and EPT Capabilities.". If ( CPUID.01H:ECX.[5] && IA32_VMX_PROCBASED_C
+  TLS[63] && ( IA32_VMX_PROCBASED_C TLS2[33] IA32_VMX_PROCBASED_C TLS2[37]) ).
+
+  @param  ECX  MSR_IA32_VMX_EPT_VPID_CAP (0x0000048C)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_VMX_EPT_VPID_CAP);
+  @endcode
+  @note MSR_IA32_VMX_EPT_VPID_CAP is defined as IA32_VMX_EPT_VPID_CAP in SDM.
+**/
+#define MSR_IA32_VMX_EPT_VPID_CAP                0x0000048C
+
+
+/**
+  Capability Reporting Register of Pinbased VM-execution Flex Controls (R/O)
+  See Appendix A.3.1, "Pin-Based VMExecution Controls.". If (
+  CPUID.01H:ECX.[5] = 1 && IA32_VMX_BASIC[55] ).
+
+  @param  ECX  MSR_IA32_VMX_TRUE_PINBASED_CTLS (0x0000048D)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_VMX_TRUE_PINBASED_CTLS);
+  @endcode
+  @note MSR_IA32_VMX_TRUE_PINBASED_CTLS is defined as IA32_VMX_TRUE_PINBASED_CTLS in SDM.
+**/
+#define MSR_IA32_VMX_TRUE_PINBASED_CTLS          0x0000048D
+
+
+/**
+  Capability Reporting Register of Primary  Processor-based VM-execution Flex
+  Controls (R/O) See Appendix A.3.2, "Primary Processor- Based VM-Execution
+  Controls.". If( CPUID.01H:ECX.[5] = 1 && IA32_VMX_BASIC[55] ).
+
+  @param  ECX  MSR_IA32_VMX_TRUE_PROCBASED_CTLS (0x0000048E)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_VMX_TRUE_PROCBASED_CTLS);
+  @endcode
+  @note MSR_IA32_VMX_TRUE_PROCBASED_CTLS is defined as IA32_VMX_TRUE_PROCBASED_CTLS in SDM.
+**/
+#define MSR_IA32_VMX_TRUE_PROCBASED_CTLS         0x0000048E
+
+
+/**
+  Capability Reporting Register of VM-exit  Flex Controls (R/O) See Appendix
+  A.4, "VM-Exit Controls.". If( CPUID.01H:ECX.[5] = 1 && IA32_VMX_BASIC[55] ).
+
+  @param  ECX  MSR_IA32_VMX_TRUE_EXIT_CTLS (0x0000048F)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_VMX_TRUE_EXIT_CTLS);
+  @endcode
+  @note MSR_IA32_VMX_TRUE_EXIT_CTLS is defined as IA32_VMX_TRUE_EXIT_CTLS in SDM.
+**/
+#define MSR_IA32_VMX_TRUE_EXIT_CTLS              0x0000048F
+
+
+/**
+  Capability Reporting Register of VMentry Flex Controls (R/O) See Appendix
+  A.5, "VM-Entry Controls.". If( CPUID.01H:ECX.[5] = 1 && IA32_VMX_BASIC[55] ).
+
+  @param  ECX  MSR_IA32_VMX_TRUE_ENTRY_CTLS (0x00000490)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_VMX_TRUE_ENTRY_CTLS);
+  @endcode
+  @note MSR_IA32_VMX_TRUE_ENTRY_CTLS is defined as IA32_VMX_TRUE_ENTRY_CTLS in SDM.
+**/
+#define MSR_IA32_VMX_TRUE_ENTRY_CTLS             0x00000490
+
+
+/**
+  Capability Reporting Register of VMfunction Controls (R/O). If(
+  CPUID.01H:ECX.[5] = 1 && IA32_VMX_BASIC[55] ).
+
+  @param  ECX  MSR_IA32_VMX_VMFUNC (0x00000491)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_VMX_VMFUNC);
+  @endcode
+  @note MSR_IA32_VMX_VMFUNC is defined as IA32_VMX_VMFUNC in SDM.
+**/
+#define MSR_IA32_VMX_VMFUNC                      0x00000491
+
+
+/**
+  Full Width Writable IA32_PMCn Alias (R/W). (If CPUID.0AH: EAX[15:8] > n) &&
+  IA32_PERF_CAPABILITIES[ 13] = 1.
+
+  @param  ECX  MSR_IA32_A_PMCn
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_A_PMC0);
+  AsmWriteMsr64 (MSR_IA32_A_PMC0, Msr);
+  @endcode
+  @note MSR_IA32_A_PMC0 is defined as IA32_A_PMC0 in SDM.
+        MSR_IA32_A_PMC1 is defined as IA32_A_PMC1 in SDM.
+        MSR_IA32_A_PMC2 is defined as IA32_A_PMC2 in SDM.
+        MSR_IA32_A_PMC3 is defined as IA32_A_PMC3 in SDM.
+        MSR_IA32_A_PMC4 is defined as IA32_A_PMC4 in SDM.
+        MSR_IA32_A_PMC5 is defined as IA32_A_PMC5 in SDM.
+        MSR_IA32_A_PMC6 is defined as IA32_A_PMC6 in SDM.
+        MSR_IA32_A_PMC7 is defined as IA32_A_PMC7 in SDM.
+  @{
+**/
+#define MSR_IA32_A_PMC0                          0x000004C1
+#define MSR_IA32_A_PMC1                          0x000004C2
+#define MSR_IA32_A_PMC2                          0x000004C3
+#define MSR_IA32_A_PMC3                          0x000004C4
+#define MSR_IA32_A_PMC4                          0x000004C5
+#define MSR_IA32_A_PMC5                          0x000004C6
+#define MSR_IA32_A_PMC6                          0x000004C7
+#define MSR_IA32_A_PMC7                          0x000004C8
+/// @}
+
+
+/**
+  (R/W). If IA32_MCG_CAP.LMCE_P =1.
+
+  @param  ECX  MSR_IA32_MCG_EXT_CTL (0x000004D0)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_MCG_EXT_CTL_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_MCG_EXT_CTL_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_MCG_EXT_CTL_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_MCG_EXT_CTL);
+  AsmWriteMsr64 (MSR_IA32_MCG_EXT_CTL, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_MCG_EXT_CTL is defined as IA32_MCG_EXT_CTL in SDM.
+**/
+#define MSR_IA32_MCG_EXT_CTL                     0x000004D0
+
+/**
+  MSR information returned for MSR index #MSR_IA32_MCG_EXT_CTL
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] LMCE_EN.
+    ///
+    UINT32  LMCE_EN:1;
+    UINT32  Reserved1:31;
+    UINT32  Reserved2:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_MCG_EXT_CTL_REGISTER;
+
+
+/**
+  Status and SVN Threshold of SGX Support for ACM (RO). If CPUID.(EAX=07H,
+  ECX=0H): EBX[2] = 1.
+
+  @param  ECX  MSR_IA32_SGX_SVN_STATUS (0x00000500)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_SGX_SVN_STATUS_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_SGX_SVN_STATUS_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_SGX_SVN_STATUS_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_SGX_SVN_STATUS);
+  @endcode
+  @note MSR_IA32_SGX_SVN_STATUS is defined as IA32_SGX_SVN_STATUS in SDM.
+**/
+#define MSR_IA32_SGX_SVN_STATUS                  0x00000500
+
+/**
+  MSR information returned for MSR index #MSR_IA32_SGX_SVN_STATUS
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Lock. See Section 41.11.3, "Interactions with Authenticated
+    /// Code Modules (ACMs)".
+    ///
+    UINT32  Lock:1;
+    UINT32  Reserved1:15;
+    ///
+    /// [Bits 23:16] SGX_SVN_SINIT. See Section 41.11.3, "Interactions with
+    /// Authenticated Code Modules (ACMs)".
+    ///
+    UINT32  SGX_SVN_SINIT:8;
+    UINT32  Reserved2:8;
+    UINT32  Reserved3:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_SGX_SVN_STATUS_REGISTER;
+
+
+/**
+  Trace Output Base Register (R/W). If ((CPUID.(EAX=07H, ECX=0):EBX[25] = 1)
+  && ( (CPUID.(EAX=14H,ECX=0): ECX[0] = 1) (CPUID.(EAX=14H,ECX=0): ECX[2] = 1)
+  ) ).
+
+  @param  ECX  MSR_IA32_RTIT_OUTPUT_BASE (0x00000560)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_RTIT_OUTPUT_BASE_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_RTIT_OUTPUT_BASE_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_RTIT_OUTPUT_BASE_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_RTIT_OUTPUT_BASE);
+  AsmWriteMsr64 (MSR_IA32_RTIT_OUTPUT_BASE, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_RTIT_OUTPUT_BASE is defined as IA32_RTIT_OUTPUT_BASE in SDM.
+**/
+#define MSR_IA32_RTIT_OUTPUT_BASE                0x00000560
+
+/**
+  MSR information returned for MSR index #MSR_IA32_RTIT_OUTPUT_BASE
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    UINT32  Reserved:7;
+    ///
+    /// [Bits 31:7] Base physical address.
+    ///
+    UINT32  Base:25;
+    ///
+    /// [Bits 63:32] Base physical address.
+    ///
+    UINT32  BaseHi:32;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_RTIT_OUTPUT_BASE_REGISTER;
+
+
+/**
+  Trace Output Mask Pointers Register (R/W). If ((CPUID.(EAX=07H,
+  ECX=0):EBX[25] = 1) && ( (CPUID.(EAX=14H,ECX=0): ECX[0] = 1)
+  (CPUID.(EAX=14H,ECX=0): ECX[2] = 1) ) ).
+
+  @param  ECX  MSR_IA32_RTIT_OUTPUT_MASK_PTRS (0x00000561)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_RTIT_OUTPUT_MASK_PTRS_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_RTIT_OUTPUT_MASK_PTRS_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_RTIT_OUTPUT_MASK_PTRS_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_RTIT_OUTPUT_MASK_PTRS);
+  AsmWriteMsr64 (MSR_IA32_RTIT_OUTPUT_MASK_PTRS, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_RTIT_OUTPUT_MASK_PTRS is defined as IA32_RTIT_OUTPUT_MASK_PTRS in SDM.
+**/
+#define MSR_IA32_RTIT_OUTPUT_MASK_PTRS           0x00000561
+
+/**
+  MSR information returned for MSR index #MSR_IA32_RTIT_OUTPUT_MASK_PTRS
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    UINT32  Reserved:7;
+    ///
+    /// [Bits 31:7] MaskOrTableOffset.
+    ///
+    UINT32  MaskOrTableOffset:25;
+    ///
+    /// [Bits 63:32] Output Offset.
+    ///
+    UINT32  OutputOffset:32;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_RTIT_OUTPUT_MASK_PTRS_REGISTER;
+
+/**
+  Format of ToPA table entries.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] END. See Section 35.2.6.2, "Table of Physical Addresses (ToPA)".
+    ///
+    UINT32  END:1;
+    UINT32  Reserved1:1;
+    ///
+    /// [Bit 2] INT. See Section 35.2.6.2, "Table of Physical Addresses (ToPA)".
+    ///
+    UINT32  INT:1;
+    UINT32  Reserved2:1;
+    ///
+    /// [Bit 4] STOP. See Section 35.2.6.2, "Table of Physical Addresses (ToPA)".
+    ///
+    UINT32  STOP:1;
+    UINT32  Reserved3:1;
+    ///
+    /// [Bit 6:9] Indicates the size of the associated output region. See Section
+    /// 35.2.6.2, "Table of Physical Addresses (ToPA)".
+    ///
+    UINT32  Size:4;
+    UINT32  Reserved4:2;
+    ///
+    /// [Bit 12:31] Output Region Base Physical Address low part.
+    /// [Bit 12:31] Output Region Base Physical Address [12:63] value to match.
+    /// ATTENTION: The size of the address field is determined by the processor's
+    /// physical-address width (MAXPHYADDR) in bits, as reported in
+    /// CPUID.80000008H:EAX[7:0]. the above part of address reserved.
+    /// True address field is [12:MAXPHYADDR-1], [MAXPHYADDR:63] is reserved part.
+    /// Detail see Section 35.2.6.2, "Table of Physical Addresses (ToPA)".
+    ///
+    UINT32  Base:20;
+    ///
+    /// [Bit 32:63] Output Region Base Physical Address high part.
+    /// [Bit 32:63] Output Region Base Physical Address [12:63] value to match.
+    /// ATTENTION: The size of the address field is determined by the processor's
+    /// physical-address width (MAXPHYADDR) in bits, as reported in
+    /// CPUID.80000008H:EAX[7:0]. the above part of address reserved.
+    /// True address field is [12:MAXPHYADDR-1], [MAXPHYADDR:63] is reserved part.
+    /// Detail see Section 35.2.6.2, "Table of Physical Addresses (ToPA)".
+    ///
+    UINT32  BaseHi:32;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} RTIT_TOPA_TABLE_ENTRY;
+
+///
+/// The size of the associated output region usd by Topa.
+///
+typedef enum {
+  RtitTopaMemorySize4K = 0,
+  RtitTopaMemorySize8K,
+  RtitTopaMemorySize16K,
+  RtitTopaMemorySize32K,
+  RtitTopaMemorySize64K,
+  RtitTopaMemorySize128K,
+  RtitTopaMemorySize256K,
+  RtitTopaMemorySize512K,
+  RtitTopaMemorySize1M,
+  RtitTopaMemorySize2M,
+  RtitTopaMemorySize4M,
+  RtitTopaMemorySize8M,
+  RtitTopaMemorySize16M,
+  RtitTopaMemorySize32M,
+  RtitTopaMemorySize64M,
+  RtitTopaMemorySize128M
+} RTIT_TOPA_MEMORY_SIZE;
+
+/**
+  Trace Control Register (R/W). If (CPUID.(EAX=07H, ECX=0):EBX[25] = 1).
+
+  @param  ECX  MSR_IA32_RTIT_CTL (0x00000570)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_RTIT_CTL_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_RTIT_CTL_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_RTIT_CTL_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_RTIT_CTL);
+  AsmWriteMsr64 (MSR_IA32_RTIT_CTL, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_RTIT_CTL is defined as IA32_RTIT_CTL in SDM.
+**/
+#define MSR_IA32_RTIT_CTL                        0x00000570
+
+/**
+  MSR information returned for MSR index #MSR_IA32_RTIT_CTL
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] TraceEn.
+    ///
+    UINT32  TraceEn:1;
+    ///
+    /// [Bit 1] CYCEn. If (CPUID.(EAX=07H, ECX=0):EBX[1] = 1).
+    ///
+    UINT32  CYCEn:1;
+    ///
+    /// [Bit 2] OS.
+    ///
+    UINT32  OS:1;
+    ///
+    /// [Bit 3] User.
+    ///
+    UINT32  User:1;
+    ///
+    /// [Bit 4] PwrEvtEn.
+    ///
+    UINT32  PwrEvtEn:1;
+    ///
+    /// [Bit 5] FUPonPTW.
+    ///
+    UINT32  FUPonPTW:1;
+    ///
+    /// [Bit 6] FabricEn. If (CPUID.(EAX=07H, ECX=0):ECX[3] = 1).
+    ///
+    UINT32  FabricEn:1;
+    ///
+    /// [Bit 7] CR3 filter.
+    ///
+    UINT32  CR3:1;
+    ///
+    /// [Bit 8] ToPA.
+    ///
+    UINT32  ToPA:1;
+    ///
+    /// [Bit 9] MTCEn. If (CPUID.(EAX=07H, ECX=0):EBX[3] = 1).
+    ///
+    UINT32  MTCEn:1;
+    ///
+    /// [Bit 10] TSCEn.
+    ///
+    UINT32  TSCEn:1;
+    ///
+    /// [Bit 11] DisRETC.
+    ///
+    UINT32  DisRETC:1;
+    ///
+    /// [Bit 12] PTWEn.
+    ///
+    UINT32  PTWEn:1;
+    ///
+    /// [Bit 13] BranchEn.
+    ///
+    UINT32  BranchEn:1;
+    ///
+    /// [Bits 17:14] MTCFreq. If (CPUID.(EAX=07H, ECX=0):EBX[3] = 1).
+    ///
+    UINT32  MTCFreq:4;
+    UINT32  Reserved3:1;
+    ///
+    /// [Bits 22:19] CYCThresh. If (CPUID.(EAX=07H, ECX=0):EBX[1] = 1).
+    ///
+    UINT32  CYCThresh:4;
+    UINT32  Reserved4:1;
+    ///
+    /// [Bits 27:24] PSBFreq. If (CPUID.(EAX=07H, ECX=0):EBX[1] = 1).
+    ///
+    UINT32  PSBFreq:4;
+    UINT32  Reserved5:4;
+    ///
+    /// [Bits 35:32] ADDR0_CFG. If (CPUID.(EAX=07H, ECX=1):EAX[2:0] > 0).
+    ///
+    UINT32  ADDR0_CFG:4;
+    ///
+    /// [Bits 39:36] ADDR1_CFG. If (CPUID.(EAX=07H, ECX=1):EAX[2:0] > 1).
+    ///
+    UINT32  ADDR1_CFG:4;
+    ///
+    /// [Bits 43:40] ADDR2_CFG. If (CPUID.(EAX=07H, ECX=1):EAX[2:0] > 2).
+    ///
+    UINT32  ADDR2_CFG:4;
+    ///
+    /// [Bits 47:44] ADDR3_CFG. If (CPUID.(EAX=07H, ECX=1):EAX[2:0] > 3).
+    ///
+    UINT32  ADDR3_CFG:4;
+    UINT32  Reserved6:16;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_RTIT_CTL_REGISTER;
+
+
+/**
+  Tracing Status Register (R/W). If (CPUID.(EAX=07H, ECX=0):EBX[25] = 1).
+
+  @param  ECX  MSR_IA32_RTIT_STATUS (0x00000571)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_RTIT_STATUS_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_RTIT_STATUS_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_RTIT_STATUS_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_RTIT_STATUS);
+  AsmWriteMsr64 (MSR_IA32_RTIT_STATUS, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_RTIT_STATUS is defined as IA32_RTIT_STATUS in SDM.
+**/
+#define MSR_IA32_RTIT_STATUS                     0x00000571
+
+/**
+  MSR information returned for MSR index #MSR_IA32_RTIT_STATUS
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] FilterEn, (writes ignored).
+    /// If (CPUID.(EAX=07H, ECX=0):EBX[2] = 1).
+    ///
+    UINT32  FilterEn:1;
+    ///
+    /// [Bit 1] ContexEn, (writes ignored).
+    ///
+    UINT32  ContexEn:1;
+    ///
+    /// [Bit 2] TriggerEn, (writes ignored).
+    ///
+    UINT32  TriggerEn:1;
+    UINT32  Reserved1:1;
+    ///
+    /// [Bit 4] Error.
+    ///
+    UINT32  Error:1;
+    ///
+    /// [Bit 5] Stopped.
+    ///
+    UINT32  Stopped:1;
+    UINT32  Reserved2:26;
+    ///
+    /// [Bits 48:32] PacketByteCnt. If (CPUID.(EAX=07H, ECX=0):EBX[1] > 3).
+    ///
+    UINT32  PacketByteCnt:17;
+    UINT32  Reserved3:15;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_RTIT_STATUS_REGISTER;
+
+
+/**
+  Trace Filter CR3 Match Register (R/W).
+  If (CPUID.(EAX=07H, ECX=0):EBX[25] = 1).
+
+  @param  ECX  MSR_IA32_RTIT_CR3_MATCH (0x00000572)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_RTIT_CR3_MATCH_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_RTIT_CR3_MATCH_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_RTIT_CR3_MATCH_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_RTIT_CR3_MATCH);
+  AsmWriteMsr64 (MSR_IA32_RTIT_CR3_MATCH, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_RTIT_CR3_MATCH is defined as IA32_RTIT_CR3_MATCH in SDM.
+**/
+#define MSR_IA32_RTIT_CR3_MATCH                  0x00000572
+
+/**
+  MSR information returned for MSR index #MSR_IA32_RTIT_CR3_MATCH
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    UINT32  Reserved:5;
+    ///
+    /// [Bits 31:5] CR3[63:5] value to match.
+    ///
+    UINT32  Cr3:27;
+    ///
+    /// [Bits 63:32] CR3[63:5] value to match.
+    ///
+    UINT32  Cr3Hi:32;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_RTIT_CR3_MATCH_REGISTER;
+
+
+/**
+  Region n Start Address (R/W). If (CPUID.(EAX=07H, ECX=1):EAX[2:0] > n).
+
+  @param  ECX  MSR_IA32_RTIT_ADDRn_A
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_RTIT_ADDR_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_RTIT_ADDR_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_RTIT_ADDR_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_RTIT_ADDR0_A);
+  AsmWriteMsr64 (MSR_IA32_RTIT_ADDR0_A, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_RTIT_ADDR0_A is defined as IA32_RTIT_ADDR0_A in SDM.
+        MSR_IA32_RTIT_ADDR1_A is defined as IA32_RTIT_ADDR1_A in SDM.
+        MSR_IA32_RTIT_ADDR2_A is defined as IA32_RTIT_ADDR2_A in SDM.
+        MSR_IA32_RTIT_ADDR3_A is defined as IA32_RTIT_ADDR3_A in SDM.
+  @{
+**/
+#define MSR_IA32_RTIT_ADDR0_A                    0x00000580
+#define MSR_IA32_RTIT_ADDR1_A                    0x00000582
+#define MSR_IA32_RTIT_ADDR2_A                    0x00000584
+#define MSR_IA32_RTIT_ADDR3_A                    0x00000586
+/// @}
+
+
+/**
+  Region n End Address (R/W). If (CPUID.(EAX=07H, ECX=1):EAX[2:0] > n).
+
+  @param  ECX  MSR_IA32_RTIT_ADDRn_B
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_RTIT_ADDR_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_RTIT_ADDR_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_RTIT_ADDR_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_RTIT_ADDR0_B);
+  AsmWriteMsr64 (MSR_IA32_RTIT_ADDR0_B, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_RTIT_ADDR0_B is defined as IA32_RTIT_ADDR0_B in SDM.
+        MSR_IA32_RTIT_ADDR1_B is defined as IA32_RTIT_ADDR1_B in SDM.
+        MSR_IA32_RTIT_ADDR2_B is defined as IA32_RTIT_ADDR2_B in SDM.
+        MSR_IA32_RTIT_ADDR3_B is defined as IA32_RTIT_ADDR3_B in SDM.
+  @{
+**/
+#define MSR_IA32_RTIT_ADDR0_B                    0x00000581
+#define MSR_IA32_RTIT_ADDR1_B                    0x00000583
+#define MSR_IA32_RTIT_ADDR2_B                    0x00000585
+#define MSR_IA32_RTIT_ADDR3_B                    0x00000587
+/// @}
+
+
+/**
+  MSR information returned for MSR indexes
+  #MSR_IA32_RTIT_ADDR0_A to #MSR_IA32_RTIT_ADDR3_A and
+  #MSR_IA32_RTIT_ADDR0_B to #MSR_IA32_RTIT_ADDR3_B
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 31:0] Virtual Address.
+    ///
+    UINT32  VirtualAddress:32;
+    ///
+    /// [Bits 47:32] Virtual Address.
+    ///
+    UINT32  VirtualAddressHi:16;
+    ///
+    /// [Bits 63:48] SignExt_VA.
+    ///
+    UINT32  SignExt_VA:16;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_RTIT_ADDR_REGISTER;
+
+
+/**
+  DS Save Area (R/W) Points to the linear address of the first byte of the DS
+  buffer management area, which is used to manage the BTS and PEBS buffers.
+  See Section 18.6.3.4, "Debug Store (DS) Mechanism.". If(
+  CPUID.01H:EDX.DS[21] = 1. The linear address of the first byte of the DS
+  buffer management area, if IA-32e mode is active.
+
+  @param  ECX  MSR_IA32_DS_AREA (0x00000600)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_DS_AREA_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_DS_AREA_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_DS_AREA);
+  AsmWriteMsr64 (MSR_IA32_DS_AREA, Msr);
+  @endcode
+  @note MSR_IA32_DS_AREA is defined as IA32_DS_AREA in SDM.
+**/
+#define MSR_IA32_DS_AREA                         0x00000600
+
+
+/**
+  TSC Target of Local APIC's TSC Deadline Mode (R/W). If CPUID.01H:ECX.[24] =
+  1.
+
+  @param  ECX  MSR_IA32_TSC_DEADLINE (0x000006E0)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_TSC_DEADLINE);
+  AsmWriteMsr64 (MSR_IA32_TSC_DEADLINE, Msr);
+  @endcode
+  @note MSR_IA32_TSC_DEADLINE is defined as IA32_TSC_DEADLINE in SDM.
+**/
+#define MSR_IA32_TSC_DEADLINE                    0x000006E0
+
+
+/**
+  Enable/disable HWP (R/W). If CPUID.06H:EAX.[7] = 1.
+
+  @param  ECX  MSR_IA32_PM_ENABLE (0x00000770)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_PM_ENABLE_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_PM_ENABLE_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_PM_ENABLE_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_PM_ENABLE);
+  AsmWriteMsr64 (MSR_IA32_PM_ENABLE, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_PM_ENABLE is defined as IA32_PM_ENABLE in SDM.
+**/
+#define MSR_IA32_PM_ENABLE                       0x00000770
+
+/**
+  MSR information returned for MSR index #MSR_IA32_PM_ENABLE
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] HWP_ENABLE (R/W1-Once). See Section 14.4.2, "Enabling HWP". If
+    /// CPUID.06H:EAX.[7] = 1.
+    ///
+    UINT32  HWP_ENABLE:1;
+    UINT32  Reserved1:31;
+    UINT32  Reserved2:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_PM_ENABLE_REGISTER;
+
+
+/**
+  HWP Performance Range Enumeration (RO). If CPUID.06H:EAX.[7] = 1.
+
+  @param  ECX  MSR_IA32_HWP_CAPABILITIES (0x00000771)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_HWP_CAPABILITIES_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_HWP_CAPABILITIES_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_HWP_CAPABILITIES_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_HWP_CAPABILITIES);
+  @endcode
+  @note MSR_IA32_HWP_CAPABILITIES is defined as IA32_HWP_CAPABILITIES in SDM.
+**/
+#define MSR_IA32_HWP_CAPABILITIES                0x00000771
+
+/**
+  MSR information returned for MSR index #MSR_IA32_HWP_CAPABILITIES
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 7:0] Highest_Performance See Section 14.4.3, "HWP Performance
+    /// Range and Dynamic Capabilities". If CPUID.06H:EAX.[7] = 1.
+    ///
+    UINT32  Highest_Performance:8;
+    ///
+    /// [Bits 15:8] Guaranteed_Performance See Section 14.4.3, "HWP
+    /// Performance Range and Dynamic Capabilities". If CPUID.06H:EAX.[7] = 1.
+    ///
+    UINT32  Guaranteed_Performance:8;
+    ///
+    /// [Bits 23:16] Most_Efficient_Performance See Section 14.4.3, "HWP
+    /// Performance Range and Dynamic Capabilities". If CPUID.06H:EAX.[7] = 1.
+    ///
+    UINT32  Most_Efficient_Performance:8;
+    ///
+    /// [Bits 31:24] Lowest_Performance See Section 14.4.3, "HWP Performance
+    /// Range and Dynamic Capabilities". If CPUID.06H:EAX.[7] = 1.
+    ///
+    UINT32  Lowest_Performance:8;
+    UINT32  Reserved:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_HWP_CAPABILITIES_REGISTER;
+
+
+/**
+  Power Management Control Hints for All Logical Processors in a Package
+  (R/W). If CPUID.06H:EAX.[11] = 1.
+
+  @param  ECX  MSR_IA32_HWP_REQUEST_PKG (0x00000772)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_HWP_REQUEST_PKG_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_HWP_REQUEST_PKG_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_HWP_REQUEST_PKG_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_HWP_REQUEST_PKG);
+  AsmWriteMsr64 (MSR_IA32_HWP_REQUEST_PKG, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_HWP_REQUEST_PKG is defined as IA32_HWP_REQUEST_PKG in SDM.
+**/
+#define MSR_IA32_HWP_REQUEST_PKG                 0x00000772
+
+/**
+  MSR information returned for MSR index #MSR_IA32_HWP_REQUEST_PKG
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 7:0] Minimum_Performance See Section 14.4.4, "Managing HWP". If
+    /// CPUID.06H:EAX.[11] = 1.
+    ///
+    UINT32  Minimum_Performance:8;
+    ///
+    /// [Bits 15:8] Maximum_Performance See Section 14.4.4, "Managing HWP". If
+    /// CPUID.06H:EAX.[11] = 1.
+    ///
+    UINT32  Maximum_Performance:8;
+    ///
+    /// [Bits 23:16] Desired_Performance See Section 14.4.4, "Managing HWP".
+    /// If CPUID.06H:EAX.[11] = 1.
+    ///
+    UINT32  Desired_Performance:8;
+    ///
+    /// [Bits 31:24] Energy_Performance_Preference See Section 14.4.4,
+    /// "Managing HWP". If CPUID.06H:EAX.[11] = 1 && CPUID.06H:EAX.[10] = 1.
+    ///
+    UINT32  Energy_Performance_Preference:8;
+    ///
+    /// [Bits 41:32] Activity_Window See Section 14.4.4, "Managing HWP". If
+    /// CPUID.06H:EAX.[11] = 1 && CPUID.06H:EAX.[9] = 1.
+    ///
+    UINT32  Activity_Window:10;
+    UINT32  Reserved:22;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_HWP_REQUEST_PKG_REGISTER;
+
+
+/**
+  Control HWP Native Interrupts (R/W). If CPUID.06H:EAX.[8] = 1.
+
+  @param  ECX  MSR_IA32_HWP_INTERRUPT (0x00000773)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_HWP_INTERRUPT_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_HWP_INTERRUPT_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_HWP_INTERRUPT_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_HWP_INTERRUPT);
+  AsmWriteMsr64 (MSR_IA32_HWP_INTERRUPT, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_HWP_INTERRUPT is defined as IA32_HWP_INTERRUPT in SDM.
+**/
+#define MSR_IA32_HWP_INTERRUPT                   0x00000773
+
+/**
+  MSR information returned for MSR index #MSR_IA32_HWP_INTERRUPT
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] EN_Guaranteed_Performance_Change. See Section 14.4.6, "HWP
+    /// Notifications". If CPUID.06H:EAX.[8] = 1.
+    ///
+    UINT32  EN_Guaranteed_Performance_Change:1;
+    ///
+    /// [Bit 1] EN_Excursion_Minimum. See Section 14.4.6, "HWP Notifications".
+    /// If CPUID.06H:EAX.[8] = 1.
+    ///
+    UINT32  EN_Excursion_Minimum:1;
+    UINT32  Reserved1:30;
+    UINT32  Reserved2:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_HWP_INTERRUPT_REGISTER;
+
+
+/**
+  Power Management Control Hints to a Logical Processor (R/W). If
+  CPUID.06H:EAX.[7] = 1.
+
+  @param  ECX  MSR_IA32_HWP_REQUEST (0x00000774)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_HWP_REQUEST_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_HWP_REQUEST_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_HWP_REQUEST_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_HWP_REQUEST);
+  AsmWriteMsr64 (MSR_IA32_HWP_REQUEST, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_HWP_REQUEST is defined as IA32_HWP_REQUEST in SDM.
+**/
+#define MSR_IA32_HWP_REQUEST                     0x00000774
+
+/**
+  MSR information returned for MSR index #MSR_IA32_HWP_REQUEST
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 7:0] Minimum_Performance See Section 14.4.4, "Managing HWP". If
+    /// CPUID.06H:EAX.[7] = 1.
+    ///
+    UINT32  Minimum_Performance:8;
+    ///
+    /// [Bits 15:8] Maximum_Performance See Section 14.4.4, "Managing HWP". If
+    /// CPUID.06H:EAX.[7] = 1.
+    ///
+    UINT32  Maximum_Performance:8;
+    ///
+    /// [Bits 23:16] Desired_Performance See Section 14.4.4, "Managing HWP".
+    /// If CPUID.06H:EAX.[7] = 1.
+    ///
+    UINT32  Desired_Performance:8;
+    ///
+    /// [Bits 31:24] Energy_Performance_Preference See Section 14.4.4,
+    /// "Managing HWP". If CPUID.06H:EAX.[7] = 1 && CPUID.06H:EAX.[10] = 1.
+    ///
+    UINT32  Energy_Performance_Preference:8;
+    ///
+    /// [Bits 41:32] Activity_Window See Section 14.4.4, "Managing HWP". If
+    /// CPUID.06H:EAX.[7] = 1 && CPUID.06H:EAX.[9] = 1.
+    ///
+    UINT32  Activity_Window:10;
+    ///
+    /// [Bit 42] Package_Control See Section 14.4.4, "Managing HWP". If
+    /// CPUID.06H:EAX.[7] = 1 && CPUID.06H:EAX.[11] = 1.
+    ///
+    UINT32  Package_Control:1;
+    UINT32  Reserved:21;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_HWP_REQUEST_REGISTER;
+
+
+/**
+  Log bits indicating changes to  Guaranteed & excursions to Minimum (R/W). If
+  CPUID.06H:EAX.[7] = 1.
+
+  @param  ECX  MSR_IA32_HWP_STATUS (0x00000777)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_HWP_STATUS_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_HWP_STATUS_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_HWP_STATUS_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_HWP_STATUS);
+  AsmWriteMsr64 (MSR_IA32_HWP_STATUS, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_HWP_STATUS is defined as IA32_HWP_STATUS in SDM.
+**/
+#define MSR_IA32_HWP_STATUS                      0x00000777
+
+/**
+  MSR information returned for MSR index #MSR_IA32_HWP_STATUS
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Guaranteed_Performance_Change (R/WC0). See Section 14.4.5,
+    /// "HWP Feedback". If CPUID.06H:EAX.[7] = 1.
+    ///
+    UINT32  Guaranteed_Performance_Change:1;
+    UINT32  Reserved1:1;
+    ///
+    /// [Bit 2] Excursion_To_Minimum (R/WC0). See Section 14.4.5, "HWP
+    /// Feedback". If CPUID.06H:EAX.[7] = 1.
+    ///
+    UINT32  Excursion_To_Minimum:1;
+    UINT32  Reserved2:29;
+    UINT32  Reserved3:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_HWP_STATUS_REGISTER;
+
+
+/**
+  x2APIC ID Register (R/O) See x2APIC Specification. If CPUID.01H:ECX[21] = 1
+  && IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_APICID (0x00000802)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_APICID);
+  @endcode
+  @note MSR_IA32_X2APIC_APICID is defined as IA32_X2APIC_APICID in SDM.
+**/
+#define MSR_IA32_X2APIC_APICID                   0x00000802
+
+
+/**
+  x2APIC Version Register (R/O). If CPUID.01H:ECX.[21] = 1 &&
+  IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_VERSION (0x00000803)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_VERSION);
+  @endcode
+  @note MSR_IA32_X2APIC_VERSION is defined as IA32_X2APIC_VERSION in SDM.
+**/
+#define MSR_IA32_X2APIC_VERSION                  0x00000803
+
+
+/**
+  x2APIC Task Priority Register (R/W). If CPUID.01H:ECX.[21] = 1 &&
+  IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_TPR (0x00000808)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_TPR);
+  AsmWriteMsr64 (MSR_IA32_X2APIC_TPR, Msr);
+  @endcode
+  @note MSR_IA32_X2APIC_TPR is defined as IA32_X2APIC_TPR in SDM.
+**/
+#define MSR_IA32_X2APIC_TPR                      0x00000808
+
+
+/**
+  x2APIC Processor Priority Register (R/O). If CPUID.01H:ECX.[21] = 1 &&
+  IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_PPR (0x0000080A)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_PPR);
+  @endcode
+  @note MSR_IA32_X2APIC_PPR is defined as IA32_X2APIC_PPR in SDM.
+**/
+#define MSR_IA32_X2APIC_PPR                      0x0000080A
+
+
+/**
+  x2APIC EOI Register (W/O). If CPUID.01H:ECX.[21] = 1 && IA32_APIC_BASE.[10]
+  = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_EOI (0x0000080B)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = 0;
+  AsmWriteMsr64 (MSR_IA32_X2APIC_EOI, Msr);
+  @endcode
+  @note MSR_IA32_X2APIC_EOI is defined as IA32_X2APIC_EOI in SDM.
+**/
+#define MSR_IA32_X2APIC_EOI                      0x0000080B
+
+
+/**
+  x2APIC Logical Destination Register (R/O). If CPUID.01H:ECX.[21] = 1 &&
+  IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_LDR (0x0000080D)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_LDR);
+  @endcode
+  @note MSR_IA32_X2APIC_LDR is defined as IA32_X2APIC_LDR in SDM.
+**/
+#define MSR_IA32_X2APIC_LDR                      0x0000080D
+
+
+/**
+  x2APIC Spurious Interrupt Vector Register (R/W). If CPUID.01H:ECX.[21] = 1
+  && IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_SIVR (0x0000080F)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_SIVR);
+  AsmWriteMsr64 (MSR_IA32_X2APIC_SIVR, Msr);
+  @endcode
+  @note MSR_IA32_X2APIC_SIVR is defined as IA32_X2APIC_SIVR in SDM.
+**/
+#define MSR_IA32_X2APIC_SIVR                     0x0000080F
+
+
+/**
+  x2APIC In-Service Register Bits (n * 32 + 31):(n * 32) (R/O).
+  If CPUID.01H:ECX.[21] = 1 && IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_ISRn
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_ISR0);
+  @endcode
+  @note MSR_IA32_X2APIC_ISR0 is defined as IA32_X2APIC_ISR0 in SDM.
+        MSR_IA32_X2APIC_ISR1 is defined as IA32_X2APIC_ISR1 in SDM.
+        MSR_IA32_X2APIC_ISR2 is defined as IA32_X2APIC_ISR2 in SDM.
+        MSR_IA32_X2APIC_ISR3 is defined as IA32_X2APIC_ISR3 in SDM.
+        MSR_IA32_X2APIC_ISR4 is defined as IA32_X2APIC_ISR4 in SDM.
+        MSR_IA32_X2APIC_ISR5 is defined as IA32_X2APIC_ISR5 in SDM.
+        MSR_IA32_X2APIC_ISR6 is defined as IA32_X2APIC_ISR6 in SDM.
+        MSR_IA32_X2APIC_ISR7 is defined as IA32_X2APIC_ISR7 in SDM.
+  @{
+**/
+#define MSR_IA32_X2APIC_ISR0                     0x00000810
+#define MSR_IA32_X2APIC_ISR1                     0x00000811
+#define MSR_IA32_X2APIC_ISR2                     0x00000812
+#define MSR_IA32_X2APIC_ISR3                     0x00000813
+#define MSR_IA32_X2APIC_ISR4                     0x00000814
+#define MSR_IA32_X2APIC_ISR5                     0x00000815
+#define MSR_IA32_X2APIC_ISR6                     0x00000816
+#define MSR_IA32_X2APIC_ISR7                     0x00000817
+/// @}
+
+
+/**
+  x2APIC Trigger Mode Register Bits (n * 32 + ):(n * 32) (R/O).
+  If CPUID.01H:ECX.[21] = 1 && IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_TMRn
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_TMR0);
+  @endcode
+  @note MSR_IA32_X2APIC_TMR0 is defined as IA32_X2APIC_TMR0 in SDM.
+        MSR_IA32_X2APIC_TMR1 is defined as IA32_X2APIC_TMR1 in SDM.
+        MSR_IA32_X2APIC_TMR2 is defined as IA32_X2APIC_TMR2 in SDM.
+        MSR_IA32_X2APIC_TMR3 is defined as IA32_X2APIC_TMR3 in SDM.
+        MSR_IA32_X2APIC_TMR4 is defined as IA32_X2APIC_TMR4 in SDM.
+        MSR_IA32_X2APIC_TMR5 is defined as IA32_X2APIC_TMR5 in SDM.
+        MSR_IA32_X2APIC_TMR6 is defined as IA32_X2APIC_TMR6 in SDM.
+        MSR_IA32_X2APIC_TMR7 is defined as IA32_X2APIC_TMR7 in SDM.
+  @{
+**/
+#define MSR_IA32_X2APIC_TMR0                     0x00000818
+#define MSR_IA32_X2APIC_TMR1                     0x00000819
+#define MSR_IA32_X2APIC_TMR2                     0x0000081A
+#define MSR_IA32_X2APIC_TMR3                     0x0000081B
+#define MSR_IA32_X2APIC_TMR4                     0x0000081C
+#define MSR_IA32_X2APIC_TMR5                     0x0000081D
+#define MSR_IA32_X2APIC_TMR6                     0x0000081E
+#define MSR_IA32_X2APIC_TMR7                     0x0000081F
+/// @}
+
+
+/**
+  x2APIC Interrupt Request Register Bits (n* 32 + 31):(n * 32) (R/O).
+  If CPUID.01H:ECX.[21] = 1 && IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_IRRn
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_IRR0);
+  @endcode
+  @note MSR_IA32_X2APIC_IRR0 is defined as IA32_X2APIC_IRR0 in SDM.
+        MSR_IA32_X2APIC_IRR1 is defined as IA32_X2APIC_IRR1 in SDM.
+        MSR_IA32_X2APIC_IRR2 is defined as IA32_X2APIC_IRR2 in SDM.
+        MSR_IA32_X2APIC_IRR3 is defined as IA32_X2APIC_IRR3 in SDM.
+        MSR_IA32_X2APIC_IRR4 is defined as IA32_X2APIC_IRR4 in SDM.
+        MSR_IA32_X2APIC_IRR5 is defined as IA32_X2APIC_IRR5 in SDM.
+        MSR_IA32_X2APIC_IRR6 is defined as IA32_X2APIC_IRR6 in SDM.
+        MSR_IA32_X2APIC_IRR7 is defined as IA32_X2APIC_IRR7 in SDM.
+  @{
+**/
+#define MSR_IA32_X2APIC_IRR0                     0x00000820
+#define MSR_IA32_X2APIC_IRR1                     0x00000821
+#define MSR_IA32_X2APIC_IRR2                     0x00000822
+#define MSR_IA32_X2APIC_IRR3                     0x00000823
+#define MSR_IA32_X2APIC_IRR4                     0x00000824
+#define MSR_IA32_X2APIC_IRR5                     0x00000825
+#define MSR_IA32_X2APIC_IRR6                     0x00000826
+#define MSR_IA32_X2APIC_IRR7                     0x00000827
+/// @}
+
+
+/**
+  x2APIC Error Status Register (R/W). If CPUID.01H:ECX.[21] = 1 &&
+  IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_ESR (0x00000828)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_ESR);
+  AsmWriteMsr64 (MSR_IA32_X2APIC_ESR, Msr);
+  @endcode
+  @note MSR_IA32_X2APIC_ESR is defined as IA32_X2APIC_ESR in SDM.
+**/
+#define MSR_IA32_X2APIC_ESR                      0x00000828
+
+
+/**
+  x2APIC LVT Corrected Machine Check Interrupt Register (R/W). If
+  CPUID.01H:ECX.[21] = 1 && IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_LVT_CMCI (0x0000082F)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_LVT_CMCI);
+  AsmWriteMsr64 (MSR_IA32_X2APIC_LVT_CMCI, Msr);
+  @endcode
+  @note MSR_IA32_X2APIC_LVT_CMCI is defined as IA32_X2APIC_LVT_CMCI in SDM.
+**/
+#define MSR_IA32_X2APIC_LVT_CMCI                 0x0000082F
+
+
+/**
+  x2APIC Interrupt Command Register (R/W). If CPUID.01H:ECX.[21] = 1 &&
+  IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_ICR (0x00000830)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_ICR);
+  AsmWriteMsr64 (MSR_IA32_X2APIC_ICR, Msr);
+  @endcode
+  @note MSR_IA32_X2APIC_ICR is defined as IA32_X2APIC_ICR in SDM.
+**/
+#define MSR_IA32_X2APIC_ICR                      0x00000830
+
+
+/**
+  x2APIC LVT Timer Interrupt Register (R/W). If CPUID.01H:ECX.[21] = 1 &&
+  IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_LVT_TIMER (0x00000832)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_LVT_TIMER);
+  AsmWriteMsr64 (MSR_IA32_X2APIC_LVT_TIMER, Msr);
+  @endcode
+  @note MSR_IA32_X2APIC_LVT_TIMER is defined as IA32_X2APIC_LVT_TIMER in SDM.
+**/
+#define MSR_IA32_X2APIC_LVT_TIMER                0x00000832
+
+
+/**
+  x2APIC LVT Thermal Sensor Interrupt Register (R/W). If CPUID.01H:ECX.[21] =
+  1 && IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_LVT_THERMAL (0x00000833)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_LVT_THERMAL);
+  AsmWriteMsr64 (MSR_IA32_X2APIC_LVT_THERMAL, Msr);
+  @endcode
+  @note MSR_IA32_X2APIC_LVT_THERMAL is defined as IA32_X2APIC_LVT_THERMAL in SDM.
+**/
+#define MSR_IA32_X2APIC_LVT_THERMAL              0x00000833
+
+
+/**
+  x2APIC LVT Performance Monitor Interrupt Register (R/W). If
+  CPUID.01H:ECX.[21] = 1 && IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_LVT_PMI (0x00000834)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_LVT_PMI);
+  AsmWriteMsr64 (MSR_IA32_X2APIC_LVT_PMI, Msr);
+  @endcode
+  @note MSR_IA32_X2APIC_LVT_PMI is defined as IA32_X2APIC_LVT_PMI in SDM.
+**/
+#define MSR_IA32_X2APIC_LVT_PMI                  0x00000834
+
+
+/**
+  x2APIC LVT LINT0 Register (R/W). If CPUID.01H:ECX.[21] = 1 &&
+  IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_LVT_LINT0 (0x00000835)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_LVT_LINT0);
+  AsmWriteMsr64 (MSR_IA32_X2APIC_LVT_LINT0, Msr);
+  @endcode
+  @note MSR_IA32_X2APIC_LVT_LINT0 is defined as IA32_X2APIC_LVT_LINT0 in SDM.
+**/
+#define MSR_IA32_X2APIC_LVT_LINT0                0x00000835
+
+
+/**
+  x2APIC LVT LINT1 Register (R/W). If CPUID.01H:ECX.[21] = 1 &&
+  IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_LVT_LINT1 (0x00000836)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_LVT_LINT1);
+  AsmWriteMsr64 (MSR_IA32_X2APIC_LVT_LINT1, Msr);
+  @endcode
+  @note MSR_IA32_X2APIC_LVT_LINT1 is defined as IA32_X2APIC_LVT_LINT1 in SDM.
+**/
+#define MSR_IA32_X2APIC_LVT_LINT1                0x00000836
+
+
+/**
+  x2APIC LVT Error Register (R/W). If CPUID.01H:ECX.[21] = 1 &&
+  IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_LVT_ERROR (0x00000837)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_LVT_ERROR);
+  AsmWriteMsr64 (MSR_IA32_X2APIC_LVT_ERROR, Msr);
+  @endcode
+  @note MSR_IA32_X2APIC_LVT_ERROR is defined as IA32_X2APIC_LVT_ERROR in SDM.
+**/
+#define MSR_IA32_X2APIC_LVT_ERROR                0x00000837
+
+
+/**
+  x2APIC Initial Count Register (R/W). If CPUID.01H:ECX.[21] = 1 &&
+  IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_INIT_COUNT (0x00000838)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_INIT_COUNT);
+  AsmWriteMsr64 (MSR_IA32_X2APIC_INIT_COUNT, Msr);
+  @endcode
+  @note MSR_IA32_X2APIC_INIT_COUNT is defined as IA32_X2APIC_INIT_COUNT in SDM.
+**/
+#define MSR_IA32_X2APIC_INIT_COUNT               0x00000838
+
+
+/**
+  x2APIC Current Count Register (R/O). If CPUID.01H:ECX.[21] = 1 &&
+  IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_CUR_COUNT (0x00000839)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_CUR_COUNT);
+  @endcode
+  @note MSR_IA32_X2APIC_CUR_COUNT is defined as IA32_X2APIC_CUR_COUNT in SDM.
+**/
+#define MSR_IA32_X2APIC_CUR_COUNT                0x00000839
+
+
+/**
+  x2APIC Divide Configuration Register (R/W). If CPUID.01H:ECX.[21] = 1 &&
+  IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_DIV_CONF (0x0000083E)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_X2APIC_DIV_CONF);
+  AsmWriteMsr64 (MSR_IA32_X2APIC_DIV_CONF, Msr);
+  @endcode
+  @note MSR_IA32_X2APIC_DIV_CONF is defined as IA32_X2APIC_DIV_CONF in SDM.
+**/
+#define MSR_IA32_X2APIC_DIV_CONF                 0x0000083E
+
+
+/**
+  x2APIC Self IPI Register (W/O). If CPUID.01H:ECX.[21] = 1 &&
+  IA32_APIC_BASE.[10] = 1.
+
+  @param  ECX  MSR_IA32_X2APIC_SELF_IPI (0x0000083F)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = 0;
+  AsmWriteMsr64 (MSR_IA32_X2APIC_SELF_IPI, Msr);
+  @endcode
+  @note MSR_IA32_X2APIC_SELF_IPI is defined as IA32_X2APIC_SELF_IPI in SDM.
+**/
+#define MSR_IA32_X2APIC_SELF_IPI                 0x0000083F
+
+
+/**
+  Silicon Debug Feature Control (R/W). If CPUID.01H:ECX.[11] = 1.
+
+  @param  ECX  MSR_IA32_DEBUG_INTERFACE (0x00000C80)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_DEBUG_INTERFACE_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_DEBUG_INTERFACE_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_DEBUG_INTERFACE_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_DEBUG_INTERFACE);
+  AsmWriteMsr64 (MSR_IA32_DEBUG_INTERFACE, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_DEBUG_INTERFACE is defined as IA32_DEBUG_INTERFACE in SDM.
+**/
+#define MSR_IA32_DEBUG_INTERFACE                 0x00000C80
+
+/**
+  MSR information returned for MSR index #MSR_IA32_DEBUG_INTERFACE
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Enable (R/W) BIOS set 1 to enable Silicon debug features.
+    /// Default is 0. If CPUID.01H:ECX.[11] = 1.
+    ///
+    UINT32  Enable:1;
+    UINT32  Reserved1:29;
+    ///
+    /// [Bit 30] Lock (R/W): If 1, locks any further change to the MSR. The
+    /// lock bit is set automatically on the first SMI assertion even if not
+    /// explicitly set by BIOS. Default is 0. If CPUID.01H:ECX.[11] = 1.
+    ///
+    UINT32  Lock:1;
+    ///
+    /// [Bit 31] Debug Occurred (R/O): This "sticky bit" is set by hardware to
+    /// indicate the status of bit 0. Default is 0. If CPUID.01H:ECX.[11] = 1.
+    ///
+    UINT32  DebugOccurred:1;
+    UINT32  Reserved2:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_DEBUG_INTERFACE_REGISTER;
+
+
+/**
+  L3 QOS Configuration (R/W). If ( CPUID.(EAX=10H, ECX=1):ECX.[2] = 1 ).
+
+  @param  ECX  MSR_IA32_L3_QOS_CFG (0x00000C81)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_L3_QOS_CFG_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_L3_QOS_CFG_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_L3_QOS_CFG_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_L3_QOS_CFG);
+  AsmWriteMsr64 (MSR_IA32_L3_QOS_CFG, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_L3_QOS_CFG is defined as IA32_L3_QOS_CFG in SDM.
+**/
+#define MSR_IA32_L3_QOS_CFG                      0x00000C81
+
+/**
+  MSR information returned for MSR index #MSR_IA32_L3_QOS_CFG
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Enable (R/W) Set 1 to enable L3 CAT masks and COS to operate
+    /// in Code and Data Prioritization (CDP) mode.
+    ///
+    UINT32  Enable:1;
+    UINT32  Reserved1:31;
+    UINT32  Reserved2:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_L3_QOS_CFG_REGISTER;
+
+/**
+  L2 QOS Configuration (R/W). If ( CPUID.(EAX=10H, ECX=2):ECX.[2] = 1 ).
+
+  @param  ECX  MSR_IA32_L2_QOS_CFG (0x00000C82)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_L2_QOS_CFG_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_L2_QOS_CFG_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_L2_QOS_CFG_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_L2_QOS_CFG);
+  AsmWriteMsr64 (MSR_IA32_L2_QOS_CFG, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_L2_QOS_CFG is defined as IA32_L2_QOS_CFG in SDM.
+**/
+#define MSR_IA32_L2_QOS_CFG                      0x00000C82
+
+/**
+  MSR information returned for MSR index #MSR_IA32_L2_QOS_CFG
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Enable (R/W) Set 1 to enable L2 CAT masks and COS to operate
+    /// in Code and Data Prioritization (CDP) mode.
+    ///
+    UINT32  Enable:1;
+    UINT32  Reserved1:31;
+    UINT32  Reserved2:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_L2_QOS_CFG_REGISTER;
+
+/**
+  Monitoring Event Select Register (R/W). If ( CPUID.(EAX=07H, ECX=0):EBX.[12]
+  = 1 ).
+
+  @param  ECX  MSR_IA32_QM_EVTSEL (0x00000C8D)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_QM_EVTSEL_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_QM_EVTSEL_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_QM_EVTSEL_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_QM_EVTSEL);
+  AsmWriteMsr64 (MSR_IA32_QM_EVTSEL, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_QM_EVTSEL is defined as IA32_QM_EVTSEL in SDM.
+**/
+#define MSR_IA32_QM_EVTSEL                       0x00000C8D
+
+/**
+  MSR information returned for MSR index #MSR_IA32_QM_EVTSEL
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 7:0] Event ID: ID of a supported monitoring event to report via
+    /// IA32_QM_CTR.
+    ///
+    UINT32  EventID:8;
+    UINT32  Reserved:24;
+    ///
+    /// [Bits 63:32] Resource Monitoring ID: ID for monitoring hardware to
+    /// report monitored data via IA32_QM_CTR. N = Ceil (Log:sub:`2` (
+    /// CPUID.(EAX= 0FH, ECX=0H).EBX[31:0] +1)).
+    ///
+    UINT32  ResourceMonitoringID:32;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_QM_EVTSEL_REGISTER;
+
+
+/**
+  Monitoring Counter Register (R/O). If ( CPUID.(EAX=07H, ECX=0):EBX.[12] = 1
+  ).
+
+  @param  ECX  MSR_IA32_QM_CTR (0x00000C8E)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_QM_CTR_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_QM_CTR_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_QM_CTR_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_QM_CTR);
+  @endcode
+  @note MSR_IA32_QM_CTR is defined as IA32_QM_CTR in SDM.
+**/
+#define MSR_IA32_QM_CTR                          0x00000C8E
+
+/**
+  MSR information returned for MSR index #MSR_IA32_QM_CTR
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 31:0] Resource Monitored Data.
+    ///
+    UINT32  ResourceMonitoredData:32;
+    ///
+    /// [Bits 61:32] Resource Monitored Data.
+    ///
+    UINT32  ResourceMonitoredDataHi:30;
+    ///
+    /// [Bit 62] Unavailable: If 1, indicates data for this RMID is not
+    /// available or not monitored for this resource or RMID.
+    ///
+    UINT32  Unavailable:1;
+    ///
+    /// [Bit 63] Error: If 1, indicates and unsupported RMID or event type was
+    /// written to IA32_PQR_QM_EVTSEL.
+    ///
+    UINT32  Error:1;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_QM_CTR_REGISTER;
+
+
+/**
+  Resource Association Register (R/W). If ( (CPUID.(EAX=07H, ECX=0):EBX[12]
+  =1) or (CPUID.(EAX=07H, ECX=0):EBX[15] =1 ) ).
+
+  @param  ECX  MSR_IA32_PQR_ASSOC (0x00000C8F)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_PQR_ASSOC_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_PQR_ASSOC_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_PQR_ASSOC_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_PQR_ASSOC);
+  AsmWriteMsr64 (MSR_IA32_PQR_ASSOC, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_PQR_ASSOC is defined as IA32_PQR_ASSOC in SDM.
+**/
+#define MSR_IA32_PQR_ASSOC                       0x00000C8F
+
+/**
+  MSR information returned for MSR index #MSR_IA32_PQR_ASSOC
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 31:0] Resource Monitoring ID (R/W): ID for monitoring hardware
+    /// to track internal operation, e.g. memory access. N = Ceil (Log:sub:`2`
+    /// ( CPUID.(EAX= 0FH, ECX=0H).EBX[31:0] +1)).
+    ///
+    UINT32  ResourceMonitoringID:32;
+    ///
+    /// [Bits 63:32] COS (R/W). The class of service (COS) to enforce (on
+    /// writes); returns the current COS when read. If ( CPUID.(EAX=07H,
+    /// ECX=0):EBX.[15] = 1 ).
+    ///
+    UINT32  COS:32;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_PQR_ASSOC_REGISTER;
+
+
+/**
+  Supervisor State of MPX Configuration. (R/W). If (CPUID.(EAX=07H,
+  ECX=0H):EBX[14] = 1).
+
+  @param  ECX  MSR_IA32_BNDCFGS (0x00000D90)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_BNDCFGS_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_BNDCFGS_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_BNDCFGS_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_BNDCFGS);
+  AsmWriteMsr64 (MSR_IA32_BNDCFGS, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_BNDCFGS is defined as IA32_BNDCFGS in SDM.
+**/
+#define MSR_IA32_BNDCFGS                         0x00000D90
+
+/**
+  MSR information returned for MSR index #MSR_IA32_BNDCFGS
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] EN: Enable Intel MPX in supervisor mode.
+    ///
+    UINT32  EN:1;
+    ///
+    /// [Bit 1] BNDPRESERVE: Preserve the bounds registers for near branch
+    /// instructions in the absence of the BND prefix.
+    ///
+    UINT32  BNDPRESERVE:1;
+    UINT32  Reserved:10;
+    ///
+    /// [Bits 31:12] Base Address of Bound Directory.
+    ///
+    UINT32  Base:20;
+    ///
+    /// [Bits 63:32] Base Address of Bound Directory.
+    ///
+    UINT32  BaseHi:32;
+  } Bits;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_BNDCFGS_REGISTER;
+
+
+/**
+  Extended Supervisor State Mask (R/W). If( CPUID.(0DH, 1):EAX.[3] = 1.
+
+  @param  ECX  MSR_IA32_XSS (0x00000DA0)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_XSS_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_XSS_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_XSS_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_XSS);
+  AsmWriteMsr64 (MSR_IA32_XSS, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_XSS is defined as IA32_XSS in SDM.
+**/
+#define MSR_IA32_XSS                             0x00000DA0
+
+/**
+  MSR information returned for MSR index #MSR_IA32_XSS
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    UINT32  Reserved1:8;
+    ///
+    /// [Bit 8] Trace Packet Configuration State (R/W).
+    ///
+    UINT32  TracePacketConfigurationState:1;
+    UINT32  Reserved2:23;
+    UINT32  Reserved3:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_XSS_REGISTER;
+
+
+/**
+  Package Level Enable/disable HDC (R/W). If CPUID.06H:EAX.[13] = 1.
+
+  @param  ECX  MSR_IA32_PKG_HDC_CTL (0x00000DB0)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_PKG_HDC_CTL_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_PKG_HDC_CTL_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_PKG_HDC_CTL_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_PKG_HDC_CTL);
+  AsmWriteMsr64 (MSR_IA32_PKG_HDC_CTL, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_PKG_HDC_CTL is defined as IA32_PKG_HDC_CTL in SDM.
+**/
+#define MSR_IA32_PKG_HDC_CTL                     0x00000DB0
+
+/**
+  MSR information returned for MSR index #MSR_IA32_PKG_HDC_CTL
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] HDC_Pkg_Enable (R/W) Force HDC idling or wake up HDC-idled
+    /// logical processors in the package. See Section 14.5.2, "Package level
+    /// Enabling HDC". If CPUID.06H:EAX.[13] = 1.
+    ///
+    UINT32  HDC_Pkg_Enable:1;
+    UINT32  Reserved1:31;
+    UINT32  Reserved2:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_PKG_HDC_CTL_REGISTER;
+
+
+/**
+  Enable/disable HWP (R/W). If CPUID.06H:EAX.[13] = 1.
+
+  @param  ECX  MSR_IA32_PM_CTL1 (0x00000DB1)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_PM_CTL1_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_PM_CTL1_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_PM_CTL1_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_PM_CTL1);
+  AsmWriteMsr64 (MSR_IA32_PM_CTL1, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_PM_CTL1 is defined as IA32_PM_CTL1 in SDM.
+**/
+#define MSR_IA32_PM_CTL1                         0x00000DB1
+
+/**
+  MSR information returned for MSR index #MSR_IA32_PM_CTL1
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] HDC_Allow_Block (R/W) Allow/Block this logical processor for
+    /// package level HDC control. See Section 14.5.3.
+    /// If CPUID.06H:EAX.[13] = 1.
+    ///
+    UINT32  HDC_Allow_Block:1;
+    UINT32  Reserved1:31;
+    UINT32  Reserved2:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_PM_CTL1_REGISTER;
+
+
+/**
+  Per-Logical_Processor HDC Idle Residency (R/0). If CPUID.06H:EAX.[13] = 1.
+  Stall_Cycle_Cnt (R/W) Stalled cycles due to HDC forced idle on this logical
+  processor. See Section 14.5.4.1. If CPUID.06H:EAX.[13] = 1.
+
+  @param  ECX  MSR_IA32_THREAD_STALL (0x00000DB2)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_THREAD_STALL);
+  @endcode
+  @note MSR_IA32_THREAD_STALL is defined as IA32_THREAD_STALL in SDM.
+**/
+#define MSR_IA32_THREAD_STALL                    0x00000DB2
+
+
+/**
+  Extended Feature Enables. If ( CPUID.80000001H:EDX.[2 0]
+  CPUID.80000001H:EDX.[2 9]).
+
+  @param  ECX  MSR_IA32_EFER (0xC0000080)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_EFER_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_EFER_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_EFER_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_EFER);
+  AsmWriteMsr64 (MSR_IA32_EFER, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_EFER is defined as IA32_EFER in SDM.
+**/
+#define MSR_IA32_EFER                            0xC0000080
+
+/**
+  MSR information returned for MSR index #MSR_IA32_EFER
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] SYSCALL Enable: IA32_EFER.SCE (R/W) Enables SYSCALL/SYSRET
+    /// instructions in 64-bit mode.
+    ///
+    UINT32  SCE:1;
+    UINT32  Reserved1:7;
+    ///
+    /// [Bit 8] IA-32e Mode Enable: IA32_EFER.LME (R/W) Enables IA-32e mode
+    /// operation.
+    ///
+    UINT32  LME:1;
+    UINT32  Reserved2:1;
+    ///
+    /// [Bit 10] IA-32e Mode Active: IA32_EFER.LMA (R) Indicates IA-32e mode
+    /// is active when set.
+    ///
+    UINT32  LMA:1;
+    ///
+    /// [Bit 11] Execute Disable Bit Enable: IA32_EFER.NXE (R/W).
+    ///
+    UINT32  NXE:1;
+    UINT32  Reserved3:20;
+    UINT32  Reserved4:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_EFER_REGISTER;
+
+
+/**
+  System Call Target Address (R/W). If CPUID.80000001:EDX.[29] = 1.
+
+  @param  ECX  MSR_IA32_STAR (0xC0000081)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_STAR);
+  AsmWriteMsr64 (MSR_IA32_STAR, Msr);
+  @endcode
+  @note MSR_IA32_STAR is defined as IA32_STAR in SDM.
+**/
+#define MSR_IA32_STAR                            0xC0000081
+
+
+/**
+  IA-32e Mode System Call Target Address (R/W). If CPUID.80000001:EDX.[29] = 1.
+
+  @param  ECX  MSR_IA32_LSTAR (0xC0000082)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_LSTAR);
+  AsmWriteMsr64 (MSR_IA32_LSTAR, Msr);
+  @endcode
+  @note MSR_IA32_LSTAR is defined as IA32_LSTAR in SDM.
+**/
+#define MSR_IA32_LSTAR                           0xC0000082
+
+/**
+  IA-32e Mode System Call Target Address (R/W) Not used, as the SYSCALL
+  instruction is not recognized in compatibility mode. If
+  CPUID.80000001:EDX.[29] = 1.
+
+  @param  ECX  MSR_IA32_CSTAR (0xC0000083)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_CSTAR);
+  AsmWriteMsr64 (MSR_IA32_CSTAR, Msr);
+  @endcode
+  @note MSR_IA32_CSTAR is defined as IA32_CSTAR in SDM.
+**/
+#define MSR_IA32_CSTAR                           0xC0000083
+
+/**
+  System Call Flag Mask (R/W). If CPUID.80000001:EDX.[29] = 1.
+
+  @param  ECX  MSR_IA32_FMASK (0xC0000084)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_FMASK);
+  AsmWriteMsr64 (MSR_IA32_FMASK, Msr);
+  @endcode
+  @note MSR_IA32_FMASK is defined as IA32_FMASK in SDM.
+**/
+#define MSR_IA32_FMASK                           0xC0000084
+
+
+/**
+  Map of BASE Address of FS (R/W). If CPUID.80000001:EDX.[29] = 1.
+
+  @param  ECX  MSR_IA32_FS_BASE (0xC0000100)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_FS_BASE);
+  AsmWriteMsr64 (MSR_IA32_FS_BASE, Msr);
+  @endcode
+  @note MSR_IA32_FS_BASE is defined as IA32_FS_BASE in SDM.
+**/
+#define MSR_IA32_FS_BASE                         0xC0000100
+
+
+/**
+  Map of BASE Address of GS (R/W). If CPUID.80000001:EDX.[29] = 1.
+
+  @param  ECX  MSR_IA32_GS_BASE (0xC0000101)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_GS_BASE);
+  AsmWriteMsr64 (MSR_IA32_GS_BASE, Msr);
+  @endcode
+  @note MSR_IA32_GS_BASE is defined as IA32_GS_BASE in SDM.
+**/
+#define MSR_IA32_GS_BASE                         0xC0000101
+
+
+/**
+  Swap Target of BASE Address of GS (R/W). If CPUID.80000001:EDX.[29] = 1.
+
+  @param  ECX  MSR_IA32_KERNEL_GS_BASE (0xC0000102)
+  @param  EAX  Lower 32-bits of MSR value.
+  @param  EDX  Upper 32-bits of MSR value.
+
+  <b>Example usage</b>
+  @code
+  UINT64  Msr;
+
+  Msr = AsmReadMsr64 (MSR_IA32_KERNEL_GS_BASE);
+  AsmWriteMsr64 (MSR_IA32_KERNEL_GS_BASE, Msr);
+  @endcode
+  @note MSR_IA32_KERNEL_GS_BASE is defined as IA32_KERNEL_GS_BASE in SDM.
+**/
+#define MSR_IA32_KERNEL_GS_BASE                  0xC0000102
+
+
+/**
+  Auxiliary TSC (RW). If CPUID.80000001H: EDX[27] = 1.
+
+  @param  ECX  MSR_IA32_TSC_AUX (0xC0000103)
+  @param  EAX  Lower 32-bits of MSR value.
+               Described by the type MSR_IA32_TSC_AUX_REGISTER.
+  @param  EDX  Upper 32-bits of MSR value.
+               Described by the type MSR_IA32_TSC_AUX_REGISTER.
+
+  <b>Example usage</b>
+  @code
+  MSR_IA32_TSC_AUX_REGISTER  Msr;
+
+  Msr.Uint64 = AsmReadMsr64 (MSR_IA32_TSC_AUX);
+  AsmWriteMsr64 (MSR_IA32_TSC_AUX, Msr.Uint64);
+  @endcode
+  @note MSR_IA32_TSC_AUX is defined as IA32_TSC_AUX in SDM.
+**/
+#define MSR_IA32_TSC_AUX                         0xC0000103
+
+/**
+  MSR information returned for MSR index #MSR_IA32_TSC_AUX
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 31:0] AUX: Auxiliary signature of TSC.
+    ///
+    UINT32  AUX:32;
+    UINT32  Reserved:32;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+  ///
+  /// All bit fields as a 64-bit value
+  ///
+  UINT64  Uint64;
+} MSR_IA32_TSC_AUX_REGISTER;
+
+#endif

--- a/BootloaderCommonPkg/Include/Register/Intel/Cpuid.h
+++ b/BootloaderCommonPkg/Include/Register/Intel/Cpuid.h
@@ -1,0 +1,3997 @@
+/** @file
+  Intel CPUID leaf definitions.
+
+  Provides defines for CPUID leaf indexes.  Data structures are provided for
+  registers returned by a CPUID leaf that contain one or more bit fields.
+  If a register returned is a single 32-bit value, then a data structure is
+  not provided for that register.
+
+  Copyright (c) 2015 - 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Specification Reference:
+  Intel(R) 64 and IA-32 Architectures Software Developer's Manual, Volume 2A,
+  November 2018, CPUID instruction.
+
+**/
+
+#ifndef __INTEL_CPUID_H__
+#define __INTEL_CPUID_H__
+
+/**
+  CPUID Signature Information
+
+  @param   EAX  CPUID_SIGNATURE (0x00)
+
+  @retval  EAX  Returns the highest value the CPUID instruction recognizes for
+                returning basic processor information. The value is returned is
+                processor specific.
+  @retval  EBX  First 4 characters of a vendor identification string.
+  @retval  ECX  Last 4 characters of a vendor identification string.
+  @retval  EDX  Middle 4 characters of a vendor identification string.
+
+  <b>Example usage</b>
+  @code
+  UINT32 Eax;
+  UINT32 Ebx;
+  UINT32 Ecx;
+  UINT32 Edx;
+
+  AsmCpuid (CPUID_SIGNATURE, &Eax, &Ebx, &Ecx, &Edx);
+  @endcode
+**/
+#define CPUID_SIGNATURE                         0x00
+
+///
+/// @{ CPUID signature values returned by Intel processors
+///
+#define CPUID_SIGNATURE_GENUINE_INTEL_EBX  SIGNATURE_32 ('G', 'e', 'n', 'u')
+#define CPUID_SIGNATURE_GENUINE_INTEL_EDX  SIGNATURE_32 ('i', 'n', 'e', 'I')
+#define CPUID_SIGNATURE_GENUINE_INTEL_ECX  SIGNATURE_32 ('n', 't', 'e', 'l')
+///
+/// @}
+///
+
+
+/**
+  CPUID Version Information
+
+  @param   EAX  CPUID_VERSION_INFO (0x01)
+
+  @retval  EAX  Returns Model, Family, Stepping Information described by the
+                type CPUID_VERSION_INFO_EAX.
+  @retval  EBX  Returns Brand, Cache Line Size, and Initial APIC ID described by
+                the type CPUID_VERSION_INFO_EBX.
+  @retval  ECX  CPU Feature Information described by the type
+                CPUID_VERSION_INFO_ECX.
+  @retval  EDX  CPU Feature Information described by the type
+                CPUID_VERSION_INFO_EDX.
+
+  <b>Example usage</b>
+  @code
+  CPUID_VERSION_INFO_EAX  Eax;
+  CPUID_VERSION_INFO_EBX  Ebx;
+  CPUID_VERSION_INFO_ECX  Ecx;
+  CPUID_VERSION_INFO_EDX  Edx;
+
+  AsmCpuid (CPUID_VERSION_INFO, &Eax.Uint32, &Ebx.Uint32, &Ecx.Uint32, &Edx.Uint32);
+  @endcode
+**/
+#define CPUID_VERSION_INFO                      0x01
+
+/**
+  CPUID Version Information returned in EAX for CPUID leaf
+  #CPUID_VERSION_INFO.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    UINT32  SteppingId:4;        ///< [Bits   3:0] Stepping ID
+    UINT32  Model:4;             ///< [Bits   7:4] Model
+    UINT32  FamilyId:4;          ///< [Bits  11:8] Family
+    UINT32  ProcessorType:2;     ///< [Bits 13:12] Processor Type
+    UINT32  Reserved1:2;         ///< [Bits 15:14] Reserved
+    UINT32  ExtendedModelId:4;   ///< [Bits 19:16] Extended Model ID
+    UINT32  ExtendedFamilyId:8;  ///< [Bits 27:20] Extended Family ID
+    UINT32  Reserved2:4;         ///< Reserved
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32    Uint32;
+} CPUID_VERSION_INFO_EAX;
+
+///
+/// @{ Define value for bit field CPUID_VERSION_INFO_EAX.ProcessorType
+///
+#define CPUID_VERSION_INFO_EAX_PROCESSOR_TYPE_ORIGINAL_OEM_PROCESSOR     0x00
+#define CPUID_VERSION_INFO_EAX_PROCESSOR_TYPE_INTEL_OVERDRIVE_PROCESSOR  0x01
+#define CPUID_VERSION_INFO_EAX_PROCESSOR_TYPE_DUAL_PROCESSOR             0x02
+///
+/// @}
+///
+
+/**
+  CPUID Version Information returned in EBX for CPUID leaf
+  #CPUID_VERSION_INFO.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 7:0] Provides an entry into a brand string table that contains
+    /// brand strings for IA-32 processors.
+    ///
+    UINT32  BrandIndex:8;
+    ///
+    /// [Bits 15:8] Indicates the size of the cache line flushed by the CLFLUSH
+    /// and CLFLUSHOPT instructions in 8-byte increments. This field was
+    /// introduced in the Pentium 4 processor.
+    ///
+    UINT32  CacheLineSize:8;
+    ///
+    /// [Bits 23:16] Maximum number of addressable IDs for logical processors
+    /// in this physical package.
+    ///
+    /// @note
+    /// The nearest power-of-2 integer that is not smaller than EBX[23:16] is
+    /// the number of unique initial APICIDs reserved for addressing different
+    /// logical processors in a physical package. This field is only valid if
+    /// CPUID.1.EDX.HTT[bit 28]= 1.
+    ///
+    UINT32  MaximumAddressableIdsForLogicalProcessors:8;
+    ///
+    /// [Bits 31:24] The 8-bit ID that is assigned to the local APIC on the
+    /// processor during power up. This field was introduced in the Pentium 4
+    /// processor.
+    ///
+    UINT32  InitialLocalApicId:8;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32    Uint32;
+} CPUID_VERSION_INFO_EBX;
+
+/**
+  CPUID Version Information returned in ECX for CPUID leaf
+  #CPUID_VERSION_INFO.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Streaming SIMD Extensions 3 (SSE3).  A value of 1 indicates the
+    /// processor supports this technology
+    ///
+    UINT32  SSE3:1;
+    ///
+    /// [Bit 1] A value of 1 indicates the processor supports the PCLMULQDQ
+    /// instruction.  Carryless Multiplication
+    ///
+    UINT32  PCLMULQDQ:1;
+    ///
+    /// [Bit 2] 64-bit DS Area.  A value of 1 indicates the processor supports
+    /// DS area using 64-bit layout.
+    ///
+    UINT32  DTES64:1;
+    ///
+    /// [Bit 3] MONITOR/MWAIT.  A value of 1 indicates the processor supports
+    /// this feature.
+    ///
+    UINT32  MONITOR:1;
+    ///
+    /// [Bit 4] CPL Qualified Debug Store.  A value of 1 indicates the processor
+    /// supports the extensions to the Debug Store feature to allow for branch
+    /// message storage qualified by CPL
+    ///
+    UINT32  DS_CPL:1;
+    ///
+    /// [Bit 5] Virtual Machine Extensions.  A value of 1 indicates that the
+    /// processor supports this technology.
+    ///
+    UINT32  VMX:1;
+    ///
+    /// [Bit 6] Safer Mode Extensions. A value of 1 indicates that the processor
+    /// supports this technology
+    ///
+    UINT32  SMX:1;
+    ///
+    /// [Bit 7] Enhanced Intel SpeedStep(R) technology.  A value of 1 indicates
+    /// that the processor supports this technology
+    ///
+    UINT32  EIST:1;
+    ///
+    /// [Bit 8] Thermal Monitor 2.  A value of 1 indicates whether the processor
+    /// supports this technology
+    ///
+    UINT32  TM2:1;
+    ///
+    /// [Bit 9] A value of 1 indicates the presence of the Supplemental Streaming
+    /// SIMD Extensions 3 (SSSE3). A value of 0 indicates the instruction
+    /// extensions are not present in the processor.
+    ///
+    UINT32  SSSE3:1;
+    ///
+    /// [Bit 10] L1 Context ID.  A value of 1 indicates the L1 data cache mode
+    /// can be set to either adaptive mode or shared mode. A value of 0 indicates
+    /// this feature is not supported. See definition of the IA32_MISC_ENABLE MSR
+    /// Bit 24 (L1 Data Cache Context Mode) for details
+    ///
+    UINT32  CNXT_ID:1;
+    ///
+    /// [Bit 11] A value of 1 indicates the processor supports IA32_DEBUG_INTERFACE
+    /// MSR for silicon debug
+    ///
+    UINT32  SDBG:1;
+    ///
+    /// [Bit 12] A value of 1 indicates the processor supports FMA (Fused Multiple
+    ///  Add) extensions using YMM state.
+    ///
+    UINT32  FMA:1;
+    ///
+    /// [Bit 13] CMPXCHG16B Available.  A value of 1 indicates that the feature
+    /// is available.
+    ///
+    UINT32  CMPXCHG16B:1;
+    ///
+    /// [Bit 14] xTPR Update Control.  A value of 1 indicates that the processor
+    /// supports changing IA32_MISC_ENABLE[Bit 23].
+    ///
+    UINT32  xTPR_Update_Control:1;
+    ///
+    /// [Bit 15] Perfmon and Debug Capability:  A value of 1 indicates the
+    /// processor supports the performance and debug feature indication MSR
+    /// IA32_PERF_CAPABILITIES.
+    ///
+    UINT32  PDCM:1;
+    UINT32  Reserved:1;
+    ///
+    /// [Bit 17] Process-context identifiers.  A value of 1 indicates that the
+    /// processor supports PCIDs and that software may set CR4.PCIDE to 1.
+    ///
+    UINT32  PCID:1;
+    ///
+    /// [Bit 18] A value of 1 indicates the processor supports the ability to
+    /// prefetch data from a memory mapped device.  Direct Cache Access.
+    ///
+    UINT32  DCA:1;
+    ///
+    /// [Bit 19] A value of 1 indicates that the processor supports SSE4.1.
+    ///
+    UINT32  SSE4_1:1;
+    ///
+    /// [Bit 20] A value of 1 indicates that the processor supports SSE4.2.
+    ///
+    UINT32  SSE4_2:1;
+    ///
+    /// [Bit 21] A value of 1 indicates that the processor supports x2APIC
+    /// feature.
+    ///
+    UINT32  x2APIC:1;
+    ///
+    /// [Bit 22] A value of 1 indicates that the processor supports MOVBE
+    /// instruction.
+    ///
+    UINT32  MOVBE:1;
+    ///
+    /// [Bit 23] A value of 1 indicates that the processor supports the POPCNT
+    /// instruction.
+    ///
+    UINT32  POPCNT:1;
+    ///
+    /// [Bit 24] A value of 1 indicates that the processor's local APIC timer
+    /// supports one-shot operation using a TSC deadline value.
+    ///
+    UINT32  TSC_Deadline:1;
+    ///
+    /// [Bit 25] A value of 1 indicates that the processor supports the AESNI
+    /// instruction extensions.
+    ///
+    UINT32  AESNI:1;
+    ///
+    /// [Bit 26] A value of 1 indicates that the processor supports the
+    /// XSAVE/XRSTOR processor extended states feature, the XSETBV/XGETBV
+    /// instructions, and XCR0.
+    ///
+    UINT32  XSAVE:1;
+    ///
+    /// [Bit 27] A value of 1 indicates that the OS has set CR4.OSXSAVE[Bit 18]
+    /// to enable XSETBV/XGETBV instructions to access XCR0 and to support
+    /// processor extended state management using XSAVE/XRSTOR.
+    ///
+    UINT32  OSXSAVE:1;
+    ///
+    /// [Bit 28] A value of 1 indicates the processor supports the AVX instruction
+    /// extensions.
+    ///
+    UINT32  AVX:1;
+    ///
+    /// [Bit 29] A value of 1 indicates that processor supports 16-bit
+    /// floating-point conversion instructions.
+    ///
+    UINT32  F16C:1;
+    ///
+    /// [Bit 30] A value of 1 indicates that processor supports RDRAND instruction.
+    ///
+    UINT32  RDRAND:1;
+    ///
+    /// [Bit 31] Always returns 0.
+    ///
+    UINT32  NotUsed:1;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32    Uint32;
+} CPUID_VERSION_INFO_ECX;
+
+/**
+  CPUID Version Information returned in EDX for CPUID leaf
+  #CPUID_VERSION_INFO.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Floating Point Unit On-Chip. The processor contains an x87 FPU.
+    ///
+    UINT32  FPU:1;
+    ///
+    /// [Bit 1] Virtual 8086 Mode Enhancements.  Virtual 8086 mode enhancements,
+    /// including CR4.VME for controlling the feature, CR4.PVI for protected
+    /// mode virtual interrupts, software interrupt indirection, expansion of
+    /// the TSS with the software indirection bitmap, and EFLAGS.VIF and
+    /// EFLAGS.VIP flags.
+    ///
+    UINT32  VME:1;
+    ///
+    /// [Bit 2] Debugging Extensions.  Support for I/O breakpoints, including
+    /// CR4.DE for controlling the feature, and optional trapping of accesses to
+    /// DR4 and DR5.
+    ///
+    UINT32  DE:1;
+    ///
+    /// [Bit 3] Page Size Extension.  Large pages of size 4 MByte are supported,
+    /// including CR4.PSE for controlling the feature, the defined dirty bit in
+    /// PDE (Page Directory Entries), optional reserved bit trapping in CR3,
+    /// PDEs, and PTEs.
+    ///
+    UINT32  PSE:1;
+    ///
+    /// [Bit 4] Time Stamp Counter.  The RDTSC instruction is supported,
+    /// including CR4.TSD for controlling privilege.
+    ///
+    UINT32  TSC:1;
+    ///
+    /// [Bit 5] Model Specific Registers RDMSR and WRMSR Instructions.  The
+    /// RDMSR and WRMSR instructions are supported. Some of the MSRs are
+    /// implementation dependent.
+    ///
+    UINT32  MSR:1;
+    ///
+    /// [Bit 6] Physical Address Extension.  Physical addresses greater than 32
+    /// bits are supported: extended page table entry formats, an extra level in
+    /// the page translation tables is defined, 2-MByte pages are supported
+    /// instead of 4 Mbyte pages if PAE bit is 1.
+    ///
+    UINT32  PAE:1;
+    ///
+    /// [Bit 7] Machine Check Exception.  Exception 18 is defined for Machine
+    /// Checks, including CR4.MCE for controlling the feature. This feature does
+    /// not define the model-specific implementations of machine-check error
+    /// logging, reporting, and processor shutdowns. Machine Check exception
+    /// handlers may have to depend on processor version to do model specific
+    /// processing of the exception, or test for the presence of the Machine
+    /// Check feature.
+    ///
+    UINT32  MCE:1;
+    ///
+    /// [Bit 8] CMPXCHG8B Instruction.  The compare-and-exchange 8 bytes(64 bits)
+    /// instruction is supported (implicitly locked and atomic).
+    ///
+    UINT32  CX8:1;
+    ///
+    /// [Bit 9] APIC On-Chip.  The processor contains an Advanced Programmable
+    /// Interrupt Controller (APIC), responding to memory mapped commands in the
+    /// physical address range FFFE0000H to FFFE0FFFH (by default - some
+    /// processors permit the APIC to be relocated).
+    ///
+    UINT32  APIC:1;
+    UINT32  Reserved1:1;
+    ///
+    /// [Bit 11] SYSENTER and SYSEXIT Instructions.  The SYSENTER and SYSEXIT
+    /// and associated MSRs are supported.
+    ///
+    UINT32  SEP:1;
+    ///
+    /// [Bit 12] Memory Type Range Registers.  MTRRs are supported. The MTRRcap
+    /// MSR contains feature bits that describe what memory types are supported,
+    /// how many variable MTRRs are supported, and whether fixed MTRRs are
+    /// supported.
+    ///
+    UINT32  MTRR:1;
+    ///
+    /// [Bit 13] Page Global Bit.  The global bit is supported in paging-structure
+    /// entries that map a page, indicating TLB entries that are common to
+    /// different processes and need not be flushed. The CR4.PGE bit controls
+    /// this feature.
+    ///
+    UINT32  PGE:1;
+    ///
+    /// [Bit 14] Machine Check Architecture. A value of 1 indicates the Machine
+    /// Check Architecture of reporting machine errors is supported. The MCG_CAP
+    /// MSR contains feature bits describing how many banks of error reporting
+    /// MSRs are supported.
+    ///
+    UINT32  MCA:1;
+    ///
+    /// [Bit 15] Conditional Move Instructions.  The conditional move instruction
+    /// CMOV is supported. In addition, if x87 FPU is present as indicated by the
+    /// CPUID.FPU feature bit, then the FCOMI and FCMOV instructions are supported.
+    ///
+    UINT32  CMOV:1;
+    ///
+    /// [Bit 16] Page Attribute Table.  Page Attribute Table is supported. This
+    /// feature augments the Memory Type Range Registers (MTRRs), allowing an
+    /// operating system to specify attributes of memory accessed through a
+    /// linear address on a 4KB granularity.
+    ///
+    UINT32  PAT:1;
+    ///
+    /// [Bit 17] 36-Bit Page Size Extension.  4-MByte pages addressing physical
+    /// memory beyond 4 GBytes are supported with 32-bit paging. This feature
+    /// indicates that upper bits of the physical address of a 4-MByte page are
+    /// encoded in bits 20:13 of the page-directory entry. Such physical
+    /// addresses are limited by MAXPHYADDR and may be up to 40 bits in size.
+    ///
+    UINT32  PSE_36:1;
+    ///
+    /// [Bit 18] Processor Serial Number.  The processor supports the 96-bit
+    /// processor identification number feature and the feature is enabled.
+    ///
+    UINT32  PSN:1;
+    ///
+    /// [Bit 19] CLFLUSH Instruction.  CLFLUSH Instruction is supported.
+    ///
+    UINT32  CLFSH:1;
+    UINT32  Reserved2:1;
+    ///
+    /// [Bit 21] Debug Store.  The processor supports the ability to write debug
+    /// information into a memory resident buffer.  This feature is used by the
+    /// branch trace store (BTS) and precise event-based sampling (PEBS)
+    /// facilities.
+    ///
+    UINT32  DS:1;
+    ///
+    /// [Bit 22] Thermal Monitor and Software Controlled Clock Facilities.  The
+    /// processor implements internal MSRs that allow processor temperature to
+    /// be monitored and processor performance to be modulated in predefined
+    /// duty cycles under software control.
+    ///
+    UINT32  ACPI:1;
+    ///
+    /// [Bit 23] Intel MMX Technology.  The processor supports the Intel MMX
+    /// technology.
+    ///
+    UINT32  MMX:1;
+    ///
+    /// [Bit 24] FXSAVE and FXRSTOR Instructions.  The FXSAVE and FXRSTOR
+    /// instructions are supported for fast save and restore of the floating
+    /// point context. Presence of this bit also indicates that CR4.OSFXSR is
+    /// available for an operating system to indicate that it supports the
+    /// FXSAVE and FXRSTOR instructions.
+    ///
+    UINT32  FXSR:1;
+    ///
+    /// [Bit 25] SSE.  The processor supports the SSE extensions.
+    ///
+    UINT32  SSE:1;
+    ///
+    /// [Bit 26] SSE2.  The processor supports the SSE2 extensions.
+    ///
+    UINT32  SSE2:1;
+    ///
+    /// [Bit 27] Self Snoop.  The processor supports the management of
+    /// conflicting memory types by performing a snoop of its own cache
+    /// structure for transactions issued to the bus.
+    ///
+    UINT32  SS:1;
+    ///
+    /// [Bit 28] Max APIC IDs reserved field is Valid.  A value of 0 for HTT
+    /// indicates there is only a single logical processor in the package and
+    /// software should assume only a single APIC ID is reserved. A value of 1
+    /// for HTT indicates the value in CPUID.1.EBX[23:16] (the Maximum number of
+    /// addressable IDs for logical processors in this package) is valid for the
+    /// package.
+    ///
+    UINT32  HTT:1;
+    ///
+    /// [Bit 29] Thermal Monitor.  The processor implements the thermal monitor
+    /// automatic thermal control circuitry (TCC).
+    ///
+    UINT32  TM:1;
+    UINT32  Reserved3:1;
+    ///
+    /// [Bit 31] Pending Break Enable.  The processor supports the use of the
+    /// FERR#/PBE# pin when the processor is in the stop-clock state (STPCLK# is
+    /// asserted) to signal the processor that an interrupt is pending and that
+    /// the processor should return to normal operation to handle the interrupt.
+    /// Bit 10 (PBE enable) in the IA32_MISC_ENABLE MSR enables this capability.
+    ///
+    UINT32  PBE:1;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32    Uint32;
+} CPUID_VERSION_INFO_EDX;
+
+
+/**
+  CPUID Cache and TLB Information
+
+  @param   EAX  CPUID_CACHE_INFO (0x02)
+
+  @retval  EAX  Cache and TLB Information described by the type
+                CPUID_CACHE_INFO_CACHE_TLB.
+                CPUID_CACHE_INFO_CACHE_TLB.CacheDescriptor[0] always returns
+                0x01 and must be ignored.  Only valid if
+                CPUID_CACHE_INFO_CACHE_TLB.Bits.NotValid is clear.
+  @retval  EBX  Cache and TLB Information described by the type
+                CPUID_CACHE_INFO_CACHE_TLB.  Only valid if
+                CPUID_CACHE_INFO_CACHE_TLB.Bits.NotValid is clear.
+  @retval  ECX  Cache and TLB Information described by the type
+                CPUID_CACHE_INFO_CACHE_TLB.  Only valid if
+                CPUID_CACHE_INFO_CACHE_TLB.Bits.NotValid is clear.
+  @retval  EDX  Cache and TLB Information described by the type
+                CPUID_CACHE_INFO_CACHE_TLB.  Only valid if
+                CPUID_CACHE_INFO_CACHE_TLB.Bits.NotValid is clear.
+
+  <b>Example usage</b>
+  @code
+  CPUID_CACHE_INFO_CACHE_TLB  Eax;
+  CPUID_CACHE_INFO_CACHE_TLB  Ebx;
+  CPUID_CACHE_INFO_CACHE_TLB  Ecx;
+  CPUID_CACHE_INFO_CACHE_TLB  Edx;
+
+  AsmCpuid (CPUID_CACHE_INFO, &Eax.Uint32, &Ebx.Uint32, &Ecx.Uint32, &Edx.Uint32);
+  @endcode
+
+  <b>Cache Descriptor values</b>
+  <table>
+  <tr><th>Value </th><th> Type    </th><th> Description </th></tr>
+  <tr><td> 0x00 </td><td> General </td><td> Null descriptor, this byte contains no information</td></tr>
+  <tr><td> 0x01 </td><td> TLB     </td><td> Instruction TLB: 4 KByte pages, 4-way set associative, 32 entries</td></tr>
+  <tr><td> 0x02 </td><td> TLB     </td><td> Instruction TLB: 4 MByte pages, fully associative, 2 entries</td></tr>
+  <tr><td> 0x03 </td><td> TLB     </td><td> Data TLB: 4 KByte pages, 4-way set associative, 64 entries</td></tr>
+  <tr><td> 0x04 </td><td> TLB     </td><td> Data TLB: 4 MByte pages, 4-way set associative, 8 entries</td></tr>
+  <tr><td> 0x05 </td><td> TLB     </td><td> Data TLB1: 4 MByte pages, 4-way set associative, 32 entries</td></tr>
+  <tr><td> 0x06 </td><td> Cache   </td><td> 1st-level instruction cache: 8 KBytes, 4-way set associative,
+                                            32 byte line size</td></tr>
+  <tr><td> 0x08 </td><td> Cache   </td><td> 1st-level instruction cache: 16 KBytes, 4-way set associative,
+                                            32 byte line size</td></tr>
+  <tr><td> 0x09 </td><td> Cache   </td><td> 1st-level instruction cache: 32KBytes, 4-way set associative,
+                                            64 byte line size</td></tr>
+  <tr><td> 0x0A </td><td> Cache   </td><td> 1st-level data cache: 8 KBytes, 2-way set associative, 32 byte line size</td></tr>
+  <tr><td> 0x0B </td><td> TLB     </td><td> Instruction TLB: 4 MByte pages, 4-way set associative, 4 entries</td></tr>
+  <tr><td> 0x0C </td><td> Cache   </td><td> 1st-level data cache: 16 KBytes, 4-way set associative, 32 byte line size</td></tr>
+  <tr><td> 0x0D </td><td> Cache   </td><td> 1st-level data cache: 16 KBytes, 4-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0x0E </td><td> Cache   </td><td> 1st-level data cache: 24 KBytes, 6-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0x1D </td><td> Cache   </td><td> 2nd-level cache: 128 KBytes, 2-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0x21 </td><td> Cache   </td><td> 2nd-level cache: 256 KBytes, 8-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0x22 </td><td> Cache   </td><td> 3rd-level cache: 512 KBytes, 4-way set associative, 64 byte line size,
+                                            2 lines per sector</td></tr>
+  <tr><td> 0x23 </td><td> Cache   </td><td> 3rd-level cache: 1 MBytes, 8-way set associative, 64 byte line size,
+                                            2 lines per sector</td></tr>
+  <tr><td> 0x24 </td><td> Cache   </td><td> 2nd-level cache: 1 MBytes, 16-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0x25 </td><td> Cache   </td><td> 3rd-level cache: 2 MBytes, 8-way set associative, 64 byte line size,
+                                            2 lines per sector</td></tr>
+  <tr><td> 0x29 </td><td> Cache   </td><td> 3rd-level cache: 4 MBytes, 8-way set associative, 64 byte line size,
+                                            2 lines per sector</td></tr>
+  <tr><td> 0x2C </td><td> Cache   </td><td> 1st-level data cache: 32 KBytes, 8-way set associative,
+                                            64 byte line size</td></tr>
+  <tr><td> 0x30 </td><td> Cache   </td><td> 1st-level instruction cache: 32 KBytes, 8-way set associative,
+                                            64 byte line size</td></tr>
+  <tr><td> 0x40 </td><td> Cache   </td><td> No 2nd-level cache or, if processor contains a valid 2nd-level cache,
+                                            no 3rd-level cache</td></tr>
+  <tr><td> 0x41 </td><td> Cache   </td><td> 2nd-level cache: 128 KBytes, 4-way set associative, 32 byte line size</td></tr>
+  <tr><td> 0x42 </td><td> Cache   </td><td> 2nd-level cache: 256 KBytes, 4-way set associative, 32 byte line size</td></tr>
+  <tr><td> 0x43 </td><td> Cache   </td><td> 2nd-level cache: 512 KBytes, 4-way set associative, 32 byte line size</td></tr>
+  <tr><td> 0x44 </td><td> Cache   </td><td> 2nd-level cache: 1 MByte, 4-way set associative, 32 byte line size</td></tr>
+  <tr><td> 0x45 </td><td> Cache   </td><td> 2nd-level cache: 2 MByte, 4-way set associative, 32 byte line size</td></tr>
+  <tr><td> 0x46 </td><td> Cache   </td><td> 3rd-level cache: 4 MByte, 4-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0x47 </td><td> Cache   </td><td> 3rd-level cache: 8 MByte, 8-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0x48 </td><td> Cache   </td><td> 2nd-level cache: 3MByte, 12-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0x49 </td><td> Cache   </td><td> 3rd-level cache: 4MB, 16-way set associative, 64-byte line size
+                                            (Intel Xeon processor MP, Family 0FH, Model 06H)<BR>
+                                            2nd-level cache: 4 MByte, 16-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0x4A </td><td> Cache   </td><td> 3rd-level cache: 6MByte, 12-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0x4B </td><td> Cache   </td><td> 3rd-level cache: 8MByte, 16-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0x4C </td><td> Cache   </td><td> 3rd-level cache: 12MByte, 12-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0x4D </td><td> Cache   </td><td> 3rd-level cache: 16MByte, 16-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0x4E </td><td> Cache   </td><td> 2nd-level cache: 6MByte, 24-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0x4F </td><td> TLB     </td><td> Instruction TLB: 4 KByte pages, 32 entries</td></tr>
+  <tr><td> 0x50 </td><td> TLB     </td><td> Instruction TLB: 4 KByte and 2-MByte or 4-MByte pages, 64 entries</td></tr>
+  <tr><td> 0x51 </td><td> TLB     </td><td> Instruction TLB: 4 KByte and 2-MByte or 4-MByte pages, 128 entries</td></tr>
+  <tr><td> 0x52 </td><td> TLB     </td><td> Instruction TLB: 4 KByte and 2-MByte or 4-MByte pages, 256 entries</td></tr>
+  <tr><td> 0x55 </td><td> TLB     </td><td> Instruction TLB: 2-MByte or 4-MByte pages, fully associative, 7 entries</td></tr>
+  <tr><td> 0x56 </td><td> TLB     </td><td> Data TLB0: 4 MByte pages, 4-way set associative, 16 entries</td></tr>
+  <tr><td> 0x57 </td><td> TLB     </td><td> Data TLB0: 4 KByte pages, 4-way associative, 16 entries</td></tr>
+  <tr><td> 0x59 </td><td> TLB     </td><td> Data TLB0: 4 KByte pages, fully associative, 16 entries</td></tr>
+  <tr><td> 0x5A </td><td> TLB     </td><td> Data TLB0: 2 MByte or 4 MByte pages, 4-way set associative, 32 entries</td></tr>
+  <tr><td> 0x5B </td><td> TLB     </td><td> Data TLB: 4 KByte and 4 MByte pages, 64 entries</td></tr>
+  <tr><td> 0x5C </td><td> TLB     </td><td> Data TLB: 4 KByte and 4 MByte pages,128 entries</td></tr>
+  <tr><td> 0x5D </td><td> TLB     </td><td> Data TLB: 4 KByte and 4 MByte pages,256 entries</td></tr>
+  <tr><td> 0x60 </td><td> Cache   </td><td> 1st-level data cache: 16 KByte, 8-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0x61 </td><td> TLB     </td><td> Instruction TLB: 4 KByte pages, fully associative, 48 entries</td></tr>
+  <tr><td> 0x63 </td><td> TLB     </td><td> Data TLB: 2 MByte or 4 MByte pages, 4-way set associative,
+                                            32 entries and a separate array with 1 GByte pages, 4-way set associative,
+                                            4 entries</td></tr>
+  <tr><td> 0x64 </td><td> TLB     </td><td> Data TLB: 4 KByte pages, 4-way set associative, 512 entries</td></tr>
+  <tr><td> 0x66 </td><td> Cache   </td><td> 1st-level data cache: 8 KByte, 4-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0x67 </td><td> Cache   </td><td> 1st-level data cache: 16 KByte, 4-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0x68 </td><td> Cache   </td><td> 1st-level data cache: 32 KByte, 4-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0x6A </td><td> Cache   </td><td> uTLB: 4 KByte pages, 8-way set associative, 64 entries</td></tr>
+  <tr><td> 0x6B </td><td> Cache   </td><td> DTLB: 4 KByte pages, 8-way set associative, 256 entries</td></tr>
+  <tr><td> 0x6C </td><td> Cache   </td><td> DTLB: 2M/4M pages, 8-way set associative, 128 entries</td></tr>
+  <tr><td> 0x6D </td><td> Cache   </td><td> DTLB: 1 GByte pages, fully associative, 16 entries</td></tr>
+  <tr><td> 0x70 </td><td> Cache   </td><td> Trace cache: 12 K-uop, 8-way set associative</td></tr>
+  <tr><td> 0x71 </td><td> Cache   </td><td> Trace cache: 16 K-uop, 8-way set associative</td></tr>
+  <tr><td> 0x72 </td><td> Cache   </td><td> Trace cache: 32 K-uop, 8-way set associative</td></tr>
+  <tr><td> 0x76 </td><td> TLB     </td><td> Instruction TLB: 2M/4M pages, fully associative, 8 entries</td></tr>
+  <tr><td> 0x78 </td><td> Cache   </td><td> 2nd-level cache: 1 MByte, 4-way set associative, 64byte line size</td></tr>
+  <tr><td> 0x79 </td><td> Cache   </td><td> 2nd-level cache: 128 KByte, 8-way set associative, 64 byte line size,
+                                            2 lines per sector</td></tr>
+  <tr><td> 0x7A </td><td> Cache   </td><td> 2nd-level cache: 256 KByte, 8-way set associative, 64 byte line size,
+                                            2 lines per sector</td></tr>
+  <tr><td> 0x7B </td><td> Cache   </td><td> 2nd-level cache: 512 KByte, 8-way set associative, 64 byte line size,
+                                            2 lines per sector</td></tr>
+  <tr><td> 0x7C </td><td> Cache   </td><td> 2nd-level cache: 1 MByte, 8-way set associative, 64 byte line size,
+                                            2 lines per sector</td></tr>
+  <tr><td> 0x7D </td><td> Cache   </td><td> 2nd-level cache: 2 MByte, 8-way set associative, 64byte line size</td></tr>
+  <tr><td> 0x7F </td><td> Cache   </td><td> 2nd-level cache: 512 KByte, 2-way set associative, 64-byte line size</td></tr>
+  <tr><td> 0x80 </td><td> Cache   </td><td> 2nd-level cache: 512 KByte, 8-way set associative, 64-byte line size</td></tr>
+  <tr><td> 0x82 </td><td> Cache   </td><td> 2nd-level cache: 256 KByte, 8-way set associative, 32 byte line size</td></tr>
+  <tr><td> 0x83 </td><td> Cache   </td><td> 2nd-level cache: 512 KByte, 8-way set associative, 32 byte line size</td></tr>
+  <tr><td> 0x84 </td><td> Cache   </td><td> 2nd-level cache: 1 MByte, 8-way set associative, 32 byte line size</td></tr>
+  <tr><td> 0x85 </td><td> Cache   </td><td> 2nd-level cache: 2 MByte, 8-way set associative, 32 byte line size</td></tr>
+  <tr><td> 0x86 </td><td> Cache   </td><td> 2nd-level cache: 512 KByte, 4-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0x87 </td><td> Cache   </td><td> 2nd-level cache: 1 MByte, 8-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0xA0 </td><td> DTLB    </td><td> DTLB: 4k pages, fully associative, 32 entries</td></tr>
+  <tr><td> 0xB0 </td><td> TLB     </td><td> Instruction TLB: 4 KByte pages, 4-way set associative, 128 entries</td></tr>
+  <tr><td> 0xB1 </td><td> TLB     </td><td> Instruction TLB: 2M pages, 4-way, 8 entries or 4M pages, 4-way, 4 entries</td></tr>
+  <tr><td> 0xB2 </td><td> TLB     </td><td> Instruction TLB: 4KByte pages, 4-way set associative, 64 entries</td></tr>
+  <tr><td> 0xB3 </td><td> TLB     </td><td> Data TLB: 4 KByte pages, 4-way set associative, 128 entries</td></tr>
+  <tr><td> 0xB4 </td><td> TLB     </td><td> Data TLB1: 4 KByte pages, 4-way associative, 256 entries</td></tr>
+  <tr><td> 0xB5 </td><td> TLB     </td><td> Instruction TLB: 4KByte pages, 8-way set associative, 64 entries</td></tr>
+  <tr><td> 0xB6 </td><td> TLB     </td><td> Instruction TLB: 4KByte pages, 8-way set associative,
+                                            128 entries</td></tr>
+  <tr><td> 0xBA </td><td> TLB     </td><td> Data TLB1: 4 KByte pages, 4-way associative, 64 entries</td></tr>
+  <tr><td> 0xC0 </td><td> TLB     </td><td> Data TLB: 4 KByte and 4 MByte pages, 4-way associative, 8 entries</td></tr>
+  <tr><td> 0xC1 </td><td> STLB    </td><td> Shared 2nd-Level TLB: 4 KByte/2MByte pages, 8-way associative,
+                                            1024 entries</td></tr>
+  <tr><td> 0xC2 </td><td> DTLB    </td><td> DTLB: 4 KByte/2 MByte pages, 4-way associative, 16 entries</td></tr>
+  <tr><td> 0xC3 </td><td> STLB    </td><td> Shared 2nd-Level TLB: 4 KByte /2 MByte pages, 6-way associative,
+                                            1536 entries. Also 1GBbyte pages, 4-way, 16 entries.</td></tr>
+  <tr><td> 0xC4 </td><td> DTLB    </td><td> DTLB: 2M/4M Byte pages, 4-way associative, 32 entries</td></tr>
+  <tr><td> 0xCA </td><td> STLB    </td><td> Shared 2nd-Level TLB: 4 KByte pages, 4-way associative, 512 entries</td></tr>
+  <tr><td> 0xD0 </td><td> Cache   </td><td> 3rd-level cache: 512 KByte, 4-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0xD1 </td><td> Cache   </td><td> 3rd-level cache: 1 MByte, 4-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0xD2 </td><td> Cache   </td><td> 3rd-level cache: 2 MByte, 4-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0xD6 </td><td> Cache   </td><td> 3rd-level cache: 1 MByte, 8-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0xD7 </td><td> Cache   </td><td> 3rd-level cache: 2 MByte, 8-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0xD8 </td><td> Cache   </td><td> 3rd-level cache: 4 MByte, 8-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0xDC </td><td> Cache   </td><td> 3rd-level cache: 1.5 MByte, 12-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0xDD </td><td> Cache   </td><td> 3rd-level cache: 3 MByte, 12-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0xDE </td><td> Cache   </td><td> 3rd-level cache: 6 MByte, 12-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0xE2 </td><td> Cache   </td><td> 3rd-level cache: 2 MByte, 16-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0xE3 </td><td> Cache   </td><td> 3rd-level cache: 4 MByte, 16-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0xE4 </td><td> Cache   </td><td> 3rd-level cache: 8 MByte, 16-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0xEA </td><td> Cache   </td><td> 3rd-level cache: 12MByte, 24-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0xEB </td><td> Cache   </td><td> 3rd-level cache: 18MByte, 24-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0xEC </td><td> Cache   </td><td> 3rd-level cache: 24MByte, 24-way set associative, 64 byte line size</td></tr>
+  <tr><td> 0xF0 </td><td> Prefetch</td><td> 64-Byte prefetching</td></tr>
+  <tr><td> 0xF1 </td><td> Prefetch</td><td> 128-Byte prefetching</td></tr>
+  <tr><td> 0xFE </td><td> General </td><td> CPUID leaf 2 does not report TLB descriptor information; use CPUID
+                                            leaf 18H to query TLB and other address translation parameters.</td></tr>
+  <tr><td> 0xFF </td><td> General </td><td> CPUID leaf 2 does not report cache descriptor information,
+                                            use CPUID leaf 4 to query cache parameters</td></tr>
+  </table>
+**/
+#define CPUID_CACHE_INFO                        0x02
+
+/**
+  CPUID Cache and TLB Information returned in EAX, EBX, ECX, and EDX for CPUID
+  leaf #CPUID_CACHE_INFO.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    UINT32  Reserved:31;
+    ///
+    /// [Bit 31] If 0, then the cache descriptor bytes in the register are valid.
+    /// if 1, then none of the cache descriptor bytes in the register are valid.
+    ///
+    UINT32  NotValid:1;
+  } Bits;
+  ///
+  /// Array of Cache and TLB descriptor bytes
+  ///
+  UINT8   CacheDescriptor[4];
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_CACHE_INFO_CACHE_TLB;
+
+
+/**
+  CPUID Processor Serial Number
+
+  Processor serial number (PSN) is not supported in the Pentium 4 processor
+  or later.  On all models, use the PSN flag (returned using CPUID) to check
+  for PSN support before accessing the feature.
+
+  @param   EAX  CPUID_SERIAL_NUMBER (0x03)
+
+  @retval  EAX  Reserved.
+  @retval  EBX  Reserved.
+  @retval  ECX  Bits 31:0 of 96 bit processor serial number. (Available in
+                Pentium III processor only; otherwise, the value in this
+                register is reserved.)
+  @retval  EDX  Bits 63:32 of 96 bit processor serial number. (Available in
+                Pentium III processor only; otherwise, the value in this
+                register is reserved.)
+
+  <b>Example usage</b>
+  @code
+  UINT32  Ecx;
+  UINT32  Edx;
+
+  AsmCpuid (CPUID_SERIAL_NUMBER, NULL, NULL, &Ecx, &Edx);
+  @endcode
+**/
+#define CPUID_SERIAL_NUMBER                     0x03
+
+
+/**
+  CPUID Cache Parameters
+
+  @param   EAX  CPUID_CACHE_PARAMS (0x04)
+  @param   ECX  Cache Level.  Valid values start at 0.  Software can enumerate
+                the deterministic cache parameters for each level of the cache
+                hierarchy starting with an index value of 0, until the
+                parameters report the value associated with the CacheType
+                field in CPUID_CACHE_PARAMS_EAX is 0.
+
+  @retval  EAX  Returns cache type information described by the type
+                CPUID_CACHE_PARAMS_EAX.
+  @retval  EBX  Returns cache line and associativity information described by
+                the type CPUID_CACHE_PARAMS_EBX.
+  @retval  ECX  Returns the number of sets in the cache.
+  @retval  EDX  Returns cache WINVD/INVD behavior described by the type
+                CPUID_CACHE_PARAMS_EDX.
+
+  <b>Example usage</b>
+  @code
+  UINT32                  CacheLevel;
+  CPUID_CACHE_PARAMS_EAX  Eax;
+  CPUID_CACHE_PARAMS_EBX  Ebx;
+  UINT32                  Ecx;
+  CPUID_CACHE_PARAMS_EDX  Edx;
+
+  CacheLevel = 0;
+  do {
+    AsmCpuidEx (
+      CPUID_CACHE_PARAMS, CacheLevel,
+      &Eax.Uint32, &Ebx.Uint32, &Ecx, &Edx.Uint32
+      );
+    CacheLevel++;
+  } while (Eax.Bits.CacheType != CPUID_CACHE_PARAMS_CACHE_TYPE_NULL);
+  @endcode
+**/
+#define CPUID_CACHE_PARAMS                      0x04
+
+/**
+  CPUID Cache Parameters Information returned in EAX for CPUID leaf
+  #CPUID_CACHE_PARAMS.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 4:0] Cache type field.  If #CPUID_CACHE_PARAMS_CACHE_TYPE_NULL,
+    /// then there is no information for the requested cache level.
+    ///
+    UINT32  CacheType:5;
+    ///
+    /// [Bits 7:5] Cache level (Starts at 1).
+    ///
+    UINT32  CacheLevel:3;
+    ///
+    /// [Bit 8] Self Initializing cache level (does not need SW initialization).
+    ///
+    UINT32  SelfInitializingCache:1;
+    ///
+    /// [Bit 9] Fully Associative cache.
+    ///
+    UINT32  FullyAssociativeCache:1;
+    ///
+    /// [Bits 13:10] Reserved.
+    ///
+    UINT32  Reserved:4;
+    ///
+    /// [Bits 25:14] Maximum number of addressable IDs for logical processors
+    /// sharing this cache.
+    ///
+    /// Add one to the return value to get the result.
+    /// The nearest power-of-2 integer that is not smaller than (1 + EAX[25:14])
+    /// is the number of unique initial APIC IDs reserved for addressing
+    /// different logical processors sharing this cache.
+    ///
+    UINT32  MaximumAddressableIdsForLogicalProcessors:12;
+    ///
+    /// [Bits 31:26] Maximum number of addressable IDs for processor cores in
+    /// the physical package.
+    ///
+    /// The nearest power-of-2 integer that is not smaller than (1 + EAX[31:26])
+    /// is the number of unique Core_IDs reserved for addressing different
+    /// processor cores in a physical package. Core ID is a subset of bits of
+    /// the initial APIC ID.
+    /// The returned value is constant for valid initial values in ECX. Valid
+    /// ECX values start from 0.
+    ///
+    UINT32  MaximumAddressableIdsForProcessorCores:6;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_CACHE_PARAMS_EAX;
+
+///
+/// @{ Define value for bit field CPUID_CACHE_PARAMS_EAX.CacheType
+///
+#define CPUID_CACHE_PARAMS_CACHE_TYPE_NULL         0x00
+#define CPUID_CACHE_PARAMS_CACHE_TYPE_DATA         0x01
+#define CPUID_CACHE_PARAMS_CACHE_TYPE_INSTRUCTION  0x02
+#define CPUID_CACHE_PARAMS_CACHE_TYPE_UNIFIED      0x03
+///
+/// @}
+///
+
+/**
+  CPUID Cache Parameters Information returned in EBX for CPUID leaf
+  #CPUID_CACHE_PARAMS.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 11:0] System Coherency Line Size.  Add one to the return value to
+    /// get the result.
+    ///
+    UINT32  LineSize:12;
+    ///
+    /// [Bits 21:12] Physical Line Partitions.  Add one to the return value to
+    /// get the result.
+    ///
+    UINT32  LinePartitions:10;
+    ///
+    /// [Bits 31:22] Ways of associativity.  Add one to the return value to get
+    /// the result.
+    ///
+    UINT32  Ways:10;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_CACHE_PARAMS_EBX;
+
+/**
+  CPUID Cache Parameters Information returned in EDX for CPUID leaf
+  #CPUID_CACHE_PARAMS.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Write-Back Invalidate/Invalidate.
+    /// 0 = WBINVD/INVD from threads sharing this cache acts upon lower level
+    /// caches for threads sharing this cache.
+    /// 1 = WBINVD/INVD is not guaranteed to act upon lower level caches of
+    /// non-originating threads sharing this cache.
+    ///
+    UINT32  Invalidate:1;
+    ///
+    /// [Bit 1] Cache Inclusiveness.
+    /// 0 = Cache is not inclusive of lower cache levels.
+    /// 1 = Cache is inclusive of lower cache levels.
+    ///
+    UINT32  CacheInclusiveness:1;
+    ///
+    /// [Bit 2] Complex Cache Indexing.
+    /// 0 = Direct mapped cache.
+    /// 1 = A complex function is used to index the cache, potentially using all
+    /// address bits.
+    ///
+    UINT32  ComplexCacheIndexing:1;
+    UINT32  Reserved:29;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_CACHE_PARAMS_EDX;
+
+
+/**
+  CPUID MONITOR/MWAIT Information
+
+  @param   EAX  CPUID_MONITOR_MWAIT (0x05)
+
+  @retval  EAX  Smallest monitor-line size in bytes described by the type
+                CPUID_MONITOR_MWAIT_EAX.
+  @retval  EBX  Largest monitor-line size in bytes described by the type
+                CPUID_MONITOR_MWAIT_EBX.
+  @retval  ECX  Enumeration of Monitor-Mwait extensions support described by
+                the type CPUID_MONITOR_MWAIT_ECX.
+  @retval  EDX  Sub C-states supported described by the type
+                CPUID_MONITOR_MWAIT_EDX.
+
+  <b>Example usage</b>
+  @code
+  CPUID_MONITOR_MWAIT_EAX  Eax;
+  CPUID_MONITOR_MWAIT_EBX  Ebx;
+  CPUID_MONITOR_MWAIT_ECX  Ecx;
+  CPUID_MONITOR_MWAIT_EDX  Edx;
+
+  AsmCpuid (CPUID_MONITOR_MWAIT, &Eax.Uint32, &Ebx.Uint32, &Ecx.Uint32, &Edx.Uint32);
+  @endcode
+**/
+#define CPUID_MONITOR_MWAIT                     0x05
+
+/**
+  CPUID MONITOR/MWAIT Information returned in EAX for CPUID leaf
+  #CPUID_MONITOR_MWAIT.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 15:0] Smallest monitor-line size in bytes (default is processor's
+    /// monitor granularity).
+    ///
+    UINT32  SmallestMonitorLineSize:16;
+    UINT32  Reserved:16;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_MONITOR_MWAIT_EAX;
+
+/**
+  CPUID MONITOR/MWAIT Information returned in EBX for CPUID leaf
+  #CPUID_MONITOR_MWAIT.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 15:0] Largest monitor-line size in bytes (default is processor's
+    /// monitor granularity).
+    ///
+    UINT32  LargestMonitorLineSize:16;
+    UINT32  Reserved:16;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_MONITOR_MWAIT_EBX;
+
+/**
+  CPUID MONITOR/MWAIT Information returned in ECX for CPUID leaf
+  #CPUID_MONITOR_MWAIT.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] If 0, then only EAX and EBX are valid.  If 1, then EAX, EBX, ECX,
+    /// and EDX are valid.
+    ///
+    UINT32  ExtensionsSupported:1;
+    ///
+    /// [Bit 1] Supports treating interrupts as break-event for MWAIT, even when
+    /// interrupts disabled.
+    ///
+    UINT32  InterruptAsBreak:1;
+    UINT32  Reserved:30;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_MONITOR_MWAIT_ECX;
+
+/**
+  CPUID MONITOR/MWAIT Information returned in EDX for CPUID leaf
+  #CPUID_MONITOR_MWAIT.
+
+  @note
+  The definition of C0 through C7 states for MWAIT extension are
+  processor-specific C-states, not ACPI C-states.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 3:0] Number of C0 sub C-states supported using MWAIT.
+    ///
+    UINT32  C0States:4;
+    ///
+    /// [Bits 7:4] Number of C1 sub C-states supported using MWAIT.
+    ///
+    UINT32  C1States:4;
+    ///
+    /// [Bits 11:8] Number of C2 sub C-states supported using MWAIT.
+    ///
+    UINT32  C2States:4;
+    ///
+    /// [Bits 15:12] Number of C3 sub C-states supported using MWAIT.
+    ///
+    UINT32  C3States:4;
+    ///
+    /// [Bits 19:16] Number of C4 sub C-states supported using MWAIT.
+    ///
+    UINT32  C4States:4;
+    ///
+    /// [Bits 23:20] Number of C5 sub C-states supported using MWAIT.
+    ///
+    UINT32  C5States:4;
+    ///
+    /// [Bits 27:24] Number of C6 sub C-states supported using MWAIT.
+    ///
+    UINT32  C6States:4;
+    ///
+    /// [Bits 31:28] Number of C7 sub C-states supported using MWAIT.
+    ///
+    UINT32  C7States:4;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_MONITOR_MWAIT_EDX;
+
+
+/**
+  CPUID Thermal and Power Management
+
+  @param   EAX  CPUID_THERMAL_POWER_MANAGEMENT (0x06)
+
+  @retval  EAX  Thermal and power management features described by the type
+                CPUID_THERMAL_POWER_MANAGEMENT_EAX.
+  @retval  EBX  Number of Interrupt Thresholds in Digital Thermal Sensor
+                described by the type CPUID_THERMAL_POWER_MANAGEMENT_EBX.
+  @retval  ECX  Performance features described by the type
+                CPUID_THERMAL_POWER_MANAGEMENT_ECX.
+  @retval  EDX  Reserved.
+
+  <b>Example usage</b>
+  @code
+  CPUID_THERMAL_POWER_MANAGEMENT_EAX  Eax;
+  CPUID_THERMAL_POWER_MANAGEMENT_EBX  Ebx;
+  CPUID_THERMAL_POWER_MANAGEMENT_ECX  Ecx;
+
+  AsmCpuid (CPUID_THERMAL_POWER_MANAGEMENT, &Eax.Uint32, &Ebx.Uint32, &Ecx.Uint32, NULL);
+  @endcode
+**/
+#define CPUID_THERMAL_POWER_MANAGEMENT          0x06
+
+/**
+  CPUID Thermal and Power Management Information returned in EAX for CPUID leaf
+  #CPUID_THERMAL_POWER_MANAGEMENT.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Digital temperature sensor is supported if set.
+    ///
+    UINT32  DigitalTemperatureSensor:1;
+    ///
+    /// [Bit 1] Intel Turbo Boost Technology Available (see IA32_MISC_ENABLE[38]).
+    ///
+    UINT32  TurboBoostTechnology:1;
+    ///
+    /// [Bit 2] APIC-Timer-always-running feature is supported if set.
+    ///
+    UINT32  ARAT:1;
+    UINT32  Reserved1:1;
+    ///
+    /// [Bit 4] Power limit notification controls are supported if set.
+    ///
+    UINT32  PLN:1;
+    ///
+    /// [Bit 5] Clock modulation duty cycle extension is supported if set.
+    ///
+    UINT32  ECMD:1;
+    ///
+    /// [Bit 6] Package thermal management is supported if set.
+    ///
+    UINT32  PTM:1;
+    ///
+    /// [Bit 7] HWP base registers (IA32_PM_ENABLE[Bit 0], IA32_HWP_CAPABILITIES,
+    /// IA32_HWP_REQUEST, IA32_HWP_STATUS) are supported if set.
+    ///
+    UINT32  HWP:1;
+    ///
+    /// [Bit 8] IA32_HWP_INTERRUPT MSR is supported if set.
+    ///
+    UINT32  HWP_Notification:1;
+    ///
+    /// [Bit 9] IA32_HWP_REQUEST[Bits 41:32] is supported if set.
+    ///
+    UINT32  HWP_Activity_Window:1;
+    ///
+    /// [Bit 10] IA32_HWP_REQUEST[Bits 31:24] is supported if set.
+    ///
+    UINT32  HWP_Energy_Performance_Preference:1;
+    ///
+    /// [Bit 11] IA32_HWP_REQUEST_PKG MSR is supported if set.
+    ///
+    UINT32  HWP_Package_Level_Request:1;
+    UINT32  Reserved2:1;
+    ///
+    /// [Bit 13] HDC base registers IA32_PKG_HDC_CTL, IA32_PM_CTL1,
+    /// IA32_THREAD_STALL MSRs are supported if set.
+    ///
+    UINT32  HDC:1;
+    ///
+    /// [Bit 14] Intel Turbo Boost Max Technology 3.0 available.
+    ///
+    UINT32  TurboBoostMaxTechnology30:1;
+    ///
+    /// [Bit 15] HWP Capabilities.
+    /// Highest Performance change is supported if set.
+    ///
+    UINT32  HWPCapabilities:1;
+    ///
+    /// [Bit 16] HWP PECI override is supported if set.
+    ///
+    UINT32  HWPPECIOverride:1;
+    ///
+    /// [Bit 17] Flexible HWP is supported if set.
+    ///
+    UINT32  FlexibleHWP:1;
+    ///
+    /// [Bit 18] Fast access mode for the IA32_HWP_REQUEST MSR is supported if set.
+    ///
+    UINT32  FastAccessMode:1;
+    UINT32  Reserved4:1;
+    ///
+    /// [Bit 20] Ignoring Idle Logical Processor HWP request is supported if set.
+    ///
+    UINT32  IgnoringIdleLogicalProcessorHWPRequest:1;
+    UINT32  Reserved5:11;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_THERMAL_POWER_MANAGEMENT_EAX;
+
+/**
+  CPUID Thermal and Power Management Information returned in EBX for CPUID leaf
+  #CPUID_THERMAL_POWER_MANAGEMENT.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// {Bits 3:0] Number of Interrupt Thresholds in Digital Thermal Sensor.
+    ///
+    UINT32  InterruptThresholds:4;
+    UINT32  Reserved:28;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_THERMAL_POWER_MANAGEMENT_EBX;
+
+/**
+  CPUID Thermal and Power Management Information returned in ECX for CPUID leaf
+  #CPUID_THERMAL_POWER_MANAGEMENT.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Hardware Coordination Feedback Capability (Presence of IA32_MPERF
+    /// and IA32_APERF). The capability to provide a measure of delivered
+    /// processor performance (since last reset of the counters), as a percentage
+    /// of the expected processor performance when running at the TSC frequency.
+    ///
+    UINT32  HardwareCoordinationFeedback:1;
+    UINT32  Reserved1:2;
+    ///
+    /// [Bit 3] If this bit is set, then the processor supports performance-energy
+    /// bias preference and the architectural MSR called IA32_ENERGY_PERF_BIAS
+    /// (1B0H).
+    ///
+    UINT32  PerformanceEnergyBias:1;
+    UINT32  Reserved2:28;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_THERMAL_POWER_MANAGEMENT_ECX;
+
+
+/**
+  CPUID Structured Extended Feature Flags Enumeration
+
+  @param   EAX  CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS (0x07)
+  @param   ECX  CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS_SUB_LEAF_INFO (0x00).
+
+  @note
+  If ECX contains an invalid sub-leaf index, EAX/EBX/ECX/EDX return 0.  Sub-leaf
+  index n is invalid if n exceeds the value that sub-leaf 0 returns in EAX.
+
+  @retval  EAX  The maximum input value for ECX to retrieve sub-leaf information.
+  @retval  EBX  Structured Extended Feature Flags described by the type
+                CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS_EBX.
+  @retval  EBX  Structured Extended Feature Flags described by the type
+                CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS_ECX.
+  @retval  EDX  Reserved.
+
+  <b>Example usage</b>
+  @code
+  UINT32                                       Eax;
+  CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS_EBX  Ebx;
+  CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS_ECX  Ecx;
+  UINT32                                       SubLeaf;
+
+  AsmCpuidEx (
+    CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS,
+    CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS_SUB_LEAF_INFO,
+    &Eax, NULL, NULL, NULL
+    );
+  for (SubLeaf = 0; SubLeaf <= Eax; SubLeaf++) {
+    AsmCpuidEx (
+      CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS,
+      SubLeaf,
+      NULL, &Ebx.Uint32, &Ecx.Uint32, NULL
+      );
+  }
+  @endcode
+**/
+#define CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS                0x07
+
+///
+/// CPUID Structured Extended Feature Flags Enumeration sub-leaf
+///
+#define CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS_SUB_LEAF_INFO  0x00
+
+/**
+  CPUID Structured Extended Feature Flags Enumeration in EBX for CPUID leaf
+  #CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS sub leaf
+  #CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS_SUB_LEAF_INFO.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Supports RDFSBASE/RDGSBASE/WRFSBASE/WRGSBASE if 1.
+    ///
+    UINT32  FSGSBASE:1;
+    ///
+    /// [Bit 1] IA32_TSC_ADJUST MSR is supported if 1.
+    ///
+    UINT32  IA32_TSC_ADJUST:1;
+    ///
+    /// [Bit 2] Intel SGX is supported if 1. See section 37.7 "DISCOVERING SUPPORT
+    /// FOR INTEL(R) SGX AND ENABLING ENCLAVE INSTRUCTIONS".
+    ///
+    UINT32  SGX:1;
+    ///
+    /// [Bit 3] If 1 indicates the processor supports the first group of advanced
+    /// bit manipulation extensions (ANDN, BEXTR, BLSI, BLSMSK, BLSR, TZCNT)
+    ///
+    UINT32  BMI1:1;
+    ///
+    /// [Bit 4] Hardware Lock Elision
+    ///
+    UINT32  HLE:1;
+    ///
+    /// [Bit 5] If 1 indicates the processor supports AVX2 instruction extensions.
+    ///
+    UINT32  AVX2:1;
+    ///
+    /// [Bit 6] x87 FPU Data Pointer updated only on x87 exceptions if 1.
+    ///
+    UINT32  FDP_EXCPTN_ONLY:1;
+    ///
+    /// [Bit 7] Supports Supervisor-Mode Execution Prevention if 1.
+    ///
+    UINT32  SMEP:1;
+    ///
+    /// [Bit 8] If 1 indicates the processor supports the second group of
+    /// advanced bit manipulation extensions (BZHI, MULX, PDEP, PEXT, RORX,
+    /// SARX, SHLX, SHRX)
+    ///
+    UINT32  BMI2:1;
+    ///
+    /// [Bit 9] Supports Enhanced REP MOVSB/STOSB if 1.
+    ///
+    UINT32  EnhancedRepMovsbStosb:1;
+    ///
+    /// [Bit 10] If 1, supports INVPCID instruction for system software that
+    /// manages process-context identifiers.
+    ///
+    UINT32  INVPCID:1;
+    ///
+    /// [Bit 11] Restricted Transactional Memory
+    ///
+    UINT32  RTM:1;
+    ///
+    /// [Bit 12] Supports Intel(R) Resource Director Technology (Intel(R) RDT)
+    /// Monitoring capability if 1.
+    ///
+    UINT32  RDT_M:1;
+    ///
+    /// [Bit 13] Deprecates FPU CS and FPU DS values if 1.
+    ///
+    UINT32  DeprecateFpuCsDs:1;
+    ///
+    /// [Bit 14] Supports Intel(R) Memory Protection Extensions if 1.
+    ///
+    UINT32  MPX:1;
+    ///
+    /// [Bit 15] Supports Intel(R) Resource Director Technology (Intel(R) RDT)
+    /// Allocation capability if 1.
+    ///
+    UINT32  RDT_A:1;
+    ///
+    /// [Bit 16] AVX512F.
+    ///
+    UINT32  AVX512F:1;
+    ///
+    /// [Bit 17] AVX512DQ.
+    ///
+    UINT32  AVX512DQ:1;
+    ///
+    /// [Bit 18] If 1 indicates the processor supports the RDSEED instruction.
+    ///
+    UINT32  RDSEED:1;
+    ///
+    /// [Bit 19] If 1 indicates the processor supports the ADCX and ADOX
+    /// instructions.
+    ///
+    UINT32  ADX:1;
+    ///
+    /// [Bit 20] Supports Supervisor-Mode Access Prevention (and the CLAC/STAC
+    /// instructions) if 1.
+    ///
+    UINT32  SMAP:1;
+    ///
+    /// [Bit 21] AVX512_IFMA.
+    ///
+    UINT32  AVX512_IFMA:1;
+    UINT32  Reserved6:1;
+    ///
+    /// [Bit 23] If 1 indicates the processor supports the CLFLUSHOPT instruction.
+    ///
+    UINT32  CLFLUSHOPT:1;
+    ///
+    /// [Bit 24] If 1 indicates the processor supports the CLWB instruction.
+    ///
+    UINT32  CLWB:1;
+    ///
+    /// [Bit 25] If 1 indicates the processor supports the Intel Processor Trace
+    /// extensions.
+    ///
+    UINT32  IntelProcessorTrace:1;
+    ///
+    /// [Bit 26] AVX512PF. (Intel Xeon Phi only.).
+    ///
+    UINT32  AVX512PF:1;
+    ///
+    /// [Bit 27] AVX512ER. (Intel Xeon Phi only.).
+    ///
+    UINT32  AVX512ER:1;
+    ///
+    /// [Bit 28] AVX512CD.
+    ///
+    UINT32  AVX512CD:1;
+    ///
+    /// [Bit 29] Supports Intel(R) Secure Hash Algorithm Extensions (Intel(R)
+    /// SHA Extensions) if 1.
+    ///
+    UINT32  SHA:1;
+    ///
+    /// [Bit 30] AVX512BW.
+    ///
+    UINT32  AVX512BW:1;
+    ///
+    /// [Bit 31] AVX512VL.
+    ///
+    UINT32  AVX512VL:1;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS_EBX;
+
+/**
+  CPUID Structured Extended Feature Flags Enumeration in ECX for CPUID leaf
+  #CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS sub leaf
+  #CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS_SUB_LEAF_INFO.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] If 1 indicates the processor supports the PREFETCHWT1 instruction.
+    /// (Intel Xeon Phi only.)
+    ///
+    UINT32  PREFETCHWT1:1;
+    ///
+    /// [Bit 1] AVX512_VBMI.
+    ///
+    UINT32  AVX512_VBMI:1;
+    ///
+    /// [Bit 2] Supports user-mode instruction prevention if 1.
+    ///
+    UINT32  UMIP:1;
+    ///
+    /// [Bit 3] Supports protection keys for user-mode pages if 1.
+    ///
+    UINT32  PKU:1;
+    ///
+    /// [Bit 4] If 1, OS has set CR4.PKE to enable protection keys (and the
+    /// RDPKRU/WRPKRU instructions).
+    ///
+    UINT32  OSPKE:1;
+    UINT32  Reserved5:9;
+    ///
+    /// [Bits 14] AVX512_VPOPCNTDQ. (Intel Xeon Phi only.).
+    ///
+    UINT32  AVX512_VPOPCNTDQ:1;
+    UINT32  Reserved7:1;
+    ///
+    /// [Bits 16] Supports 5-level paging if 1.
+    ///
+    UINT32  FiveLevelPage:1;
+    ///
+    /// [Bits 21:17] The value of MAWAU used by the BNDLDX and BNDSTX instructions
+    /// in 64-bit mode.
+    ///
+    UINT32  MAWAU:5;
+    ///
+    /// [Bit 22] RDPID and IA32_TSC_AUX are available if 1.
+    ///
+    UINT32  RDPID:1;
+    UINT32  Reserved3:7;
+    ///
+    /// [Bit 30] Supports SGX Launch Configuration if 1.
+    ///
+    UINT32  SGX_LC:1;
+    UINT32  Reserved4:1;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS_ECX;
+
+/**
+  CPUID Structured Extended Feature Flags Enumeration in EDX for CPUID leaf
+  #CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS sub leaf
+  #CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS_SUB_LEAF_INFO.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 1:0] Reserved.
+    ///
+    UINT32  Reserved1:2;
+    ///
+    /// [Bit 2] AVX512_4VNNIW. (Intel Xeon Phi only.)
+    ///
+    UINT32  AVX512_4VNNIW:1;
+    ///
+    /// [Bit 3] AVX512_4FMAPS. (Intel Xeon Phi only.)
+    ///
+    UINT32  AVX512_4FMAPS:1;
+    ///
+    /// [Bit 25:4] Reserved.
+    ///
+    UINT32  Reserved2:22;
+    ///
+    /// [Bit 26] Enumerates support for indirect branch restricted speculation
+    /// (IBRS) and the indirect branch pre-dictor barrier (IBPB). Processors
+    /// that set this bit support the IA32_SPEC_CTRL MSR and the IA32_PRED_CMD
+    /// MSR. They allow software to set IA32_SPEC_CTRL[0] (IBRS) and
+    /// IA32_PRED_CMD[0] (IBPB).
+    ///
+    UINT32  EnumeratesSupportForIBRSAndIBPB:1;
+    ///
+    /// [Bit 27] Enumerates support for single thread indirect branch
+    /// predictors (STIBP). Processors that set this bit support the
+    /// IA32_SPEC_CTRL MSR. They allow software to set IA32_SPEC_CTRL[1]
+    /// (STIBP).
+    ///
+    UINT32  EnumeratesSupportForSTIBP:1;
+    ///
+    /// [Bit 28] Enumerates support for L1D_FLUSH. Processors that set this bit
+    /// support the IA32_FLUSH_CMD MSR. They allow software to set
+    /// IA32_FLUSH_CMD[0] (L1D_FLUSH).
+    ///
+    UINT32  EnumeratesSupportForL1D_FLUSH:1;
+    ///
+    /// [Bit 29] Enumerates support for the IA32_ARCH_CAPABILITIES MSR.
+    ///
+    UINT32  EnumeratesSupportForCapability:1;
+    ///
+    /// [Bit 30] Reserved.
+    ///
+    UINT32  Reserved3:1;
+    ///
+    /// [Bit 31] Enumerates support for Speculative Store Bypass Disable (SSBD).
+    /// Processors that set this bit sup-port the IA32_SPEC_CTRL MSR. They allow
+    /// software to set IA32_SPEC_CTRL[2] (SSBD).
+    ///
+    UINT32  EnumeratesSupportForSSBD:1;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_STRUCTURED_EXTENDED_FEATURE_FLAGS_EDX;
+
+/**
+  CPUID Direct Cache Access Information
+
+  @param   EAX  CPUID_DIRECT_CACHE_ACCESS_INFO (0x09)
+
+  @retval  EAX  Value of bits [31:0] of IA32_PLATFORM_DCA_CAP MSR (address 1F8H).
+  @retval  EBX  Reserved.
+  @retval  ECX  Reserved.
+  @retval  EDX  Reserved.
+
+  <b>Example usage</b>
+  @code
+  UINT32  Eax;
+
+  AsmCpuid (CPUID_DIRECT_CACHE_ACCESS_INFO, &Eax, NULL, NULL, NULL);
+  @endcode
+**/
+#define CPUID_DIRECT_CACHE_ACCESS_INFO              0x09
+
+
+/**
+  CPUID Architectural Performance Monitoring
+
+  @param   EAX  CPUID_ARCHITECTURAL_PERFORMANCE_MONITORING (0x0A)
+
+  @retval  EAX  Architectural Performance Monitoring information described by
+                the type CPUID_ARCHITECTURAL_PERFORMANCE_MONITORING_EAX.
+  @retval  EBX  Architectural Performance Monitoring information described by
+                the type CPUID_ARCHITECTURAL_PERFORMANCE_MONITORING_EBX.
+  @retval  ECX  Reserved.
+  @retval  EDX  Architectural Performance Monitoring information described by
+                the type CPUID_ARCHITECTURAL_PERFORMANCE_MONITORING_EDX.
+
+  <b>Example usage</b>
+  @code
+  CPUID_ARCHITECTURAL_PERFORMANCE_MONITORING_EAX  Eax;
+  CPUID_ARCHITECTURAL_PERFORMANCE_MONITORING_EBX  Ebx;
+  CPUID_ARCHITECTURAL_PERFORMANCE_MONITORING_EDX  Edx;
+
+  AsmCpuid (CPUID_ARCHITECTURAL_PERFORMANCE_MONITORING, &Eax.Uint32, &Ebx.Uint32, NULL, &Edx.Uint32);
+  @endcode
+**/
+#define CPUID_ARCHITECTURAL_PERFORMANCE_MONITORING  0x0A
+
+/**
+  CPUID Architectural Performance Monitoring EAX for CPUID leaf
+  #CPUID_ARCHITECTURAL_PERFORMANCE_MONITORING.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 7:0] Version ID of architectural performance monitoring.
+    ///
+    UINT32  ArchPerfMonVerID:8;
+    ///
+    /// [Bits 15:8] Number of general-purpose performance monitoring counter
+    /// per logical processor.
+    ///
+    /// IA32_PERFEVTSELx MSRs start at address 186H and occupy a contiguous
+    /// block of MSR address space. Each performance event select register is
+    /// paired with a corresponding performance counter in the 0C1H address
+    /// block.
+    ///
+    UINT32  PerformanceMonitorCounters:8;
+    ///
+    /// [Bits 23:16] Bit width of general-purpose, performance monitoring counter.
+    ///
+    /// The bit width of an IA32_PMCx MSR. This the number of valid bits for
+    /// read operation. On write operations, the lower-order 32 bits of the MSR
+    /// may be written with any value, and the high-order bits are sign-extended
+    /// from the value of bit 31.
+    ///
+    UINT32  PerformanceMonitorCounterWidth:8;
+    ///
+    /// [Bits 31:24] Length of EBX bit vector to enumerate architectural
+    /// performance monitoring events.
+    ///
+    UINT32  EbxBitVectorLength:8;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_ARCHITECTURAL_PERFORMANCE_MONITORING_EAX;
+
+/**
+  CPUID Architectural Performance Monitoring EBX for CPUID leaf
+  #CPUID_ARCHITECTURAL_PERFORMANCE_MONITORING.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Core cycle event not available if 1.
+    ///
+    UINT32  UnhaltedCoreCycles:1;
+    ///
+    /// [Bit 1] Instruction retired event not available if 1.
+    ///
+    UINT32  InstructionsRetired:1;
+    ///
+    /// [Bit 2] Reference cycles event not available if 1.
+    ///
+    UINT32  UnhaltedReferenceCycles:1;
+    ///
+    /// [Bit 3] Last-level cache reference event not available if 1.
+    ///
+    UINT32  LastLevelCacheReferences:1;
+    ///
+    /// [Bit 4] Last-level cache misses event not available if 1.
+    ///
+    UINT32  LastLevelCacheMisses:1;
+    ///
+    /// [Bit 5] Branch instruction retired event not available if 1.
+    ///
+    UINT32  BranchInstructionsRetired:1;
+    ///
+    /// [Bit 6] Branch mispredict retired event not available if 1.
+    ///
+    UINT32  AllBranchMispredictRetired:1;
+    UINT32  Reserved:25;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_ARCHITECTURAL_PERFORMANCE_MONITORING_EBX;
+
+/**
+  CPUID Architectural Performance Monitoring EDX for CPUID leaf
+  #CPUID_ARCHITECTURAL_PERFORMANCE_MONITORING.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 4:0] Number of fixed-function performance counters
+    /// (if Version ID > 1).
+    ///
+    UINT32  FixedFunctionPerformanceCounters:5;
+    ///
+    /// [Bits 12:5] Bit width of fixed-function performance counters
+    /// (if Version ID > 1).
+    ///
+    UINT32  FixedFunctionPerformanceCounterWidth:8;
+    UINT32  Reserved1:2;
+    ///
+    /// [Bits 15] AnyThread deprecation.
+    ///
+    UINT32  AnyThreadDeprecation:1;
+    UINT32  Reserved2:16;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_ARCHITECTURAL_PERFORMANCE_MONITORING_EDX;
+
+
+/**
+  CPUID Extended Topology Information
+
+  @note
+  CPUID leaf 1FH is a preferred superset to leaf 0BH. Intel recommends first
+  checking for the existence of Leaf 1FH before using leaf 0BH.
+  Most of Leaf 0BH output depends on the initial value in ECX.  The EDX output
+  of leaf 0BH is always valid and does not vary with input value in ECX.  Output
+  value in ECX[7:0] always equals input value in ECX[7:0].
+  Sub-leaf index 0 enumerates SMT level. Each subsequent higher sub-leaf index
+  enumerates a higher-level topological entity in hierarchical order.
+  For sub-leaves that return an invalid level-type of 0 in ECX[15:8]; EAX and
+  EBX will return 0.
+  If an input value n in ECX returns the invalid level-type of 0 in ECX[15:8],
+  other input values with ECX > n also return 0 in ECX[15:8].
+
+  @param   EAX  CPUID_EXTENDED_TOPOLOGY (0x0B)
+  @param   ECX  Level number
+
+  @retval  EAX  Extended topology information described by the type
+                CPUID_EXTENDED_TOPOLOGY_EAX.
+  @retval  EBX  Extended topology information described by the type
+                CPUID_EXTENDED_TOPOLOGY_EBX.
+  @retval  ECX  Extended topology information described by the type
+                CPUID_EXTENDED_TOPOLOGY_ECX.
+  @retval  EDX  x2APIC ID the current logical processor.
+
+  <b>Example usage</b>
+  @code
+  CPUID_EXTENDED_TOPOLOGY_EAX  Eax;
+  CPUID_EXTENDED_TOPOLOGY_EBX  Ebx;
+  CPUID_EXTENDED_TOPOLOGY_ECX  Ecx;
+  UINT32                       Edx;
+  UINT32                       LevelNumber;
+
+  LevelNumber = 0;
+  do {
+    AsmCpuidEx (
+      CPUID_EXTENDED_TOPOLOGY, LevelNumber,
+      &Eax.Uint32, &Ebx.Uint32, &Ecx.Uint32, &Edx
+      );
+    LevelNumber++;
+  } while (Eax.Bits.ApicIdShift != 0);
+  @endcode
+**/
+#define CPUID_EXTENDED_TOPOLOGY                             0x0B
+
+/**
+  CPUID Extended Topology Information EAX for CPUID leaf #CPUID_EXTENDED_TOPOLOGY.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 4:0] Number of bits to shift right on x2APIC ID to get a unique
+    /// topology ID of the next level type.  All logical processors with the
+    /// same next level ID share current level.
+    ///
+    /// @note
+    /// Software should use this field (EAX[4:0]) to enumerate processor
+    /// topology of the system.
+    ///
+    UINT32  ApicIdShift:5;
+    UINT32  Reserved:27;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_EXTENDED_TOPOLOGY_EAX;
+
+/**
+  CPUID Extended Topology Information EBX for CPUID leaf #CPUID_EXTENDED_TOPOLOGY.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 15:0] Number of logical processors at this level type. The number
+    /// reflects configuration as shipped by Intel.
+    ///
+    /// @note
+    /// Software must not use EBX[15:0] to enumerate processor topology of the
+    /// system. This value in this field (EBX[15:0]) is only intended for
+    /// display/diagnostic purposes. The actual number of logical processors
+    /// available to BIOS/OS/Applications may be different from the value of
+    /// EBX[15:0], depending on software and platform hardware configurations.
+    ///
+    UINT32  LogicalProcessors:16;
+    UINT32  Reserved:16;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_EXTENDED_TOPOLOGY_EBX;
+
+/**
+  CPUID Extended Topology Information ECX for CPUID leaf #CPUID_EXTENDED_TOPOLOGY.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 7:0] Level number. Same value in ECX input.
+    ///
+    UINT32  LevelNumber:8;
+    ///
+    /// [Bits 15:8] Level type.
+    ///
+    /// @note
+    /// The value of the "level type" field is not related to level numbers in
+    /// any way, higher "level type" values do not mean higher levels.
+    ///
+    UINT32  LevelType:8;
+    UINT32  Reserved:16;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_EXTENDED_TOPOLOGY_ECX;
+
+///
+/// @{ Define value for CPUID_EXTENDED_TOPOLOGY_ECX.LevelType
+///
+#define   CPUID_EXTENDED_TOPOLOGY_LEVEL_TYPE_INVALID        0x00
+#define   CPUID_EXTENDED_TOPOLOGY_LEVEL_TYPE_SMT            0x01
+#define   CPUID_EXTENDED_TOPOLOGY_LEVEL_TYPE_CORE           0x02
+///
+/// @}
+///
+
+
+/**
+  CPUID Extended State Information
+
+  @param   EAX  CPUID_EXTENDED_STATE (0x0D)
+  @param   ECX  CPUID_EXTENDED_STATE_MAIN_LEAF (0x00).
+                CPUID_EXTENDED_STATE_SUB_LEAF (0x01).
+                CPUID_EXTENDED_STATE_SIZE_OFFSET (0x02).
+                Sub leafs 2..n based on supported bits in XCR0 or IA32_XSS_MSR.
+**/
+#define CPUID_EXTENDED_STATE                                0x0D
+
+/**
+  CPUID Extended State Information Main Leaf
+
+  @param   EAX  CPUID_EXTENDED_STATE (0x0D)
+  @param   ECX  CPUID_EXTENDED_STATE_MAIN_LEAF (0x00)
+
+  @retval  EAX  Reports the supported bits of the lower 32 bits of XCR0. XCR0[n]
+                can be set to 1 only if EAX[n] is 1.  The format of the extended
+                state main leaf is described by the type
+                CPUID_EXTENDED_STATE_MAIN_LEAF_EAX.
+  @retval  EBX  Maximum size (bytes, from the beginning of the XSAVE/XRSTOR save
+                area) required by enabled features in XCR0. May be different than
+                ECX if some features at the end of the XSAVE save area are not
+                enabled.
+  @retval  ECX  Maximum size (bytes, from the beginning of the XSAVE/XRSTOR save
+                area) of the XSAVE/XRSTOR save area required by all supported
+                features in the processor, i.e., all the valid bit fields in XCR0.
+  @retval  EDX  Reports the supported bits of the upper 32 bits of XCR0.
+                XCR0[n+32] can be set to 1 only if EDX[n] is 1.
+
+  <b>Example usage</b>
+  @code
+  CPUID_EXTENDED_STATE_MAIN_LEAF_EAX  Eax;
+  UINT32                              Ebx;
+  UINT32                              Ecx;
+  UINT32                              Edx;
+
+  AsmCpuidEx (
+    CPUID_EXTENDED_STATE, CPUID_EXTENDED_STATE_MAIN_LEAF,
+    &Eax.Uint32, &Ebx, &Ecx, &Edx
+    );
+  @endcode
+**/
+#define CPUID_EXTENDED_STATE_MAIN_LEAF                      0x00
+
+/**
+  CPUID Extended State Information EAX for CPUID leaf #CPUID_EXTENDED_STATE,
+  sub-leaf #CPUID_EXTENDED_STATE_MAIN_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] x87 state.
+    ///
+    UINT32  x87:1;
+    ///
+    /// [Bit 1] SSE state.
+    ///
+    UINT32  SSE:1;
+    ///
+    /// [Bit 2] AVX state.
+    ///
+    UINT32  AVX:1;
+    ///
+    /// [Bits 4:3] MPX state.
+    ///
+    UINT32  MPX:2;
+    ///
+    /// [Bits 7:5] AVX-512 state.
+    ///
+    UINT32  AVX_512:3;
+    ///
+    /// [Bit 8] Used for IA32_XSS.
+    ///
+    UINT32  IA32_XSS:1;
+    ///
+    /// [Bit 9] PKRU state.
+    ///
+    UINT32  PKRU:1;
+    UINT32  Reserved1:3;
+    ///
+    /// [Bit 13] Used for IA32_XSS, part 2.
+    ///
+    UINT32  IA32_XSS_2:1;
+    UINT32  Reserved2:18;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_EXTENDED_STATE_MAIN_LEAF_EAX;
+
+/**
+  CPUID Extended State Information Sub Leaf
+
+  @param   EAX  CPUID_EXTENDED_STATE (0x0D)
+  @param   ECX  CPUID_EXTENDED_STATE_SUB_LEAF (0x01)
+
+  @retval  EAX  The format of the extended state sub-leaf is described by the
+                type CPUID_EXTENDED_STATE_SUB_LEAF_EAX.
+  @retval  EBX  The size in bytes of the XSAVE area containing all states
+                enabled by XCRO | IA32_XSS.
+  @retval  ECX  The format of the extended state sub-leaf is described by the
+                type CPUID_EXTENDED_STATE_SUB_LEAF_ECX.
+  @retval  EDX  Reports the supported bits of the upper 32 bits of the
+                IA32_XSS MSR. IA32_XSS[n+32] can be set to 1 only if EDX[n] is 1.
+
+  <b>Example usage</b>
+  @code
+  CPUID_EXTENDED_STATE_SUB_LEAF_EAX  Eax;
+  UINT32                             Ebx;
+  CPUID_EXTENDED_STATE_SUB_LEAF_ECX  Ecx;
+  UINT32                             Edx;
+
+  AsmCpuidEx (
+    CPUID_EXTENDED_STATE, CPUID_EXTENDED_STATE_SUB_LEAF,
+    &Eax.Uint32, &Ebx, &Ecx.Uint32, &Edx
+    );
+  @endcode
+**/
+#define CPUID_EXTENDED_STATE_SUB_LEAF                       0x01
+
+/**
+  CPUID Extended State Information EAX for CPUID leaf #CPUID_EXTENDED_STATE,
+  sub-leaf #CPUID_EXTENDED_STATE_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] XSAVEOPT is available.
+    ///
+    UINT32  XSAVEOPT:1;
+    ///
+    /// [Bit 1] Supports XSAVEC and the compacted form of XRSTOR if set.
+    ///
+    UINT32  XSAVEC:1;
+    ///
+    /// [Bit 2] Supports XGETBV with ECX = 1 if set.
+    ///
+    UINT32  XGETBV:1;
+    ///
+    /// [Bit 3] Supports XSAVES/XRSTORS and IA32_XSS if set.
+    ///
+    UINT32  XSAVES:1;
+    UINT32  Reserved:28;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_EXTENDED_STATE_SUB_LEAF_EAX;
+
+/**
+  CPUID Extended State Information ECX for CPUID leaf #CPUID_EXTENDED_STATE,
+  sub-leaf #CPUID_EXTENDED_STATE_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 7:0] Used for XCR0.
+    ///
+    UINT32  XCR0:1;
+    ///
+    /// [Bit 8] PT STate.
+    ///
+    UINT32  PT:1;
+    ///
+    /// [Bit 9] Used for XCR0.
+    ///
+    UINT32  XCR0_1:1;
+    UINT32  Reserved1:3;
+    ///
+    /// [Bit 13] HWP state.
+    ///
+    UINT32  HWPState:1;
+    UINT32  Reserved8:18;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_EXTENDED_STATE_SUB_LEAF_ECX;
+
+/**
+  CPUID Extended State Information Size and Offset Sub Leaf
+
+  @note
+  Leaf 0DH output depends on the initial value in ECX.
+  Each sub-leaf index (starting at position 2) is supported if it corresponds to
+  a supported bit in either the XCR0 register or the IA32_XSS MSR.
+  If ECX contains an invalid sub-leaf index, EAX/EBX/ECX/EDX return 0. Sub-leaf
+  n (0 <= n <= 31) is invalid if sub-leaf 0 returns 0 in EAX[n] and sub-leaf 1
+  returns 0 in ECX[n]. Sub-leaf n (32 <= n <= 63) is invalid if sub-leaf 0
+  returns 0 in EDX[n-32] and sub-leaf 1 returns 0 in EDX[n-32].
+
+  @param   EAX  CPUID_EXTENDED_STATE (0x0D)
+  @param   ECX  CPUID_EXTENDED_STATE_SIZE_OFFSET (0x02).  Sub leafs 2..n based
+                on supported bits in XCR0 or IA32_XSS_MSR.
+
+  @retval  EAX  The size in bytes (from the offset specified in EBX) of the save
+                area for an extended state feature associated with a valid
+                sub-leaf index, n.
+  @retval  EBX  The offset in bytes of this extended state component's save area
+                from the beginning of the XSAVE/XRSTOR area.  This field reports
+                0 if the sub-leaf index, n, does not map to a valid bit in the
+                XCR0 register.
+  @retval  ECX  The format of the extended state components's save area as
+                described by the type CPUID_EXTENDED_STATE_SIZE_OFFSET_ECX.
+                This field reports 0 if the sub-leaf index, n, is invalid.
+  @retval  EDX  This field reports 0 if the sub-leaf index, n, is invalid;
+                otherwise it is reserved.
+
+  <b>Example usage</b>
+  @code
+  UINT32                                Eax;
+  UINT32                                Ebx;
+  CPUID_EXTENDED_STATE_SIZE_OFFSET_ECX  Ecx;
+  UINT32                                Edx;
+  UINTN                                 SubLeaf;
+
+  for (SubLeaf = CPUID_EXTENDED_STATE_SIZE_OFFSET; SubLeaf < 32; SubLeaf++) {
+    AsmCpuidEx (
+      CPUID_EXTENDED_STATE, SubLeaf,
+      &Eax, &Ebx, &Ecx.Uint32, &Edx
+      );
+  }
+  @endcode
+**/
+#define CPUID_EXTENDED_STATE_SIZE_OFFSET                    0x02
+
+/**
+  CPUID Extended State Information ECX for CPUID leaf #CPUID_EXTENDED_STATE,
+  sub-leaf #CPUID_EXTENDED_STATE_SIZE_OFFSET.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Is set if the bit n (corresponding to the sub-leaf index) is
+    /// supported in the IA32_XSS MSR; it is clear if bit n is instead supported
+    /// in XCR0.
+    ///
+    UINT32  XSS:1;
+    ///
+    /// [Bit 1] is set if, when the compacted format of an XSAVE area is used,
+    /// this extended state component located on the next 64-byte boundary
+    /// following the preceding state component (otherwise, it is located
+    /// immediately following the preceding state component).
+    ///
+    UINT32  Compacted:1;
+    UINT32  Reserved:30;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_EXTENDED_STATE_SIZE_OFFSET_ECX;
+
+
+/**
+  CPUID Intel Resource Director Technology (Intel RDT) Monitoring Information
+
+  @param   EAX  CPUID_INTEL_RDT_MONITORING (0x0F)
+  @param   ECX  CPUID_INTEL_RDT_MONITORING_ENUMERATION_SUB_LEAF (0x00).
+                CPUID_INTEL_RDT_MONITORING_L3_CACHE_SUB_LEAF (0x01).
+
+**/
+#define CPUID_INTEL_RDT_MONITORING                          0x0F
+
+/**
+  CPUID Intel Resource Director Technology (Intel RDT) Monitoring Information
+  Enumeration Sub-leaf
+
+  @param   EAX  CPUID_INTEL_RDT_MONITORING (0x0F)
+  @param   ECX  CPUID_INTEL_RDT_MONITORING_ENUMERATION_SUB_LEAF (0x00)
+
+  @retval  EAX  Reserved.
+  @retval  EBX  Maximum range (zero-based) of RMID within this physical
+                processor of all types.
+  @retval  ECX  Reserved.
+  @retval  EDX  L3 Cache Intel RDT Monitoring Information Enumeration described by
+                the type CPUID_INTEL_RDT_MONITORING_ENUMERATION_SUB_LEAF_EDX.
+
+  <b>Example usage</b>
+  @code
+  UINT32                                                  Ebx;
+  CPUID_INTEL_RDT_MONITORING_ENUMERATION_SUB_LEAF_EDX     Edx;
+
+  AsmCpuidEx (
+    CPUID_INTEL_RDT_MONITORING, CPUID_INTEL_RDT_MONITORING_ENUMERATION_SUB_LEAF,
+    NULL, &Ebx, NULL, &Edx.Uint32
+    );
+  @endcode
+**/
+#define CPUID_INTEL_RDT_MONITORING_ENUMERATION_SUB_LEAF     0x00
+
+/**
+  CPUID Intel RDT Monitoring Information EDX for CPUID leaf
+  #CPUID_INTEL_RDT_MONITORING, sub-leaf
+  #CPUID_INTEL_RDT_MONITORING_ENUMERATION_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    UINT32  Reserved1:1;
+    ///
+    /// [Bit 1] Supports L3 Cache Intel RDT Monitoring if 1.
+    ///
+    UINT32  L3CacheRDT_M:1;
+    UINT32  Reserved2:30;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_RDT_MONITORING_ENUMERATION_SUB_LEAF_EDX;
+
+/**
+  CPUID L3 Cache Intel RDT Monitoring Capability Enumeration Sub-leaf
+
+  @param   EAX  CPUID_INTEL_RDT_MONITORING (0x0F)
+  @param   ECX  CPUID_INTEL_RDT_MONITORING_L3_CACHE_SUB_LEAF (0x01)
+
+  @retval  EAX  Reserved.
+  @retval  EBX  Conversion factor from reported IA32_QM_CTR value to occupancy metric (bytes).
+  @retval  ECX  Maximum range (zero-based) of RMID of this resource type.
+  @retval  EDX  L3 Cache Intel RDT Monitoring Capability information described by the
+                type CPUID_INTEL_RDT_MONITORING_L3_CACHE_SUB_LEAF_EDX.
+
+  <b>Example usage</b>
+  @code
+  UINT32                                            Ebx;
+  UINT32                                            Ecx;
+  CPUID_INTEL_RDT_MONITORING_L3_CACHE_SUB_LEAF_EDX  Edx;
+
+  AsmCpuidEx (
+    CPUID_INTEL_RDT_MONITORING, CPUID_INTEL_RDT_MONITORING_L3_CACHE_SUB_LEAF,
+    NULL, &Ebx, &Ecx, &Edx.Uint32
+    );
+  @endcode
+**/
+#define CPUID_INTEL_RDT_MONITORING_L3_CACHE_SUB_LEAF        0x01
+
+/**
+  CPUID L3 Cache Intel RDT Monitoring Capability Information EDX for CPUID leaf
+  #CPUID_INTEL_RDT_MONITORING, sub-leaf
+  #CPUID_INTEL_RDT_MONITORING_L3_CACHE_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] Supports L3 occupancy monitoring if 1.
+    ///
+    UINT32  L3CacheOccupancyMonitoring:1;
+    ///
+    /// [Bit 1] Supports L3 Total Bandwidth monitoring if 1.
+    ///
+    UINT32  L3CacheTotalBandwidthMonitoring:1;
+    ///
+    /// [Bit 2] Supports L3 Local Bandwidth monitoring if 1.
+    ///
+    UINT32  L3CacheLocalBandwidthMonitoring:1;
+    UINT32  Reserved:29;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_RDT_MONITORING_L3_CACHE_SUB_LEAF_EDX;
+
+
+/**
+  CPUID Intel Resource Director Technology (Intel RDT) Allocation Information
+
+  @param   EAX  CPUID_INTEL_RDT_ALLOCATION (0x10).
+  @param   ECX  CPUID_INTEL_RDT_ALLOCATION_ENUMERATION_SUB_LEAF (0x00).
+                CPUID_INTEL_RDT_ALLOCATION_L3_CACHE_SUB_LEAF (0x01).
+                CPUID_INTEL_RDT_ALLOCATION_L2_CACHE_SUB_LEAF (0x02).
+**/
+#define CPUID_INTEL_RDT_ALLOCATION                          0x10
+
+/**
+  Intel Resource Director Technology (Intel RDT) Allocation Enumeration Sub-leaf
+
+  @param   EAX  CPUID_INTEL_RDT_ALLOCATION (0x10)
+  @param   ECX  CPUID_INTEL_RDT_ALLOCATION_ENUMERATION_SUB_LEAF (0x00).
+
+  @retval  EAX  Reserved.
+  @retval  EBX  L3 and L2 Cache Allocation Technology information described by
+                the type CPUID_INTEL_RDT_ALLOCATION_ENUMERATION_SUB_LEAF_EBX.
+  @retval  ECX  Reserved.
+  @retval  EDX  Reserved.
+
+  <b>Example usage</b>
+  @code
+  CPUID_INTEL_RDT_ALLOCATION_ENUMERATION_SUB_LEAF_EBX  Ebx;
+
+  AsmCpuidEx (
+    CPUID_INTEL_RDT_ALLOCATION, CPUID_INTEL_RDT_ALLOCATION_ENUMERATION_SUB_LEAF,
+    NULL, &Ebx.Uint32, NULL, NULL
+    );
+  @endcode
+**/
+#define CPUID_INTEL_RDT_ALLOCATION_ENUMERATION_SUB_LEAF     0x00
+
+/**
+  CPUID L3 and L2 Cache Allocation Support Information EBX for CPUID leaf
+  #CPUID_INTEL_RDT_ALLOCATION, sub-leaf
+  #CPUID_INTEL_RDT_ALLOCATION_ENUMERATION_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    UINT32  Reserved1:1;
+    ///
+    /// [Bit 1] Supports L3 Cache Allocation Technology if 1.
+    ///
+    UINT32  L3CacheAllocation:1;
+    ///
+    /// [Bit 2] Supports L2 Cache Allocation Technology if 1.
+    ///
+    UINT32  L2CacheAllocation:1;
+    ///
+    /// [Bit 3] Supports Memory Bandwidth Allocation if 1.
+    ///
+    UINT32  MemoryBandwidth:1;
+    UINT32  Reserved3:28;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_RDT_ALLOCATION_ENUMERATION_SUB_LEAF_EBX;
+
+
+/**
+  L3 Cache Allocation Technology Enumeration Sub-leaf
+
+  @param   EAX  CPUID_INTEL_RDT_ALLOCATION (0x10)
+  @param   ECX  CPUID_INTEL_RDT_ALLOCATION_L3_CACHE_SUB_LEAF (0x01)
+
+  @retval  EAX  RESID L3 Cache Allocation Technology information described by
+                the type CPUID_INTEL_RDT_ALLOCATION_L3_CACHE_SUB_LEAF_EAX.
+  @retval  EBX  Bit-granular map of isolation/contention of allocation units.
+  @retval  ECX  RESID L3 Cache Allocation Technology information described by
+                the type CPUID_INTEL_RDT_ALLOCATION_L3_CACHE_SUB_LEAF_ECX.
+  @retval  EDX  RESID L3 Cache Allocation Technology information described by
+                the type CPUID_INTEL_RDT_ALLOCATION_L3_CACHE_SUB_LEAF_EDX.
+
+  <b>Example usage</b>
+  @code
+  CPUID_INTEL_RDT_ALLOCATION_L3_CACHE_SUB_LEAF_EAX  Eax;
+  UINT32                                            Ebx;
+  CPUID_INTEL_RDT_ALLOCATION_L3_CACHE_SUB_LEAF_ECX  Ecx;
+  CPUID_INTEL_RDT_ALLOCATION_L3_CACHE_SUB_LEAF_EDX  Edx;
+
+  AsmCpuidEx (
+    CPUID_INTEL_RDT_ALLOCATION, CPUID_INTEL_RDT_ALLOCATION_L3_CACHE_SUB_LEAF,
+    &Eax.Uint32, &Ebx, &Ecx.Uint32, &Edx.Uint32
+    );
+  @endcode
+**/
+#define CPUID_INTEL_RDT_ALLOCATION_L3_CACHE_SUB_LEAF        0x01
+
+/**
+  CPUID L3 Cache Allocation Technology Information EAX for CPUID leaf
+  #CPUID_INTEL_RDT_ALLOCATION, sub-leaf
+  #CPUID_INTEL_RDT_ALLOCATION_L3_CACHE_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 4:0] Length of the capacity bit mask for the corresponding ResID
+    /// using minus-one notation.
+    ///
+    UINT32  CapacityLength:5;
+    UINT32  Reserved:27;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_RDT_ALLOCATION_L3_CACHE_SUB_LEAF_EAX;
+
+/**
+  CPUID L3 Cache Allocation Technology Information ECX for CPUID leaf
+  #CPUID_INTEL_RDT_ALLOCATION, sub-leaf
+  #CPUID_INTEL_RDT_ALLOCATION_L3_CACHE_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    UINT32  Reserved3:2;
+    ///
+    /// [Bit 2] Code and Data Prioritization Technology supported if 1.
+    ///
+    UINT32  CodeDataPrioritization:1;
+    UINT32  Reserved2:29;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_RDT_ALLOCATION_L3_CACHE_SUB_LEAF_ECX;
+
+/**
+  CPUID L3 Cache Allocation Technology Information EDX for CPUID leaf
+  #CPUID_INTEL_RDT_ALLOCATION, sub-leaf
+  #CPUID_INTEL_RDT_ALLOCATION_L3_CACHE_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 15:0] Highest COS number supported for this ResID.
+    ///
+    UINT32  HighestCosNumber:16;
+    UINT32  Reserved:16;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_RDT_ALLOCATION_L3_CACHE_SUB_LEAF_EDX;
+
+/**
+  L2 Cache Allocation Technology Enumeration Sub-leaf
+
+  @param   EAX  CPUID_INTEL_RDT_ALLOCATION (0x10)
+  @param   ECX  CPUID_INTEL_RDT_ALLOCATION_L2_CACHE_SUB_LEAF (0x02)
+
+  @retval  EAX  RESID L2 Cache Allocation Technology information described by
+                the type CPUID_INTEL_RDT_ALLOCATION_L2_CACHE_SUB_LEAF_EAX.
+  @retval  EBX  Bit-granular map of isolation/contention of allocation units.
+  @retval  ECX  Reserved.
+  @retval  EDX  RESID L2 Cache Allocation Technology information described by
+                the type CPUID_INTEL_RDT_ALLOCATION_L2_CACHE_SUB_LEAF_EDX.
+
+  <b>Example usage</b>
+  @code
+  CPUID_INTEL_RDT_ALLOCATION_L2_CACHE_SUB_LEAF_EAX  Eax;
+  UINT32                                            Ebx;
+  CPUID_INTEL_RDT_ALLOCATION_L2_CACHE_SUB_LEAF_EDX  Edx;
+
+  AsmCpuidEx (
+    CPUID_INTEL_RDT_ALLOCATION, CPUID_INTEL_RDT_ALLOCATION_L2_CACHE_SUB_LEAF,
+    &Eax.Uint32, &Ebx, NULL, &Edx.Uint32
+    );
+  @endcode
+**/
+#define CPUID_INTEL_RDT_ALLOCATION_L2_CACHE_SUB_LEAF        0x02
+
+/**
+  CPUID L2 Cache Allocation Technology Information EAX for CPUID leaf
+  #CPUID_INTEL_RDT_ALLOCATION, sub-leaf
+  #CPUID_INTEL_RDT_ALLOCATION_L2_CACHE_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 4:0] Length of the capacity bit mask for the corresponding ResID
+    /// using minus-one notation.
+    ///
+    UINT32  CapacityLength:5;
+    UINT32  Reserved:27;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_RDT_ALLOCATION_L2_CACHE_SUB_LEAF_EAX;
+
+/**
+  CPUID L2 Cache Allocation Technology Information EDX for CPUID leaf
+  #CPUID_INTEL_RDT_ALLOCATION, sub-leaf
+  #CPUID_INTEL_RDT_ALLOCATION_L2_CACHE_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 15:0] Highest COS number supported for this ResID.
+    ///
+    UINT32  HighestCosNumber:16;
+    UINT32  Reserved:16;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_RDT_ALLOCATION_L2_CACHE_SUB_LEAF_EDX;
+
+/**
+  Memory Bandwidth Allocation Enumeration Sub-leaf
+
+  @param   EAX  CPUID_INTEL_RDT_ALLOCATION (0x10)
+  @param   ECX  CPUID_INTEL_RDT_ALLOCATION_MEMORY_BANDWIDTH_SUB_LEAF (0x03)
+
+  @retval  EAX  RESID memory bandwidth Allocation Technology information
+                described by the type
+                CPUID_INTEL_RDT_ALLOCATION_MEMORY_BANDWIDTH_SUB_LEAF_EAX.
+  @retval  EBX  Reserved.
+  @retval  ECX  RESID memory bandwidth Allocation Technology information
+                described by the type
+                CPUID_INTEL_RDT_ALLOCATION_MEMORY_BANDWIDTH_SUB_LEAF_ECX.
+  @retval  EDX  RESID memory bandwidth Allocation Technology information
+                described by the type
+                CPUID_INTEL_RDT_ALLOCATION_MEMORY_BANDWIDTH_SUB_LEAF_EDX.
+
+  <b>Example usage</b>
+  @code
+  CPUID_INTEL_RDT_ALLOCATION_MEMORY_BANDWIDTH_SUB_LEAF_EAX  Eax;
+  UINT32                                                    Ebx;
+  CPUID_INTEL_RDT_ALLOCATION_MEMORY_BANDWIDTH_SUB_LEAF_ECX  Ecx;
+  CPUID_INTEL_RDT_ALLOCATION_MEMORY_BANDWIDTH_SUB_LEAF_EDX  Edx;
+
+
+  AsmCpuidEx (
+    CPUID_INTEL_RDT_ALLOCATION, CPUID_INTEL_RDT_ALLOCATION_MEMORY_BANDWIDTH_SUB_LEAF,
+    &Eax.Uint32, &Ebx, NULL, &Edx.Uint32
+    );
+  @endcode
+**/
+#define CPUID_INTEL_RDT_ALLOCATION_MEMORY_BANDWIDTH_SUB_LEAF        0x03
+
+/**
+  CPUID memory bandwidth Allocation Technology Information EAX for CPUID leaf
+  #CPUID_INTEL_RDT_ALLOCATION, sub-leaf
+  #CPUID_INTEL_RDT_ALLOCATION_MEMORY_BANDWIDTH_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 11:0] Reports the maximum MBA throttling value supported for
+    /// the corresponding ResID using minus-one notation.
+    ///
+    UINT32  MaximumMBAThrottling:12;
+    UINT32  Reserved:20;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_RDT_ALLOCATION_MEMORY_BANDWIDTH_SUB_LEAF_EAX;
+
+/**
+  CPUID memory bandwidth Allocation Technology Information ECX for CPUID leaf
+  #CPUID_INTEL_RDT_ALLOCATION, sub-leaf
+  #CPUID_INTEL_RDT_ALLOCATION_MEMORY_BANDWIDTH_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 1:0] Reserved.
+    ///
+    UINT32  Reserved1:2;
+    ///
+    /// [Bits 3] Reports whether the response of the delay values is linear.
+    ///
+    UINT32  Liner:1;
+    UINT32  Reserved2:29;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_RDT_ALLOCATION_MEMORY_BANDWIDTH_SUB_LEAF_ECX;
+
+/**
+  CPUID memory bandwidth Allocation Technology Information EDX for CPUID leaf
+  #CPUID_INTEL_RDT_ALLOCATION, sub-leaf
+  #CPUID_INTEL_RDT_ALLOCATION_MEMORY_BANDWIDTH_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 15:0] Highest COS number supported for this ResID.
+    ///
+    UINT32  HighestCosNumber:16;
+    UINT32  Reserved:16;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_RDT_ALLOCATION_MEMORY_BANDWIDTH_SUB_LEAF_EDX;
+
+/**
+  Intel SGX resource capability and configuration.
+  See Section 37.7.2 "Intel(R) SGX Resource Enumeration Leaves".
+
+  If CPUID.(EAX=07H, ECX=0H):EBX.SGX = 1, the processor also supports querying
+  CPUID with EAX=12H on Intel SGX resource capability and configuration.
+
+  @param   EAX  CPUID_INTEL_SGX (0x12)
+  @param   ECX  CPUID_INTEL_SGX_CAPABILITIES_0_SUB_LEAF (0x00).
+                CPUID_INTEL_SGX_CAPABILITIES_1_SUB_LEAF (0x01).
+                CPUID_INTEL_SGX_CAPABILITIES_RESOURCES_SUB_LEAF (0x02).
+                Sub leafs 2..n based on the sub-leaf-type encoding (returned in EAX[3:0])
+                until the sub-leaf type is invalid.
+
+**/
+#define CPUID_INTEL_SGX                                  0x12
+
+/**
+  Sub-Leaf 0 Enumeration of Intel SGX Capabilities.
+  Enumerates Intel SGX capability, including enclave instruction opcode support.
+
+  @param   EAX  CPUID_INTEL_SGX (0x12)
+  @param   ECX  CPUID_INTEL_SGX_CAPABILITIES_0_SUB_LEAF (0x00)
+
+  @retval  EAX  The format of Sub-Leaf 0 Enumeration of Intel SGX Capabilities is
+                described by the type CPUID_INTEL_SGX_CAPABILITIES_0_SUB_LEAF_EAX.
+  @retval  EBX  MISCSELECT: Reports the bit vector of supported extended features
+                that can be written to the MISC region of the SSA.
+  @retval  ECX  Reserved.
+  @retval  EDX  The format of Sub-Leaf 0 Enumeration of Intel SGX Capabilities is
+                described by the type CPUID_INTEL_SGX_CAPABILITIES_0_SUB_LEAF_EDX.
+
+  <b>Example usage</b>
+  @code
+  CPUID_INTEL_SGX_CAPABILITIES_0_SUB_LEAF_EAX  Eax;
+  UINT32                                       Ebx;
+  CPUID_INTEL_SGX_CAPABILITIES_0_SUB_LEAF_EDX  Edx;
+
+  AsmCpuidEx (
+    CPUID_INTEL_SGX, CPUID_INTEL_SGX_CAPABILITIES_0_SUB_LEAF,
+    &Eax.Uint32, &Ebx, NULL, &Edx.Uint32
+    );
+  @endcode
+**/
+#define CPUID_INTEL_SGX_CAPABILITIES_0_SUB_LEAF          0x00
+
+/**
+  Sub-Leaf 0 Enumeration of Intel SGX Capabilities EAX for CPUID leaf #CPUID_INTEL_SGX,
+  sub-leaf #CPUID_INTEL_SGX_CAPABILITIES_0_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] If 1, indicates leaf functions of SGX1 instruction are supported.
+    ///
+    UINT32  SGX1:1;
+    ///
+    /// [Bit 1] If 1, indicates leaf functions of SGX2 instruction are supported.
+    ///
+    UINT32  SGX2:1;
+    UINT32  Reserved1:3;
+    ///
+    /// [Bit 5] If 1, indicates Intel SGX supports ENCLV instruction leaves
+    /// EINCVIRTCHILD, EDECVIRTCHILD, and ESETCONTEXT.
+    ///
+    UINT32  ENCLV:1;
+    ///
+    /// [Bit 6] If 1, indicates Intel SGX supports ENCLS instruction leaves ETRACKC,
+    /// ERDINFO, ELDBC, and ELDUC.
+    ///
+    UINT32  ENCLS:1;
+    UINT32  Reserved2:25;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_SGX_CAPABILITIES_0_SUB_LEAF_EAX;
+
+/**
+  Sub-Leaf 0 Enumeration of Intel SGX Capabilities EDX for CPUID leaf #CPUID_INTEL_SGX,
+  sub-leaf #CPUID_INTEL_SGX_CAPABILITIES_0_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 7:0] The maximum supported enclave size is 2^(EDX[7:0]) bytes
+    /// when not in 64-bit mode.
+    ///
+    UINT32  MaxEnclaveSize_Not64:8;
+    ///
+    /// [Bit 15:8] The maximum supported enclave size is 2^(EDX[15:8]) bytes
+    /// when operating in 64-bit mode.
+    ///
+    UINT32  MaxEnclaveSize_64:8;
+    UINT32  Reserved:16;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_SGX_CAPABILITIES_0_SUB_LEAF_EDX;
+
+
+/**
+  Sub-Leaf 1 Enumeration of Intel SGX Capabilities.
+  Enumerates Intel SGX capability of processor state configuration and enclave
+  configuration in the SECS structure.
+
+  @param   EAX  CPUID_INTEL_SGX (0x12)
+  @param   ECX  CPUID_INTEL_SGX_CAPABILITIES_1_SUB_LEAF (0x01)
+
+  @retval  EAX  Report the valid bits of SECS.ATTRIBUTES[31:0] that software can
+                set with ECREATE. SECS.ATTRIBUTES[n] can be set to 1 using ECREATE
+                only if EAX[n] is 1, where n < 32.
+  @retval  EBX  Report the valid bits of SECS.ATTRIBUTES[63:32] that software can
+                set with ECREATE. SECS.ATTRIBUTES[n+32] can be set to 1 using ECREATE
+                only if EBX[n] is 1, where n < 32.
+  @retval  ECX  Report the valid bits of SECS.ATTRIBUTES[95:64] that software can
+                set with ECREATE. SECS.ATTRIBUTES[n+64] can be set to 1 using ECREATE
+                only if ECX[n] is 1, where n < 32.
+  @retval  EDX  Report the valid bits of SECS.ATTRIBUTES[127:96] that software can
+                set with ECREATE. SECS.ATTRIBUTES[n+96] can be set to 1 using ECREATE
+                only if EDX[n] is 1, where n < 32.
+
+  <b>Example usage</b>
+  @code
+  UINT32  Eax;
+  UINT32  Ebx;
+  UINT32  Ecx;
+  UINT32  Edx;
+
+  AsmCpuidEx (
+    CPUID_INTEL_SGX, CPUID_INTEL_SGX_CAPABILITIES_1_SUB_LEAF,
+    &Eax, &Ebx, &Ecx, &Edx
+    );
+  @endcode
+**/
+#define CPUID_INTEL_SGX_CAPABILITIES_1_SUB_LEAF          0x01
+
+
+/**
+  Sub-Leaf Index 2 or Higher Enumeration of Intel SGX Resources.
+  Enumerates available EPC resources.
+
+  @param   EAX  CPUID_INTEL_SGX (0x12)
+  @param   ECX  CPUID_INTEL_SGX_CAPABILITIES_RESOURCES_SUB_LEAF (0x02)
+
+  @retval  EAX  The format of Sub-Leaf Index 2 or Higher Enumeration of Intel SGX
+                Resources is described by the type
+                CPUID_INTEL_SGX_CAPABILITIES_RESOURCES_SUB_LEAF_EAX.
+  @retval  EBX  The format of Sub-Leaf Index 2 or Higher Enumeration of Intel SGX
+                Resources is described by the type
+                CPUID_INTEL_SGX_CAPABILITIES_RESOURCES_SUB_LEAF_EBX.
+  @retval  EDX  The format of Sub-Leaf Index 2 or Higher Enumeration of Intel SGX
+                Resources is described by the type
+                CPUID_INTEL_SGX_CAPABILITIES_RESOURCES_SUB_LEAF_ECX.
+  @retval  EDX  The format of Sub-Leaf Index 2 or Higher Enumeration of Intel SGX
+                Resources is described by the type
+                CPUID_INTEL_SGX_CAPABILITIES_RESOURCES_SUB_LEAF_EDX.
+
+  <b>Example usage</b>
+  @code
+  CPUID_INTEL_SGX_CAPABILITIES_RESOURCES_SUB_LEAF_EAX  Eax;
+  CPUID_INTEL_SGX_CAPABILITIES_RESOURCES_SUB_LEAF_EBX  Ebx;
+  CPUID_INTEL_SGX_CAPABILITIES_RESOURCES_SUB_LEAF_ECX  Ecx;
+  CPUID_INTEL_SGX_CAPABILITIES_RESOURCES_SUB_LEAF_EDX  Edx;
+
+  AsmCpuidEx (
+    CPUID_INTEL_SGX, CPUID_INTEL_SGX_CAPABILITIES_RESOURCES_SUB_LEAF,
+    &Eax.Uint32, &Ebx.Uint32, &Ecx.Uint32, &Edx.Uint32
+    );
+  @endcode
+**/
+#define CPUID_INTEL_SGX_CAPABILITIES_RESOURCES_SUB_LEAF  0x02
+
+/**
+  Sub-Leaf Index 2 or Higher Enumeration of Intel SGX Resources EAX for CPUID
+  leaf #CPUID_INTEL_SGX, sub-leaf #CPUID_INTEL_SGX_CAPABILITIES_RESOURCES_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 3:0] Sub-leaf-type encoding.
+    /// 0000b: This sub-leaf is invalid, EBX:EAX and EDX:ECX report 0.
+    /// 0001b: This sub-leaf provides information on the Enclave Page Cache (EPC)
+    ///        in EBX:EAX and EDX:ECX.
+    /// All other encoding are reserved.
+    ///
+    UINT32  SubLeafType:4;
+    UINT32  Reserved:8;
+    ///
+    /// [Bit 31:12] If EAX[3:0] = 0001b, these are bits 31:12 of the physical address of
+    /// the base of the EPC section.
+    ///
+    UINT32  LowAddressOfEpcSection:20;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_SGX_CAPABILITIES_RESOURCES_SUB_LEAF_EAX;
+
+/**
+  Sub-Leaf Index 2 or Higher Enumeration of Intel SGX Resources EBX for CPUID
+  leaf #CPUID_INTEL_SGX, sub-leaf #CPUID_INTEL_SGX_CAPABILITIES_RESOURCES_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 19:0] If EAX[3:0] = 0001b, these are bits 51:32 of the physical address of
+    /// the base of the EPC section.
+    ///
+    UINT32  HighAddressOfEpcSection:20;
+    UINT32  Reserved:12;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_SGX_CAPABILITIES_RESOURCES_SUB_LEAF_EBX;
+
+/**
+  Sub-Leaf Index 2 or Higher Enumeration of Intel SGX Resources ECX for CPUID
+  leaf #CPUID_INTEL_SGX, sub-leaf #CPUID_INTEL_SGX_CAPABILITIES_RESOURCES_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 3:0] The EPC section encoding.
+    /// 0000b: Not valid.
+    /// 0001b: The EPC section is confidentiality, integrity and replay protected.
+    /// All other encoding are reserved.
+    ///
+    UINT32  EpcSection:4;
+    UINT32  Reserved:8;
+    ///
+    /// [Bit 31:12] If EAX[3:0] = 0001b, these are bits 31:12 of the size of the
+    /// corresponding EPC section within the Processor Reserved Memory.
+    ///
+    UINT32  LowSizeOfEpcSection:20;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_SGX_CAPABILITIES_RESOURCES_SUB_LEAF_ECX;
+
+/**
+  Sub-Leaf Index 2 or Higher Enumeration of Intel SGX Resources EDX for CPUID
+  leaf #CPUID_INTEL_SGX, sub-leaf #CPUID_INTEL_SGX_CAPABILITIES_RESOURCES_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 19:0] If EAX[3:0] = 0001b, these are bits 51:32 of the size of the
+    /// corresponding EPC section within the Processor Reserved Memory.
+    ///
+    UINT32  HighSizeOfEpcSection:20;
+    UINT32  Reserved:12;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_SGX_CAPABILITIES_RESOURCES_SUB_LEAF_EDX;
+
+
+/**
+  CPUID Intel Processor Trace Information
+
+  @param   EAX  CPUID_INTEL_PROCESSOR_TRACE (0x14)
+  @param   ECX  CPUID_INTEL_PROCESSOR_TRACE_MAIN_LEAF (0x00).
+                CPUID_INTEL_PROCESSOR_TRACE_SUB_LEAF (0x01).
+
+**/
+#define CPUID_INTEL_PROCESSOR_TRACE                         0x14
+
+/**
+  CPUID Intel Processor Trace Information Main Leaf
+
+  @param   EAX  CPUID_INTEL_PROCEDSSOR_TRACE (0x14)
+  @param   ECX  CPUID_INTEL_PROCEDSSOR_TRACE_MAIN_LEAF (0x00)
+
+  @retval  EAX  Reports the maximum sub-leaf supported in leaf 14H.
+  @retval  EBX  Returns Intel processor trace information described by the
+                type CPUID_INTEL_PROCESSOR_TRACE_MAIN_LEAF_EBX.
+  @retval  ECX  Returns Intel processor trace information described by the
+                type CPUID_INTEL_PROCESSOR_TRACE_MAIN_LEAF_ECX.
+  @retval  EDX  Reserved.
+
+  <b>Example usage</b>
+  @code
+  UINT32                                     Eax;
+  CPUID_INTEL_PROCESSOR_TRACE_MAIN_LEAF_EBX  Ebx;
+  CPUID_INTEL_PROCESSOR_TRACE_MAIN_LEAF_ECX  Ecx;
+
+  AsmCpuidEx (
+    CPUID_INTEL_PROCESSOR_TRACE, CPUID_INTEL_PROCESSOR_TRACE_MAIN_LEAF,
+    &Eax, &Ebx.Uint32, &Ecx.Uint32, NULL
+    );
+  @endcode
+**/
+#define CPUID_INTEL_PROCESSOR_TRACE_MAIN_LEAF               0x00
+
+/**
+  CPUID Intel Processor Trace EBX for CPUID leaf #CPUID_INTEL_PROCESSOR_TRACE,
+  sub-leaf #CPUID_INTEL_PROCESSOR_TRACE_MAIN_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] If 1, indicates that IA32_RTIT_CTL.CR3Filter can be set to 1,
+    /// and that IA32_RTIT_CR3_MATCH MSR can be accessed.
+    ///
+    UINT32  Cr3Filter:1;
+    ///
+    /// [Bit 1] If 1, indicates support of Configurable PSB and Cycle-Accurate
+    /// Mode.
+    ///
+    UINT32  ConfigurablePsb:1;
+    ///
+    /// [Bit 2] If 1, indicates support of IP Filtering, TraceStop filtering,
+    /// and preservation of Intel PT MSRs across warm reset.
+    ///
+    UINT32  IpTraceStopFiltering:1;
+    ///
+    /// [Bit 3] If 1, indicates support of MTC timing packet and suppression of
+    /// COFI-based packets.
+    ///
+    UINT32  Mtc:1;
+    ///
+    /// [Bit 4] If 1, indicates support of PTWRITE. Writes can set
+    /// IA32_RTIT_CTL[12] (PTWEn) and IA32_RTIT_CTL[5] (FUPonPTW), and PTWRITE
+    /// can generate packets.
+    ///
+    UINT32  PTWrite:1;
+    ///
+    /// [Bit 5] If 1, indicates support of Power Event Trace. Writes can set
+    /// IA32_RTIT_CTL[4] (PwrEvtEn), enabling Power Event Trace packet
+    /// generation.
+    ///
+    UINT32  PowerEventTrace:1;
+    UINT32  Reserved:26;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_PROCESSOR_TRACE_MAIN_LEAF_EBX;
+
+/**
+  CPUID Intel Processor Trace ECX for CPUID leaf #CPUID_INTEL_PROCESSOR_TRACE,
+  sub-leaf #CPUID_INTEL_PROCESSOR_TRACE_MAIN_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] If 1, Tracing can be enabled with IA32_RTIT_CTL.ToPA = 1, hence
+    /// utilizing the ToPA output scheme; IA32_RTIT_OUTPUT_BASE and
+    /// IA32_RTIT_OUTPUT_MASK_PTRS MSRs can be accessed.
+    ///
+    UINT32  RTIT:1;
+    ///
+    /// [Bit 1] If 1, ToPA tables can hold any number of output entries, up to
+    /// the maximum allowed by the MaskOrTableOffset field of
+    /// IA32_RTIT_OUTPUT_MASK_PTRS.
+    ///
+    UINT32  ToPA:1;
+    ///
+    /// [Bit 2] If 1, indicates support of Single-Range Output scheme.
+    ///
+    UINT32  SingleRangeOutput:1;
+    ///
+    /// [Bit 3] If 1, indicates support of output to Trace Transport subsystem.
+    ///
+    UINT32  TraceTransportSubsystem:1;
+    UINT32  Reserved:27;
+    ///
+    /// [Bit 31] If 1, generated packets which contain IP payloads have LIP
+    /// values, which include the CS base component.
+    ///
+    UINT32  LIP:1;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_PROCESSOR_TRACE_MAIN_LEAF_ECX;
+
+
+/**
+  CPUID Intel Processor Trace Information Sub-leaf
+
+  @param   EAX  CPUID_INTEL_PROCEDSSOR_TRACE (0x14)
+  @param   ECX  CPUID_INTEL_PROCESSOR_TRACE_SUB_LEAF (0x01)
+
+  @retval  EAX  Returns Intel processor trace information described by the
+                type CPUID_INTEL_PROCESSOR_TRACE_SUB_LEAF_EAX.
+  @retval  EBX  Returns Intel processor trace information described by the
+                type CPUID_INTEL_PROCESSOR_TRACE_SUB_LEAF_EBX.
+  @retval  ECX  Reserved.
+  @retval  EDX  Reserved.
+
+  <b>Example usage</b>
+  @code
+  UINT32                                    MaximumSubLeaf;
+  UINT32                                    SubLeaf;
+  CPUID_INTEL_PROCESSOR_TRACE_SUB_LEAF_EAX  Eax;
+  CPUID_INTEL_PROCESSOR_TRACE_SUB_LEAF_EBX  Ebx;
+
+  AsmCpuidEx (
+    CPUID_INTEL_PROCESSOR_TRACE, CPUID_INTEL_PROCESSOR_TRACE_MAIN_LEAF,
+    &MaximumSubLeaf, NULL, NULL, NULL
+    );
+
+  for (SubLeaf = CPUID_INTEL_PROCESSOR_TRACE_SUB_LEAF; SubLeaf <= MaximumSubLeaf; SubLeaf++) {
+    AsmCpuidEx (
+      CPUID_INTEL_PROCESSOR_TRACE, SubLeaf,
+      &Eax.Uint32, &Ebx.Uint32, NULL, NULL
+      );
+  }
+  @endcode
+**/
+#define CPUID_INTEL_PROCESSOR_TRACE_SUB_LEAF                0x01
+
+/**
+  CPUID Intel Processor Trace EAX for CPUID leaf #CPUID_INTEL_PROCESSOR_TRACE,
+  sub-leaf #CPUID_INTEL_PROCESSOR_TRACE_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 2:0] Number of configurable Address Ranges for filtering.
+    ///
+    UINT32  ConfigurableAddressRanges:3;
+    UINT32  Reserved:13;
+    ///
+    /// [Bits 31:16] Bitmap of supported MTC period encodings
+    ///
+    UINT32  MtcPeriodEncodings:16;
+
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_PROCESSOR_TRACE_SUB_LEAF_EAX;
+
+/**
+  CPUID Intel Processor Trace EBX for CPUID leaf #CPUID_INTEL_PROCESSOR_TRACE,
+  sub-leaf #CPUID_INTEL_PROCESSOR_TRACE_SUB_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 15:0] Bitmap of supported Cycle Threshold value encodings.
+    ///
+    UINT32  CycleThresholdEncodings:16;
+    ///
+    /// [Bits 31:16] Bitmap of supported Configurable PSB frequency encodings.
+    ///
+    UINT32  PsbFrequencyEncodings:16;
+
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_INTEL_PROCESSOR_TRACE_SUB_LEAF_EBX;
+
+
+/**
+  CPUID Time Stamp Counter and Nominal Core Crystal Clock Information
+
+  @note
+  If EBX[31:0] is 0, the TSC/"core crystal clock" ratio is not enumerated.
+  EBX[31:0]/EAX[31:0] indicates the ratio of the TSC frequency and the core
+  crystal clock frequency.
+  If ECX is 0, the nominal core crystal clock frequency is not enumerated.
+  "TSC frequency" = "core crystal clock frequency" * EBX/EAX.
+  The core crystal clock may differ from the reference clock, bus clock, or core
+  clock frequencies.
+
+  @param   EAX  CPUID_TIME_STAMP_COUNTER (0x15)
+
+  @retval  EAX  An unsigned integer which is the denominator of the
+                TSC/"core crystal clock" ratio
+  @retval  EBX  An unsigned integer which is the numerator of the
+                TSC/"core crystal clock" ratio.
+  @retval  ECX  An unsigned integer which is the nominal frequency
+                of the core crystal clock in Hz.
+  @retval  EDX  Reserved.
+
+  <b>Example usage</b>
+  @code
+  UINT32  Eax;
+  UINT32  Ebx;
+  UINT32  Ecx;
+
+  AsmCpuid (CPUID_TIME_STAMP_COUNTER, &Eax, &Ebx, &Ecx, NULL);
+  @endcode
+**/
+#define CPUID_TIME_STAMP_COUNTER                            0x15
+
+
+/**
+  CPUID Processor Frequency Information
+
+  @note
+  Data is returned from this interface in accordance with the processor's
+  specification and does not reflect actual values. Suitable use of this data
+  includes the display of processor information in like manner to the processor
+  brand string and for determining the appropriate range to use when displaying
+  processor information e.g. frequency history graphs. The returned information
+  should not be used for any other purpose as the returned information does not
+  accurately correlate to information / counters returned by other processor
+  interfaces.  While a processor may support the Processor Frequency Information
+  leaf, fields that return a value of zero are not supported.
+
+  @param   EAX  CPUID_TIME_STAMP_COUNTER (0x16)
+
+  @retval  EAX  Returns processor base frequency information described by the
+                type CPUID_PROCESSOR_FREQUENCY_EAX.
+  @retval  EBX  Returns maximum frequency information described by the type
+                CPUID_PROCESSOR_FREQUENCY_EBX.
+  @retval  ECX  Returns bus frequency information described by the type
+                CPUID_PROCESSOR_FREQUENCY_ECX.
+  @retval  EDX  Reserved.
+
+  <b>Example usage</b>
+  @code
+  CPUID_PROCESSOR_FREQUENCY_EAX  Eax;
+  CPUID_PROCESSOR_FREQUENCY_EBX  Ebx;
+  CPUID_PROCESSOR_FREQUENCY_ECX  Ecx;
+
+  AsmCpuid (CPUID_PROCESSOR_FREQUENCY, &Eax.Uint32, &Ebx.Uint32, &Ecx.Uint32, NULL);
+  @endcode
+**/
+#define CPUID_PROCESSOR_FREQUENCY                           0x16
+
+/**
+  CPUID Processor Frequency Information EAX for CPUID leaf
+  #CPUID_PROCESSOR_FREQUENCY.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 15:0] Processor Base Frequency (in MHz).
+    ///
+    UINT32  ProcessorBaseFrequency:16;
+    UINT32  Reserved:16;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_PROCESSOR_FREQUENCY_EAX;
+
+/**
+  CPUID Processor Frequency Information EBX for CPUID leaf
+  #CPUID_PROCESSOR_FREQUENCY.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 15:0] Maximum Frequency (in MHz).
+    ///
+    UINT32  MaximumFrequency:16;
+    UINT32  Reserved:16;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_PROCESSOR_FREQUENCY_EBX;
+
+/**
+  CPUID Processor Frequency Information ECX for CPUID leaf
+  #CPUID_PROCESSOR_FREQUENCY.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 15:0] Bus (Reference) Frequency (in MHz).
+    ///
+    UINT32  BusFrequency:16;
+    UINT32  Reserved:16;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_PROCESSOR_FREQUENCY_ECX;
+
+
+/**
+  CPUID SoC Vendor Information
+
+  @param   EAX  CPUID_SOC_VENDOR (0x17)
+  @param   ECX  CPUID_SOC_VENDOR_MAIN_LEAF (0x00)
+                CPUID_SOC_VENDOR_BRAND_STRING1 (0x01)
+                CPUID_SOC_VENDOR_BRAND_STRING1 (0x02)
+                CPUID_SOC_VENDOR_BRAND_STRING1 (0x03)
+
+  @note
+  Leaf 17H output depends on the initial value in ECX.  SOC Vendor Brand String
+  is a UTF-8 encoded string padded with trailing bytes of 00H.  The complete SOC
+  Vendor Brand String is constructed by concatenating in ascending order of
+  EAX:EBX:ECX:EDX and from the sub-leaf 1 fragment towards sub-leaf 3.
+
+**/
+#define CPUID_SOC_VENDOR                                    0x17
+
+/**
+  CPUID SoC Vendor Information
+
+  @param   EAX  CPUID_SOC_VENDOR (0x17)
+  @param   ECX  CPUID_SOC_VENDOR_MAIN_LEAF (0x00)
+
+  @retval  EAX  MaxSOCID_Index. Reports the maximum input value of supported
+                sub-leaf in leaf 17H.
+  @retval  EBX  Returns SoC Vendor information described by the type
+                CPUID_SOC_VENDOR_MAIN_LEAF_EBX.
+  @retval  ECX  Project ID. A unique number an SOC vendor assigns to its SOC
+                projects.
+  @retval  EDX  Stepping ID. A unique number within an SOC project that an SOC
+                vendor assigns.
+
+  <b>Example usage</b>
+  @code
+  UINT32                          Eax;
+  CPUID_SOC_VENDOR_MAIN_LEAF_EBX  Ebx;
+  UINT32                          Ecx;
+  UINT32                          Edx;
+
+  AsmCpuidEx (
+    CPUID_SOC_VENDOR, CPUID_SOC_VENDOR_MAIN_LEAF,
+    &Eax, &Ebx.Uint32, &Ecx, &Edx
+    );
+  @endcode
+**/
+#define CPUID_SOC_VENDOR_MAIN_LEAF                          0x00
+
+/**
+  CPUID SoC Vendor Information EBX for CPUID leaf #CPUID_SOC_VENDOR sub-leaf
+  #CPUID_SOC_VENDOR_MAIN_LEAF.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 15:0] SOC Vendor ID.
+    ///
+    UINT32  SocVendorId:16;
+    ///
+    /// [Bit 16] If 1, the SOC Vendor ID field is assigned via an industry
+    /// standard enumeration scheme. Otherwise, the SOC Vendor ID field is
+    /// assigned by Intel.
+    ///
+    UINT32  IsVendorScheme:1;
+    UINT32  Reserved:15;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_SOC_VENDOR_MAIN_LEAF_EBX;
+
+/**
+  CPUID SoC Vendor Information
+
+  @param   EAX  CPUID_SOC_VENDOR (0x17)
+  @param   ECX  CPUID_SOC_VENDOR_BRAND_STRING1 (0x01)
+
+  @retval  EAX  SOC Vendor Brand String. UTF-8 encoded string of type
+                CPUID_SOC_VENDOR_BRAND_STRING_DATA.
+  @retval  EBX  SOC Vendor Brand String. UTF-8 encoded string of type
+                CPUID_SOC_VENDOR_BRAND_STRING_DATA.
+  @retval  ECX  SOC Vendor Brand String. UTF-8 encoded string of type
+                CPUID_SOC_VENDOR_BRAND_STRING_DATA.
+  @retval  EDX  SOC Vendor Brand String. UTF-8 encoded string of type
+                CPUID_SOC_VENDOR_BRAND_STRING_DATA.
+
+  <b>Example usage</b>
+  @code
+  CPUID_SOC_VENDOR_BRAND_STRING_DATA  Eax;
+  CPUID_SOC_VENDOR_BRAND_STRING_DATA  Ebx;
+  CPUID_SOC_VENDOR_BRAND_STRING_DATA  Ecx;
+  CPUID_SOC_VENDOR_BRAND_STRING_DATA  Edx;
+
+  AsmCpuidEx (
+    CPUID_SOC_VENDOR, CPUID_SOC_VENDOR_BRAND_STRING1,
+    &Eax.Uint32, &Ebx.Uint32, &Ecx.Uint32, &Edx.Uint32
+    );
+  @endcode
+**/
+#define CPUID_SOC_VENDOR_BRAND_STRING1                      0x01
+
+/**
+  CPUID SoC Vendor Brand String for CPUID leafs #CPUID_SOC_VENDOR_BRAND_STRING1,
+  #CPUID_SOC_VENDOR_BRAND_STRING2, and #CPUID_SOC_VENDOR_BRAND_STRING3.
+**/
+typedef union {
+  ///
+  /// 4 UTF-8 characters of Soc Vendor Brand String
+  ///
+  CHAR8   BrandString[4];
+  ///
+  /// All fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_SOC_VENDOR_BRAND_STRING_DATA;
+
+/**
+  CPUID SoC Vendor Information
+
+  @param   EAX  CPUID_SOC_VENDOR (0x17)
+  @param   ECX  CPUID_SOC_VENDOR_BRAND_STRING2 (0x02)
+
+  @retval  EAX  SOC Vendor Brand String. UTF-8 encoded string of type
+                CPUID_SOC_VENDOR_BRAND_STRING_DATA.
+  @retval  EBX  SOC Vendor Brand String. UTF-8 encoded string of type
+                CPUID_SOC_VENDOR_BRAND_STRING_DATA.
+  @retval  ECX  SOC Vendor Brand String. UTF-8 encoded string of type
+                CPUID_SOC_VENDOR_BRAND_STRING_DATA.
+  @retval  EDX  SOC Vendor Brand String. UTF-8 encoded string of type
+                CPUID_SOC_VENDOR_BRAND_STRING_DATA.
+
+  <b>Example usage</b>
+  @code
+  CPUID_SOC_VENDOR_BRAND_STRING_DATA  Eax;
+  CPUID_SOC_VENDOR_BRAND_STRING_DATA  Ebx;
+  CPUID_SOC_VENDOR_BRAND_STRING_DATA  Ecx;
+  CPUID_SOC_VENDOR_BRAND_STRING_DATA  Edx;
+
+  AsmCpuidEx (
+    CPUID_SOC_VENDOR, CPUID_SOC_VENDOR_BRAND_STRING2,
+    &Eax.Uint32, &Ebx.Uint32, &Ecx.Uint32, &Edx.Uint32
+    );
+  @endcode
+**/
+#define CPUID_SOC_VENDOR_BRAND_STRING2                      0x02
+
+/**
+  CPUID SoC Vendor Information
+
+  @param   EAX  CPUID_SOC_VENDOR (0x17)
+  @param   ECX  CPUID_SOC_VENDOR_BRAND_STRING3 (0x03)
+
+  @retval  EAX  SOC Vendor Brand String. UTF-8 encoded string of type
+                CPUID_SOC_VENDOR_BRAND_STRING_DATA.
+  @retval  EBX  SOC Vendor Brand String. UTF-8 encoded string of type
+                CPUID_SOC_VENDOR_BRAND_STRING_DATA.
+  @retval  ECX  SOC Vendor Brand String. UTF-8 encoded string of type
+                CPUID_SOC_VENDOR_BRAND_STRING_DATA.
+  @retval  EDX  SOC Vendor Brand String. UTF-8 encoded string of type
+                CPUID_SOC_VENDOR_BRAND_STRING_DATA.
+
+  <b>Example usage</b>
+  @code
+  CPUID_SOC_VENDOR_BRAND_STRING_DATA  Eax;
+  CPUID_SOC_VENDOR_BRAND_STRING_DATA  Ebx;
+  CPUID_SOC_VENDOR_BRAND_STRING_DATA  Ecx;
+  CPUID_SOC_VENDOR_BRAND_STRING_DATA  Edx;
+
+  AsmCpuidEx (
+    CPUID_SOC_VENDOR, CPUID_SOC_VENDOR_BRAND_STRING3,
+    &Eax.Uint32, &Ebx.Uint32, &Ecx.Uint32, &Edx.Uint32
+    );
+  @endcode
+**/
+#define CPUID_SOC_VENDOR_BRAND_STRING3                      0x03
+
+/**
+  CPUID Deterministic Address Translation Parameters
+
+  @note
+  Each sub-leaf enumerates a different address translation structure.
+  If ECX contains an invalid sub-leaf index, EAX/EBX/ECX/EDX return 0. Sub-leaf
+  index n is invalid if n exceeds the value that sub-leaf 0 returns in EAX. A
+  sub-leaf index is also invalid if EDX[4:0] returns 0.
+  Valid sub-leaves do not need to be contiguous or in any particular order. A
+  valid sub-leaf may be in a higher input ECX value than an invalid sub-leaf or
+  than a valid sub-leaf of a higher or lower-level structure.
+  * Some unified TLBs will allow a single TLB entry to satisfy data read/write
+  and instruction fetches. Others will require separate entries (e.g., one
+  loaded on data read/write and another loaded on an instruction fetch).
+  Please see the Intel 64 and IA-32 Architectures Optimization Reference Manual
+  for details of a particular product.
+  ** Add one to the return value to get the result.
+
+  @param   EAX  CPUID_DETERMINISTIC_ADDRESS_TRANSLATION_PARAMETERS (0x18)
+  @param   ECX  CPUID_DETERMINISTIC_ADDRESS_TRANSLATION_PARAMETERS_MAIN_LEAF (0x00)
+                CPUID_DETERMINISTIC_ADDRESS_TRANSLATION_PARAMETERS_SUB_LEAF  (0x*)
+
+**/
+#define CPUID_DETERMINISTIC_ADDRESS_TRANSLATION_PARAMETERS             0x18
+
+/**
+  CPUID Deterministic Address Translation Parameters
+
+  @param   EAX  CPUID_DETERMINISTIC_ADDRESS_TRANSLATION_PARAMETERS (0x18)
+  @param   ECX  CPUID_DETERMINISTIC_ADDRESS_TRANSLATION_PARAMETERS_MAIN_LEAF (0x00)
+
+  @retval  EAX  Reports the maximum input value of supported sub-leaf in leaf 18H.
+  @retval  EBX  Returns Deterministic Address Translation Parameters described by
+                the type CPUID_DETERMINISTIC_ADDRESS_TRANSLATION_PARAMETERS_EBX.
+  @retval  ECX  Number of Sets.
+  @retval  EDX  Returns Deterministic Address Translation Parameters described by
+                the type CPUID_DETERMINISTIC_ADDRESS_TRANSLATION_PARAMETERS_EDX.
+
+  <b>Example usage</b>
+  @code
+  UINT32                                                  Eax;
+  CPUID_DETERMINISTIC_ADDRESS_TRANSLATION_PARAMETERS_EBX  Ebx;
+  UINT32                                                  Ecx;
+  CPUID_DETERMINISTIC_ADDRESS_TRANSLATION_PARAMETERS_EDX  Edx;
+
+  AsmCpuidEx (
+    CPUID_DETERMINISTIC_ADDRESS_TRANSLATION_PARAMETERS,
+    CPUID_DETERMINISTIC_ADDRESS_TRANSLATION_PARAMETERS_MAIN_LEAF,
+    &Eax, &Ebx.Uint32, &Ecx, &Edx.Uint32
+    );
+  @endcode
+**/
+#define CPUID_DETERMINISTIC_ADDRESS_TRANSLATION_PARAMETERS_MAIN_LEAF   0x00
+
+/**
+  CPUID Deterministic Address Translation Parameters EBX for CPUID leafs.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 0] 4K page size entries supported by this structure.
+    ///
+    UINT32  Page4K:1;
+    ///
+    /// [Bits 1] 2MB page size entries supported by this structure.
+    ///
+    UINT32  Page2M:1;
+    ///
+    /// [Bits 2] 4MB page size entries supported by this structure.
+    ///
+    UINT32  Page4M:1;
+    ///
+    /// [Bits 3] 1 GB page size entries supported by this structure.
+    ///
+    UINT32  Page1G:1;
+    ///
+    /// [Bits 7:4] Reserved.
+    ///
+    UINT32  Reserved1:4;
+    ///
+    /// [Bits 10:8] Partitioning (0: Soft partitioning between the logical
+    /// processors sharing this structure)
+    ///
+    UINT32  Partitioning:3;
+    ///
+    /// [Bits 15:11] Reserved.
+    ///
+    UINT32  Reserved2:5;
+    ///
+    /// [Bits 31:16] W = Ways of associativity.
+    ///
+    UINT32  Way:16;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_DETERMINISTIC_ADDRESS_TRANSLATION_PARAMETERS_EBX;
+
+/**
+  CPUID Deterministic Address Translation Parameters EDX for CPUID leafs.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 4:0] Translation cache type field.
+    ///
+    UINT32  TranslationCacheType:5;
+    ///
+    /// [Bits 7:5] Translation cache level (starts at 1).
+    ///
+    UINT32  TranslationCacheLevel:3;
+    ///
+    /// [Bits 8] Fully associative structure.
+    ///
+    UINT32  FullyAssociative:1;
+    ///
+    /// [Bits 13:9] Reserved.
+    ///
+    UINT32  Reserved1:5;
+    ///
+    /// [Bits 25:14] Maximum number of addressable IDs for logical
+    /// processors sharing this translation cache.
+    ///
+    UINT32  MaximumNum:12;
+    ///
+    /// [Bits 31:26] Reserved.
+    ///
+    UINT32  Reserved2:6;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_DETERMINISTIC_ADDRESS_TRANSLATION_PARAMETERS_EDX;
+
+///
+/// @{ Define value for CPUID_DETERMINISTIC_ADDRESS_TRANSLATION_PARAMETERS_EDX.TranslationCacheType
+///
+#define   CPUID_DETERMINISTIC_ADDRESS_TRANSLATION_PARAMETERS_TRANSLATION_CACHE_TYPE_INVALID          0x00
+#define   CPUID_DETERMINISTIC_ADDRESS_TRANSLATION_PARAMETERS_TRANSLATION_CACHE_TYPE_DATA_TLB         0x01
+#define   CPUID_DETERMINISTIC_ADDRESS_TRANSLATION_PARAMETERS_TRANSLATION_CACHE_TYPE_INSTRUCTION_TLB  0x02
+#define   CPUID_DETERMINISTIC_ADDRESS_TRANSLATION_PARAMETERS_TRANSLATION_CACHE_TYPE_UNIFIED_TLB      0x03
+///
+/// @}
+///
+
+
+/**
+  CPUID V2 Extended Topology Enumeration Leaf
+
+  @note
+  CPUID leaf 1FH is a preferred superset to leaf 0BH. Intel recommends first checking
+  for the existence of Leaf 1FH and using this if available.
+  Most of Leaf 1FH output depends on the initial value in ECX. The EDX output of leaf
+  1FH is always valid and does not vary with input value in ECX. Output value in ECX[7:0]
+  always equals input value in ECX[7:0]. Sub-leaf index 0 enumerates SMT level. Each
+  subsequent higher sub-leaf index enumerates a higher-level topological entity in
+  hierarchical order. For sub-leaves that return an invalid level-type of 0 in ECX[15:8];
+  EAX and EBX will return 0. If an input value n in ECX returns the invalid level-type of
+  0 in ECX[15:8], other input values with ECX > n also return 0 in ECX[15:8].
+
+  Software should use this field (EAX[4:0]) to enumerate processor topology of the system.
+  Software must not use EBX[15:0] to enumerate processor topology of the system. This value
+  in this field (EBX[15:0]) is only intended for display/diagnostic purposes. The actual
+  number of logical processors available to BIOS/OS/Applications may be different from the
+  value of EBX[15:0], depending on software and platform hardware configurations.
+
+  @param   EAX  CPUID_V2_EXTENDED_TOPOLOGY                        (0x1F)
+  @param   ECX  Level number
+
+**/
+#define CPUID_V2_EXTENDED_TOPOLOGY                                     0x1F
+
+///
+/// @{ Define value for CPUID_EXTENDED_TOPOLOGY_ECX.LevelType
+/// The value of the "level type" field is not related to level numbers in
+/// any way, higher "level type" values do not mean higher levels.
+///
+#define   CPUID_V2_EXTENDED_TOPOLOGY_LEVEL_TYPE_MODULE                  0x03
+#define   CPUID_V2_EXTENDED_TOPOLOGY_LEVEL_TYPE_TILE                    0x04
+#define   CPUID_V2_EXTENDED_TOPOLOGY_LEVEL_TYPE_DIE                     0x05
+///
+/// @}
+///
+
+/**
+  CPUID Extended Function
+
+  @param   EAX  CPUID_EXTENDED_FUNCTION (0x80000000)
+
+  @retval  EAX  Maximum Input Value for Extended Function CPUID Information.
+  @retval  EBX  Reserved.
+  @retval  ECX  Reserved.
+  @retval  EDX  Reserved.
+
+  <b>Example usage</b>
+  @code
+  UINT32  Eax;
+
+  AsmCpuid (CPUID_EXTENDED_FUNCTION, &Eax, NULL, NULL, NULL);
+  @endcode
+**/
+#define CPUID_EXTENDED_FUNCTION                 0x80000000
+
+
+/**
+  CPUID Extended Processor Signature and Feature Bits
+
+  @param   EAX  CPUID_EXTENDED_CPU_SIG (0x80000001)
+
+  @retval  EAX  CPUID_EXTENDED_CPU_SIG.
+  @retval  EBX  Reserved.
+  @retval  ECX  Extended Processor Signature and Feature Bits information
+                described by the type CPUID_EXTENDED_CPU_SIG_ECX.
+  @retval  EDX  Extended Processor Signature and Feature Bits information
+                described by the type CPUID_EXTENDED_CPU_SIG_EDX.
+
+  <b>Example usage</b>
+  @code
+  UINT32                      Eax;
+  CPUID_EXTENDED_CPU_SIG_ECX  Ecx;
+  CPUID_EXTENDED_CPU_SIG_EDX  Edx;
+
+  AsmCpuid (CPUID_EXTENDED_CPU_SIG, &Eax, NULL, &Ecx.Uint32, &Edx.Uint32);
+  @endcode
+**/
+#define CPUID_EXTENDED_CPU_SIG                  0x80000001
+
+/**
+  CPUID Extended Processor Signature and Feature Bits ECX for CPUID leaf
+  #CPUID_EXTENDED_CPU_SIG.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bit 0] LAHF/SAHF available in 64-bit mode.
+    ///
+    UINT32  LAHF_SAHF:1;
+    UINT32  Reserved1:4;
+    ///
+    /// [Bit 5] LZCNT.
+    ///
+    UINT32  LZCNT:1;
+    UINT32  Reserved2:2;
+    ///
+    /// [Bit 8] PREFETCHW.
+    ///
+    UINT32  PREFETCHW:1;
+    UINT32  Reserved3:23;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_EXTENDED_CPU_SIG_ECX;
+
+/**
+  CPUID Extended Processor Signature and Feature Bits EDX for CPUID leaf
+  #CPUID_EXTENDED_CPU_SIG.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    UINT32  Reserved1:11;
+    ///
+    /// [Bit 11] SYSCALL/SYSRET available in 64-bit mode.
+    ///
+    UINT32  SYSCALL_SYSRET:1;
+    UINT32  Reserved2:8;
+    ///
+    /// [Bit 20] Execute Disable Bit available.
+    ///
+    UINT32  NX:1;
+    UINT32  Reserved3:5;
+    ///
+    /// [Bit 26] 1-GByte pages are available if 1.
+    ///
+    UINT32  Page1GB:1;
+    ///
+    /// [Bit 27] RDTSCP and IA32_TSC_AUX are available if 1.
+    ///
+    UINT32  RDTSCP:1;
+    UINT32  Reserved4:1;
+    ///
+    /// [Bit 29] Intel(R) 64 Architecture available if 1.
+    ///
+    UINT32  LM:1;
+    UINT32  Reserved5:2;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_EXTENDED_CPU_SIG_EDX;
+
+
+/**
+  CPUID Processor Brand String
+
+  @param   EAX  CPUID_BRAND_STRING1 (0x80000002)
+
+  @retval  EAX  Processor Brand String in type CPUID_BRAND_STRING_DATA.
+  @retval  EBX  Processor Brand String Continued in type CPUID_BRAND_STRING_DATA.
+  @retval  ECX  Processor Brand String Continued in type CPUID_BRAND_STRING_DATA.
+  @retval  EDX  Processor Brand String Continued in type CPUID_BRAND_STRING_DATA.
+
+  <b>Example usage</b>
+  @code
+  CPUID_BRAND_STRING_DATA  Eax;
+  CPUID_BRAND_STRING_DATA  Ebx;
+  CPUID_BRAND_STRING_DATA  Ecx;
+  CPUID_BRAND_STRING_DATA  Edx;
+
+  AsmCpuid (CPUID_BRAND_STRING1, &Eax.Uint32, &Ebx.Uint32, &Ecx.Uint32, &Edx.Uint32);
+  @endcode
+**/
+#define CPUID_BRAND_STRING1                     0x80000002
+
+/**
+  CPUID Processor Brand String for CPUID leafs #CPUID_BRAND_STRING1,
+  #CPUID_BRAND_STRING2, and #CPUID_BRAND_STRING3.
+**/
+typedef union {
+  ///
+  /// 4 ASCII characters of Processor Brand String
+  ///
+  CHAR8   BrandString[4];
+  ///
+  /// All fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_BRAND_STRING_DATA;
+
+/**
+  CPUID Processor Brand String
+
+  @param   EAX  CPUID_BRAND_STRING2 (0x80000003)
+
+  @retval  EAX  Processor Brand String Continued in type CPUID_BRAND_STRING_DATA.
+  @retval  EBX  Processor Brand String Continued in type CPUID_BRAND_STRING_DATA.
+  @retval  ECX  Processor Brand String Continued in type CPUID_BRAND_STRING_DATA.
+  @retval  EDX  Processor Brand String Continued in type CPUID_BRAND_STRING_DATA.
+
+  <b>Example usage</b>
+  @code
+  CPUID_BRAND_STRING_DATA  Eax;
+  CPUID_BRAND_STRING_DATA  Ebx;
+  CPUID_BRAND_STRING_DATA  Ecx;
+  CPUID_BRAND_STRING_DATA  Edx;
+
+  AsmCpuid (CPUID_BRAND_STRING2, &Eax.Uint32, &Ebx.Uint32, &Ecx.Uint32, &Edx.Uint32);
+  @endcode
+**/
+#define CPUID_BRAND_STRING2                     0x80000003
+
+/**
+  CPUID Processor Brand String
+
+  @param   EAX  CPUID_BRAND_STRING3 (0x80000004)
+
+  @retval  EAX  Processor Brand String Continued in type CPUID_BRAND_STRING_DATA.
+  @retval  EBX  Processor Brand String Continued in type CPUID_BRAND_STRING_DATA.
+  @retval  ECX  Processor Brand String Continued in type CPUID_BRAND_STRING_DATA.
+  @retval  EDX  Processor Brand String Continued in type CPUID_BRAND_STRING_DATA.
+
+  <b>Example usage</b>
+  @code
+  CPUID_BRAND_STRING_DATA  Eax;
+  CPUID_BRAND_STRING_DATA  Ebx;
+  CPUID_BRAND_STRING_DATA  Ecx;
+  CPUID_BRAND_STRING_DATA  Edx;
+
+  AsmCpuid (CPUID_BRAND_STRING3, &Eax.Uint32, &Ebx.Uint32, &Ecx.Uint32, &Edx.Uint32);
+  @endcode
+**/
+#define CPUID_BRAND_STRING3                     0x80000004
+
+
+/**
+  CPUID Extended Cache information
+
+  @param   EAX  CPUID_EXTENDED_CACHE_INFO (0x80000006)
+
+  @retval  EAX  Reserved.
+  @retval  EBX  Reserved.
+  @retval  ECX  Extended cache information described by the type
+                CPUID_EXTENDED_CACHE_INFO_ECX.
+  @retval  EDX  Reserved.
+
+  <b>Example usage</b>
+  @code
+  CPUID_EXTENDED_CACHE_INFO_ECX  Ecx;
+
+  AsmCpuid (CPUID_EXTENDED_CACHE_INFO, NULL, NULL, &Ecx.Uint32, NULL);
+  @endcode
+**/
+#define CPUID_EXTENDED_CACHE_INFO               0x80000006
+
+/**
+  CPUID Extended Cache information ECX for CPUID leaf #CPUID_EXTENDED_CACHE_INFO.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 7:0] Cache line size in bytes.
+    ///
+    UINT32  CacheLineSize:8;
+    UINT32  Reserved:4;
+    ///
+    /// [Bits 15:12] L2 Associativity field.  Supported values are in the range
+    /// #CPUID_EXTENDED_CACHE_INFO_ECX_L2_ASSOCIATIVITY_DISABLED to
+    /// #CPUID_EXTENDED_CACHE_INFO_ECX_L2_ASSOCIATIVITY_FULL
+    ///
+    UINT32  L2Associativity:4;
+    ///
+    /// [Bits 31:16] Cache size in 1K units.
+    ///
+    UINT32  CacheSize:16;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_EXTENDED_CACHE_INFO_ECX;
+
+///
+/// @{ Define value for bit field CPUID_EXTENDED_CACHE_INFO_ECX.L2Associativity
+///
+#define CPUID_EXTENDED_CACHE_INFO_ECX_L2_ASSOCIATIVITY_DISABLED       0x00
+#define CPUID_EXTENDED_CACHE_INFO_ECX_L2_ASSOCIATIVITY_DIRECT_MAPPED  0x01
+#define CPUID_EXTENDED_CACHE_INFO_ECX_L2_ASSOCIATIVITY_2_WAY          0x02
+#define CPUID_EXTENDED_CACHE_INFO_ECX_L2_ASSOCIATIVITY_4_WAY          0x04
+#define CPUID_EXTENDED_CACHE_INFO_ECX_L2_ASSOCIATIVITY_8_WAY          0x06
+#define CPUID_EXTENDED_CACHE_INFO_ECX_L2_ASSOCIATIVITY_16_WAY         0x08
+#define CPUID_EXTENDED_CACHE_INFO_ECX_L2_ASSOCIATIVITY_32_WAY         0x0A
+#define CPUID_EXTENDED_CACHE_INFO_ECX_L2_ASSOCIATIVITY_48_WAY         0x0B
+#define CPUID_EXTENDED_CACHE_INFO_ECX_L2_ASSOCIATIVITY_64_WAY         0x0C
+#define CPUID_EXTENDED_CACHE_INFO_ECX_L2_ASSOCIATIVITY_96_WAY         0x0D
+#define CPUID_EXTENDED_CACHE_INFO_ECX_L2_ASSOCIATIVITY_128_WAY        0x0E
+#define CPUID_EXTENDED_CACHE_INFO_ECX_L2_ASSOCIATIVITY_FULL           0x0F
+///
+/// @}
+///
+
+/**
+  CPUID Extended Time Stamp Counter information
+
+  @param   EAX  CPUID_EXTENDED_TIME_STAMP_COUNTER (0x80000007)
+
+  @retval  EAX  Reserved.
+  @retval  EBX  Reserved.
+  @retval  ECX  Reserved.
+  @retval  EDX  Extended time stamp counter (TSC) information described by the
+                type CPUID_EXTENDED_TIME_STAMP_COUNTER_EDX.
+
+  <b>Example usage</b>
+  @code
+  CPUID_EXTENDED_TIME_STAMP_COUNTER_EDX  Edx;
+
+  AsmCpuid (CPUID_EXTENDED_TIME_STAMP_COUNTER, NULL, NULL, NULL, &Edx.Uint32);
+  @endcode
+**/
+#define CPUID_EXTENDED_TIME_STAMP_COUNTER       0x80000007
+
+/**
+  CPUID Extended Time Stamp Counter information EDX for CPUID leaf
+  #CPUID_EXTENDED_TIME_STAMP_COUNTER.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    UINT32  Reserved1:8;
+    ///
+    /// [Bit 8] Invariant TSC available if 1.
+    ///
+    UINT32  InvariantTsc:1;
+    UINT32  Reserved2:23;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_EXTENDED_TIME_STAMP_COUNTER_EDX;
+
+
+/**
+  CPUID Linear Physical Address Size
+
+  @param   EAX  CPUID_VIR_PHY_ADDRESS_SIZE (0x80000008)
+
+  @retval  EAX  Linear/Physical Address Size described by the type
+                CPUID_VIR_PHY_ADDRESS_SIZE_EAX.
+  @retval  EBX  Reserved.
+  @retval  ECX  Reserved.
+  @retval  EDX  Reserved.
+
+  <b>Example usage</b>
+  @code
+  CPUID_VIR_PHY_ADDRESS_SIZE_EAX  Eax;
+
+  AsmCpuid (CPUID_VIR_PHY_ADDRESS_SIZE, &Eax.Uint32, NULL, NULL, NULL);
+  @endcode
+**/
+#define CPUID_VIR_PHY_ADDRESS_SIZE              0x80000008
+
+/**
+  CPUID Linear Physical Address Size EAX for CPUID leaf
+  #CPUID_VIR_PHY_ADDRESS_SIZE.
+**/
+typedef union {
+  ///
+  /// Individual bit fields
+  ///
+  struct {
+    ///
+    /// [Bits 7:0] Number of physical address bits.
+    ///
+    /// @note
+    /// If CPUID.80000008H:EAX[7:0] is supported, the maximum physical address
+    /// number supported should come from this field.
+    ///
+    UINT32  PhysicalAddressBits:8;
+    ///
+    /// [Bits 15:8] Number of linear address bits.
+    ///
+    UINT32  LinearAddressBits:8;
+    UINT32  Reserved:16;
+  } Bits;
+  ///
+  /// All bit fields as a 32-bit value
+  ///
+  UINT32  Uint32;
+} CPUID_VIR_PHY_ADDRESS_SIZE_EAX;
+
+#endif

--- a/BootloaderCommonPkg/Include/Register/Intel/LocalApic.h
+++ b/BootloaderCommonPkg/Include/Register/Intel/LocalApic.h
@@ -1,27 +1,13 @@
 /** @file
   IA32 Local APIC Definitions.
 
-  Copyright (c) 2010 - 2015, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
-#ifndef __LOCAL_APIC_H__
-#define __LOCAL_APIC_H__
-
-//
-// Definitions for IA32 architectural MSRs
-//
-#define MSR_IA32_APIC_BASE_ADDRESS              0x1B
-
-//
-// Definitions for CPUID instruction
-//
-#define CPUID_SIGNATURE                         0x0
-#define CPUID_VERSION_INFO                      0x1
-#define CPUID_EXTENDED_TOPOLOGY                 0xB
-#define CPUID_EXTENDED_FUNCTION                 0x80000000
-#define CPUID_VIR_PHY_ADDRESS_SIZE              0x80000008
+#ifndef __INTEL_LOCAL_APIC_H__
+#define __INTEL_LOCAL_APIC_H__
 
 //
 // Definition for Local APIC registers and related values
@@ -55,19 +41,6 @@
 #define LOCAL_APIC_DESTINATION_SHORTHAND_SELF               1
 #define LOCAL_APIC_DESTINATION_SHORTHAND_ALL_INCLUDING_SELF 2
 #define LOCAL_APIC_DESTINATION_SHORTHAND_ALL_EXCLUDING_SELF 3
-
-typedef union {
-  struct {
-    UINT32  Reserved0: 8;    ///< Reserved.
-    UINT32  Bsp: 1;          ///< Processor is BSP.
-    UINT32  Reserved1: 1;    ///< Reserved.
-    UINT32  Extd: 1;         ///< Enable x2APIC mode.
-    UINT32  En: 1;           ///< xAPIC global enable/disable.
-    UINT32  ApicBaseLow: 20; ///< APIC Base physical address. The actual field width depends on physical address width.
-    UINT32  ApicBaseHigh: 32;
-  } Bits;
-  UINT64    Uint64;
-} MSR_IA32_APIC_BASE;
 
 //
 // Local APIC Version Register.

--- a/BootloaderCommonPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.inf
+++ b/BootloaderCommonPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.inf
@@ -1,0 +1,44 @@
+## @file
+#  The Local Apic library supports x2APIC capable processors which have xAPIC and x2APIC modes.
+#
+#  Note: Local APIC library assumes local APIC is enabled. It does not handle cases
+#  where local APIC is disabled.
+#
+#  Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020, AMD Inc. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = BaseXApicX2ApicLib
+  MODULE_UNI_FILE                = BaseXApicX2ApicLib.uni
+  FILE_GUID                      = 967B6E05-F10D-4c10-8BF7-365291CA143F
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.1
+  LIBRARY_CLASS                  = LocalApicLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  BaseXApicX2ApicLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  TimerLib
+  IoLib
+  PcdLib
+
+[Pcd]
+  gPlatformCommonLibTokenSpaceGuid.PcdCpuInitIpiDelayInMicroSeconds
+  gPlatformCommonLibTokenSpaceGuid.PcdCpuLocalApicBaseAddress

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -69,7 +69,7 @@
   MemoryAllocationLib|BootloaderCorePkg/Library/MemoryAllocationLib/MemoryAllocationLib.inf
   MpInitLib|BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
   StageLib|BootloaderCorePkg/Library/StageLib/StageLib.inf
-  LocalApicLib|BootloaderCommonPkg/Library/BaseXApicLib/BaseXApicLib.inf
+  LocalApicLib|BootloaderCommonPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.inf
   SecureBootLib|BootloaderCommonPkg/Library/SecureBootLib/SecureBootLib.inf
   TpmLib|BootloaderCommonPkg/Library/TpmLib/TpmLib.inf
   BootloaderCommonLib|BootloaderCommonPkg/Library/BootloaderCommonLib/BootloaderCommonLib.inf
@@ -319,6 +319,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdPreOsCheckerEnabled | $(ENABLE_PRE_OS_CHECKER)
   gPlatformCommonLibTokenSpaceGuid.PcdDmaProtectionEnabled | $(ENABLE_DMA_PROTECTION)
   gPlatformCommonLibTokenSpaceGuid.PcdMultiUsbBootDeviceEnabled |  $(ENABLE_MULTI_USB_BOOT_DEV)
+  gPlatformCommonLibTokenSpaceGuid.PcdCpuX2ApicEnabled    | $(SUPPORT_X2APIC)
   gPlatformModuleTokenSpaceGuid.PcdAriSupport             | $(SUPPORT_ARI)
   gPlatformModuleTokenSpaceGuid.PcdSrIovSupport           | $(SUPPORT_SR_IOV)
   gPlatformModuleTokenSpaceGuid.PcdEnableSetup            | $(ENABLE_SBL_SETUP)

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
@@ -62,3 +62,4 @@
   gPlatformModuleTokenSpaceGuid.PcdLegacyEfSegmentEnabled
   gPlatformModuleTokenSpaceGuid.PcdSplashLogoAddress
   gPlatformModuleTokenSpaceGuid.PcdSplashEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdCpuX2ApicEnabled

--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
@@ -187,6 +187,11 @@ ApFunc (
   // Enable more CPU featurs
   AsmEnableAvx ();
 
+  if (FeaturePcdGet (PcdCpuX2ApicEnabled)) {
+    // Enable X2APIC if desired
+    SetApicMode (LOCAL_APIC_MODE_X2APIC);
+  }
+
   //
   // CPU specific init
   //
@@ -245,6 +250,11 @@ BspInit (
 
   mMpDataStruct.SmmRebaseDoneCounter = 0;
 
+  if (FeaturePcdGet (PcdCpuX2ApicEnabled)) {
+    // Enable X2APIC if desired
+    SetApicMode (LOCAL_APIC_MODE_X2APIC);
+  }
+
   //
   // CPU specific init
   //
@@ -294,6 +304,12 @@ MpInit (
       Status = EFI_UNSUPPORTED;
     } else {
       DEBUG ((DEBUG_INIT, "MP Init%a\n", DebugCodeEnabled() ? " (Wakeup)" : ""));
+
+      if (FeaturePcdGet (PcdCpuX2ApicEnabled)) {
+        // Enable X2APIC if desired
+        SetApicMode (LOCAL_APIC_MODE_X2APIC);
+        DEBUG ((DEBUG_INFO, "APIC Mode: %d\n", GetApicMode ()));
+      }
 
       // Init structure for lock
       mMpDataStruct.SmmRebaseDoneCounter = 0;

--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
@@ -57,3 +57,4 @@
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegSize
   gPlatformModuleTokenSpaceGuid.PcdSmmRebaseMode
   gPlatformModuleTokenSpaceGuid.PcdFuncCpuInitHook
+  gPlatformCommonLibTokenSpaceGuid.PcdCpuX2ApicEnabled

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -218,6 +218,7 @@ class BaseBoard(object):
 
         self.SUPPORT_ARI           = 0
         self.SUPPORT_SR_IOV        = 0
+        self.SUPPORT_X2APIC        = 0
 
         self.BUILD_CSME_UPDATE_DRIVER    = 0
 


### PR DESCRIPTION
This patch added X2APIC support. It is to enable the case when
APIC ID is greater than 255. This patch only handle core wakeup
portion. Platform still needs to handle ACPI related changes for
X2APIC.

X2APIC lib is backward compatible with XAPIC lib. So there is no
need to use XAPIC lib anymore.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>