### PR TITLE
[TGL] Add CFG for USB20Enable

### DIFF
--- a/Platform/TigerlakeBoardPkg/CfgData/CfgDataDef.yaml
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgDataDef.yaml
@@ -176,7 +176,15 @@ template:
     - $ACTION      :
         page         : MEM_$(1)
 
-
+  USB_PORT_TMPL: >
+    - Usb$(1)Port$(2) :
+        name : Enable USB$(1) port $(2)
+        type : Combo
+        option : $EN_DIS
+        help : >
+               Enable/disable USB$(1) port $(2).
+        length : 1b
+        value : 1
 
   - !include Platform/CommonBoardPkg/CfgData/Template_BootOption.yaml
 

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_Ddr4.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_Ddr4.dlt
@@ -30,6 +30,8 @@ MEMORY_CFG_DATA.DqMapCpu2DramMc1Ch3                         | {4,  3,  5,  2,  6
 
 MEMORY_CFG_DATA.DmaControlGuarantee                         | 1
 
+SILICON_CFG_DATA.PortUsb20Enable.Usb2Port1                  | 0
+
 #
 # By default use Osloader Payload, set to "UEFI" to select UEFI payload.
 #

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_DdrLp4.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_DdrLp4.dlt
@@ -25,6 +25,8 @@ MEMORY_CFG_DATA.SpdDataSel110                               | 1
 MEMORY_CFG_DATA.SpdDataSel120                               | 1
 MEMORY_CFG_DATA.SpdDataSel130                               | 1
 
+SILICON_CFG_DATA.PortUsb20Enable.Usb2Port1                  | 0
+
 #
 # By default use Osloader Payload, set to "UEFI" to select UEFI payload.
 #

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -294,7 +294,26 @@
                      Enable/disable HD Audio DMIC_N.
       length       : 0x02
       value        : { 0x00, 0x00 }
+  - PortUsb20Enable :
+    - $STRUCT      :
+        name         : Enable USB2 Ports
+        length       : 0x02
+    - !expand { USB_PORT_TMPL : [ 2, 0 ] }
+    - !expand { USB_PORT_TMPL : [ 2, 1 ] }
+    - !expand { USB_PORT_TMPL : [ 2, 2 ] }
+    - !expand { USB_PORT_TMPL : [ 2, 3 ] }
+    - !expand { USB_PORT_TMPL : [ 2, 4 ] }
+    - !expand { USB_PORT_TMPL : [ 2, 5 ] }
+    - !expand { USB_PORT_TMPL : [ 2, 6 ] }
+    - !expand { USB_PORT_TMPL : [ 2, 7 ] }
+    - !expand { USB_PORT_TMPL : [ 2, 8 ] }
+    - !expand { USB_PORT_TMPL : [ 2, 9 ] }
+    - !expand { USB_PORT_TMPL : [ 2, 10 ] }
+    - !expand { USB_PORT_TMPL : [ 2, 11 ] }
+    - !expand { USB_PORT_TMPL : [ 2, 12 ] }
+    - !expand { USB_PORT_TMPL : [ 2, 13 ] }
+    - !expand { USB_PORT_TMPL : [ 2, 14 ] }
+    - !expand { USB_PORT_TMPL : [ 2, 15 ] }
   - Dummy        :
-      length       : 0x1
+      length       : 0x3
       value        : 0x0
-

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1522,16 +1522,17 @@ UpdateFspConfig (
       FspsConfig->PchTsn1MacAddressHigh      = TsnSubRegion->Config.Port[1].MacAddr.U32MacAddr[1];
       FspsConfig->PchTsn1MacAddressLow       = TsnSubRegion->Config.Port[1].MacAddr.U32MacAddr[0];
     }
+    for (Index = 0; Index < (sizeof (FspsConfig->PortUsb20Enable) / sizeof (FspsConfig->PortUsb20Enable[0])); Index++) {
+      FspsConfig->PortUsb20Enable[Index] = ((*((UINT32*) (&SiCfgData->PortUsb20Enable))) >> Index) & 0x1;
+    }
   }
 
-  FspsConfig->PortUsb20Enable[1] = 0x0;
   FspsConfig->PortUsb30Enable[0] = 0x1;
   FspsConfig->PortUsb30Enable[1] = 0x1;
   FspsConfig->PortUsb30Enable[2] = 0x1;
   FspsConfig->PortUsb30Enable[3] = 0x1;
 
   if (IsPchH ()) {
-    FspsConfig->PortUsb20Enable[1] = 0x1;
     FspsConfig->PortUsb30Enable[4] = 0x1;
     FspsConfig->PortUsb30Enable[5] = 0x1;
     FspsConfig->PortUsb30Enable[6] = 0x1;


### PR DESCRIPTION
The default values for USB20Enable from FSP
is set to enabled. Some platforms need to
disable some of these USB20 ports (e.g. TGL-U
DDR4 and LPDDR4 RVP). Add CFG data field for
the USB20Enable settings per port.

Signed-off-by: James Gutbub <james.gutbub@intel.com>