### PR TITLE
[CFL] Add PCI 64bit resource support

### DIFF
--- a/Platform/CoffeelakeBoardPkg/BoardConfig.py
+++ b/Platform/CoffeelakeBoardPkg/BoardConfig.py
@@ -40,6 +40,11 @@ class Board(BaseBoard):
         self.PCI_MEM32_BASE       = 0x9F000000
         self.ACPI_PM_TIMER_BASE   = 0x1808
 
+        self._PCI_ENUM_DOWNGRADE_PMEM64 = 1
+        self._PCI_ENUM_DOWNGRADE_MEM64  = 1
+        self._PCI_ENUM_DOWNGRADE_BUS0   = 1
+        self.PCI_MEM64_BASE             = 0x4000000000
+
         self.FLASH_BASE_ADDRESS   = 0xFE000000
         self.FLASH_BASE_SIZE      = (self.FLASH_LAYOUT_START - self.FLASH_BASE_ADDRESS)
 

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1842,7 +1842,8 @@ UpdateFrameBufferInfo (
 )
 {
   if (PcdGetBool (PcdIntelGfxEnabled)) {
-    GfxInfo->FrameBufferBase = PciRead32 (PCI_LIB_ADDRESS(0, 2, 0, 0x18)) & 0xFFFFFF00;
+    GfxInfo->FrameBufferBase  = LShiftU64 (PciRead32 (PCI_LIB_ADDRESS(0, 2, 0, 0x1C)), 32);
+    GfxInfo->FrameBufferBase += (PciRead32 (PCI_LIB_ADDRESS(0, 2, 0, 0x18)) & 0xFFFFFF00);
   }
 }
 
@@ -2329,6 +2330,8 @@ PlatformUpdateAcpiGnvs (
 
   SaNvs->Mmio32Base   = PcdGet32(PcdPciResourceMem32Base);
   SaNvs->Mmio32Length = ACPI_MMIO_BASE_ADDRESS - SaNvs->Mmio32Base;
+  SaNvs->Mmio64Base   = PcdGet64(PcdPciResourceMem64Base);
+  SaNvs->Mmio64Length = SaNvs->Mmio64Base;
 
   SaNvs->AlsEnable                    = 0;
   SaNvs->IgdState                     = 1;

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -89,3 +89,4 @@
   gPlatformCommonLibTokenSpaceGuid.PcdDmaProtectionEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferAlignment
   gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferSize
+  gPlatformModuleTokenSpaceGuid.PcdPciResourceMem64Base


### PR DESCRIPTION
This patch added required support to enable PCI 64 bit resource
allocation. By default, all downgrading is enabled so that it has
the same behavior as current code. To enable 64 bit resource,
set related downgrading flag to 0.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>