### PR TITLE
[WIP]Allow dynamic setting for payload ID GPIO pin config

### DIFF
--- a/Platform/ApollolakeBoardPkg/CfgData/CfgDataDef.yaml
+++ b/Platform/ApollolakeBoardPkg/CfgData/CfgDataDef.yaml
@@ -93,39 +93,6 @@ configs:
         length       : 0x03
         value        : 0
 
-  - $ACTION      :
-      page         : PSEL:PLT:"Payload Selection GPIO"
-  - $ACTION      :
-      page         : PSEL
-  - PLATFORM_CFG_DATA :
-    - !expand { CFGHDR_TMPL : [ PLATFORM_CFG_DATA, 0x280, 0, 0 ] }
-    - PayloadSelGpio :
-      - $STRUCT      :
-          name         : GPIO pin for switching payload
-          struct       : PAYLOAD_SEL_GPIO_PIN
-          length       : 0x04
-          value        : 0x000000c5
-      - PadInfo      :
-          name         : Pin Number
-          type         : Combo
-          option       : !include CfgData_GpioPinOption.yaml
-          condition    : ($PLATFORM_CFG_DATA.PayloadSelGpio.Enable > 0)
-          help         : >
-                         Specify GPIO Pin Number
-          length       : 24b
-      - Rsvd1        :
-          name         : Reserved
-          type         : Reserved
-          length       : 7b
-      - Enable       :
-          name         : Payload Selection Pin Enable
-          type         : Combo
-          option       : $EN_DIS
-          help         : >
-                         Enable/Disable this pin for payload selection.
-          order        : 0000.0000
-          length       : 1b
-
 
   - !include CfgData_Memory.yaml
 

--- a/Platform/ApollolakeBoardPkg/CfgData/CfgData_Ext_JuniperHill.dlt
+++ b/Platform/ApollolakeBoardPkg/CfgData/CfgData_Ext_JuniperHill.dlt
@@ -15,8 +15,8 @@ PLAT_NAME_CFG_DATA.PlatformName                     | 'JNH'
 
 GEN_CFG_DATA.PayloadId                              | 'AUTO'
 
-PLATFORM_CFG_DATA.PayloadSelGpio.Enable             | 0x1
-PLATFORM_CFG_DATA.PayloadSelGpio.PadInfo            | 0x168C5
+GEN_CFG_DATA.PayloadSelGpio.Enable                  | 0x1
+GEN_CFG_DATA.PayloadSelGpio.PinNum                  | 0x168C5
 
 MEMORY_CFG_DATA.Package                             | 0x0
 MEMORY_CFG_DATA.Profile                             | 0x19

--- a/Platform/ApollolakeBoardPkg/CfgData/CfgData_Ext_OxbHill.dlt
+++ b/Platform/ApollolakeBoardPkg/CfgData/CfgData_Ext_OxbHill.dlt
@@ -15,8 +15,8 @@ PLAT_NAME_CFG_DATA.PlatformName                     | 'OXH'
 
 GEN_CFG_DATA.PayloadId                              | 'AUTO'
 
-PLATFORM_CFG_DATA.PayloadSelGpio.Enable             | 0x1
-PLATFORM_CFG_DATA.PayloadSelGpio.PadInfo            | 0x168C5
+GEN_CFG_DATA.PayloadSelGpio.Enable                  | 0x1
+GEN_CFG_DATA.PayloadSelGpio.PinNum                  | 0x168C5
 
 MEMORY_CFG_DATA.Package                             | 0x0
 MEMORY_CFG_DATA.Profile                             | 0x19

--- a/Platform/ApollolakeBoardPkg/CfgData/CfgData_Int_LeafHill.dlt
+++ b/Platform/ApollolakeBoardPkg/CfgData/CfgData_Int_LeafHill.dlt
@@ -15,5 +15,5 @@ PLAT_NAME_CFG_DATA.PlatformName          | 'LeafHill'
 
 GEN_CFG_DATA.PayloadId                   | 'AUTO'
 
-PLATFORM_CFG_DATA.PayloadSelGpio.Enable    | 0x1
-PLATFORM_CFG_DATA.PayloadSelGpio.PadInfo   | 0x168C5
+GEN_CFG_DATA.PayloadSelGpio.Enable       | 0x1
+GEN_CFG_DATA.PayloadSelGpio.PinNum       | 0x168C5

