### PR TITLE
Fix stack alignment issue in x64 build

### DIFF
--- a/BootloaderCorePkg/Library/MpInitLib/X64/MpFuncs.nasm
+++ b/BootloaderCorePkg/Library/MpInitLib/X64/MpFuncs.nasm
@@ -160,7 +160,6 @@ CallApFunc:
 
 BITS 64
 LongModeStart:
-    pop            rax
 
     ; Call C Function
     mov            eax, dword [esi + CProcedureLocation]


### PR DESCRIPTION
GCC x64 build requires stack to be aligned at 16 bytes. In MpInit
nasm file, SBL set the initial stack to be 16-byte aligned. However,
later on unbalanced push/pop breaks the 16-byte alignment. This
patch removed extra stack pop so that the stack will always stay at
the original initial value.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>