### PR TITLE
[TGL] Add TCC V2 support

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -49,6 +49,7 @@
   gEfiVariableIndexTableGuid                    = { 0x8cfdb8c8, 0xd6b2, 0x40f3, { 0x8e, 0x97, 0x02, 0x30, 0x7c, 0xc9, 0x8b, 0x7c } }
   gEdkiiWorkingBlockSignatureGuid               = { 0x9e58292b, 0x7c68, 0x497d, { 0xa0, 0xce, 0x65,  0x0, 0xfd, 0x9f, 0x1b, 0x95 } }
   gEdkiiFpdtExtendedFirmwarePerformanceGuid     = { 0x3b387bfd, 0x7abc, 0x4cf2, { 0xa0, 0xca, 0xb6, 0xa1, 0x6c, 0x1b, 0x1b, 0x25 } }
+  gTccRtctHobGuid                               = { 0x6bddb43d, 0x1782, 0x4d9c, { 0xb6, 0x80, 0xe3, 0xde, 0x45, 0xe0, 0x37, 0x4a } }
 
 [PcdsFixedAtBuild]
   gPlatformCommonLibTokenSpaceGuid.PcdMaxLibraryDataEntry    |          8 | UINT32 | 0x20000100
@@ -283,4 +284,4 @@
   gPlatformCommonLibTokenSpaceGuid.PcdMultiUsbBootDeviceEnabled   | FALSE  | BOOLEAN | 0x20000219
   # Control if X2APIC should be used or not
   gPlatformCommonLibTokenSpaceGuid.PcdCpuX2ApicEnabled            | FALSE  | BOOLEAN | 0x20000220
-
+  gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled                  | FALSE  | BOOLEAN | 0x20000221

--- a/BootloaderCommonPkg/Include/Guid/LoaderPlatformInfoGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/LoaderPlatformInfoGuid.h
@@ -26,6 +26,7 @@ extern EFI_GUID gLoaderPlatformInfoGuid;
 #define        FEATURE_MMC_FORCE_TUNING         BIT3
 #define        FEATURE_VERIFIED_BOOT            BIT4
 #define        FEATURE_PRE_OS_CHECKER_BOOT      BIT5
+#define        FEATURE_TCC_RUN_RTCM             BIT6
 
 //
 //Definition for LOADER_PLATFORM_INFO.HwState

--- a/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
+++ b/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
@@ -14,6 +14,7 @@
 #include <Guid/LoaderPlatformDataGuid.h>
 #include <Guid/DeviceTableHobGuid.h>
 #include <Guid/KeyHashGuid.h>
+#include <Guid/LoaderPlatformInfoGuid.h>
 #include <Library/BaseLib.h>
 #include <Library/CryptoLib.h>
 
@@ -53,15 +54,6 @@ typedef struct {
 } LOADER_COMPRESSED_HEADER;
 
 #pragma pack()