--- a/Platform/CoffeelakeBoardPkg/CfgData/CfgDataInt_Whl.dlt
+++ b/Platform/CoffeelakeBoardPkg/CfgData/CfgDataInt_Whl.dlt
@@ -39,8 +39,8 @@ GPU_CFG_DATA.DdiPortDHpd                 | 0x0
 GPU_CFG_DATA.DdiPortFHpd                 | 0x0
 
 GEN_CFG_DATA.PayloadId                   | 'AUTO'
-
-SILICON_CFG_DATA.PayloadSelGpio          | 0x80A5
+GEN_CFG_DATA.PayloadSelGpio.Enable       | 0x1
+GEN_CFG_DATA.PayloadSelGpio.PinNum       | 0x80A5
 
 GPIO_CFG_DATA.GpioPinConfig1_GPP_A00.GPIOSkip_GPP_A00 | 1
 GPIO_CFG_DATA.GpioPinConfig1_GPP_A01.GPIOSkip_GPP_A01 | 1

--- a/Platform/CoffeelakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/CoffeelakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -36,43 +36,7 @@
                      Enable or Disable legacy serial port expose to OS; <b>0- Disable</b>; 1- Enable.
       length       : 0x01
       value        : 0x00
-  - $ACTION      :
-      page         : PSEL:SIL:"Payload Selection GPIO"
-  - $ACTION      :
-      page         : PSEL
-  - PayloadSelGpio :
-    - $STRUCT      :
-        name         : GPIO pin for switching payload
-        struct       : PAYLOAD_SEL_GPIO_PIN
-        help         : >
-                       specify GPIO PIN number to read and switch payloads
-        length       : 0x02
-        value        : 0
-    - Group        :
-        name         : Pad Group
-        type         : Combo
-        option       : 0x0:GROUP_A, 0x1:GROUP_B, 0x2:GROUP_C, 0x3:GROUP_D, 0x4:GROUP_E, 0x5:GROUP_F, 0x6:GROUP_G, 0x7:GROUP_H, 0x8:GROUP_I, 0x9 :GROUP_J, 0xA:GROUP_K
-        help         : >
-                       Specify Pad Group
-        length       : 4bW
-    - PinNum       :
-        name         : Pin Number
-        type         : EditNum, DEC, (0,24)
-        help         : >
-                       Specify Pin Number
-        length       : 5bW
-    - Rsvd1        :
-        name         : Reserved
-        type         : Reserved
-        length       : 6bW
-    - Enable       :
-        name         : Payload Selection Pin Enable
-        type         : Combo
-        option       : $EN_DIS
-        help         : >
-                       Enable/Disable this pin for payload selection.
-        length       : 1bW
   - SiliconRsvd  :
-      length       : 0x03
+      length       : 0x01
       value        : 0x00
 

--- a/Platform/CometlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/CometlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -1,155 +1,42 @@
 ## @file
-
 #
-
 #  Slim Bootloader CFGDATA Option File.
-
 #
-
-#  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
-
+#  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
-
 #
-
 ##
 
-
-
-
-
 - $ACTION      :
-
     page         : SIL
-
 - SILICON_CFG_DATA :
-
   - !expand { CFGHDR_TMPL : [ SILICON_CFG_DATA, 0x600, 0, 0 ] }
-
   - ECEnable     :
-
       name         : Enable EC Device
-
       type         : Combo
-
       option       : $EN_DIS
-
       help         : >
-
                      Enable/disable EC
-
       length       : 0x01
-
       value        : 0x01
-
   - DebugInterfaceEnable :
-
       name         : Enable or Disable processor debug features
-
       type         : Combo
-
       option       : $EN_DIS
-
       help         : >
-
                      Enable or Disable processor debug features; <b>0- Disable</b>; 1- Enable.
-
       length       : 0x01
-
       value        : 0x00
-
   - EnableLegacySerial :
-
       name         : Enable or Disable legacy serial port expose to OS
-
       type         : Combo
-
       option       : $EN_DIS
-
       help         : >
-
                      Enable or Disable legacy serial port expose to OS; <b>0- Disable</b>; 1- Enable.
-
       length       : 0x01
-
       value        : 0x00
