### PR TITLE
[EHL] Enable SOF driver for audio

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/AcpiTables/Dsdt/HdaI2sCodec.asl
+++ b/Platform/ElkhartlakeBoardPkg/AcpiTables/Dsdt/HdaI2sCodec.asl
@@ -1,0 +1,92 @@
+/**@file
+ I2S Audio Codec ACPI
+
+  Copyright (c) 2017 Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+// HD Audio I2S codecs
+#define HDAC_I2S_DISABLED 0
+#define HDAC_I2S_ALC274   1
+#define HDAC_I2S_ALC5660  2
+
+///
+/// I2S HW Audio Codec ACPI definition body
+///
+//-----------------------------------
+//  HD Audio I2S Codec device
+//  Disabled               (I2SC = 0)
+//  Realtek ALC274         (I2SC = 1)
+//  Realtek ALC5660I       (I2SC = 2)
+//-----------------------------------
+Device (HDAC)
+{
+  Name (_HID, "INT00000")
+  Name (_CID, "INT00000")
+  Name (_DDN, "Intel(R) Smart Sound Technology Audio Codec")
+  Name (_UID, 1)
+  Name (CADR, 0) // Codec I2C address
+  Name (CDIS, 0) // Codec Disabled state
+
+  Method(_INI) {
+    If (LEqual(I2SC, HDAC_I2S_ALC274)) { // ALC274
+      Store ("INT34C2", _HID)
+      Store ("INT34C2", _CID)
+      Store (0x1C, CADR)
+      Return
+    }
+    If (LEqual(I2SC, HDAC_I2S_ALC5660)) { // ALC5660
+      Store ("INTC1027", _HID)
+      Store ("INTC1027", _CID)
+      Store (0x1C, CADR)
+      Return
+    }
+  }
+
+  Method (_CRS, 0, NotSerialized) {
+
+    Name (GBUF, ResourceTemplate () {
+      GpioInt (Edge, ActiveHigh, ExclusiveAndWake, PullDefault, 0x0000, "\\_SB.GPI0", 0x00, ResourceConsumer, GINT ) { 0 }
+    })
+    CreateWordField(GBUF,GINT._PIN,GPIN)
+    CreateField(GBUF,GINT._POL,2,GLVL)
+    CreateBitField(GBUF,GINT._MOD,GTRG)
+
+    // IICB: Method generates 'I2cSerialBus' descriptor buffer
+    // CADR: Device variable with codec address (set in _INI based on codec model)
+    // I2SB: NVS variable with I2C controller connection
+    // INTB: Method generates 'Interrupt' descriptor buffer
+    // I2SI: NVS variable with codec jack detection pin
+    If (LEqual(I2SC, HDAC_I2S_ALC5660)) {
+      Store (GNUM(I2SI),GPIN)
+      Store (0,GLVL) // gpioint active high
+      Store (1,GTRG) // gpioint edge triggered
+      Return (ConcatenateResTemplate(IICB(CADR, I2SB), GBUF))
+    } Else {
+      Store (GNUM(I2SI),GPIN)
+      Store (1,GLVL) // gpioint active low
+      Store (0,GTRG) // gpioint level triggered
+      Return (ConcatenateResTemplate(IICB(CADR, I2SB), GBUF))
+    }
+  }
+
+  Method (_STA, 0, NotSerialized) {
+    If (LAnd(LNotEqual(I2SC, HDAC_I2S_DISABLED), LNotEqual(CDIS, 1))) {
+      Return (0xF)  // I2S Codec Enabled
+    }
+
+    If (LEqual (CDIS, 1)) {
+      Return (0xD)  // Disabled from _DIS 1101b - Present/Disabled (via Device Manager)
+    }
+
+    Return (0x0)  // I2S Codec Dialed (via BIOS Policy/Setup)
+  }
+
+  Method (_SRS, 0x1, Serialized) {
+    Store (0, CDIS) // Clear Disabled bit
+  }
+
+  Method (_DIS, 0x0, NotSerialized) {
+    Store (1, CDIS) // Set Disabled bit
+  }
+}  // Device (HDAC)

--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_GpuConfig.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_GpuConfig.yaml
@@ -188,6 +188,13 @@
                      Enable/disable HDA SDI lanes.
       length       : 0x02
       value        : { 0x00, 0x00}
+  - PchHdaDspUaaCompliance :
+      name         : Universal Audio Architecture compliance for DSP enabled system
+      type         : Combo
+      help         : >
+                     0: Not-UAA Compliant (Intel SST driver supported only), 1: UAA Compliant (HDA Inbox driver or SST driver supported
+      length       : 0x01
+      value        : 0x0
   - Dummy        :
-      length       : 0x04
+      length       : 0x03
       value        : 0x0

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -602,6 +602,7 @@ UpdateFspConfig (
     Fspmcfg->PchHdaIDispLinkFrequency   = GfxCfgData->PchHdaIDispLinkFrequency;
     Fspmcfg->PchHdaIDispLinkTmode       = GfxCfgData->PchHdaIDispLinkTmode;
     Fspmcfg->PchHdaIDispCodecDisconnect = GfxCfgData->PchHdaIDispCodecDisconnect;
+    Fspmcfg->PchHdaDspUaaCompliance     = GfxCfgData->PchHdaDspUaaCompliance;
 
     switch (GfxCfgData->PchHdAudioLinkMode) {
       case HDAUDIO_LINK_MODE_HDA:


### PR DESCRIPTION
1. Add missing HDAC initialization in ACPI
2. Add PchHdaDspUaaCompliance in CfgData to allowed modification
using Config Editor tool

Signed-off-by: jinjhuli <jin.jhu.lim@intel.com>