### PR TITLE
Print Payload ID in human readable format

### DIFF
--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
@@ -736,9 +736,19 @@ LoadComponentWithCallback (
   BOOLEAN                   IsInFlash;
   COMPONENT_CALLBACK_INFO   CbInfo;
   UINT32                    ComponentId;
+  UINT64                    ContainerIdBuf;
+  UINT64                    ComponentIdBuf;
 
   ComponentId = ContainerSig;
   CompLoc = 0;
+
+  ComponentIdBuf = ComponentName;
+  if (ContainerSig < COMP_TYPE_INVALID) {
+    ContainerIdBuf = FLASH_MAP_SIG_HEADER;
+  } else {
+    ContainerIdBuf = ContainerSig;
+  }
+  DEBUG ((DEBUG_INFO, "Loading Component %4a:%4a\n", (CHAR8 *)&ContainerIdBuf, (CHAR8 *)&ComponentIdBuf));
 
   if (ContainerSig < COMP_TYPE_INVALID) {
     // Check if it is component type

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -68,11 +68,11 @@ PreparePayload (
   UINT32                         Dst;
   UINT32                         DstLen;
   VOID                          *DstAdr;
-  BOOLEAN                        IsNormalPld;
   UINT32                         PayloadId;
   UINT32                         ContainerSig;
   UINT32                         ComponentName;
   UINT8                          BootMode;
+  UINT64                         SignatureBuf;
 
   BootMode = GetBootMode();
   //
@@ -83,13 +83,11 @@ PreparePayload (
   }
   // Load payload to PcdPayloadLoadBase.
   PayloadId   = GetPayloadId ();
-  DEBUG ((DEBUG_INFO, "Loading Payload ID 0x%08X\n", PayloadId));
-  IsNormalPld = (PayloadId == 0) ? TRUE : FALSE;
   if (BootMode == BOOT_ON_FLASH_UPDATE) {
     ContainerSig  = COMP_TYPE_PAYLOAD_FWU;
     ComponentName = FLASH_MAP_SIG_FWUPDATE;
   } else {
-    if (IsNormalPld) {
+    if (PayloadId == 0) {
       ContainerSig  = COMP_TYPE_PAYLOAD;
       ComponentName = FLASH_MAP_SIG_PAYLOAD;
     } else {
@@ -97,6 +95,8 @@ PreparePayload (
       ComponentName = PayloadId;
     }
   }
+  SignatureBuf = ComponentName;
+  DEBUG ((DEBUG_INFO, "Loading Payload ID %4a\n", (CHAR8 *)&SignatureBuf));
 
   Dst = PcdGet32 (PcdPayloadExeBase);
   if (FixedPcdGetBool (PcdPayloadLoadHigh)) {


### PR DESCRIPTION
This patch printed Playload ID in human readable string format
instead of HEX string.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>