### PR TITLE
[TGL] Add EC-less board support

### DIFF
--- a/Platform/TigerlakeBoardPkg/AcpiTables/Dsdt/HidPlatformEventDev.asl
+++ b/Platform/TigerlakeBoardPkg/AcpiTables/Dsdt/HidPlatformEventDev.asl
@@ -126,7 +126,7 @@ Scope(\_SB)
       }
     }
 
-//#if FixedPcdGetBool(PcdEcEnable) == 1
+
     //
     // HID Button Load Method - called by Platform to say HID driver is capable of receiving 5-button array notifies.
     // Input: None
@@ -135,6 +135,11 @@ Scope(\_SB)
     //
     Method(BTNL,0,Serialized) // HID Button Enable/Disable Method
     {
+      // Skip if EC is not available
+      If (LEqual(ECON, 0)) {
+        Return ()
+      }
+
       //
       // Clear PBST so that we can hide the default power button.
       //

--- a/Platform/TigerlakeBoardPkg/AcpiTables/Dsdt/Platform.asl
+++ b/Platform/TigerlakeBoardPkg/AcpiTables/Dsdt/Platform.asl
@@ -654,20 +654,21 @@ Method(_WAK,1,Serialized)
       \_SB.TCWK(Arg0)
     }
   }
-//#if FixedPcdGetBool(PcdEcEnable) == 1
-  If(LOr(LEqual(Arg0,3), LEqual(Arg0,4)))  // If S3 or S4 Resume
-  {
-    //
-    // If Using Control Method Power Button, notify PWRD device with 0x2
-    //
-    If(LEqual(\_SB.PWRB.PBST, 0x1)) {
-      If(PBSS) { //Power Button woke the system
-        Notify(\_SB.PWRB, 0x02) // Send release notification to Power Button device 0x02
-        Store(1, PBSS)
+
+  If (LEqual(ECON,1)) {
+    If(LOr(LEqual(Arg0,3), LEqual(Arg0,4)))  // If S3 or S4 Resume
+    {
+      //
+      // If Using Control Method Power Button, notify PWRD device with 0x2
+      //
+      If(LEqual(\_SB.PWRB.PBST, 0x1)) {
+        If(PBSS) { //Power Button woke the system
+          Notify(\_SB.PWRB, 0x02) // Send release notification to Power Button device 0x02
+          Store(1, PBSS)
+        }
       }
     }
   }
-//#endif
 
   If(LEqual(Arg0,3))
   {

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -244,7 +244,15 @@
                      Enable/disable Timed GPIO1    0- Disable; 1- Enable.
       length       : 0x01
       value        : 0x0
+  - EcEnable     :
+      name         : Enable EC Device
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     Enable/disable EC
+      length       : 0x01
+      value        : 0x01
   - Dummy        :
-      length       : 0x2
+      length       : 0x1
       value        : 0x0
 

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1002,17 +1002,19 @@ BoardInit (
       ProgramSecuritySetting ();
     }
 
-    //
-    // Enable decoding of I/O locations 62h and 66h to LPC
-    //
-    LpcBase = MM_PCI_ADDRESS (0, PCI_DEVICE_NUMBER_PCH_LPC, 0, 0);
-    MmioOr16 (LpcBase + R_LPC_CFG_IOE, B_LPC_CFG_IOE_ME1);
+    SiCfgData = (SILICON_CFG_DATA *)FindConfigDataByTag (CDATA_SILICON_TAG);
+    if ((SiCfgData != NULL) && (SiCfgData->EcEnable == 1)){
+      //
+      // Enable decoding of I/O locations 62h and 66h to LPC
+      //
+      LpcBase = MM_PCI_ADDRESS (0, PCI_DEVICE_NUMBER_PCH_LPC, 0, 0);
+      MmioOr16 (LpcBase + R_LPC_CFG_IOE, B_LPC_CFG_IOE_ME1);
 
-    //
-    // Enable EC's ACPI mode to control power to motherboard during Sleep (S3)
-    //
-    IoWrite16 (EC_C_PORT, EC_C_ACPI_ENABLE);
-
+      //
+      // Enable EC's ACPI mode to control power to motherboard during Sleep (S3)
+      //
+      IoWrite16 (EC_C_PORT, EC_C_ACPI_ENABLE);
+    }
     break;
 
   case ReadyToBoot:
@@ -2150,6 +2152,13 @@ PlatformUpdateAcpiTable (
   Ptr  = (UINT8 *)Table;
   End  = (UINT8 *)Table + Table->Length;
 
+  if (Table->Signature == EFI_ACPI_5_0_EMBEDDED_CONTROLLER_BOOT_RESOURCES_TABLE_SIGNATURE) {
+    SiCfgData = (SILICON_CFG_DATA *)FindConfigDataByTag (CDATA_SILICON_TAG);
+    if ((SiCfgData == NULL) || (SiCfgData->EcEnable == 0)) {
+      return EFI_UNSUPPORTED;
+    }
+  }
+
   if (Table->Signature == EFI_ACPI_5_0_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE) {
     for (; Ptr < End; Ptr++) {
       if (*(Ptr-1) != AML_NAME_OP)
@@ -2655,17 +2664,19 @@ PlatformUpdateAcpiGnvs (
   PlatformNvs->NativePCIESupport = 1;
   PlatformNvs->PciDelayOptimizationEcr = 0;
   PlatformNvs->ApicEnable = 1;
-  PlatformNvs->EcAvailable = 1;
   PlatformNvs->Ps2MouseEnable = 1;
   PlatformNvs->UsbTypeCSupport = 1;
-  PlatformNvs->EcLowPowerMode               = 1;
 
-  if (IsPchLp ()) {
-    PlatformNvs->EcSmiGpioPin                 = GPIO_VER2_LP_GPP_E7;
-    PlatformNvs->EcLowPowerModeGpioPin        = GPIO_VER2_LP_GPP_E8;
-  } else if (IsPchH ()) {
-    PlatformNvs->EcSmiGpioPin                 = GPIO_VER2_H_GPP_E3;
-    PlatformNvs->EcLowPowerModeGpioPin        = GPIO_VER2_H_GPP_B23;
+  if ((SiCfgData != NULL) && (SiCfgData->EcEnable == 1)) {
+    PlatformNvs->EcAvailable                  = 1;
+    PlatformNvs->EcLowPowerMode               = 1;
+    if (IsPchLp ()) {
+      PlatformNvs->EcSmiGpioPin               = GPIO_VER2_LP_GPP_E7;
+      PlatformNvs->EcLowPowerModeGpioPin      = GPIO_VER2_LP_GPP_E8;
+    } else if (IsPchH ()) {
+      PlatformNvs->EcSmiGpioPin               = GPIO_VER2_H_GPP_E3;
+      PlatformNvs->EcLowPowerModeGpioPin      = GPIO_VER2_H_GPP_B23;
+    }
   }
 
   PlatformNvs->Ac1TripPoint                 = 55;
@@ -2867,12 +2878,18 @@ PlatformUpdateAcpiGnvs (
   PlatformNvs->PcdRealBattery1Control = 0x1;
   PlatformNvs->PcdRealBattery2Control = 0x2;
   PlatformNvs->PcdConvertableDockSupport = 0x1;
-  PlatformNvs->PcdEcHotKeyF3Support = 0x1;
-  PlatformNvs->PcdEcHotKeyF4Support = 0x1;
-  PlatformNvs->PcdEcHotKeyF5Support = 0x1;
-  PlatformNvs->PcdEcHotKeyF6Support = 0x1;
-  PlatformNvs->PcdEcHotKeyF7Support = 0x1;
-  PlatformNvs->PcdEcHotKeyF8Support = 0x1;
+
+  if ((SiCfgData != NULL) && (SiCfgData->EcEnable == 1)) {
+    PlatformNvs->PcdEcHotKeyF3Support = 0x1;
+    PlatformNvs->PcdEcHotKeyF4Support = 0x1;
+    PlatformNvs->PcdEcHotKeyF5Support = 0x1;
+    PlatformNvs->PcdEcHotKeyF6Support = 0x1;
+    PlatformNvs->PcdEcHotKeyF7Support = 0x1;
+    PlatformNvs->PcdEcHotKeyF8Support = 0x1;
+    PlatformNvs->PcdAcpiEnableAllButtonSupport = 0x1;
+    PlatformNvs->PcdAcpiHidDriverButtonSupport = 0x1;
+  }
+
   PlatformNvs->PcdVirtualButtonVolumeUpSupport = 0x1;
   PlatformNvs->PcdVirtualButtonVolumeDownSupport = 0x1;
   PlatformNvs->PcdVirtualButtonHomeButtonSupport = 0x1;
@@ -2880,8 +2897,7 @@ PlatformUpdateAcpiGnvs (
   PlatformNvs->PcdSlateModeSwitchSupport = 0x1;
   PlatformNvs->PcdAcDcAutoSwitchSupport = 0x1;
   PlatformNvs->PcdPmPowerButtonGpioPin = 0x9050003;
-  PlatformNvs->PcdAcpiEnableAllButtonSupport = 0x1;
-  PlatformNvs->PcdAcpiHidDriverButtonSupport = 0x1;
+
   PlatformNvs->UCMS = 0x1;
   PlatformNvs->WwanPerstGpio = 0x9000011;
   PlatformNvs->PcieSlot1WakeGpio = 0x90C0005;


### PR DESCRIPTION
Current TGL implementation assumed EC always exists on the board.
It does not work for EC-less design. In this patch, a EcEnable
CFGDATA is added to control it.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>