### PR TITLE
[TGL] Increase CFG data mempool and skip debug UART init

### DIFF
--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -206,7 +206,7 @@ class Board(BaseBoard):
 
         self.LOADER_RSVD_MEM_SIZE = 0x500000
 
-        self.CFG_DATABASE_SIZE    = self.CFGDATA_SIZE
+        self.CFG_DATABASE_SIZE    = self.CFGDATA_SIZE + 0x1000
         self._generated_cfg_file_prefix = 'Autogen_'
 
         # _CFGDATA_INT_FILE - Internal cfg data is generally used for internal boards like MRBs, RVPs etc.

--- a/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -188,6 +188,7 @@ UpdateFspConfig (
   if (DebugPort < PCH_MAX_SERIALIO_UART_CONTROLLERS) {
     Fspmcfg->PcdDebugInterfaceFlags = BIT4;
     Fspmcfg->SerialIoUartDebugControllerNumber = DebugPort;
+    Fspmcfg->SerialIoUartDebugMode = 4;
   } else {
     Fspmcfg->PcdDebugInterfaceFlags = BIT1;
     if (DebugPort == 0xFF) {


### PR DESCRIPTION
With the recent additions to the CFG data (new DLT for
UPXi11 and new fields added) the CFG data size alloced
in memory seems to have run out of space, need to add
space to load the CFG data. Also, we need to specify
in FSP-M to skip UART init for the debug port we are
using when it is a PCH UART or we lose debug messages
in Stage2 onward if using a debug FSP.

Signed-off-by: James Gutbub <james.gutbub@intel.com>