### PR TITLE
Add a Pci Enum Hook function

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -186,6 +186,7 @@
   gPlatformModuleTokenSpaceGuid.PcdFuncCpuInitHook        | 0x00000000 | UINT32 | 0x2000019A
   gPlatformModuleTokenSpaceGuid.PcdFspsUpdPtr             | 0x00000000 | UINT32 | 0x2000019B
   gPlatformModuleTokenSpaceGuid.PcdAcpiTableTemplatePtr   | 0x00000000 | UINT32 | 0x2000019C
+  gPlatformModuleTokenSpaceGuid.PcdPciEnumHookProc       | 0x00000000 | UINT32 | 0x2000019D
 
   gPlatformModuleTokenSpaceGuid.PcdPciResAllocTableBase   | 0x00000000 | UINT32 | 0x200001A0
   gPlatformModuleTokenSpaceGuid.PcdPciResourceIoBase      | 0x00000000 | UINT32 | 0x200001A1

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -282,6 +282,7 @@
   gPlatformModuleTokenSpaceGuid.PcdFuncCpuInitHook   | 0x00000000
   gPlatformModuleTokenSpaceGuid.PcdFspsUpdPtr        | 0x00000000
   gPlatformModuleTokenSpaceGuid.PcdAcpiTableTemplatePtr | 0
+  gPlatformModuleTokenSpaceGuid.PcdPciEnumHookProc   | 0x00000000
 
   gPlatformModuleTokenSpaceGuid.PcdPciResAllocTableBase    | 0x00000000
 

--- a/BootloaderCorePkg/Include/Library/PciEnumerationLib.h
+++ b/BootloaderCorePkg/Include/Library/PciEnumerationLib.h
@@ -8,6 +8,26 @@
 #ifndef __PCI_ENUMERTION_LIB_H__
 #define __PCI_ENUMERTION_LIB_H__
 
+typedef enum {
+  ///
+  /// This notification is only applicable to PCI-PCI bridges and
+  /// indicates that the PCI enumerator is about to begin enumerating
+  /// the bus behind the PCI-PCI Bridge. This notification is sent after
+  /// the primary bus number, the secondary bus number and the subordinate
+  /// bus number registers in the PCI-PCI Bridge are programmed to valid
+  /// (not necessary final) values
+  ///
+  EfiPciBeforeChildBusEnumeration,
+
+  ///
+  /// This notification is sent before the PCI enumerator probes BAR registers
+  /// for every valid PCI function.
+  ///
+  EfiPciBeforeResourceCollection
+} EFI_PCI_CONTROLLER_RESOURCE_ALLOCATION_PHASE;
+
+typedef VOID   (EFIAPI *PLATFORM_PCI_ENUM_HOOK_PROC) (UINT8 Bus, UINT8 Dev, UINT8 Fun, EFI_PCI_CONTROLLER_RESOURCE_ALLOCATION_PHASE Phase);
+
 /**
  Enumerates the PCI devices allocates the required memory resource.
  Program the allocated memory resource to PCI BAR.

--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.inf
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.inf
@@ -56,3 +56,4 @@
   gPlatformModuleTokenSpaceGuid.PcdAriSupport
   gPlatformModuleTokenSpaceGuid.PcdSrIovSupport
   gPlatformModuleTokenSpaceGuid.PcdPciResAllocTableBase
+  gPlatformModuleTokenSpaceGuid.PcdPciEnumHookProc


### PR DESCRIPTION
This patch adds a platform hook function ability
in Pci Enum Lib to enable platform to perform a
PCI Enum specific work-around routine to detect
some controllers.

Signed-off-by: Talamudupula <stalamudupula@gmail.com>