### PR TITLE
[QSP] Add Simics QSP board support based on QEMU package

### DIFF
--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -1,7 +1,7 @@
 ## @file
 # This file is used to provide board specific image information.
 #
-#  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -28,9 +28,9 @@ class Board(BaseBoard):
 
         self.VERINFO_IMAGE_ID          = 'SB_QEMU '
         self.VERINFO_PROJ_MAJOR_VER    = 1
-        self.VERINFO_PROJ_MINOR_VER    = 0
+        self.VERINFO_PROJ_MINOR_VER    = 1
         self.VERINFO_SVN               = 1
-        self.VERINFO_BUILD_DATE        = '09/25/2017'
+        self.VERINFO_BUILD_DATE        = '05/03/2021'
 
         self.BOARD_NAME           = 'qemu'
         self.BOARD_PKG_NAME       = 'QemuBoardPkg'
@@ -169,7 +169,7 @@ class Board(BaseBoard):
         #self._PLATFORM_ID         = 1
 
         self._CFGDATA_INT_FILE    = []
-        self._CFGDATA_EXT_FILE    = ['CfgDataExt_Brd1.dlt', 'CfgDataExt_Brd31.dlt']
+        self._CFGDATA_EXT_FILE    = ['CfgDataExt_Brd1.dlt', 'CfgDataExt_Brd31.dlt', 'CfgDataExt_QSP.dlt']
 
         # If mulitple VBT table support is required, list them as:
         #   {VbtImageId1 : VbtFileName1, VbtImageId2 : VbtFileName2, ...}

--- a/Platform/QemuBoardPkg/CfgData/CfgDataExt_QSP.dlt
+++ b/Platform/QemuBoardPkg/CfgData/CfgDataExt_QSP.dlt
@@ -1,0 +1,21 @@
+## @file
+#
+#  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+#
+# Delta configuration values for platform ID 0x0002, QSP
+#
+# This file is not auto-generated. Rather, users must input all the settings
+# that are needed to be overwritten from the base DSC into this file.
+# This file is similar to changing BSF file in BCT for the new settings.
+#
+
+PLATFORMID_CFG_DATA.PlatformId | 2
+
+PLAT_NAME_CFG_DATA.PlatformName            | 'QSP'
+
+GEN_CFG_DATA.PayloadId                     | 'AUTO'
+GEN_CFG_DATA.CurrentBoot                   | 16
+
+!include CfgDataExt_Inc.dlt

--- a/Platform/QemuBoardPkg/Include/ConfigDataDefs.h
+++ b/Platform/QemuBoardPkg/Include/ConfigDataDefs.h
@@ -1,12 +1,15 @@
 /** @file
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017-2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
 #ifndef _CONFIG_DATA_DEFS_H_
 #define _CONFIG_DATA_DEFS_H_
+
+
+#define  PLATFORM_ID_QSP_SIMICS            0x2
 
 #include <ConfigDataCommonDefs.h>
 

--- a/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -24,8 +24,10 @@
 #include <Library/FspSupportLib.h>
 #include <Library/BootloaderCoreLib.h>
 #include <Library/BoardSupportLib.h>
+#include <Library/PciCf8Lib.h>
 #include <FspmUpd.h>
 #include <BlCommon.h>
+#include <PlatformBase.h>
 #include <ConfigDataDefs.h>
 #include "GpioTbl.h"
 
@@ -148,23 +150,32 @@ VOID BoardDetection (
 )
 {
   UINT8  BoardId;
-
-  //
-  // Reuse CMOS 0x38 BIT0 as board ID
-  //   [0]  Board ID (0, 1)
-  //          0: BoardID 1
-  //          1: BoardID 31
-  //   Use '-no-fd-bootchk' to select board 31
-  //   By default, it is board 1
-  //   BoardID 0 is already reserved for default
-  //
-  IoWrite8 (0x70, 0x38);
-  BoardId = IoRead8  (0x71) & BIT0;
-
-  if (BoardId > 0) {
-    BoardId = 31;
+  UINT16 mHostBridgeDevId;
+  IoWrite32 (0xCF8, PCI_TO_CF8_ADDRESS(PCI_CF8_LIB_ADDRESS (0, 0, 0, 0)));
+  mHostBridgeDevId = (IoRead32 (0xCFC) >> 16);
+  DEBUG ((DEBUG_INFO, "Host Bridge Device ID:0x%X\n", mHostBridgeDevId));
+  if (mHostBridgeDevId == INTEL_X58_ICH10_DEVICE_ID) {
+    BoardId = 2; //Simics QSP board
+    DEBUG ((DEBUG_INFO, "Board ID:0x%X - Loading Simics QSP!\n", BoardId));
   } else {
-    BoardId = 1;
+    //
+    // Reuse CMOS 0x38 BIT0 as board ID
+    //   [0]  Board ID (0, 1)
+    //          0: BoardID 1
+    //          1: BoardID 31
+    //   Use '-no-fd-bootchk' to select board 31
+    //   By default, it is board 1
+    //   BoardID 0 is already reserved for default
+    //
+    IoWrite8 (0x70, 0x38);
+    BoardId = IoRead8  (0x71) & BIT0;
+
+    if (BoardId > 0) {
+      BoardId = 31;
+    } else {
+      BoardId = 1;
+    }
+    DEBUG ((DEBUG_INFO, "Board ID:0x%X - Loading QEMU!\n", BoardId));
   }
 
   SetPlatformId (BoardId);
@@ -198,10 +209,12 @@ BoardInit (
     BoardDetection ();
     UpdateBootMode ();
     if (!FeaturePcdGet (PcdStage1BXip)) {
-      SpiConstructor ();
-      VariableConstructor (PcdGet32 (PcdVariableRegionBase), PcdGet32 (PcdVariableRegionSize));
-      Status = TestVariableService ();
-      ASSERT_EFI_ERROR (Status);
+      if (GetPlatformId () != PLATFORM_ID_QSP_SIMICS) {
+        SpiConstructor ();
+        VariableConstructor (PcdGet32 (PcdVariableRegionBase), PcdGet32 (PcdVariableRegionSize));
+        Status = TestVariableService ();
+        ASSERT_EFI_ERROR (Status);
+      }
     }
     break;
   case PostConfigInit:

--- a/Silicon/QemuSocPkg/Include/PlatformBase.h
+++ b/Silicon/QemuSocPkg/Include/PlatformBase.h
@@ -7,6 +7,10 @@
 
 #ifndef _PLATFORM_BASE_H_
 
+#define PCI_TO_CF8_ADDRESS(A) \
+  ((UINT32) ((((A) >> 4) & 0x00ffff00) | ((A) & 0xfc) | 0x80000000))
+
+#define  INTEL_X58_ICH10_DEVICE_ID         0x3400  // Host Bridge DID for Simics QSP
 #define  ACPI_BASE_ADDRESS                 0x400
 #define  LOCAL_APIC_BASE_ADDRESS           0xFEE00000  // Local APIC
 #define  IO_APIC_BASE_ADDRESS              0xFEC00000


### PR DESCRIPTION
Officially add Simics QSP board (X58Ich10Board) support on top of
QEMU package.

Here are the changes:
1. Add Simics QSP detection based on Host Bridge DID
2. Add new QSP dlt file (Platform ID: 2) and QSP name changes
3. Set the PCI_MEM32 base to 0xF0000000 for QSP
4. Update minor version and date

Signed-off-by: LeanSheng <lean.sheng.tan@intel.com>