### PR TITLE
Disable debug prints before serial init

### DIFF
--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -368,6 +368,9 @@ SecStartup2 (
   BoardInit (PostTempRamInit);
   AddMeasurePoint (0x1040);
 
+  // Set DebugPrintErrorLevel to default PCD.
+  SetDebugPrintErrorLevel (PcdGet32 (PcdDebugPrintErrorLevel));
+
   if (DebugCodeEnabled()) {
     DEBUG ((DEBUG_INFO, "\n============= %a STAGE1A =============\n",mBootloaderName));
   } else {
@@ -460,7 +463,7 @@ SecStartup (
   LdrGlobal->MemPoolStart          = StackTop;
   LdrGlobal->MemPoolCurrTop        = LdrGlobal->MemPoolEnd;
   LdrGlobal->MemPoolCurrBottom     = LdrGlobal->MemPoolStart;
-  LdrGlobal->DebugPrintErrorLevel  = PcdGet32 (PcdDebugPrintErrorLevel);
+  LdrGlobal->DebugPrintErrorLevel  = 0;
   LdrGlobal->PerfData.PerfIndex    = 2;
   LdrGlobal->PerfData.FreqKhz      = GetTimeStampFrequency ();
   LdrGlobal->PerfData.TimeStamp[0] = Stage1aAsmParam->TimeStamp | 0x1000000000000000ULL;

--- a/BootloaderCorePkg/Stage1A/Stage1A.h
+++ b/BootloaderCorePkg/Stage1A/Stage1A.h
@@ -29,6 +29,7 @@
 #include <Library/DebugAgentLib.h>
 #include <Library/ContainerLib.h>
 #include <Library/StageLib.h>
+#include <Library/DebugPrintErrorLevelLib.h>
 #include <Guid/FspHeaderFile.h>
 #include <Guid/FlashMapInfoGuid.h>
 #include <Guid/LoaderPlatformDataGuid.h>


### PR DESCRIPTION
Set debug print error level to 0 by default.
This will prevent code to print debug messages via
UART, if it is not yet initielized.

After PostTempRamInit, when platforms did UartInit,
we can set it back to default PCD value, or leave it
as it is if the platform has set a custom level.

Signed-off-by: Talamudupula <stalamudupula@gmail.com>