### PR TITLE
Fix firmware update version check

### DIFF
--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -1,7 +1,7 @@
 /** @file
 This driver is to update firmware in boot media.
 
-Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -51,6 +51,7 @@ VerifySblVersion (
   BOOT_LOADER_VERSION   *CurrentBlVersion;
   VOID                  *GuidHob;
   EFI_STATUS            Status;
+  EXT_BOOT_LOADER_VERSION  *ExtBlVersion;
 
   //
   // SVN check for BIOS
@@ -66,7 +67,8 @@ VerifySblVersion (
     DEBUG((DEBUG_ERROR, "Failed to get current firmware version\n"));
     return EFI_NOT_FOUND;
   }
-  CurrentBlVersion = (BOOT_LOADER_VERSION *)GET_GUID_HOB_DATA (GuidHob);
+  ExtBlVersion = (EXT_BOOT_LOADER_VERSION *)GET_GUID_HOB_DATA (GuidHob);
+  CurrentBlVersion = &ExtBlVersion->Version;
 
   //
   // Get base address of Stage 1A in capsule Image


### PR DESCRIPTION
As part of the commit e21c74f42ef7c455f22f34c9f2137e7747b0d3aa,
it used the HOB to get the firmware version info. However, the
HOB firmware version structure is not exactly the same as SBL
firmware version structure. It needs to be adjusted accordingly.
This patch addressed this issue.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>