### PR TITLE
Fix NVMe failure because of bus master not enabled

### DIFF
--- a/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpress.h
+++ b/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpress.h
@@ -93,6 +93,7 @@ struct _NVME_CONTROLLER_PRIVATE_DATA {
   UINT32                              Signature;
   UINT32                              NvmeHCBase;
   UINT64                              PciAttributes;
+  UINTN                               PciBaseAddr;
   EFI_NVM_EXPRESS_PASS_THRU_MODE      PassThruMode;
   EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL  Passthru;
 


### PR DESCRIPTION
With recent code change of disabling all PCI bus master
by default, NVME may not work in some platform (e.g., Qemu).
This patch set/clear bus master during NVMe init/deinit.

Signed-off-by: Stanley Chang <stanley.chang@intel.com>