### PR TITLE
Enhance ConfigEditor to handle error condition

### DIFF
--- a/BootloaderCorePkg/Tools/ConfigEditor.py
+++ b/BootloaderCorePkg/Tools/ConfigEditor.py
@@ -509,7 +509,8 @@ class application(tkinter.Frame):
             result = self.evaluate_condition(item)
             if result == 2:
                 # Gray
-                widget.configure(state='disabled')
+                if not isinstance(widget, custom_table):
+                    widget.configure(state='disabled')
             elif result == 0:
                 # Hide
                 visible = False
@@ -517,7 +518,9 @@ class application(tkinter.Frame):
             else:
                 # Show
                 widget.grid()
-                widget.configure(state='normal')
+                if not isinstance(widget, custom_table):
+                    widget.configure(state='normal')
+
 
         return visible
 

--- a/BootloaderCorePkg/Tools/GenCfgData.py
+++ b/BootloaderCorePkg/Tools/GenCfgData.py
@@ -769,6 +769,8 @@ class CGenCfgData:
 
     def get_value (self, value_str, bit_length, array = True):
         value_str = value_str.strip()
+        if len(value_str) == 0:
+            return 0
         if value_str[0] == "'" and value_str[-1] == "'" or \
            value_str[0] == '"' and value_str[-1] == '"':
             value_str = value_str[1:-1]


### PR DESCRIPTION
This patch enhanced ConfigEditor to handle the case that the app
will crash when "Value" is not provided in YAML. It also fixed
an hide/show issue for Table type widget.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>