### PR TITLE
[EHL] Disable New GPIO scheme by default

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Ext_IotgCrb.dlt
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Ext_IotgCrb.dlt
@@ -31,7 +31,7 @@ GPIO_CFG_DATA.GpioPinConfig1_GPP_D13.GPIOSkip_GPP_D13 | 0
 
 # Enable to test TCC mode & tuning
 # FEATURES_CFG_DATA.Features.Tcc    | 0x1
-FEATURES_CFG_DATA.Features.NewGpioSchemeEnable      | 0x1
+FEATURES_CFG_DATA.Features.NewGpioSchemeEnable      | 0x0
 # Enable S0ix by default. For EHL, only S0i2.0 is supported
 FEATURES_CFG_DATA.Features.S0ix     | 0x1
 


### PR DESCRIPTION
Disable the new GPIO scheme by default in dlt file
Only enable this option for kernel version 4.18.0-315
Alternatively with kernel module parameter
'module_blacklist=pinctrl_elkhartlake' will works
without enabling this GPIO scheme.

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>