### PR TITLE
[WHL] Clear power button status on normal boot flow

### DIFF
--- a/Silicon/CoffeelakePkg/Include/Register/PchRegsPmc.h
+++ b/Silicon/CoffeelakePkg/Include/Register/PchRegsPmc.h
@@ -20,6 +20,7 @@
 #define R_ACPI_IO_PM1_STS                        0x00
 #define B_ACPI_IO_PM1_STS_WAK                    BIT15
 #define B_ACPI_IO_PM1_STS_PRBTNOR                BIT11
+#define B_ACPI_IO_PM1_STS_PRBTN                  BIT8
 #define R_ACPI_IO_PM1_EN_MASK                    0xFFFF0000
 #define B_ACPI_IO_PM1_EN_PWRBTN_EN               BIT24
 


### PR DESCRIPTION
When S3 resume fails for some reason, the power button status will
be not be cleared on next boot. It might trigger shutdown event in
payload. This patch will clear power button status bit on normal
boot flow so that system can still boot properly.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>