### PR TITLE
[CFL] Fix reading bpmgen2 params

### DIFF
--- a/Platform/CoffeelakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/CoffeelakeBoardPkg/Script/StitchIfwi.py
@@ -66,7 +66,7 @@ stitching ingredients listed in step 2 below, please contact your Intel represen
 """
 
 def gen_bpmgen2_params (stitch_cfg_file, InFile, OutFile):
-    InFileptr = open(InFile, 'r')
+    InFileptr = open(InFile, 'r', encoding='utf8')
     lines = InFileptr.readlines()
     InFileptr.close()
 


### PR DESCRIPTION
Default Bpmgen params created by bpmgen tool
has unicode characters. This patch fixes reading the
file with unicode chars.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>