### PR TITLE
[X64] Read the first time stamp before TempRamInit

### DIFF
--- a/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Main.asm
+++ b/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Main.asm
@@ -58,6 +58,13 @@ TempRamInitStack:
 
 Continue:
     ;
+    ; Read time stamp
+    ;
+    rdtsc
+    mov     esi, eax
+    mov     edi, edx
+
+    ;
     ; Get FSP-T base in EAX
     ;
     mov     eax, ADDR_OF(BuildPatchData)
@@ -133,6 +140,12 @@ jumpTo64BitAndLandHere:
     xor     rax, rax
     mov     eax, 0FFFFFFFCh
     mov     eax, dword [rax]
+
+    ;
+    ; EDI/ESI time stamp to RDI
+    ;
+    shl     rdi, 32
+    add     rdi, rsi
 
     ; Restore the BIST value to EAX register
     ;

--- a/BootloaderCorePkg/Stage1A/X64/SecEntry.nasm
+++ b/BootloaderCorePkg/Stage1A/X64/SecEntry.nasm
@@ -29,14 +29,8 @@ ASM_PFX(_ModuleEntryPoint):
         movd    mm0, eax
 
         ;
-        ; Read time stamp in esi
+        ; RDI: time stamp
         ;
-        mov     rbx, rdx
-        rdtsc
-        mov     rsi, rdx
-        shl     rsi, 32
-        add     rsi, rax
-        mov     rdx, rbx
 
         ;
         ; Add a dummy reference to TempRamInitParams to prevent
@@ -90,7 +84,7 @@ CheckStackRangeDone:
 CheckStatusDone:
         ; Setup HOB
         push    rbx                  ; Status
-        push    rsi                  ; TimeStamp[0] [63:0]
+        push    rdi                  ; TimeStamp[0] [63:0]
         shl     rdx, 32              ; Move CarTop to high 32bit
         add     rdx, rcx             ; Add back CarBase
         push    rdx


### PR DESCRIPTION
Currently, the 1st time stamp includes FSP-T execution time in X64.
This will read the 1st time stamp before TempRamInit.

Signed-off-by: Aiden Park <aiden.park@intel.com>