### PR TITLE
Rename LowPowerS0Idle to S0ix

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgDataDef.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgDataDef.yaml
@@ -7,6 +7,8 @@
 #
 ##
 
+variable:
+  COND_S0IX_DIS  : ($FEATURES_CFG_DATA.Features.S0ix == 0)
 
 template:
   CFGHDR_TMPL: >

--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Ext_IotgCrb.dlt
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Ext_IotgCrb.dlt
@@ -25,8 +25,9 @@ GPIO_CFG_DATA.GpioPinConfig1_GPP_D13.GPIOSkip_GPP_D13 | 0
 
 # Enable to test TCC mode & tuning
 # FEATURES_CFG_DATA.Features.Tcc    | 0x1
-FEATURES_CFG_DATA.Features.LowPowerIdle      | 0x1
 FEATURES_CFG_DATA.Features.NewGpioSchemeEnable      | 0x1
+# Enable S0ix by default. For EHL, only S0i2.0 is supported
+FEATURES_CFG_DATA.Features.S0ix     | 0x1
 
 # Preserve ISI SPI Pins across ResetResume power-cycling
 GPIO_CFG_DATA.GpioPinConfig1_GPP_U04.GPIOSkip_GPP_U04 | 0x0

--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Features.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Features.yaml
@@ -41,12 +41,12 @@
         help         : >
                        To 'opt-in' for debug, please select 'Enabled' with the desired debug probe type. Enabling this BIOS option may alter the default value of other debug-related BIOS options.\Manual- Do not use Platform Debug Consent to override other debug-relevant policies, but the user must set each debug option manually, aimed at advanced users.\nNote- DCI OOB (aka BSSB) uses CCA probe;[DCI OOB+DbC] and [USB2 DbC] have the same setting.
         length       : 3b
-    - LowPowerIdle   :
-        name         : Low Power Idle Enable
+    - S0ix         :
+        name         : S0ix (Low Power Idle) Enable
         type         : Combo
         option       : $EN_DIS
         help         : >
-                       Enable/Disable Low Power Idle feature. 1:Low Power Idle Enabled, 0:Low Power Idle Disabled
+                       Enable/Disable S0ix feature. 1:S0ix Enabled, 0:S0ix Disabled
         length       : 1b
     - NewGpioSchemeEnable   :
         name         : New GPIO Scheme Enable

--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Memory.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Memory.yaml
@@ -2,7 +2,7 @@
 #
 #  Slim Bootloader CFGDATA Option File.
 #
-#  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -261,6 +261,7 @@
   - TcssXdciEn   :
       name         : TCSS USB DEVICE (xDCI) Enable}
       option       : $EN_DIS
+      condition    : $(COND_S0IX_DIS)
       help         : >
                      Set TCSS XDCI. 0:Disabled  1:Enabled - xHCI must be enabled if xDCI is enabled
       length       : 0x01

--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -2,7 +2,7 @@
 #
 #  Slim Bootloader CFGDATA Option File.
 #
-#  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -462,6 +462,7 @@
       name         : Enable xDCI controller
       type         : Combo
       option       : $EN_DIS
+      condition    : $(COND_S0IX_DIS)
       help         : >
                      Enable/disable to xDCI controller.
       length       : 0x01

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgDataDef.yaml
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgDataDef.yaml
@@ -7,6 +7,8 @@
 #
 ##
 
+variable:
+  COND_S0IX_DIS  : ($FEATURES_CFG_DATA.Features.S0ix == 0)
 
 template:
   CFGHDR_TMPL: >

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Features.yaml
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Features.yaml
@@ -2,7 +2,7 @@
 #
 #  Slim Bootloader CFGDATA Option File.
 #
-#  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -34,12 +34,12 @@
         help         : >
                        Enable/Disable MeasuredBoot feature. 1:MeasuredBoot Enabled (default), 0:MeasuredBoot Disabled
         length       : 1b
-    - LowPowerS0Idle   :
-        name         : Low Power S0 Idle Enable (S0ix)
+    - S0ix         :
+        name         : S0ix (Low Power S0 Idle) Enable
         type         : Combo
         option       : $EN_DIS
         help         : >
