### PR TITLE
Allow platform to create ACPI table dynamically

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -183,6 +183,7 @@
   gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsCnt       |     0x0000 | UINT16 | 0x20000199
   gPlatformModuleTokenSpaceGuid.PcdFuncCpuInitHook        | 0x00000000 | UINT32 | 0x2000019A
   gPlatformModuleTokenSpaceGuid.PcdFspsUpdPtr             | 0x00000000 | UINT32 | 0x2000019B
+  gPlatformModuleTokenSpaceGuid.PcdAcpiTableTemplatePtr   | 0x00000000 | UINT32 | 0x2000019C
 
   gPlatformModuleTokenSpaceGuid.PcdPciResAllocTableBase   | 0x00000000 | UINT32 | 0x200001A0
   gPlatformModuleTokenSpaceGuid.PcdPciResourceIoBase      | 0x00000000 | UINT32 | 0x200001A1

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -281,6 +281,7 @@
   gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsCnt  | 0x40
   gPlatformModuleTokenSpaceGuid.PcdFuncCpuInitHook   | 0x00000000
   gPlatformModuleTokenSpaceGuid.PcdFspsUpdPtr        | 0x00000000
+  gPlatformModuleTokenSpaceGuid.PcdAcpiTableTemplatePtr | 0
 
   gPlatformModuleTokenSpaceGuid.PcdPciResAllocTableBase    | 0x00000000
 

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
@@ -63,3 +63,4 @@
   gPlatformModuleTokenSpaceGuid.PcdSplashLogoAddress
   gPlatformModuleTokenSpaceGuid.PcdSplashEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdCpuX2ApicEnabled
+  gPlatformModuleTokenSpaceGuid.PcdAcpiTableTemplatePtr

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLibInternal.h
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLibInternal.h
@@ -18,6 +18,7 @@
 #include <Library/BootloaderCoreLib.h>
 #include <IndustryStandard/Acpi.h>
 
+#define  MAX_ACPI_TEMPLATE_NUM  16
 
 #define  ACPI_ALIGN()       (Current = (UINT8 *)ALIGN_POINTER (Current, 0x10))
 #define  ACPI_ALIGN_PAGE()  (Current = (UINT8 *)ALIGN_POINTER (Current, 0x1000))

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -5,61 +5,29 @@
 
 **/
 
-#include <PiPei.h>
-#include <Library/BaseLib.h>
-#include <Library/PciLib.h>
-#include <Library/BaseMemoryLib.h>
-#include <Library/DebugLib.h>
-#include <Library/IoLib.h>
-#include <Library/GpioLib.h>
-#include <Library/SiGpioLib.h>
-#include <Library/SpiFlashLib.h>
-#include <Library/SocInitLib.h>
-#include <Library/BoardInitLib.h>
-#include <Library/ConfigDataLib.h>
-#include <Library/SerialPortLib.h>
-#include <Library/VariableLib.h>
-#include <Library/BootloaderCoreLib.h>
-#include <Library/BlMemoryAllocationLib.h>
-#include <Library/FspSupportLib.h>
-#include <Library/BoardSupportLib.h>
-#include <Library/ContainerLib.h>
-#include <Guid/GraphicsInfoHob.h>
-#include <Guid/SystemTableInfoGuid.h>
-#include <Guid/SerialPortInfoGuid.h>
-#include <Guid/SmmInformationGuid.h>
-#include <FspsUpd.h>
-#include <BlCommon.h>
-#include <GlobalNvsArea.h>
-#include <PlatformBase.h>
-#include <ConfigDataDefs.h>
-#include "GpioTbl.h"
+#include <Stage2BoardInitLibInternal.h>
 
-#define GRAPHICS_DATA_SIG    SIGNATURE_32 ('Q', 'G', 'F', 'X')
+STATIC
+CONST EFI_ACPI_TEST_TABLE  mAcpiTestTableTemplate = {
+  {
+    SIGNATURE_32('T', 'E', 'S', 'T'),
+    sizeof (EFI_ACPI_TEST_TABLE),
+    1,     // Revision
+    0x00,  // Checksum will be updated at runtime
+    EFI_ACPI_OEM_ID,                 // OEM ID is a 6 bytes long field
+    EFI_ACPI_OEM_TABLE_ID,           // OEM Table ID(8 bytes long)
+    EFI_ACPI_OEM_REVISION,           // OEM Revision
+    EFI_ACPI_CREATOR_ID,             // Creator ID
+    EFI_ACPI_CREATOR_REVISION        // Creator Revision
+  },
+  0
+};
 
