### PR TITLE
[TGL] Use MR2 FSP and Microcode for TGL-U

### DIFF
--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -24,8 +24,8 @@ class Board(BaseBoard):
         super(Board, self).__init__(*args, **kwargs)
 
         self.VERINFO_IMAGE_ID       = 'SBL_TGL'
-        self.VERINFO_PROJ_MAJOR_VER = 0
-        self.VERINFO_PROJ_MINOR_VER = 8
+        self.VERINFO_PROJ_MAJOR_VER = 1
+        self.VERINFO_PROJ_MINOR_VER = 2
         self.VERINFO_SVN            = 1
         self.VERINFO_BUILD_DATE     = time.strftime("%m/%d/%Y")
 

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -63,7 +63,7 @@
   - PchTsnLinkSpeed :
       name         : TSN Link Speed
       type         : Combo
-      option       : 0:24Mhz 2.5Gbps, 1:24Mhz 1Gbps, 2:38.4Mhz 2.5Gbps, 3:38.4Mhz 1Gbps
+      option       :   0: Reserved, 1: Reserved, 2: 38.4Mhz 2.5Gbps, 3: 38.4Mhz 1Gbps
       help         : >
                      Set TSN Link Speed.
       length       : 0x01

--- a/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -92,9 +92,11 @@ TccModePreMemConfig (
   FspmUpd->FspmConfig.HyperThreading         = 0;
   FspmUpd->FspmConfig.GtClosEnable           = 1;
   FspmUpd->FspmConfig.BiosGuard              = 0x0;
+  FspmUpd->FspmConfig.VmxEnable              = 1;    // RTCM need enable VMX
 
-  //FspmUpd->FspmConfig.SoftwareSramEnPreMem   = (UINT8)TccCfgData->TccSoftSram;
-  //FspmUpd->FspmConfig.DsoTuningEnPreMem      = (UINT8)TccCfgData->TccTuning;
+  FspmUpd->FspmConfig.SoftwareSramEnPreMem   = TccCfgData->TccSoftSram;
+  FspmUpd->FspmConfig.DsoTuningEnPreMem      = TccCfgData->TccTuning;
+  FspmUpd->FspmConfig.TccErrorLogEnPreMem    = TccCfgData->TccErrorLog;
 
   // Load TCC stream config from container
   TccStreamBase = NULL;
@@ -104,8 +106,8 @@ TccModePreMemConfig (
   if (EFI_ERROR (Status) || (TccStreamSize < sizeof(TCC_STREAM_CONFIGURATION))) {
     DEBUG ((DEBUG_INFO, "Load TCC Stream %r, size = 0x%x\n", Status, TccStreamSize));
   } else {
-    //FspmUpd->FspmConfig.TccStreamCfgBasePreMem = (UINT32)(UINTN)TccStreamBase;
-    //FspmUpd->FspmConfig.TccStreamCfgSizePreMem = TccStreamSize;
+    FspmUpd->FspmConfig.TccStreamCfgBasePreMem = (UINT32)(UINTN)TccStreamBase;
+    FspmUpd->FspmConfig.TccStreamCfgSizePreMem = TccStreamSize;
     DEBUG ((DEBUG_INFO, "Load TCC stream @0x%p, size = 0x%x\n", TccStreamBase, TccStreamSize));
 
     if (TccCfgData->TccTuning != 0) {
@@ -129,8 +131,8 @@ TccModePreMemConfig (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_INFO, "TCC Cache config not found! %r\n", Status));
   } else {
-    //FspmUpd->FspmConfig.TccCacheCfgBasePreMem = (UINT32)(UINTN)TccCacheBase;
-    //FspmUpd->FspmConfig.TccCacheCfgSizePreMem = TccCacheSize;
+    FspmUpd->FspmConfig.TccCacheCfgBasePreMem = (UINT32)(UINTN)TccCacheBase;
+    FspmUpd->FspmConfig.TccCacheCfgSizePreMem = TccCacheSize;
     DEBUG ((DEBUG_INFO, "Load TCC cache @0x%p, size = 0x%x\n", TccCacheBase, TccCacheSize));
   }
 

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1179,9 +1179,10 @@ TccModePostMemConfig (
     FspsUpd->FspsConfig.CpuPcieRpMultiVcEnabled[Index] = 1;
   }
 
-  //FspsUpd->FspsConfig.SoftwareSramEn  = (UINT8)TccCfgData->TccSoftSram;
-  //FspsUpd->FspsConfig.DsoTuningEn     = (UINT8)TccCfgData->TccTuning;
-  //FspsUpd->FspsConfig.IfuEnable       = 0;
+  FspsUpd->FspsConfig.SoftwareSramEn  = TccCfgData->TccSoftSram;
+  FspsUpd->FspsConfig.DsoTuningEn     = TccCfgData->TccTuning;
+  FspsUpd->FspsConfig.TccErrorLogEn   = TccCfgData->TccErrorLog;
+  FspsUpd->FspsConfig.IfuEnable       = 0;
 
   // Load TCC stream config from container
   TccStreamBase = NULL;
@@ -1244,8 +1245,8 @@ TccModePostMemConfig (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_INFO, "TCC CRL not found! %r\n", Status));
   } else {
-    //FspsUpd->FspsConfig.TccCrlBinBase = (UINT32)(UINTN)TccCrlBase;
-    //FspsUpd->FspsConfig.TccCrlBinSize = TccCrlSize;
+    FspsUpd->FspsConfig.TccCrlBinBase = (UINT32)(UINTN)TccCrlBase;
+    FspsUpd->FspsConfig.TccCrlBinSize = TccCrlSize;
     DEBUG ((DEBUG_INFO, "Load tcc crl @0x%p, size = 0x%x\n", TccCrlBase, TccCrlSize));
   }
 
