### PR TITLE
[EHL] HPET acpi fix for s0ix

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/AcpiTables/Dsdt/LpcDev.asl
+++ b/Platform/ElkhartlakeBoardPkg/AcpiTables/Dsdt/LpcDev.asl
@@ -7,7 +7,6 @@
 
 #include <Register/PmcRegs.h>
 
-External(\SDBG, MethodObj)
 
 Device(HPET)  // High Performance Event Timer
 {
@@ -39,6 +38,27 @@ Device(HPET)  // High Performance Event Timer
     }
 
     Return(BUF0)
+  }
+
+  OperationRegion(ETDI,SystemMemory,0xFED00000,0x1FF)
+  Field(ETDI, AnyAcc, NoLock, Preserve)
+  {
+    Offset(0),
+    GEID, 64,
+    Offset(0x10),
+    GECF, 64,
+    Offset(0x20),
+    GEST, 64,
+    Offset(0xF0),
+    MAIN, 64,
+    Offset(0x100),
+    TCN0, 8,
+    Offset(0x108),
+    TCM0, 8,
+    Offset(0x120),
+    TCN1, 8,
+    Offset(0x128),
+    TCM1, 8,
   }
 }
 

--- a/Platform/ElkhartlakeBoardPkg/AcpiTables/Dsdt/Pep.asl
+++ b/Platform/ElkhartlakeBoardPkg/AcpiTables/Dsdt/Pep.asl
@@ -7,6 +7,7 @@
 
 External(\_SB.PC00.DPOF)
 External(\_SB.PC00.SPIF.SPIS)
+External(\_SB.PC00.LPCB.HPET.TCN1)
 
 If(LOr(LEqual(S0ID, 1),LGreaterEqual(OSYS, 2015))){
   Scope(\_SB.PC00.GFX0) {
@@ -871,7 +872,8 @@ Scope(\_SB)
           If(LEqual(S0ID, 1)) { //S0ID: >=1: CS 0: non-CS
             // call method specific to CS platforms when the system is in a
             // standby state with very limited SW activities
-            \_SB.PC00.SPIF.SPIS() - Clear SPI Synchronous SMI Status bit
+            \_SB.PC00.SPIF.SPIS() // Clear SPI Synchronous SMI Status bit
+            Store(0x0000000000000000, \_SB.PC00.LPCB.HPET.TCN1)
             \GUAM(1) // 0x01 - Power State Standby (CS Resiliency Entry)
           }
         }


### PR DESCRIPTION
Fix typo error in \_SB.PC00.SPIF.SPIS()
De-assert the TIMER1_INT_ENB_CNF bit upon
entering s0ix in ACPI

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>