### PR TITLE
[EHL] Gbe device status fix

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/UpdateAcpiGnvs.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/UpdateAcpiGnvs.c
@@ -62,9 +62,9 @@ CheckGbeStatus (
   )
 {
   UINT16 PmeCtrlStatus;
-  //Check device status
   PmeCtrlStatus = PciRead16 (GbeBase + PMECTRLSTATUS_OFFSET);
-  if ((PmeCtrlStatus & POWERSTATE) != POWERSTATE) {
+  //Check device status if not D0 then update it to D0
+  if ((PmeCtrlStatus & POWERSTATE) != 0x0) {
     PciWrite16 ((GbeBase + PMECTRLSTATUS_OFFSET), (PmeCtrlStatus & ~POWERSTATE));
     DEBUG ((DEBUG_INFO, "GbeBase:0x%x -> PMECTRLSTATUS:0x%x\n", GbeBase, PmeCtrlStatus));
   }


### PR DESCRIPTION
Check Gbe device status and update it to D0
if non-D0 state was detected.

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>