### PR TITLE
[TGL] add control for TCSS PTM Enable

### DIFF
--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -176,6 +176,13 @@
                      Enable/Disable ITBT Root Port
       length       : 0x04
       value        : { 0x1, 0x1, 0x1, 0x1 }
+  - TcssPcieRootPortPtmEn :
+      name         : Enable/Disable PTM for TCSS PCIe Root Port
+      type         : EditNum, HEX, (0x00,0xFFFFFFFF)
+      help         : >
+                     Enable/Disable Precision Time Measurement (PTM) for TCSS PCIe Root Ports
+      length       : 0x04
+      value        : { 0x0, 0x0, 0x0, 0x0 }
   - PmSupport    :
       name         : Enable/Disable IGFX PmSupport
       type         : Combo

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1418,14 +1418,6 @@ UpdateFspConfig (
   // Enable IEH
   FspsConfig->IehMode = 0x1;
 
-  // PTM configuration
-  for (Index = 0; Index < GetPchMaxPciePortNum(); Index++) {
-    FspsConfig->PciePtm[Index] = 0x1;
-  }
-  for (Index = 0; Index < 4; Index++) {
-    FspsConfig->CpuPcieRpPtmEnabled[Index] = 0x1;
-    FspsConfig->PtmEnabled[Index] = 0x1;
-  }
   FspsConfig->SerialIoSpiMode[1] = 0x1;
   for (Index = 0; Index < GetPchMaxSerialIoSpiControllersNum (); Index++) {
     for (CsIndex = 0; CsIndex < PCH_MAX_SERIALIO_SPI_CHIP_SELECTS; CsIndex++) {
@@ -1604,6 +1596,7 @@ UpdateFspConfig (
     FspsConfig->EnableTimedGpio1 = SiCfgData->EnableTimedGpio1;
     FspsConfig->XdciEnable       = SiCfgData->XdciEnable;
     CopyMem (FspsConfig->ITbtPcieRootPortEn, SiCfgData->ITbtPcieRootPortEn, sizeof(SiCfgData->ITbtPcieRootPortEn));
+    CopyMem (FspsConfig->PtmEnabled, SiCfgData->TcssPcieRootPortPtmEn, sizeof(SiCfgData->TcssPcieRootPortPtmEn));
   }
 
   if (FeaturePcdGet (PcdTccEnabled)) {


### PR DESCRIPTION
According to EDS, TCSS PTM Enable (PTME on [B0,D7,F0] offset 158h)
should not be set unless a associated downstream port already has
PTM Enable set.

This patch adds a CfgData control for each TCSS PCIe Root Port.
User can enable each of them when a downstream port meets the
requirement. The new CfgData control is similiar to the following
setup in UEFI BIOS Menu:

    Intel Advanced -> SA -> TCSS -> PCIE RP[]

Last, this patch also removes redundant PTM configurations,
because (a) PTM settings will be overridden by built-in
CfgData_Silicon.yaml or customized DLT; b) even for customized 
SBL, FSP will use default PTM settings.

Signed-off-by: Stanley Chang <stanley.chang@intel.com>