### PR TITLE
Fix buffer overflow for copy in S3SaveRestore lib

### DIFF
--- a/BootloaderCorePkg/Include/Library/S3SaveRestoreLib.h
+++ b/BootloaderCorePkg/Include/Library/S3SaveRestoreLib.h
@@ -116,6 +116,7 @@ TriggerPayloadSwSmi (
   designated for S3 save/restore purpose.
 
   @param    DataPtr               Address of the structure to be copied to TSEG
+  @param    IsHdrOnly             Reserve TotalSize, but populate only Header info
 
   @retval   EFI_OUT_OF_RESOURCES  If SmmSize is exceeding 4KiB
   @retval   EFI_OUT_OF_RESOURCES  If appeding new struct exceeds SmmSize
@@ -125,7 +126,8 @@ TriggerPayloadSwSmi (
 EFI_STATUS
 EFIAPI
 AppendS3Info (
-  IN  VOID    *DataPtr
+  IN  VOID     *DataPtr,
+  IN  BOOLEAN   IsHdrOnly
   );
 
 

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1077,12 +1077,12 @@ BoardInit (
       //
       mSmmBaseInfo.SmmBaseHdr.Count     = (UINT8) MpGetInfo()->CpuCount;
       mSmmBaseInfo.SmmBaseHdr.TotalSize = sizeof(BL_PLD_COMM_HDR) + mSmmBaseInfo.SmmBaseHdr.Count * sizeof(CPU_SMMBASE);
-      Status = AppendS3Info ((VOID *)&mSmmBaseInfo);
+      Status = AppendS3Info ((VOID *)&mSmmBaseInfo, TRUE);
       //
       // Set REG_INFO struct in TSEG region except 'Val' for regs
       //
       mS3SaveReg.S3SaveHdr.TotalSize = sizeof(BL_PLD_COMM_HDR) + mS3SaveReg.S3SaveHdr.Count * sizeof(REG_INFO);
-      AppendS3Info ((VOID *)&mS3SaveReg);
+      AppendS3Info ((VOID *)&mS3SaveReg, FALSE);
     }
     break;
   case EndOfStages:

--- a/Platform/CometlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CometlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1142,12 +1142,12 @@ BoardInit (
       //
       mSmmBaseInfo.SmmBaseHdr.Count     = (UINT8) MpGetInfo()->CpuCount;
       mSmmBaseInfo.SmmBaseHdr.TotalSize = sizeof(BL_PLD_COMM_HDR) + mSmmBaseInfo.SmmBaseHdr.Count * sizeof(CPU_SMMBASE);
-      Status = AppendS3Info ((VOID *)&mSmmBaseInfo);
+      Status = AppendS3Info ((VOID *)&mSmmBaseInfo, TRUE);
       //
       // Set REG_INFO struct in TSEG region except 'Val' for regs
       //
       mS3SaveReg.S3SaveHdr.TotalSize = sizeof(BL_PLD_COMM_HDR) + mS3SaveReg.S3SaveHdr.Count * sizeof(REG_INFO);
-      AppendS3Info ((VOID *)&mS3SaveReg);
+      AppendS3Info ((VOID *)&mS3SaveReg, FALSE);
     }
     break;
   case EndOfStages:

--- a/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1140,12 +1140,12 @@ BoardInit (
       //
       mSmmBaseInfo.SmmBaseHdr.Count     = (UINT8) MpGetInfo()->CpuCount;
       mSmmBaseInfo.SmmBaseHdr.TotalSize = sizeof(BL_PLD_COMM_HDR) + mSmmBaseInfo.SmmBaseHdr.Count * sizeof(CPU_SMMBASE);
-      Status = AppendS3Info ((VOID *)&mSmmBaseInfo);
+      Status = AppendS3Info ((VOID *)&mSmmBaseInfo, TRUE);
       //
       // Set REG_INFO struct in TSEG region except 'Val' for regs
       //
       mS3SaveReg.S3SaveHdr.TotalSize = sizeof(BL_PLD_COMM_HDR) + mS3SaveReg.S3SaveHdr.Count * sizeof(REG_INFO);
-      AppendS3Info ((VOID *)&mS3SaveReg);
+      AppendS3Info ((VOID *)&mS3SaveReg, FALSE);
     }
     break;
   case EndOfStages:

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -809,9 +809,9 @@ BoardInit (
       if (GetBootMode() != BOOT_ON_S3_RESUME) {
         mSmmBaseInfo.SmmBaseHdr.Count     = (UINT8) MpGetInfo()->CpuCount;
         mSmmBaseInfo.SmmBaseHdr.TotalSize = sizeof(BL_PLD_COMM_HDR) + mSmmBaseInfo.SmmBaseHdr.Count * sizeof(CPU_SMMBASE);
-        Status = AppendS3Info ((VOID *)&mSmmBaseInfo);
+        Status = AppendS3Info ((VOID *)&mSmmBaseInfo, TRUE);
         mS3SaveReg.S3SaveHdr.TotalSize = sizeof(BL_PLD_COMM_HDR) + mS3SaveReg.S3SaveHdr.Count * sizeof(REG_INFO);
-        AppendS3Info ((VOID *)&mS3SaveReg);
+        AppendS3Info ((VOID *)&mS3SaveReg, FALSE);
       }
     }
     if ((GetBootMode() != BOOT_ON_FLASH_UPDATE) && (GetPayloadId() != 0)) {

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -987,12 +987,12 @@ BoardInit (
         //
         mSmmBaseInfo.SmmBaseHdr.Count     = (UINT8) MpGetInfo()->CpuCount;
         mSmmBaseInfo.SmmBaseHdr.TotalSize = sizeof(BL_PLD_COMM_HDR) + mSmmBaseInfo.SmmBaseHdr.Count * sizeof(CPU_SMMBASE);
-        Status = AppendS3Info ((VOID *)&mSmmBaseInfo);
+        Status = AppendS3Info ((VOID *)&mSmmBaseInfo, TRUE);
         //
         // Set REG_INFO struct in TSEG region except 'Val' for regs
         //
         mS3SaveReg.S3SaveHdr.TotalSize = sizeof(BL_PLD_COMM_HDR) + mS3SaveReg.S3SaveHdr.Count * sizeof(REG_INFO);
-        AppendS3Info ((VOID *)&mS3SaveReg);
+        AppendS3Info ((VOID *)&mS3SaveReg, FALSE);
       }
     }
     if ((GetBootMode() != BOOT_ON_FLASH_UPDATE) && (GetPayloadId() != 0)) {


### PR DESCRIPTION
For appending Save/Restore structs in TSEG area,
bootloader should reserve space for TotalSize and
for certain structs, only header info should be
actually populated. Rest should be all Zeros.

Signed-off-by: Talamudupula <stalamudupula@gmail.com>