### PR TITLE
[EHL] fix s0ix issue for pcie attach

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/UpdateAcpiGnvs.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/UpdateAcpiGnvs.c
@@ -696,6 +696,7 @@ PlatformUpdateAcpiGnvs (
   PlatformNvs->PcieSlot1RstGpio                 = GPIO_VER3_GPD11;
   PlatformNvs->PcieSlot1RstGpioPolarity         = 0;
   PlatformNvs->PcieSlot1RpNumber                = 1;
+  PlatformNvs->PcieSlot1ClkSrc                  = 0;
   //
   // PCH PCIe x1 Slot 2 GPIO pin configuration
   //


### PR DESCRIPTION
S0ix failed to enter when pcie card is attaching.
The _OFF method of RP01 power resource didnt get
called upon entering s0ix.
Workaround with performing the action in _OFF method
in low power idle entering callback.

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>