### PR TITLE
Update path for oem key manifets

### DIFF
--- a/Platform/CommonBoardPkg/Script/security_stitch_help.py
+++ b/Platform/CommonBoardPkg/Script/security_stitch_help.py
@@ -95,7 +95,7 @@ def update_btGuard_xml(btg_profile, stitch_dir, tree):
         node.attrib['value'] = '0x1'
 
         node = tree.find('./PlatformProtection/PlatformIntegrity/OemExtInputFile')
-        node.attrib['value'] = '$SourceDir\OemExtInputFile.bin'
+        node.attrib['value'] = os.path.join(output_dir, "OemExtInputFile.bin")
 
     node = tree.find('./PlatformProtection/BootGuardConfiguration/BtGuardProfileConfig')
     node.attrib['value'] = btg_profile_values[btguardprofile]


### PR DESCRIPTION
Some platforms FIT tool do not detect sourceDir.
Change to absoulte path.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>