### PR TITLE
[APL] Enable IA untrusted mode at end of SBL stage

### DIFF
--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -757,6 +757,19 @@ ClearFspHob (
 }
 
 /**
+  Set IA Untrust mode at the end.
+
+**/
+VOID
+EFIAPI
+EnterIaUnTrustMode (
+  VOID
+  )
+{
+  AsmMsrOr64 (EFI_MSR_POWER_MISC, B_EFI_MSR_POWER_MISC_ENABLE_IA_UNTRUSTED_MODE);
+}
+
+/**
   Set SPI flash EISS and LE and clear FSP HOBs.
 **/
 VOID
@@ -771,19 +784,9 @@ ProgramSecuritySetting (
 
   // Set the BIOS Lock Enable and EISS bits
   MmioOr8 (SpiBaseAddress + R_SPI_BCR, (UINT8) (B_SPI_BCR_BLE | B_SPI_BCR_EISS));
-}
 
-/**
-  Set IA Untrust mode at the end.
-
-**/
-VOID
-EFIAPI
-EnterIaUnTrustMode (
-  VOID
-  )
-{
-  AsmMsrOr64 (EFI_MSR_POWER_MISC, B_EFI_MSR_POWER_MISC_ENABLE_IA_UNTRUSTED_MODE);
+  // Enter untrust mode
+  EnterIaUnTrustMode ();
 }
 
 /**


### PR DESCRIPTION
Current APL SBL code will enable IA_UNTRUSTED mode only at end of
firmware notification. It might be too late for certain conditions.
This patch moves it to be set at end of stage in SBL. In this way,
it ensures the bit is set before launching any external payload.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>