### PR TITLE
Thunk support from 32bit to 64bit

### DIFF
--- a/BootloaderCommonPkg/Include/Library/PagingLib.h
+++ b/BootloaderCommonPkg/Include/Library/PagingLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -179,6 +179,16 @@ JumpToLongMode (
   IN  UINT64                Context1,  OPTIONAL
   IN  UINT64                Context2,  OPTIONAL
   IN  UINT64                NewStack
+  );
+
+/**
+  Load page table for long mode.
+
+**/
+VOID
+EFIAPI
+LoadPageTableForLongMode (
+  VOID
   );
 
 /**

--- a/BootloaderCommonPkg/Library/ThunkLib/Ia32/DispatchExecute.c
+++ b/BootloaderCommonPkg/Library/ThunkLib/Ia32/DispatchExecute.c
@@ -3,7 +3,7 @@
   Provide a thunk function to transition from long mode to compatibility mode to execute 32-bit code and then transit
   back to long mode.
 
-  Copyright (c) 2014 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -13,6 +13,26 @@
 #include <Library/PagingLib.h>
 
 typedef EFI_STATUS (EFIAPI *EXECUTE_32BIT_CODE) (UINT32 Param1, UINT32 Param2);
+
+/**
+  Wrapper for a thunk to switch to long mode to execute 64-bit code and then
+  switch back to 32-bit mode.
+
+  @param[in] Function     The 64bit code entry to be executed.
+  @param[in] Param1       The first parameter to pass to 64bit code.
+  @param[in] Param2       The second parameter to pass to 64bit code.
+  @param[in] Unused       Unused.
+
+  @return Status.         Status returned from the calling function.
+**/
+EFI_STATUS
+EFIAPI
+AsmExecute64BitCode (
+  IN UINT64           Function,
+  IN UINT64           Param1,
+  IN UINT64           Param2,
+  IN UINT64           Unused
+  );
 
 /**
   Wrapper for a thunk  to transition from long mode to compatibility mode to execute 32-bit code and then transit back to
@@ -45,12 +65,12 @@ Execute32BitCode (
 
 /**
   Jump into funciton in X64 mode.
-  This function will not return.
+  This function will return back to 32bit mode.
 
-  @param[in] Function     The 32bit code entry to be executed.
-  @param[in] Param1       The first parameter to pass to 32bit code.
-  @param[in] Param2       The second parameter to pass to 32bit code.
-  @param[in] ExeInMem     If thunk needs to be executed from memory copy.
+  @param[in] Function     The 64bit code entry to be executed.
+  @param[in] Param1       The first parameter to pass to 64bit code.
+  @param[in] Param2       The second parameter to pass to 64bit code.
+  @param[in] ExeInMem     Not used.
 
   @return EFI_SUCCESS     Dummy return value.
 **/
@@ -63,14 +83,17 @@ Execute64BitCode (
   IN BOOLEAN     ExeInMem
   )
 {
-  UINTN          NewStack;
+  EFI_STATUS       Status;
 
-  NewStack = 0;
-  JumpToLongMode ((UINT64)(UINTN)Function,
-                  (UINT64)(UINTN)Param1,
-                  (UINT64)(UINTN)Param2,
-                  (UINT64)(UINTN)&NewStack);
+  LoadPageTableForLongMode ();
 
-  return EFI_SUCCESS;
+  Status = AsmExecute64BitCode (
+              (UINT64)(UINTN)Function,
+              (UINT64)(UINTN)Param1,
+              (UINT64)(UINTN)Param2,
+              (UINT64)(UINTN)0
+           );
+
+  return Status;
 }
 

