### PR TITLE
Oem Key revocation feature support

### DIFF
--- a/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
+++ b/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
@@ -48,6 +48,11 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define FW_UPDATE_COMP_CSME_DRIVER SIGNATURE_32('C', 'S', 'M', 'D')
 #define FW_UPDATE_COMP_CMD_REQUEST SIGNATURE_32('C', 'M', 'D', 'I')
 
+#define FW_UPDATE_COMP_CSME_REGION_ORDER      1
+#define FW_UPDATE_COMP_CSME_DRIVER_ORDER      2
+#define FW_UPDATE_COMP_BIOS_REGION_ORDER      3
+#define FW_UPDATE_COMP_DEFAULT_ORDER          4
+
 
 #define FW_UPDATE_STATUS_SIGNATURE SIGNATURE_32 ('F', 'W', 'U', 'S')
 #define FW_UPDATE_STATUS_VERSION   0x1
@@ -655,4 +660,22 @@ SetArbSvnCommit (
    IN  CHAR8     *CmdDataBuf,
    IN  UINTN     CmdDataSize
    );
+
+/**
+  Oem Key Revocation
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      Oem Key Revocation is successful.
+  @retval  others           Error happened while doing commit.
+
+**/
+EFI_STATUS
+EFIAPI
+SetOemKeyRevocation (
+   IN  CHAR8     *CmdDataBuf,
+   IN  UINTN     CmdDataSize
+   );
+
 #endif

--- a/PayloadPkg/FirmwareUpdate/CmdFwUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/CmdFwUpdate.c
@@ -19,10 +19,14 @@
 
 #define FLASH_DESCRIPTOR_LOCK_STR     "FLASHDESCLOCK"
 #define ARB_SVN_COMMIT_STR            "ARBSVNCOMMIT"
+#define OEM_KEY_REVOCATION_STR        "OEMKEYREVOCATION"
+
 
 typedef UINT32 CMDI_TYPE;
 #define CMDI_TYPE_SPI_DESCRIPTOR_LOCK       BIT0
 #define CMDI_TYPE_ARB_SVN_COMMIT            BIT1
+#define CMDI_TYPE_OEM_KEY_REVOCATIION       BIT2
+
 
 /*
   Firmware update command handler
@@ -55,6 +59,9 @@ FwUpdateCmdHandler (
   } else if (AsciiStrnCmp (CmdBuf, ARB_SVN_COMMIT_STR, AsciiStrLen(ARB_SVN_COMMIT_STR)) == 0) {
       *CmdProcessed  =  CMDI_TYPE_ARB_SVN_COMMIT;
       Status = SetArbSvnCommit (CmdBuf, BufLen);
+  } else if (AsciiStrnCmp (CmdBuf, OEM_KEY_REVOCATION_STR, AsciiStrLen(OEM_KEY_REVOCATION_STR)) == 0) {
+      *CmdProcessed  =  CMDI_TYPE_OEM_KEY_REVOCATIION;
+      Status = SetOemKeyRevocation (CmdBuf, BufLen);
   }
 
   return Status;

--- a/PayloadPkg/FirmwareUpdate/CsmeFwUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/CsmeFwUpdate.c
@@ -281,7 +281,7 @@ StartCsmeUpdate (
   UINT32            Timer;
   UINT32            PreviousPercent;
 
-  AllowSameVersion  = FALSE;
+  AllowSameVersion  = TRUE;
   EnabledState      = FALSE;
   IsSameVersion     = FALSE;
   InProgress        = FALSE;

--- a/Silicon/ApollolakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/ApollolakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -469,3 +469,23 @@ SetArbSvnCommit (
 {
   return EFI_UNSUPPORTED;
 }
+
+/**
+  Oem Key Revocation
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      Oem Key Revocation is successful.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+SetOemKeyRevocation (
+   IN  CHAR8     *CmdDataBuf,
+   IN  UINTN     CmdDataSize
+   )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/CoffeelakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -410,3 +410,23 @@ SetArbSvnCommit (
 {
   return EFI_UNSUPPORTED;
 }
+
+/**
+  Oem Key Revocation
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      Oem Key Revocation is successful.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+SetOemKeyRevocation (
+   IN  CHAR8     *CmdDataBuf,
+   IN  UINTN     CmdDataSize
+   )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/Silicon/CometlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/CometlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -370,3 +370,23 @@ SetArbSvnCommit (
 {
   return EFI_UNSUPPORTED;
 }
+
+/**
+  Oem Key Revocation
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      Oem Key Revocation is successful.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+SetOemKeyRevocation (
+   IN  CHAR8     *CmdDataBuf,
+   IN  UINTN     CmdDataSize
+   )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/Silicon/CometlakevPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/CometlakevPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -370,3 +370,23 @@ SetArbSvnCommit (
 {
   return EFI_UNSUPPORTED;
 }
+
+/**
+  Oem Key Revocation
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      Oem Key Revocation is successful.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+SetOemKeyRevocation (
+   IN  CHAR8     *CmdDataBuf,
+   IN  UINTN     CmdDataSize
+   )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/Silicon/ElkhartlakePkg/Include/Library/HeciInitLib.h
+++ b/Silicon/ElkhartlakePkg/Include/Library/HeciInitLib.h
@@ -417,4 +417,19 @@ EFI_STATUS
 HeciArbSvnCommitMsg (
   VOID
   );
+
+/**
+  This command is used to indicate to the FW to revoke a OEM key.
+  It should be executed when MBP data indicates that a key is pending for
+  revocation.
+
+  @retval EFI_SUCCESS             Command succeeded
+  @retval EFI_UNSUPPORTED         Current ME mode doesn't support this function
+  @retval EFI_DEVICE_ERROR        HECI Device error, command aborts abnormally
+**/
+EFI_STATUS
+EFIAPI
+HeciRevokeOemKey (
+   VOID
+   );
 #endif

