### PR TITLE
[EHL] Update the EHL BoardPkg version to 2.0

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/BoardConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/BoardConfig.py
@@ -23,8 +23,8 @@ class Board(BaseBoard):
         super(Board, self).__init__(*args, **kwargs)
 
         self.VERINFO_IMAGE_ID     = 'SB_EHLK '
-        self.VERINFO_PROJ_MAJOR_VER = 1
-        self.VERINFO_PROJ_MINOR_VER = 1
+        self.VERINFO_PROJ_MAJOR_VER = 2
+        self.VERINFO_PROJ_MINOR_VER = 0
         self.VERINFO_SVN          = 1
         self.VERINFO_BUILD_DATE   = time.strftime("%m/%d/%Y")
         self.LOWEST_SUPPORTED_FW_VER = ((self.VERINFO_PROJ_MAJOR_VER << 8) + self.VERINFO_PROJ_MINOR_VER)


### PR DESCRIPTION
Update EHL BoardPkg version to 2.0 to allign with current
software package version:
PROJ_MAJOR_VER -> 2 (Maintenance Release candidate)
PROJ_MINOR_VER -> 0 (1st revision of MR1 release)

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>