### PR TITLE
[QEMU] Fix compiler error for NOOPT build in Windows

### DIFF
--- a/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
+++ b/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
@@ -1,7 +1,7 @@
 /** @file
 The header file for firmware update library.
 
-Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -590,9 +590,13 @@ UpdateCsme (
   and 16-bit PCI configuration read cycles may be used at the beginning and the
   end of the range.
 
-  If StartAddress > 0x0FFFFFFF, then ASSERT().
-  If ((StartAddress & 0xFFF) + Size) > 0x1000, then ASSERT().
-  If Size > 0 and Buffer is NULL, then ASSERT().
+  StartAddress is in EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_PCI_ADDRESS format.
+  - when register offset is  < 0x100, it is :    bbddffrr
+  - when register offset is >= 0x100, it is : rrrbbddff00
+
+  If StartAddress is not aligned with format defined, then ASSERT().
+  If the range to be read exceeds a single PCI function, then ASSERT().
+  If Buffer is NULL or Size == 0, then ASSERT().
 
   @param  StartAddress  The starting address that encodes the PCI Bus, Device,
                         Function and Register.

--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
@@ -1838,7 +1838,7 @@ PciEnumeration (
   mDefaultResRange.IoBase       = PcdGet32 (PcdPciResourceIoBase);
   mDefaultResRange.Mmio32Base   = PcdGet32 (PcdPciResourceMem32Base);
   mDefaultResRange.Mmio64Base   = PcdGet64 (PcdPciResourceMem64Base);
-  mDefaultResRange.Mmio64Limit  = PcdGet64 (PcdPciResourceMem64Base) + (PcdGet64 (PcdPciResourceMem64Base) >> 1);
+  mDefaultResRange.Mmio64Limit  = PcdGet64 (PcdPciResourceMem64Base) + (RShiftU64 (PcdGet64 (PcdPciResourceMem64Base), 1));
 
   EnumPolicy = (PCI_ENUM_POLICY_INFO *)PcdGetPtr (PcdPciEnumPolicyInfo);
   RootBridgeCount = 0;

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -101,6 +101,8 @@ class Board(BaseBoard):
         self.STAGE1B_XIP          = 0
 
         self.STAGE1A_SIZE         = 0x00010000
+        if self.NO_OPT_MODE:
+            self.STAGE1A_SIZE    += 0x1000
         self.STAGE1B_SIZE         = 0x00030000
         self.STAGE2_SIZE          = 0x00018000
 
@@ -123,6 +125,8 @@ class Board(BaseBoard):
             self.NON_REDUNDANT_SIZE = 0x400000
         else:
             self.TOP_SWAP_SIZE      = 0x010000
+            if self.NO_OPT_MODE:
+                self.TOP_SWAP_SIZE  = 0x020000
             self.REDUNDANT_SIZE     = 0x080000
             self.NON_VOLATILE_SIZE  = 0x001000
             self.NON_REDUNDANT_SIZE = 0x2DF000
@@ -153,9 +157,12 @@ class Board(BaseBoard):
         self.STAGE2_FD_SIZE       = 0x00060000
 
         if self.NO_OPT_MODE:
-            self.STAGE2_SIZE         += 0x2000
+            if self.FSPDEBUG_MODE == 1:
+                self.STAGE2_SIZE     += 0x8000
+            else:
+                self.STAGE2_SIZE     += 0x2000
             self.PAYLOAD_SIZE        += 0xA000
-            self.OS_LOADER_FD_SIZE   += 0x22000
+            self.OS_LOADER_FD_SIZE   += 0x23000
             self.FWUPDATE_SIZE       += 0x8000
             self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 


### PR DESCRIPTION
- fix __aullshr link error for NOOPT build in Windows
  due to compiler intrinsics functions
- adjust Stage1A/TopSwap/OsLoader FD size for NOOPT target
- adjust Stage2 size for NOOPT target when DEBUG FSP is used

Signed-off-by: Vincent Chen <vincent.chen@intel.com>