### PR TITLE
[TGL] increase stack size for FSP-m

### DIFF
--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -124,7 +124,7 @@ class Board(BaseBoard):
 
         self.STAGE2_FD_BASE       = 0x01000000
 
-        self.STAGE1_STACK_SIZE    = 0x00030000
+        self.STAGE1_STACK_SIZE    = 0x00040000
         self.STAGE1_DATA_SIZE     = 0x00010000
 
         self.PAYLOAD_EXE_BASE     = 0x00B00000

--- a/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -364,8 +364,8 @@ UpdateFspConfig (
   }
 
   // Value from EDKII bios, refine these settings later.
-  FspmArchUpd->StackBase = 0xFEF3FF00;
-  FspmArchUpd->StackSize = 0x40000;
+  FspmArchUpd->StackBase = 0xFEF4FF00;
+  FspmArchUpd->StackSize = 0x50000;
   Fspmcfg->TcssXdciEn = 0x1;
 
   // Following UPDs are related to TCC . But all of these are also generic features that can be changed regardless of TCC feature.


### PR DESCRIPTION
MRC requires a larger stack when MrcSafeConfig is disabled
with FSP-m UPD.

Signed-off-by: Stanley Chang <stanley.chang@intel.com>