### PR TITLE
Cleanup Platform code to access LoaderGlobalData via APIs

### DIFF
--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -511,4 +511,50 @@ GetTempRamInfo (
   OUT UINT32  *Size
   );
 
+/**
+  This function retrieves the address of S3Data.
+
+  @retval    S3Data pointer address.
+
+**/
+VOID *
+EFIAPI
+GetS3DataPtr (
+  VOID
+  );
+
+/**
+  This function sets features configuration.
+
+  @param Features   The features the platform supports.
+
+**/
+VOID
+EFIAPI
+SetFeatureCfg (
+  IN  UINT32  Features
+  );
+
+/**
+  This function clears FSP Hob Data and pointer.
+
+**/
+VOID
+EFIAPI
+ClearFspHob (
+  VOID
+  );
+
+/**
+  This function retrieves the Version Information pointer.
+
+  @retval    Version Information pointer address.
+
+**/
+VOID *
+EFIAPI
+GetVerInfoPtr (
+  VOID
+  );
+
 #endif

--- a/BootloaderCorePkg/Library/BootloaderCoreLib/BootloaderCoreLib.c
+++ b/BootloaderCorePkg/Library/BootloaderCoreLib/BootloaderCoreLib.c
@@ -444,3 +444,72 @@ GetTempRamInfo (
 
   return EFI_SUCCESS;
 }
+
+/**
+  This function retrieves the address of S3Data.
+
+  @retval    S3Data pointer address.
+
+**/
+VOID *
+EFIAPI
+GetS3DataPtr (
+  VOID
+  )
+{
+  return GetLoaderGlobalDataPointer()->S3DataPtr;
+}
+
+/**
+  This function sets features configuration.
+
+  @param Features   The features the platform supports.
+
+**/
+VOID
+EFIAPI
+SetFeatureCfg (
+  IN  UINT32  Features
+  )
+{
+  GetLoaderGlobalDataPointer()->LdrFeatures = Features;
+}
+
+/**
+  This function clears FSP Hob Data and pointer.
+
+**/
+VOID
+EFIAPI
+ClearFspHob (
+  VOID
+  )
+{
+  VOID                        *FspHobList;
+  EFI_HOB_HANDOFF_INFO_TABLE  *HandOffHob;
+  UINT32                       Length;
+
+  FspHobList = GetLoaderGlobalDataPointer()->FspHobList;
+  if (FspHobList != NULL) {
+    HandOffHob = (EFI_HOB_HANDOFF_INFO_TABLE *) FspHobList;
+    Length     = (UINT32)((UINTN)HandOffHob->EfiEndOfHobList - (UINTN)HandOffHob);
+    ZeroMem (HandOffHob, Length);
+
+    GetLoaderGlobalDataPointer()->FspHobList = NULL;
+  }
+}
+
+/**
+  This function retrieves the Version Information pointer.
+
+  @retval    Version Information pointer address.
+
+**/
+VOID *
+EFIAPI
+GetVerInfoPtr (
+  VOID
+  )
+{
+  return GetLoaderGlobalDataPointer()->VerInfoPtr;
+}

--- a/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -405,7 +405,6 @@ PlatformFeaturesInit (
   )
 {
   FEATURES_CFG_DATA           *FeaturesCfgData;
-  LOADER_GLOBAL_DATA          *LdrGlobal;
   UINT32                       Features;
   PLATFORM_DATA               *PlatformData;
 
@@ -445,10 +444,8 @@ PlatformFeaturesInit (
     DEBUG ((DEBUG_INFO, "FEATURES CFG DATA NOT FOUND!\n"));
   }
 
-  LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
-  LdrGlobal->LdrFeatures = Features;
-
-  DEBUG ((DEBUG_INFO, "PlatformFeaturesInit: LdrGlobal->LdrFeatures 0x%x\n",LdrGlobal->LdrFeatures));
+  SetFeatureCfg (Features);
+  DEBUG ((DEBUG_INFO, "PlatformFeaturesInit: Features 0x%x\n", GetFeatureCfg ()));
 }
 
 /**

--- a/Platform/CometlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CometlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -469,7 +469,6 @@ PlatformFeaturesInit (
   )
 {
   FEATURES_CFG_DATA           *FeaturesCfgData;
-  LOADER_GLOBAL_DATA          *LdrGlobal;
   UINT32                       Features;
   PLATFORM_DATA               *PlatformData;
   UINTN                        HeciBaseAddress;
@@ -516,10 +515,8 @@ PlatformFeaturesInit (
     DEBUG ((DEBUG_INFO, "FEATURES CFG DATA NOT FOUND!\n"));
   }
 
-  LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
-  LdrGlobal->LdrFeatures = Features;
-
-  DEBUG ((DEBUG_INFO, "PlatformFeaturesInit: LdrGlobal->LdrFeatures 0x%x\n",LdrGlobal->LdrFeatures));
+  SetFeatureCfg (Features);
+  DEBUG ((DEBUG_INFO, "PlatformFeaturesInit: Features 0x%x\n", GetFeatureCfg ()));
 }
 
 /**
@@ -533,7 +530,7 @@ TpmInitialize (
   EFI_STATUS                   Status;
   UINT8                        BootMode;
   PLATFORM_DATA               *PlatformData;
-  LOADER_GLOBAL_DATA          *LdrGlobal;
+  UINT32                       Features;
 
   PlatformData = (PLATFORM_DATA *)GetPlatformDataPtr ();
 
@@ -562,8 +559,9 @@ TpmInitialize (
   } else {
     DisableTpm();
 
-    LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
-    LdrGlobal->LdrFeatures &= ~FEATURE_MEASURED_BOOT;
+    Features  = GetFeatureCfg ();
+    Features &= (UINT32)(~FEATURE_MEASURED_BOOT);
+    SetFeatureCfg (Features);
   }
 
 }

--- a/Platform/CometlakevBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CometlakevBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -465,7 +465,6 @@ PlatformFeaturesInit (
   )
 {
   FEATURES_CFG_DATA           *FeaturesCfgData;
-  LOADER_GLOBAL_DATA          *LdrGlobal;
   UINT32                       Features;
   PLATFORM_DATA               *PlatformData;
   UINTN                        HeciBaseAddress;
@@ -512,10 +511,8 @@ PlatformFeaturesInit (
     DEBUG ((DEBUG_INFO, "FEATURES CFG DATA NOT FOUND!\n"));
   }
 
-  LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
-  LdrGlobal->LdrFeatures = Features;
-
-  DEBUG ((DEBUG_INFO, "PlatformFeaturesInit: LdrGlobal->LdrFeatures 0x%x\n",LdrGlobal->LdrFeatures));
+  SetFeatureCfg (Features);
+  DEBUG ((DEBUG_INFO, "PlatformFeaturesInit: Features 0x%x\n", GetFeatureCfg ()));
 }
 
 /**
@@ -529,7 +526,7 @@ TpmInitialize (
   EFI_STATUS                   Status;
   UINT8                        BootMode;
   PLATFORM_DATA               *PlatformData;
-  LOADER_GLOBAL_DATA          *LdrGlobal;
+  UINT32                       Features;
 
   PlatformData = (PLATFORM_DATA *)GetPlatformDataPtr ();
 
@@ -558,8 +555,9 @@ TpmInitialize (
   } else {
     DisableTpm();
 
-    LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
-    LdrGlobal->LdrFeatures &= ~FEATURE_MEASURED_BOOT;
+    Features  = GetFeatureCfg ();
+    Features &= (UINT32)(~FEATURE_MEASURED_BOOT);
+    SetFeatureCfg (Features);
   }
 
 }

--- a/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -663,30 +663,6 @@ UpdateBlRsvdRegion ()
 }
 
 /**
-  Clear FSP HOB data
-
-**/
-VOID
-ClearFspHob (
-  VOID
-  )
-{
-  LOADER_GLOBAL_DATA          *LdrGlobal;
-  EFI_HOB_HANDOFF_INFO_TABLE  *HandOffHob;
-  UINT32                      Length;
-
-  LdrGlobal  = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
-  if (LdrGlobal->FspHobList == NULL) {
-    return;
-  }
-
-  HandOffHob = (EFI_HOB_HANDOFF_INFO_TABLE  *) LdrGlobal->FspHobList;
-  Length     = (UINT32)((UINTN) HandOffHob->EfiEndOfHobList - (UINTN)HandOffHob);
-  ZeroMem (HandOffHob, Length);
-  LdrGlobal->FspHobList = NULL;
-}
-
-/**
   Add a Smbios type string into a buffer
 
 **/
