### PR TITLE
Support ELF32/64 format payloads regardless of operation mode

### DIFF
--- a/BootloaderCommonPkg/Include/Library/ElfLib.h
+++ b/BootloaderCommonPkg/Include/Library/ElfLib.h
@@ -10,6 +10,7 @@
 #define __ELF_LIB_H__
 
 #include <Uefi/UefiBaseType.h>
+#include <IndustryStandard/PeImage.h>
 
 /**
   Check if the image is a bootable ELF image.
@@ -40,9 +41,28 @@ IsElfImage (
   @retval EFI_SUCCESS             ELF binary is loaded successfully.
 **/
 EFI_STATUS
+EFIAPI
 LoadElfImage (
   IN  CONST VOID                  *ImageBase,
   OUT       VOID                 **EntryPoint
+  );
+
+/**
+  Extract and return the machine type from ELF image.
+
+  @param[in]  ImageBase           Memory address of an image.
+  @param[out] MachinePtr          The pointer to machine type to return.
+
+  @retval EFI_SUCCESS             Machine was returned successfully.
+  @retval EFI_UNSUPPORTED         Unsupported image format.
+  @retval EFI_INVALID_PARAMETER   The ImageBase pointer is NULL.
+
+**/
+EFI_STATUS
+EFIAPI
+GetElfMachine (
+  IN  VOID                        *ImageBase,
+  OUT UINT16                      *MachinePtr      OPTIONAL
   );
 
 #endif /* __ELF_LIB_H__ */

--- a/BootloaderCommonPkg/Library/ElfLib/ElfLibInternal.h
+++ b/BootloaderCommonPkg/Library/ElfLib/ElfLibInternal.h
@@ -12,6 +12,7 @@
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
+#include <IndustryStandard/PeImage.h>
 #include "ElfCommon.h"
 #include "Elf32.h"
 #include "Elf64.h"

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -183,7 +183,10 @@ NormalBootPath (
     UefiSig = Dst[0];
     Status  = LoadFvImage (Dst, Stage2Param->PayloadActualLength, (VOID **)&PldEntry, &PldMachine);
   } else if (IsElfImage (Dst)) {
-    Status = LoadElfImage (Dst, (VOID *)&PldEntry);
+    Status = GetElfMachine (Dst, &PldMachine);
+    if (!EFI_ERROR(Status)) {
+      Status = LoadElfImage (Dst, (VOID *)&PldEntry);
+    }
   } else {
     if (FeaturePcdGet (PcdLinuxPayloadEnabled)) {
       if (IsBzImage (Dst)) {


### PR DESCRIPTION
This allows to load and execute ELF32 or ELF64 format payloads
regardless of Ia32 or X64 SBL operation modes.

Signed-off-by: Aiden Park <aiden.park@intel.com>