### PR TITLE
[TGL] Enable UPX i11 basic boot

### DIFF
--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -204,7 +204,7 @@ class Board(BaseBoard):
         # Cfg data dlt files for internal boards could also put into external cfg data if want to update cfg data for these platforms
         # for test purpose. Based on the platform id, relevant data is populated for each platform.
         self._CFGDATA_INT_FILE = []
-        self._CFGDATA_EXT_FILE = [self._generated_cfg_file_prefix + 'CfgData_Int_Tglu_Ddr4.dlt', self._generated_cfg_file_prefix  + 'CfgData_Int_Tglu_DdrLp4.dlt', self._generated_cfg_file_prefix  + 'CfgData_Int_Tglh_Ddr4.dlt']
+        self._CFGDATA_EXT_FILE = [self._generated_cfg_file_prefix + 'CfgData_Int_Tglu_Ddr4.dlt', self._generated_cfg_file_prefix  + 'CfgData_Int_Tglu_DdrLp4.dlt', self._generated_cfg_file_prefix  + 'CfgData_Int_Tglh_Ddr4.dlt', self._generated_cfg_file_prefix + 'CfgDataExt_Upx11.dlt']
 
         # If mulitple VBT table support is required, list them as:
         #   {VbtImageId1 : VbtFileName1, VbtImageId2 : VbtFileName2, ...}

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgDataExt_Upx11.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgDataExt_Upx11.dlt
@@ -1,0 +1,34 @@
+## @file
+#
+#  Platform Configuration Delta File.
+#
+#  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+#
+
+PLATFORMID_CFG_DATA.PlatformId                              | 0x0004
+PLAT_NAME_CFG_DATA.PlatformName                             | 'UPXi11'
+
+MEMORY_CFG_DATA.DqsMapCpu2DramMc0Ch1                        | {0, 1}
+MEMORY_CFG_DATA.DqsMapCpu2DramMc0Ch3                        | {0, 1}
+MEMORY_CFG_DATA.DqsMapCpu2DramMc1Ch0                        | {0, 1}
+MEMORY_CFG_DATA.DqsMapCpu2DramMc1Ch3                        | {0, 1}
+
+MEMORY_CFG_DATA.DqMapCpu2DramMc0Ch0                         | {13, 12, 14, 15, 11,  8,  9, 10, 2,  3,  1,  0,  7,  4,  5,  6}
+MEMORY_CFG_DATA.DqMapCpu2DramMc0Ch1                         | {11, 12, 13, 10, 14,  8, 15,  9, 2,  3,  1,  0,  6,  5,  7,  4}
+MEMORY_CFG_DATA.DqMapCpu2DramMc0Ch2                         | {15, 14, 12, 13, 11, 10,  8,  9, 0,  1,  2,  3,  4,  7,  6,  5}
+MEMORY_CFG_DATA.DqMapCpu2DramMc0Ch3                         | {12, 13, 11, 10,  9, 15,  8, 14, 2,  3,  0,  1,  5,  4,  7,  6}
+MEMORY_CFG_DATA.DqMapCpu2DramMc1Ch0                         | {15, 14, 13, 12, 10,  8,  9, 11, 0,  1,  2,  3,  7,  4,  5,  6}
+MEMORY_CFG_DATA.DqMapCpu2DramMc1Ch1                         | {15, 14, 11, 10, 13, 12,  8,  9, 1,  7,  0,  6,  3,  5,  2,  4}
+MEMORY_CFG_DATA.DqMapCpu2DramMc1Ch2                         | {15, 14, 13, 12,  9, 10, 11,  8, 0,  1,  7,  6,  3,  2,  5,  4}
+MEMORY_CFG_DATA.DqMapCpu2DramMc1Ch3                         | {4,  3,  5,  2,  6,  7,  0,  1, 15, 14, 10, 11, 12,  9,  8, 13}
+
+MEMORY_CFG_DATA.DmaControlGuarantee                         | 1
+
+SILICON_CFG_DATA.EcEnable                                   | 0
+FEATURES_CFG_DATA.Features.FusaEnable                       | 0
+
+GEN_CFG_DATA.PayloadId                                      | 0
+

--- a/Platform/TigerlakeBoardPkg/Include/PlatformBoardId.h
+++ b/Platform/TigerlakeBoardPkg/Include/PlatformBoardId.h
@@ -20,6 +20,8 @@ Defines Platform BoardIds
 // TigerLake Board Id 0x03
 #define BoardIdTglULp4Type4               0x03
 
+// TigerLake Board Id 0x04
+#define BoardIdTglUpxi11                  0x04
 
 // TigerLake Board Id 0x0A
 #define BomIdTglUDdr4Main                 0x00


### PR DESCRIPTION
Support for Up Xtreme i11 TGL based board has
been started, with this patch we are able to
boot the board using Slim Bootloader via OS
Loader payload. The PCIe x4 slot on the board
is able to detect NVMe-to-PCIe x4 adapter media
but the other IO on the Up Xtreme i11 board
will need enabling in subsequent patches. Debug
output is coming from header CN11 on the board
(e.g. UART2).

To stitch the SlimBootloader.bin into the default
IFWI retrieved from the Up Xterme i11 use the
StitchLoader.py script with '-p' argument as given
below:

python Platform\TigerlakeBoardPkg\Script\StitchLoader.py -p 0xAA000204 -i board_default_ifwi_orig.bin -s Outputs\tgl\SlimBootloader.bin -o sbl_ifwi_tgl-upx.bin

Signed-off-by: James Gutbub <james.gutbub@intel.com>