### PR TITLE
[TGL] Read boot Tjunctions

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -1,7 +1,7 @@
 ## @file
 # Provides bootloader driver related package definitions.
 #
-# Copyright (c) 2016 - 2020, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -217,3 +217,4 @@
   gPlatformModuleTokenSpaceGuid.PcdSrIovSupport           | FALSE      | BOOLEAN | 0x20000212
   gPlatformModuleTokenSpaceGuid.PcdEnableSetup            | FALSE      | BOOLEAN | 0x20000213
   gPlatformModuleTokenSpaceGuid.PcdLegacyEfSegmentEnabled | TRUE       | BOOLEAN | 0x20000214
+  gPlatformModuleTokenSpaceGuid.PcdEnableDts              | FALSE      | BOOLEAN | 0x20000215

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -328,6 +328,7 @@
   gPlatformModuleTokenSpaceGuid.PcdSrIovSupport           | $(SUPPORT_SR_IOV)
   gPlatformModuleTokenSpaceGuid.PcdEnableSetup            | $(ENABLE_SBL_SETUP)
   gPayloadTokenSpaceGuid.PcdPayloadModuleEnabled          | $(ENABLE_PAYLOD_MODULE)
+  gPlatformModuleTokenSpaceGuid.PcdEnableDts              | $(ENABLE_DTS)
 
 !ifdef $(S3_DEBUG)
   gPlatformModuleTokenSpaceGuid.PcdS3DebugEnabled         | $(S3_DEBUG)

