### PR TITLE
Generate signed slimboot binary to output path

### DIFF
--- a/Platform/CoffeelakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/CoffeelakeBoardPkg/Script/StitchIfwi.py
@@ -501,6 +501,11 @@ def main():
                     type=str, required=True,
                     help='specify the platform specific stitch config file')
 
+    ap.add_argument('-op',
+                     dest='outpath',
+                     default = '',
+                     help = "Specify path to write output IFIW and signed bin files")
+
     args = ap.parse_args()
 
     stitch_cfg_file = load_source('StitchIfwiConfig', args.config_file)
@@ -539,10 +544,13 @@ def main():
         raise Exception ('Stitching process failed !')
     os.chdir(curr_dir)
 
-    generated_ifwi_file = os.path.join(stitch_dir, 'Temp', 'Ifwi.bin')
-
-    ifwi_file_name = 'sbl_ifwi_%s.bin' % (args.platform)
+    generated_ifwi_file = os.path.join(work_dir, 'Temp', 'Ifwi.bin')
+    ifwi_file_name = os.path.join(args.outpath,'sbl_ifwi_%s.bin' % (args.platform))
     shutil.copy(generated_ifwi_file, ifwi_file_name)
+
+    generated_signed_sbl =  os.path.join(work_dir, 'Temp', 'SlimBootloader.bin')
+    sbl_file_name = os.path.join(args.outpath,'SlimBootloader_%s.bin' % (args.platform))
+    shutil.copy(generated_signed_sbl, sbl_file_name)
 
     print ("\nIFWI Stitching completed successfully !")
     print ("Boot Guard Profile: %s" % args.btg_profile.upper())

--- a/Platform/CometlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/CometlakeBoardPkg/Script/StitchIfwi.py
@@ -435,6 +435,7 @@ def main():
     ap.add_argument('-r', dest='remove', action = "store_true", default = False, help = "delete temporary files after stitch")
     ap.add_argument('-t', dest='tpm', default = 'ptt', choices=['ptt', 'dtpm', 'none'], help='specify TPM type')
     ap.add_argument('-fusa', dest='fusa', action = "store_true", default = False, help = "Patch IFWI to generate Fusa ifwi")
+    ap.add_argument('-op', dest='outpath', default = '', help = "Specify path to write output IFIW and signed bin files")
     args = ap.parse_args()
 
     stitch_cfg_file = load_source('StitchIfwiConfig', args.config_file)
@@ -460,8 +461,12 @@ def main():
     os.chdir(curr_dir)
 
     generated_ifwi_file = os.path.join(work_dir, 'Temp', 'Ifwi.bin')
-    ifwi_file_name = 'sbl_ifwi_%s.bin' % (args.platform)
+    ifwi_file_name = os.path.join(args.outpath,'sbl_ifwi_%s.bin' % (args.platform))
     shutil.copy(generated_ifwi_file, ifwi_file_name)
+
+    generated_signed_sbl =  os.path.join(work_dir, 'Temp', 'SlimBootloader.bin')
+    sbl_file_name = os.path.join(args.outpath,'SlimBootloader_%s.bin' % (args.platform))
+    shutil.copy(generated_signed_sbl, sbl_file_name)
 
     if args.fusa:
         print ("patch IFWI to generate Fusa ifwi")

--- a/Platform/CometlakevBoardPkg/Script/StitchIfwi.py
+++ b/Platform/CometlakevBoardPkg/Script/StitchIfwi.py
@@ -435,6 +435,8 @@ def main():
     ap.add_argument('-r', dest='remove', action = "store_true", default = False, help = "delete temporary files after stitch")
     ap.add_argument('-t', dest='tpm', default = 'ptt', choices=['ptt', 'dtpm', 'none'], help='specify TPM type')
     ap.add_argument('-fusa', dest='fusa', action = "store_true", default = False, help = "Patch IFWI to generate Fusa ifwi")
+    ap.add_argument('-op', dest='outpath', default = '', help = "Specify path to write output IFIW and signed bin files")
+
     args = ap.parse_args()
 
     stitch_cfg_file = load_source('StitchIfwiConfig', args.config_file)
@@ -460,8 +462,12 @@ def main():
     os.chdir(curr_dir)
 
     generated_ifwi_file = os.path.join(work_dir, 'Temp', 'Ifwi.bin')
