### PR TITLE
[EHL] Fix in RVP board support

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Int_IotgRvp1.dlt
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Int_IotgRvp1.dlt
@@ -42,3 +42,8 @@ GPIO_CFG_DATA.GpioPinConfig0_GPP_C22.GPIOResetConfig_GPP_C22 | 0x1
 GPIO_CFG_DATA.GpioPinConfig0_GPP_C23.GPIOResetConfig_GPP_C23 | 0x1
 GPIO_CFG_DATA.GpioPinConfig0_GPP_D17.GPIOResetConfig_GPP_D17 | 0x1
 GPIO_CFG_DATA.GpioPinConfig0_GPP_D18.GPIOResetConfig_GPP_D18 | 0x1
+#To support GPIO Lock in RVP board
+GPIO_CFG_DATA.GpioPinConfig1_GPP_B02.GPIOLockConfig_GPP_B02 | 0x3
+GPIO_CFG_DATA.GpioPinConfig1_GPP_E02.GPIOLockConfig_GPP_E02 | 0x3
+GPIO_CFG_DATA.GpioPinConfig1_GPP_F04.GPIOLockConfig_GPP_F04 | 0x3
+GPIO_CFG_DATA.GpioPinConfig1_GPP_F20.GPIOLockConfig_GPP_F20 | 0x3


### PR DESCRIPTION
Added Gpio Lock config in dlt file for RVP board

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>