-
-  - $ACTION      :
-
-      page         : PSEL:SIL:"Payload Selection GPIO"
-
-  - $ACTION      :
-
-      page         : PSEL
-
-  - PayloadSelGpio :
-
-    - $STRUCT      :
-
-        name         : GPIO pin for switching payload
-
-        struct       : PAYLOAD_SEL_GPIO_PIN
-
-        help         : >
-
-                       specify GPIO PIN number to read and switch payloads
-
-        length       : 0x02
-
-        value        : 0
-
-    - Group        :
-
-        name         : Pad Group
-
-        type         : Combo
-
-        option       : 0x0:GROUP_A, 0x1:GROUP_B, 0x2:GROUP_C, 0x3:GROUP_D, 0x4:GROUP_E, 0x5:GROUP_F, 0x6:GROUP_G, 0x7:GROUP_H, 0x8:GROUP_I, 0x9 :GROUP_J, 0xA:GROUP_K
-
-        help         : >
-
-                       Specify Pad Group
-
-        length       : 4bW
-
-    - PinNum       :
-
-        name         : Pin Number
-
-        type         : EditNum, INT, (0,24)
-
-        help         : >
-
-                       Specify Pin Number
-
-        length       : 5bW
-
-    - Rsvd1        :
-
-        name         : Reserved
-
-        type         : Reserved
-
-        length       : 6bW
-
-    - Enable       :
-
-        name         : Payload Selection Pin Enable
-
-        type         : Combo
-
-        option       : $EN_DIS
-
-        help         : >
-
-                       Enable/Disable this pin for payload selection.
-
-        length       : 1bW
-
   - SiliconRsvd  :
-
-      length       : 0x03
-
+      length       : 0x01
       value        : 0x00
 
 

--- a/Platform/CometlakevBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/CometlakevBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -36,43 +36,7 @@
                      Enable or Disable legacy serial port expose to OS; <b>0- Disable</b>; 1- Enable.
       length       : 0x01
       value        : 0x00
-  - $ACTION      :
-      page         : PSEL:SIL:"Payload Selection GPIO"
-  - $ACTION      :
-      page         : PSEL
-  - PayloadSelGpio :
-    - $STRUCT      :
-        name         : GPIO pin for switching payload
-        struct       : PAYLOAD_SEL_GPIO_PIN
-        help         : >
-                       specify GPIO PIN number to read and switch payloads
-        length       : 0x02
-        value        : 0
-    - Group        :
-        name         : Pad Group
-        type         : Combo
-        option       : 0x0:GROUP_A, 0x1:GROUP_B, 0x2:GROUP_C, 0x3:GROUP_D, 0x4:GROUP_E, 0x5:GROUP_F, 0x6:GROUP_G, 0x7:GROUP_H, 0x8:GROUP_I, 0x9 :GROUP_J, 0xA:GROUP_K
-        help         : >
-                       Specify Pad Group
-        length       : 4bW
-    - PinNum       :
-        name         : Pin Number
-        type         : EditNum, INT, (0,24)
-        help         : >
-                       Specify Pin Number
-        length       : 5bW
-    - Rsvd1        :
-        name         : Reserved
-        type         : Reserved
-        length       : 6bW
-    - Enable       :
-        name         : Payload Selection Pin Enable
-        type         : Combo
-        option       : $EN_DIS
-        help         : >
-                       Enable/Disable this pin for payload selection.
-        length       : 1bW
   - SiliconRsvd  :
-      length       : 0x03
+      length       : 0x01
       value        : 0x00
 

--- a/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -999,6 +999,43 @@ GpioInit (
   return GpioConfigurePads (GpioEntries, (GPIO_INIT_CONFIG *) GpioCfgDataBuffer);
 }
 
