### PR TITLE
Fix error logs for capsule file too small

### DIFF
--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -560,6 +560,11 @@ AuthenticateCapsule (
   FwUpdStatusOffset = PcdGet32(PcdFwUpdStatusBase);
 
   Header = (FIRMWARE_UPDATE_HEADER *)FwImage;
+  if (FwSize < sizeof (FIRMWARE_UPDATE_HEADER)) {
+    DEBUG ((DEBUG_ERROR, "Invalid capsule: file is too small. file size=%d\n", FwSize));
+    return EFI_INVALID_PARAMETER;
+  }
+
   if (!CompareGuid (&Header->FileGuid, &gFirmwareUpdateImageFileGuid)) {
     DEBUG ((DEBUG_ERROR, "Invalid capsule: Image file guid is not expected. guid=%g\n", &Header->FileGuid));
     return EFI_INVALID_PARAMETER;


### PR DESCRIPTION
If the capsule file is too small, it should not only
show "the guid is not expected" that may mislead users
using a release-build image. This patch prints out
specific error if opening a small-than-expected capsule.

Signed-off-by: Stanley Chang <stanley.chang@intel.com>