### PR TITLE
Get RTCM from OS boot media instead IFWI

### DIFF
--- a/PayloadPkg/OsLoader/ExtraModSupport.c
+++ b/PayloadPkg/OsLoader/ExtraModSupport.c
@@ -38,7 +38,7 @@ CallExtraModule (
   PLD_EXTRA_MOD_ARGS   ModArgs;
   VOID                *ExtraImageBase;
 
-  ExtraImageBase = LoadedImage->ImageData.Addr;
+  ExtraImageBase = LoadedImage->Image.Common.BootFile.Addr;
 
   // Prepare memory for extra modules
   ZeroMem (&ModArgs, sizeof(ModArgs));


### PR DESCRIPTION
RTCM will sit in OS boot media instead of IFWI image
So update SBL logic to load RTCM from OS boot media.

If the RTCM could not be found, SBL should continue
boot normal OS.

Signed-off-by: Guo Dong <guo.dong@intel.com>