### PR TITLE
[EHL] PchCycleDecoding support

### DIFF
--- a/Silicon/ElkhartlakePkg/Include/Register/PchRegsLpc.h
+++ b/Silicon/ElkhartlakePkg/Include/Register/PchRegsLpc.h
@@ -52,5 +52,20 @@ typedef UINT8 PCH_STEPPING;
 
 #define R_LPC_CFG_BC                              0xDC            ///< Bios Control
 
+#define R_PCH_LPC_IOD                             0x80
+#define R_PCH_LPC_IOE                             0x82
+#define R_PCH_LPC_GEN1_DEC                        0x84
+#define B_PCH_LPC_GENX_DEC_IODRA                  0x00FC0000
+#define B_PCH_LPC_GENX_DEC_IOBAR                  0x0000FFFC
+#define B_PCH_LPC_GENX_DEC_EN                     0x00000001
+#define R_PCH_ESPI_CS1GIR1                        0xA4
+
+//
+// APM Registers
+//
+
+#define R_PCH_ESPI_PCBC                           0xDC            ///< Peripheral Channel BIOS Control
+#define B_PCH_ESPI_PCBC_ESPI_EN                   BIT2            ///< eSPI Enable Pin Strap
+
 
 #endif

--- a/Silicon/ElkhartlakePkg/Library/PchCycleDecodingLib/PchCycleDecodingLib.c
+++ b/Silicon/ElkhartlakePkg/Library/PchCycleDecodingLib/PchCycleDecodingLib.c
@@ -233,7 +233,7 @@ PchLpcGenIoRangeSet (
 
   LpcEspiGenIoRangeMax = PCH_LPC_GEN_IO_RANGE_MAX;
   EspiPcbc = PciRead32 ((UINTN)(LpcBase + R_PCH_ESPI_PCBC));
-  if (IsPchH () && ((EspiPcbc & B_PCH_ESPI_PCBC_ESPI_EN) != 0)) {
+  if ((EspiPcbc & B_PCH_ESPI_PCBC_ESPI_EN) != 0) {
     LpcEspiGenIoRangeMax = PCH_H_ESPI_GEN_IO_RANGE_MAX;
   }
 
@@ -364,7 +364,7 @@ PchLpcGenIoRangeGet (
     LpcGenIoRangeList->Range[Index].Enable   = Data32 & B_PCH_LPC_GENX_DEC_EN;
   }
   EspiPcbc = PciRead32 ((UINTN)(LpcBase + R_PCH_ESPI_PCBC));
-  if (IsPchH () && ((EspiPcbc & B_PCH_ESPI_PCBC_ESPI_EN) != 0)) {
+  if ((EspiPcbc & B_PCH_ESPI_PCBC_ESPI_EN) != 0) {
     Data32 = PciRead32 ((UINTN)(LpcBase + R_PCH_ESPI_CS1GIR1));
     LpcGenIoRangeList->Range[PCH_LPC_GEN_IO_RANGE_MAX].BaseAddr = Data32 & B_PCH_LPC_GENX_DEC_IOBAR;
     LpcGenIoRangeList->Range[PCH_LPC_GEN_IO_RANGE_MAX].Length   = ((Data32 & B_PCH_LPC_GENX_DEC_IODRA) >> 16) + 4;
@@ -482,7 +482,7 @@ PchEspiMemRange2Set (
   // PCH eSPI Enable Pin Strap check
   //
   EspiPcbc = PciRead32 (LpcBase + R_PCH_ESPI_PCBC);
-  if (IsPchH () && ((EspiPcbc & B_PCH_ESPI_PCBC_ESPI_EN) != 0)) {
+  if ((EspiPcbc & B_PCH_ESPI_PCBC_ESPI_EN) != 0) {
     return EFI_UNSUPPORTED;
   }
 


### PR DESCRIPTION
1. Add missing definition for PchCycleDecoding.
2. Remove PCH H checking.

Signed-off-by: jinjhuli <jin.jhu.lim@intel.com>