--- a/BootloaderCommonPkg/Library/ThunkLib/Ia32/Thunk32To64.nasm
+++ b/BootloaderCommonPkg/Library/ThunkLib/Ia32/Thunk32To64.nasm
@@ -1,0 +1,120 @@
+;
+; Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;
+; Module Name:
+;
+;    Thunk32To64To.nasm
+;
+; Abstract:
+;
+;   This is the assembly code to transition from compatibility mode to long mode
+;   to execute 64-bit code and then transit back to compatibility mode.
+;
+;-------------------------------------------------------------------------------
+    DEFAULT REL
+    SECTION .text
+
+;----------------------------------------------------------------------------
+; Procedure:    AsmExecute64BitCode
+;
+; Input:        None
+;
+; Output:       None
+;
+; Prototype:    UINT32
+;               AsmExecute64BitCode (
+;                 IN UINT64           Function,
+;                 IN UINT64           Param1,
+;                 IN UINT64           Param2,
+;                 IN UINT64           GdtrPtr
+;                 );
+;
+;
+; Description:  A thunk function to execute 64-bit code.
+;
+;----------------------------------------------------------------------------
+global ASM_PFX(AsmExecute64BitCode)
+ASM_PFX(AsmExecute64BitCode):
+    push    ebp
+    mov     ebp, esp
+    push    ebx
+
+    sub     esp, 8
+    sidt    [esp]                       ; save IDT
+    sub     esp, 8
+    sgdt    [esp]                       ; save GDT
+
+    cli
+    push    0x38                        ; seg for far retf
+    push    LongModeStart               ; off for far retf
+    mov     eax, cr4
+    or      al, (1 << 5)
+    mov     cr4, eax                    ; enable PAE
+    mov     ecx, 0xc0000080
+    rdmsr
+    or      ah, 1                       ; set LME
+    wrmsr
+    mov     eax, cr0
+    bts     eax, 31                     ; set PG
+    mov     cr0, eax                    ; enable paging
+    retf                                ; topmost 2 dwords hold the address
+
+LongModeStart:
+BITS 64
+    mov     eax, [ebp + 8]              ; function address
+    mov     ecx, [ebp + 16]             ; arg1
+    mov     edx, [ebp + 24]             ; arg2
+    mov     ebp, esp                    ; save esp
+    add     rsp, -0x20                  ; add rsp, -20h
+    and     rsp, -0x10                  ; align to 16
+    call    rax                         ; call rbx
+    mov     rbx, rax                    ; convert status to 32bit
+    shr     rbx, 32
+    or      ebx, eax
+    mov     rax, 0x10                   ; load compatible mode code selector
+    shl     rax, 32
+    mov     edx, Compatible             ; assume address < 4G
+    or      rax, rdx
+    push    rax
+    retf
+
+Compatible:
+BITS 32
+    ; Reload DS/ES/SS to make sure they are correct referred to current GDT
+    mov     ax, 0x18                    ; load compatible mode data selector
+    mov     ds, ax
+    mov     es, ax
+    mov     ss, ax
+
+    ; Disable paging
+    mov     eax, cr0
+    btc     eax, 31
+    mov     cr0, eax
+
+    ; Clear EFER.LME
+    mov     ecx, 0xC0000080
+    rdmsr
+    btc     eax, 8
+    wrmsr
+
+    ; clear CR4 PAE
+    mov     eax, cr4
+    btc     eax, 5
+    mov     cr4, eax
+
+    ; Restore stack pointer
+    mov     esp, ebp
+
+    ; Restore GDT/IDT
+    lgdt    [esp]
+    add     esp, 8
+    lidt    [esp]
+    add     esp, 8
+
+    mov     eax, ebx
+    pop     ebx
+    pop     ebp
+    ret
+

--- a/BootloaderCommonPkg/Library/ThunkLib/ThunkLib.inf
+++ b/BootloaderCommonPkg/Library/ThunkLib/ThunkLib.inf
@@ -18,6 +18,7 @@
 
 [Sources.IA32]
   Ia32/DispatchExecute.c
+  Ia32/Thunk32To64.nasm
 
 [Sources.X64]
   X64/DispatchExecute.c


### PR DESCRIPTION
This patch added thunk support from 32bit to 64bit. It allows SBL
to call 64bit API entry from 32 bit compatible mode.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>