### PR TITLE
[EHL] GpioLock update

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -751,6 +751,7 @@ BoardInit (
     if (GetBootMode() != BOOT_ON_FLASH_UPDATE) {
       UpdatePayloadId ();
     }
+    GpioLockPads();
     break;
   case PostSiliconInit:
     // Set TSEG base/size PCD


### PR DESCRIPTION
Issue seen in Yocto RT kernel that PSE GBE0 Transmission.
Found out that GPPC_A_5.pmode=0 (RGMII0_TXCTL) which expected
to be 0x1.
override become 0x0.
After investigation these PADCFGLOCK_GPP_A_0 and PADCFGLOCKTX_GPP_A_0
registers should be 0xFFFFFF to lock the GPIO GPPC_A_x to prevent
modificaiton to the GPIO.
Implemented GpioLock function in GpioLib.c to fix this issue.

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>