### PR TITLE
[QEMU] extend auto test timeout

### DIFF
--- a/Platform/QemuBoardPkg/Script/TestCases/linux_boot.py
+++ b/Platform/QemuBoardPkg/Script/TestCases/linux_boot.py
@@ -62,7 +62,7 @@ def main():
 
     # run QEMU boot with timeout
     output = []
-    lines = run_qemu(bios_img, os_dir, timeout = 8)
+    lines = run_qemu(bios_img, os_dir, timeout = 10)
     output.extend(lines)
 
     # check test result


### PR DESCRIPTION
Recently, github CI test case, Qemu-linux_boot.py, randomly fails.

Comparing the logs between failed and pass cases, we can find:

  1. the failure is caused by timeout before Minimal Linux
     completely boots into console and shows "Welcome to Minimal
     Linux" messages.

     Although such timeout can be a real error (true-positive),
     it is also possible just a false alarm (false-positive)...

  2. for a failed case, a force push to trigger another CI check
     can result in pass, even no code changes. Thus, the timeout
     failure points to CI environment (e.g., loading) - a false alarm.

  3. the margin (of pass case to timeout) is about 0.4 sec.

This patch increases timeout for 2 seconds to avoid unexpected
test timeout caused CI envornment (e.g., loading).

Signed-off-by: Stanley Chang <stanley.chang@intel.com>