### PR TITLE
Add ELF image support for OsLoader

### DIFF
--- a/PayloadPkg/OsLoader/OsLoader.h
+++ b/PayloadPkg/OsLoader/OsLoader.h
@@ -5,8 +5,8 @@
 
 **/
 
-#ifndef __LINUX_LOADER_H__
-#define __LINUX_LOADER_H__
+#ifndef __OS_LOADER_H__
+#define __OS_LOADER_H__
 
 #include <Library/LiteFvLib.h>
 #include <Library/PartitionLib.h>
@@ -79,11 +79,12 @@
 #define LOADED_IMAGE_IAS         BIT0
 #define LOADED_IMAGE_MULTIBOOT   BIT1
 #define LOADED_IMAGE_LINUX       BIT2
-#define LOADED_IMAGE_PE32        BIT3
+#define LOADED_IMAGE_PE          BIT3
 #define LOADED_IMAGE_FV          BIT4
 #define LOADED_IMAGE_CONTAINER   BIT5
 #define LOADED_IMAGE_COMPONENT   BIT6
 #define LOADED_IMAGE_RUN_EXTRA   BIT7
+#define LOADED_IMAGE_ELF         BIT8
 
 #define MAX_EXTRA_FILE_NUMBER    16
 
@@ -137,9 +138,9 @@ typedef union {
 } LOADED_IMAGE_TYPE;
 
 typedef struct {
-  UINT8                   Flags;
+  UINT16                  Flags;
   UINT8                   LoadImageType;
-  UINT16                  Reserved;
+  UINT8                   Reserved;
   IMAGE_DATA              ImageData;
   EFI_HANDLE              HwPartHandle;
   LOADED_IMAGE_TYPE       Image;

--- a/PayloadPkg/OsLoader/PreOsChecker.c
+++ b/PayloadPkg/OsLoader/PreOsChecker.c
@@ -122,7 +122,7 @@ EFI_STATUS
 EFIAPI
 StartPreOsChecker (
   IN  VOID   *BootParam,
-  IN  UINT8  ImageFlags
+  IN  UINT16  ImageFlags
   )
 {
   PRE_OS_PAYLOAD_PARAM       PreOsParams;

--- a/PayloadPkg/OsLoader/PreOsChecker.h
+++ b/PayloadPkg/OsLoader/PreOsChecker.h
@@ -53,7 +53,7 @@ EFI_STATUS
 EFIAPI
 StartPreOsChecker (
   IN  VOID   *OsBootParam,
-  IN  UINT8  ImageFlags
+  IN  UINT16  ImageFlags
   );
 
 #endif /* __PRE_OS_CHECKER_H__ */

--- a/PayloadPkg/OsLoader/PreOsSupport.c
+++ b/PayloadPkg/OsLoader/PreOsSupport.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2019 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -59,7 +59,7 @@ GetNormalOsInfo (
     PreOsParams->OsBootState.Esi     = BootState->Esi;
     PreOsParams->OsBootState.Edi     = BootState->Edi;
     PreOsParams->OsBootState.Eip     = BootState->EntryPoint;
-  } else if ((LoadedImage->Flags & LOADED_IMAGE_PE32) != 0) {
+  } else if ((LoadedImage->Flags & LOADED_IMAGE_PE) != 0) {
     BootState = &LoadedImage->Image.MultiBoot.BootState;
     PreOsParams->OsBootState.Eip     = BootState->EntryPoint;
   } else {


### PR DESCRIPTION
This patch enhanced OsLoader to support ELF image boot on top of
PE, FV, Multiboot and Kernel. As a result, a new image flag
LOADED_IMAGE_ELF is added to indicate ELF image type.

Verified SBL can boot uboot ELF image (non-Multiboot) on QEMU.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>