### PR TITLE
[TGL] Add iTBT PCIe root port enablment config

### DIFF
--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -169,6 +169,13 @@
                      Enable(Default)- Enable IGFX RenderStandby, Disable- Disable IGFX RenderStandby
       length       : 0x01
       value        : 0x1
+  - ITbtPcieRootPortEn :
+      name         : Enable/Disable ITBT Root Port
+      type         : EditNum, HEX, (0x00,0xFFFFFFFF)
+      help         : >
+                     Enable/Disable ITBT Root Port
+      length       : 0x04
+      value        : { 0x1, 0x1, 0x1, 0x1 }
   - PmSupport    :
       name         : Enable/Disable IGFX PmSupport
       type         : Combo

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1588,15 +1588,12 @@ UpdateFspConfig (
   FspsConfig->SkipMpInit = 0;
 
   FspsConfig->UsbTcPortEn = 0xf;
-  FspsConfig->ITbtPcieRootPortEn[0] = 0x1;
-  FspsConfig->ITbtPcieRootPortEn[1] = 0x1;
-  FspsConfig->ITbtPcieRootPortEn[2] = 0x1;
-  FspsConfig->ITbtPcieRootPortEn[3] = 0x1;
 
   if (SiCfgData != NULL) {
     FspsConfig->EnableTimedGpio0 = SiCfgData->EnableTimedGpio0;
     FspsConfig->EnableTimedGpio1 = SiCfgData->EnableTimedGpio1;
     FspsConfig->XdciEnable       = SiCfgData->XdciEnable;
+    CopyMem (FspsConfig->ITbtPcieRootPortEn, SiCfgData->ITbtPcieRootPortEn, sizeof(SiCfgData->ITbtPcieRootPortEn));
   }
 
   if (FeaturePcdGet (PcdTccEnabled)) {


### PR DESCRIPTION
This patch replaces the original hard-coded iTBT root ports control with
a CFG option. The default value is to enable them.

Signed-off-by: Stanley Chang <stanley.chang@intel.com>