### PR TITLE
[EHL] Enabled TGPIO

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1556,9 +1556,6 @@ UpdateFspConfig (
     Fspscfg->PseTsnGbePhyInterfaceType[0]    = 1;
     Fspscfg->PseTsnGbePhyInterfaceType[1]    = 1;
 
-    Fspscfg->EnableTimedGpio0     = 0;
-    Fspscfg->EnableTimedGpio1     = 0;
-
     // AMT_ME_CONFIG
     Fspscfg->AmtEnabled           = SiCfgData->AmtEnabled;
     Fspscfg->FwProgress           = SiCfgData->FwProgress;

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/UpdateAcpiGnvs.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/UpdateAcpiGnvs.c
@@ -529,6 +529,7 @@ PlatformUpdateAcpiGnvs (
   EFI_STATUS              Status;
   FEATURES_CFG_DATA       *FeaturesCfgData;
   BOOLEAN                 PchSciSupported;
+  SILICON_CFG_DATA        *SiCfgData;
 
   PchSciSupported         = PchIsSciSupported ();
   GlobalNvs               = (GLOBAL_NVS_AREA *) GnvsIn;
@@ -538,6 +539,7 @@ PlatformUpdateAcpiGnvs (
   SaNvs                   = (SYSTEM_AGENT_NVS_AREA *) &GlobalNvs->SaNvs;
   FeaturesCfgData         = (FEATURES_CFG_DATA *) FindConfigDataByTag(CDATA_FEATURES_TAG);
   ZeroMem (GlobalNvs, sizeof (GLOBAL_NVS_AREA));
+  SiCfgData = (SILICON_CFG_DATA *)FindConfigDataByTag (CDATA_SILICON_TAG);
 
   //
   // Update ASL PCIE port address according to root port device and function
@@ -675,6 +677,10 @@ PlatformUpdateAcpiGnvs (
   DEBUG((DEBUG_INFO, "PseCanPciMmBase1 = 0x%x\n ", PseCanPciMmBase));
   if (PseCanPciMmBase != 0xFFFF) {
     PchNvs->PseCan1Enabled                        = 1;
+  }
+  if (SiCfgData != NULL) {
+      PchNvs->EnableTimedGpio0 = (UINT8)SiCfgData->EnableTimedGpio0;
+      PchNvs->EnableTimedGpio1 = (UINT8)SiCfgData->EnableTimedGpio1;
   }
 
   // Update Platform


### PR DESCRIPTION
Enabled TimedGPIO 0/1 in PCH Nvs referring to
FSP UPD of TimedPgio 0/1

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>