### PR TITLE
Enabling GPIO Debug Port

### DIFF
--- a/BootloaderCommonPkg/Include/Guid/LoaderPlatformDataGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/LoaderPlatformDataGuid.h
@@ -16,7 +16,9 @@ extern EFI_GUID gLoaderPlatformDataGuid;
 
 #define  DEBUG_OUTPUT_DEVICE_LOG_BUFFER     BIT0
 #define  DEBUG_OUTPUT_DEVICE_SERIAL_PORT    BIT1
-#define  DEBUG_OUTPUT_DEVICE_CONSOLE        BIT2
+#define  DEBUG_OUTPUT_DEVICE_DEBUG_PORT     BIT2
+#define  DEBUG_OUTPUT_DEVICE_CONSOLE        BIT7
+
 
 typedef struct {
   UINT8                     Revision;

--- a/BootloaderCommonPkg/Include/Library/ConsoleInLib.h
+++ b/BootloaderCommonPkg/Include/Library/ConsoleInLib.h
@@ -12,6 +12,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 typedef enum {
   ConsoleInSerialPort  = BIT0,
   ConsoleInUsbKeyboard = BIT1,
+  ConsoleInDebugPort   = BIT2,
   ConsoleInAll         = 0xFFFFFFFF,
 } CONSOLE_IN_DEVICE_TYPE;
 

--- a/BootloaderCommonPkg/Include/Library/ConsoleOutLib.h
+++ b/BootloaderCommonPkg/Include/Library/ConsoleOutLib.h
@@ -79,6 +79,7 @@
 typedef enum {
   ConsoleOutSerialPort  = BIT0,
   ConsoleOutFrameBuffer = BIT1,
+  ConsoleOutDebugPort   = BIT2,
   ConsoleOutAll         = 0xFFFFFFFF,
 } CONSOLE_OUT_DEVICE_TYPE;
 

--- a/BootloaderCommonPkg/Include/Library/DebugPortLib.h
+++ b/BootloaderCommonPkg/Include/Library/DebugPortLib.h
@@ -1,0 +1,63 @@
+/** @file
+
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __DEBUG_PORT_LIB_H__
+#define __DEBUG_PORT_LIB_H__
+
+/**
+  Write data from buffer to debug port.
+
+  Writes NumberOfBytes data bytes from Buffer to the debug port.
+  The number of bytes actually written to the debug port is returned.
+  If the return value is less than NumberOfBytes, then the write operation failed.
+
+  @param  Buffer           Pointer to the data buffer to be written.
+  @param  NumberOfBytes    Number of bytes to written to the debug port.
+
+  @retval 0                NumberOfBytes is 0.
+  @retval >0               The number of bytes written to the debug port.
+**/
+UINTN
+EFIAPI
+DebugPortWrite (
+  IN UINT8    *Buffer,
+  IN UINTN    NumberOfBytes
+  );
+
+/**
+  Reads data from a debug port into a buffer.
+
+  @param  Buffer           Pointer to the data buffer to store the data read from the debug port.
+  @param  NumberOfBytes    Number of bytes to read from the debug port.
+
+  @retval 0                NumberOfBytes is 0.
+  @retval >0               The number of bytes read from the debug port.
+**/
+UINTN
+EFIAPI
+DebugPortRead (
+  OUT UINT8 *Buffer,
+  IN UINTN  NumberOfBytes
+  );
+
+/**
+  Polls a debug port to see if there is any data waiting to be read.
+
+  Polls adebug port to see if there is any data waiting to be read.
+  If there is data waiting to be read from the debug port, then TRUE is returned.
+  If there is no data waiting to be read from the debug port, then FALSE is returned.
+
+  @retval TRUE             Data is waiting to be read from the debug port.
+  @retval FALSE            There is no data waiting to be read from the debug port.
+**/
+BOOLEAN
+EFIAPI
+DebugPortPoll (
+  VOID
+  );
+
+#endif

--- a/BootloaderCommonPkg/Library/BootloaderDebugLib/BootloaderDebugLib.inf
+++ b/BootloaderCommonPkg/Library/BootloaderDebugLib/BootloaderDebugLib.inf
@@ -30,6 +30,7 @@
 
 [LibraryClasses]
   SerialPortLib
+  DebugPortLib
   DebugLogBufferLib
   ConsoleOutLib
   BaseMemoryLib

--- a/BootloaderCommonPkg/Library/BootloaderDebugLib/DebugLib.c
+++ b/BootloaderCommonPkg/Library/BootloaderDebugLib/DebugLib.c
@@ -12,6 +12,7 @@
 #include <Library/PcdLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/SerialPortLib.h>
+#include <Library/DebugPortLib.h>
 #include <Library/DebugLogBufferLib.h>
 #include <Library/BootloaderCommonLib.h>
 #include <Library/DebugPrintErrorLevelLib.h>
@@ -92,6 +93,10 @@ DebugPrint (
 
   if (OutputToSerial) {
     SerialPortWrite ((UINT8 *)Buffer, Length);
+  }
+
+  if (PcdGet32 (PcdDebugOutputDeviceMask) & DEBUG_OUTPUT_DEVICE_DEBUG_PORT) {
+    DebugPortWrite ((UINT8 *)Buffer, Length);
   }
 }
 

--- a/BootloaderCommonPkg/Library/ConsoleInLib/ConsoleInLib.c
+++ b/BootloaderCommonPkg/Library/ConsoleInLib/ConsoleInLib.c
@@ -10,6 +10,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/UsbKbLib.h>
 #include <Library/SerialPortLib.h>
 #include <Library/ConsoleInLib.h>
+#include <Library/DebugPortLib.h>
 
 /**
   Poll a console to see if there is any data waiting to be read.
@@ -35,6 +36,12 @@ ConsolePoll (
 
   if ((PcdGet32 (PcdConsoleInDeviceMask) & ConsoleInUsbKeyboard) != 0) {
     if (KeyboardPoll ()) {
+      return TRUE;
+    }
+  }
+
+  if ((PcdGet32 (PcdConsoleInDeviceMask) & ConsoleInDebugPort) != 0) {
+    if (DebugPortPoll ()) {
       return TRUE;
     }
   }
@@ -77,6 +84,14 @@ ConsoleRead (
     if ((PcdGet32 (PcdConsoleInDeviceMask) & ConsoleInUsbKeyboard) != 0) {
       if (KeyboardPoll () && (Count < NumberOfBytes)) {
         ReadCount = KeyboardRead (Buffer, 1);
+        Buffer += ReadCount;
+        Count  += ReadCount;
+      }
+    }
+
+    if ((PcdGet32 (PcdConsoleInDeviceMask) & ConsoleInDebugPort) != 0) {
+      if (DebugPortPoll () && (Count < NumberOfBytes)) {
+        ReadCount = DebugPortRead (Buffer, 1);
         Buffer += ReadCount;
         Count  += ReadCount;
       }

--- a/BootloaderCommonPkg/Library/ConsoleInLib/ConsoleInLib.inf
+++ b/BootloaderCommonPkg/Library/ConsoleInLib/ConsoleInLib.inf
@@ -26,6 +26,7 @@
   BaseLib
   SerialPortLib
   UsbKbLib
+  DebugPortLib
 
 [Guids]
 

--- a/BootloaderCommonPkg/Library/ConsoleOutLib/ConsoleOutLib.c
+++ b/BootloaderCommonPkg/Library/ConsoleOutLib/ConsoleOutLib.c
@@ -17,6 +17,7 @@
 #include <Library/SerialPortLib.h>
 #include <Library/HobLib.h>
 #include <Library/ConsoleOutLib.h>
+#include <Library/DebugPortLib.h>
 
 /**
   Write data from buffer to the console.
@@ -45,6 +46,10 @@ ConsoleWrite (
 
   if (PcdGet32 (PcdConsoleOutDeviceMask) & ConsoleOutFrameBuffer) {
     FrameBufferWrite ((UINT8 *)Buffer, NumberOfBytes);
+  }
+
+  if (PcdGet32 (PcdConsoleOutDeviceMask) & ConsoleOutDebugPort) {
+    DebugPortWrite ((UINT8 *)Buffer, NumberOfBytes);
   }
 
   return NumberOfBytes;

--- a/BootloaderCommonPkg/Library/ConsoleOutLib/ConsoleOutLib.inf
+++ b/BootloaderCommonPkg/Library/ConsoleOutLib/ConsoleOutLib.inf
@@ -30,6 +30,7 @@
   BaseLib
   GraphicsLib
   SerialPortLib
+  DebugPortLib
 
 [Guids]
 

--- a/BootloaderCommonPkg/Library/DebugPortLib/DebugPortLibNull.c
+++ b/BootloaderCommonPkg/Library/DebugPortLib/DebugPortLibNull.c
@@ -1,0 +1,69 @@
+/** @file
+
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+
+/**
+  Write data from buffer to debug port.
+
+  Writes NumberOfBytes data bytes from Buffer to the debug port.
+  The number of bytes actually written to the debug port is returned.
+  If the return value is less than NumberOfBytes, then the write operation failed.
+
+  @param  Buffer           Pointer to the data buffer to be written.
+  @param  NumberOfBytes    Number of bytes to written to the debug port.
+
+  @retval 0                NumberOfBytes is 0.
+  @retval >0               The number of bytes written to the debug port.
+**/
+UINTN
+EFIAPI
+DebugPortWrite (
+  IN UINT8    *Buffer,
+  IN UINTN    NumberOfBytes
+  )
+{
+  return 0;
+}
+
+/**
+  Reads data from a debug port into a buffer.
+
+  @param  Buffer           Pointer to the data buffer to store the data read from the debug port.
+  @param  NumberOfBytes    Number of bytes to read from the debug port.
+
+  @retval 0                NumberOfBytes is 0.
+  @retval >0               The number of bytes read from the debug port.
+**/
+UINTN
+EFIAPI
+DebugPortRead (
+  OUT UINT8 *Buffer,
+  IN UINTN  NumberOfBytes
+  )
+{
+  return 0;
+}
+
+/**
+  Polls a debug port to see if there is any data waiting to be read.
+
+  Polls adebug port to see if there is any data waiting to be read.
+  If there is data waiting to be read from the debug port, then TRUE is returned.
+  If there is no data waiting to be read from the debug port, then FALSE is returned.
+
+  @retval TRUE             Data is waiting to be read from the debug port.
+  @retval FALSE            There is no data waiting to be read from the debug port.
+**/
+BOOLEAN
+EFIAPI
+DebugPortPoll (
+  VOID
+  )
+{
+  return FALSE;
+}

--- a/BootloaderCommonPkg/Library/DebugPortLib/DebugPortLibNull.inf
+++ b/BootloaderCommonPkg/Library/DebugPortLib/DebugPortLibNull.inf
@@ -1,0 +1,32 @@
+## @file
+#
+#  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = DebugPortLib
+  FILE_GUID                      = 1891E882-8997-4066-9379-1E1168072530
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = DebugPortLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 IPF
+#
+
+[Sources]
+  DebugPortLibNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+
+[LibraryClasses]
+  BaseLib
+
+[Pcd]

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -131,6 +131,7 @@
   BoardSupportLib|Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.inf
   PagingLib|BootloaderCommonPkg/Library/PagingLib/PagingLib.inf
   TimerLib|BootloaderCommonPkg/Library/AcpiTimerLib/AcpiTimerLib.inf
+  DebugPortLib|BootloaderCommonPkg/Library/DebugPortLib/DebugPortLibNull.inf
 
 ################################################################################
 #
@@ -146,9 +147,9 @@
   gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask            | 0x27
 !endif
 
-  # Limit DEBUG output device to be serial port (BIT1) and log buffer (BIT0) for stages.
+  # Exclude platform console devices BIT7 as debug output for SBL stage 1 and 2.
   # Once in payload, more debug devices can be enabled, such as frame buffer.
-  gPlatformCommonLibTokenSpaceGuid.PcdDebugOutputDeviceMask  | $(DEBUG_OUTPUT_DEVICE_MASK) & 3
+  gPlatformCommonLibTokenSpaceGuid.PcdDebugOutputDeviceMask  | $(DEBUG_OUTPUT_DEVICE_MASK) & 0xFFFFFF7F
 
   gPlatformCommonLibTokenSpaceGuid.PcdDebugPortNumber      | $(DEBUG_PORT_NUMBER)
 
@@ -247,6 +248,7 @@
 
   gPlatformCommonLibTokenSpaceGuid.PcdCompSignHashAlg             | $(SIGN_HASH_TYPE)
   gPlatformModuleTokenSpaceGuid.PcdFastBootEnabled                | $(ENABLE_FAST_BOOT)
+
 
 [PcdsPatchableInModule]
   gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel   | 0x8000004F

--- a/Platform/CoffeelakeBoardPkg/BoardConfig.py
+++ b/Platform/CoffeelakeBoardPkg/BoardConfig.py
@@ -66,7 +66,7 @@ class Board(BaseBoard):
         # BIT1: Serial port
         # BIT2: Platform debug port
         # BIT7: Platform console devices
-        self.DEBUG_OUTPUT_DEVICE_MASK = 0x03
+        self.DEBUG_OUTPUT_DEVICE_MASK = 0x07
 
         # CSME update library is required to enable this option and will be available as part of CSME kit
         self.BUILD_CSME_UPDATE_DRIVER   = 0
@@ -192,6 +192,7 @@ class Board(BaseBoard):
             common_libs.append ('MeFwUpdateLib|Silicon/$(SILICON_PKG_NAME)/Library/MeFwUpdateLib/MeFwUpdateLib.inf')
         if debug_port_enable:
             common_libs.append ('GpioDebugPortLib|Platform/CommonBoardPkg/Library/GpioDebugPortLib/GpioDebugPortLib.inf')
+            common_libs.append ('MailboxDebugPortLib|Platform/CommonBoardPkg/Library/MailboxDebugPortLib/MailboxDebugPortLib.inf')
             common_libs.append ('DebugPortLib|Platform/$(BOARD_PKG_NAME)/Library/DebugPortLib/DebugPortLib.inf')
         dsc['LibraryClasses.%s' % self.BUILD_ARCH]   = common_libs
 
@@ -204,12 +205,18 @@ class Board(BaseBoard):
             #   - Get GPIO community ID. It is community 1 for H12.
             #   - Look up PID_GPIOCOM1 in file PchRegsPcr.h for PortId. It is 0x6D.
             #    IOSF_MMIO = 0xFD000000 + (PortId<<16) + GpioOffset
-            gpio_pad   = 0x0407000C
-            iosf_mmio  = 0xFD6D09D0
+            gpio_pad     = 0x0407000C
+            iosf_mmio    = 0xFD6D09D0
             fixed_pcds = [
-                'gCommonBoardTokenSpaceGuid.PcdGpioDebugPortPinPad   | 0x%08X' % gpio_pad,
-                'gCommonBoardTokenSpaceGuid.PcdGpioDebugPortMmioBase | 0x%08X' % iosf_mmio,
+                'gCommonBoardTokenSpaceGuid.PcdGpioDebugPortPinPad      | 0x%08X' % gpio_pad,
+                'gCommonBoardTokenSpaceGuid.PcdGpioDebugPortMmioBase    | 0x%08X' % iosf_mmio
             ]
+
+            mailbox_mmio = 0xFD6E0120
+            fixed_pcds.append (
+                'gCommonBoardTokenSpaceGuid.PcdMailboxDebugPortMmioBase | 0x%08X' % mailbox_mmio,
+            )
+
         if len(fixed_pcds) > 0:
             dsc['PcdsFixedAtBuild.%s' % self.BUILD_ARCH] = fixed_pcds
 

--- a/Platform/CoffeelakeBoardPkg/CfgData/CfgDataExt_Upx.dlt
+++ b/Platform/CoffeelakeBoardPkg/CfgData/CfgDataExt_Upx.dlt
@@ -458,3 +458,7 @@ GPIO_CFG_DATA.GpioPinConfig0_GPP_E22 | 0x0350A381
 GPIO_CFG_DATA.GpioPinConfig1_GPP_E22 | 0x04162001
 GPIO_CFG_DATA.GpioPinConfig0_GPP_E23 | 0x0350A281
 GPIO_CFG_DATA.GpioPinConfig1_GPP_E23 | 0x04172001
+
+MEMORY_CFG_DATA.PchTraceHubMode          | 0x2
+MEMORY_CFG_DATA.PlatformDebugConsent     | 0x1
+SILICON_CFG_DATA.DebugInterfaceEnable    | 0x1

--- a/Platform/CoffeelakeBoardPkg/Library/DebugPortLib/DebugPortLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/DebugPortLib/DebugPortLib.c
@@ -29,7 +29,7 @@ DebugPortWrite (
   IN UINTN    NumberOfBytes
   )
 {
-  //GpioDebugPortWrite    (Buffer, NumberOfBytes);
+  GpioDebugPortWrite    (Buffer, NumberOfBytes);
   MailboxDebugPortWrite (Buffer, NumberOfBytes);
   return NumberOfBytes;
 }

--- a/Platform/CoffeelakeBoardPkg/Library/DebugPortLib/DebugPortLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/DebugPortLib/DebugPortLib.c
@@ -1,0 +1,70 @@
+/** @file
+
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+#include <Library/GpioDebugPortLib.h>
+
+/**
+  Write data from buffer to debug port.
+
+  Writes NumberOfBytes data bytes from Buffer to the debug port.
+  The number of bytes actually written to the debug port is returned.
+  If the return value is less than NumberOfBytes, then the write operation failed.
+
+  @param  Buffer           Pointer to the data buffer to be written.
+  @param  NumberOfBytes    Number of bytes to written to the debug port.
+
+  @retval 0                NumberOfBytes is 0.
+  @retval >0               The number of bytes written to the debug port.
+**/
+UINTN
+EFIAPI
+DebugPortWrite (
+  IN UINT8    *Buffer,
+  IN UINTN    NumberOfBytes
+  )
+{
+  return GpioDebugPortWrite (Buffer, NumberOfBytes);
+}
+
+/**
+  Reads data from a debug port into a buffer.
+
+  @param  Buffer           Pointer to the data buffer to store the data read from the debug port.
+  @param  NumberOfBytes    Number of bytes to read from the debug port.
+
+  @retval 0                NumberOfBytes is 0.
+  @retval >0               The number of bytes read from the debug port.
+**/
+UINTN
+EFIAPI
+DebugPortRead (
+  OUT UINT8 *Buffer,
+  IN UINTN  NumberOfBytes
+  )
+{
+  return 0;
+}
+
+/**
+  Polls a debug port to see if there is any data waiting to be read.
+
+  Polls adebug port to see if there is any data waiting to be read.
+  If there is data waiting to be read from the debug port, then TRUE is returned.
+  If there is no data waiting to be read from the debug port, then FALSE is returned.
+
+  @retval TRUE             Data is waiting to be read from the debug port.
+  @retval FALSE            There is no data waiting to be read from the debug port.
+**/
+BOOLEAN
+EFIAPI
+DebugPortPoll (
+  VOID
+  )
+{
+  return FALSE;
+}

--- a/Platform/CoffeelakeBoardPkg/Library/DebugPortLib/DebugPortLib.inf
+++ b/Platform/CoffeelakeBoardPkg/Library/DebugPortLib/DebugPortLib.inf
@@ -1,0 +1,34 @@
+## @file
+#
+#  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = DebugPortLib
+  FILE_GUID                      = 1891E882-8997-4066-9379-1E1168072530
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = DebugPortLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 IPF
+#
+
+[Sources]
+  DebugPortLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+  Platform/CommonBoardPkg/CommonBoardPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  GpioDebugPortLib
+
+[Pcd]

--- a/Platform/CoffeelakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
@@ -265,7 +265,9 @@ BoardInit (
     }
 
     if ((PcdGet32 (PcdDebugOutputDeviceMask) & DEBUG_OUTPUT_DEVICE_DEBUG_PORT) != 0) {
-      GpioConfigurePads (1, (GPIO_INIT_CONFIG *)mGpioDebugPortPinTable);
+      if (PcdGet32 (PcdGpioDebugPortMmioBase)  != 0) {
+        GpioConfigurePads (1, (GPIO_INIT_CONFIG *)mGpioDebugPortPinTable);
+      }
     }
 
     PlatformHookSerialPortInitialize ();

--- a/Platform/CoffeelakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
@@ -95,6 +95,10 @@ CONST GPIO_INIT_CONFIG mUartGpioTable[] = {
   {GPIO_CNL_LP_GPP_C21, {GpioPadModeNative1, GpioHostOwnGpio, GpioDirNone,  GpioOutDefault, GpioIntDis, GpioHostDeepReset,  GpioTermNone}},//SERIALIO_UART2_TXD
 };
 
+CONST GPIO_INIT_CONFIG mGpioDebugPortPinTable[] = {
+  {FixedPcdGet32(PcdGpioDebugPortPinPad), {GpioPadModeGpio, GpioHostOwnGpio, GpioDirOut,  GpioOutHigh, GpioIntDis, GpioHostDeepReset,  GpioTermNone}},
+};
+
 typedef enum {
   BootPartition1,
   BootPartition2,
@@ -259,6 +263,11 @@ BoardInit (
     if (DebugPort < PCH_MAX_SERIALIO_UART_CONTROLLERS) {
       GpioConfigurePads (2, (GPIO_INIT_CONFIG *)mUartGpioTable + (DebugPort << 1));
     }
+
+    if ((PcdGet32 (PcdDebugOutputDeviceMask) & DEBUG_OUTPUT_DEVICE_DEBUG_PORT) != 0) {
+      GpioConfigurePads (1, (GPIO_INIT_CONFIG *)mGpioDebugPortPinTable);
+    }
+
     PlatformHookSerialPortInitialize ();
     SerialPortInitialize ();
     Status = GetBootPartition (&BootPartition);

--- a/Platform/CoffeelakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.inf
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.inf
@@ -57,4 +57,5 @@
   gPlatformCommonLibTokenSpaceGuid.PcdDebugPortNumber
   gPlatformCommonLibTokenSpaceGuid.PcdDebugOutputDeviceMask
   gCommonBoardTokenSpaceGuid.PcdGpioDebugPortPinPad
+  gCommonBoardTokenSpaceGuid.PcdGpioDebugPortMmioBase
 

--- a/Platform/CoffeelakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.inf
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.inf
@@ -55,3 +55,6 @@
   gPlatformModuleTokenSpaceGuid.PcdPayloadBase
   gPlatformModuleTokenSpaceGuid.PcdPciMmcfgBase
   gPlatformCommonLibTokenSpaceGuid.PcdDebugPortNumber
+  gPlatformCommonLibTokenSpaceGuid.PcdDebugOutputDeviceMask
+  gCommonBoardTokenSpaceGuid.PcdGpioDebugPortPinPad
+

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -714,7 +714,7 @@ PrintGpioConfigTable (
   GpioInitConf = (GPIO_INIT_CONFIG *)GpioConfData;
   for (Index  = 0; Index < GpioPinNum; Index++) {
     PadDataPtr = (UINT32 *)&GpioInitConf->GpioConfig;
-    DEBUG ((DEBUG_INFO, "GPIO PAD: 0x%08X   DATA: 0x%08X 0x%08X\n", GpioInitConf->GpioPad, PadDataPtr[0], PadDataPtr[1]));
+    DEBUG ((DEBUG_VERBOSE, "GPIO PAD: 0x%08X   DATA: 0x%08X 0x%08X\n", GpioInitConf->GpioPad, PadDataPtr[0], PadDataPtr[1]));
     GpioInitConf++;
   }
 }

--- a/Platform/CoffeelakeBoardPkg/Script/MailboxDebugPort.py
+++ b/Platform/CoffeelakeBoardPkg/Script/MailboxDebugPort.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+## @ MailboxDebugPort.py
+#
+# Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+import sys
+import ipccli
+import struct
+import msvcrt
+
+class MAILBOX_COMM:
+    def __init__(self):
+        self.ipc  = ipccli.baseaccess()
+        self.portid    = 0x6e
+        self.offset    = 0x120
+        self.iosf_acc  = True
+        self.flow_ctrl = True
+        self.last_read = self.mailbox_rw (0)
+
+    def mailbox_rw (self, value = None):
+        if value is None:
+            if self.iosf_acc:
+                value = self.ipc.stateport.cnp_tpsb0.tap2iosfsb32(self.portid, self.offset, 0, 0, 6, 0)
+                value = value.ToUInt32 ()
+            else:
+                value = self.ipc.stateport.cnp_tpsb0.sbreg(bar=0, fid=0, offsetset=self.offset, portid=self.portid, typecode=6)
+                value = value.ToUInt64 () & 0xffffffff
+            return value
+        else:
+            if self.iosf_acc:
+                self.ipc.stateport.cnp_tpsb0.tap2iosfsb32(self.portid, self.offset, 0, 0, 7, 0, newValue=value)
+            else:
+                self.ipc.stateport.cnp_tpsb0.sbreg(bar=0, fid=0, offsetset=self.offset, portid=self.portid, typecode=7, newValue = value)
+            return value
+
+    def read (self):
+        data32 = self.mailbox_rw ()
+        if self.last_read != data32:
+            self.last_read = data32
+            if data32 & 0x01:
+                val = (data32 >> 8) & 0xff
+                msg = chr(val)
+                sys.stdout.write (msg)
+                if val == 0x0D:
+                    sys.stdout.flush()
+                if self.flow_ctrl:
+                    data32 = data32 & 0xFFFFFFFE
+                    self.mailbox_rw (data32)
+                    self.last_read = data32
+                return True
+        else:
+            if msvcrt.kbhit():
+                key   = ord(msvcrt.getch())
+                if key == 0x1b:
+                    return None
+                data32 = ((data32 | 0x02) & 0xff00ffff) + (key << 16)
+                self.mailbox_rw (data32)
+            return False
+
+        return False
+
+def run ():
+  # Display SBL debug message through mailbox debug port communication
+  dbg_port = MAILBOX_COMM()
+  while True:
+      ret = dbg_port.read ()
+      if ret is None:
+          break

--- a/Platform/CommonBoardPkg/CommonBoardPkg.dec
+++ b/Platform/CommonBoardPkg/CommonBoardPkg.dec
@@ -18,7 +18,8 @@
   gCommonBoardTokenSpaceGuid  = { 0x3a22489e, 0x5443, 0x4135, { 0xad, 0x93, 0x23, 0x7f, 0x20, 0xbc, 0x88, 0x3b } }
 
 [PcdsFixedAtBuild]
-  gCommonBoardTokenSpaceGuid.PcdGpioDebugPortMmioBase    | 0xFF000000 | UINT32 | 0x20000800
+  gCommonBoardTokenSpaceGuid.PcdGpioDebugPortMmioBase    | 0x00000000 | UINT32 | 0x20000800
   gCommonBoardTokenSpaceGuid.PcdGpioDebugPortMmioMask    | 0x00000001 | UINT32 | 0x20000801
   gCommonBoardTokenSpaceGuid.PcdGpioDebugPortBaudRate    |      19200 | UINT32 | 0x20000802
   gCommonBoardTokenSpaceGuid.PcdGpioDebugPortPinPad      | 0x00000000 | UINT32 | 0x20000803
+  gCommonBoardTokenSpaceGuid.PcdMailboxDebugPortMmioBase | 0x00000000 | UINT32 | 0x20000810

--- a/Platform/CommonBoardPkg/CommonBoardPkg.dec
+++ b/Platform/CommonBoardPkg/CommonBoardPkg.dec
@@ -8,10 +8,17 @@
 [Defines]
   DEC_SPECIFICATION              = 0x00010005
   PACKAGE_NAME                   = CommonBoardPkg
-  PACKAGE_GUID                   = BF594493-59FA-4027-8F14-2929415CE6B7
+  PACKAGE_GUID                   = 3A22489E-5443-4135-AD93-237F20BC883B
   PACKAGE_VERSION                = 0.1
 
 [Includes]
   Include
 
+[Guids]
+  gCommonBoardTokenSpaceGuid  = { 0x3a22489e, 0x5443, 0x4135, { 0xad, 0x93, 0x23, 0x7f, 0x20, 0xbc, 0x88, 0x3b } }
 
+[PcdsFixedAtBuild]
+  gCommonBoardTokenSpaceGuid.PcdGpioDebugPortMmioBase    | 0xFF000000 | UINT32 | 0x20000800
+  gCommonBoardTokenSpaceGuid.PcdGpioDebugPortMmioMask    | 0x00000001 | UINT32 | 0x20000801
+  gCommonBoardTokenSpaceGuid.PcdGpioDebugPortBaudRate    |      19200 | UINT32 | 0x20000802
+  gCommonBoardTokenSpaceGuid.PcdGpioDebugPortPinPad      | 0x00000000 | UINT32 | 0x20000803

--- a/Platform/CommonBoardPkg/Include/Library/GpioDebugPortLib.h
+++ b/Platform/CommonBoardPkg/Include/Library/GpioDebugPortLib.h
@@ -1,0 +1,34 @@
+/** @file
+  Provide GPIO debug port library functions.
+
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __GPIO_DEBUG_PORT_LIB_H__
+#define __GPIO_DEBUG_PORT_LIB_H__
+
+
+/**
+  Write data from buffer to the console.
+
+  Writes NumberOfBytes data bytes from Buffer to the virtual console.
+
+  If Buffer is NULL, then ASSERT().
+
+  If NumberOfBytes is zero, then return 0.
+
+  @param  Buffer           Pointer to the data buffer to be written.
+  @param  NumberOfBytes    Number of bytes to write to the console.
+
+  @retval >0               The number of bytes written to the console.
+**/
+UINTN
+EFIAPI
+GpioDebugPortWrite (
+  IN UINT8     *Buffer,
+  IN UINTN      NumberOfBytes
+  );
+
+#endif

--- a/Platform/CommonBoardPkg/Include/Library/MailboxDebugPortLib.h
+++ b/Platform/CommonBoardPkg/Include/Library/MailboxDebugPortLib.h
@@ -6,8 +6,8 @@
 **/
 
 #include <PiPei.h>
-#include <Library/GpioDebugPortLib.h>
-#include <Library/MailboxDebugPortLib.h>
+
+#ifndef __MAILBOX_DEBUG_PORT_LIB_H__
 
 /**
   Write data from buffer to debug port.
@@ -24,15 +24,10 @@
 **/
 UINTN
 EFIAPI
-DebugPortWrite (
+MailboxDebugPortWrite (
   IN UINT8    *Buffer,
   IN UINTN    NumberOfBytes
-  )
-{
-  //GpioDebugPortWrite    (Buffer, NumberOfBytes);
-  MailboxDebugPortWrite (Buffer, NumberOfBytes);
-  return NumberOfBytes;
-}
+  );
 
 /**
   Reads data from a debug port into a buffer.
@@ -45,13 +40,10 @@ DebugPortWrite (
 **/
 UINTN
 EFIAPI
-DebugPortRead (
+MailboxDebugPortRead (
   OUT UINT8 *Buffer,
   IN UINTN  NumberOfBytes
-  )
-{
-  return MailboxDebugPortRead (Buffer, NumberOfBytes);
-}
+  );
 
 /**
   Polls a debug port to see if there is any data waiting to be read.
@@ -65,9 +57,8 @@ DebugPortRead (
 **/
 BOOLEAN
 EFIAPI
-DebugPortPoll (
+MailboxDebugPortPoll (
   VOID
-  )
-{
-  return MailboxDebugPortPoll ();
-}
+  );
+
+#endif

--- a/Platform/CommonBoardPkg/Library/GpioDebugPortLib/GpioDebugPortLib.c
+++ b/Platform/CommonBoardPkg/Library/GpioDebugPortLib/GpioDebugPortLib.c
@@ -86,11 +86,14 @@ GpioDebugPortWrite (
   IN UINTN      NumberOfBytes
   )
 {
-  while (NumberOfBytes > 0) {
-    GpioDebugPortWriteByte (*Buffer);
-    Buffer++;
-    NumberOfBytes--;
+  if (PcdGet32 (PcdGpioDebugPortMmioBase) != 0) {
+    while (NumberOfBytes > 0) {
+      GpioDebugPortWriteByte (*Buffer);
+      Buffer++;
+      NumberOfBytes--;
+    }
+  } else {
+    NumberOfBytes = 0;
   }
-
   return NumberOfBytes;
 }

--- a/Platform/CommonBoardPkg/Library/GpioDebugPortLib/GpioDebugPortLib.c
+++ b/Platform/CommonBoardPkg/Library/GpioDebugPortLib/GpioDebugPortLib.c
@@ -1,0 +1,96 @@
+/** @file
+
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/IoLib.h>
+#include <Library/TimeStampLib.h>
+
+/**
+  Set GPIO TX pin to required level.
+
+**/
+VOID
+SetGpioTxPin (
+  IN UINT32  Level
+)
+{
+  UINT32  Data32;
+
+  Data32 = MmioRead32 (PcdGet32 (PcdGpioDebugPortMmioBase));
+  if (Level == 0) {
+    Data32 &= (UINT32)(~(PcdGet32 (PcdGpioDebugPortMmioMask)));
+  } else {
+    Data32 |= PcdGet32 (PcdGpioDebugPortMmioMask);
+  }
+  MmioWrite32 (PcdGet32 (PcdGpioDebugPortMmioBase), Data32);
+}
+
+/**
+  Send one byte through GPIO TX pin using bit bang.
+
+**/
+VOID
+GpioDebugPortWriteByte (
+  IN UINT8  Value
+)
+{
+  UINT8   Idx;
+  UINT32  Word;
+  UINT32  Baud;
+  UINT64  Freq;
+  UINT64  Ts0;
+  UINT64  Ts1;
+
+  Baud = PcdGet32 (PcdGpioDebugPortBaudRate);
+  Freq = GetTimeStampFrequency ();
+
+  // Prepare 10 bits, 1 start bit, 8 data bits, 1 stop bits
+  Word = (Value << 1) | BIT9;
+  Ts0  = ReadTimeStamp ();
+  for (Idx = 0; Idx < 10; Idx++) {
+    SetGpioTxPin (Word & (1 << Idx));
+    // Wait for 1 bit calculated by current baud rate
+    Ts1 = Ts0 + DivU64x32 (MultU64x32(Freq, (Idx + 1) * 1000), Baud);
+    while (ReadTimeStamp () < Ts1) {
+      CpuPause ();
+    }
+  }
+
+}
+
+
+/**
+  Write data from buffer to the console.
+
+  Writes NumberOfBytes data bytes from Buffer to the virtual console.
+
+  If Buffer is NULL, then ASSERT().
+
+  If NumberOfBytes is zero, then return 0.
+
+  @param  Buffer           Pointer to the data buffer to be written.
+  @param  NumberOfBytes    Number of bytes to write to the console.
+
+  @retval >0               The number of bytes written to the console.
+**/
+UINTN
+EFIAPI
+GpioDebugPortWrite (
+  IN UINT8     *Buffer,
+  IN UINTN      NumberOfBytes
+  )
+{
+  while (NumberOfBytes > 0) {
+    GpioDebugPortWriteByte (*Buffer);
+    Buffer++;
+    NumberOfBytes--;
+  }
+
+  return NumberOfBytes;
+}

--- a/Platform/CommonBoardPkg/Library/GpioDebugPortLib/GpioDebugPortLib.inf
+++ b/Platform/CommonBoardPkg/Library/GpioDebugPortLib/GpioDebugPortLib.inf
@@ -1,0 +1,39 @@
+## @file
+#
+#  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = GpioDebugPortLib
+  FILE_GUID                      = 4F577DA6-A1D9-427A-BB01-21CB97B3F779
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = GpioDebugPortLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 IPF
+#
+
+[Sources]
+  GpioDebugPortLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+  Platform/CommonBoardPkg/CommonBoardPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  PcdLib
+  IoLib
+
+[Pcd]
+  gCommonBoardTokenSpaceGuid.PcdGpioDebugPortMmioBase
+  gCommonBoardTokenSpaceGuid.PcdGpioDebugPortMmioMask
+  gCommonBoardTokenSpaceGuid.PcdGpioDebugPortBaudRate
+

--- a/Platform/CommonBoardPkg/Library/MailboxDebugPortLib/MailboxDebugPortLib.inf
+++ b/Platform/CommonBoardPkg/Library/MailboxDebugPortLib/MailboxDebugPortLib.inf
@@ -7,11 +7,11 @@
 
 [Defines]
   INF_VERSION                    = 0x00010005
-  BASE_NAME                      = DebugPortLib
-  FILE_GUID                      = 1891E882-8997-4066-9379-1E1168072530
+  BASE_NAME                      = MailboxDebugPortLib
+  FILE_GUID                      = 42280273-BFFB-4D2A-A301-74B7ED89975B
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = DebugPortLib
+  LIBRARY_CLASS                  = MailboxDebugPortLib
 
 #
 # The following information is for reference only and not required by the build tools.
@@ -20,7 +20,7 @@
 #
 
 [Sources]
-  DebugPortLib.c
+  MailboxDebugPortLib.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -29,7 +29,9 @@
 
 [LibraryClasses]
   BaseLib
-  GpioDebugPortLib
-  MailboxDebugPortLib
+  PcdLib
+  IoLib
 
 [Pcd]
+  gCommonBoardTokenSpaceGuid.PcdMailboxDebugPortMmioBase
+


### PR DESCRIPTION
This patch set added GPIO debug port support.  It also provides an example in CFL.