### PR TITLE
[EHL] Add GPIO payload selection configuration

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgDataDef.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgDataDef.yaml
@@ -22,27 +22,25 @@ template:
 
   GPIO_TMPL: >
     - $ACTION      :
-        page         : GIO_$(1):GIO:"GPIO $(1)"
-    - $ACTION      :
-        page         : GIO_$(1)
-    - GpioPinConfig0_$(1) :
+        page         : GIO_$(1)$(2):GIO_$(1):"$(1)$(2)"
+    - GpioPinConfig0_$(1)$(2) :
       - $STRUCT      :
-          name         : GPIO $(1) PIN Config0
+          name         : GPIO $(1)$(2) PIN Config0
           type         : EditNum, HEX, (0x00000000,0xFFFFFFFF)
           help         : >
-                         GPIO $(1) PIN Configuration
+                         GPIO $(1)$(2) PIN Configuration
           length       : 0x04
-          value        : $(2)
-      - GPIOPADMode_$(1) :
+          value        : $(3)
+      - GPIOPADMode_$(1)$(2) :
           name         : PadMode
           type         : Combo
           option       : 0x0:Hardware Default, 0x1:GPIO control of the pad, 0x3:Native function 1, 0x5:Native function 2, 0x7:Native function 3, 0x9:Native function 4, 0xB:Native function 5, 0xD:Native function 6, 0xF:Native function 7, 0x11:Native function 8
           help         : >
                          GPIO PAD Mode. If GPIO is set to one of NativeX modes then following settings are not applicable and can be skipped:-
                          Interrupt related settings, Host Software Ownership, Output/Input enabling/disabling, Output lock
-          condition    : $GPIO_CFG_DATA.GpioPinConfig1_$(1).GPIOSkip_$(1) == 0
+          condition    : $GPIO_CFG_DATA.GpioPinConfig1_$(1)$(2).GPIOSkip_$(1)$(2) == 0
           length       : 5b
-      - GPIOHostSoftPadOwn_$(1) :
+      - GPIOHostSoftPadOwn_$(1)$(2) :
           name         : HostSoftPadOwn
           type         : Combo
           option       : 0x0:Host Ownership Default(Leave ownership value unmodified), 0x1:Host ownership to ACPI, 0x3:Host ownership to GPIO Driver mode
@@ -53,9 +51,9 @@ template:
                          If GPIO is configured to generate SCI/SMI/NMI then this setting must be used for interrupts to work.
                          - HOST ownership to GPIO Driver mode - Use this setting only if GPIO pad should be controlled by GPIO OS Driver.
                          GPIO OS Driver will be able to control the pad if appropriate entry in ACPI exists.
-          condition    : $GPIO_CFG_DATA.GpioPinConfig1_$(1).GPIOSkip_$(1) == 0
+          condition    : $GPIO_CFG_DATA.GpioPinConfig1_$(1)$(2).GPIOSkip_$(1)$(2) == 0
           length       : 2b
-      - GPIODirection_$(1) :
+      - GPIODirection_$(1)$(2) :
           name         : Direction
           type         : Combo
           option       : 0x0:DirDefault, 0x9:DirInOut, 0x19:DirInInvOut, 0xB:DirIn, 0x1B:DirInInv, 0x5:DirOut, 0x7:DirNone
@@ -65,18 +63,18 @@ template:
                          - DirInInvOut = Set pad for both output and input with inversion, - DirIn = Set pad for input only,
                          - DirInInv = Set pad for input with inversion, - DirOut = Set pad for output only,
                          - DirNone  = Disable both output and input.
-          condition    : $GPIO_CFG_DATA.GpioPinConfig1_$(1).GPIOSkip_$(1) == 0
+          condition    : $GPIO_CFG_DATA.GpioPinConfig1_$(1)$(2).GPIOSkip_$(1)$(2) == 0
           length       : 6b
-      - GPIOOutputState_$(1) :
+      - GPIOOutputState_$(1)$(2) :
           name         : OutputState
           type         : Combo
           option       : 0x0:OutDefault, 0x1:OutLow, 0x3:OutHigh
           help         : >
                          GPIO Output State.This field is relevant only if output is enabled:-
                          - OutDefault = Leave output value unmodified, - OutLow = Set output to low, - OutHigh = Set output to high
-          condition    : $GPIO_CFG_DATA.GpioPinConfig1_$(1).GPIOSkip_$(1) == 0
+          condition    : $GPIO_CFG_DATA.GpioPinConfig1_$(1)$(2).GPIOSkip_$(1)$(2) == 0
           length       : 2b
-      - GPIOInterruptConfig_$(1) :
+      - GPIOInterruptConfig_$(1)$(2) :
           name         : InterruptConfig
           type         : Combo
           option       : >
@@ -97,9 +95,9 @@ template:
                          - IntDefault = Leave value of interrupt routing unmodified, - IntDisable = Disable IOxAPIC/SCI/SMI/NMI interrupt generation,
                          - IntNmi = Enable NMI interrupt only, - IntSmi = Enable SMI interrupt only, - IntSci = Enable SCI interrupt only, - IntApic = Enable IOxAPIC interrupt only,
                          - IntLevel = Set interrupt as level triggered, - IntEdge = Set interrupt as edge triggered, - IntLvlEdgDis = Disable interrupt trigger, - IntBothEdge = Set interrupt as both edge triggered
-          condition    : $GPIO_CFG_DATA.GpioPinConfig1_$(1).GPIOSkip_$(1) == 0
+          condition    : $GPIO_CFG_DATA.GpioPinConfig1_$(1)$(2).GPIOSkip_$(1)$(2) == 0
           length       : 9b
-      - GPIOResetConfig_$(1) :
+      - GPIOResetConfig_$(1)$(2) :
           name         : Power/ResetConfig
           type         : Combo
           option       : 0x0:ResetDefault, 0x1:ResetResume, 0x3:HostDeepReset, 0x5:PlatformReset, 0x7:DswReset
@@ -109,17 +107,17 @@ template:
                          - HostDeepReset = Pad settings will reset on:Warm/Cold/Global reset,DeepSx transition,G3,
                          - PlatformReset = Pad settings will reset on:S3/S4/S5 transition, Warm/Cold/Global reset, DeepSx transition, G3
                          - DswReset = Pad settings will reset on G3
-          condition    : $GPIO_CFG_DATA.GpioPinConfig1_$(1).GPIOSkip_$(1) == 0
+          condition    : $GPIO_CFG_DATA.GpioPinConfig1_$(1)$(2).GPIOSkip_$(1)$(2) == 0
           length       : 8b
-    - GpioPinConfig1_$(1) :
+    - GpioPinConfig1_$(1)$(2) :
       - $STRUCT      :
