### PR TITLE
[CorePkg] Add GetTempRamInfo() API

### DIFF
--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -213,6 +213,8 @@ typedef struct {
   UINT8             PlatformName[PLATFORM_NAME_SIZE];
   UINT32            LdrFeatures;
   BL_PERF_DATA      PerfData;
+  UINT32            CarBase;
+  UINT32            CarSize;
 } LOADER_GLOBAL_DATA;
 
 /**
@@ -490,6 +492,23 @@ UINT32
 EFIAPI
 GetUsableMemoryTop (
   VOID
+  );
+
+/**
+ This function retrieves TempRam Base and Size reported from FSP-T.
+
+  @param[out] Base          Base address of TempRam
+  @param[out] Size          Size of TempRam
+
+  @retval EFI_SUCCESS       Retrieved TempRam Base and Size
+  @retval EFI_UNSUPPORTED   No valid info exists
+
+**/
+EFI_STATUS
+EFIAPI
+GetTempRamInfo (
+  OUT UINT32  *Base,
+  OUT UINT32  *Size
   );
 
 #endif

--- a/BootloaderCorePkg/Library/BootloaderCoreLib/BootloaderCoreLib.c
+++ b/BootloaderCorePkg/Library/BootloaderCoreLib/BootloaderCoreLib.c
@@ -407,3 +407,40 @@ GetUsableMemoryTop (
 {
   return GetLoaderGlobalDataPointer()->MemUsableTop;
 }
+
+/**
+ This function retrieves TempRam Base and Size reported from FSP-T.
+
+  @param[out] Base          Base address of TempRam
+  @param[out] Size          Size of TempRam
+
+  @retval EFI_SUCCESS       Retrieved TempRam Base and Size
+  @retval EFI_UNSUPPORTED   No valid info exists
+
+**/
+EFI_STATUS
+EFIAPI
+GetTempRamInfo (
+  OUT UINT32  *Base,
+  OUT UINT32  *Size
+  )
+{
+  UINT32  CarBase;
+  UINT32  CarSize;
+
+  CarBase = GetLoaderGlobalDataPointer()->CarBase;
+  CarSize = GetLoaderGlobalDataPointer()->CarSize;
+
+  if ((CarBase == 0) || (CarSize == 0)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  if (Base != NULL) {
+    *Base = CarBase;
+  }
+  if (Size != NULL) {
+    *Size = CarSize;
+  }
+
+  return EFI_SUCCESS;
+}

--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -472,6 +472,9 @@ SecStartup (
   // Any platform (board init lib) can update these according to
   // the config data passed in or these defaults remain
   LdrGlobal->LdrFeatures           = FEATURE_MEASURED_BOOT | FEATURE_ACPI;
+  // TempRam Base and Size
+  LdrGlobal->CarBase               = Stage1aAsmParam->CarBase;
+  LdrGlobal->CarSize               = Stage1aAsmParam->CarTop - LdrGlobal->CarBase;
 
   LoadGdt (&GdtTable, (IA32_DESCRIPTOR *)&mGdt);
   LoadIdt (&IdtTable, (UINT32)(UINTN)LdrGlobal);

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -655,6 +655,11 @@ ContinueFunc (
   AddMeasurePoint (0x2060);
   ASSERT_EFI_ERROR (Status);
 
+  LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
+  ASSERT (LdrGlobal != NULL);
+  LdrGlobal->CarBase = 0;
+  LdrGlobal->CarSize = 0;
+
   BoardInit (PostTempRamExit);
   AddMeasurePoint (0x2070);
 
@@ -685,7 +690,6 @@ ContinueFunc (
     }
   }
 
-  LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
   DEBUG ((DEBUG_INFO, "Memory FSP @ 0x%08X\n", LdrGlobal->StackTop));
   DEBUG ((DEBUG_INFO, "Memory TOP @ 0x%08X\n", LdrGlobal->MemPoolStart));
 


### PR DESCRIPTION
Some platforms need TempRam Base & Size information to calculate
FspmArchUpd StackBase & Size at runtime.
The TempRam Base & Size info will be only valid until TempRamExit.

Signed-off-by: Aiden Park <aiden.park@intel.com>