### PR TITLE
[TGLU] Oem Key revocation feature support

### DIFF
--- a/Silicon/TigerlakePchPkg/Include/Library/HeciInitLib.h
+++ b/Silicon/TigerlakePchPkg/Include/Library/HeciInitLib.h
@@ -377,4 +377,18 @@ HeciArbSvnCommitMsg (
   VOID
   );
 
+/**
+  This command is used to indicate to the FW to revoke a OEM key.
+  It should be executed when MBP data indicates that a key is pending for
+  revocation.
+
+  @retval EFI_SUCCESS             Command succeeded
+  @retval EFI_UNSUPPORTED         Current ME mode doesn't support this function
+  @retval EFI_DEVICE_ERROR        HECI Device error, command aborts abnormally
+**/
+EFI_STATUS
+EFIAPI
+HeciRevokeOemKey (
+   VOID
+   );
 #endif

--- a/Silicon/TigerlakePchPkg/Library/HeciInitLib/HeciPeiDxe.c
+++ b/Silicon/TigerlakePchPkg/Library/HeciInitLib/HeciPeiDxe.c
@@ -494,3 +494,115 @@ HeciArbSvnGetInfoMsg (
   FreePool (ArbSvnGetInfo);
   return Status;
 }
+
+/**
+  The command is used to get the information about OEM keys, such as
+  key hash, revocation status, validity.
+
+  @param[in, out] OemKeyStatus    Status of OEM keys
+
+  @retval EFI_SUCCESS             Command succeeded
+  @retval EFI_UNSUPPORTED         Current ME mode doesn't support this function
+  @retval EFI_DEVICE_ERROR        HECI Device error, command aborts abnormally
+**/
+EFI_STATUS
+HeciGetOemKeyStatus(
+  IN OUT  OEM_KEY_STATUS *OemKeyStatus
+  )
+{
+  EFI_STATUS               Status;
+  UINT32                   Length;
+  UINT32                   RecvLength;
+  OEM_KEY_STATUS_BUFFER    OemKeyStatusBuff;
+  UINT32                   MeMode;
+
+  Status = HeciGetMeMode (&MeMode);
+  if (EFI_ERROR (Status) || (MeMode != ME_MODE_NORMAL)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  ZeroMem (&OemKeyStatusBuff, sizeof (OemKeyStatusBuff));
+  OemKeyStatusBuff.Request.MkhiHeader.Data           = 0;
+  OemKeyStatusBuff.Request.MkhiHeader.Fields.GroupId = MKHI_MCA_GROUP_ID;
+  OemKeyStatusBuff.Request.MkhiHeader.Fields.Command = MCA_GET_OEM_KEY_STATUS_CMD;
+  Length                                         = sizeof (OEM_KEY_STATUS_REQ);
+  RecvLength                                     = sizeof (OEM_KEY_STATUS_ACK);
+
+  Status = HeciSendwAck (
+                   HECI1_DEVICE,
+                   (UINT32 *) &OemKeyStatusBuff,
+                   Length,
+                   &RecvLength,
+                   BIOS_FIXED_HOST_ADDR,
+                   HECI_MCHI_MESSAGE_ADDR
+                   );
+
+  if (!EFI_ERROR (Status)) {
+      if ((OemKeyStatusBuff.Response.MkhiHeader.Fields.Command == MCA_GET_OEM_KEY_STATUS_CMD) &&
+            (OemKeyStatusBuff.Response.MkhiHeader.Fields.IsResponse == 1) &&
+            (OemKeyStatusBuff.Response.MkhiHeader.Fields.Result == 0)) {
+        CopyMem (OemKeyStatus, &OemKeyStatusBuff.Response.OemKeyStatus, sizeof(OEM_KEY_STATUS));
+    } else {
+      Status = EFI_DEVICE_ERROR;
+    }
+  }
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "HeciGetOemKeyStatus Result: %08x \n", OemKeyStatusBuff.Response.MkhiHeader.Fields.Result));
+  }
+
+  return Status;
+}
+
+
+/**
+  This command is used to indicate to the FW to revoke a OEM key.
+  It should be executed when MBP data indicates that a key is pending for
+  revocation.
+
+  @retval EFI_SUCCESS             Command succeeded
+  @retval EFI_UNSUPPORTED         Current ME mode doesn't support this function
+  @retval EFI_DEVICE_ERROR        HECI Device error, command aborts abnormally
+**/
+EFI_STATUS
+HeciRevokeOemKey (
+  VOID
+  )
+{
+  EFI_STATUS               Status;
+  UINT32                   Length;
+  UINT32                   RecvLength;
+  OEM_KEY_REVOKE_BUFFER    OemKeyRevoke;
+  UINT32                   MeMode;
+
+  Status = HeciGetMeMode (&MeMode);
+  if (EFI_ERROR (Status) || (MeMode != ME_MODE_NORMAL)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  ZeroMem (&OemKeyRevoke, sizeof (OEM_KEY_REVOKE_BUFFER));
+  OemKeyRevoke.Request.MkhiHeader.Data           = 0;
+  OemKeyRevoke.Request.MkhiHeader.Fields.GroupId = MKHI_MCA_GROUP_ID;
+  OemKeyRevoke.Request.MkhiHeader.Fields.Command = MCA_REVOKE_OEM_KEY_HASH_CMD;
+  Length                                         = sizeof (OEM_KEY_REVOKE);
+  RecvLength                                     = sizeof (OEM_KEY_REVOKE_ACK);
+
+  Status = HeciSendwAck (
+                   HECI1_DEVICE,
+                   (UINT32 *) &OemKeyRevoke,
+                   Length,
+                   &RecvLength,
+                   BIOS_FIXED_HOST_ADDR,
+                   HECI_MCHI_MESSAGE_ADDR
+                   );
+
+  if (!EFI_ERROR (Status) && OemKeyRevoke.Response.MkhiHeader.Fields.Result != MkhiStatusSuccess) {
+    Status = EFI_DEVICE_ERROR;
+  }
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "HeciRevokeOemKey Result: %08x \n", OemKeyRevoke.Response.MkhiHeader.Fields.Result));
+  }
+
+  return Status;
+}