-          name         : GPIO $(1) PIN Config1
+          name         : GPIO $(1)$(2) PIN Config1
           type         : EditNum, HEX, (0x00000000,0xFFFFFFFF)
           help         : >
-                         GPIO $(1) PIN Configuration
+                         GPIO $(1)$(2) PIN Configuration
           length       : 0x04
-          value        : $(3)
-      - GPIOElectricalCfg_$(1) :
+          value        : $(4)
+      - GPIOElectricalCfg_$(1)$(2) :
           name         : GPIO ElectricalCfg
           type         : Combo
           option       : 0x0:TermDefault, 0x1:TermNone, 0x5:TermNone, 0x9:TermWpd20K, 0x13:TermWpu1K, 0x17:TermWpu2K, 0x15:TermWpu5K, 0x19:TermWpu20K, 0x1B:TermWpu1K2K, 0x1F:TermNative, 0x20:NoTolerance1v8, 0x60:Tolerance1v8
@@ -129,9 +127,9 @@ template:
                          - TermWpu1K = 1kOhm weak pull-up, - TermWpu2K = 2kOhm weak pull-up, - TermWpu5K = 5kOhm weak pull-up, - TermWpu20K = 20kOhm weak pull-up, - TermWpu1K2K = 1kOhm & 2kOhm weak pull-up,
                          - TermNative = Native function. This setting is applicable only to some native modes,
                          - NoTolerance1v8 = Disable 1.8V pad tolerance, Tolerance1v8 = Enable 1.8V pad tolerance
-          condition    : $GPIO_CFG_DATA.GpioPinConfig1_$(1).GPIOSkip_$(1) == 0
+          condition    : $GPIO_CFG_DATA.GpioPinConfig1_$(1)$(2).GPIOSkip_$(1)$(2) == 0
           length       : 9b
-      - GPIOLockConfig_$(1) :
+      - GPIOLockConfig_$(1)$(2) :
           name         : LockConfig
           type         : Combo
           option       : 0x0:LockDefault, 0x1:PadConfigLock, 0x3:PadConfigUnlock, 0x5:PadLock , 0xC:OutputStateUnlock, 0xF:PadUnlock
@@ -140,29 +138,29 @@ template:
                          - LockDefault = Leave value of pad as-is, - PadConfigLock = Lock Pad configuration,
                          - PadConfigUnlock = Leave Pad configuration unlocked, - PadLock = Lock both Pad configuration and output control,
                          - OutputStateUnlock = Leave Pad output control unlocked, PadUnlock = Leave both Pad configuration and output control unlocked
-          condition    : $GPIO_CFG_DATA.GpioPinConfig1_$(1).GPIOSkip_$(1) == 0
+          condition    : $GPIO_CFG_DATA.GpioPinConfig1_$(1)$(2).GPIOSkip_$(1)$(2) == 0
           length       : 4b
-      - Reserved1_$(1) :
+      - Reserved1_$(1)$(2) :
           name         : Reserved1
           type         : Reserved
           length       : 3b
-      - PadNum_$(1)  :
+      - PadNum_$(1)$(2)  :
           name         : PadNum
           type         : Reserved
           length       : 8b
-      - GrpIdx_$(1)  :
+      - GrpIdx_$(1)$(2)  :
           name         : GrpIdx
           type         : Reserved
           length       : 5b
-      - Reserved2_$(1) :
+      - Reserved2_$(1)$(2) :
           name         : Reserved2
           type         : Reserved
           length       : 1b
-      - Hide_$(1)    :
+      - Hide_$(1)$(2)    :
           name         : Hide
           type         : Reserved
           length       : 1b
-      - GPIOSkip_$(1) :
+      - GPIOSkip_$(1)$(2) :
           name         : GPIO Skip
           type         : Combo
           option       : $EN_DIS
@@ -259,6 +257,52 @@ configs:
         length       : 0x8
         value        : 0xFFFFFFFFFFFFFFFF
     - Reserved     :
+        length       : 0x02
+        value        : 0x0
+
+
+  - $ACTION      :
+      page         : PIDSEL:PLT:"Payload Selection GPIO"
+  - PLATFORM_CFG_DATA :
+    - !expand { CFGHDR_TMPL : [ PLATFORM_CFG_DATA, 0x280, 0, 0 ] }
+    - PayloadSelGpio :
+      - $STRUCT      :
+          name         : GPIO pin for switching payload
+          struct       : PAYLOAD_SEL_GPIO_PIN
+          length       : 0x02
+      - PinGroup     :
+          name         : Pin Group
+          type         : Combo
+          option       : >
+                         0x0B:GPP_A, 0x00:GPP_B, 0x0D:GPP_C, 0x05:GPP_D, 0x10:GPP_E, 0x0E:GPP_F, 0x02:GPP_G, 0x04:GPP_H,
+                         0x12:GPP_R, 0x0A:GPP_S, 0x01:GPP_T, 0x06:GPP_U, 0x03:GPP_V, 0x08:GPD
+          condition    : ($PLATFORM_CFG_DATA.PayloadSelGpio.Enable > 0)
+          help         : >
+                         Specify GPIO Group Number
+          length       : 7bW
+          value        : 0
+      - Enable       :
+          name         : Payload Selection Pin Enable
+          type         : Combo
+          option       : $EN_DIS
+          help         : >
+                         Enable/Disable this pin for payload selection between OsLoader and UEFI.
+          order        : 0000.0000
+          length       : 1bW
+          value        : 0
+      - PinNumber    :
+          name         : Pin Number
+          type         : Combo
+          option       : >
+                         0:0, 1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8, 9:9,
+                         10:10, 11:11, 12:12, 13:13, 14:14, 15:15, 16:16, 17:17,
+                         18:18, 19:19, 20:20, 21:21, 22:22, 23:23
+          length       : 8bW
+          value        : 0
+          condition    : ($PLATFORM_CFG_DATA.PayloadSelGpio.Enable > 0)
+          help         : >
+                         Specify GPIO Pin Number
+    - Dummy        :
         length       : 0x02
         value        : 0x0
 

--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Ext_IotgCrb.dlt
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Ext_IotgCrb.dlt
@@ -20,6 +20,12 @@ MEMORY_CFG_DATA.MemorySpdPtr10    | {FILE: Spd_Lpddr4_8G.bin}
 
 # GPIO for payload selection pin J2E1 pins 2-4
 GEN_CFG_DATA.PayloadId | 'AUTO'
+
+# GPIO_VER3_H_GPP_D13 for payload selection pin
+PLATFORM_CFG_DATA.PayloadSelGpio.Enable                     | 1
+PLATFORM_CFG_DATA.PayloadSelGpio.PinGroup                   | 5
+PLATFORM_CFG_DATA.PayloadSelGpio.PinNumber                  | 13
+
 GPIO_CFG_DATA.GpioPinConfig0_GPP_D13.GPIODirection_GPP_D13 | 0xB
 GPIO_CFG_DATA.GpioPinConfig1_GPP_D13.GPIOSkip_GPP_D13 | 0
 

