### PR TITLE
Remove next line char during csme fw update

### DIFF
--- a/PayloadPkg/FirmwareUpdate/CsmeFwUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/CsmeFwUpdate.c
@@ -240,7 +240,7 @@ DisplaySendStatus (
   UINT32 value = bytesSentToFw * 100 / totalBytesToSendToFw;
 
   if (value != 100) {
-    DEBUG((DEBUG_ERROR, " Sending the update image to FW for verification:  [ %u%% ] \r \n", value));
+    DEBUG((DEBUG_ERROR, " Sending the update image to FW for verification:  [ %u%% ] \r", value));
   } else {
     DEBUG((DEBUG_ERROR, " Sending the update image to FW for verification:  [ COMPLETE ] \n"));
   }


### PR DESCRIPTION
This patch removed next line character printed during
progress update of csme firmware update, this would remove
lot of prints in the next line and show progress much more
user friendly.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>