### PR TITLE
[CML][TGL] Fix klockwork scanning issues.

### DIFF
--- a/Platform/CometlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CometlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1325,11 +1325,15 @@ UpdateFspConfig (
   FspsUpd->FspsConfig.TcoIrqSelect        = 9;
 
   HdaVerbTablePtr = (UINT32 *) AllocateZeroPool (2 * sizeof (UINT32));
-  HdaVerbTableNum = 0;
-  HdaVerbTablePtr[HdaVerbTableNum++]   = (UINT32)(UINTN) &HdaVerbTableDisplayAudio;
-  HdaVerbTablePtr[HdaVerbTableNum++]   = (UINT32)(UINTN) &CmlHdaVerbTableAlc711;
-  FspsUpd->FspsConfig.PchHdaVerbTablePtr      = (UINT32)(UINTN) HdaVerbTablePtr;
-  FspsUpd->FspsConfig.PchHdaVerbTableEntryNum = HdaVerbTableNum;
+  if (HdaVerbTablePtr != NULL) {
+    HdaVerbTableNum = 0;
+    HdaVerbTablePtr[HdaVerbTableNum++]   = (UINT32)(UINTN) &HdaVerbTableDisplayAudio;
+    HdaVerbTablePtr[HdaVerbTableNum++]   = (UINT32)(UINTN) &CmlHdaVerbTableAlc711;
+    FspsUpd->FspsConfig.PchHdaVerbTablePtr      = (UINT32)(UINTN) HdaVerbTablePtr;
+    FspsUpd->FspsConfig.PchHdaVerbTableEntryNum = HdaVerbTableNum;
+  } else {
+    DEBUG ((DEBUG_ERROR, "UpdateFspConfig Error: Could not allocate Memory for HdaVerbTable\n"));
+  }
 
   FspsUpd->FspsConfig.GraphicsConfigPtr   = PcdGet32(PcdGraphicsVbtAddress);
 

--- a/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1320,12 +1320,16 @@ UpdateFspConfig (
   FspsUpd->FspsConfig.TcoIrqSelect        = 9;
 
   HdaVerbTablePtr = (UINT32 *) AllocateZeroPool (2 * sizeof (UINT32));
-  HdaVerbTableNum = 0;
-  HdaVerbTablePtr[HdaVerbTableNum++]   = (UINT32)(UINTN) &HdaVerbTableDisplayAudio;
-  HdaVerbTablePtr[HdaVerbTableNum++]   = (UINT32)(UINTN) &CmlHdaVerbTableAlc711;
-  FspsUpd->FspsConfig.PchHdaVerbTablePtr      = (UINT32)(UINTN) HdaVerbTablePtr;
-  FspsUpd->FspsConfig.PchHdaVerbTableEntryNum = HdaVerbTableNum;
 
+  if (HdaVerbTablePtr != NULL) {
+    HdaVerbTableNum = 0;
+    HdaVerbTablePtr[HdaVerbTableNum++]   = (UINT32)(UINTN) &HdaVerbTableDisplayAudio;
+    HdaVerbTablePtr[HdaVerbTableNum++]   = (UINT32)(UINTN) &CmlHdaVerbTableAlc711;
+    FspsUpd->FspsConfig.PchHdaVerbTablePtr      = (UINT32)(UINTN) HdaVerbTablePtr;
+    FspsUpd->FspsConfig.PchHdaVerbTableEntryNum = HdaVerbTableNum;
+  } else {
+    DEBUG ((DEBUG_ERROR, "UpdateFspConfig Error: Could not allocate Memory for HdaVerbTable\n"));
+  }
   FspsUpd->FspsConfig.GraphicsConfigPtr   = PcdGet32(PcdGraphicsVbtAddress);
 
   CopyMem (&FspsUpd->FspsConfig.PxRcConfig, mPxRcConfig, sizeof(mPxRcConfig));

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1393,13 +1393,17 @@ UpdateFspConfig (
   SiCfgData = (SILICON_CFG_DATA *)FindConfigDataByTag (CDATA_SILICON_TAG);
   if ((SiCfgData != NULL) && SiCfgData->PchHdaEnable == 1) {
     HdaVerbTablePtr = (UINT32 *) AllocateZeroPool (4 * sizeof (UINT32));
-    HdaVerbTableNum = 0;
-    HdaVerbTablePtr[HdaVerbTableNum++]   = (UINT32)(UINTN) &HdaVerbTableDisplayAudio;
-    HdaVerbTablePtr[HdaVerbTableNum++]   = (UINT32)(UINTN) &TglHdaVerbTableAlc711;
-    HdaVerbTablePtr[HdaVerbTableNum++]   = (UINT32)(UINTN) &TglHdaVerbTableAlc701;
-    HdaVerbTablePtr[HdaVerbTableNum++]   = (UINT32)(UINTN) &TglHdaVerbTableAlc274;
-    FspsUpd->FspsConfig.PchHdaVerbTablePtr      = (UINT32)(UINTN) HdaVerbTablePtr;
-    FspsUpd->FspsConfig.PchHdaVerbTableEntryNum = HdaVerbTableNum;
+    if (HdaVerbTablePtr != NULL) {
+      HdaVerbTableNum = 0;
+      HdaVerbTablePtr[HdaVerbTableNum++]   = (UINT32)(UINTN) &HdaVerbTableDisplayAudio;
+      HdaVerbTablePtr[HdaVerbTableNum++]   = (UINT32)(UINTN) &TglHdaVerbTableAlc711;
+      HdaVerbTablePtr[HdaVerbTableNum++]   = (UINT32)(UINTN) &TglHdaVerbTableAlc701;
+      HdaVerbTablePtr[HdaVerbTableNum++]   = (UINT32)(UINTN) &TglHdaVerbTableAlc274;
+      FspsUpd->FspsConfig.PchHdaVerbTablePtr      = (UINT32)(UINTN) HdaVerbTablePtr;
+      FspsUpd->FspsConfig.PchHdaVerbTableEntryNum = HdaVerbTableNum;
+    } else {
+      DEBUG ((DEBUG_ERROR, "UpdateFspConfig Error: Could not allocate Memory for HdaVerbTable\n"));
+    }
   }
   if (PcdGetBool (PcdFramebufferInitEnabled)) {
     FspsConfig->GraphicsConfigPtr = (UINT32) GetVbtAddress();


### PR DESCRIPTION
Add check for Pointer 'HdaVerbTablePtr' returned from call to function
'AllocateZeroPool'

Signed-off-by: Randy Lin <randy.lin@intel.com>