### PR TITLE
Update CsmePciReadBuffer callback prototype params

### DIFF
--- a/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
+++ b/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
@@ -601,7 +601,7 @@ UpdateCsme (
 EFI_STATUS
 EFIAPI
 CsmePciReadBuffer (
-  IN      UINTN     StartAddress,
+  IN      UINT64    StartAddress,
   IN      UINTN     Size,
   OUT     VOID      *Buffer
   );

--- a/PayloadPkg/FirmwareUpdate/CsmeFwUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/CsmeFwUpdate.c
@@ -104,7 +104,7 @@ DisplaySendStatus (
 EFI_STATUS
 EFIAPI
 CsmePciReadBuffer (
-  IN      UINTN     StartAddress,
+  IN      UINT64    StartAddress,
   IN      UINTN     Size,
   OUT     VOID      *Buffer
   )


### PR DESCRIPTION
CsmePciReadBuffer function prototype is aligned as
per the CSME fwupdate lib. It fixes issue with
CSME capsule fw update.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>