### PR TITLE
[TGL] fix fw update hang due to rom size change

### DIFF
--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -170,9 +170,19 @@ class Board(BaseBoard):
         Redundant_Components_Size = self.UCODE_SIZE + self.STAGE2_SIZE + self.STAGE1B_SIZE + self.FWUPDATE_SIZE + self.CFGDATA_SIZE + self.KEYHASH_SIZE
         if Redundant_Components_Size > self.REDUNDANT_SIZE:
             raise Exception ('Redundant region size 0x%x is smaller than required components size 0x%x!' % (self.REDUNDANT_SIZE, Redundant_Components_Size))
-        self.NON_REDUNDANT_SIZE   = 0x2B2000 + self.SIIPFW_SIZE
         self.NON_VOLATILE_SIZE    = 0x001000
-        self.SLIMBOOTLOADER_SIZE  = (self.TOP_SWAP_SIZE + self.REDUNDANT_SIZE) * 2 + self.NON_REDUNDANT_SIZE + self.NON_VOLATILE_SIZE
+        # For firmware update, please keep SLIMBOOTLOADER_SIZE unchanged!
+        # The info can be found in the 'RomSize' of Outputs/tgl/FlashMap.txt
+        # Max size for 16MB IFWI: 0xAD8000
+        # Default value in UEFI BIOS (32MB IFWI): 0xC00000
+        self.SLIMBOOTLOADER_SIZE  = 0xAD0000
+        self.NON_REDUNDANT_SIZE   = self.SLIMBOOTLOADER_SIZE - \
+                                    (self.TOP_SWAP_SIZE + self.REDUNDANT_SIZE) * 2 - \
+                                    self.NON_VOLATILE_SIZE
+        Non_Redundant_Components_Size = self.PAYLOAD_SIZE + self.EPAYLOAD_SIZE + self.MRCDATA_SIZE + \
+                                        self.UEFI_VARIABLE_SIZE + self.VARIABLE_SIZE + self.SIIPFW_SIZE
+        if self.NON_REDUNDANT_SIZE < Non_Redundant_Components_Size:
+            raise Exception ('Non redundant region size 0x%x is smaller than required components size 0x%x!' % (self.NON_REDUNDANT_SIZE, Non_Redundant_Components_Size))
 
         self.PLD_HEAP_SIZE        = 0x04000000
         self.PLD_STACK_SIZE       = 0x00020000

--- a/Silicon/TigerlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/TigerlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -1,7 +1,7 @@
 /** @file
   This file contains the implementation of FirmwareUpdateLib library.
 
-  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -286,6 +286,13 @@ GetFirmwareUpdateInfo (
     DEBUG ((DEBUG_INFO, "RedundantRegion    Offset/Size = 0x%08X/0x%X\n", RedundantRegionOffset, RedundantRegionSize));
     DEBUG ((DEBUG_INFO, "NonRedundantRegion Offset/Size = 0x%08X/0x%X\n", NonRedundantRegionOffset,
             NonRedundantRegionSize));
+
+    if (FlashMap->RomSize != ImageHdr->UpdateImageSize) {
+      DEBUG ((DEBUG_ERROR, "Rom size (SLIMBOOTLOADER_SIZE) mismatches!\n"));
+      DEBUG ((DEBUG_ERROR, "  Current running SBL = 0x%08X Capsule = 0x%08X\n",
+              FlashMap->RomSize, ImageHdr->UpdateImageSize));
+      return EFI_ABORTED;
+    }
 
     //
     // Top Swap region


### PR DESCRIPTION
This patch fixes a hang issue during fw update caused by
mismatching bios rom size. For a fw update, the TopSwap
size, Redundant Region size, and total BIOS region must be
identical.

This patch also adds check on rom size during fw update.
The check only works for a running SBL previously built with
this patch.

Signed-off-by: Stanley Chang <stanley.chang@intel.com>