### PR TITLE
Resolve fs cmd KW issue

### DIFF
--- a/BootloaderCommonPkg/Include/Guid/OsBootOptionGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/OsBootOptionGuid.h
@@ -63,7 +63,6 @@ typedef enum {
   OsBootDeviceUsb,
   OsBootDeviceNvme,
   OsBootDeviceMemory,
-  OsBootDeviceGraphics,
   OsBootDeviceMax
 } OS_BOOT_MEDIUM_TYPE;
 

--- a/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -36,7 +36,6 @@ CONST PLT_DEVICE  mPlatformDevices[]= {
   {{0x00000300}, OsBootDeviceSd    , 0 },
   {{0x00000300}, OsBootDeviceNvme  , 0 },
   {{0x00000400}, OsBootDeviceUsb   , 0 },
-  {{0x00000100}, OsBootDeviceGraphics, 0 },
   {{0x01000000}, OsBootDeviceMemory, 0 }
 };
 

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -36,6 +36,11 @@ CONST DISPLAY_TIMING_INFO mDefaultTiming = {
   600,   1,  4,   23, 1
 };
 
+UINT8
+GetGraphicsDeviceNumber (
+  VOID
+);
+
 /**
   Test variable services.
 
@@ -231,7 +236,7 @@ EmuGraphicsInit (
     GfxPolicy.DisaplayTimingInfo.Vdisp = QemuVbt->ResY;
   }
 
-  DevPciBase = GetDeviceAddr (OsBootDeviceGraphics, 0);
+  DevPciBase = ((UINT32) GetGraphicsDeviceNumber ()) << 8;
   Status = GraphicsInit (DevPciBase, &GfxPolicy);
   if (!EFI_ERROR (Status)) {
     Status = GetGraphicOutputModeInfo (&GopMode);


### PR DESCRIPTION
Currently the PLT_DEVICE_TABLE is limited
to only using OS_BOOT_MEDIUM_TYPE devices
but ideally should be capable of mapping
any system device into the table. For the
time being we will remove the OsBootDeviceGraphics
since it created some KW issue in the fs command.

Signed-off-by: James Gutbub <james.gutbub@intel.com>