### PR TITLE
[EHL] Fix CFGDATA issues on EHL

### DIFF
--- a/BootloaderCorePkg/Tools/GenCfgData.py
+++ b/BootloaderCorePkg/Tools/GenCfgData.py
@@ -873,7 +873,7 @@ class CGenCfgData:
                     try:
                         (op_val, op_str) = option.split(':')
                     except:
-                        raise SystemExit ("Exception: Invalide option format '%s' !" % option)
+                        raise SystemExit ("Exception: Invalid option format '%s' for item '%s' !" % (option, item['cname']))
                     tmp_list.append((op_val, op_str))
         return  tmp_list
 

--- a/BootloaderCorePkg/Tools/GenCfgDataDsc.py
+++ b/BootloaderCorePkg/Tools/GenCfgDataDsc.py
@@ -1655,7 +1655,7 @@ EndList
                     try:
                         (OpVal, OpStr) = Option.split(':')
                     except:
-                        raise Exception("Invalide option format '%s' !" % Option)
+                        raise Exception("Invalid option format '%s' !" % Option)
                     TmpList.append((OpVal, OpStr))
         return  TmpList
 

--- a/BootloaderCorePkg/Tools/SblSetup.py
+++ b/BootloaderCorePkg/Tools/SblSetup.py
@@ -1851,7 +1851,7 @@ def get_cfg_item_options (item):
             try:
                 (op_val, op_str) = option.split(':')
             except:
-                raise SystemExit ("Exception: Invalide option format '%s' !" % option)
+                raise SystemExit ("Exception: Invalid option format '%s' !" % option)
             tmp_list.append((op_val, op_str))
     return  tmp_list
 

--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Memory.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Memory.yaml
@@ -1399,6 +1399,7 @@
   - IbeccErrorInj :
       name         : IbeccErrorInj Note- Modification accepts the disclaimer shown in the Help text
       type         : Combo
+      option       : $EN_DIS
       help         : >
                      Disclaimer- Warning- This must NOT be enabled for production!!! Enabling Error Injection allows attackers who have access to the Host Operating System to inject IBECC errors that can cause unintended # memory corruption and enable the leak of security data in the BIOS stolen memory regions.
       length       : 0x01


### PR DESCRIPTION
EHL CFGDATA has missing options for Combo type configuration. And
it will cause ConfigEditor exception. This patch added the missing
options. And it also fixed typos.

It fixed issue #1122.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>