### PR TITLE
[PCI] Disable PCI devices bus master by default

### DIFF
--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
@@ -1224,9 +1224,13 @@ EnablePciDevice (
   CurrentLink = Parent->ChildList.ForwardLink;
   while (CurrentLink != NULL && CurrentLink != &Parent->ChildList) {
     PciIoDevice = PCI_IO_DEVICE_FROM_LINK (CurrentLink);
-    PciExpressOr16 (PciIoDevice->Address + PCI_COMMAND_OFFSET, \
-                    EFI_PCI_COMMAND_IO_SPACE | EFI_PCI_COMMAND_MEMORY_SPACE | EFI_PCI_COMMAND_BUS_MASTER);
+    PciExpressOr16 (PciIoDevice->Address + PCI_COMMAND_OFFSET,
+                    EFI_PCI_COMMAND_IO_SPACE | EFI_PCI_COMMAND_MEMORY_SPACE);
     if (PciIoDevice->ChildList.ForwardLink != &PciIoDevice->ChildList) {
+      if (IS_PCI_BRIDGE (&(PciIoDevice->Pci))) {
+        PciExpressOr16 (PciIoDevice->Address + PCI_COMMAND_OFFSET,
+                        EFI_PCI_COMMAND_BUS_MASTER);
+      }
       EnablePciDevice (PciIoDevice);
     }
     CurrentLink = CurrentLink->ForwardLink;


### PR DESCRIPTION
This will disable all PCI bus master by default, and enable it only if
- the original bus master was enabled before PCI enumeration
- Or the device is PCI Bridge

Signed-off-by: Aiden Park <aiden.park@intel.com>