### PR TITLE
Add CLANG toolchain build support

### DIFF
--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/ippbase.h
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/ippbase.h
@@ -22,7 +22,12 @@
 extern "C" {
 #endif
 
-#if defined( _WIN32 ) || defined ( _WIN64 )
+#if defined(__clang__)
+  #define __STDCALL   __attribute__((stdcall))
+  #define __CDECL     __attribute__((cdecl))
+  #define __INT64     long long
+  #define __UINT64    unsigned long long
+#elif defined( _WIN32 ) || defined ( _WIN64 )
   #define __STDCALL  __stdcall
   #define __CDECL    __cdecl
   #define __INT64    __int64
@@ -30,9 +35,10 @@ extern "C" {
 #else
   #define __STDCALL
   #define __CDECL
-  #define __INT64    long long
+  #define __INT64     long long
   #define __UINT64    unsigned long long
 #endif
+
 
 #define IPP_PI    ( 3.14159265358979323846 )  /* ANSI C does not support M_PI */
 #define IPP_2PI   ( 6.28318530717958647692 )  /* 2*pi                         */

--- a/BootloaderCommonPkg/Library/IppCryptoLib/rsa_verify.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/rsa_verify.c
@@ -169,6 +169,8 @@ int VerifyRsaPssSignature (CONST PUB_KEY_HDR *PubKeyHdr, CONST SIGNATURE_HDR *Si
   Ipp8u *bn_buf_ptr;
   const IppsHashMethod  *pHashMethod = NULL;
 
+  scratch_buf = NULL;
+
   signature_verified = 0;
 
   rsa_n = (Ipp8u *) PubKeyHdr->KeyData;
@@ -248,10 +250,10 @@ int VerifyRsaPssSignature (CONST PUB_KEY_HDR *PubKeyHdr, CONST SIGNATURE_HDR *Si
   }
 
   if ((SignatureHdr->HashAlg == HASH_TYPE_SHA256)
-          && (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_256)){
+          && ((FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_256) != 0)){
     pHashMethod = ippsHashMethod_SHA256();
   } else if ((SignatureHdr->HashAlg == HASH_TYPE_SHA384)
-          && (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_384)){
+          && ((FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_384) != 0)){
      pHashMethod = ippsHashMethod_SHA384();
   }
 
@@ -262,7 +264,7 @@ int VerifyRsaPssSignature (CONST PUB_KEY_HDR *PubKeyHdr, CONST SIGNATURE_HDR *Si
   }
 
   Done:
-    if (scratch_buf) {
+    if (scratch_buf != NULL) {
       FreeTemporaryMemory (scratch_buf);
     }
     if (bn_buf) {

--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -203,6 +203,22 @@ class PciEnumPolicyInfo(Structure):
         self.BusScanType        = 0
         self.NumOfBus           = 0
 
+
+def get_clang_info ():
+    if os.name == 'posix':
+        toolchain_path   = ''
+    else:
+        # On windows, still need visual studio to provide nmake build utility
+        toolchain, toolchain_prefix, toolchain_path, toolchain_ver = get_visual_studio_info ()
+        os.environ['CLANG_HOST_BIN'] =  os.path.join(toolchain_path, "bin\\Hostx64\\x64\\n")
+        toolchain_path   = 'C:\\Program Files\\LLVM\\bin\\'
+    toolchain        = 'CLANGPDB'
+    toolchain_prefix = 'CLANG_BIN'
+    clang_path = os.path.join(toolchain_path, 'clang')
+    clang_ver  = run_process ([clang_path, '-dumpversion'], capture_out = True)
+    toolchain_ver = clang_ver.strip()
+    return (toolchain, toolchain_prefix, toolchain_path, toolchain_ver)
+
 def get_visual_studio_info (preference = ''):
 
     toolchain        = ''

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -72,23 +72,32 @@ def prep_env (toolchain_preferred = ''):
         clang_ver = clang_ver.strip()
         toolchain_ver = clang_ver
     elif os.name == 'posix':
-        toolchain = 'GCC49'
-        gcc_ver = run_process (['gcc', '-dumpversion'], capture_out = True)
-        gcc_ver = gcc_ver.strip()
-        if int(gcc_ver.split('.')[0]) > 4:
-            toolchain = 'GCC5'
-        os.environ['PATH'] = os.environ['PATH'] + ':' + os.path.join(sblsource, 'BaseTools/BinWrappers/PosixLike')
-        toolchain_ver = gcc_ver
+        if toolchain_preferred.startswith('clang'):
+            os.environ['PATH'] = os.environ['PATH'] + ':' + os.path.join(sblsource, 'BaseTools/BinWrappers/PosixLike')
+            toolchain, toolchain_prefix, toolchain_path, toolchain_ver = get_clang_info ()
+        else:
+            toolchain = 'GCC49'
+            gcc_ver = run_process (['gcc', '-dumpversion'], capture_out = True)
+            gcc_ver = gcc_ver.strip()
+            if int(gcc_ver.split('.')[0]) > 4:
+                toolchain = 'GCC5'
+            os.environ['PATH'] = os.environ['PATH'] + ':' + os.path.join(sblsource, 'BaseTools/BinWrappers/PosixLike')
+            toolchain_ver = gcc_ver
     elif os.name == 'nt':
         os.environ['PATH'] = os.environ['PATH'] + ';' + os.path.join(sblsource, 'BaseTools\\Bin\\Win32')
         os.environ['PATH'] = os.environ['PATH'] + ';' + os.path.join(sblsource, 'BaseTools\\BinWrappers\\WindowsLike')
         os.environ['PYTHONPATH'] = os.path.join(sblsource, 'BaseTools', 'Source', 'Python')
-
-        toolchain, toolchain_prefix, toolchain_path, toolchain_ver = get_visual_studio_info (toolchain_preferred)
+        if toolchain_preferred.startswith('clang'):
+            toolchain, toolchain_prefix, toolchain_path, toolchain_ver = get_clang_info ()
+            if not toolchain:
+                print("Could not find supported CLANG version !")
+        else:
+            toolchain, toolchain_prefix, toolchain_path, toolchain_ver = get_visual_studio_info (toolchain_preferred)
+            if not toolchain:
+                print("Could not find supported Visual Studio version !")
         if toolchain:
             os.environ[toolchain_prefix] = toolchain_path
         else:
-            print("Could not find supported Visual Studio version !")
             sys.exit(1)
         if 'NASM_PREFIX' not in os.environ:
             os.environ['NASM_PREFIX'] = "C:\\Nasm\\"


### PR DESCRIPTION
This patch will enable CLANG toolchain build on Windows.  Currently
CLANG toolchain build still needs Visual Studio to provide nmake
utility.
To build with CLANG, please add build option "-t clang". It assume
CLANG is installed at default path. It has been tested with SBL
QEMU x86 build.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>