### PR TITLE
Build option to disable os verified boot disable

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -283,4 +283,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdMultiUsbBootDeviceEnabled   | FALSE  | BOOLEAN | 0x20000219
   # Control if X2APIC should be used or not
   gPlatformCommonLibTokenSpaceGuid.PcdCpuX2ApicEnabled            | FALSE  | BOOLEAN | 0x20000220
+  # This PCD will disable the verified boot for OS load with OSloader
+  gPlatformCommonLibTokenSpaceGuid.PcdOsVerifiedBootDisabled     | FALSE      | BOOLEAN | 0x20000221
+
 

--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
@@ -391,7 +391,12 @@ AutheticateContainerInternal (
       AuthData = (UINT8 *)ContainerHdr + ALIGN_UP(ContainerHdrSize, AUTH_DATA_ALIGN);
       if ((AuthType == AUTH_TYPE_NONE) && FeaturePcdGet (PcdVerifiedBootEnabled)) {
         Status = EFI_SECURITY_VIOLATION;
-      } else {
+      } else if ((ContainerHeader->Signature == CONTAINER_BOOT_SIGNATURE)
+                                                    && FeaturePcdGet (PcdVerifiedBootEnabled)
+                                                    && FeaturePcdGet (PcdOsVerifiedBootDisabled)) {
+          DEBUG((DEBUG_INFO, "NOTE: OS VERIFIED BOOT DISABLED!!\n"));
+          Status = EFI_SUCCESS;
+        } else {
         Status = AuthenticateComponent ((UINT8 *)ContainerHdr, ContainerHdrSize,
                                         AuthType, AuthData, NULL,
                                         GetContainerKeyUsageBySig (ContainerHeader->Signature));

--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.inf
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.inf
@@ -31,3 +31,4 @@
   gPlatformCommonLibTokenSpaceGuid.PcdContainerMaxNumber
   gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdCompSignHashAlg
+  gPlatformCommonLibTokenSpaceGuid.PcdOsVerifiedBootDisabled

--- a/BootloaderCommonPkg/Library/TpmLib/TpmLib.c
+++ b/BootloaderCommonPkg/Library/TpmLib/TpmLib.c
@@ -780,7 +780,8 @@ TpmExtendSecureBootPolicy (
   EFI_STATUS                 Status;
   UINT8                      Data;
 
-  Data = FeaturePcdGet (PcdVerifiedBootEnabled);
+  // Check PcdVerifiedBootEnabled and PcdOsVerifiedBootDisabled for secure boot policy
+  Data = FeaturePcdGet (PcdVerifiedBootEnabled) && !(FeaturePcdGet (PcdOsVerifiedBootDisabled));
 
   Status = TpmHashAndExtendPcrEventLog (7, &Data, sizeof (Data), EV_EFI_VARIABLE_DRIVER_CONFIG, sizeof ("SecureBootPolicy"), (UINT8*)"SecureBootPolicy");
 

--- a/BootloaderCommonPkg/Library/TpmLib/TpmLib.inf
+++ b/BootloaderCommonPkg/Library/TpmLib/TpmLib.inf
@@ -44,6 +44,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdTpmLibId                  ## CONSUMES
   gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled       ## CONSUMES
   gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashMask      ## CONSUMES
+  gPlatformCommonLibTokenSpaceGuid.PcdOsVerifiedBootDisabled    ## CONSUMES
 
 [LibraryClasses]
   BaseLib

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -298,6 +298,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdMinDecompression    | FALSE
   gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootEnabled | $(HAVE_MEASURED_BOOT)
   gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled | $(HAVE_VERIFIED_BOOT)
+  gPlatformCommonLibTokenSpaceGuid.PcdOsVerifiedBootDisabled | $(OS_VERIFIED_BOOT_DISABLED)
   gPlatformModuleTokenSpaceGuid.PcdIntelGfxEnabled        | $(HAVE_VBT_BIN)
   gPlatformModuleTokenSpaceGuid.PcdAcpiEnabled            | $(HAVE_ACPI_TABLE)
   gPlatformModuleTokenSpaceGuid.PcdSmpEnabled             | $(ENABLE_SMP_INIT)

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -186,6 +186,7 @@ class BaseBoard(object):
         self.HAVE_FIT_TABLE        = 0
         self.HAVE_VERIFIED_BOOT    = 0
         self.HAVE_MEASURED_BOOT    = 0
+        self.OS_VERIFIED_BOOT_DISABLED          = 0
         self.HAVE_FSP_BIN          = 1
         self.HAVE_ACPI_TABLE       = 1
         self.HAVE_PSD_TABLE        = 0
@@ -1406,14 +1407,15 @@ def main():
             if args.board == name:
                 brdcfg = module_names[index]
                 board  = brdcfg.Board(
-                                        BUILD_ARCH        = args.arch.upper(), \
-                                        RELEASE_MODE      = args.release,     \
-                                        NO_OPT_MODE       = args.noopt,       \
-                                        FSPDEBUG_MODE     = args.fspdebug,    \
-                                        USE_VERSION       = args.usever,      \
-                                        _PAYLOAD_NAME     = args.payload,     \
-                                        _FSP_PATH_NAME    = args.fsppath,     \
-                                        KEY_GEN           = args.keygen
+                                        BUILD_ARCH                     = args.arch.upper(), \
+                                        RELEASE_MODE                   = args.release,     \
+                                        NO_OPT_MODE                    = args.noopt,       \
+                                        FSPDEBUG_MODE                  = args.fspdebug,    \
+                                        USE_VERSION                    = args.usever,      \
+                                        _PAYLOAD_NAME                  = args.payload,     \
+                                        _FSP_PATH_NAME                 = args.fsppath,     \
+                                        KEY_GEN                        = args.keygen,      \
+                                        OS_VERIFIED_BOOT_DISABLED      = args.noosverify
                                         );
                 os.environ['PLT_SOURCE']  = os.path.abspath (os.path.join (os.path.dirname (board_cfgs[index]), '../..'))
                 Build(board).build()
@@ -1429,6 +1431,7 @@ def main():
     buildp.add_argument('-p',  '--payload' , dest='payload', type=str, help='Payload file name', default ='OsLoader.efi')
     buildp.add_argument('board', metavar='board', choices=board_names, help='Board Name (%s)' % ', '.join(board_names))
     buildp.add_argument('-k', '--keygen', action='store_true', help='Generate default keys for signing')
+    buildp.add_argument('-n', '--noosverify', action='store_true', help='Disable verified boot for os loading. Use for debug')
     buildp.set_defaults(func=cmd_build)
 
     def cmd_clean(args):


### PR DESCRIPTION
Add -n to sbl build to disable verified boot while
loading os through osloader. Container header verification
would be disabled when this option is enabled. This option
is to be used for developer use only.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>