### PR TITLE
Adjust PCI resource check condition

### DIFF
--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
@@ -1594,8 +1594,10 @@ PciProgramResources (
       Root->PciBar[BarType - 1].BaseAddress = Address;
       ProgramResource (Root, BarType);
 
-      ResBase[Index] += Root->PciBar[BarType - 1].Length;
-      ASSERT (ResBase[Index] <= ResLimit[Index]);
+      if (Root->PciBar[BarType - 1].Length > 0) {
+        ResBase[Index] += Root->PciBar[BarType - 1].Length;
+        ASSERT (ResBase[Index] <= ResLimit[Index]);
+      }
     }
 
     CurrentLink = CurrentLink->ForwardLink;


### PR DESCRIPTION
Current PciBus lib expects the root bridge resource base should not be
greater than limit. It is true for normal case. However, to mark the
source is unavailable, the base could be less than the limit in some
case. PCI bus lib should only validate the resource that does have a
request.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>