### PR TITLE
[EHL] Operational region for ACPI Control SMI_EN access

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/AcpiTables/Dsdt/Platform.asl
+++ b/Platform/ElkhartlakeBoardPkg/AcpiTables/Dsdt/Platform.asl
@@ -152,6 +152,14 @@ Field (SPRT, ByteAcc, Lock, Preserve) {
 
 }
 
+// Operational region for ACPI Control (SMI_EN) access
+//
+OperationRegion (SMIN, SystemIO, (ACPI_BASE_ADDRESS + R_ACPI_IO_SMI_EN), 0x4)
+Field (SMIN, AnyAcc, NoLock, Preserve)
+{
+  SMIE, 32
+}
+
 // The _PIC Control Method is optional for ACPI design.  It allows the
 // OS to inform the ASL code which interrupt controller is being used,
 // the 8259 or APIC.  The reference code in this document will address


### PR DESCRIPTION
SMIE is checked in Tpm asl before SMI is triggered.
Removal of this definition causes physical presence
usecases failure.

TEST=Verified TPM clear usecases with windows boots

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>