### PR TITLE
Add TCC V2 support

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -1,7 +1,7 @@
 ## @file
 # Provides bootloader driver related package definitions.
 #
-# Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -49,6 +49,7 @@
   gEfiVariableIndexTableGuid                    = { 0x8cfdb8c8, 0xd6b2, 0x40f3, { 0x8e, 0x97, 0x02, 0x30, 0x7c, 0xc9, 0x8b, 0x7c } }
   gEdkiiWorkingBlockSignatureGuid               = { 0x9e58292b, 0x7c68, 0x497d, { 0xa0, 0xce, 0x65,  0x0, 0xfd, 0x9f, 0x1b, 0x95 } }
   gEdkiiFpdtExtendedFirmwarePerformanceGuid     = { 0x3b387bfd, 0x7abc, 0x4cf2, { 0xa0, 0xca, 0xb6, 0xa1, 0x6c, 0x1b, 0x1b, 0x25 } }
+  gTccRtctHobGuid                               = { 0x6bddb43d, 0x1782, 0x4d9c, { 0xb6, 0x80, 0xe3, 0xde, 0x45, 0xe0, 0x37, 0x4a } }
 
 [PcdsFixedAtBuild]
   gPlatformCommonLibTokenSpaceGuid.PcdMaxLibraryDataEntry    |          8 | UINT32 | 0x20000100
@@ -283,4 +284,4 @@
   gPlatformCommonLibTokenSpaceGuid.PcdMultiUsbBootDeviceEnabled   | FALSE  | BOOLEAN | 0x20000219
   # Control if X2APIC should be used or not
   gPlatformCommonLibTokenSpaceGuid.PcdCpuX2ApicEnabled            | FALSE  | BOOLEAN | 0x20000220
-
+  gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled                  | FALSE  | BOOLEAN | 0x20000221

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -1,7 +1,7 @@
 ## @file
 # Provides driver and definitions to build bootloader.
 #
-# Copyright (c) 2016 - 2020, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -309,6 +309,7 @@
   gPlatformModuleTokenSpaceGuid.PcdSplashEnabled          | $(ENABLE_SPLASH)
   gPlatformModuleTokenSpaceGuid.PcdFramebufferInitEnabled | $(ENABLE_FRAMEBUFFER_INIT)
   gPlatformModuleTokenSpaceGuid.PcdVtdEnabled             | $(ENABLE_VTD)
+  gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled          | $(ENABLE_TCC)
   gPlatformModuleTokenSpaceGuid.PcdPsdBiosEnabled         | $(HAVE_PSD_TABLE)
   gPayloadTokenSpaceGuid.PcdGrubBootCfgEnabled            | $(ENABLE_GRUB_CONFIG)
   gPlatformModuleTokenSpaceGuid.PcdSmbiosEnabled          | $(ENABLE_SMBIOS)

--- a/Platform/CommonBoardPkg/CfgData/CfgData_Tcc.yaml
+++ b/Platform/CommonBoardPkg/CfgData/CfgData_Tcc.yaml
@@ -1,0 +1,46 @@
+## @file
+#
+#  Slim Bootloader CFGDATA Option File.
+#
+#  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+
+- $ACTION      :
+    page         : TCC:PLT:"TCC Features"
+- $ACTION      :
+    page         : TCC
+- TCC_CFG_DATA :
+  - !expand { CFGHDR_TMPL : [ TCC_CFG_DATA, 0x320, 0, 0 ] }
+  - TccEnable      :
+      name         : TCC Enable
+      type         : Combo
+      option       : 0:Disabled, 1:Enabled
+      help         : >
+                     Enable/Disable TCC feature. 1:TCC Enabled, 0:TCC Disabled
+      length       : 0x1
+      value        : 0x1
+  - TccTuning      :
+      name         : TCC DSO tuning Enable
+      type         : Combo
+      option       : 0:Disabled, 1:Enabled
+      help         : >
+                     Enable/Disable TCC Data Stream Optimizer(DSO) Tuning. 1:DSO Enabled, 0:DSO Disabled
+      length       : 0x1
+      value        : 0x1
+  - TccSoftSram    :
+      name         : TCC Software SRAM Enable
+      type         : Combo
+      option       : 0:Disabled, 1:Enabled
+      help         : >
+                     Enable/Disable TSoftware SRAM. 1:Enabled, 0: Disabled
+                     Enable will allocate part of LLC as SSRAM for TCC feature.
+      length       : 0x1
+      value        : 0x1
+  - Dummy        :
+      length       : 0x1
+      value        : 0x0
+
+

