### PR TITLE
Add extra images boot support

### DIFF
--- a/PayloadPkg/OsLoader/BootParameters.c
+++ b/PayloadPkg/OsLoader/BootParameters.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -300,14 +300,10 @@ UpdateOsParameters (
   }
 
   if ((CurrentBootOption->BootFlags & BOOT_FLAGS_EXTRA) != 0) {
-    //
-    // TODO:
-    // Extra image is loaded in LoadedExtraImages
-    // update OS boot parameter here.
-    //
-    DEBUG ((DEBUG_ERROR, "Warning: Extra image parameters are not handled yet.\n"));
-    if (LoadedExtraImages == NULL) {
-      DEBUG ((DEBUG_ERROR, "Warning: Extra image not loaded.\n"));
+    if ((LoadedExtraImages != NULL) && ((LoadedExtraImages->Flags & LOADED_IMAGE_RUN_EXTRA) != 0)) {
+      DEBUG ((DEBUG_INFO, "Extra image is loaded and will run before OS.\n"));
+    } else {
+      DEBUG ((DEBUG_ERROR, "Warning: Extra image not loaded, or need pass it to OS in boot parameter.\n"));
     }
   }
 

--- a/PayloadPkg/OsLoader/OsLoader.h
+++ b/PayloadPkg/OsLoader/OsLoader.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -74,6 +74,7 @@
 #define EOF                      "<eof>"
 #define GPT_PART_ENTRIES_MAX     4
 
+// For LOADED_IMAGE Flags
 #define LOADED_IMAGE_IAS         BIT0
 #define LOADED_IMAGE_MULTIBOOT   BIT1
 #define LOADED_IMAGE_LINUX       BIT2
@@ -81,6 +82,7 @@
 #define LOADED_IMAGE_FV          BIT4
 #define LOADED_IMAGE_CONTAINER   BIT5
 #define LOADED_IMAGE_COMPONENT   BIT6
+#define LOADED_IMAGE_RUN_EXTRA   BIT7
 
 #define MAX_EXTRA_FILE_NUMBER    16
 


### PR DESCRIPTION
Before normal OS boot, some images need run firstly.
These images will return to SBL after complete.
This patch uses OS boot option extra images to
support this use case.

It uses a string in the boot option to indicate this
container image need run before OS.
Container component name format: "!XXXX\YYYY:ZZZZ"
"XXXX" and "YYYY" are container and component signature.
For "ZZZZ", Value "POSN" means this component will be
run before OS. Value "POSR" means this component need
runtime memory to run it.

Signed-off-by: Guo Dong <guo.dong@intel.com>