### PR TITLE
[EHL] Enable POSC for all boot option

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_BootOption.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_BootOption.yaml
@@ -9,10 +9,15 @@
 
 - $ACTION      :
     page         : OS
-- !expand { BOOT_OPTION_TMPL : [ 0 ,   0    ,  20 ,    5   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 1 , 0x9E    ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
-- !expand { BOOT_OPTION_TMPL : [ 2 , 0x1F   ,  16 ,    0   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_rtcm' ] }
-- !expand { BOOT_OPTION_TMPL : [ 3 ,   0    ,  16 ,    2   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 4 ,   0    ,  16 ,    6   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 5 ,   0    ,  16 ,    3   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 6 ,   0    ,  16 ,    3   ,   1   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 0  ,   0    ,  20 ,    5   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 1  , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
+- !expand { BOOT_OPTION_TMPL : [ 2  ,   0    ,  20 ,    0   ,   0   ,    1  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 3  , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
+- !expand { BOOT_OPTION_TMPL : [ 4  ,   0    ,  20 ,    2   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 5  , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
+- !expand { BOOT_OPTION_TMPL : [ 6  ,   0    ,  20 ,    6   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 7  , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
+- !expand { BOOT_OPTION_TMPL : [ 8  ,   0    ,  20 ,    3   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 9  , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
+- !expand { BOOT_OPTION_TMPL : [ 10 ,   0    ,  20 ,    3   ,   1   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 11 , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }


### PR DESCRIPTION
Enable POSC for all boot medium in Cfgdata_BootOption.yaml
by default
If Non-Fusa sku was detect and the boot flag will
change to exclude POSC
User can modify the boot flag to exclude the POSC in
yaml file as well

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>