### PR TITLE
Remove trailing space from OemPublicKeyHash field

### DIFF
--- a/Platform/CommonBoardPkg/Script/security_stitch_help.py
+++ b/Platform/CommonBoardPkg/Script/security_stitch_help.py
@@ -85,6 +85,7 @@ def update_btGuard_xml(btg_profile, stitch_dir, tree):
             oemkeyhash = ""
             for b in hash:
                 oemkeyhash = oemkeyhash + "%02X " % b
+            oemkeyhash = oemkeyhash[:-1]
         print("oemkeyhash:")
         print(oemkeyhash)
 


### PR DESCRIPTION
When boot guard profile is non-zero the OemPublicKeyHash
will be populated in the stitching XML file but FIT/mFIT
is giving a warning message:

OemPublicKeyHash. Exception: set_value failed.

This will remove the trailing space added to the last byte
given in the OemPublicKeyHash and resolve the warning.

Signed-off-by: James Gutbub <james.gutbub@intel.com>