### PR TITLE
[UP2] GPIO fix for PCIe slot

### DIFF
--- a/Platform/ApollolakeBoardPkg/CfgData/CfgData_Ext_Up2.dlt
+++ b/Platform/ApollolakeBoardPkg/CfgData/CfgData_Ext_Up2.dlt
@@ -34,3 +34,6 @@ PCIE_RP_CFG_DATA.PcieRpFeatures3.En      | 0x1
 PCIE_RP_CFG_DATA.PcieRpFeatures5.En      | 0x1
 PCIE_RP_CFG_DATA.PcieRpFeatures2.ClkReqNum | 0x0
 PCIE_RP_CFG_DATA.PcieRpFeatures4.ClkReqNum | 0x2
+
+GPIO_CFG_DATA.GPIO_213_Half1.DefValue    | 1
+GPIO_CFG_DATA.GPIO_213_Half1.Direction   | 2


### PR DESCRIPTION
This patch configured UP2 GPIO213 default to be output with level
high. It will select the PCIe interface as default. The original
default was mSATA.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>