### PR TITLE
Fix return code of SearchDirectory

### DIFF
--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.c
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
   Copyright (c) 1997 Manuel Bouyer.
@@ -573,7 +573,7 @@ SearchDirectory (
     }
     Fp->SeekPtr += BufSize;
   }
-  return EFI_UNSUPPORTED;
+  return EFI_NOT_FOUND;
 }
 
 /**


### PR DESCRIPTION
This patch changes the return code of SearchDirectory
to EFI_NOT_FOUND when a file to search cannot be found