### PR TITLE
[TGL] Fix RTC S3 wake hang

### DIFF
--- a/Silicon/TigerlakePchPkg/Include/PchAccess.h
+++ b/Silicon/TigerlakePchPkg/Include/PchAccess.h
@@ -1,7 +1,7 @@
 /** @file
   Macros that simplify accessing PCH devices's PCI registers.
 
-  Copyright (c) 1999 - 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 1999 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 #ifndef _PCH_ACCESS_H_
@@ -65,6 +65,7 @@
 //#include "Register/PchRegsFia.h"
 #include "Register/PmcRegs.h"
 #include "Register/PchRegsSpi.h"
-#include <Register/PchRegsSerialIoTgl.h>
+#include "Register/PchRegsSerialIoTgl.h"
+#include "Register/RtcRegs.h"
 
 #endif

--- a/Silicon/TigerlakePchPkg/Include/Register/PmcRegs.h
+++ b/Silicon/TigerlakePchPkg/Include/Register/PmcRegs.h
@@ -30,7 +30,7 @@
   - RegisterName:
     Full register name.
 
-  Copyright (c) 1999 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 1999 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -54,6 +54,7 @@
 // ACPI and legacy I/O register offsets from ACPIBASE
 //
 #define R_ACPI_IO_PM1_STS                        0x00
+#define B_ACPI_IO_PM1_STS_RTC_EN                 BIT26
 #define B_ACPI_IO_PM1_STS_WAK                    BIT15
 #define B_ACPI_IO_PM1_STS_PRBTNOR                BIT11
 #define B_ACPI_IO_PM1_STS_RTC                    BIT10
@@ -64,6 +65,7 @@
 #define B_ACPI_IO_PM1_EN_PWRBTN                  BIT8
 
 #define R_ACPI_IO_PM1_CNT                        0x04
+#define B_ACPI_IO_PM1_CNT_SCI_EN                 BIT0
 #define B_ACPI_IO_PM1_CNT_SLP_TYP                (BIT12 | BIT11 | BIT10)
 #define V_ACPI_IO_PM1_CNT_S0                     0
 #define V_ACPI_IO_PM1_CNT_S3                     (BIT12 | BIT10)

--- a/Silicon/TigerlakePchPkg/Include/Register/RtcRegs.h
+++ b/Silicon/TigerlakePchPkg/Include/Register/RtcRegs.h
@@ -1,0 +1,44 @@
+/** @file
+  Register names for RTC device
+
+Conventions:
+
+  - Register definition format:
+    Prefix_[GenerationName]_[ComponentName]_SubsystemName_RegisterSpace_RegisterName
+  - Prefix:
+    Definitions beginning with "R_" are registers
+    Definitions beginning with "B_" are bits within registers
+    Definitions beginning with "V_" are meaningful values within the bits
+    Definitions beginning with "S_" are register size
+    Definitions beginning with "N_" are the bit position
+  - [GenerationName]:
+    Three letter acronym of the generation is used (e.g. SKL,KBL,CNL etc.).
+    Register name without GenerationName applies to all generations.
+  - [ComponentName]:
+    This field indicates the component name that the register belongs to (e.g. PCH, SA etc.)
+    Register name without ComponentName applies to all components.
+    Register that is specific to -H denoted by "_PCH_H_" in component name.
+    Register that is specific to -LP denoted by "_PCH_LP_" in component name.
+  - SubsystemName:
+    This field indicates the subsystem name of the component that the register belongs to
+    (e.g. PCIE, USB, SATA, GPIO, PMC etc.).
+  - RegisterSpace:
+    MEM - MMIO space register of subsystem.
+    IO  - IO space register of subsystem.
+    PCR - Private configuration register of subsystem.
+    CFG - PCI configuration space register of subsystem.
+  - RegisterName:
+    Full register name.
+
+  Copyright (c) 2021 Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _REGS_RTC_H_
+#define _REGS_RTC_H_
+
+#define R_RTC_IO_INDEX                           0x70
+#define R_RTC_IO_TARGET                          0x71
+
+#define R_RTC_IO_REGC                            0x0C
+
+#endif


### PR DESCRIPTION
This patch clears RTC Alarm when RTC is the S3 wake up source.
Without clearing it, SMI# will be triggered once SMI_EN is set
by RestoreS3RegInfo, but no handler to clear it which results
in hang.

Signed-off-by: Stanley Chang <stanley.chang@intel.com>