--- a/BootloaderCorePkg/Library/SmbiosInitLib/SmbiosInitLib.c
+++ b/BootloaderCorePkg/Library/SmbiosInitLib/SmbiosInitLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -246,15 +246,9 @@ AppendSmbiosType (
   // Find current Type127 and replace it with new Type Data
   //
   SmbiosEntry->TableLength -= ( ((SMBIOS_STRUCTURE *)mType127Ptr)->Length + TYPE_TERMINATOR_SIZE);
+  TypeHdr->Handle = ((SMBIOS_STRUCTURE *)mType127Ptr)->Handle;
   CopyMem (mType127Ptr, TypeData, TypeLength);
   SmbiosEntry->TableLength += TypeLength;
-
-  //
-  // Not incrementing the NumberOfSmbiosStructures here,
-  // as FinalizeSmbios () will do it again. That can be
-  // counted towards the newly added type structure.
-  //
-  TypeHdr->Handle = SmbiosEntry->NumberOfSmbiosStructures;
 
   //
   // After appending, update with Typ127 and patch entry point

--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -59,6 +59,8 @@ class Board(BaseBoard):
         self.SKIP_STAGE1A_SOURCE_DEBUG  = 0
         self.ENABLE_SPLASH        = 1
         self.ENABLE_FRAMEBUFFER_INIT    = 1
+        # 1: To read ambient temperature at boot time 0: Disable the feature
+        self.ENABLE_DTS           = 1
         self.ENABLE_FAST_BOOT     = 0
         self.HAVE_FUSA            = 1
         # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Dts.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Dts.c
@@ -1,0 +1,208 @@
+/** @file
+
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <PiPei.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/IoLib.h>
+#include <Library/SmbiosInitLib.h>
+#include <IndustryStandard/SmBios.h>
+#include <CpuRegs.h>
+#include <Register/PmcRegs.h>
+#include <CpuDataStruct.h>
+#include <PchReservedResources.h>
+#include "Dts.h"
+
+typedef enum {
+  TemperatureProbeSiteOther = 0x1,
+  TemperatureProbeSiteUnknown,
+  TemperatureProbeSiteProcessor,
+  TemperatureProbeSiteDisk,
+  TemperatureProbeSitePeripheralBay,
+  TemperatureProbeSiteSystemManagementModule,
+  TemperatureProbeSiteMotherboard,
+  TemperatureProbeSiteMemoryModule,
+  TemperatureProbeSiteProcessorModule,
+  TemperatureProbeSitePowerUnit = 0x10,
+  TemperatureProbeSiteAddinCard,
+  TemperatureProbeSiteFrontPanelBoard,
+  TemperatureProbeSiteBackPanelBoard,
+  TemperatureProbeSitePowerSystemBoard,
+  TemperatureProbeSiteDriveBackPlane
+} TEMPERATURE_PROBE_SITE;
+
+typedef enum {
+  TemperatureProbeStatusOther = 0x1,
+  TemperatureProbeStatusUnknown,
+  TemperatureProbeStatusOk,
+  TemperatureProbeStatusNoncritical,
+  TemperatureProbeStatusCritical,
+  TemperatureProbeStatusNonrecoverable
+} TEMPERATURE_PROBE_STATUS;
+
+typedef enum {
+  DtsPch = 0x0,
+  DtsCpu
+} INDEX_DTS;
+
+STATIC CHAR8 *mDtsSite[] = {
+  "Tjunction of PCH at Boot",
+  "Tjunction of CPU at Boot"
+};
+
+STATIC SMBIOS_TABLE_TYPE28  mDtsInfo[] = {
+  {                                        // Tjunction of PCH
+    {                                       // Hdr
+      SMBIOS_TYPE_TEMPERATURE_PROBE,        /// Hdr.Type
+      sizeof (SMBIOS_TABLE_TYPE28),         /// Hdr.Size
+      0                                     /// Hdr.Handle
+    },
+    1,                                      // Description: string index 1
+    {                                       // LocationAndStatus
+      TemperatureProbeSiteOther,            /// Site: Other
+      TemperatureProbeStatusUnknown         /// Status: init as unknown, updated in runtime
+    },
+    1000,                                   // Maximum value: 100.0 deg C. Unit in 1/10 deg C
+    0xFE70,                                 // Maximum value: -40.0 deg C. Unit in 1/10 deg C
+    1000,                                   // Resolution: 1.000 deg C. Unit in 1/1000 deg C
+    100,                                    // Tolerance: 10.0 deg C. Unit in 1/10 degC
+    0x8000,                                 // Accuracy: unknow
+    0,                                      // OEMDefined
+    0x8000                                  // NominalValue: init as unknown, updated in runtime
+  },
+  {                                        // Tjunction of CPU
+    {                                       // Hdr
+      SMBIOS_TYPE_TEMPERATURE_PROBE,        /// Hdr.Type
+      sizeof (SMBIOS_TABLE_TYPE28),         /// Hdr.Size
+      0                                     /// Hdr.Handle
+    },
+    1,                                      // Description: string index 1
+    {                                       // LocationAndStatus
+      TemperatureProbeSiteProcessor,        /// Site: Processor
+      TemperatureProbeStatusUnknown         /// Status: init as unknown, updated in runtime
+    },
+    1000,                                   // Maximum value: 100.0 deg C. Unit in 1/10 deg C
+    0xFE70,                                 // Maximum value: -40.0 deg C. Unit in 1/10 deg C
+    1000,                                   // Resolution: 1.000 deg C. Unit in 1/1000 deg C
+    100,                                    // Tolerance: 10.0 deg C. Unit in 1/10 degC
+    0x8000,                                 // Accuracy: unknow
+    0,                                      // OEMDefined
+    0x8000                                  // NominalValue: init as unknown, updated in runtime
+  }
+};
+
+/**
+  Read Pch DTS
+
+**/
+VOID
+EFIAPI
+ReadPchDts (
+  VOID
+  )
+{
+  UINT16          Dts;
+
+  // According to EDS, the register is in 2s complement, where
+  //   0x1: 1 deg C, 0x0: 0 deg C, 0x1FF: -1 deg C, and 0x1D8: -40 deg C
+  Dts = MmioRead16 (PCH_PWRM_BASE_ADDRESS + R_PMC_PWRM_THERMAL_TSS0) & B_PMC_PWRM_THERMAL_TSS0_TSR_MASK;
+
+  // As silicon limitation, no out-of-range check (Tj beyond -40 or 100)
+  if (Dts <= 0xFF) {
+    mDtsInfo[DtsPch].NominalValue = Dts * 10;
+  } else {
+    // Prepend 0xFE00 because TSR bit fields are 9-bit
+    mDtsInfo[DtsPch].NominalValue = (Dts | 0xFE00) * 10;
+  }
+  mDtsInfo[DtsPch].LocationAndStatus.TemperatureProbeStatus = TemperatureProbeStatusOk;
+
+  DEBUG ((DEBUG_INFO, "Boot-time Pch Dts: 0x%x\n", mDtsInfo[DtsPch].NominalValue));
+}
+
+/**
+  Read CPU Dts
+
+**/
+VOID
+EFIAPI
+ReadCpuDts (
+  VOID
+  )
+{
+  MSR_REGISTER    ThermStatus;
+  MSR_REGISTER    TemperatureTarget;
+  INT16           Dts;
+
+  ThermStatus.Qword = AsmReadMsr64(MSR_IA32_THERM_STATUS);
+
+  if ((ThermStatus.Dwords.Low & B_IA32_THERM_STATUS_VALID) == 0) {
+    return;
+  }
+
+  TemperatureTarget.Qword = AsmReadMsr64(MSR_TEMPERATURE_TARGET);
+
+  // As silicon limitation, no out-of-range check (Tj beyond -40 or 100)
+  Dts = (INT16)TemperatureTarget.Bytes.ThirdByte - (INT16)ThermStatus.Bytes.ThirdByte;
+  mDtsInfo[DtsCpu].NominalValue = (UINT16)(Dts * 10);
+  mDtsInfo[DtsCpu].LocationAndStatus.TemperatureProbeStatus = TemperatureProbeStatusOk;
+
+  DEBUG ((DEBUG_INFO, "Boot-time Cpu DTS: 0x%x\n", mDtsInfo[DtsCpu].NominalValue));
+}
+
+/**
+  Append Boot DTS to Smbios
+
+  @retval EFI_SUCCESS             Initialized necessary information successfully
+  @retval EFI_OUT_OF_RESOURCES    Failed to allocate memory
+  @retval other                   other errors
+
+**/
+EFI_STATUS
+EFIAPI
+AppendSmbiosBootDts (
+  VOID
+  )
+{
+  EFI_STATUS        Status;
+  UINT16            Index;
+  UINT16            Cnt;
+  VOID              *TypeAddr;
+  UINT16            Length;
+  CHAR8             *StringPtr;
+
+  // allocate enough memory for type 28 and its string (only one string)
+  Length = sizeof (SMBIOS_TABLE_TYPE28) + SMBIOS_STRING_MAX_LENGTH + sizeof (CHAR8);
+  TypeAddr = AllocatePool (Length);
+  if (TypeAddr == NULL) {
+    DEBUG ((DEBUG_ERROR, "Unable to allocate memory\n"));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Cnt = sizeof (mDtsInfo) / sizeof (mDtsInfo[0]);
+  for (Index = 0; Index < Cnt; Index++) {
+    // copy type 28 structure
+    CopyMem (TypeAddr, &mDtsInfo[Index], sizeof (SMBIOS_TABLE_TYPE28));
+
+    // add 1st string: Description
+    StringPtr = (CHAR8 *)TypeAddr + sizeof (SMBIOS_TABLE_TYPE28);
+    CopyMem (StringPtr, mDtsSite[Index], AsciiStrSize (mDtsSite[Index]));
+    StringPtr += AsciiStrSize (mDtsSite[Index]); // smbios string terminates with null
+
+
+    // additional null for last string
+    *StringPtr = 0;
+
+    // calculate total length
+    Length = (UINT16)(StringPtr - (CHAR8 *)TypeAddr + 1);
+
+    Status = AppendSmbiosType (TypeAddr, Length);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  }
+  return EFI_SUCCESS;
+}

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Dts.h
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Dts.h
@@ -1,0 +1,46 @@
+/** @file
+
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __DTS_H__
+#define __DTS_H__
+
+/**
+  Read PCH DTS
+
+**/
+VOID
+EFIAPI
+ReadPchDts (
+  VOID
+  );
+
+/**
+  Read CPU DTS
+
+**/
+VOID
+EFIAPI
+ReadCpuDts (
+  VOID
+  );
+
+/**
+  Append Boot DTS to Smbios
+
+  @retval EFI_SUCCESS             Initialized necessary information successfully
+  @retval EFI_OUT_OF_RESOURCES    Failed to allocate memory
+  @retval other                   other errors
+
+**/
+EFI_STATUS
+EFIAPI
+AppendSmbiosBootDts (
+  VOID
+  );
+
+
+#endif /* __DTS_H__ */

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -80,6 +80,7 @@
 #include <TccConfigSubRegions.h>
 #include <Library/LocalApicLib.h>
 #include <Library/TccLib.h>
+#include "Dts.h"
 
 BOOLEAN mTccDsoTuning      = FALSE;
 UINT8   mTccRtd3Support    = 0;
@@ -865,6 +866,10 @@ BoardInit (
     DEBUG ((DEBUG_INFO, "PCH gen (0x%x), series (0x%x), stepping (0x%x)\n", PchGeneration(), PchSeries(), PchStepping()));
     DEBUG ((DEBUG_INFO, "LPC DeviceId (0x%x)\n", PchGetLpcDid()));
 
+    if (FeaturePcdGet (PcdSmbiosEnabled) && FeaturePcdGet (PcdEnableDts)) {
+      ReadPchDts ();
+    }
+
     EnableLegacyRegions ();
     ConfigureGpio (CDATA_GPIO_TAG, 0, NULL);
     if (GetBootMode() != BOOT_ON_FLASH_UPDATE) {
@@ -931,6 +936,9 @@ BoardInit (
     //
     if (FeaturePcdGet (PcdSmbiosEnabled)) {
       InitializeSmbiosInfo ();
+      if (FeaturePcdGet (PcdEnableDts)) {
+        ReadCpuDts ();
+      }
     }
     break;
   case PostPciEnumeration:
@@ -950,6 +958,9 @@ BoardInit (
 
     break;
   case PrePayloadLoading:
+    if (FeaturePcdGet (PcdSmbiosEnabled) && FeaturePcdGet (PcdEnableDts)) {
+      AppendSmbiosBootDts ();
+    }
     IgdOpRegionPlatformInit ();
 
     ///

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -29,6 +29,8 @@
   FusaLib.c
   LowPowerSupport.c
   LowPowerSupport.h
+  Dts.h
+  Dts.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -64,6 +66,7 @@
   MeExtMeasurementLib
   BasePchPciBdfLib
   TccLib
+  SmbiosInitLib
 
 [Guids]
   gOsConfigDataGuid
@@ -103,3 +106,4 @@
   gPlatformModuleTokenSpaceGuid.PcdFspsUpdPtr
   gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled
   gPlatformModuleTokenSpaceGuid.PcdAcpiTableTemplatePtr
+  gPlatformModuleTokenSpaceGuid.PcdEnableDts

--- a/Silicon/TigerlakePchPkg/Include/Register/PmcRegs.h
+++ b/Silicon/TigerlakePchPkg/Include/Register/PmcRegs.h
@@ -176,6 +176,8 @@
 #define R_PMC_PWRM_MODPHY_PM_CFG5                           0x10D0
 #define R_PMC_PWRM_MODPHY_PM_CFG6                           0x10D4
 
+#define R_PMC_PWRM_THERMAL_TSS0                             0x1560                      ///< Temperature Sensor Control and Status
+#define B_PMC_PWRM_THERMAL_TSS0_TSR_MASK                    0x1FF
 
 #define R_PMC_PWRM_WADT_AC                                  0x1800
 

--- a/Silicon/TigerlakePkg/Include/CpuRegs.h
+++ b/Silicon/TigerlakePkg/Include/CpuRegs.h
@@ -9,7 +9,7 @@
   - Definitions beginning with "S_" are register sizes
   - Definitions beginning with "N_" are the bit position
 
-  Copyright (c) 2004 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2004 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 #ifndef _CPU_REGS_H_
@@ -29,8 +29,8 @@
 #define B_BOOT_GUARD_SACM_INFO_NEM_ENABLED                            BIT0
 
 
-#define V_MSR_TEMPERATURE_TARGET_TCC_ACTIVATION_OFFSET_MASK           0x3F
-
+#define MSR_IA32_THERM_STATUS                                         0x0000019C
+#define B_IA32_THERM_STATUS_VALID                                     BIT31
 
 #define MSR_TEMPERATURE_TARGET                                        0x000001A2
 #define V_MSR_TEMPERATURE_TARGET_TCC_ACTIVATION_OFFSET_MASK           0x3F


### PR DESCRIPTION
The patch adds a feature to read Dts at boot. The feature
is analogous to UEFI BIOS:

    Thermal Conf -> Platform Thermal Conf -> Boot DTS Read

Specifically, the feature reads Tjunctions of PCH and CPU
and stores them as Smbios Type-28 entries.

The patch also fixes AppendSmbiosType in SmbiosInitLib:
    A newly added structure should inherit the Handle from
    previous Type-127 (end-of-table) structure.

Signed-off-by: Stanley Chang <stanley.chang@intel.com>