### PR TITLE
[EHL] Remove unused feature flag for PreOS checker

### DIFF
--- a/BootloaderCommonPkg/Include/Guid/LoaderPlatformInfoGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/LoaderPlatformInfoGuid.h
@@ -25,7 +25,6 @@ extern EFI_GUID gLoaderPlatformInfoGuid;
 #define        FEATURE_MMC_TUNING               BIT2
 #define        FEATURE_MMC_FORCE_TUNING         BIT3
 #define        FEATURE_VERIFIED_BOOT            BIT4
-#define        FEATURE_PRE_OS_CHECKER_BOOT      BIT5
 
 //
 //Definition for LOADER_PLATFORM_INFO.HwState

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -708,12 +708,9 @@ BoardInit (
     // Set pre-OS checker features flag
     LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
     if (FeaturePcdGet (PcdPreOsCheckerEnabled) && PchIsSciSupported ()) {
-      LdrGlobal->LdrFeatures |= FEATURE_PRE_OS_CHECKER_BOOT;
       if (!SciBootSuccess ()) {
         DEBUG ((DEBUG_WARN, "SCI device has boot issue\n"));
       }
-    } else {
-      LdrGlobal->LdrFeatures &= (~FEATURE_PRE_OS_CHECKER_BOOT);
     }
     ClearSmbusStatus ();
 


### PR DESCRIPTION
FEATURE_PRE_OS_CHECKER_BOOT is not used by any core or platform code.
So just remove it.

Signed-off-by: Guo Dong <guo.dong@intel.com>