### PR TITLE
[Common] Fix config data boot option index

### DIFF
--- a/Platform/CommonBoardPkg/CfgData/Template_BootOption.yaml
+++ b/Platform/CommonBoardPkg/CfgData/Template_BootOption.yaml
@@ -14,7 +14,7 @@ BOOT_OPTION_TMPL: >
   - $ACTION      :
       page         : OS_$(1)
   - BOOT_OPTION_CFG_DATA_$(1) :
-    - !expand { CFGHDR_TMPL : [ BOOT_OPTION_CFG_DATA_$(1), 0x05$(1), 0, 0 ] }
+    - !expand { CFGHDR_TMPL : [ BOOT_OPTION_CFG_DATA_$(1), (0x050 + $(1)), 0, 0 ] }
     - ImageType_$(1) :
         name         : Image Type
         type         : Combo

--- a/Platform/CommonBoardPkg/Include/ConfigDataCommonDefs.h
+++ b/Platform/CommonBoardPkg/Include/ConfigDataCommonDefs.h
@@ -11,8 +11,8 @@
 // Note: Any Config TAG that is less than 0x100 will be considered as Common TAG
 // and it is applicable for all platforms.
 
-// 0x050 to 0x05F is reserved for boot option tag
-#define  MAX_BOOT_OPTION_CFGDATA_ENTRY  16
+// 0x050 to 0x06F is reserved for boot option tag
+#define  MAX_BOOT_OPTION_CFGDATA_ENTRY  32
 #define  CDATA_BOOT_OPTION_TAG          0x050
 
 #define  CDATA_CAPSULE_TAG              0x080


### PR DESCRIPTION
Current index only support up to 0xF as the CFGHDR_TMPL
as it amend into 0x05 (eg. 0x05$(1))
Update the logic to (0x050 + $(1)) instead to support
index larger than 0xF

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>