### PR TITLE
[TGL] Fix TGL PCH Debug UART issue

### DIFF
--- a/Silicon/TigerlakePkg/Library/PlatformHookLib/PlatformHookLib.c
+++ b/Silicon/TigerlakePkg/Library/PlatformHookLib/PlatformHookLib.c
@@ -179,6 +179,7 @@ PlatformHookSerialPortInitialize (
     // Bring UART out of reset
     //
     MmioWrite32 (BarAddress + R_SERIAL_IO_MEM_PPR_RESETS, B_SERIAL_IO_MEM_PPR_RESETS_IDMA | B_SERIAL_IO_MEM_PPR_RESETS_APB | B_SERIAL_IO_MEM_PPR_RESETS_FUNC);
+    MmioRead32 (BarAddress + R_SERIAL_IO_MEM_PPR_RESETS);
 
     //
     // Set clock


### PR DESCRIPTION
On TGL platform, if change current DEBUG UART to PCH UART, there
is no output from SBL at all.

This patch fixed this issue by:
  - Skip UART init in FSP-T and let SBL do UART init itself.
  - Disable any debug output before UART init is done.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>