### PR TITLE
Program BAR0/1 for PPB

### DIFF
--- a/BootloaderCorePkg/Library/PciEnumerationLib/InternalPciEnumerationLib.h
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/InternalPciEnumerationLib.h
@@ -49,6 +49,7 @@
 
 #define PPB_BAR_0                             0
 #define PPB_BAR_1                             1
+#define PPB_MAX_BAR                           2
 
 #define PCI_IO_DEVICE_FROM_LINK(a)       BASE_CR (a, PCI_IO_DEVICE, Link)
 #define PCI_BAR_RESOURCE_FROM_LINK(a)    BASE_CR (a, PCI_BAR_RESOURCE, Link)
@@ -124,6 +125,11 @@ struct _PCI_IO_DEVICE {
   // BAR for this PCI Device
   //
   PCI_BAR                                   PciBar[PCI_MAX_BAR];
+
+  //
+  // PPB Non-Apperture BAR for 0x10/0x14
+  //
+  PCI_BAR                                   PpbBar[PPB_MAX_BAR];
 
   //
   // The resource decode the bridge supports


### PR DESCRIPTION
Current PCI Enum Lib scopes for only Apperture resources
for a PPB. But some OSes (like ESXi) expect BAR0 & BAR1
(Offset 0x10/0x14) to be allocated resources accordingly.
Otherwise, PPB enumeration doesnt happen correctly and
devices behind PPB are not registered at all.

This patch adds the functionality to assign valid resources
to BAR0(0x10) and BAR1(0x14) for a PPB also.

Signed-off-by: Talamudupula <stalamudupula@gmail.com>