--- a/Silicon/TigerlakePchPkg/Library/HeciInitLib/MbpData.c
+++ b/Silicon/TigerlakePchPkg/Library/HeciInitLib/MbpData.c
@@ -103,7 +103,10 @@ MbpDebugPrint (
     DEBUG ((DEBUG_INFO, " Flags         : 0x%x\n", MbpPtr->ArbSvnState.ArbSvnData.Flags));
     DEBUG ((DEBUG_INFO, " MinCseArbSvn  : 0x%x\n", MbpPtr->ArbSvnState.ArbSvnData.MinCseArbSvn));
     DEBUG ((DEBUG_INFO, " CurrCseArbSvn : 0x%x\n", MbpPtr->ArbSvnState.ArbSvnData.CurrCseArbSvn));
-    DEBUG ((DEBUG_INFO, " Reserved      : 0x%x\n", MbpPtr->ArbSvnState.ArbSvnData.Reserved));
+  }
+
+  if (MbpPtr->OemKeyRevoke.Available == TRUE) {
+    DEBUG ((DEBUG_INFO, "OemKeyRevocation Extension Available !! \n"));
   }
 
   DEBUG ((DEBUG_INFO, "\n------------------------ MeBiosPayload Data End--------------\n"));

--- a/Silicon/TigerlakePchPkg/Library/HeciInitLib/MeBiosPayloadData.h
+++ b/Silicon/TigerlakePchPkg/Library/HeciInitLib/MeBiosPayloadData.h
@@ -1,7 +1,7 @@
 /** @file
   Interface definition details for MBP.
 
-  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 #ifndef _ME_BIOS_PAYLOAD_DATA_H_
@@ -49,7 +49,7 @@ typedef union {
 #define MBP_ITEM_ID(ApplicationId, ItemId) ((ApplicationId << 4) | ItemId)
 
 #define MBP_ITEM_ID_MEASURED_BOOT     MBP_ITEM_ID(MbpAppIdKernel, MbpItemIdMeasuredBoot)
-
+#define MBP_ITEM_ID_OEM_KEY_REVOKE    MBP_ITEM_ID(MbpAppIdKernel, MbpItemIdOemKeyRevoke)
 
 //
 // Enum for AppId
@@ -71,7 +71,8 @@ typedef enum {
   MbpItemIdUnconfigOnRtc              = 8,
   MbpItemIdShipState                  = 9,
   MbpItemIdFwArbSvn                   = 14,
-  MbpItemIdMeasuredBoot               = 15
+  MbpItemIdMeasuredBoot               = 15,
+  MbpItemIdOemKeyRevoke               = 16
 } MBP_KERNEL_ITEM_ID;
 typedef enum {
   MbpItemIdHwaMtu = 1
@@ -202,6 +203,12 @@ typedef struct {
   UINT8                       Reserved[3];
 } MBP_MEASURED_BOOT_SUPPORT;
 
+typedef struct {
+  UINT32                      OemKeyDataRsrvd;
+  BOOLEAN                     Available;
+  UINT8                       Reserved[3];
+} MBP_OEM_KEY_REVOKE;
+
 ///
 /// ME BIOS Payload structure containing insensitive data only
 ///
@@ -217,6 +224,7 @@ typedef struct {
   MBP_IFWI_DNX_REQUEST       IfwiDnxRequest;
   MBP_ICC_PROFILE            IccProfile;
   MBP_MEASURED_BOOT_SUPPORT  MeasuredBootSupport;
+  MBP_OEM_KEY_REVOKE         OemKeyRevoke;
 } ME_BIOS_PAYLOAD;
 
 ///

--- a/Silicon/TigerlakePchPkg/Library/HeciInitLib/MkhiMsgs.h
+++ b/Silicon/TigerlakePchPkg/Library/HeciInitLib/MkhiMsgs.h
@@ -51,6 +51,8 @@ typedef union {
 #define MCA_READ_FILE_EX_CMD              0x0A
 #define MCA_ARB_SVN_COMMIT_CMD            0x1B
 #define MCA_ARB_SVN_GET_INFO_CMD          0x1C
+#define MCA_REVOKE_OEM_KEY_HASH_CMD       0x2F
+#define MCA_GET_OEM_KEY_STATUS_CMD        0x0D
 ///
 /// Defines for GEN_GROUP Command
 ///
@@ -448,6 +450,50 @@ typedef union {
   ARB_SVN_GET_INFO_ACK   Response;
 } ARB_SVN_GET_INFO_BUFFER;
 
+///
+/// OEM Key Revocation
+///
+typedef struct {
+  MKHI_MESSAGE_HEADER MkhiHeader;
+} OEM_KEY_REVOKE;
+
+typedef struct {
+  MKHI_MESSAGE_HEADER MkhiHeader;
+} OEM_KEY_REVOKE_ACK;
+
+typedef union {
+  OEM_KEY_REVOKE       Request;
+  OEM_KEY_REVOKE_ACK   Response;
+} OEM_KEY_REVOKE_BUFFER;
+
+
+typedef struct {
+  MKHI_MESSAGE_HEADER MkhiHeader;
+} OEM_KEY_STATUS_REQ;
+
+typedef struct {
+  UINT8               Valid;
+  UINT8               InUse;
+  UINT8               Revoked;
+  UINT8               KeyHash[64];
+} KEY_INFO;
+
+typedef struct {
+  UINT8               RevocationEnabled;
+  UINT8               NumKeySupported;
+  UINT32              KeyHashType;
+  KEY_INFO            Keys[2];
+} OEM_KEY_STATUS;
+
+typedef struct {
+  MKHI_MESSAGE_HEADER MkhiHeader;
+  OEM_KEY_STATUS      OemKeyStatus;
+} OEM_KEY_STATUS_ACK;
+
+typedef union {
+  OEM_KEY_STATUS_REQ   Request;
+  OEM_KEY_STATUS_ACK   Response;
+} OEM_KEY_STATUS_BUFFER;
 
 typedef union {
   UINT32 Data;

--- a/Silicon/TigerlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/TigerlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -509,6 +509,12 @@ SetOemKeyRevocation (
    IN  UINTN     CmdDataSize
    )
 {
-  return EFI_UNSUPPORTED;
-}
+  EFI_STATUS Status;
 
+  Status = HeciRevokeOemKey ();
+  if (EFI_ERROR (Status)) {
+    DEBUG((DEBUG_ERROR, "Oem Revoke Key status -  %r\n", Status));
+  }
+
+  return Status;
+}


### PR DESCRIPTION
TGL supports multiple OEM keys and their revocation
by CSE. This patch supports HECI APIs for OemkeyRevoke
and to get key status. This is port from TGLH platform
implemetation.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>