### PR TITLE
[TGL] Add Fusa Enable CFG option

### DIFF
--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Features.yaml
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Features.yaml
@@ -19,7 +19,7 @@
         name         : PlatformFeatures
         struct       : FEATURES_DATA
         length       : 0x04
-        value        : 0x00000003
+        value        : 0x0000000B
     - Acpi         :
         name         : ACPI Enable
         type         : Combo
@@ -41,11 +41,18 @@
         help         : >
                        Enable/Disable Low Power Idle feature. 1:Low Power S0 Idle Enabled, 0:Low Power S0 Idle Disabled
         length       : 1b
+    - FusaEnable   :
+        name         : Fusa Enable
+        type         : Combo
+        option       : $EN_DIS
+        help         : >
+                       Fusa Enabled feature. 1:Enabled (default), 0:Disabled
+        length       : 1b
     - Rsvd         :
         name         : Reserved
         type         : Reserved
         help         : >
                        reserved bits
-        length       : 29b
+        length       : 28b
 
 

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -858,6 +858,7 @@ BoardInit (
   EFI_PEI_GRAPHICS_INFO_HOB *FspGfxHob;
   VOID                      *FspHobList;
   SILICON_CFG_DATA          *SiCfgData;
+  FEATURES_CFG_DATA         *FeaturesCfgData;
   UINTN                     LpcBase;
   BL_SW_SMI_INFO            *BlSwSmiInfo;
 
@@ -929,7 +930,10 @@ BoardInit (
     }
     BuildOsConfigDataHob ();
     if (FeaturePcdGet (PcdFusaEnabled)) {
-      FusaKeyOffProcessing();
+      FeaturesCfgData = (FEATURES_CFG_DATA *) FindConfigDataByTag(CDATA_FEATURES_TAG);
+      if ((FeaturesCfgData != NULL) && (FeaturesCfgData->Features.FusaEnable == 1)) {
+          FusaKeyOffProcessing();
+      }
     }
     //
     // Initialize Smbios Info for SmbiosInit


### PR DESCRIPTION
Not every board will want to boot with
Fusa Enabled (ex. UPX i11 board). We can
allow for Fusa to be skipped using CFG
instead of just BoardConfig flag.

Signed-off-by: James Gutbub <james.gutbub@intel.com>