--- a/Silicon/ElkhartlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/ElkhartlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -20,6 +20,7 @@
 #include <Library/PchSbiAccessLib.h>
 #include <Library/PchPcrLib.h>
 #include <Library/HeciInitLib.h>
+#include <Library/PciLib.h>
 #include <CsmeUpdateDriver.h>
 #include "SpiRegionAccess.h"
 
@@ -485,6 +486,35 @@ SetArbSvnCommit (
     DEBUG((DEBUG_INFO, "ARB SVN commit failed -  0x%x\n", Status));
   } else {
     DEBUG((DEBUG_INFO, "ARB SVN commit SUCCESS \n"));
+  }
+
+  return Status;
+}
+
+/**
+  Oem Key Revocation
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      Oem Key Revocation is successful.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+SetOemKeyRevocation (
+   IN  CHAR8     *CmdDataBuf,
+   IN  UINTN     CmdDataSize
+   )
+{
+  EFI_STATUS Status;
+
+  Status = HeciRevokeOemKey ();
+  if (EFI_ERROR (Status)) {
+    DEBUG((DEBUG_ERROR, "Oem Revoke Key failed -  0x%x\n", Status));
+  } else {
+    DEBUG((DEBUG_INFO, "Oem Revoke Key SUCCESS \n"));
   }
 
   return Status;

--- a/Silicon/ElkhartlakePkg/Library/HeciInitLib/MbpData.c
+++ b/Silicon/ElkhartlakePkg/Library/HeciInitLib/MbpData.c
@@ -105,6 +105,10 @@ MbpDebugPrint (
     DEBUG ((DEBUG_INFO, " CurrCseArbSvn : 0x%x\n", MbpPtr->ArbSvnState.ArbSvnData.CurrCseArbSvn));
   }
 
+  if (MbpPtr->OemKeyRevoke.Available == TRUE) {
+    DEBUG ((DEBUG_INFO, "OemKeyRevocation Extension Available !! \n"));
+  }
+
   DEBUG ((DEBUG_INFO, "\n------------------------ MeBiosPayload Data End--------------\n"));
 }
 

--- a/Silicon/ElkhartlakePkg/Library/HeciInitLib/MeBiosPayloadData.h
+++ b/Silicon/ElkhartlakePkg/Library/HeciInitLib/MeBiosPayloadData.h
@@ -50,7 +50,7 @@ typedef union {
 #define MBP_ITEM_ID(ApplicationId, ItemId) ((ApplicationId << 4) | ItemId)
 
 #define MBP_ITEM_ID_MEASURED_BOOT     MBP_ITEM_ID(MbpAppIdKernel, MbpItemIdMeasuredBoot)
-
+#define MBP_ITEM_ID_OEM_KEY_REVOKE    MBP_ITEM_ID(MbpAppIdKernel, MbpItemIdOemKeyRevoke)
 
 //
 // Enum for AppId
@@ -72,11 +72,14 @@ typedef enum {
   MbpItemIdUnconfigOnRtc              = 8,
   MbpItemIdShipState                  = 9,
   MbpItemIdFwArbSvn                   = 14,
-  MbpItemIdMeasuredBoot               = 15
+  MbpItemIdMeasuredBoot               = 15,
+  MbpItemIdOemKeyRevoke               = 16
 } MBP_KERNEL_ITEM_ID;
+
 typedef enum {
   MbpItemIdHwaMtu = 1
 } MBP_HWA_ITEM_ID;
+
 typedef enum {
   MbpItemIdMphyMbpData = 3
 } MBP_ICC_ITEM_ID;
@@ -143,18 +146,6 @@ typedef union {
 } HWA_DATA;
 
 typedef struct {
-  UINT32  PwrbtnMrst;
-  UINT32  MrstPltrst;
-  UINT32  PltrstCpurst;
-} MBP_PERF_DATA;
-
-typedef struct {
-  MBP_PERF_DATA MbpPerfData;
-  BOOLEAN       Available;
-  UINT8         Reserved[3];
-} PLAT_BOOT_PERF_DATA;
-
-typedef struct {
   HWA_DATA Data;
   BOOLEAN  Available;
   UINT8    Reserved[3];
@@ -170,6 +161,21 @@ typedef struct {
   BOOLEAN                     Available;
   UINT8                       Reserved[3];
 } MBP_ME_UNCONF_ON_RTC_STATE;
+typedef struct {
+  UINT32                      TimeStamp0;
+  UINT16                      TimeStamp1;
+  UINT16                      TimeStamp2;
+  UINT16                      TimeStamp3;
+  UINT16                      TimeStamp4;
+  UINT16                      TimeStamp5;
+  UINT16                      TimeStamp6;
+} MBP_PERF_DATA;
+
+typedef struct {
+  MBP_PERF_DATA               Data;
+  BOOLEAN                     Available;
+  UINT8                       Reserved[3];
+} MBP_PERF_DATA_EX;
 
 typedef struct {
   /*
@@ -191,8 +197,17 @@ typedef struct {
 } MBP_ARB_SVN_STATE;
 
 typedef struct {
-  UINT32 ChipsetInitVer[3];
+  UINT32  ChipsetInitVer[3];
+  BOOLEAN Available;
+  UINT8   Reserved[3];
 } MBP_MPHY_DATA;
+
+
+
+typedef struct {
+  UINT32  IsiCfgIdentifier;
+  BOOLEAN Available;
+} MBP_ISI_CONFIG_DATA;
 
 ///
 /// MBP IFWI DNX request structure containing IFWI Dnx request
@@ -215,6 +230,12 @@ typedef struct {
   UINT8                       Reserved[3];
 } MBP_MEASURED_BOOT_SUPPORT;
 
+typedef struct {
+  UINT32                      OemKeyDataRsrvd;
+  BOOLEAN                     Available;
+  UINT8                       Reserved[3];
+} MBP_OEM_KEY_REVOKE;
+
 ///
 /// ME BIOS Payload structure containing insensitive data only
 ///
@@ -224,13 +245,15 @@ typedef struct {
   MBP_FW_FEATURES_STATE      FwFeaturesState;
   MBP_PLAT_TYPE              FwPlatType;
   MBP_HWA_REQ                HwaRequest;
-  PLAT_BOOT_PERF_DATA        PlatBootPerfData;
   MBP_ME_UNCONF_ON_RTC_STATE UnconfigOnRtcClearState;
+  MBP_PERF_DATA_EX           PerfDataEx;
   MBP_ARB_SVN_STATE          ArbSvnState;
   MBP_MPHY_DATA              MphyData;
   MBP_IFWI_DNX_REQUEST       IfwiDnxRequest;
   MBP_ICC_PROFILE            IccProfile;
   MBP_MEASURED_BOOT_SUPPORT  MeasuredBootSupport;
+  MBP_ISI_CONFIG_DATA        IsiConfigData;
+  MBP_OEM_KEY_REVOKE         OemKeyRevoke;
 } ME_BIOS_PAYLOAD;
 
 

--- a/Silicon/ElkhartlakePkg/Library/HeciInitLib/MkhiMsgs.h
+++ b/Silicon/ElkhartlakePkg/Library/HeciInitLib/MkhiMsgs.h
@@ -57,6 +57,9 @@ typedef union {
 #define MCA_READ_FILE_EX_CMD              0x0A
 #define MCA_ARB_SVN_COMMIT_CMD            0x1B
 #define MCA_ARB_SVN_GET_INFO_CMD          0x1C
+#define MCA_REVOKE_OEM_KEY_HASH_CMD       0x2F
+#define MCA_GET_OEM_KEY_STATUS_CMD        0x0D
+
 ///
 /// Defines for GEN_GROUP Command
 ///
@@ -457,6 +460,51 @@ typedef union {
   ARB_SVN_GET_INFO_ACK   Response;
 } ARB_SVN_GET_INFO_BUFFER;
 
+
+///
+/// OEM Key Revocation
+///
+typedef struct {
+  MKHI_MESSAGE_HEADER MkhiHeader;
+} OEM_KEY_REVOKE;
+
+typedef struct {
+  MKHI_MESSAGE_HEADER MkhiHeader;
+} OEM_KEY_REVOKE_ACK;
+
+typedef union {
+  OEM_KEY_REVOKE       Request;
+  OEM_KEY_REVOKE_ACK   Response;
+} OEM_KEY_REVOKE_BUFFER;
+
+
+typedef struct {
+  MKHI_MESSAGE_HEADER MkhiHeader;
+} OEM_KEY_STATUS_REQ;
+
+typedef struct {
+  UINT8               Valid;
+  UINT8               InUse;
+  UINT8               Revoked;
+  UINT8               KeyHash[64];
+} KEY_INFO;
+
+typedef struct {
+  UINT8               RevocationEnabled;
+  UINT8               NumKeySupported;
+  UINT32              KeyHashType;
+  KEY_INFO            Keys[2];
+} OEM_KEY_STATUS;
+
+typedef struct {
+  MKHI_MESSAGE_HEADER MkhiHeader;
+  OEM_KEY_STATUS      OemKeyStatus;
+} OEM_KEY_STATUS_ACK;
+
+typedef union {
+  OEM_KEY_STATUS_REQ   Request;
+  OEM_KEY_STATUS_ACK   Response;
+} OEM_KEY_STATUS_BUFFER;
 
 typedef union {
   UINT32 Data;

--- a/Silicon/QemuSocPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/QemuSocPkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -433,3 +433,23 @@ SetArbSvnCommit (
 {
   return EFI_UNSUPPORTED;
 }
+
+/**
+  Oem Key Revocation
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      Oem Key Revocation is successful.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+SetOemKeyRevocation (
+   IN  CHAR8     *CmdDataBuf,
+   IN  UINTN     CmdDataSize
+   )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/Silicon/TigerlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/TigerlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -491,3 +491,24 @@ SetArbSvnCommit (
 
   return Status;
 }
+
+/**
+  Oem Key Revocation
+
+  @param[in]  CmdDataBuf    Pointer to command buffer.
+  @param[in]  CmdDataSize   size of command data.
+
+  @retval  EFI_SUCCESS      Oem Key Revocation is successful.
+  @retval  others           Error happening when updating.
+
+**/
+EFI_STATUS
+EFIAPI
+SetOemKeyRevocation (
+   IN  CHAR8     *CmdDataBuf,
+   IN  UINTN     CmdDataSize
+   )
+{
+  return EFI_UNSUPPORTED;
+}
+


### PR DESCRIPTION
EHL, TGL supports multiple OEM keys and their revocation
by CSE. This patch supports,
- CMDI interface to perform key revocation using
  OEMKEYREVOCATION string in cmd file.
- EHL HECI APIs for OemkeyRevoke and to get key status
- FW components are sorted as per required order.
  CSME and BIOS should be signed with new keys and
  both components would go together with capsule update.
- CSME can be updated for same version.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>