### PR TITLE
[CFL] Resolve StitchIfwi.py issue

### DIFF
--- a/Platform/CoffeelakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/CoffeelakeBoardPkg/Script/StitchIfwi.py
@@ -544,11 +544,11 @@ def main():
         raise Exception ('Stitching process failed !')
     os.chdir(curr_dir)
 
-    generated_ifwi_file = os.path.join(work_dir, 'Temp', 'Ifwi.bin')
+    generated_ifwi_file = os.path.join(stitch_dir, 'Temp', 'Ifwi.bin')
     ifwi_file_name = os.path.join(args.outpath,'sbl_ifwi_%s.bin' % (args.platform))
     shutil.copy(generated_ifwi_file, ifwi_file_name)
 
-    generated_signed_sbl =  os.path.join(work_dir, 'Temp', 'SlimBootloader.bin')
+    generated_signed_sbl =  os.path.join(stitch_dir, 'Temp', 'SlimBootloader.bin')
     sbl_file_name = os.path.join(args.outpath,'SlimBootloader_%s.bin' % (args.platform))
     shutil.copy(generated_signed_sbl, sbl_file_name)
 


### PR DESCRIPTION
Recent addition of '-op' argument may have
unintentionally created an issue by using an
unassigned variable 'work_dir' where the
intended variable to be used may have been
'stitch_dir'. This patch resolves the issue
and able to successfully stitch an IFWI once
again.

Signed-off-by: James Gutbub <james.gutbub@intel.com>