--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Gpio.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Gpio.yaml
@@ -51,265 +51,307 @@
     - GpioTableData :
         length       : 0
         value        : 0
-  - !expand { GPIO_TMPL : [ GPP_A00,  0x0150A383,  0x0B002001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A01,  0x0150A383,  0x0B012001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A02,  0x0150A383,  0x0B022001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A03,  0x0150A383,  0x0B032001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A04,  0x0150A383,  0x0B042001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A05,  0x0150A383,  0x0B052001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A06,  0x0150A383,  0x0B062001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A07,  0x0150A383,  0x0B072001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A08,  0x0150A383,  0x0B082001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A09,  0x0150A383,  0x0B092001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A10,  0x0150A383,  0x0B0A2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A11,  0x0150A383,  0x0B0B2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A12,  0x0150A383,  0x0B0C2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A13,  0x0150A383,  0x0B0D2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A14,  0x0150A383,  0x0B0E2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A15,  0x0150A383,  0x0B0F2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A16,  0x0150A383,  0x0B102001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A17,  0x0150A383,  0x0B112001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A18,  0x0150A383,  0x0B122001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A19,  0x0150A383,  0x0B132001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A20,  0x0150A383,  0x0B142001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A21,  0x0150A383,  0x0B152001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A22,  0x0150A383,  0x0B162001 ] }
-  - !expand { GPIO_TMPL : [ GPP_A23,  0x0150A383,  0x0B172001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B00,  0x0350A383,  0x80002001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B01,  0x0350A383,  0x80012001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B02,  0x0534AD81,  0x00022001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B03,  0x0350A381,  0x00032001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B04,  0x0350A381,  0x00042001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B05,  0x0350A381,  0x00052001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B06,  0x0350A381,  0x80062001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B07,  0x0350A381,  0x80072001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B08,  0x0350A381,  0x80082001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B09,  0x0350A385,  0x00092001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B10,  0x0350A385,  0x000A2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B11,  0x0350A381,  0x800B2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B12,  0x0350A383,  0x800C2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B13,  0x0350A383,  0x800D2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B14,  0x0550E281,  0x000E2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B15,  0x0518A583,  0x000F2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B16,  0x0550E283,  0x00102001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B17,  0x0510E283,  0x00112001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B18,  0x0350A283,  0x00122001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B19,  0x0350A383,  0x00132001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B20,  0x0350A383,  0x00142001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B21,  0x0350A381,  0x80152001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B22,  0x0350A283,  0x00162001 ] }
-  - !expand { GPIO_TMPL : [ GPP_B23,  0x0350A281,  0x80172001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C00,  0x0350A383,  0x0D002001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C01,  0x0350A383,  0x0D012001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C02,  0x0350A285,  0x0D022001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C03,  0x0150A283,  0x0D032001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C04,  0x0150A483,  0x0D042001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C05,  0x0350A281,  0x8D052001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C06,  0x0150A283,  0x0D062001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C07,  0x0150A483,  0x0D072001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C08,  0x0350A385,  0x8D082009 ] }
-  - !expand { GPIO_TMPL : [ GPP_C09,  0x0350A383,  0x0D092001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C10,  0x0350A383,  0x0D0A2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C11,  0x0350A383,  0x0D0B2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C12,  0x0350A383,  0x0D0C2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C13,  0x0350A383,  0x0D0D2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C14,  0x0350A385,  0x0D0E2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C15,  0x0350A383,  0x0D0F2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C16,  0x0150A483,  0x0D102001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C17,  0x0150A283,  0x0D112001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C18,  0x0350A381,  0x8D122001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C19,  0x0350A381,  0x8D132001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C20,  0x0350A389,  0x0D142001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C21,  0x0350A389,  0x0D152001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C22,  0x0350A381,  0x8D162001 ] }
-  - !expand { GPIO_TMPL : [ GPP_C23,  0x0350A381,  0x8D172001 ] }
-  - !expand { GPIO_TMPL : [ GPP_D00,  0x0350A381,  0x85002001 ] }
-  - !expand { GPIO_TMPL : [ GPP_D01,  0x0350A381,  0x85012001 ] }
-  - !expand { GPIO_TMPL : [ GPP_D02,  0x0350A381,  0x85022001 ] }
-  - !expand { GPIO_TMPL : [ GPP_D03,  0x0350A381,  0x05032001 ] }
-  - !expand { GPIO_TMPL : [ GPP_D04,  0x0350A381,  0x85042001 ] }
-  - !expand { GPIO_TMPL : [ GPP_D05,  0x0350A383,  0x05052001 ] }
-  - !expand { GPIO_TMPL : [ GPP_D06,  0x0350A383,  0x05062001 ] }
-  - !expand { GPIO_TMPL : [ GPP_D07,  0x0350A383,  0x05072001 ] }
-  - !expand { GPIO_TMPL : [ GPP_D08,  0x0350A381,  0x85082001 ] }
-  - !expand { GPIO_TMPL : [ GPP_D09,  0x0350A38F,  0x05092001 ] }
-  - !expand { GPIO_TMPL : [ GPP_D10,  0x0350A38F,  0x050A2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_D11,  0x0350A38F,  0x050B2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_D12,  0x0350A38F,  0x050C2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_D13,  0x0350A381,  0x850D2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_D14,  0x0350A381,  0x850E2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_D15,  0x0350A381,  0x850F2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_D16,  0x0350A381,  0x85102001 ] }
-  - !expand { GPIO_TMPL : [ GPP_D17,  0x0350A381,  0x05112001 ] }
-  - !expand { GPIO_TMPL : [ GPP_D18,  0x0350A381,  0x85122001 ] }
-  - !expand { GPIO_TMPL : [ GPP_D19,  0x0350A383,  0x05132001 ] }
-  - !expand { GPIO_TMPL : [ GPD00,    0x0750A383,  0x08002019 ] }
-  - !expand { GPIO_TMPL : [ GPD01,    0x0550A383,  0x08012001 ] }
-  - !expand { GPIO_TMPL : [ GPD02,    0x0350AD81,  0x08022001 ] }
-  - !expand { GPIO_TMPL : [ GPD03,    0x0750A383,  0x08032019 ] }
-  - !expand { GPIO_TMPL : [ GPD04,    0x0750A283,  0x88042001 ] }
-  - !expand { GPIO_TMPL : [ GPD05,    0x0750A283,  0x88052001 ] }
-  - !expand { GPIO_TMPL : [ GPD06,    0x0750A283,  0x88062001 ] }
-  - !expand { GPIO_TMPL : [ GPD07,    0x0550E281,  0x08072001 ] }
-  - !expand { GPIO_TMPL : [ GPD08,    0x0750A383,  0x88082001 ] }
-  - !expand { GPIO_TMPL : [ GPD09,    0x0750A281,  0x08092001 ] }
-  - !expand { GPIO_TMPL : [ GPD10,    0x0750A283,  0x880A2001 ] }
-  - !expand { GPIO_TMPL : [ GPD11,    0x0550E281,  0x080B2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E00,  0x0550E281,  0x10002001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E01,  0x0350A381,  0x10012001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E02,  0x0314AD81,  0x10022001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E03,  0x0350A383,  0x10032001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E04,  0x0350A381,  0x10042001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E05,  0x0350A383,  0x10052001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E06,  0x0350A281,  0x10062001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E07,  0x0350A383,  0x10072001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E08,  0x0350A385,  0x10082001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E09,  0x0350A381,  0x10092001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E10,  0x0350E281,  0x100A2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E11,  0x0350E281,  0x100B2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E12,  0x0350A381,  0x100C2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E13,  0x0350A381,  0x100D2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E14,  0x0350A383,  0x100E2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E15,  0x0350A385,  0x900F2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E16,  0x0350A385,  0x90102001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E17,  0x0518AD81,  0x10112001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E18,  0x0350A38B,  0x1012201F ] }
-  - !expand { GPIO_TMPL : [ GPP_E19,  0x0350A28B,  0x9013201F ] }
-  - !expand { GPIO_TMPL : [ GPP_E20,  0x0350A381,  0x90142001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E21,  0x0350A381,  0x90152001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E22,  0x0350A381,  0x90162001 ] }
-  - !expand { GPIO_TMPL : [ GPP_E23,  0x0350A281,  0x90172001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F00,  0x0350A383,  0x8E002001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F01,  0x0350A383,  0x0E012019 ] }
-  - !expand { GPIO_TMPL : [ GPP_F02,  0x0350A383,  0x8E022001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F03,  0x0350A383,  0x0E032019 ] }
-  - !expand { GPIO_TMPL : [ GPP_F04,  0x0314AD81,  0x0E042015 ] }
-  - !expand { GPIO_TMPL : [ GPP_F05,  0x0350A383,  0x0E052001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F06,  0x0350A381,  0x8E062001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F07,  0x0350A281,  0x8E072001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F08,  0x0350A38B,  0x8E082001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F09,  0x0350A383,  0x8E092001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F10,  0x0350A281,  0x8E0A2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F11,  0x0350A38B,  0x8E0B2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F12,  0x0350A38B,  0x8E0C2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F13,  0x0350A38B,  0x0E0D2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F14,  0x0350A38B,  0x8E0E2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F15,  0x0350A38B,  0x8E0F2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F16,  0x0350A38B,  0x0E102001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F17,  0x0350A38B,  0x8E112001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F18,  0x0350A381,  0x8E122001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F19,  0x0350A381,  0x8E132001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F20,  0x0314AD81,  0x0E142001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F21,  0x0550E281,  0x0E152001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F22,  0x0350A381,  0x8E162001 ] }
-  - !expand { GPIO_TMPL : [ GPP_F23,  0x0350A381,  0x8E172001 ] }
-  - !expand { GPIO_TMPL : [ GPP_G00,  0x0350A383,  0x0200201F ] }
-  - !expand { GPIO_TMPL : [ GPP_G01,  0x0350A383,  0x0201201F ] }
-  - !expand { GPIO_TMPL : [ GPP_G02,  0x0350A383,  0x0202201F ] }
-  - !expand { GPIO_TMPL : [ GPP_G03,  0x0350A383,  0x0203201F ] }
-  - !expand { GPIO_TMPL : [ GPP_G04,  0x0350A383,  0x0204201F ] }
-  - !expand { GPIO_TMPL : [ GPP_G05,  0x0350A383,  0x02052001 ] }
-  - !expand { GPIO_TMPL : [ GPP_G06,  0x0350A383,  0x02062001 ] }
-  - !expand { GPIO_TMPL : [ GPP_G07,  0x0350A381,  0x82072001 ] }
-  - !expand { GPIO_TMPL : [ GPP_G08,  0x0350A385,  0x82082001 ] }
-  - !expand { GPIO_TMPL : [ GPP_G09,  0x0350A385,  0x82092001 ] }
-  - !expand { GPIO_TMPL : [ GPP_G10,  0x0350A381,  0x820A2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_G11,  0x0350A381,  0x820B2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_G12,  0x0350A381,  0x820C2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_G13,  0x0350A389,  0x020D2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_G14,  0x0350A389,  0x020E2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_G15,  0x0350A381,  0x020F2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_G16,  0x0350A381,  0x02102001 ] }
-  - !expand { GPIO_TMPL : [ GPP_G17,  0x0350A385,  0x02112001 ] }
-  - !expand { GPIO_TMPL : [ GPP_G18,  0x0350A385,  0x02122019 ] }
-  - !expand { GPIO_TMPL : [ GPP_G19,  0x0318A581,  0x02132001 ] }
-  - !expand { GPIO_TMPL : [ GPP_G20,  0x0350A381,  0x02142001 ] }
-  - !expand { GPIO_TMPL : [ GPP_G21,  0x0350A381,  0x02152001 ] }
-  - !expand { GPIO_TMPL : [ GPP_G22,  0x0350A381,  0x02162001 ] }
-  - !expand { GPIO_TMPL : [ GPP_G23,  0x0350A383,  0x02172001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H00,  0x0150A583,  0x04002001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H01,  0x0150A283,  0x04012001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H02,  0x0150A483,  0x04022001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H03,  0x0150A483,  0x04032001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H04,  0x0350A383,  0x04042001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H05,  0x0350A383,  0x04052001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H06,  0x0350A383,  0x04062001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H07,  0x0350A383,  0x04072001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H08,  0x0350A383,  0x04082001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H09,  0x0350A383,  0x04092001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H10,  0x0350A381,  0x840A2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H11,  0x0350A381,  0x840B2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H12,  0x0350A383,  0x040C2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H13,  0x0350A383,  0x040D2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H14,  0x0350A389,  0x040E2019 ] }
-  - !expand { GPIO_TMPL : [ GPP_H15,  0x0350A383,  0x040F2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H16,  0x0350A385,  0x04102001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H17,  0x0350A383,  0x04112001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H18,  0x0350A383,  0x84122001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H19,  0x0350A385,  0x04132001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H20,  0x0350A385,  0x04142001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H21,  0x0350A383,  0x04152001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H22,  0x0350A383,  0x04162001 ] }
-  - !expand { GPIO_TMPL : [ GPP_H23,  0x0350A383,  0x04172001 ] }
-  - !expand { GPIO_TMPL : [ GPP_R00,  0x0350A385,  0x12002001 ] }
-  - !expand { GPIO_TMPL : [ GPP_R01,  0x0350A385,  0x1201201F ] }
-  - !expand { GPIO_TMPL : [ GPP_R02,  0x0350A285,  0x1202201F ] }
-  - !expand { GPIO_TMPL : [ GPP_R03,  0x0350A385,  0x1203201F ] }
-  - !expand { GPIO_TMPL : [ GPP_R04,  0x0350A38B,  0x12042001 ] }
-  - !expand { GPIO_TMPL : [ GPP_R05,  0x0350A38B,  0x12052001 ] }
-  - !expand { GPIO_TMPL : [ GPP_R06,  0x0350A38B,  0x12062001 ] }
-  - !expand { GPIO_TMPL : [ GPP_R07,  0x0350A38B,  0x12072001 ] }
-  - !expand { GPIO_TMPL : [ GPP_S00,  0x0310A383,  0x8A002009 ] }
-  - !expand { GPIO_TMPL : [ GPP_S01,  0x0310A383,  0x8A012009 ] }
-  - !expand { GPIO_TMPL : [ GPP_T00,  0x0350A387,  0x01002001 ] }
-  - !expand { GPIO_TMPL : [ GPP_T01,  0x0350A387,  0x01012001 ] }
-  - !expand { GPIO_TMPL : [ GPP_T02,  0x0350A387,  0x01022001 ] }
-  - !expand { GPIO_TMPL : [ GPP_T03,  0x0350A387,  0x01032001 ] }
-  - !expand { GPIO_TMPL : [ GPP_T04,  0x0150A583,  0x01042001 ] }
-  - !expand { GPIO_TMPL : [ GPP_T05,  0x0150A283,  0x01052001 ] }
-  - !expand { GPIO_TMPL : [ GPP_T06,  0x0150A483,  0x01062001 ] }
-  - !expand { GPIO_TMPL : [ GPP_T07,  0x0150A483,  0x01072001 ] }
-  - !expand { GPIO_TMPL : [ GPP_T08,  0x0350A381,  0x81082001 ] }
-  - !expand { GPIO_TMPL : [ GPP_T09,  0x0350A383,  0x01092001 ] }
-  - !expand { GPIO_TMPL : [ GPP_T10,  0x0350A383,  0x010A2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_T11,  0x0350A383,  0x010B2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_T12,  0x0150A383,  0x010C2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_T13,  0x0150A383,  0x010D2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_T14,  0x0150A387,  0x010E2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_T15,  0x0150A383,  0x010F2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_U00,  0x0150A583,  0x06002001 ] }
-  - !expand { GPIO_TMPL : [ GPP_U01,  0x0150E281,  0x06012001 ] }
-  - !expand { GPIO_TMPL : [ GPP_U02,  0x0150A483,  0x06022001 ] }
-  - !expand { GPIO_TMPL : [ GPP_U03,  0x0150A483,  0x06032001 ] }
-  - !expand { GPIO_TMPL : [ GPP_U04,  0x0350A381,  0x86042001 ] }
-  - !expand { GPIO_TMPL : [ GPP_U05,  0x0350A381,  0x86052001 ] }
-  - !expand { GPIO_TMPL : [ GPP_U06,  0x0350A381,  0x86062001 ] }
-  - !expand { GPIO_TMPL : [ GPP_U07,  0x0350A381,  0x86072001 ] }
-  - !expand { GPIO_TMPL : [ GPP_U08,  0x0350A381,  0x86082001 ] }
-  - !expand { GPIO_TMPL : [ GPP_U09,  0x0350A381,  0x86092001 ] }
-  - !expand { GPIO_TMPL : [ GPP_U10,  0x0350A381,  0x860A2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_U11,  0x0350A381,  0x860B2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_U12,  0x0350A383,  0x860C2009 ] }
-  - !expand { GPIO_TMPL : [ GPP_U13,  0x0350A383,  0x860D2009 ] }
-  - !expand { GPIO_TMPL : [ GPP_U14,  0x0350A383,  0x060E2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_U15,  0x0350A383,  0x060F2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_U16,  0x0350A383,  0x06102001 ] }
-  - !expand { GPIO_TMPL : [ GPP_U17,  0x0350A383,  0x06112001 ] }
-  - !expand { GPIO_TMPL : [ GPP_U18,  0x0350A383,  0x06122001 ] }
-  - !expand { GPIO_TMPL : [ GPP_U19,  0x0350A381,  0x86132001 ] }
-  - !expand { GPIO_TMPL : [ GPP_V00,  0x0350A383,  0x03002019 ] }
-  - !expand { GPIO_TMPL : [ GPP_V01,  0x0350A383,  0x03012019 ] }
-  - !expand { GPIO_TMPL : [ GPP_V02,  0x0350A383,  0x03022019 ] }
-  - !expand { GPIO_TMPL : [ GPP_V03,  0x0350A383,  0x03032019 ] }
-  - !expand { GPIO_TMPL : [ GPP_V04,  0x0350A383,  0x03042019 ] }
-  - !expand { GPIO_TMPL : [ GPP_V05,  0x0350A383,  0x03052019 ] }
-  - !expand { GPIO_TMPL : [ GPP_V06,  0x0350A383,  0x03062019 ] }
-  - !expand { GPIO_TMPL : [ GPP_V07,  0x0350A383,  0x03072019 ] }
-  - !expand { GPIO_TMPL : [ GPP_V08,  0x0350A383,  0x03082019 ] }
-  - !expand { GPIO_TMPL : [ GPP_V09,  0x0350A383,  0x03092009 ] }
-  - !expand { GPIO_TMPL : [ GPP_V10,  0x0350A383,  0x030A2009 ] }
-  - !expand { GPIO_TMPL : [ GPP_V11,  0x0350A383,  0x030B2019 ] }
-  - !expand { GPIO_TMPL : [ GPP_V12,  0x0350A381,  0x830C2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_V13,  0x0550E281,  0x030D2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_V14,  0x0550E281,  0x030E2001 ] }
-  - !expand { GPIO_TMPL : [ GPP_V15,  0x0518A581,  0x030F2001 ] }
+
+  - $ACTION      :
+      page         : GIO_GPP_A:GIO:"GPIO GPP_A"
+  - !expand { GPIO_TMPL : [ GPP_A,  00,  0x0150A383,  0x0B002001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  01,  0x0150A383,  0x0B012001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  02,  0x0150A383,  0x0B022001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  03,  0x0150A383,  0x0B032001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  04,  0x0150A383,  0x0B042001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  05,  0x0150A383,  0x0B052001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  06,  0x0150A383,  0x0B062001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  07,  0x0150A383,  0x0B072001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  08,  0x0150A383,  0x0B082001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  09,  0x0150A383,  0x0B092001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  10,  0x0150A383,  0x0B0A2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  11,  0x0150A383,  0x0B0B2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  12,  0x0150A383,  0x0B0C2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  13,  0x0150A383,  0x0B0D2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  14,  0x0150A383,  0x0B0E2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  15,  0x0150A383,  0x0B0F2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  16,  0x0150A383,  0x0B102001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  17,  0x0150A383,  0x0B112001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  18,  0x0150A383,  0x0B122001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  19,  0x0150A383,  0x0B132001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  20,  0x0150A383,  0x0B142001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  21,  0x0150A383,  0x0B152001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  22,  0x0150A383,  0x0B162001 ] }
+  - !expand { GPIO_TMPL : [ GPP_A,  23,  0x0150A383,  0x0B172001 ] }
+
+  - $ACTION      :
+      page         : GIO_GPP_B:GIO:"GPIO GPP_B"
+  - !expand { GPIO_TMPL : [ GPP_B,  00,  0x0350A383,  0x80002001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  01,  0x0350A383,  0x80012001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  02,  0x0534AD81,  0x00022001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  03,  0x0350A381,  0x00032001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  04,  0x0350A381,  0x00042001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  05,  0x0350A381,  0x00052001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  06,  0x0350A381,  0x80062001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  07,  0x0350A381,  0x80072001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  08,  0x0350A381,  0x80082001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  09,  0x0350A385,  0x00092001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  10,  0x0350A385,  0x000A2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  11,  0x0350A381,  0x800B2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  12,  0x0350A383,  0x800C2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  13,  0x0350A383,  0x800D2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  14,  0x0550E281,  0x000E2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  15,  0x0518A583,  0x000F2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  16,  0x0550E283,  0x00102001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  17,  0x0510E283,  0x00112001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  18,  0x0350A283,  0x00122001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  19,  0x0350A383,  0x00132001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  20,  0x0350A383,  0x00142001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  21,  0x0350A381,  0x80152001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  22,  0x0350A283,  0x00162001 ] }
+  - !expand { GPIO_TMPL : [ GPP_B,  23,  0x0350A281,  0x80172001 ] }
+
+  - $ACTION      :
+      page         : GIO_GPP_C:GIO:"GPIO GPP_C"
+  - !expand { GPIO_TMPL : [ GPP_C,  00,  0x0350A383,  0x0D002001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  01,  0x0350A383,  0x0D012001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  02,  0x0350A285,  0x0D022001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  03,  0x0150A283,  0x0D032001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  04,  0x0150A483,  0x0D042001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  05,  0x0350A281,  0x8D052001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  06,  0x0150A283,  0x0D062001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  07,  0x0150A483,  0x0D072001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  08,  0x0350A385,  0x8D082009 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  09,  0x0350A383,  0x0D092001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  10,  0x0350A383,  0x0D0A2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  11,  0x0350A383,  0x0D0B2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  12,  0x0350A383,  0x0D0C2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  13,  0x0350A383,  0x0D0D2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  14,  0x0350A385,  0x0D0E2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  15,  0x0350A383,  0x0D0F2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  16,  0x0150A483,  0x0D102001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  17,  0x0150A283,  0x0D112001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  18,  0x0350A381,  0x8D122001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  19,  0x0350A381,  0x8D132001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  20,  0x0350A389,  0x0D142001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  21,  0x0350A389,  0x0D152001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  22,  0x0350A381,  0x8D162001 ] }
+  - !expand { GPIO_TMPL : [ GPP_C,  23,  0x0350A381,  0x8D172001 ] }
+
+  - $ACTION      :
+      page         : GIO_GPP_D:GIO:"GPIO GPP_D"
+  - !expand { GPIO_TMPL : [ GPP_D,  00,  0x0350A381,  0x85002001 ] }
+  - !expand { GPIO_TMPL : [ GPP_D,  01,  0x0350A381,  0x85012001 ] }
+  - !expand { GPIO_TMPL : [ GPP_D,  02,  0x0350A381,  0x85022001 ] }
+  - !expand { GPIO_TMPL : [ GPP_D,  03,  0x0350A381,  0x05032001 ] }
+  - !expand { GPIO_TMPL : [ GPP_D,  04,  0x0350A381,  0x85042001 ] }
+  - !expand { GPIO_TMPL : [ GPP_D,  05,  0x0350A383,  0x05052001 ] }
+  - !expand { GPIO_TMPL : [ GPP_D,  06,  0x0350A383,  0x05062001 ] }
+  - !expand { GPIO_TMPL : [ GPP_D,  07,  0x0350A383,  0x05072001 ] }
+  - !expand { GPIO_TMPL : [ GPP_D,  08,  0x0350A381,  0x85082001 ] }
+  - !expand { GPIO_TMPL : [ GPP_D,  09,  0x0350A38F,  0x05092001 ] }
+  - !expand { GPIO_TMPL : [ GPP_D,  10,  0x0350A38F,  0x050A2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_D,  11,  0x0350A38F,  0x050B2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_D,  12,  0x0350A38F,  0x050C2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_D,  13,  0x0350A381,  0x850D2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_D,  14,  0x0350A381,  0x850E2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_D,  15,  0x0350A381,  0x850F2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_D,  16,  0x0350A381,  0x85102001 ] }
+  - !expand { GPIO_TMPL : [ GPP_D,  17,  0x0350A381,  0x05112001 ] }
+  - !expand { GPIO_TMPL : [ GPP_D,  18,  0x0350A381,  0x85122001 ] }
+  - !expand { GPIO_TMPL : [ GPP_D,  19,  0x0350A383,  0x05132001 ] }
+
+  - $ACTION      :
+      page         : GIO_GPD:GIO:"GPIO GPD"
+  - !expand { GPIO_TMPL : [ GPD,  00,    0x0750A383,  0x08002019 ] }
+  - !expand { GPIO_TMPL : [ GPD,  01,    0x0550A383,  0x08012001 ] }
+  - !expand { GPIO_TMPL : [ GPD,  02,    0x0350AD81,  0x08022001 ] }
+  - !expand { GPIO_TMPL : [ GPD,  03,    0x0750A383,  0x08032019 ] }
+  - !expand { GPIO_TMPL : [ GPD,  04,    0x0750A283,  0x88042001 ] }
+  - !expand { GPIO_TMPL : [ GPD,  05,    0x0750A283,  0x88052001 ] }
+  - !expand { GPIO_TMPL : [ GPD,  06,    0x0750A283,  0x88062001 ] }
+  - !expand { GPIO_TMPL : [ GPD,  07,    0x0550E281,  0x08072001 ] }
+  - !expand { GPIO_TMPL : [ GPD,  08,    0x0750A383,  0x88082001 ] }
+  - !expand { GPIO_TMPL : [ GPD,  09,    0x0750A281,  0x08092001 ] }
+  - !expand { GPIO_TMPL : [ GPD,  10,    0x0750A283,  0x880A2001 ] }
+  - !expand { GPIO_TMPL : [ GPD,  11,    0x0550E281,  0x080B2001 ] }
+
+  - $ACTION      :
+      page         : GIO_GPP_E:GIO:"GPIO GPP_E"
+  - !expand { GPIO_TMPL : [ GPP_E,  00,  0x0550E281,  0x10002001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  01,  0x0350A381,  0x10012001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  02,  0x0314AD81,  0x10022001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  03,  0x0350A383,  0x10032001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  04,  0x0350A381,  0x10042001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  05,  0x0350A383,  0x10052001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  06,  0x0350A281,  0x10062001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  07,  0x0350A383,  0x10072001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  08,  0x0350A385,  0x10082001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  09,  0x0350A381,  0x10092001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  10,  0x0350E281,  0x100A2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  11,  0x0350E281,  0x100B2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  12,  0x0350A381,  0x100C2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  13,  0x0350A381,  0x100D2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  14,  0x0350A383,  0x100E2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  15,  0x0350A385,  0x900F2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  16,  0x0350A385,  0x90102001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  17,  0x0518AD81,  0x10112001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  18,  0x0350A38B,  0x1012201F ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  19,  0x0350A28B,  0x9013201F ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  20,  0x0350A381,  0x90142001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  21,  0x0350A381,  0x90152001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  22,  0x0350A381,  0x90162001 ] }
+  - !expand { GPIO_TMPL : [ GPP_E,  23,  0x0350A281,  0x90172001 ] }
+
+  - $ACTION      :
+      page         : GIO_GPP_F:GIO:"GPIO GPP_F"
+  - !expand { GPIO_TMPL : [ GPP_F, 00,  0x0350A383,  0x8E002001 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 01,  0x0350A383,  0x0E012019 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 02,  0x0350A383,  0x8E022001 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 03,  0x0350A383,  0x0E032019 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 04,  0x0314AD81,  0x0E042015 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 05,  0x0350A383,  0x0E052001 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 06,  0x0350A381,  0x8E062001 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 07,  0x0350A281,  0x8E072001 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 08,  0x0350A38B,  0x8E082001 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 09,  0x0350A383,  0x8E092001 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 10,  0x0350A281,  0x8E0A2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 11,  0x0350A38B,  0x8E0B2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 12,  0x0350A38B,  0x8E0C2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 13,  0x0350A38B,  0x0E0D2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 14,  0x0350A38B,  0x8E0E2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 15,  0x0350A38B,  0x8E0F2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 16,  0x0350A38B,  0x0E102001 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 17,  0x0350A38B,  0x8E112001 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 18,  0x0350A381,  0x8E122001 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 19,  0x0350A381,  0x8E132001 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 20,  0x0314AD81,  0x0E142001 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 21,  0x0550E281,  0x0E152001 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 22,  0x0350A381,  0x8E162001 ] }
+  - !expand { GPIO_TMPL : [ GPP_F, 23,  0x0350A381,  0x8E172001 ] }
+
+  - $ACTION      :
+      page         : GIO_GPP_G:GIO:"GPIO GPP_G"
+  - !expand { GPIO_TMPL : [ GPP_G,  00,  0x0350A383,  0x0200201F ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  01,  0x0350A383,  0x0201201F ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  02,  0x0350A383,  0x0202201F ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  03,  0x0350A383,  0x0203201F ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  04,  0x0350A383,  0x0204201F ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  05,  0x0350A383,  0x02052001 ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  06,  0x0350A383,  0x02062001 ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  07,  0x0350A381,  0x82072001 ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  08,  0x0350A385,  0x82082001 ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  09,  0x0350A385,  0x82092001 ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  10,  0x0350A381,  0x820A2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  11,  0x0350A381,  0x820B2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  12,  0x0350A381,  0x820C2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  13,  0x0350A389,  0x020D2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  14,  0x0350A389,  0x020E2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  15,  0x0350A381,  0x020F2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  16,  0x0350A381,  0x02102001 ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  17,  0x0350A385,  0x02112001 ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  18,  0x0350A385,  0x02122019 ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  19,  0x0318A581,  0x02132001 ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  20,  0x0350A381,  0x02142001 ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  21,  0x0350A381,  0x02152001 ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  22,  0x0350A381,  0x02162001 ] }
+  - !expand { GPIO_TMPL : [ GPP_G,  23,  0x0350A383,  0x02172001 ] }
+
+  - $ACTION      :
+      page         : GIO_GPP_H:GIO:"GPIO GPP_H"
+  - !expand { GPIO_TMPL : [ GPP_H,  00,  0x0150A583,  0x04002001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  01,  0x0150A283,  0x04012001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  02,  0x0150A483,  0x04022001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  03,  0x0150A483,  0x04032001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  04,  0x0350A383,  0x04042001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  05,  0x0350A383,  0x04052001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  06,  0x0350A383,  0x04062001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  07,  0x0350A383,  0x04072001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  08,  0x0350A383,  0x04082001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  09,  0x0350A383,  0x04092001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  10,  0x0350A381,  0x840A2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  11,  0x0350A381,  0x840B2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  12,  0x0350A383,  0x040C2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  13,  0x0350A383,  0x040D2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  14,  0x0350A389,  0x040E2019 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  15,  0x0350A383,  0x040F2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  16,  0x0350A385,  0x04102001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  17,  0x0350A383,  0x04112001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  18,  0x0350A383,  0x84122001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  19,  0x0350A385,  0x04132001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  20,  0x0350A385,  0x04142001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  21,  0x0350A383,  0x04152001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  22,  0x0350A383,  0x04162001 ] }
+  - !expand { GPIO_TMPL : [ GPP_H,  23,  0x0350A383,  0x04172001 ] }
+
+  - $ACTION      :
+      page         : GIO_GPP_R:GIO:"GPIO GPP_R"
+  - !expand { GPIO_TMPL : [ GPP_R,  00,  0x0350A385,  0x12002001 ] }
+  - !expand { GPIO_TMPL : [ GPP_R,  01,  0x0350A385,  0x1201201F ] }
+  - !expand { GPIO_TMPL : [ GPP_R,  02,  0x0350A285,  0x1202201F ] }
+  - !expand { GPIO_TMPL : [ GPP_R,  03,  0x0350A385,  0x1203201F ] }
+  - !expand { GPIO_TMPL : [ GPP_R,  04,  0x0350A38B,  0x12042001 ] }
+  - !expand { GPIO_TMPL : [ GPP_R,  05,  0x0350A38B,  0x12052001 ] }
+  - !expand { GPIO_TMPL : [ GPP_R,  06,  0x0350A38B,  0x12062001 ] }
+  - !expand { GPIO_TMPL : [ GPP_R,  07,  0x0350A38B,  0x12072001 ] }
+
+  - $ACTION      :
+      page         : GIO_GPP_S:GIO:"GPIO GPP_S"
+  - !expand { GPIO_TMPL : [ GPP_S,  00,  0x0310A383,  0x8A002009 ] }
+  - !expand { GPIO_TMPL : [ GPP_S,  01,  0x0310A383,  0x8A012009 ] }
+
+  - $ACTION      :
+      page         : GIO_GPP_T:GIO:"GPIO GPP_T"
+  - !expand { GPIO_TMPL : [ GPP_T,  00,  0x0350A387,  0x01002001 ] }
+  - !expand { GPIO_TMPL : [ GPP_T,  01,  0x0350A387,  0x01012001 ] }
+  - !expand { GPIO_TMPL : [ GPP_T,  02,  0x0350A387,  0x01022001 ] }
+  - !expand { GPIO_TMPL : [ GPP_T,  03,  0x0350A387,  0x01032001 ] }
+  - !expand { GPIO_TMPL : [ GPP_T,  04,  0x0150A583,  0x01042001 ] }
+  - !expand { GPIO_TMPL : [ GPP_T,  05,  0x0150A283,  0x01052001 ] }
+  - !expand { GPIO_TMPL : [ GPP_T,  06,  0x0150A483,  0x01062001 ] }
+  - !expand { GPIO_TMPL : [ GPP_T,  07,  0x0150A483,  0x01072001 ] }
+  - !expand { GPIO_TMPL : [ GPP_T,  08,  0x0350A381,  0x81082001 ] }
+  - !expand { GPIO_TMPL : [ GPP_T,  09,  0x0350A383,  0x01092001 ] }
+  - !expand { GPIO_TMPL : [ GPP_T,  10,  0x0350A383,  0x010A2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_T,  11,  0x0350A383,  0x010B2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_T,  12,  0x0150A383,  0x010C2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_T,  13,  0x0150A383,  0x010D2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_T,  14,  0x0150A387,  0x010E2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_T,  15,  0x0150A383,  0x010F2001 ] }
+
+  - $ACTION      :
+      page         : GIO_GPP_U:GIO:"GPIO GPP_U"
+  - !expand { GPIO_TMPL : [ GPP_U,  00,  0x0150A583,  0x06002001 ] }
+  - !expand { GPIO_TMPL : [ GPP_U,  01,  0x0150E281,  0x06012001 ] }
+  - !expand { GPIO_TMPL : [ GPP_U,  02,  0x0150A483,  0x06022001 ] }
+  - !expand { GPIO_TMPL : [ GPP_U,  03,  0x0150A483,  0x06032001 ] }
+  - !expand { GPIO_TMPL : [ GPP_U,  04,  0x0350A381,  0x86042001 ] }
+  - !expand { GPIO_TMPL : [ GPP_U,  05,  0x0350A381,  0x86052001 ] }
+  - !expand { GPIO_TMPL : [ GPP_U,  06,  0x0350A381,  0x86062001 ] }
+  - !expand { GPIO_TMPL : [ GPP_U,  07,  0x0350A381,  0x86072001 ] }
+  - !expand { GPIO_TMPL : [ GPP_U,  08,  0x0350A381,  0x86082001 ] }
+  - !expand { GPIO_TMPL : [ GPP_U,  09,  0x0350A381,  0x86092001 ] }
+  - !expand { GPIO_TMPL : [ GPP_U,  10,  0x0350A381,  0x860A2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_U,  11,  0x0350A381,  0x860B2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_U,  12,  0x0350A383,  0x860C2009 ] }
+  - !expand { GPIO_TMPL : [ GPP_U,  13,  0x0350A383,  0x860D2009 ] }
+  - !expand { GPIO_TMPL : [ GPP_U,  14,  0x0350A383,  0x060E2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_U,  15,  0x0350A383,  0x060F2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_U,  16,  0x0350A383,  0x06102001 ] }
+  - !expand { GPIO_TMPL : [ GPP_U,  17,  0x0350A383,  0x06112001 ] }
+  - !expand { GPIO_TMPL : [ GPP_U,  18,  0x0350A383,  0x06122001 ] }
+  - !expand { GPIO_TMPL : [ GPP_U,  19,  0x0350A381,  0x86132001 ] }
+
+  - $ACTION      :
+      page         : GIO_GPP_V:GIO:"GPIO GPP_V"
+  - !expand { GPIO_TMPL : [ GPP_V,  00,  0x0350A383,  0x03002019 ] }
+  - !expand { GPIO_TMPL : [ GPP_V,  01,  0x0350A383,  0x03012019 ] }
+  - !expand { GPIO_TMPL : [ GPP_V,  02,  0x0350A383,  0x03022019 ] }
+  - !expand { GPIO_TMPL : [ GPP_V,  03,  0x0350A383,  0x03032019 ] }
+  - !expand { GPIO_TMPL : [ GPP_V,  04,  0x0350A383,  0x03042019 ] }
+  - !expand { GPIO_TMPL : [ GPP_V,  05,  0x0350A383,  0x03052019 ] }
+  - !expand { GPIO_TMPL : [ GPP_V,  06,  0x0350A383,  0x03062019 ] }
+  - !expand { GPIO_TMPL : [ GPP_V,  07,  0x0350A383,  0x03072019 ] }
+  - !expand { GPIO_TMPL : [ GPP_V,  08,  0x0350A383,  0x03082019 ] }
+  - !expand { GPIO_TMPL : [ GPP_V,  09,  0x0350A383,  0x03092009 ] }
+  - !expand { GPIO_TMPL : [ GPP_V,  10,  0x0350A383,  0x030A2009 ] }
+  - !expand { GPIO_TMPL : [ GPP_V,  11,  0x0350A383,  0x030B2019 ] }
+  - !expand { GPIO_TMPL : [ GPP_V,  12,  0x0350A381,  0x830C2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_V,  13,  0x0550E281,  0x030D2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_V,  14,  0x0550E281,  0x030E2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_V,  15,  0x0518A581,  0x030F2001 ] }

--- a/Silicon/ElkhartlakePkg/Include/Register/GpioPinsVer3.h
+++ b/Silicon/ElkhartlakePkg/Include/Register/GpioPinsVer3.h
@@ -39,6 +39,7 @@
 /// require GpioPad as argument. Encoding used here
 /// has all information required by library functions
 ///
+#define GPIO_VER3_GPP_B0                  0x0B000000
 #define GPIO_VER3_GPP_B1                  0x0B000001
 #define GPIO_VER3_GPP_B2                  0x0B000002
 #define GPIO_VER3_GPP_B14                 0x0B00000E


### PR DESCRIPTION
This patch added payload selection GPIO configuration
hardcoded GPIO pin for payload selection.

It also fixed #1196.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>
Co-authored-by: Lean Sheng Tan <lean.sheng.tan@intel.com>