### PR TITLE
[IAS] Consider signature for size only if enabled

### DIFF
--- a/BootloaderCommonPkg/Include/Library/IasImageLib.h
+++ b/BootloaderCommonPkg/Include/Library/IasImageLib.h
@@ -144,8 +144,8 @@ IasGetFiles (
 #define IAS_PAYLOAD_CRC(h)            (* (UINT32*) (((UINT32*) (h)) + (h)->DataOffset + (h)->DataLength))
 #define IAS_PAYLOAD_END(h)            (IAS_PAYLOAD(h) + (h)->DataLength + sizeof(UINT32))
 #define IAS_SIGNATURE(h)              (((UINT32)(UINTN)h) + ROUNDED_UP((h)->DataOffset + (h)->DataLength + sizeof(UINT32), 256))
-#define IAS_PUBLIC_KEY(h)             ((IAS_SIGNATURE(h) + 256))
-#define IAS_IMAGE_END(h)              ((IAS_PUBLIC_KEY(h) + (( (h)->ImageType  & 1<<9 ) == (1 <<9) ? 260 : 0)))
+#define IAS_PUBLIC_KEY(h)             (((( (h)->ImageType  & BIT8 ) == BIT8 ? IAS_SIGNATURE(h) + 256 : IAS_PAYLOAD_END(h))))
+#define IAS_IMAGE_END(h)              ((IAS_PUBLIC_KEY(h) + (( (h)->ImageType  & BIT9 ) == BIT9 ? 260 : 0)))
 #define IAS_IMAGE_SIZE(h)             (((UINT32) IAS_IMAGE_END(h)) - ((UINT32)(UINTN)h))
 
 // Note: Alignment argument must be a power of two.


### PR DESCRIPTION
As per specification of the IAS-Image format 
https://github.com/intel/iasimage/blob/master/docs/02_mcd.md
the signature and public key are optional.

As per specification of the header format 
https://github.com/intel/iasimage/blob/master/docs/02_mcd.md#image-type

The 8th bit indicate if the signature is included, while the 9th bit indicates whether
the public key is included.

While the previous solution checked if public key is enabled, it did not check if
the signature is included, but rather assumed that it is always included.

This will lead to a miss-calculation of the `IAS_IMAGE_END` and `IAS_IMAGE_SIZE`
which on the other hand will cause `IsIasImageValid()` to fail, which will fail the loading
of unsigned IAS-Images.