### PR TITLE
Allow Ext23Lib symbolic links to have longer paths

### DIFF
--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.c
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.c
@@ -735,7 +735,7 @@ Ext2fsOpen (
 #ifndef LIBSA_NO_FS_SYMLINK
   INODE32 ParentInumber;
   INT32 Nlinks;
-  CHAR8 NameBuf[MAX_FILE_PATH_LEN+1];
+  CHAR8 NameBuf[MAXPATHLEN+1];
   CHAR8 *Buf;
 
   Nlinks = 0;
@@ -878,8 +878,8 @@ Ext2fsOpen (
 
       Len = AsciiStrLen (Cp);
 
-      if (LinkLength + Len > MAX_FILE_PATH_LEN ||
-          ++Nlinks > MAXSYMLINKS) {
+      if (((LinkLength + Len) > MAXPATHLEN) ||
+          ((++Nlinks) > MAXSYMLINKS)) {
         Status = RETURN_LOAD_ERROR;
         goto out;
       }

--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.h
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.h
@@ -95,6 +95,8 @@
 
 #define MAXSYMLINKS 1
 
+#define MAXPATHLEN 260
+
 #undef  EXT2FS_DEBUG
 
 #undef  LIBSA_FS_SINGLECOMPONENT


### PR DESCRIPTION
In the Ext23Lib support for symbolic links was recently enabled
but there was a limitation imposed to use the CFG data boot
option filepath limit of 16 bytes which does not need to be also
be imposed on symbolic link paths. This will allow symbolic link
paths to be up to 260 characters long.

Signed-off-by: James Gutbub <james.gutbub@intel.com>