### PR TITLE
[EHL] Enable tcc in boot option

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_BootOption.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_BootOption.yaml
@@ -11,13 +11,14 @@
     page         : OS
 - !expand { BOOT_OPTION_TMPL : [ 0  ,   0    ,  20 ,    5   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
 - !expand { BOOT_OPTION_TMPL : [ 1  , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
-- !expand { BOOT_OPTION_TMPL : [ 2  ,   0    ,  20 ,    0   ,   0   ,    1  ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 3  , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
-- !expand { BOOT_OPTION_TMPL : [ 4  ,   0    ,  20 ,    2   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 5  , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
-- !expand { BOOT_OPTION_TMPL : [ 6  ,   0    ,  20 ,    6   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 7  , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
-- !expand { BOOT_OPTION_TMPL : [ 8  ,   0    ,  20 ,    3   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 9  , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
-- !expand { BOOT_OPTION_TMPL : [ 10 ,   0    ,  20 ,    3   ,   1   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 11 , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
+- !expand { BOOT_OPTION_TMPL : [ 2  , 0x1F   ,  16 ,    5   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_rtcm' ] }
+- !expand { BOOT_OPTION_TMPL : [ 3  ,   0    ,  20 ,    0   ,   0   ,    1  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 4  , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
+- !expand { BOOT_OPTION_TMPL : [ 5  ,   0    ,  20 ,    2   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 6  , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
+- !expand { BOOT_OPTION_TMPL : [ 7  ,   0    ,  20 ,    6   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 8  , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
+- !expand { BOOT_OPTION_TMPL : [ 9  ,   0    ,  20 ,    3   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 10 , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
+- !expand { BOOT_OPTION_TMPL : [ 11 ,   0    ,  20 ,    3   ,   1   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 12 , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }


### PR DESCRIPTION
Re-enable sbl_rtcm in EHL boot option due to
mistakenly removed it in previous commit of
f01a5b33fba3da04bc6c0d632ce9450413a4651a

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>