-    ifwi_file_name = 'sbl_ifwi_%s.bin' % (args.platform)
+    ifwi_file_name = os.path.join(args.outpath,'sbl_ifwi_%s.bin' % (args.platform))
     shutil.copy(generated_ifwi_file, ifwi_file_name)
+
+    generated_signed_sbl =  os.path.join(work_dir, 'Temp', 'SlimBootloader.bin')
+    sbl_file_name = os.path.join(args.outpath,'SlimBootloader_%s.bin' % (args.platform))
+    shutil.copy(generated_signed_sbl, sbl_file_name)
 
     if args.fusa:
         print ("patch IFWI to generate Fusa ifwi")

--- a/Platform/ElkhartlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/ElkhartlakeBoardPkg/Script/StitchIfwi.py
@@ -195,6 +195,7 @@ def main():
     ap.add_argument('-t', dest='tpm', default = 'ptt', choices=['ptt', 'dtpm', 'none'], help='specify TPM type')
     ap.add_argument('-k', dest='key_dir', type=str, required=True, help='specify the path to Sbl Keys directory')
     ap.add_argument('-o', dest='option', default = '', help = "Platform specific stitch option. Format: '-o option1;option2;...' For each option its format is 'parameter:data'. Try -o help for more information")
+    ap.add_argument('-op', dest='outpath', default = '', help = "Specify path to write output IFIW and signed bin files")
 
     args = ap.parse_args()
 
@@ -235,9 +236,13 @@ def main():
     os.chdir(curr_dir)
 
     generated_ifwi_file = os.path.join(work_dir, 'Temp', 'Ifwi.bin')
-
-    ifwi_file_name = 'sbl_ifwi_%s.bin' % (args.platform)
+    ifwi_file_name = os.path.join(args.outpath,'sbl_ifwi_%s.bin' % (args.platform))
     shutil.copy(generated_ifwi_file, ifwi_file_name)
+
+    generated_signed_sbl =  os.path.join(work_dir, 'Temp', 'SlimBootloader.bin')
+    sbl_file_name = os.path.join(args.outpath,'SlimBootloader_%s.bin' % (args.platform))
+    shutil.copy(generated_signed_sbl, sbl_file_name)
+
     list_val = [1,0,2,4,16,249,15] #List of values to override
     softstrap_write(ifwi_file_name,0xc18,list_val[0],1) #FUSA SOFTSTRAP due to CSME 2041 update
     ###################################################################################

--- a/Platform/TigerlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/TigerlakeBoardPkg/Script/StitchIfwi.py
@@ -172,6 +172,7 @@ def main():
     ap.add_argument('-r', dest='remove', action = "store_true", default = False, help = "delete temporary files after stitch")
     ap.add_argument('-t', dest='tpm', default = 'ptt', choices=['ptt', 'dtpm', 'none'], help='specify TPM type')
     ap.add_argument('-o', dest='option', default = '', help = "Platform specific stitch option. Format: '-o option1;option2;...' For each option its format is 'parameter:data'. Try -o help for more information")
+    ap.add_argument('-op', dest='outpath', default = '', help = "Specify path to write output IFIW and signed bin files")
 
     args = ap.parse_args()
 
@@ -211,9 +212,12 @@ def main():
     os.chdir(curr_dir)
 
     generated_ifwi_file = os.path.join(work_dir, 'Temp', 'Ifwi.bin')
-
-    ifwi_file_name = 'sbl_ifwi_%s.bin' % (args.platform)
+    ifwi_file_name = os.path.join(args.outpath,'sbl_ifwi_%s.bin' % (args.platform))
     shutil.copy(generated_ifwi_file, ifwi_file_name)
+
+    generated_signed_sbl =  os.path.join(work_dir, 'Temp', 'SlimBootloader.bin')
+    sbl_file_name = os.path.join(args.outpath,'SlimBootloader_%s.bin' % (args.platform))
+    shutil.copy(generated_signed_sbl, sbl_file_name)
 
     print ("\nIFWI Stitching completed successfully !")
     print ("Boot Guard Profile: %s" % args.btg_profile.upper())


### PR DESCRIPTION
Currently final IFWI gets generated output path.
Copy the signed slimboot binary to out path.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>