### PR TITLE
[FWU] Fix a pointer misusing in capsule name

### DIFF
--- a/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
+++ b/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
@@ -283,7 +283,7 @@ LoadCapsuleImage (
   // Find capsule using the name provided in configuration data
   //
   if (CapsuleInfo->FileName[0] != 0) {
-    AsciiStrToUnicodeStrS ((CONST CHAR8 *)(&CapsuleInfo->FileName), FileName, MAX_FILE_LEN);
+    AsciiStrToUnicodeStrS ((CONST CHAR8 *)&CapsuleInfo->FileName[0], FileName, MAX_FILE_LEN);
 
     Status = OpenFile (FsHandle, FileName, &FileHandle);
     if (EFI_ERROR(Status)) {


### PR DESCRIPTION
This will fix an invalid pointer operation while copying capsule filename
from capsule info config data to a unicode buffer.

Signed-off-by: Aiden Park <aiden.park@intel.com>