### PR TITLE
fix TSeg full during warn reset

### DIFF
--- a/BootloaderCorePkg/Include/Library/S3SaveRestoreLib.h
+++ b/BootloaderCorePkg/Include/Library/S3SaveRestoreLib.h
@@ -112,6 +112,17 @@ TriggerPayloadSwSmi (
 );
 
 /**
+  This function clears TSEG area designated for S3
+  save/restore purpose.
+
+**/
+VOID
+EFIAPI
+ClearS3SaveRegion (
+  VOID
+);
+
+/**
   This function appends information in TSEG area
   designated for S3 save/restore purpose.
 

--- a/BootloaderCorePkg/Library/S3SaveRestoreLib/S3SaveRestore.c
+++ b/BootloaderCorePkg/Library/S3SaveRestoreLib/S3SaveRestore.c
@@ -140,6 +140,27 @@ TriggerPayloadSwSmi (
 }
 
 /**
+  This function clears TSEG area designated for S3
+  save/restore purpose.
+
+**/
+VOID
+EFIAPI
+ClearS3SaveRegion (
+  VOID
+)
+{
+  LDR_SMM_INFO      LdrSmmInfo;
+  UINT8             *SmmBase;
+
+  PlatformUpdateHobInfo (&gSmmInformationGuid, &LdrSmmInfo);
+  SmmBase = (UINT8 *)(UINTN)LdrSmmInfo.SmmBase;
+  if (LdrSmmInfo.Flags & SMM_FLAGS_4KB_COMMUNICATION) {
+    ZeroMem (SmmBase, SIZE_4KB);
+  }
+}
+
+/**
   This function appends information in TSEG area
   designated for S3 save/restore purpose.
 

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1051,6 +1051,7 @@ BoardInit (
       DEBUG ((DEBUG_WARN, "VBT not found %r\n", Status));
     }
     if (GetPayloadId () == UEFI_PAYLOAD_ID_SIGNATURE && GetBootMode() != BOOT_ON_S3_RESUME) {
+      ClearS3SaveRegion ();
       //
       // Set SMMBASE_INFO dummy strucutre in TSEG before others
       //

--- a/Platform/CometlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CometlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1123,6 +1123,7 @@ BoardInit (
       DEBUG ((DEBUG_WARN, "VBT not found %r\n", Status));
     }
     if (GetPayloadId () == UEFI_PAYLOAD_ID_SIGNATURE && GetBootMode() != BOOT_ON_S3_RESUME) {
+      ClearS3SaveRegion ();
       //
       // Set SMMBASE_INFO dummy strucutre in TSEG before others
       //

--- a/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1121,6 +1121,7 @@ BoardInit (
       DEBUG ((DEBUG_WARN, "VBT not found %r\n", Status));
     }
     if (GetPayloadId () == UEFI_PAYLOAD_ID_SIGNATURE && GetBootMode() != BOOT_ON_S3_RESUME) {
+      ClearS3SaveRegion ();
       //
       // Set SMMBASE_INFO dummy strucutre in TSEG before others
       //

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -756,6 +756,7 @@ BoardInit (
     ClearSmi ();
     if (GetPayloadId () == UEFI_PAYLOAD_ID_SIGNATURE) {
       if (GetBootMode() != BOOT_ON_S3_RESUME) {
+        ClearS3SaveRegion ();
         mSmmBaseInfo.SmmBaseHdr.Count     = (UINT8) MpGetInfo()->CpuCount;
         mSmmBaseInfo.SmmBaseHdr.TotalSize = sizeof(BL_PLD_COMM_HDR) + mSmmBaseInfo.SmmBaseHdr.Count * sizeof(CPU_SMMBASE);
         Status = AppendS3Info ((VOID *)&mSmmBaseInfo, TRUE);

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -966,6 +966,7 @@ BoardInit (
     ClearSmi ();
     if (GetPayloadId () == UEFI_PAYLOAD_ID_SIGNATURE) {
       if (GetBootMode() != BOOT_ON_S3_RESUME) {
+        ClearS3SaveRegion ();
         //
         // Set SMMBASE_INFO dummy strucutre in TSEG before others
         //


### PR DESCRIPTION
This patch fixes TSeg region full problem after multiple
warn reset. Each time of warm reset, except S3 resume, the
TSeg region should be clear.

Signed-off-by: Stanley Chang <stanley.chang@intel.com>