### PR TITLE
[QEMU] Support usb-storage with qemu-xhci or nec-usb-xhci

### DIFF
--- a/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -36,6 +36,7 @@ CONST PLT_DEVICE  mPlatformDevices[]= {
   {{0x00000300}, OsBootDeviceSd    , 0 },
   {{0x00000300}, OsBootDeviceNvme  , 0 },
   {{0x00000400}, OsBootDeviceUsb   , 0 },
+  {{0x00000300}, OsBootDeviceUsb   , 1 }, // usb-storage with qemu-xhci or nec-usb-xhci
   {{0x01000000}, OsBootDeviceMemory, 0 }
 };
 


### PR DESCRIPTION
This patch adds a new platform device to support a usb-storage
on a emulated xhci bus device (qemu-xhci or nec-usb-xhci) where
the XHCI controller locates at PCI 0x0:0x3:0x0.

Signed-off-by: Stanley Chang <stanley.chang@intel.com>