### PR TITLE
[EHL] fix stitching TSN fw without tsn option

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/ElkhartlakeBoardPkg/Script/StitchIfwi.py
@@ -104,9 +104,9 @@ def replace_component (ifwi_src_path, flash_path, file_path, comp_alg, pri_key, 
     IFWI_PARSER.replace_component (ifwi_bin, comp_bin, flash_path)
     gen_file_from_object (ifwi_src_path, ifwi_bin)
 
-def replace_components (ifwi_src_path, stitch_cfg_file):
+def replace_components (ifwi_src_path, stitch_cfg_file, plt_params_list):
     print ("Replacing components.......")
-    replace_list = stitch_cfg_file.get_component_replace_list ()
+    replace_list = stitch_cfg_file.get_component_replace_list (plt_params_list)
     for flash_path, file_path, comp_alg, pri_key, svn in replace_list:
         replace_component (ifwi_src_path, flash_path, file_path, comp_alg, pri_key, svn)
 
@@ -139,7 +139,7 @@ def stitch (stitch_dir, stitch_cfg_file, sbl_file, btg_profile, plt_params_list,
         fd.close()
 
     print("Replace components in both partitions....")
-    replace_components (os.path.join(temp_dir, "SlimBootloader.bin"), stitch_cfg_file)
+    replace_components (os.path.join(temp_dir, "SlimBootloader.bin"), stitch_cfg_file, plt_params_list)
 
     # Generate xml
     gen_xml_file(stitch_dir, stitch_cfg_file, btg_profile, plt_params_list, platform, tpm)

--- a/Platform/ElkhartlakeBoardPkg/Script/StitchIfwiConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/Script/StitchIfwiConfig.py
@@ -72,7 +72,7 @@ def get_platform_sku():
     }
     return platform_sku
 
-def get_component_replace_list():
+def get_component_replace_list(plt_params_list):
     replace_list = [
        #    Path                   file name              compress    Key                           SVN
       ('IFWI/BIOS/TS0/ACM0',      'Input/acm.bin',        'dummy',    '',                            ''),
@@ -89,21 +89,22 @@ def get_component_replace_list():
         replace_list.append (
             ('IFWI/BIOS/NRD/IPFW/PSEF', 'IPFW/PseFw.bin',          'lz4',     'KEY_ID_CONTAINER_COMP_RSA3072', 0),   # OSE FW
         )
-    if os.path.exists('IPFW/PseTsnIpConfig.bin'):
-        print ("PseTsnIpConfig.bin found")
-        replace_list.append (
-            ('IFWI/BIOS/NRD/IPFW/TSIP', 'IPFW/PseTsnIpConfig.bin', 'lz4',     'KEY_ID_CONTAINER_COMP_RSA3072', 0),   # PSE TSN IP
-        )
-    if os.path.exists('IPFW/TsnConfig.bin'):
-        print ("TsnConfig.bin found")
-        replace_list.append (
-            ('IFWI/BIOS/NRD/IPFW/TSNC', 'IPFW/TsnConfig.bin',      'lz4',     'KEY_ID_CONTAINER_COMP_RSA3072', 0),   # TSN Config
-        )
-    if os.path.exists('IPFW/TsnMacAddr.bin'):
-        print ("TsnMacAddr.bin found")
-        replace_list.append (
-            ('IFWI/BIOS/NRD/IPFW/TMAC', 'IPFW/TsnMacAddr.bin',     'lz4',     'KEY_ID_CONTAINER_COMP_RSA3072', 0),   # TSN MAC Address
-        )
+    if 'tsn' in plt_params_list:
+        if os.path.exists('IPFW/PseTsnIpConfig.bin'):
+            print ("PseTsnIpConfig.bin found")
+            replace_list.append (
+                ('IFWI/BIOS/NRD/IPFW/TSIP', 'IPFW/PseTsnIpConfig.bin', 'lz4',     'KEY_ID_CONTAINER_COMP_RSA3072', 0),   # PSE TSN IP
+            )
+        if os.path.exists('IPFW/TsnConfig.bin'):
+            print ("TsnConfig.bin found")
+            replace_list.append (
+                ('IFWI/BIOS/NRD/IPFW/TSNC', 'IPFW/TsnConfig.bin',      'lz4',     'KEY_ID_CONTAINER_COMP_RSA3072', 0),   # TSN Config
+            )
+        if os.path.exists('IPFW/TsnMacAddr.bin'):
+            print ("TsnMacAddr.bin found")
+            replace_list.append (
+                ('IFWI/BIOS/NRD/IPFW/TMAC', 'IPFW/TsnMacAddr.bin',     'lz4',     'KEY_ID_CONTAINER_COMP_RSA3072', 0),   # TSN MAC Address
+            )
     if os.path.exists('IPFW/crl.bin'):
         print ("crl.bin found")
         replace_list.append (


### PR DESCRIPTION
when 'tsn' is not specified in stitching option, TSN FWs
should be not replaced.

Signed-off-by: Stanley Chang <stanley.chang@intel.com>