+/**
+  Update current boot Payload ID.
+
+**/
+VOID
+UpdatePayloadId (
+  VOID
+  )
+{
+  EFI_STATUS      Status;
+  GEN_CFG_DATA    *GenCfgData;
+  UINT32          PayloadId;
+  UINT8           GpioChipsetId;
+  UINT32          PayloadSelGpioData;
+  UINT32          PayloadSelGpioPin;
+
+  GenCfgData = (GEN_CFG_DATA *)FindConfigDataByTag (CDATA_GEN_TAG);
+  if (GenCfgData == NULL) {
+    ASSERT (FALSE);
+    return;
+  }
+
+  if (GenCfgData->PayloadId != AUTO_PAYLOAD_ID_SIGNATURE || !GenCfgData->PayloadSelGpio.Enable) {
+    SetPayloadId (GenCfgData->PayloadId);
+    return;
+  }
+
+  // Switch payloads based on configured GPIO pin
+  GpioChipsetId = IsPchLp() ? GPIO_CNL_LP_CHIPSET_ID : GPIO_CNL_H_CHIPSET_ID;
+  PayloadSelGpioPin = (GenCfgData->PayloadSelGpio.PinNum) | (GpioChipsetId << 24);
+  DEBUG ((DEBUG_INFO, "GPIO Payload pin 0x%X\n", PayloadSelGpioPin));
+  Status = GpioGetInputValue (PayloadSelGpioPin, &PayloadSelGpioData);
+  ASSERT (Status == RETURN_SUCCESS);
+  PayloadId = PayloadSelGpioData ? 0 : UEFI_PAYLOAD_ID_SIGNATURE;
+  DEBUG ((DEBUG_INFO, "Set PayloadId to 0x%X based on GPIO config\n", PayloadId));
+  SetPayloadId (PayloadId);
+}
 
 /**
   Initialize Board specific things in Stage2 Phase
@@ -1012,7 +1049,6 @@ BoardInit (
   IN  BOARD_INIT_PHASE    InitPhase
 )
 {
-  GEN_CFG_DATA    *GenericCfgData;
   SILICON_CFG_DATA  *SiliconCfgData;
   EFI_STATUS      Status;
   UINT32          RgnBase;
@@ -1026,9 +1062,6 @@ BoardInit (
   UINT32          Length;
   UINT32          TsegBase;
   UINT32          TsegSize;
-  UINT32          PayloadSelGpioData;
-  UINT32          PayloadSelGpioPad;
-  UINT32          PayloadId;
   UINTN           PmcBaseAddr;
   EFI_PEI_GRAPHICS_INFO_HOB *FspGfxHob;
   LOADER_GLOBAL_DATA        *LdrGlobal;
@@ -1039,45 +1072,11 @@ BoardInit (
     GpioInit ();
     SpiConstructor ();
 
-    PayloadId = GetPayloadId ();
-    GenericCfgData = (GEN_CFG_DATA *)FindConfigDataByTag (CDATA_GEN_TAG);
-    if (GenericCfgData != NULL) {
-      if (GenericCfgData->PayloadId == AUTO_PAYLOAD_ID_SIGNATURE) {
-        PayloadId = 0;
-      } else {
-        PayloadId = GenericCfgData->PayloadId;
-      }
-    }
-
-    //
-    // Switch payloads based on configured GPIO pin
-    //
-    SiliconCfgData = (SILICON_CFG_DATA *)FindConfigDataByTag (CDATA_SILICON_TAG);
-    if ((SiliconCfgData != NULL) && (SiliconCfgData->PayloadSelGpio.Enable != 0)){
-      if (IsPchLp() == TRUE) {
-        PayloadSelGpioPad = GPIO_CFG_PIN_TO_PAD(SiliconCfgData->PayloadSelGpio) | (GPIO_CNL_LP_CHIPSET_ID << 24);
-      } else {
-        PayloadSelGpioPad = GPIO_CFG_PIN_TO_PAD(SiliconCfgData->PayloadSelGpio) | (GPIO_CNL_H_CHIPSET_ID << 24);
-      }
-      Status = GpioGetInputValue (PayloadSelGpioPad, &PayloadSelGpioData);
-      if (!EFI_ERROR (Status)) {
-        if (PayloadSelGpioData == 0) {
-          PayloadId = 0;
-        } else {
-          if ((GenericCfgData != NULL) && (GenericCfgData->PayloadId == AUTO_PAYLOAD_ID_SIGNATURE)) {
-            PayloadId = UEFI_PAYLOAD_ID_SIGNATURE;
-          }
-        }
-        DEBUG ((DEBUG_INFO, "Set PayloadId to 0x%08X based on GPIO config\n", PayloadId));
-      }
-    }
-    mSiliconCfgData = SiliconCfgData;
-
-    SetPayloadId (PayloadId);
-
-    if (GetLoaderGlobalDataPointer ()->BootMode != BOOT_ON_FLASH_UPDATE) {
+    if (GetBootMode() != BOOT_ON_FLASH_UPDATE) {
+      UpdatePayloadId ();
       UpdateBlRsvdRegion ();
     }
+
     Status = GetComponentInfo (FLASH_MAP_SIG_VARIABLE, &RgnBase, &RgnSize);
     if (!EFI_ERROR(Status)) {
       VariableConstructor (RgnBase, RgnSize);

--- a/Platform/CommonBoardPkg/CfgData/CfgData_Common.yaml
+++ b/Platform/CommonBoardPkg/CfgData/CfgData_Common.yaml
@@ -26,6 +26,30 @@
                      Specify payload ID string. Empty will boot default payload. Otherwise, boot specified payload ID in multi-payload binary.
       length       : 0x04
       value        : ''
+  - PayloadSelGpio :
+    - $STRUCT      :
+        name         : GPIO pin for switching payload
+        struct       : PAYLOAD_SEL_GPIO_PIN
+        length       : 0x04
+        value        : 0
+    - PinNum       :
+        name         : Pin Number
+        type         : EditNum, DEC, (0,24)
+        condition    : ($GEN_CFG_DATA.PayloadSelGpio.Enable > 0)
+        help         : >
+                       Specify GPIO Pin Number
+        length       : 24b
+    - Rsvd1        :
+        name         : Reserved
+        type         : Reserved
+        length       : 7b
+    - Enable       :
+        name         : Payload Selection Pin Enable
+        type         : Combo
+        option       : $EN_DIS
+        help         : >
+                       Enable/Disable this pin for payload selection.
+        length       : 1b
   - OsCrashMemorySize :
       name         : OS Crash Memory Size
       type         : Combo

--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Ext_IotgCrb.dlt
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Ext_IotgCrb.dlt
@@ -18,10 +18,13 @@ MEMORY_CFG_DATA.SpdAddressTable   | { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
 MEMORY_CFG_DATA.MemorySpdPtr00    | {FILE: Spd_Lpddr4_8G.bin}
 MEMORY_CFG_DATA.MemorySpdPtr10    | {FILE: Spd_Lpddr4_8G.bin}
 
-# GPIO for payload selection pin J2E1 pins 2-4
-GEN_CFG_DATA.PayloadId | 'AUTO'
-GPIO_CFG_DATA.GpioPinConfig0_GPP_D13.GPIODirection_GPP_D13 | 0xB
-GPIO_CFG_DATA.GpioPinConfig1_GPP_D13.GPIOSkip_GPP_D13 | 0
+GEN_CFG_DATA.PayloadId                                      | 'AUTO'
+# GPIO for payload selection pin J2E1 pins 2-4 (GPP_D13)
+GEN_CFG_DATA.PayloadSelGpio.Enable                          | 0x1
+GEN_CFG_DATA.PayloadSelGpio.PinNum                          | 0x5000D
+
+GPIO_CFG_DATA.GpioPinConfig0_GPP_D13.GPIODirection_GPP_D13  | 0xB
+GPIO_CFG_DATA.GpioPinConfig1_GPP_D13.GPIOSkip_GPP_D13       | 0
 
 # Enable to test TCC mode & tuning
 # FEATURES_CFG_DATA.Features.Tcc    | 0x1

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_Ddr4.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_Ddr4.dlt
@@ -37,5 +37,9 @@ MEMORY_CFG_DATA.DmaControlGuarantee | 1
 # When 3/4 is stuffed the value will read 0 for UEFI Payload.
 # When 3/4 is un-stuffed the value will read 1 for OS Loader.
 #
-GEN_CFG_DATA.PayloadId                   | 'AUTO'
+GEN_CFG_DATA.PayloadId                      | 'AUTO'
+GEN_CFG_DATA.PayloadSelGpio.Enable          | 0x1
+# LP_GPP_B15
+GEN_CFG_DATA.PayloadSelGpio.PinNum          | 0xF
+
 GPIO_CFG_DATA.GpioPinConfig0_GPP_B15.GPIODirection_GPP_B15 | 0xB

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_DdrLp4.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_DdrLp4.dlt
@@ -32,5 +32,9 @@ MEMORY_CFG_DATA.SpdDataSel130            | 1
 # When 3/4 is stuffed the value will read 0 for UEFI Payload.
 # When 3/4 is un-stuffed the value will read 1 for OS Loader.
 #
-GEN_CFG_DATA.PayloadId                   | 'AUTO'
+GEN_CFG_DATA.PayloadId                      | 'AUTO'
+GEN_CFG_DATA.PayloadSelGpio.Enable          | 0x1
+# LP_GPP_B15
+GEN_CFG_DATA.PayloadSelGpio.PinNum          | 0xF
+
 GPIO_CFG_DATA.GpioPinConfig0_GPP_B15.GPIODirection_GPP_B15 | 0xB


### PR DESCRIPTION
Here are the changes:
1. Add payload ID GPIO pin selection option to Common CfgData YAML.
2. Let each platform use Common CfgData to set payload ID gpio pin
3. Update dlt files with the default GPIO pin used for payload ID selection
4. Replace existing board cfg data PayloadSelGpio with the common cfg data version

Signed-off-by: Lean Sheng <lean.sheng.tan@intel.com>