### PR TITLE
Fix MP waking up issue on some platforms

### DIFF
--- a/BootloaderCommonPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.c
+++ b/BootloaderCommonPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.c
@@ -619,6 +619,8 @@ SendInitSipiSipi (
   IcrLow.Bits.DeliveryMode = LOCAL_APIC_DELIVERY_MODE_STARTUP;
   IcrLow.Bits.Level = 1;
   SendIpi (IcrLow.Uint32, ApicId);
+  MicroSecondDelay (200);
+  SendIpi (IcrLow.Uint32, ApicId);
 }
 
 /**
@@ -650,6 +652,8 @@ SendInitSipiSipiAllExcludingSelf (
   IcrLow.Bits.DeliveryMode = LOCAL_APIC_DELIVERY_MODE_STARTUP;
   IcrLow.Bits.Level = 1;
   IcrLow.Bits.DestinationShorthand = LOCAL_APIC_DESTINATION_SHORTHAND_ALL_EXCLUDING_SELF;
+  SendIpi (IcrLow.Uint32, 0);
+  MicroSecondDelay (200);
   SendIpi (IcrLow.Uint32, 0);
 }
 


### PR DESCRIPTION
It was reported that some platform had MP waking up issue after
switching to using X2APIC library. By comparing the library, found
X2APIC removed 2nd IPI sending in the flow. This 2nd IPI is
required per IA specification. The patch added it back.

Tests have been done and confirmed it fixed the issues seen on
thos platforms.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>