-
-//
-// Enabled features that might come from configuration data.
-//
-#define        FEATURE_ACPI                     BIT0
-#define        FEATURE_MEASURED_BOOT            BIT1
-#define        FEATURE_MMC_TUNING               BIT2
-#define        FEATURE_MMC_FORCE_TUNING         BIT3
-#define        FEATURE_VERIFIED_BOOT            BIT4
 
 #define MM_PCI_ADDRESS( Bus, Device, Function, Register ) \
   ( (UINTN)PcdGet64(PcdPciExpressBaseAddress) + \

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -308,6 +308,7 @@
   gPlatformModuleTokenSpaceGuid.PcdSplashEnabled          | $(ENABLE_SPLASH)
   gPlatformModuleTokenSpaceGuid.PcdFramebufferInitEnabled | $(ENABLE_FRAMEBUFFER_INIT)
   gPlatformModuleTokenSpaceGuid.PcdVtdEnabled             | $(ENABLE_VTD)
+  gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled          | $(ENABLE_TCC)
   gPlatformModuleTokenSpaceGuid.PcdPsdBiosEnabled         | $(HAVE_PSD_TABLE)
   gPayloadTokenSpaceGuid.PcdGrubBootCfgEnabled            | $(ENABLE_GRUB_CONFIG)
   gPlatformModuleTokenSpaceGuid.PcdSmbiosEnabled          | $(ENABLE_SMBIOS)

--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -1265,6 +1265,15 @@ PayloadMain (
   AddMeasurePoint (0x4020);
 
   //
+  // Load and run RTCM
+  //
+  if (FeaturePcdGet (PcdTccEnabled)) {
+    if ((LoaderPlatformInfo != NULL) && (LoaderPlatformInfo->LdrFeatures & FEATURE_TCC_RUN_RTCM)){
+      LoadAndRunRtcm();
+    }
+  }
+
+  //
   // Load PreOsChecker
   //
   if (LoaderPlatformInfo != NULL) {

--- a/PayloadPkg/OsLoader/OsLoader.h
+++ b/PayloadPkg/OsLoader/OsLoader.h
@@ -541,4 +541,18 @@ StartPreOsBooting (
   IN LOADED_IMAGE            *LoadedPreOsImage,
   IN LOADED_IMAGE            *LoadedImage
   );
+
+/**
+  Load and Run RTCM.
+
+  This function will load and run RTCM.
+
+  @retval  EFI_NOT_FOUND    RTCM binary file was not found.
+  @retval  EFI_LOAD_ERROR   RTCM binary file loading failed
+  @retval  EFI_SUCCESS      RTCM load and run successfully.
+**/
+EFI_STATUS
+LoadAndRunRtcm (
+  IN  VOID
+  );
 #endif

--- a/PayloadPkg/OsLoader/OsLoader.inf
+++ b/PayloadPkg/OsLoader/OsLoader.inf
@@ -1,5 +1,5 @@
 ## @file
-#  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -39,6 +39,7 @@
   PreOsSupport.c
   PreOsChecker.c
   ModService.c
+  Rtcm.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -112,6 +113,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdContainerBootEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdPreOsCheckerEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashMask
+  gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled
 
 [Depex]
   TRUE

--- a/PayloadPkg/OsLoader/Rtcm.c
+++ b/PayloadPkg/OsLoader/Rtcm.c
@@ -1,0 +1,83 @@
+/** @file
+
+  Copyright (c) 2019 - 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/BootloaderCommonLib.h>
+#include "OsLoader.h"
+
+#define SIGNATURE_IPFW    SIGNATURE_32 ('I', 'P', 'F', 'W')
+#define SIGNATURE_RTCM    SIGNATURE_32 ('T', 'C', 'C', 'R')
+
+typedef VOID (*RTCM_ENTRY)(VOID *Params);
+
+/**
+  Load and Run RTCM.
+
+  This function will load and run RTCM.
+
+  @retval  EFI_NOT_FOUND    RTCM binary file was not found.
+  @retval  EFI_LOAD_ERROR   RTCM binary file loading failed
+  @retval  EFI_SUCCESS      RTCM load and run successfully.
+**/
+EFI_STATUS
+LoadAndRunRtcm(
+  IN VOID
+)
+{
+  EFI_STATUS   Status;
+  UINT32       Length;
+  VOID         *Buffer;
+  VOID         *RtcmRunTimeBuffer;
+  RTCM_ENTRY   EntryPoint;
+  VOID         *RtcmEntry;
+
+  Buffer = NULL;
+  Length = 0;
+  RtcmRunTimeBuffer = 0;
+
+  Status = LoadComponent(SIGNATURE_IPFW, SIGNATURE_RTCM, &Buffer, &Length);
+  if (EFI_ERROR(Status) || (Buffer == NULL) || (Length == 0))
+  {
+    return EFI_NOT_FOUND;
+  }
+
+  if (!IsTePe32Image(Buffer, NULL))
+  {
+    DEBUG((DEBUG_INFO, "RTCM Image file is not a Pe32Imag \n"));
+    return EFI_LOAD_ERROR;
+  }
+
+  RtcmRunTimeBuffer = AllocateRuntimePages(EFI_SIZE_TO_PAGES(Length));
+  if (!RtcmRunTimeBuffer)
+  {
+    DEBUG((DEBUG_INFO, "Runtime memory allocation for RTCM failed \n"));
+    return EFI_LOAD_ERROR;
+  }
+
+  CopyMem(RtcmRunTimeBuffer, Buffer, (UINT32)(UINTN)Length);
+
+  Status = PeCoffRelocateImage((UINT32)(UINTN)RtcmRunTimeBuffer);
+  if (EFI_ERROR(Status))
+  {
+    DEBUG((DEBUG_INFO, "RTCM image relocation failed with Status: %r \n", Status));
+    return EFI_LOAD_ERROR;
+  }
+
+  Status = PeCoffLoaderGetEntryPoint(RtcmRunTimeBuffer, (VOID **)&RtcmEntry);
+  if (EFI_ERROR(Status))
+  {
+    DEBUG((DEBUG_INFO, "Get RTCM image EntryPoint failed with Status: %r \n", Status));
+    return EFI_LOAD_ERROR;
+  }
+
+  EntryPoint = (RTCM_ENTRY)(UINTN)RtcmEntry;
+  EntryPoint((VOID *)(UINTN)PcdGet32(PcdPayloadHobList));
+
+  return EFI_SUCCESS;
+}

--- a/Platform/CommonBoardPkg/CfgData/CfgData_Tcc.yaml
+++ b/Platform/CommonBoardPkg/CfgData/CfgData_Tcc.yaml
@@ -1,0 +1,52 @@
+## @file
+#
+#  Slim Bootloader CFGDATA Option File.
+#
+#  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+
+- $ACTION      :
+    page         : TCC:PLT:"TCC Features"
+- $ACTION      :
+    page         : TCC
+- TCC_CFG_DATA :
+  - !expand { CFGHDR_TMPL : [ TCC_CFG_DATA, 0x320, 0, 0 ] }
+  - TccEnable      :
+      name         : TCC Enable
+      type         : Combo
+      option       : 0:Disabled, 1:Enabled
+      help         : >
+                     Enable/Disable TCC feature. 1:TCC Enabled, 0:TCC Disabled
+      length       : 0x1
+      value        : 0x1
+  - TccTuning      :
+      name         : TCC DSO tuning Enable
+      type         : Combo
+      option       : 0:Disabled, 1:Enabled
+      help         : >
+                     Enable/Disable TCC Data Stream Optimizer(DSO) Tuning. 1:DSO Enabled, 0:DSO Disabled
+      length       : 0x1
+      value        : 0x1
+  - TccSoftSram    :
+      name         : TCC Software SRAM Enable
+      type         : Combo
+      option       : 0:Disabled, 1:Enabled
+      help         : >
+                     Enable/Disable TSoftware SRAM. 1:Enabled, 0: Disabled
+                     Enable will allocate part of LLC as SSRAM for TCC feature.
+      length       : 0x1
+      value        : 0x1
+  - TccRunRtcm     :
+      name         : Load and Run RTCM
+      type         : Combo
+      option       : 0:Disabled, 1:Enabled
+      help         : >
+                     Enable/Disable RTCM running from SBL. 1:Enabled, 0: Disabled
+                     Enable will make slim bootloader osloader payload to load and run TCC RTCM.
+                     This option doesn't have impact for UEFI payload (RTCM will not be loaded and run from SBL).
+      length       : 0x1
+      value        : 0x1
+


### PR DESCRIPTION
1) Add PCD PcdTccEnabled so that TCC could build out when disabled
2) Add HOB gTccRtctHobGuid produced by FSP if FSP support TCC V2
3) Add a common TCC config data in common platform package
4) Add RTCM support from OsLoader

Signed-off-by: Guo Dong <guo.dong@intel.com>