### PR TITLE
[CFL] Set Tseg size to 16MB.

### DIFF
--- a/Platform/CoffeelakeBoardPkg/CfgData/CfgData_Memory.yaml
+++ b/Platform/CoffeelakeBoardPkg/CfgData/CfgData_Memory.yaml
@@ -67,6 +67,14 @@
                      Indicates DqPinsInterleaved setting- board-dependent
       length       : 0x01
       value        : 0x1
+  - TsegSize     :
+      name         : Tseg Size
+      type         : Combo
+      option       : 0x0400000:4MB, 0x00800000:8MB, 0x01000000:16MB
+      help         : >
+                     Size of SMRAM memory reserved. 0x400000 for Release build and 0x1000000 for Debug build
+      length       : 0x04
+      value        : 0x01000000
   - MmioSize     :
       name         : MMIO Size
       type         : EditNum, HEX, (0,0xC00)

--- a/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -169,10 +169,7 @@ UpdateFspConfig (
   CopyMem (&Fspmcfg->DqsMapCpu2DramCh0, MemCfgData->DqsMapCpu2DramCh0, sizeof(MemCfgData->DqsMapCpu2DramCh0));
   CopyMem (&Fspmcfg->DqsMapCpu2DramCh1, MemCfgData->DqsMapCpu2DramCh1, sizeof(MemCfgData->DqsMapCpu2DramCh1));
   Fspmcfg->DqPinsInterleaved      = MemCfgData->DqPinsInterleaved;
-  //
-  // Tseg 4MB is enough for both debug/release build with SBL
-  //
-  Fspmcfg->TsegSize               = 0x00400000;
+  Fspmcfg->TsegSize               = MemCfgData->TsegSize;
   Fspmcfg->MmioSize               = MemCfgData->MmioSize;
   Fspmcfg->RMT                    = MemCfgData->RMT;
   FspmcfgTest->BdatEnable         = MemCfgData->BdatEnable;


### PR DESCRIPTION
This Patch did the following

-  TsegSize config options is defined in CfgData_Memory.yaml.
-  with 64GB RAM, slow boot issue was reported on ubuntu_20.0.
   Root cuase of the issue is due out of MTTR's and unable to cover
   portion of higher memory ranges. this patch fixes this issue.

Signed-off-by: Praveen Hp <praveen.hodagatta.pranesh@intel.com>