--- a/Silicon/CommonSocPkg/Include/Library/TccLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/TccLib.h
@@ -1,0 +1,31 @@
+/** @file
+
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __TCC_LIB_H__
+#define __TCC_LIB_H__
+
+#define EFI_ACPI_RTCT_SIGNATURE           SIGNATURE_32('R', 'T', 'C', 'T')
+
+#include <Base.h>
+#include <IndustryStandard/Acpi60.h>
+
+/**
+  Update RTCT  (Platform Tuning Configuration Table) ACPI Table
+
+  @param[in] RtctTable          PTCT ACPI Table entry
+
+  @retval EFI_SUCCESS           The RTCT table is updated.
+  @retval EFI_NOT_FOUND         Loader Global Pointer or TccHob not found
+  @retval EFI_INVALID_PARAMETER RTCT table is NULL
+**/
+EFI_STATUS
+EFIAPI
+UpdateAcpiRtctTable (
+  IN EFI_ACPI_DESCRIPTION_HEADER *RtctTable
+  );
+
+#endif

--- a/Silicon/CommonSocPkg/Library/TccLib/TccLib.c
+++ b/Silicon/CommonSocPkg/Library/TccLib/TccLib.c
@@ -1,0 +1,84 @@
+/** @file
+
+  Copyright (c) 2020 Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <PiPei.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/HobLib.h>
+#include <Library/BootloaderCommonLib.h>
+#include <Library/BootloaderCoreLib.h>
+#include <Library/TccLib.h>
+#include "TccRtctHob.h"
+
+
+// ACPI Definations for RTCT Table
+#define EFI_ACPI_RTCT_TABLE_REVISION      0x1
+#define EFI_ACPI_RTCT_OEM_ID              "INTEL "  // OEMID 6 bytes long
+#define EFI_ACPI_RTCT_OEM_TABLE_ID        SIGNATURE_64('S','B','L',' ',' ',' ',' ',' ')
+#define EFI_ACPI_RTCT_OEM_REVISION        0x00000005
+#define EFI_ACPI_RTCT_CREATOR_ID          SIGNATURE_32('I','N','T','L')
+#define EFI_ACPI_RTCT_CREATOR_REVISION    0x0100000D
+
+
+/**
+  Update RTCT  (Platform Tuning Configuration Table) ACPI Table
+
+  @param[in] RtctTable          PTCT ACPI Table entry
+
+  @retval EFI_SUCCESS           The RTCT table is updated.
+  @retval EFI_NOT_FOUND         Loader Global Pointer or TccHob not found
+  @retval EFI_INVALID_PARAMETER RTCT table is NULL
+**/
+EFI_STATUS
+EFIAPI
+UpdateAcpiRtctTable (
+  IN EFI_ACPI_DESCRIPTION_HEADER *RtctTable
+  )
+{
+  VOID                          *FspHobList;
+  EFI_HOB_GUID_TYPE             *GuidHob;
+  EFI_ACPI_DESCRIPTION_HEADER   *HobRtctTable;
+
+  if (RtctTable == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  GuidHob    = NULL;
+  FspHobList = GetFspHobListPtr();
+  if (FspHobList != NULL) {
+    GuidHob = GetNextGuidHob (&gTccRtctHobGuid, FspHobList);
+  }
+
+  if (GuidHob == NULL) {
+    DEBUG ((DEBUG_INFO, "RTCT FSP HOB not found.\n"));
+    return EFI_NOT_FOUND;
+  }
+
+  //
+  // Copy RTCT table from HOB, the table Length is already updated by HOB.
+  //
+  HobRtctTable = (EFI_ACPI_DESCRIPTION_HEADER *)GET_GUID_HOB_DATA (GuidHob);
+  CopyMem (RtctTable, HobRtctTable, HobRtctTable->Length);
+
+  DEBUG ((DEBUG_INFO, "HobRtctTable = 0x%p, HobRtctTable->Length = 0x%x\n", HobRtctTable, HobRtctTable->Length));
+
+  //
+  // Update other fields in ACPI table header
+  //
+  RtctTable->Signature       = EFI_ACPI_RTCT_SIGNATURE;
+  RtctTable->Revision        = EFI_ACPI_RTCT_TABLE_REVISION;
+  RtctTable->Checksum        = 0;
+  CopyMem (&RtctTable->OemId, EFI_ACPI_RTCT_OEM_ID, 6);
+  RtctTable->OemTableId      = EFI_ACPI_RTCT_OEM_TABLE_ID;
+  RtctTable->OemRevision     = EFI_ACPI_RTCT_OEM_REVISION;
+  RtctTable->CreatorId       = EFI_ACPI_RTCT_CREATOR_ID;
+  RtctTable->CreatorRevision = EFI_ACPI_RTCT_CREATOR_REVISION;
+
+  return EFI_SUCCESS;
+}
+

--- a/Silicon/CommonSocPkg/Library/TccLib/TccLib.inf
+++ b/Silicon/CommonSocPkg/Library/TccLib/TccLib.inf
@@ -1,0 +1,39 @@
+## @file
+#
+#  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = TccLib
+  FILE_GUID                      = 39EFEBD9-864B-4186-8D99-CD40D7C9C7D9
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = TccLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  TccLib.c
+  TccRtctHob.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+  BootloaderCorePkg/BootloaderCorePkg.dec
+  Silicon/CommonSocPkg/CommonSocPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  HobLib
+  BootloaderCoreLib
+
+[Guids]
+  gTccRtctHobGuid

--- a/Silicon/CommonSocPkg/Library/TccLib/TccRtctHob.h
+++ b/Silicon/CommonSocPkg/Library/TccLib/TccRtctHob.h
@@ -1,0 +1,175 @@
+/** @file
+
+  Copyright (c) 2021 Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _TCC_RTCT_HOB_H_
+#define _TCC_RTCT_HOB_H_
+
+#include <Base.h>
+#include <IndustryStandard/Acpi60.h>
+
+extern EFI_GUID gTccRtctHobGuid;
+
+//
+// RTCT Version
+//
+#define RTCT_VERSION_MAJOR         2
+#define RTCT_VERSION_MINOR         0
+
+//
+// RTCT Entry Types
+//
+typedef enum {
+  RtctCompatibilityType           = 0x00000000,
+  RtctRtcdLimitsType              = 0x00000001,
+  RtctCrlBinaryType               = 0x00000002,
+  RtctIaWayMasksType              = 0x00000003,
+  RtctWrcWayMasksType             = 0x00000004,
+  RtctGtWayMasksType              = 0x00000005,
+  RtctSsramWayMaskType            = 0x00000006,
+  RtctSoftwareSramType            = 0x00000007,
+  RtctMemoryHierarchyLatencyType  = 0x00000008,
+  RtctErrorLogAddressType         = 0x00000009
+} RtctEntryTypes;
+
+///
+/// The TCC RTCT data HOB starts with EFI_ACPI_DESCRIPTION_HEADER
+/// EFI_ACPI_DESCRIPTION_HEADER.Length has the actual data lengh for this HOB
+/// including the ACPI header.
+/// Following the EFI_ACPI_DESCRIPTION_HEADER, it is the various TCC entries
+///
+
+#pragma pack (push,1)
+
+//
+// RTCT Entry Header
+//
+typedef struct {
+  UINT16  Size;
+  UINT16  Version;
+  UINT32  Type;
+} RTCT_HEADER_ENTRY;
+
+
+#define RTCT_COMPATABILITY_VERSION 1
+
+//
+// RTCT Compatability Entry
+//
+typedef struct {
+  RTCT_HEADER_ENTRY Header;
+  UINT32            RtctVersionMajor;
+  UINT32            RtctVersionMinor;
+  UINT32            RtcdVersionMajor;
+  UINT32            RtcdVersionMinor;
+} RTCT_COMPATABILITY;
+
+
+#define RTCT_RTCD_LIMITS_VERSION 2
+
+//
+// RTCT RTCD Limits Entry
+//
+typedef struct {
+  RTCT_HEADER_ENTRY Header;
+  UINT32            MaxIaL2Cos;
+  UINT32            MaxIaL3Cos;
+  UINT32            MaxL2Instances;
+  UINT32            MaxL3Instances;
+  UINT32            MaxGtCos;
+  UINT32            MaxWrcCos;
+  UINT32            MaxTccStreams;
+  UINT32            MaxTccRegisters;
+} RTCT_RTCD_LIMITS;
+
+
+#define RTCT_CRL_BINARY_VERSION 1
+
+//
+// RTCT CRL Binary Entry
+//
+typedef struct {
+  RTCT_HEADER_ENTRY Header;
+  UINT64            Address;
+  UINT32            Size;
+} RTCT_CRL_BINARY;
+
+
+#define RTCT_IA_WAY_MASKS_VERSION 1
+//
+// RTCT IA Way Masks Entry
+//
+//
+typedef struct {
+  RTCT_HEADER_ENTRY Header;
+  UINT32            CacheLevel;
+  UINT32            CacheId;
+  UINT32            WayMask[0];
+} RTCT_IA_WAY_MASKS;
+
+
+#define RTCT_WRC_WAY_MASKS_VERSION 2
+
+//
+// RTCT WRC Way Mask Entry
+//
+typedef struct {
+  RTCT_HEADER_ENTRY Header;
+  UINT32            CacheLevel;
+  UINT32            CacheId;
+  UINT32            WayMask;
+} RTCT_WRC_WAY_MASKS;
+
+#define RTCT_GT_WAY_MASKS_VERSION 1
+
+//
+// RTCT GT Way Mask Entry
+//
+typedef struct {
+  RTCT_HEADER_ENTRY Header;
+  UINT32            CacheLevel;
+  UINT32            CacheId;
+  UINT32            WayMask[0];
+} RTCT_GT_WAY_MASKS;
+
+#define RTCT_SSRAM_WAY_MASK_VERSION 1
+//
+// RTCT SSRAM Way Mask Entry
+//
+typedef struct {
+  RTCT_HEADER_ENTRY Header;
+  UINT32            CacheLevel;
+  UINT32            CacheId;
+  UINT32            WayMask;
+} RTCT_SSRAM_WAY_MASK;
+
+#define RTCT_SOFTWARE_SRAM_VERSION 2
+
+//
+// Rtct Software SRAM Entry
+//
+typedef struct {
+  RTCT_HEADER_ENTRY Header;
+  UINT32            CacheLevel;
+  UINT32            CacheId;
+  UINT64            Base;
+  UINT32            Size;
+  UINT32            Shared;
+} RTCT_SOFTWARE_SRAM;
+
+#define RTCT_MEMORY_HIERARCHY_LATENCY_VERSION 2
+//
+// RTCT Memory Hierarchy Latency Entry
+//
+typedef struct {
+  RTCT_HEADER_ENTRY Header;
+  UINT32            Hierarchy;
+  UINT32            ClockCycles;
+  UINT32            ClockCyclesVt;
+  UINT32            CacheId[0];
+} RTCT_MEMORY_HIERARCHY_LATENCY;
+
+#pragma pack (pop)
+
+#endif


### PR DESCRIPTION
1) Add PCD PcdTccEnabled so that TCC could build out when disabled
2) Add HOB gTccRtctHobGuid produced by FSP if FSP support TCC V2
3) Add a common TCC config data in common platform package
4) Add a common TCC lib to update TCC RTCT table.

Signed-off-by: Guo Dong <guo.dong@intel.com>