### PR TITLE
Fix normalization error

### DIFF
--- a/Platform/CommonBoardPkg/Tools/GpioDataConvert.py
+++ b/Platform/CommonBoardPkg/Tools/GpioDataConvert.py
@@ -564,10 +564,12 @@ def get_sbl_dws (inp_fmt, cfg_file, parts):
     sbl_dw0 = SBL_DW0 ()
     sbl_dw1 = SBL_DW1 ()
 
-    pad_name = normalize_pad_name (parts[0])
-    pad_name = pad_name[-7:]
-    if not pad_name.startswith('GPP_'):
+    if not 'GPP_' in parts[0]:
         return '', 0x0, 0x0
+    splitdata = parts[0].split('_')
+    pin_number = splitdata[len(splitdata)-1]
+    pin_number = normalize_pad_name (pin_number)
+    pad_name = 'GPP_' + pin_number
 
     gpio_cfg_file = SourceFileLoader ('GenGpioDataConfig', cfg_file).load_module()
 


### PR DESCRIPTION
when pin number in pad name is not in <group name><xx> where
xx is pin number format. for example GPIO_VER2_LP_GPP_C2 instead of
GPIO_VER2_LP_GPP_C02, current code has a bug which does not give the
desired output which is GPP_C02.
This patch fixed this issue.

TEST= Verified on multiple platforms that the issue is fixed

Signed-off-by: Raghava <raghava.gudla@intel.com>