### PR TITLE
[EHL] Fix Stage2 Boot Option checking

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1846,7 +1846,7 @@ UpdateOsBootMediumInfo (
 
   FillBootOptionListFromCfgData (OsBootOptionList);
   // Disable PreOS checker since the SKU doesn't support it
-  if (mPchSciSupported) {
+  if (!mPchSciSupported) {
     for (Idx = 0; Idx < OsBootOptionList->OsBootOptionCount; Idx++) {
       BootOption = &(OsBootOptionList->OsBootOption[Idx]);
       if ((BootOption->BootFlags & BOOT_FLAGS_PREOS) != 0) {


### PR DESCRIPTION
Fix mPchSciSupported flag checking before changing the
flag value of boot option.
This bug was introduced from commit
b78cbcf128866b8835116a6ba77d9e7ac5c8ab00

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>