### PR TITLE
Enhance SMM rebase check condition

### DIFF
--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
@@ -175,7 +175,6 @@ CpuInit (
         break;
       }
     }
-    ASSERT (CpuIdx < SmmBaseInfo->SmmBaseHdr.Count);
   } else if (PcdGet8 (PcdSmmRebaseMode) == SMM_REBASE_ENABLE) {
     SmmRebase (Index, ApicId, 0);
   }
@@ -275,7 +274,7 @@ BspInit (
   DEBUG ((DEBUG_INFO, " BSP APIC ID: %d\n", mSysCpuInfo.CpuInfo[0].ApicId));
 
 
-  if (PcdGet8 (PcdSmmRebaseMode) == SMM_REBASE_ENABLE) {
+  if ((PcdGet8 (PcdSmmRebaseMode) == SMM_REBASE_ENABLE) || (mMpDataStruct.SmmRebaseDoneCounter > 0)) {
     // Check SMM rebase result
     if (mMpDataStruct.SmmRebaseDoneCounter != 1) {
       CpuHalt ("CPU SMM rebase failed!\n");
@@ -476,7 +475,7 @@ MpInit (
         DEBUG ((DEBUG_INFO, " CPU %2d APIC ID: %d\n", Index, mSysCpuInfo.CpuInfo[Index].ApicId));
       }
 
-      if (PcdGet8 (PcdSmmRebaseMode) == SMM_REBASE_ENABLE) {
+      if ((PcdGet8 (PcdSmmRebaseMode) == SMM_REBASE_ENABLE) || (mMpDataStruct.SmmRebaseDoneCounter > 0)) {
         // Check SMM rebase result
         if (mMpDataStruct.SmmRebaseDoneCounter != CpuCount) {
           CpuHalt ("CPU SMM rebase failed!\n");


### PR DESCRIPTION
Current SBL SMM rebasing check is only performed when PcdSmmRebaseMode
is enabled. It does not cover the case to boot UEFI payload. This patch
enhaced the check to cover UEFI payload S3 path as well.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>