@@ -739,7 +715,7 @@ InitializeSmbiosInfo (
   Index         = 0;
   PlatformId    = GetPlatformId ();
   TempSmbiosStrTbl  = (SMBIOS_TYPE_STRINGS *) AllocateTemporaryMemory (0);
-  VerInfoTbl    = GetLoaderGlobalDataPointer()->VerInfoPtr;
+  VerInfoTbl    = GetVerInfoPtr ();
 
   //
   // SMBIOS_TYPE_BIOS_INFORMATION
@@ -1031,7 +1007,7 @@ BoardInit (
   UINT32          PayloadId;
   UINTN           PmcBaseAddr;
   EFI_PEI_GRAPHICS_INFO_HOB *FspGfxHob;
-  LOADER_GLOBAL_DATA        *LdrGlobal;
+  VOID                      *FspHobList;
 
   switch (InitPhase) {
   case PreSiliconInit:
@@ -1075,7 +1051,7 @@ BoardInit (
 
     SetPayloadId (PayloadId);
 
-    if (GetLoaderGlobalDataPointer ()->BootMode != BOOT_ON_FLASH_UPDATE) {
+    if (GetBootMode () != BOOT_ON_FLASH_UPDATE) {
       UpdateBlRsvdRegion ();
     }
     Status = GetComponentInfo (FLASH_MAP_SIG_VARIABLE, &RgnBase, &RgnSize);
@@ -1096,9 +1072,12 @@ BoardInit (
     // Reinitialize the BAR for Graphics device
     //
     if (PcdGetBool (PcdFramebufferInitEnabled)) {
-      LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer();
-      FspGfxHob = (EFI_PEI_GRAPHICS_INFO_HOB *)GetGuidHobData (LdrGlobal->FspHobList, &Length,
-                    &gEfiGraphicsInfoHobGuid);
+      FspGfxHob = NULL;
+      FspHobList = GetFspHobListPtr ();
+      if (FspHobList != NULL) {
+        FspGfxHob = (EFI_PEI_GRAPHICS_INFO_HOB *)GetGuidHobData (FspHobList, &Length,
+                      &gEfiGraphicsInfoHobGuid);
+      }
       if (FspGfxHob != NULL) {
         PciAnd8 (PCI_LIB_ADDRESS(SA_IGD_BUS, SA_IGD_DEV, SA_IGD_FUN_0, PCI_COMMAND_OFFSET), \
                    (UINT8)(~EFI_PCI_COMMAND_BUS_MASTER));
@@ -2180,10 +2159,8 @@ PlatformUpdateAcpiTable (
   GLOBAL_NVS_AREA             *GlobalNvs;
   UINT32                       Base;
   UINT16                       Size;
-  LOADER_GLOBAL_DATA          *LdrGlobal;
   EFI_STATUS                   Status;
-
-  LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer();
+  VOID                        *FspHobList;
 
   GlobalNvs  = (GLOBAL_NVS_AREA *)(UINTN) PcdGet32 (PcdAcpiGnvsAddress);
 
@@ -2247,15 +2224,18 @@ PlatformUpdateAcpiTable (
   }
 
   if (Table->Signature == EFI_BDAT_TABLE_SIGNATURE) {
-    UpdateBdatAcpiTable (Table, LdrGlobal->FspHobList);
-    DEBUG ( (DEBUG_INFO, "Updated BDAT Table in AcpiTable Entries\n") );
+    FspHobList = GetFspHobListPtr ();
+    if (FspHobList != NULL) {
+      UpdateBdatAcpiTable (Table, FspHobList);
+      DEBUG ( (DEBUG_INFO, "Updated BDAT Table in AcpiTable Entries\n") );
+    }
   }
 
   if (FeaturePcdGet (PcdMeasuredBootEnabled)){
     if ((Table->Signature == EFI_ACPI_5_0_TRUSTED_COMPUTING_PLATFORM_2_TABLE_SIGNATURE) ||
           (Table->OemTableId == ACPI_SSDT_TPM2_DEVICE_OEM_TABLE_ID)) {
 
-      if (LdrGlobal->LdrFeatures & FEATURE_MEASURED_BOOT) {
+      if ((GetFeatureCfg () & FEATURE_MEASURED_BOOT) != 0) {
         Status = UpdateTpm2AcpiTable(Table);
         if (EFI_ERROR (Status)) {
           DEBUG ((DEBUG_ERROR, "UpdateTpm2AcpiTable fails! - %r\n", Status));
@@ -2298,9 +2278,7 @@ UpdateCpuNvs (
 {
   EFI_HOB_GUID_TYPE                     *GuidHob;
   CPU_INIT_DATA_HOB                     *CpuInitDataHob;
-  LOADER_GLOBAL_DATA                    *LdrGlobal;
-
-  LdrGlobal   = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer();
+  VOID                                  *FspHobList;
 
   if (CpuNvs == NULL) {
     DEBUG ((DEBUG_ERROR, "Invalid Cpu Nvs pointer!!!\n"));
@@ -2310,7 +2288,11 @@ UpdateCpuNvs (
   ///
   /// Get CPU Init Data Hob
   ///
-  GuidHob = GetNextGuidHob (&gCpuInitDataHobGuid, LdrGlobal->FspHobList);
+  GuidHob = NULL;
+  FspHobList = GetFspHobListPtr ();
+  if (FspHobList != NULL) {
+    GuidHob = GetNextGuidHob (&gCpuInitDataHobGuid, FspHobList);
+  }
   if (GuidHob == NULL) {
     DEBUG ((DEBUG_ERROR, "CPU Data HOB not available\n"));
     return;

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -880,25 +880,25 @@ PlatformFeaturesInit (
   )
 {
   FEATURES_CFG_DATA           *FeaturesCfgData;
-  LOADER_GLOBAL_DATA          *LdrGlobal;
   PLATFORM_DATA               *PlatformData;
   UINTN                        HeciBaseAddress;
+  UINT32                       LdrFeatures;
 
   // Set common features
-  LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
-  LdrGlobal->LdrFeatures |= FeaturePcdGet (PcdAcpiEnabled)?FEATURE_ACPI:0;
-  LdrGlobal->LdrFeatures |= FeaturePcdGet (PcdVerifiedBootEnabled)?FEATURE_VERIFIED_BOOT:0;
-  LdrGlobal->LdrFeatures |= FeaturePcdGet (PcdMeasuredBootEnabled)?FEATURE_MEASURED_BOOT:0;
+  LdrFeatures  = GetFeatureCfg ();
+  LdrFeatures |= FeaturePcdGet (PcdAcpiEnabled)?FEATURE_ACPI:0;
+  LdrFeatures |= FeaturePcdGet (PcdVerifiedBootEnabled)?FEATURE_VERIFIED_BOOT:0;
+  LdrFeatures |= FeaturePcdGet (PcdMeasuredBootEnabled)?FEATURE_MEASURED_BOOT:0;
 
   // Disable feature by configuration data.
   FeaturesCfgData = (FEATURES_CFG_DATA *) FindConfigDataByTag(CDATA_FEATURES_TAG);
   if (FeaturesCfgData != NULL) {
     if (FeaturesCfgData->Features.Acpi == 0) {
-      LdrGlobal->LdrFeatures &= ~FEATURE_ACPI;
+      LdrFeatures &= ~FEATURE_ACPI;
     }
 
     if (FeaturesCfgData->Features.MeasuredBoot == 0) {
-      LdrGlobal->LdrFeatures &= ~FEATURE_MEASURED_BOOT;
+      LdrFeatures &= ~FEATURE_MEASURED_BOOT;
     }
   }
 
@@ -914,12 +914,14 @@ PlatformFeaturesInit (
     GetBootGuardInfo (HeciBaseAddress, &PlatformData->BtGuardInfo);
     DEBUG ((DEBUG_INFO, "GetPlatformDataPtr is copied 0x%08X \n", PlatformData));
     if (!PlatformData->BtGuardInfo.MeasuredBoot) {
-      LdrGlobal->LdrFeatures &= ~FEATURE_MEASURED_BOOT;
+      LdrFeatures &= ~FEATURE_MEASURED_BOOT;
     }
     if (!PlatformData->BtGuardInfo.VerifiedBoot) {
-      LdrGlobal->LdrFeatures &= ~FEATURE_VERIFIED_BOOT;
+      LdrFeatures &= ~FEATURE_VERIFIED_BOOT;
     }
   }
+
+  SetFeatureCfg (LdrFeatures);
 }
 
 /**

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/UpdateAcpiGnvs.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/UpdateAcpiGnvs.c
@@ -292,7 +292,7 @@ UpdateCpuNvs (
   EFI_HOB_GUID_TYPE                     *GuidHob;
   CPU_INIT_DATA_HOB                     *CpuInitDataHob;
   CPU_CONFIG_DATA                       *CpuConfigData;
-  LOADER_GLOBAL_DATA                    *LdrGlobal;
+  VOID                                  *FspHobList;
   UINT16                                C6Latency = 0;
   UINT16                                C7Latency = 0;
   UINT16                                C8Latency = 0;
@@ -303,8 +303,6 @@ UpdateCpuNvs (
   UINT8                                 MaxRefTemp;
   UINT8                                 Index;
 
-  LdrGlobal   = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer();
-
   if (CpuNvs == NULL) {
     DEBUG ((DEBUG_ERROR, "Invalid Cpu Nvs pointer!!!\n"));
     return;
@@ -313,7 +311,11 @@ UpdateCpuNvs (
   ///
   /// Get CPU Init Data Hob
   ///
-  GuidHob = GetNextGuidHob (&gCpuInitDataHobGuid, LdrGlobal->FspHobList);
+  GuidHob = NULL;
+  FspHobList = GetFspHobListPtr ();
+  if (FspHobList != NULL) {
+    GuidHob = GetNextGuidHob (&gCpuInitDataHobGuid, FspHobList);
+  }
   if (GuidHob == NULL) {
     DEBUG ((DEBUG_ERROR, "CPU Data HOB not available\n"));
     return;

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/UpdateAcpiTable.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/UpdateAcpiTable.c
@@ -374,11 +374,10 @@ PlatformUpdateAcpiTable (
   UINT16                       Size;
   EFI_STATUS                   Status;
   TCC_CFG_DATA                *TccCfgData;
-  LOADER_GLOBAL_DATA          *LdrGlobal;
+  VOID                        *FspHobList;
   FEATURES_CFG_DATA           *FeaturesCfgData;
   EFI_ACPI_6_1_FIXED_ACPI_DESCRIPTION_TABLE *FadtPointer;
 
-  LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
   GlobalNvs  = (GLOBAL_NVS_AREA *)(UINTN) PcdGet32 (PcdAcpiGnvsAddress);
   FeaturesCfgData = (FEATURES_CFG_DATA *) FindConfigDataByTag(CDATA_FEATURES_TAG);
 
@@ -448,8 +447,11 @@ PlatformUpdateAcpiTable (
     }
     return EFI_UNSUPPORTED;
   } else if (Table->Signature == EFI_BDAT_TABLE_SIGNATURE) {
-    UpdateBdatAcpiTable (Table, LdrGlobal->FspHobList);
-    DEBUG ((DEBUG_INFO, "Updated BDAT Table in AcpiTable Entries\n"));
+    FspHobList = GetFspHobListPtr ();
+    if (FspHobList != NULL) {
+      UpdateBdatAcpiTable (Table, FspHobList);
+      DEBUG ((DEBUG_INFO, "Updated BDAT Table in AcpiTable Entries\n"));
+    }
   } else if (Table->Signature == EFI_ACPI_6_1_FIXED_ACPI_DESCRIPTION_TABLE_SIGNATURE) {
     DEBUG ( (DEBUG_INFO, "Updated FADT Table entries in AcpiTable\n") );
     FadtPointer = (EFI_ACPI_6_1_FIXED_ACPI_DESCRIPTION_TABLE *) Table;

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -202,12 +202,12 @@ BoardInit (
 )
 {
   EFI_STATUS           Status;
-  LOADER_GLOBAL_DATA  *LdrGlobal;
   UINT32               TsegBase;
   UINT64               TsegSize;
   VOID                *Buffer;
   UINT32               Length;
   UINT32               PmBase;
+  VOID                *FspHobList;
 
   switch (InitPhase) {
   case PreSiliconInit:
@@ -227,12 +227,15 @@ BoardInit (
     }
     // Get TSEG info from FSP HOB
     // It will be consumed in MpInit if SMM rebase is enabled
-    LdrGlobal  = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
-    TsegBase = (UINT32)GetFspReservedMemoryFromGuid (
-                       LdrGlobal->FspHobList,
-                       &TsegSize,
-                       &gReservedMemoryResourceHobTsegGuid
-                       );
+    TsegBase = 0;
+    FspHobList = GetFspHobListPtr ();
+    if (FspHobList != NULL) {
+      TsegBase = (UINT32)GetFspReservedMemoryFromGuid (
+                        FspHobList,
+                        &TsegSize,
+                        &gReservedMemoryResourceHobTsegGuid
+                        );
+    }
     if (TsegBase != 0) {
       Status = PcdSet32S (PcdSmramTsegBase, TsegBase);
       Status = PcdSet32S (PcdSmramTsegSize, (UINT32)TsegSize);

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/FusaLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/FusaLib.c
@@ -65,21 +65,21 @@ FindFspFusaInfoHob (
   VOID
   )
 {
-  FUSA_INFO_HOB               *FspFusaInfo;
+  FUSA_INFO_HOB                 *FspFusaInfo;
   EFI_HOB_GUID_TYPE             *GuidHob;
-  LOADER_GLOBAL_DATA            *LdrGlobal;
+  VOID                          *FspHobList;
   UINT32                         CheckIndex;
   UINT32                         TestIndex;
 
   GuidHob = NULL;
   FspFusaInfo = NULL;
-  LdrGlobal = (LOADER_GLOBAL_DATA *) GetLoaderGlobalDataPointer ();
-  if ( LdrGlobal == NULL ) {
-    return EFI_NOT_FOUND;
-  }
+
   // Find Fusa Info Hob from FSP
-  GuidHob = GetNextGuidHob (&gSiFusaInfoGuid, LdrGlobal->FspHobList);
-  if(GuidHob == NULL) {
+  FspHobList = GetFspHobListPtr ();
+  if (FspHobList != NULL) {
+    GuidHob = GetNextGuidHob (&gSiFusaInfoGuid, FspHobList);
+  }
+  if (GuidHob == NULL) {
     return EFI_NOT_FOUND;
   }
   FspFusaInfo = GET_GUID_HOB_DATA (GuidHob);

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -471,28 +471,6 @@ BuildOsConfigDataHob (
 }
 
 /**
-  Clear FSP HOB data
-
-**/
-VOID
-ClearFspHob (
-  VOID
-  )
-{
-  LOADER_GLOBAL_DATA          *LdrGlobal;
-  EFI_HOB_HANDOFF_INFO_TABLE  *HandOffHob;
-  UINTN                       Length;
-
-  LdrGlobal  = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
-  HandOffHob = (EFI_HOB_HANDOFF_INFO_TABLE  *) LdrGlobal->FspHobList;
-  if (HandOffHob != NULL) {
-    Length     = (UINT8 *) (UINTN) HandOffHob->EfiEndOfHobList - (UINT8 *)HandOffHob;
-    ZeroMem (HandOffHob, Length);
-    LdrGlobal->FspHobList = NULL;
-  }
-}
-
-/**
   Set SPI flash EISS and LE
 **/
 VOID
@@ -563,7 +541,7 @@ InitializeSmbiosInfo (
 
   Index         = 0;
   TempSmbiosStrTbl  = (SMBIOS_TYPE_STRINGS *) AllocateTemporaryMemory (0);
-  VerInfoTbl    = GetLoaderGlobalDataPointer()->VerInfoPtr;
+  VerInfoTbl    = GetVerInfoPtr ();
 
   //
   // SMBIOS_TYPE_BIOS_INFORMATION
@@ -887,7 +865,7 @@ BoardInit (
   UINT32                    TsegBase;
   UINT32                    TsegSize;
   EFI_PEI_GRAPHICS_INFO_HOB *FspGfxHob;
-  LOADER_GLOBAL_DATA        *LdrGlobal;
+  VOID                      *FspHobList;
   SILICON_CFG_DATA          *SiCfgData;
   UINTN                     LpcBase;
   BL_SW_SMI_INFO            *BlSwSmiInfo;
@@ -939,8 +917,11 @@ BoardInit (
     (VOID) PcdSet32S (PcdSmramTsegSize, (UINT32)TsegSize);
 
     if (PcdGetBool (PcdFramebufferInitEnabled)) {
-      LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer();
-      FspGfxHob = (EFI_PEI_GRAPHICS_INFO_HOB *)GetGuidHobData (LdrGlobal->FspHobList, &Length, &gEfiGraphicsInfoHobGuid);
+      FspGfxHob = NULL;
+      FspHobList = GetFspHobListPtr ();
+      if (FspHobList != NULL) {
+        FspGfxHob = (EFI_PEI_GRAPHICS_INFO_HOB *)GetGuidHobData (FspHobList, &Length, &gEfiGraphicsInfoHobGuid);
+      }
       if (FspGfxHob != NULL) {
         DEBUG ((DEBUG_INFO, "FspGfxHob->FrameBufferBase = 0x%lx\n", FspGfxHob->FrameBufferBase));
         PciWrite8 (PCI_LIB_ADDRESS(SA_IGD_BUS, SA_IGD_DEV, SA_IGD_FUN_0, PCI_COMMAND_OFFSET), \
@@ -2145,15 +2126,14 @@ PlatformUpdateAcpiTable (
   UINT32                       Base;
   UINT16                       Size;
   EFI_STATUS                   Status;
-  LOADER_GLOBAL_DATA          *LdrGlobal;
   PLATFORM_DATA               *PlatformData;
   TCC_CFG_DATA                *TccCfgData;
   SILICON_CFG_DATA            *SiCfgData;
   FEATURES_CFG_DATA           *FeaturesCfgData;
   MEMORY_CFG_DATA             *MemCfgData;
   UINTN                       DmarTableFlags;
+  VOID                        *FspHobList;
 
-  LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer();
   GlobalNvs  = (GLOBAL_NVS_AREA *)(UINTN) PcdGet32 (PcdAcpiGnvsAddress);
 
   Table = (EFI_ACPI_DESCRIPTION_HEADER *) Current;
@@ -2226,8 +2206,11 @@ PlatformUpdateAcpiTable (
     }
     return EFI_UNSUPPORTED;
   } else if (Table->Signature == EFI_BDAT_TABLE_SIGNATURE) {
-    UpdateBdatAcpiTable (Table, LdrGlobal->FspHobList);
-    DEBUG ((DEBUG_INFO, "Updated BDAT Table in AcpiTable Entries\n"));
+    FspHobList = GetFspHobListPtr ();
+    if (FspHobList != NULL) {
+      UpdateBdatAcpiTable (Table, FspHobList);
+      DEBUG ((DEBUG_INFO, "Updated BDAT Table in AcpiTable Entries\n"));
+    }
   }else if (Table->Signature == EFI_ACPI_6_1_LOW_POWER_IDLE_TABLE_STRUCTURE_SIGNATURE){
       UINT8                                  LpitStateEntries = 0;
       EFI_ACPI_6_1_GENERIC_ADDRESS_STRUCTURE SetResidencyCounter[3] = { ACPI_LPI_RES_SLP_S0_COUNTER, ACPI_LPI_RES_C10_COUNTER, ACPI_LPI_RES_PS_ON_COUNTER };
@@ -2326,7 +2309,7 @@ UpdateCpuNvs (
   EFI_HOB_GUID_TYPE                     *GuidHob;
   CPU_INIT_DATA_HOB                     *CpuInitDataHob;
   CPU_CONFIG_DATA                       *CpuConfigData;
-  LOADER_GLOBAL_DATA                    *LdrGlobal;
+  VOID                                  *FspHobList;
   UINT16                     C6Latency = 0;
   UINT16                     C7Latency = 0;
   UINT16                     C8Latency = 0;
@@ -2337,7 +2320,6 @@ UpdateCpuNvs (
   UINT8                      MaxRefTemp;
   UINT8                      Index;
 
-  LdrGlobal   = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer();
   if (CpuNvs == NULL) {
     DEBUG ((DEBUG_ERROR, "Invalid Cpu Nvs pointer!!!\n"));
     return;
@@ -2346,7 +2328,11 @@ UpdateCpuNvs (
   ///
   /// Get CPU Init Data Hob
   ///
-  GuidHob = GetNextGuidHob (&gCpuInitDataHobGuid, LdrGlobal->FspHobList);
+  GuidHob = NULL;
+  FspHobList = GetFspHobListPtr ();
+  if (FspHobList != NULL) {
+    GuidHob = GetNextGuidHob (&gCpuInitDataHobGuid, FspHobList);
+  }
   if (GuidHob == NULL) {
     DEBUG ((DEBUG_ERROR, "CPU Data HOB not available\n"));
     return;

--- a/Silicon/ApollolakePkg/Library/BootMediaLib/BootMediaLib.c
+++ b/Silicon/ApollolakePkg/Library/BootMediaLib/BootMediaLib.c
@@ -34,18 +34,20 @@ GetBootMediaType (
 {
   EFI_HOB_GUID_TYPE              *GuidHob;
   CURRENT_BOOT_MEDIA             *BootMediaData;
-  LOADER_GLOBAL_DATA             *LdrGlobal;
+  VOID                           *FspHobList;
   S3_DATA                        *S3Data;
 
-  LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer();
-
-  S3Data = (S3_DATA *)LdrGlobal->S3DataPtr;
-  if (LdrGlobal->BootMode == BOOT_ON_S3_RESUME) {
+  S3Data = (S3_DATA *)GetS3DataPtr ();
+  if (GetBootMode () == BOOT_ON_S3_RESUME) {
     *BootMediaType = S3Data->BootMediaType;
     return EFI_SUCCESS;
   }
 
-  GuidHob = GetNextGuidHob(&gEfiBootMediaHobGuid, LdrGlobal->FspHobList);
+  GuidHob = NULL;
+  FspHobList = GetFspHobListPtr ();
+  if (FspHobList != NULL) {
+    GuidHob = GetNextGuidHob (&gEfiBootMediaHobGuid, FspHobList);
+  }
   ASSERT (GuidHob != NULL);
   BootMediaData = (CURRENT_BOOT_MEDIA *)GET_GUID_HOB_DATA (GuidHob);
 
@@ -75,19 +77,20 @@ GetBootPartition (
 {
   EFI_HOB_GUID_TYPE              *GuidHob;
   CURRENT_BOOT_MEDIA             *BootMediaData;
-  LOADER_GLOBAL_DATA             *LdrGlobal;
+  VOID                           *FspHobList;
   S3_DATA                        *S3Data;
 
-  LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer();
-
-  S3Data = (S3_DATA *)LdrGlobal->S3DataPtr;
-
-  if (LdrGlobal->BootMode == BOOT_ON_S3_RESUME) {
+  S3Data = (S3_DATA *)GetS3DataPtr ();
+  if (GetBootMode () == BOOT_ON_S3_RESUME) {
     *BootPartition = S3Data->BootPartition;
     return EFI_SUCCESS;
   }
 
-  GuidHob = GetNextGuidHob(&gEfiBootMediaHobGuid, LdrGlobal->FspHobList);
+  GuidHob = NULL;
+  FspHobList = GetFspHobListPtr ();
+  if (FspHobList != NULL) {
+    GuidHob = GetNextGuidHob(&gEfiBootMediaHobGuid, FspHobList);
+  }
   ASSERT (GuidHob != NULL);
   BootMediaData = (CURRENT_BOOT_MEDIA *)GET_GUID_HOB_DATA (GuidHob);
 

--- a/Silicon/ApollolakePkg/Library/MeChipsetLib/MeChipsetLib.c
+++ b/Silicon/ApollolakePkg/Library/MeChipsetLib/MeChipsetLib.c
@@ -109,14 +109,14 @@ MeGetMeBiosPayloadHob (
   )
 {
   UINT32                    Length;
-  LOADER_GLOBAL_DATA       *LdrGlobal;
   VOID                     *MbpHeader;
+  VOID                     *FspHobList;
 
   MbpHeader  = NULL;
   Length     = 0;
-  LdrGlobal  = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
-  if (LdrGlobal != NULL) {
-    MbpHeader = GetGuidHobData (LdrGlobal->FspHobList, &Length, &gEfiHeciMbpDataHobGuid);
+  FspHobList = GetFspHobListPtr ();
+  if (FspHobList != NULL) {
+    MbpHeader  = GetGuidHobData (FspHobList, &Length, &gEfiHeciMbpDataHobGuid);
   }
   if ((MbpHeader == NULL) || (Length == 0)){
     DEBUG ((DEBUG_ERROR, "MBP Data Hob not Found!\n"));

--- a/Silicon/CometlakePkg/Library/HeciLib/HeciCore.c
+++ b/Silicon/CometlakePkg/Library/HeciLib/HeciCore.c
@@ -1724,17 +1724,14 @@ HeciMBP (
     VOID
   )
 {
-  LOADER_GLOBAL_DATA       *LdrGlobal;
   MBP_CMD_RESP_DATA        *MBPHeader;
+  VOID                     *FspHobList;
 
-  LdrGlobal = NULL;
   MBPHeader = NULL;
-
-  LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
-  if (LdrGlobal != NULL) {
-    MBPHeader = GetGuidHobData(LdrGlobal->FspHobList, NULL, &gEfiHeciMbpDataHobGuid);
+  FspHobList = GetFspHobListPtr ();
+  if (FspHobList != NULL) {
+    MBPHeader = GetGuidHobData (FspHobList, NULL, &gEfiHeciMbpDataHobGuid);
   }
-
   if (MBPHeader == NULL) {
     DEBUG ((DEBUG_ERROR, "HeciMBP MBPHeader not Found \n"));
   }

--- a/Silicon/CometlakevPkg/Library/HeciLib/HeciCore.c
+++ b/Silicon/CometlakevPkg/Library/HeciLib/HeciCore.c
@@ -1724,17 +1724,14 @@ HeciMBP (
     VOID
   )
 {
-  LOADER_GLOBAL_DATA       *LdrGlobal;
   MBP_CMD_RESP_DATA        *MBPHeader;
+  VOID                     *FspHobList;
 
-  LdrGlobal = NULL;
   MBPHeader = NULL;
-
-  LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
-  if (LdrGlobal != NULL) {
-    MBPHeader = GetGuidHobData(LdrGlobal->FspHobList, NULL, &gEfiHeciMbpDataHobGuid);
+  FspHobList = GetFspHobListPtr ();
+  if (FspHobList != NULL) {
+    MBPHeader = GetGuidHobData (FspHobList, NULL, &gEfiHeciMbpDataHobGuid);
   }
-
   if (MBPHeader == NULL) {
     DEBUG ((DEBUG_ERROR, "HeciMBP MBPHeader not Found \n"));
   }

--- a/Silicon/CommonSocPkg/Library/MeChipsetLib/MeChipsetLib.c
+++ b/Silicon/CommonSocPkg/Library/MeChipsetLib/MeChipsetLib.c
@@ -111,14 +111,14 @@ MeGetMeBiosPayloadHob (
   )
 {
   UINT32                    Length;
-  LOADER_GLOBAL_DATA       *LdrGlobal;
   VOID                     *MbpHeader;
+  VOID                     *FspHobList;
 
   MbpHeader  = NULL;
   Length     = 0;
-  LdrGlobal  = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
-  if (LdrGlobal != NULL) {
-    MbpHeader = GetGuidHobData (LdrGlobal->FspHobList, &Length, &gMeBiosPayloadHobGuid);
+  FspHobList = GetFspHobListPtr ();
+  if (FspHobList != NULL) {
+    MbpHeader  = GetGuidHobData (FspHobList, &Length, &gMeBiosPayloadHobGuid);
   }
   if ((MbpHeader == NULL) || (Length == 0)){
     DEBUG ((DEBUG_ERROR, "MBP Data Hob not Found!\n"));

--- a/Silicon/ElkhartlakePkg/Library/HeciInitLib/HeciCore.c
+++ b/Silicon/ElkhartlakePkg/Library/HeciInitLib/HeciCore.c
@@ -1336,7 +1336,7 @@ HeciGetFwVersionMsg (
   UINT32                    Length;
   GET_FW_VER                MsgGenGetFwCapsSku;
   GET_FW_VER_ACK            *MsgGenGetFwVersionAckData;
-  LOADER_GLOBAL_DATA        *LdrGlobal;
+  VOID                      *FspHobList;
   ME_BIOS_PAYLOAD           *MbpDataHob;
   UINT32                    MbpDataHobLen;
   UINT8                     *DataPtr;
@@ -1351,10 +1351,10 @@ HeciGetFwVersionMsg (
   //
   // Get Mbp Data HOB
   //
-  LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
+  FspHobList = GetFspHobListPtr ();
 
-  if ( LdrGlobal != NULL ) {
-    DataPtr = (UINT8 *)GetGuidHobData (LdrGlobal->FspHobList, &MbpDataHobLen, &gMeBiosPayloadHobGuid);
+  if ( FspHobList != NULL ) {
+    DataPtr = (UINT8 *)GetGuidHobData (FspHobList, &MbpDataHobLen, &gMeBiosPayloadHobGuid);
     if ((DataPtr != NULL) && (MbpDataHobLen > 0)) {
       MbpDataHob = (ME_BIOS_PAYLOAD *)(DataPtr+4);
       //DumpHex(16, 0, MbpDataHobLen, DataPtr);
@@ -1435,10 +1435,10 @@ HeciGetFwCapsSkuMsg (
   UINT32                    Length;
   GET_FW_CAPSKU             *MsgGenGetFwCapsSku;
   GET_FW_CAPS_SKU_ACK_DATA  *MsgGenGetFwCapsSkuAck;
-  LOADER_GLOBAL_DATA        *LdrGlobal;
+  VOID                      *FspHobList;
   ME_BIOS_PAYLOAD           *MbpDataHob;
   UINT32                    MbpDataHobLen;
-  UINT8                      *DataPtr;
+  UINT8                     *DataPtr;
 
 
   MbpDataHob = NULL;
@@ -1449,9 +1449,9 @@ HeciGetFwCapsSkuMsg (
   MsgGenGetFwCapsSku = (GET_FW_CAPSKU *)MsgGetFwCaps;
   MsgGenGetFwCapsSkuAck = (GET_FW_CAPS_SKU_ACK_DATA *)MsgGetFwCapsAck;
 
-  LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
-  if ( LdrGlobal != NULL ) {
-    DataPtr = (UINT8 *)GetGuidHobData (LdrGlobal->FspHobList, &MbpDataHobLen, &gMeBiosPayloadHobGuid);
+  FspHobList = GetFspHobListPtr ();
+  if ( FspHobList != NULL ) {
+    DataPtr = (UINT8 *)GetGuidHobData (FspHobList, &MbpDataHobLen, &gMeBiosPayloadHobGuid);
     if ((DataPtr != NULL) && (MbpDataHobLen > 0)) {
       MbpDataHob = (ME_BIOS_PAYLOAD *)(DataPtr+4);
       //DumpHex(16, 0, sizeof(MBP_ITEM_HEADER), DataPtr);

--- a/Silicon/ElkhartlakePkg/Library/HeciInitLib/MbpData.c
+++ b/Silicon/ElkhartlakePkg/Library/HeciInitLib/MbpData.c
@@ -125,16 +125,16 @@ RetrieveMBPData (
   )
 {
   ME_BIOS_PAYLOAD       *MbpBiosPayload;
-  LOADER_GLOBAL_DATA    *LdrGlobal;
+  VOID                  *FspHobList;
   UINT8                 *DataPtr;
   UINT32                MbpDataHobLen;
 
-  LdrGlobal = (LOADER_GLOBAL_DATA *) GetLoaderGlobalDataPointer ();
-  if ( LdrGlobal == NULL ) {
+  FspHobList = GetFspHobListPtr ();
+  if ( FspHobList == NULL ) {
     return EFI_NOT_FOUND;
   }
 
-  DataPtr = GetGuidHobData (LdrGlobal->FspHobList, &MbpDataHobLen, &gMeBiosPayloadHobGuid);
+  DataPtr = GetGuidHobData (FspHobList, &MbpDataHobLen, &gMeBiosPayloadHobGuid);
   if ((DataPtr != NULL) && (MbpDataHobLen > 0)) {
     MbpBiosPayload = (ME_BIOS_PAYLOAD *) (DataPtr+4);
     // Get  address for ME_BIOS_PAYLOAD_HOB.ME_BIOS_PAYLOAD

--- a/Silicon/ElkhartlakePkg/Library/MeExtMeasurementLib/MeExtMeasurementLib.c
+++ b/Silicon/ElkhartlakePkg/Library/MeExtMeasurementLib/MeExtMeasurementLib.c
@@ -238,21 +238,21 @@ MeMeasuredBootInit (
   VOID
   )
 {
-  LOADER_GLOBAL_DATA    *LdrGlobal;
+  VOID                  *FspHobList;
   BOOLEAN               CsmeMbState;
   ME_BIOS_PAYLOAD       *MbpDataHob;
   UINT8                 *DataPtr;
   UINT32                MbpDataHobLen;
   EFI_STATUS            Status;
 
-  LdrGlobal = (LOADER_GLOBAL_DATA *) GetLoaderGlobalDataPointer ();
-  if ( LdrGlobal == NULL ) {
+  FspHobList = GetFspHobListPtr ();
+  if ( FspHobList == NULL ) {
     return EFI_NOT_FOUND;
   }
 
   Status = EFI_UNSUPPORTED;
 
-  DataPtr = GetGuidHobData (LdrGlobal->FspHobList, &MbpDataHobLen, &gMeBiosPayloadHobGuid);
+  DataPtr = GetGuidHobData (FspHobList, &MbpDataHobLen, &gMeBiosPayloadHobGuid);
   if ((DataPtr != NULL) && (MbpDataHobLen > 0)) {
     MbpDataHob = (ME_BIOS_PAYLOAD *) (DataPtr+4);
     //

--- a/Silicon/ElkhartlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/ElkhartlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -78,18 +78,21 @@ IsWarmReset (
   VOID
   )
 {
-  LOADER_GLOBAL_DATA    *LdrGlobal;
+  VOID                  *FspHobList;
   MEMORY_PLATFORM_DATA  *MemPlatformData;
   UINT8                 ResetType;
   BOOLEAN               IsWarmReset;
 
   IsWarmReset     = FALSE;
-  LdrGlobal       = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
-  MemPlatformData = GetGuidHobData (
-                      LdrGlobal->FspHobList,
-                      NULL,
-                      &gSiMemoryPlatformDataGuid
-                      );
+  MemPlatformData = NULL;
+  FspHobList = GetFspHobListPtr ();
+  if (FspHobList != NULL) {
+    MemPlatformData = GetGuidHobData (
+                        FspHobList,
+                        NULL,
+                        &gSiMemoryPlatformDataGuid
+                        );
+  }
   if (MemPlatformData != NULL) {
     if (MemPlatformData->BootMode == 1) {
       IsWarmReset = TRUE;

--- a/Silicon/TigerlakePchPkg/Library/HeciInitLib/HeciCore.c
+++ b/Silicon/TigerlakePchPkg/Library/HeciInitLib/HeciCore.c
@@ -1327,7 +1327,7 @@ HeciGetFwVersionMsg (
   UINT32                    Length;
   GET_FW_VER                MsgGenGetFwCapsSku;
   GET_FW_VER_ACK            *MsgGenGetFwVersionAckData;
-  LOADER_GLOBAL_DATA        *LdrGlobal;
+  VOID                      *FspHobList;
   ME_BIOS_PAYLOAD           *MbpDataHob;
   UINT32                    MbpDataHobLen;
   UINT8                     *DataPtr;
@@ -1342,10 +1342,10 @@ HeciGetFwVersionMsg (
   //
   // Get Mbp Data HOB
   //
-  LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
+  FspHobList = GetFspHobListPtr ();
 
-  if ( LdrGlobal != NULL ) {
-    DataPtr = (UINT8 *)GetGuidHobData (LdrGlobal->FspHobList, &MbpDataHobLen, &gMeBiosPayloadHobGuid);
+  if ( FspHobList != NULL ) {
+    DataPtr = (UINT8 *)GetGuidHobData (FspHobList, &MbpDataHobLen, &gMeBiosPayloadHobGuid);
     if ((DataPtr != NULL) && (MbpDataHobLen > 0)) {
       MbpDataHob = (ME_BIOS_PAYLOAD *)(DataPtr+4);
       //DumpHex(16, 0, MbpDataHobLen, DataPtr);
@@ -1426,7 +1426,7 @@ HeciGetFwCapsSkuMsg (
   UINT32                    Length;
   GET_FW_CAPSKU             *MsgGenGetFwCapsSku;
   GET_FW_CAPS_SKU_ACK_DATA  *MsgGenGetFwCapsSkuAck;
-  LOADER_GLOBAL_DATA        *LdrGlobal;
+  VOID                      *FspHobList;
   ME_BIOS_PAYLOAD           *MbpDataHob;
   UINT32                    MbpDataHobLen;
   UINT8                      *DataPtr;
@@ -1440,9 +1440,9 @@ HeciGetFwCapsSkuMsg (
   MsgGenGetFwCapsSku = (GET_FW_CAPSKU *)MsgGetFwCaps;
   MsgGenGetFwCapsSkuAck = (GET_FW_CAPS_SKU_ACK_DATA *)MsgGetFwCapsAck;
 
-  LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
-  if ( LdrGlobal != NULL ) {
-    DataPtr = (UINT8 *)GetGuidHobData (LdrGlobal->FspHobList, &MbpDataHobLen, &gMeBiosPayloadHobGuid);
+  FspHobList = GetFspHobListPtr ();
+  if ( FspHobList != NULL ) {
+    DataPtr = (UINT8 *)GetGuidHobData (FspHobList, &MbpDataHobLen, &gMeBiosPayloadHobGuid);
     if ((DataPtr != NULL) && (MbpDataHobLen > 0)) {
       MbpDataHob = (ME_BIOS_PAYLOAD *)(DataPtr+4);
       //DumpHex(16, 0, sizeof(MBP_ITEM_HEADER), DataPtr);

--- a/Silicon/TigerlakePchPkg/Library/HeciInitLib/MbpData.c
+++ b/Silicon/TigerlakePchPkg/Library/HeciInitLib/MbpData.c
@@ -125,16 +125,16 @@ RetrieveMBPData (
   )
 {
   ME_BIOS_PAYLOAD       *MbpBiosPayload;
-  LOADER_GLOBAL_DATA    *LdrGlobal;
+  VOID                  *FspHobList;
   UINT8                 *DataPtr;
   UINT32                MbpDataHobLen;
 
-  LdrGlobal = (LOADER_GLOBAL_DATA *) GetLoaderGlobalDataPointer ();
-  if ( LdrGlobal == NULL ) {
+  FspHobList = GetFspHobListPtr ();
+  if ( FspHobList == NULL ) {
     return EFI_NOT_FOUND;
   }
 
-  DataPtr = GetGuidHobData (LdrGlobal->FspHobList, &MbpDataHobLen, &gMeBiosPayloadHobGuid);
+  DataPtr = GetGuidHobData (FspHobList, &MbpDataHobLen, &gMeBiosPayloadHobGuid);
   if ((DataPtr != NULL) && (MbpDataHobLen > 0)) {
     MbpBiosPayload = (ME_BIOS_PAYLOAD *) (DataPtr+4);
     // Get  address for ME_BIOS_PAYLOAD_HOB.ME_BIOS_PAYLOAD

--- a/Silicon/TigerlakePchPkg/Library/MeExtMeasurementLib/MeExtMeasurementLib.c
+++ b/Silicon/TigerlakePchPkg/Library/MeExtMeasurementLib/MeExtMeasurementLib.c
@@ -235,21 +235,21 @@ MeMeasuredBootInit (
   VOID
   )
 {
-  LOADER_GLOBAL_DATA    *LdrGlobal;
+  VOID                  *FspHobList;
   BOOLEAN               CsmeMbState;
   ME_BIOS_PAYLOAD       *MbpDataHob;
   UINT8                 *DataPtr;
   UINT32                MbpDataHobLen;
   EFI_STATUS            Status;
 
-  LdrGlobal = (LOADER_GLOBAL_DATA *) GetLoaderGlobalDataPointer ();
-  if ( LdrGlobal == NULL ) {
+  FspHobList = GetFspHobListPtr ();
+  if ( FspHobList == NULL ) {
     return EFI_NOT_FOUND;
   }
 
   Status = EFI_UNSUPPORTED;
 
-  DataPtr = GetGuidHobData (LdrGlobal->FspHobList, &MbpDataHobLen, &gMeBiosPayloadHobGuid);
+  DataPtr = GetGuidHobData (FspHobList, &MbpDataHobLen, &gMeBiosPayloadHobGuid);
   if ((DataPtr != NULL) && (MbpDataHobLen > 0)) {
     MbpDataHob = (ME_BIOS_PAYLOAD *) (DataPtr+4);
     //

--- a/Silicon/TigerlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/TigerlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -79,18 +79,21 @@ IsWarmReset (
   VOID
   )
 {
-  LOADER_GLOBAL_DATA    *LdrGlobal;
+  VOID                  *FspHobList;
   MEMORY_PLATFORM_DATA  *MemPlatformData;
   UINT8                 ResetType;
   BOOLEAN               IsWarmReset;
 
   IsWarmReset     = FALSE;
-  LdrGlobal       = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
-  MemPlatformData = GetGuidHobData (
-                      LdrGlobal->FspHobList,
-                      NULL,
-                      &gSiMemoryPlatformDataGuid
-                      );
+  MemPlatformData = NULL;
+  FspHobList = GetFspHobListPtr ();
+  if (FspHobList != NULL) {
+    MemPlatformData = GetGuidHobData (
+                        FspHobList,
+                        NULL,
+                        &gSiMemoryPlatformDataGuid
+                        );
+  }
   if (MemPlatformData != NULL) {
     if (MemPlatformData->BootMode == 1) {
       IsWarmReset = TRUE;


### PR DESCRIPTION
This adds additional APIs to make Platform code use APIs to access
LoaderGlobalData instead of accessing variables directly.
- GetS3DataPtr()
- SetFeatureCfg()
- ClearFspHob()
- GetVerInfoPtr()

Signed-off-by: Aiden Park <aiden.park@intel.com>