### PR TITLE
[EHL] Fix ConfigEditor tool crash and invalid options

### DIFF
--- a/Platform/CommonBoardPkg/CfgData/Template_BootOption.yaml
+++ b/Platform/CommonBoardPkg/CfgData/Template_BootOption.yaml
@@ -30,7 +30,7 @@ BOOT_OPTION_TMPL: >
     - BootFlags_$(1) :
         name         : Boot Flags
         type         : Combo
-        option       : 0:Normal, 4:PreOS support, 8:Extra image support, 12:PreOS and extra image support, 16:Mender support
+        option       : 0:Normal, 4:PreOS support, 8:Extra image support, 12:PreOS and extra image support, 16:Mender support, 20:PreOS and mender support
         help         : >
                        Specify boot flags (options)
                        When extra image or PreOS image is selected, need config them in next boot option with proper image type.

--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgDataDef.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgDataDef.yaml
@@ -230,7 +230,7 @@ configs:
     - EnableSgx    :
         name         : Software Guard eXtensions (SGX)
         type         : Combo
-        option       : 0:Disabled, 1:Enabled
+        option       : 0:Disabled, 1:Enabled, 2:Software Control
         help         : >
                        Enable/Disable Software Guard eXtensions (SGX).
         length       : 0x01

--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_BootOption.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_BootOption.yaml
@@ -11,19 +11,19 @@
     page         : OS
 - !expand { BOOT_OPTION_TMPL : [ 0  ,   0    ,  20 ,    5   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
 - !expand { BOOT_OPTION_TMPL : [ 1  , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
-- !expand { BOOT_OPTION_TMPL : [ 2  , 0x1F   ,  16 ,    5   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_rtcm' ] }
+- !expand { BOOT_OPTION_TMPL : [ 2  , 0xFF   ,  16 ,    5   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_rtcm' ] }
 - !expand { BOOT_OPTION_TMPL : [ 3  ,   0    ,  20 ,    0   ,   0   ,    1  ,     1 ,     1 , '/boot/sbl_os' ] }
 - !expand { BOOT_OPTION_TMPL : [ 4  , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
-- !expand { BOOT_OPTION_TMPL : [ 5  , 0x1F   ,  16 ,    0   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_rtcm' ] }
+- !expand { BOOT_OPTION_TMPL : [ 5  , 0xFF   ,  16 ,    0   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_rtcm' ] }
 - !expand { BOOT_OPTION_TMPL : [ 6  ,   0    ,  20 ,    2   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
 - !expand { BOOT_OPTION_TMPL : [ 7  , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
-- !expand { BOOT_OPTION_TMPL : [ 8  , 0x1F   ,  16 ,    2   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_rtcm' ] }
+- !expand { BOOT_OPTION_TMPL : [ 8  , 0xFF   ,  16 ,    2   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_rtcm' ] }
 - !expand { BOOT_OPTION_TMPL : [ 9  ,   0    ,  20 ,    6   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
 - !expand { BOOT_OPTION_TMPL : [ 10 , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
-- !expand { BOOT_OPTION_TMPL : [ 11 , 0x1F   ,  16 ,    6   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_rtcm' ] }
+- !expand { BOOT_OPTION_TMPL : [ 11 , 0xFF   ,  16 ,    6   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_rtcm' ] }
 - !expand { BOOT_OPTION_TMPL : [ 12 ,   0    ,  20 ,    3   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
 - !expand { BOOT_OPTION_TMPL : [ 13 , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
-- !expand { BOOT_OPTION_TMPL : [ 14 , 0x1F   ,  16 ,    3   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_rtcm' ] }
+- !expand { BOOT_OPTION_TMPL : [ 14 , 0xFF   ,  16 ,    3   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_rtcm' ] }
 - !expand { BOOT_OPTION_TMPL : [ 15 ,   0    ,  20 ,    3   ,   1   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
 - !expand { BOOT_OPTION_TMPL : [ 16 , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
-- !expand { BOOT_OPTION_TMPL : [ 17 , 0x1F   ,  16 ,    3   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_rtcm' ] }
+- !expand { BOOT_OPTION_TMPL : [ 17 , 0xFF   ,  16 ,    3   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_rtcm' ] }

--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_GpuConfig.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_GpuConfig.yaml
@@ -191,6 +191,7 @@
   - PchHdaDspUaaCompliance :
       name         : Universal Audio Architecture compliance for DSP enabled system
       type         : Combo
+      option       : $EN_DIS
       help         : >
                      0: Not-UAA Compliant (Intel SST driver supported only), 1: UAA Compliant (HDA Inbox driver or SST driver supported
       length       : 0x01

--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Power.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Power.yaml
@@ -1029,13 +1029,6 @@
                      VR specific mailbox commands. <b>00b - no VR specific command sent.</b>  01b - A VR mailbox command specifically for the MPS IMPV8 VR will be sent. 10b - VR specific command sent for PS4 exit issue. 11b - Reserved.
       length       : 0x01
       value        : 0x00
-  - Reserved2    :
-      name         : Reserved
-      type         : NULL
-      help         : >
-                     Reserved
-      length       : 0x01
-      value        : 0x01
   - SkipMpInit   :
       name         : Skip Multi-Processor Initialization
       type         : Combo
@@ -1143,10 +1136,5 @@
       length       : 0x8
       value        : {0x00}
   - Dummy        :
-      name         : Memory Thermal Management
-      type         : Combo
-      option       : 0:Disabled, 1:Enabled
-      help         : >
-                     Enable Memory Thermal Management
-      length       : 0x0
-      value        : 0x0
+      length       : 0x1
+      value        : 0x1

--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -1813,7 +1813,7 @@
   - CdClock      :
       name         : CdClock Frequency selection
       type         : Combo
-      option       : 0:168 Mhz, 1:307.2 Mhz, 2:312 Mhz, 3:552 Mhz, 4:556.8 Mhz, 5:648 Mhz, 6:652.8 Mhz
+      option       : 0:168 Mhz, 1:307.2 Mhz, 2:312 Mhz, 3:552 Mhz, 4:556.8 Mhz, 5:648 Mhz, 6:652.8 Mhz, 0xFF:Auto
       help         : >
                      0=168 Mhz, 1=307.2 Mhz, 2=312 Mhz, 3=552 Mhz, 4=556.8 Mhz, 5=648 Mhz, 6(Default)= 652.8 Mhz
       length       : 0x1


### PR DESCRIPTION
Here are the changes:
1. Update mismatched & incorrect config options & variables
2. Fix invalid boot options configs
3. [common] Include 'preOS + mender' support for boot flags in
   boot options template

Signed-off-by: Lean Sheng Tan <lean.sheng.tan@intel.com>