@@ -1488,20 +1489,19 @@ UpdateFspConfig (
       FspsUpd->FspsConfig.CpuPcieRpMultiVcEnabled[Index] = SiCfgData->CpuPcieRpMultiVcEnabled[Index];
       FspsUpd->FspsConfig.CpuPcieRpLtrEnable[Index]      = 1;
       FspsUpd->FspsConfig.CpuPcieRpLtrMaxSnoopLatency[Index]      = 0x1003;
-      FspsUpd->FspsConfig.CpuPcieRpLtrMaxNoSnoopLatency[Index]      = 0x1003;
+      FspsUpd->FspsConfig.CpuPcieRpLtrMaxNoSnoopLatency[Index]    = 0x1003;
       FspsUpd->FspsConfig.CpuPcieRpPmSci[Index]          = 1;
-      FspsUpd->FspsConfig.CpuPcieRpMaxPayload[Index] = 0x1;
+      FspsUpd->FspsConfig.CpuPcieRpMaxPayload[Index]     = 0x1;
     }
-    FspsUpd->FspsConfig.CpuPcieRpFunctionSwap = 0x1;
-    FspsUpd->FspsConfig.CpuPcieSetSecuredRegisterLock = 0x1;
+    FspsUpd->FspsConfig.CpuPcieRpFunctionSwap            = 0x1;
+    FspsUpd->FspsConfig.CpuPcieSetSecuredRegisterLock    = 0x1;
 
     // TSN feature support
     TsnMacAddrBase      = NULL;
     TsnMacAddrSize      = 0;
 
-    FspsConfig->PchTsnEnable       = SiCfgData->PchTsnEnable;
-    FspsConfig->PchTsnLinkSpeed[0] = SiCfgData->PchTsnLinkSpeed;
-    FspsConfig->PchTsnLinkSpeed[1] = SiCfgData->PchTsnLinkSpeed;
+    FspsConfig->PchTsnEnable    = SiCfgData->PchTsnEnable;
+    FspsConfig->PchTsnLinkSpeed = SiCfgData->PchTsnLinkSpeed;
 
     if(SiCfgData->PchTsnEnable == 1) {
       FspsConfig->PchTsnMultiVcEnable = SiCfgData->PchTsnMultiVcEnable;
@@ -1583,6 +1583,12 @@ UpdateFspConfig (
   FspsConfig->IomTypeCPortPadCfg[3] = 0x0;
 
   FspsConfig->SkipMpInit = 0;
+
+  FspsConfig->UsbTcPortEn = 0xf;
+  FspsConfig->ITbtPcieRootPortEn[0] = 0x1;
+  FspsConfig->ITbtPcieRootPortEn[1] = 0x1;
+  FspsConfig->ITbtPcieRootPortEn[2] = 0x1;
+  FspsConfig->ITbtPcieRootPortEn[3] = 0x1;
 
   if (SiCfgData != NULL) {
     FspsConfig->EnableTimedGpio0 = SiCfgData->EnableTimedGpio0;

--- a/Silicon/TigerlakePkg/FspBin/FspBin.inf
+++ b/Silicon/TigerlakePkg/FspBin/FspBin.inf
@@ -1,7 +1,7 @@
 ## @file
 #  File to describe FSP repo information
 #
-#  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -11,7 +11,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = f27fb2424f6d2701737242d073d6935cfe542700
+  COMMIT  = 4a31a4d972eaeb9aa41fef3b121df97f8f2a4e61
 
 [UserExtensions.SBL."CopyList"]
   TigerLakeFspBinPkg/TGL_IOT/Fsp.fd                    : Silicon/TigerlakePkg/FspBin/FspDbg.bin

--- a/Silicon/TigerlakePkg/Microcode/Microcode.inf
+++ b/Silicon/TigerlakePkg/Microcode/Microcode.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2019 - 2021, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 #
@@ -14,13 +14,13 @@
   VERSION_STRING       = 1.0
 
 [Sources]
- m_80_806c1_0000006e.mcb
+ m_80_806c1_0000007e.mcb
 
 [UserExtensions.SBL."CloneRepo"]
   REPO  = https://github.com/tianocore/edk2-non-osi.git
-  COMMIT= 659382a8038dccb802e642800b5efa2ac24c67ed
+  COMMIT= 9c509e9b00cc8f68a0c2293436d0572d3e4a40ce
 
 [UserExtensions.SBL."CopyList"]
-  Silicon/Intel/TigerlakeSiliconBinPkg/Microcode/m_80_806c1_0000006e.mcb  : Silicon/TigerlakePkg/Microcode/m_80_806c1_0000006e.mcb
+  Silicon/Intel/TigerlakeSiliconBinPkg/Microcode/m_80_806c1_0000007e.mcb  : Silicon/TigerlakePkg/Microcode/m_80_806c1_0000007e.mcb
 
 


### PR DESCRIPTION
MR2 FSP is available so update SBL to use MR2 FSP.
and also use new Microcode required by new FSP
Update platform code on FSP UPDs, especially enable TCC feature.
Update TGL platform version to 1.2 since MR2 released.

Signed-off-by: Guo Dong <guo.dong@intel.com>