-typedef struct {
-  UINT32     Signature;
-  UINT32     ResX;
-  UINT32     ResY;
-} GRAPHICS_DATA;
-
-UINT8
-EFIAPI
-GetSerialPortStrideSize (
-  VOID
-);
-
-UINT32
-EFIAPI
-GetSerialPortBase (
-  VOID
-  );
-
-VOID
-EFIAPI
-EnableLegacyRegions (
-  VOID
-);
+STATIC
+CONST EFI_ACPI_COMMON_HEADER *mPlatformAcpiTblTmpl[] = {
+  (EFI_ACPI_COMMON_HEADER *)&mAcpiTestTableTemplate,
+  NULL
+};
 
 /**
   Test variable services.
@@ -233,6 +201,8 @@ BoardInit (
     if (!EFI_ERROR(Status)) {
       DumpHex (2, 0, Length > 16 ? 16 : Length, Buffer);
     }
+    // Prepare platform ACPI tempate
+    Status = PcdSet32S (PcdAcpiTableTemplatePtr, (UINT32)(UINTN)mPlatformAcpiTblTmpl);
     break;
 
   case PostPciEnumeration:

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -64,3 +64,4 @@
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegSize
   gPlatformModuleTokenSpaceGuid.PcdStage1BXip
   gPlatformModuleTokenSpaceGuid.PcdEnableSetup
+  gPlatformModuleTokenSpaceGuid.PcdAcpiTableTemplatePtr

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLibInternal.h
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLibInternal.h
@@ -1,0 +1,99 @@
+/** @file
+
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _STAGE2_BOARD_INIT_LIB_INTERNAL_H_
+#define _STAGE2_BOARD_INIT_LIB_INTERNAL_H_
+
+#include <PiPei.h>
+#include <Library/BaseLib.h>
+#include <Library/PciLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/IoLib.h>
+#include <Library/GpioLib.h>
+#include <Library/SiGpioLib.h>
+#include <Library/SpiFlashLib.h>
+#include <Library/SocInitLib.h>
+#include <Library/BoardInitLib.h>
+#include <Library/ConfigDataLib.h>
+#include <Library/SerialPortLib.h>
+#include <Library/VariableLib.h>
+#include <Library/BootloaderCoreLib.h>
+#include <Library/BlMemoryAllocationLib.h>
+#include <Library/FspSupportLib.h>
+#include <Library/BoardSupportLib.h>
+#include <Library/ContainerLib.h>
+#include <Guid/GraphicsInfoHob.h>
+#include <Guid/SystemTableInfoGuid.h>
+#include <Guid/SerialPortInfoGuid.h>
+#include <Guid/SmmInformationGuid.h>
+#include <FspsUpd.h>
+#include <BlCommon.h>
+#include <GlobalNvsArea.h>
+#include <PlatformBase.h>
+#include <ConfigDataDefs.h>
+#include "GpioTbl.h"
+
+#pragma pack (1)
+
+typedef struct {
+  EFI_ACPI_DESCRIPTION_HEADER      Header;
+  UINT64                           Reserved;
+} EFI_ACPI_TEST_TABLE;
+
+typedef struct {
+  UINT32     Signature;
+  UINT32     ResX;
+  UINT32     ResY;
+} GRAPHICS_DATA;
+
+#pragma pack ()
+
+
+#define  GRAPHICS_DATA_SIG         SIGNATURE_32 ('Q', 'G', 'F', 'X')
+
+#define  EFI_ACPI_OEM_ID           {'O','E','M','I','D',' '}   // OEMID 6 bytes long
+#define  EFI_ACPI_OEM_TABLE_ID     SIGNATURE_64('O','E','M','T','A','B','L','E') // OEM table id 8 bytes long
+#define  EFI_ACPI_OEM_REVISION     0x00000001
+#define  EFI_ACPI_CREATOR_ID       SIGNATURE_32('C','R','E','A')
+#define  EFI_ACPI_CREATOR_REVISION 0x01000001
+
+/**
+  Get serial port stride register size.
+
+  @retval  The serial port register stride size.
+
+**/
+UINT8
+EFIAPI
+GetSerialPortStrideSize (
+  VOID
+);
+
+/**
+  Get serial port register base address.
+
+  @retval  The serial port register base address.
+
+**/
+UINT32
+EFIAPI
+GetSerialPortBase (
+  VOID
+  );
+
+/**
+  Enable legacy region decoding.
+
+**/
+VOID
+EFIAPI
+EnableLegacyRegions (
+  VOID
+);
+
+#endif


### PR DESCRIPTION
This patch implemented a common method for platform to create ACPI
table dynamically. Platform can provide ACPI tempalte array through
PCD PcdAcpiTableTemplatePtr. If provided, ACPI core code will try to
call platform code to patch the table, and then install the table to
ACPI RSDT/XSDT.
It also added sample code implementation in QEMU to show case how to
do it from platform code.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>