### PR TITLE
[EHL] Enable SMRR programming in SMM rebasing flow

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/BoardConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/BoardConfig.py
@@ -50,6 +50,8 @@ class Board(BaseBoard):
         self.HAVE_PSD_TABLE       = 1
         self.ENABLE_VTD           = 1
         self.ENABLE_SPLASH        = 1
+        # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)
+        self.ENABLE_SMM_REBASE    = 2
         self.ENABLE_FRAMEBUFFER_INIT = 1
 
         self.SIIPFW_SIZE = 0x1000

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -91,6 +91,7 @@
   gPlatformModuleTokenSpaceGuid.PcdSmbiosTablesBase
   gPlatformModuleTokenSpaceGuid.PcdSmmRebaseMode
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegBase
+  gPlatformModuleTokenSpaceGuid.PcdSmramTsegSize
   gPlatformCommonLibTokenSpaceGuid.PcdPreOsCheckerEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootEnabled
   gPlatformModuleTokenSpaceGuid.PcdPsdBiosEnabled


### PR DESCRIPTION
This CL is a follow up on these CL to enable SMRR programming:
https://github.com/slimbootloader/slimbootloader/pull/1106
https://github.com/slimbootloader/slimbootloader/pull/1114

In normal UEFI payload case, the UEFI will handle SMM rebasing.
If SMM rebasing is handled by SBL, SBL will put a dummy SMI handler
at the new SMBASE to prevent SMM hang. Beyond SMM rebasing, it
is also required to program SMRR registers.

This patch added this support for EHL by setting ENABLE_SMM_REBASE
flag to auto mode.

Signed-off-by: Lean Sheng Tan <lean.sheng.tan@intel.com>