### PR TITLE
[QEMU] Allow to run specific test case

### DIFF
--- a/Platform/QemuBoardPkg/Script/qemu_test.py
+++ b/Platform/QemuBoardPkg/Script/qemu_test.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
-## @ qemu_fwu.py
+## @ qemu_test.py
 #
 # QEMU test script
 #
-# Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -11,9 +11,16 @@ import os
 import sys
 import shutil
 import subprocess
-
+import fnmatch
 
 def main():
+    if len(sys.argv) > 1:
+        if sys.argv[1].endswith('.py'):
+            test_pat = sys.argv[1]
+        else:
+            test_pat = sys.argv[1] + '.py'
+    else:
+        test_pat = '*.py'
 
     sbl_img = 'Outputs/qemu/SlimBootloader.bin'
     tst_img = 'Outputs/qemu/SblFwuTest.bin'
@@ -33,6 +40,10 @@ def main():
     ]
 
     for test_file, test_args in test_cases:
+        filtered = fnmatch.filter([test_file], test_pat)
+        if len(filtered) == 0:
+            continue
+
         print ('######### Running run test %s' % test_file)
         # copy a test image so that the original image will not change
         shutil.copyfile (sbl_img, tst_img)
@@ -47,7 +58,7 @@ def main():
             return -3
         print ('######### Completed test %s\n\n' % test_file)
 
-    print ('\nAll tests passed !\n')
+    print ('\nAll test cases passed !\n')
 
     return 0
 


### PR DESCRIPTION
This patch added argument support for qemu_test.py so that a
specified test case can be launched separately. Wilecard chars
are supported for the test case name.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>