### PR TITLE
Add platform device type enum definitions

### DIFF
--- a/BootloaderCommonPkg/Include/Guid/OsBootOptionGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/OsBootOptionGuid.h
@@ -54,6 +54,7 @@ typedef enum {
   Reserved      = BIT6 | BIT7
 } RESET_CAUSE;
 
+// Define OS boot media devices
 typedef enum {
   OsBootDeviceSata,
   OsBootDeviceSd,
@@ -65,6 +66,13 @@ typedef enum {
   OsBootDeviceMemory,
   OsBootDeviceMax
 } OS_BOOT_MEDIUM_TYPE;
+
+// Define other platform devices as an extention to OS_BOOT_MEDIUM_TYPE
+typedef enum {
+  PlatformDeviceMin = OsBootDeviceMax,
+  PlatformDeviceGraphics,
+  PlatformDeviceMax
+} PLATFORM_DEVICE_TYPE;
 
 typedef enum  {
   EnumFileSystemTypeFat,


### PR DESCRIPTION
SBL defined SetDeviceAddr/GetDeviceAddr to abstract platform
device info. However, currently only boot media devices are
defined. It has cases that other platform device info is needed,
such as GFX device. This patch extended the concept to define
some other platform devices as an extenstion to
OS_BOOT_MEDIUM_TYPE. The enum values should not overlap with
the ones defined in OS_BOOT_MEDIUM_TYPE.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>