### PR TITLE
Move X2APIC enabling to common function

### DIFF
--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
@@ -368,7 +368,7 @@ UpdateMadt (
   //
   if (FeaturePcdGet (PcdCpuX2ApicEnabled)) {
     LocalX2Apic = (EFI_ACPI_5_0_PROCESSOR_LOCAL_X2APIC_STRUCTURE *)Current;
-    Length = sizeof (EFI_ACPI_5_0_PROCESSOR_LOCAL_APIC_STRUCTURE) * SysCpuInfo->CpuCount;
+    Length = sizeof (EFI_ACPI_5_0_PROCESSOR_LOCAL_X2APIC_STRUCTURE) * SysCpuInfo->CpuCount;
     ZeroMem (LocalX2Apic, Length);
     for (Index = 0; Index < SysCpuInfo->CpuCount; Index++) {
       LocalX2Apic[Index].Type             = EFI_ACPI_5_0_PROCESSOR_LOCAL_X2APIC;
@@ -377,7 +377,6 @@ UpdateMadt (
       LocalX2Apic[Index].X2ApicId         = SysCpuInfo->CpuInfo[Index].ApicId;
       LocalX2Apic[Index].Flags            = 1;
     }
-    Length = sizeof (EFI_ACPI_5_0_PROCESSOR_LOCAL_X2APIC_STRUCTURE) * SysCpuInfo->CpuCount;
   } else {
     LocalApic = (EFI_ACPI_5_0_PROCESSOR_LOCAL_APIC_STRUCTURE *)Current;
     Length = sizeof (EFI_ACPI_5_0_PROCESSOR_LOCAL_APIC_STRUCTURE) * SysCpuInfo->CpuCount;

--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
@@ -137,6 +137,14 @@ CpuInit (
   UINT32                  CpuIdx;
   PLATFORM_CPU_INIT_HOOK  PlatformCpuInitHook;
 
+  if (FeaturePcdGet (PcdCpuX2ApicEnabled)) {
+    // Enable X2APIC if desired
+    SetApicMode (LOCAL_APIC_MODE_X2APIC);
+    if (Index == 0) {
+      DEBUG ((DEBUG_INFO, "APIC Mode: %d\n", GetApicMode ()));
+    }
+  }
+
   ApicId = GetApicId();
   if (Index < PcdGet32 (PcdCpuMaxLogicalProcessorNumber)) {
     mSysCpuInfo.CpuInfo[Index].ApicId = ApicId;
@@ -186,11 +194,6 @@ ApFunc (
 
   // Enable more CPU featurs
   AsmEnableAvx ();
-
-  if (FeaturePcdGet (PcdCpuX2ApicEnabled)) {
-    // Enable X2APIC if desired
-    SetApicMode (LOCAL_APIC_MODE_X2APIC);
-  }
 
   //
   // CPU specific init
@@ -250,11 +253,6 @@ BspInit (
 
   mMpDataStruct.SmmRebaseDoneCounter = 0;
 
-  if (FeaturePcdGet (PcdCpuX2ApicEnabled)) {
-    // Enable X2APIC if desired
-    SetApicMode (LOCAL_APIC_MODE_X2APIC);
-  }
-
   //
   // CPU specific init
   //
@@ -304,12 +302,6 @@ MpInit (
       Status = EFI_UNSUPPORTED;
     } else {
       DEBUG ((DEBUG_INIT, "MP Init%a\n", DebugCodeEnabled() ? " (Wakeup)" : ""));
-
-      if (FeaturePcdGet (PcdCpuX2ApicEnabled)) {
-        // Enable X2APIC if desired
-        SetApicMode (LOCAL_APIC_MODE_X2APIC);
-        DEBUG ((DEBUG_INFO, "APIC Mode: %d\n", GetApicMode ()));
-      }
 
       // Init structure for lock
       mMpDataStruct.SmmRebaseDoneCounter = 0;


### PR DESCRIPTION
This patch removed duplicated X2APIC enabling code. Instead, it
enables X2APIC in a common function. By doing so, the very first
waking up will be done in APIC mode. Afterwards, it will be using
X2APIC mode if enabled by PCD.
This patch also fixed an X2APIC ACPI MADT issue.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>