### PR TITLE
Enforce FFS alignment in FvLib

### DIFF
--- a/BootloaderCommonPkg/Library/LiteFvLib/FvLib.c
+++ b/BootloaderCommonPkg/Library/LiteFvLib/FvLib.c
@@ -58,6 +58,7 @@ GetFirstFfsFileInFv (
     FvExHeader  = (EFI_FIRMWARE_VOLUME_EXT_HEADER *)(((UINT8 *)FvHeader) + FvHeader->ExtHeaderOffset);
     CurrentFile = (EFI_FFS_FILE_HEADER *)(((UINT8 *)FvExHeader) + FvExHeader->ExtHeaderSize);
   }
+  CurrentFile = (EFI_FFS_FILE_HEADER *) ALIGN_POINTER (CurrentFile, 8);
   return CurrentFile;
 }
 


### PR DESCRIPTION
When FV extended header exists, the first FFS pointer returned by
GetFirstFfsFileInFv() might not be 8-byte aligned. This patch
adjusted the pointer accordingly to ensure it is aligned per UEFI
spec.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>