-                       Enable/Disable Low Power Idle feature. 1:Low Power S0 Idle Enabled, 0:Low Power S0 Idle Disabled
+                       Enable/Disable S0ix feature. 1:S0ix Enabled, 0:S0ix Disabled
         length       : 1b
     - FusaEnable   :
         name         : Fusa Enable

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_Ddr4.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_Ddr4.dlt
@@ -11,6 +11,9 @@
 PLATFORMID_CFG_DATA.PlatformId                              | 0x0001
 PLAT_NAME_CFG_DATA.PlatformName                             | 'TGLU_DDR'
 
+# Enable S0ix by default
+FEATURES_CFG_DATA.Features.S0ix                             | 0x1
+
 MEMORY_CFG_DATA.DqsMapCpu2DramMc0Ch1                        | {0, 1}
 MEMORY_CFG_DATA.DqsMapCpu2DramMc0Ch3                        | {0, 1}
 MEMORY_CFG_DATA.DqsMapCpu2DramMc1Ch0                        | {0, 1}

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_DdrLp4.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_DdrLp4.dlt
@@ -11,6 +11,10 @@
 # DDRLP4 board
 PLATFORMID_CFG_DATA.PlatformId                              | 0x0003
 PLAT_NAME_CFG_DATA.PlatformName                             | 'TGLU_LP4'
