### PR TITLE
[EHL] Fix UART init issue and set UART PCI mode as default

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -1325,7 +1325,7 @@
       help         : >
                      Selects Uart operation mode. N represents controller index- Uart0, Uart1, ... Available modes- 0:SerialIoUartDisabled, 1:SerialIoUartPci, 2:SerialIoUartHidden, 3:SerialIoUartCom, 4:SerialIoUartSkipInit
       length       : 0x07
-      value        : { 0x01, 0x01, 0x02, 0x01, 0x01, 0x01, 0x01 }
+      value        : { 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01 }
   - SerialIoUartBaudRate :
       name         : Default BaudRate for each Serial IO UART
       type         : EditNum, HEX, (0x0,0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
@@ -42,7 +42,7 @@ FSPT_UPD TempRamInitParams = {
   .FsptConfig = {
     .PcdSerialIoUartDebugEnable = 1,
     .PcdSerialIoUartNumber      = FixedPcdGet32 (PcdDebugPortNumber),
-    .PcdSerialIoUartMode        = 2,
+    .PcdSerialIoUartMode        = 4,
     .PcdSerialIoUartBaudRate    = 115200,
     .PcdPciExpressBaseAddress   = FixedPcdGet32 (PcdPciMmcfgBase),
     .PcdPciExpressRegionLength  = 0x10000000,
@@ -54,7 +54,7 @@ FSPT_UPD TempRamInitParams = {
     .PcdSerialIoUartTxPinMux    = 0,
     .PcdSerialIoUartRtsPinMux   = 0,
     .PcdSerialIoUartCtsPinMux   = 0,
-    .PcdLpcUartDebugEnable      = 1,
+    .PcdLpcUartDebugEnable      = 0,
   },
   .UpdTerminator = 0x55AA,
 };

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1082,6 +1082,7 @@ UpdateFspConfig (
   UINT8       MaxSataPorts;
   UINT8       MaxUsb2Ports;
   UINT8       MaxUsb3Ports;
+  UINT8       DebugPort;
   UINT32      Index;
   UINT32      BaseAddress;
   UINT32      TotalSize;
@@ -1128,10 +1129,6 @@ UpdateFspConfig (
   // Ufs
   Fspscfg->UfsEnable[0]        = 0;
   Fspscfg->UfsEnable[1]        = 0;
-
-  if ( GetDebugPort () < PCH_MAX_SERIALIO_UART_CONTROLLERS) {
-    Fspscfg->SerialIoDebugUartNumber = GetDebugPort ();
-  }
 
   Fspscfg->DevIntConfigPtr     = (UINT32)(UINTN)mPchDevIntConfig;
   Fspscfg->NumOfDevIntConfig   = sizeof (mPchDevIntConfig) / sizeof (SI_PCH_DEVICE_INTERRUPT_CONFIG);
@@ -1415,6 +1412,12 @@ UpdateFspConfig (
       Fspscfg->SerialIoUartPowerGating[Index]     = SiCfgData->SerialIoUartPowerGating[Index];
       Fspscfg->SerialIoUartDmaEnable[Index]       = SiCfgData->SerialIoUartDmaEnable[Index];
       Fspscfg->SerialIoUartDbg2[Index]            = SiCfgData->SerialIoUartDbg2[Index];
+    }
+    DebugPort = GetDebugPort();
+    if (DebugPort < PCH_MAX_SERIALIO_UART_CONTROLLERS) {
+      Fspscfg->SerialIoDebugUartNumber = DebugPort;
+      // Skip FSP-S to reinitialize current UART port
+      Fspscfg->SerialIoUartMode[DebugPort] = 0x4;
     }
 
     // PCH I2C_CONFIG


### PR DESCRIPTION
This CL fixes the long time issue where EHL SBL failed to init
properly and solely relies on FSP to handle the UART unit, and
hence the limitation of Hidden Mode UART only, as we observed
the UART output gone missing after PCI enumeration if we set
respective UART port into PCI mode in FSP. By hiding the UART,
OS will not be able to see the UART device as PCI device and
lose control to the UART device.

Due to hardware design, different uart could use different
LPSS_IO_MEM_PCP register offset for UART clock setup.

This CL includes dynamic configuration for clock setup by
reading the size of UART control register. Since this is pretty
generic for most of platforms, will plan to move more UART codes
to common codes in the future.

Second fix changes the default UART mode for both FSP-T and FSP-S
to skip uart init, and let SBL solely handles it and setup as a
PCI device.

Signed-off-by: LeanSheng <lean.sheng.tan@intel.com>