### PR TITLE
Delay SMRR enabling

### DIFF
--- a/BootloaderCorePkg/Library/MpInitLib/Ia32/MpFuncs.nasm
+++ b/BootloaderCorePkg/Library/MpInitLib/Ia32/MpFuncs.nasm
@@ -336,3 +336,20 @@ ASM_PFX(AsmMtrrSynchUpExit):
 
     ret
 
+BITS 16
+global ASM_PFX(mDefaultSmiHandlerStart)
+global ASM_PFX(mDefaultSmiHandlerRet)
+global ASM_PFX(mDefaultSmiHandlerEnd)
+ASM_PFX(mDefaultSmiHandlerStart):
+    ; Enable valid bit in SMRR mask
+    mov ecx, 01f3h
+    rdmsr
+    cmp eax, 0
+    jz  ASM_PFX(mDefaultSmiHandlerRet)
+    or  eax, (1<<11)
+    wrmsr
+ASM_PFX(mDefaultSmiHandlerRet):
+    rsm
+ASM_PFX(mDefaultSmiHandlerEnd):
+    nop
+

--- a/BootloaderCorePkg/Library/MpInitLib/X64/MpFuncs.nasm
+++ b/BootloaderCorePkg/Library/MpInitLib/X64/MpFuncs.nasm
@@ -360,3 +360,20 @@ ASM_PFX(AsmMtrrSynchUpExit):
 
     ret
 
+
+BITS 16
+global ASM_PFX(mDefaultSmiHandlerStart)
+global ASM_PFX(mDefaultSmiHandlerRet)
+global ASM_PFX(mDefaultSmiHandlerEnd)
+ASM_PFX(mDefaultSmiHandlerStart):
+    ; Enable valid bit in SMRR mask
+    mov ecx, 01f3h
+    rdmsr
+    cmp eax, 0
+    jz  ASM_PFX(mDefaultSmiHandlerRet)
+    or  eax, (1<<11)
+    wrmsr
+ASM_PFX(mDefaultSmiHandlerRet):
+    rsm
+ASM_PFX(mDefaultSmiHandlerEnd):
+    nop

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -554,6 +554,12 @@ SecStartup (
   BoardInit (PrePayloadLoading);
   AddMeasurePoint (0x30E0);
 
+  // Trigger SMI to enable SMRR valid bit if required
+  if (SmmRebaseMode == SMM_REBASE_ENABLE) {
+    SendSmiIpiAllExcludingSelf ();
+    SendSmiIpi (GetApicId());
+  }
+
   // Continue boot flow
   if (ACPI_ENABLED() && (BootMode == BOOT_ON_S3_RESUME)) {
     S3ResumePath (Stage2Param);

--- a/BootloaderCorePkg/Stage2/Stage2.h
+++ b/BootloaderCorePkg/Stage2/Stage2.h
@@ -39,6 +39,7 @@
 #include <Library/SortLib.h>
 #include <Library/StageLib.h>
 #include <Library/ThunkLib.h>
+#include <Library/LocalApicLib.h>
 #include <Library/ContainerLib.h>
 #include <Guid/BootLoaderServiceGuid.h>
 #include <Guid/BootLoaderVersionGuid.h>

--- a/BootloaderCorePkg/Stage2/Stage2.inf
+++ b/BootloaderCorePkg/Stage2/Stage2.inf
@@ -67,6 +67,7 @@
   SortLib
   StageLib
   ThunkLib
+  LocalApicLib
 
 [Guids]
   gFspReservedMemoryResourceHobGuid


### PR DESCRIPTION
When SMRR is enabled too early, it blocked TSEG access in Stage2.
And it caused S3 related issues. This patch delays the SMRR enabling
to be after PrePayloadLoading BoardInit().

Signed-off-by: Maurice Ma <maurice.ma@intel.com>