### PR TITLE
Fix eMMC controller driver issue

### DIFF
--- a/BootloaderCommonPkg/Library/MmcAccessLib/SdMmcPciHcDxe.h
+++ b/BootloaderCommonPkg/Library/MmcAccessLib/SdMmcPciHcDxe.h
@@ -70,7 +70,7 @@ typedef struct {
 
 typedef struct {
   UINTN                               Signature;
-
+  UINTN                               SdMmcHcPciBase;
   UINT32                              SdMmcHcBase;
 
   SD_MMC_HC_SLOT                      Slot;


### PR DESCRIPTION
When the bus master decoding was disabled by default in PCI bus, the
device driver should try to enable it on its own. However, eMMC
driver does not have the enabling code. It caused the eMMC access
failure.

It fixed #1153.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>