### PR TITLE
[TGL] Update UPX GFX and SMBIOS data

### DIFF
--- a/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -407,6 +407,7 @@ UpdateFspConfig (
     CopyMem(SaDisplayConfigTable, (VOID *)(UINTN)mTglHDdr4RowDisplayDdiConfig, sizeof(mTglHDdr4RowDisplayDdiConfig));
     break;
   case BoardIdTglUDdr4:
+  case BoardIdTglUpxi11:
     CopyMem(SaDisplayConfigTable, (VOID *)(UINTN)mTglUDdr4RowDisplayDdiConfig, sizeof(mTglUDdr4RowDisplayDdiConfig));
     break;
   case BoardIdTglULp4Type4:

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -125,6 +125,7 @@ CHAR8 *mBoardIdIndex[] = {
   "TigerLake U DDR4 SODIMM RVP",           // 0x01
   "TigerLake U LPDDR4/4x T4 RVP",          // 0x03
   "TigerLake H DDR4 SODIMM RVP",           // 0x21 or 0xF
+  "Up Xtreme i11 DDR4 SODIMM",             // 0x04
 };
 
 //
@@ -605,6 +606,9 @@ InitializeSmbiosInfo (
     case 0xF:
       BrdIdx = 3;
       break;
+    case BoardIdTglUpxi11:
+      BrdIdx = 4;
+      break;
     default:
       BrdIdx = 0;
       break;
@@ -819,6 +823,7 @@ IgdOpRegionPlatformInit (
       IgdPlatformInfo.callback = (GOP_VBT_UPDATE_CALLBACK)(UINTN)&TglHDdr4GopVbtSpecificUpdate;
       break;
     case BoardIdTglUDdr4:
+    case BoardIdTglUpxi11:
       IgdPlatformInfo.callback = (GOP_VBT_UPDATE_CALLBACK)(UINTN)&TglUDdr4GopVbtSpecificUpdate;
       break;
     case BoardIdTglULp4Type4:


### PR DESCRIPTION
For the UPX i11 board we need to set
the SA display table (same as DDR4 RVP),
populate the VBT callback routine (also
same DDR4 RVP), and update the SMBIOS
base board string.

Signed-off-by: James Gutbub <james.gutbub@intel.com>