### PR TITLE
Resolve issue with MpInitLib VS2015 compiling

### DIFF
--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
@@ -343,8 +343,8 @@ MpInit (
       //
       // Copy the Rendezvous routine to the memory buffer @ < 1 MB
       //
-      mStubCodeSize = (UINT32)((UINT8 *)RendezvousFunnelProcEnd - (UINT8 *)RendezvousFunnelProcStart);
-      CopyMem (ApBuffer, (UINT8 *)RendezvousFunnelProcStart, mStubCodeSize);
+      mStubCodeSize = (UINT32)((UINT8 *)(UINTN)RendezvousFunnelProcEnd - (UINT8 *)(UINTN)RendezvousFunnelProcStart);
+      CopyMem (ApBuffer, (UINT8 *)(UINTN)RendezvousFunnelProcStart, mStubCodeSize);
       ApDataPtr = (AP_DATA_STRUCT *) (ApBuffer + mStubCodeSize);
       ZeroMem (ApDataPtr, sizeof(AP_DATA_STRUCT));
       ApDataPtr->CpuArch = IS_X64;


### PR DESCRIPTION
Need to add some typecasting to resolve a build
issue with MpInitLib when using VS2015 compiler.

Signed-off-by: James Gutbub <james.gutbub@intel.com>