### PR TITLE
Enhance 64bit to 32bit thunk code

### DIFF
--- a/BootloaderCommonPkg/Library/ThunkLib/X64/Thunk64To32.nasm
+++ b/BootloaderCommonPkg/Library/ThunkLib/X64/Thunk64To32.nasm
@@ -1,5 +1,5 @@
 ;
-; Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ;
@@ -152,6 +152,16 @@ ReturnBack:
     pop   rcx                  ; drop param1
     pop   rcx                  ; drop param2
 
+    ;
+    ; Ensure paging is always disabled
+    ;
+    mov     rax, cr0
+    bt      rax, 31
+    jnc     ReloadPagingTbl
+    btc     rax, 31
+    mov     cr0, rax
+
+ReloadPagingTbl:
     ;
     ; restore CR4 PAE
     ;


### PR DESCRIPTION
In some cases the paging will be enabled after returning from the
thunked function. To ensure the paging table can be reloaded before
switching back to x64 mode, the paging needs to be in disabled
state. This patch ensures the CR0 bit31 paging bit is cleared.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>