### PR TITLE
Enhance GpioWriteLockReg in common GpioLib

### DIFF
--- a/Silicon/CommonSocPkg/Include/Library/GpioPlatformLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/GpioPlatformLib.h
@@ -28,6 +28,18 @@ PmcGetGpioGpe (
 
 
 /**
+  Return opcode supported for writing to GPIO lock unlock register
+
+  @retval UINT8   Lock Opcode
+**/
+UINT8
+EFIAPI
+GpioGetLockOpcode (
+  VOID
+  );
+
+
+/**
   This internal procedure will check if group is within DeepSleepWell.
 
   @param[in]  Group               GPIO Group

--- a/Silicon/CommonSocPkg/Library/GpioLib/GpioLib.c
+++ b/Silicon/CommonSocPkg/Library/GpioLib/GpioLib.c
@@ -555,7 +555,7 @@ GpioWriteLockReg (
   Status = GpioPchSbiExecutionEx (
              GpioGroupInfo[GroupIndex].Community,
              RegOffset,
-             GpioLibGpioLockUnlock,
+             (GPIO_PCH_SBI_OPCODE) GpioGetLockOpcode (),
              FALSE,
              0x000F,
              0x0000,

--- a/Silicon/TigerlakePchPkg/Library/GpioPlatformLib/GpioPlatformLib.c
+++ b/Silicon/TigerlakePchPkg/Library/GpioPlatformLib/GpioPlatformLib.c
@@ -192,6 +192,21 @@ PmcGetGpioGpe (
 
 
 /**
+  Return opcode supported for writing to GPIO lock unlock register
+
+  @retval UINT8   Lock Opcode
+**/
+UINT8
+EFIAPI
+GpioGetLockOpcode (
+  VOID
+  )
+{
+  return GpioLockUnlock;
+}
+
+
+/**
   This internal procedure will check if group is within DeepSleepWell.
 
   @param[in]  Group               GPIO Group


### PR DESCRIPTION
Certain platforms can't support GpioLockUnlock, so let
them use PrivateControlWrite when they do an SBI exec.
Also updated dependent platform.

Signed-off-by: Talamudupula <stalamudupula@gmail.com>