### PR TITLE
[EHL] Fix SPI clock source gating s0ix issue

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/AcpiTables/Dsdt/Pch.asl
+++ b/Platform/ElkhartlakeBoardPkg/AcpiTables/Dsdt/Pch.asl
@@ -179,6 +179,34 @@ Scope (\_SB.PC00) {
     Name(_ADR,0x001F0004)
     Method(_DSM,4,serialized){if(PCIC(Arg0)) { return(PCID(Arg0,Arg1,Arg2,Arg3)) }; Return(Buffer() {0})}
   }
+
+  //
+  // SPI Bridge - Device 31, Function 5
+  //
+  Device(SPIF) {
+    Name(_ADR, 0x001F0005)
+
+    // It is expected for bootloader to check and clear SPI Synchronous SMI Status bit prior to S0ix entry,
+    // as this status bit might cause SPI driver unable to turn off clock source properly.
+    // This method will check if Synchronous SMI Status bit is on, then reenable Write Protect Disable bit
+    // and clear Synchronous SMI Status bit.
+    Method(SPIS)
+    {
+      If (LEqual (SYNS, 0x1)) {
+        store(0, WPDL)
+        store(1, SYNS)
+      }
+    }
+
+    OperationRegion(SPIC, PCI_Config, 0x00, 0x100)
+    Field(SPIC, AnyAcc, NoLock, Preserve)
+    {
+      Offset(R_LPC_CFG_BC), // 0xDC
+      WPDL,   1,
+      ,       7,
+      SYNS,   1,
+    }
+  }
 }
 Include("Pcr.asl")
 Include("Pmc.asl")

--- a/Platform/ElkhartlakeBoardPkg/AcpiTables/Dsdt/Pep.asl
+++ b/Platform/ElkhartlakeBoardPkg/AcpiTables/Dsdt/Pep.asl
@@ -6,6 +6,7 @@
 **/
 
 External(\_SB.PC00.DPOF)
+External(\_SB.PC00.SPIF.SPIS)
 
 If(LOr(LEqual(S0ID, 1),LGreaterEqual(OSYS, 2015))){
   Scope(\_SB.PC00.GFX0) {
@@ -870,6 +871,7 @@ Scope(\_SB)
           If(LEqual(S0ID, 1)) { //S0ID: >=1: CS 0: non-CS
             // call method specific to CS platforms when the system is in a
             // standby state with very limited SW activities
+            \_SB.PC00.SPIF.SPIS() - Clear SPI Synchronous SMI Status bit
             \GUAM(1) // 0x01 - Power State Standby (CS Resiliency Entry)
           }
         }


### PR DESCRIPTION
SPI clock source was on and gating s0ix entry, due to linux OS could
trigger SPI Write Protection Disable bit and hence set the SPI
Synchronous SMI Status bit. This CL fixes it by clearing the SPI
Synchronous SMI Status bit prior to S0ix entry.

Traditionally, it is expected for bootloader to clear this bit in
SMI handler upon S0ix entry, due to SBL being free of SMI, clearing
this bit from ACPI table has the same effect.

Signed-off-by: LeanSheng <lean.sheng.tan@intel.com>