+
+# Enable S0ix by default
+FEATURES_CFG_DATA.Features.S0ix                             | 0x1
+
 MEMORY_CFG_DATA.SpdAddressTable                             | {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 MEMORY_CFG_DATA.SpdDataSel000                               | 1
 MEMORY_CFG_DATA.SpdDataSel010                               | 1

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -2,7 +2,7 @@
 #
 #  Slim Bootloader CFGDATA Option File.
 #
-#  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -56,6 +56,7 @@
       name         : Enable PCH TSN
       type         : Combo
       option       : $EN_DIS
+      condition    : $(COND_S0IX_DIS)
       help         : >
                      Enable/disable TSN on the PCH.
       length       : 0x01
@@ -96,6 +97,7 @@
       name         : Enable or Disable CPU power states (C-states)
       type         : Combo
       option       : $EN_DIS
+      condition    : $(COND_S0IX_DIS)
       help         : >
                      Enable or Disable CPU power states (C-states). 0- Disable; <b>1- Enable</b>
       length       : 0x01
@@ -165,6 +167,7 @@
       name         : Enable/Disable IGFX RenderStandby
       type         : Combo
       option       : $EN_DIS
+      condition    : $(COND_S0IX_DIS)
       help         : >
                      Enable(Default)- Enable IGFX RenderStandby, Disable- Disable IGFX RenderStandby
       length       : 0x01
@@ -187,6 +190,7 @@
       name         : Enable/Disable IGFX PmSupport
       type         : Combo
       option       : $EN_DIS
+      condition    : $(COND_S0IX_DIS)
       help         : >
                      Enable(Default)- Enable IGFX PmSupport, Disable- Disable IGFX PmSupport
       length       : 0x01
@@ -238,6 +242,7 @@
       name         : xDCI controller
       type         : Combo
       option       : $EN_DIS
+      condition    : $(COND_S0IX_DIS)
       help         : >
                      Enable/disable to xDCI controller. 0- Disable; 1- Enable.
       length       : 0x01

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1305,6 +1305,9 @@ UpdateFspConfig (
     // Inform FSP to skip debug UART init
     FspsConfig->SerialIoDebugUartNumber = DebugPort;
     FspsConfig->SerialIoUartMode[DebugPort] = 0x4;
+    if (S0IX_STATUS() == 1) {
+      FspsConfig->SerialIoUartMode[DebugPort] = 1;    // Force UART to PCI mode to enable OS to have full control
+    }
   }
 
   //
@@ -1632,20 +1635,19 @@ UpdateFspConfig (
     FspsConfig->PmSupport = 1;
     FspsConfig->RenderStandby = 1;
     FspsConfig->SataPwrOptEnable = 1;
-    FspsConfig->SataPortsDevSlp[0]=1;
-    FspsConfig->SataPortsDevSlp[1]=1;
-    FspsConfig->SataPortsHotPlug[0]=0;
-    FspsConfig->SataPortsHotPlug[1]=0;
-    FspsConfig->SataPortsExternal[0]=0;
-    FspsConfig->SataPortsExternal[1]=0;
-    FspsConfig->Enable8254ClockGating=1;
-    FspsConfig->PchFivrDynPm=1;
-    FspsConfig->D3HotEnable=0;
-    FspsConfig->D3ColdEnable=1;
-    FspsConfig->PchLanEnable=0;
-    FspsConfig->PchTsnEnable=0;
-    FspsConfig->XdciEnable=0;
-    FspsConfig->SerialIoUartMode[2] = 1;                 // Change for UARTHidden Mode to PCI mode
+    FspsConfig->SataPortsDevSlp[0] = 1;
+    FspsConfig->SataPortsDevSlp[1] = 1;
+    FspsConfig->SataPortsHotPlug[0] = 0;
+    FspsConfig->SataPortsHotPlug[1] = 0;
+    FspsConfig->SataPortsExternal[0] = 0;
+    FspsConfig->SataPortsExternal[1] = 0;
+    FspsConfig->Enable8254ClockGating = 1;
+    FspsConfig->PchFivrDynPm = 1;
+    FspsConfig->D3HotEnable = 0;
+    FspsConfig->D3ColdEnable = 1;
+    FspsConfig->PchLanEnable = 0;
+    FspsConfig->PchTsnEnable = 0;
+    FspsConfig->XdciEnable = 0;
 
     // PCH SERIAL_UART_CONFIG
     for (Index = 0; Index < GetPchMaxSerialIoUartControllersNum (); Index++) {

--- a/Silicon/ElkhartlakePkg/Include/PlatformData.h
+++ b/Silicon/ElkhartlakePkg/Include/PlatformData.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2018 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -22,7 +22,8 @@ typedef struct {
 typedef struct {
   UINT32  VtdEnable    : 1;
   UINT32  DebugConsent : 3;
-  UINT32  Rsvd         : 28;
+  UINT32  S0ixEnable   : 1;
+  UINT32  Rsvd         : 27;
 } PLAT_FEATURES;
 
 typedef struct {
@@ -33,5 +34,6 @@ typedef struct {
 #define PLAT_DATA                         ((PLATFORM_DATA *)GetPlatformDataPtr ())
 #define PLAT_FEAT                         (PLAT_DATA->PlatformFeatures)
 #define DEBUG_CONSENT_FEATURE_ENABLED()   (UINT8) (PLAT_FEAT.DebugConsent)
+#define S0IX_STATUS()                     (BOOLEAN) (PLAT_FEAT.S0ixEnable)
 
 #endif /* __PLATFORM_DATA_H__ */

--- a/Silicon/ElkhartlakePkg/Include/TccConfigSubRegions.h
+++ b/Silicon/ElkhartlakePkg/Include/TccConfigSubRegions.h
@@ -9,7 +9,6 @@
 
 extern BOOLEAN mTccDsoTuning;
 extern UINT8   mTccRtd3Support;
-extern UINT8   mTccLowPowerS0Idle;
 
 ///
 /// TCC BIOS Configuration

--- a/Silicon/TigerlakePkg/Include/PlatformData.h
+++ b/Silicon/TigerlakePkg/Include/PlatformData.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -21,12 +21,17 @@ typedef struct {
 
 typedef struct {
   UINT32  VtdEnable    : 1;
-  UINT32  Rsvd         : 31;
+  UINT32  S0ixEnable   : 1;
+  UINT32  Rsvd         : 30;
 } PLAT_FEATURES;
 
 typedef struct {
   BOOT_GUARD_INFO     BtGuardInfo;
   PLAT_FEATURES       PlatformFeatures;
 } PLATFORM_DATA;
+
+#define PLAT_DATA                         ((PLATFORM_DATA *)GetPlatformDataPtr ())
+#define PLAT_FEAT                         (PLAT_DATA->PlatformFeatures)
+#define S0IX_STATUS()                     (BOOLEAN) (PLAT_FEAT.S0ixEnable)
 
 #endif /* __PLATFORM_DATA_H__ */


### PR DESCRIPTION
For consistency and public understanding, rework to change 'LowPowerS0Idle' to 'S0ix'.

- rename LowPowerS0Idle to S0ix
- add s0ix variable in PlatformData.h
- add s0ix flag check in stage 1B
- move Tcc s0ix support flag from stage 2 to stage 1B