### PR TITLE
Fix the boot option

### DIFF
--- a/PayloadPkg/OsLoader/LoadImage.c
+++ b/PayloadPkg/OsLoader/LoadImage.c
@@ -822,14 +822,15 @@ LoadBootImages (
   LoadedImagesInfo->Signature = LOADED_IMAGES_INFO_SIGNATURE;
 
   for (Index = 0; Index < LoadImageTypeMax; Index++) {
-    if ((Index == LoadImageTypePreOs) && !(BootFlags & BOOT_FLAGS_PREOS)) {
+    if ((Index == LoadImageTypePreOs) && ((BootFlags & BOOT_FLAGS_PREOS) == 0)) {
       continue;
     }
     if (Index == LoadImageTypeMisc) {
       continue;
     }
-    if ((Index >= LoadImageTypeExtra0) && !(BootFlags & BOOT_FLAGS_EXTRA)) {
-      if (!BootImage[Index].LbaImage.Valid) {
+
+    if (Index >= LoadImageTypeExtra0) {
+      if (((BootFlags & BOOT_FLAGS_EXTRA) == 0) || (BootImage[Index].LbaImage.Valid == 0)) {
         continue;
       }
     }
@@ -853,7 +854,7 @@ LoadBootImages (
       Status = GetBootImageFromRawPartition (OsBootOption, LoadedImage);
     }
 
-    DEBUG ((DEBUG_INFO, "LoadBootImage ImageType-%d Image\n", Index));
+    DEBUG ((DEBUG_INFO, "LoadBootImage ImageType-%d %r\n", Index, Status));
     LoadedImagesInfo->LoadedImageList[Index] = LoadedImage;
 
     if (EFI_ERROR (Status)) {

--- a/Platform/CommonBoardPkg/CfgData/Template_BootOption.yaml
+++ b/Platform/CommonBoardPkg/CfgData/Template_BootOption.yaml
@@ -2,7 +2,7 @@
 #
 #  Slim Bootloader Platform CFGDATA Template File.
 #
-#  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -18,10 +18,12 @@ BOOT_OPTION_TMPL: >
     - ImageType_$(1) :
         name         : Image Type
         type         : Combo
-        option       : 0:Default, 1:Android, 2:ClearLinux, 3:Acrn, 4:Fastboot, 0xFE:Addendum, 0xFF:Not used
+        option       : 0:Default, 1:Android, 2:ClearLinux, 3:Acrn, 4:Fastboot, 0x1E:Extra image, 0x9E:PreOS image, 0xFF:Not used
         help         : >
                        Specify boot image type.
-                       Specially 'Addendum' indicates this option is not a standalone boot option. Instead, it provides additional information for the previous boot option.
+                       Extra and PreOS image type indicates this option is not a standalone boot option. Instead, it provides additional information for the previous boot option.
+                       Extra image means load and run extra image before normal OS image. The extra image will return to SBL and SBL will continue run normal OS.
+                       PreOs image means load and run PreOS image before normal OS image. SBL prepares normal OS info and passes to PreOS so the PreOs will not return to SBL.
                        'Not used' indicates this option will be ignored.
         length       : 0x01
         value        : $(2)


### PR DESCRIPTION
When PreOS is configured from OS boot option data, the common function
FillBootOptionListFromCfgData () need update it to OS correct boot option
image LoadImageTypePreOs. Similarly when extra image is specified, need
update to extra image.
Update ImageType value and fix an image load issue for RTCM.

Signed-off-by: Guo Dong <guo.dong@intel.com>