### PR TITLE
[CML] Fix RTC S3 wake hang

### DIFF
--- a/Platform/CometlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CometlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017-2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017-2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -275,6 +275,8 @@ ClearSmi (
 {
   UINT32                SmiEn;
   UINT32                SmiSts;
+  UINT32                Pm1Sts;
+  UINT16                Pm1Cnt;
 
   SmiEn = IoRead32 ((UINTN)(UINT32)(ACPI_BASE_ADDRESS + R_ACPI_IO_SMI_EN));
   if (((SmiEn & B_ACPI_IO_SMI_EN_GBL_SMI) !=0) && ((SmiEn & B_ACPI_IO_SMI_EN_EOS) !=0)) {
@@ -284,18 +286,46 @@ ClearSmi (
   //
   // Clear the status before setting smi enable
   //
-  SmiSts = IoRead32 ((UINTN)(UINT32)(ACPI_BASE_ADDRESS + R_ACPI_IO_SMI_EN + 4));
+  SmiSts = IoRead32 ((UINTN)(UINT32)(ACPI_BASE_ADDRESS + R_ACPI_IO_SMI_STS));
+  Pm1Sts = IoRead32 ((UINTN)(ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_STS));
+  Pm1Cnt = IoRead16 ((UINTN)(ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_CNT));
+
+  // Clear RTC alarm and corresponding Pm1Sts only if wake-up source is RTC SMI#
+  if (((Pm1Sts & B_ACPI_IO_PM1_STS_RTC_EN) != 0) &&
+      ((Pm1Sts & B_ACPI_IO_PM1_STS_RTC) != 0) &&
+      ((Pm1Cnt & B_ACPI_IO_PM1_CNT_SCI_EN) == 0)) {
+    IoWrite8 (R_RTC_IO_INDEX, R_RTC_IO_REGC);
+    IoRead8 (R_RTC_IO_TARGET); /* RTC alarm is cleared upon read */
+    Pm1Sts |= B_ACPI_IO_PM1_STS_RTC;
+  }
+
   SmiSts |=
     (
       B_ACPI_IO_SMI_STS_SMBUS |
       B_ACPI_IO_SMI_STS_PERIODIC |
       B_ACPI_IO_SMI_STS_TCO |
+      B_ACPI_IO_SMI_STS_MCSMI |
       B_ACPI_IO_SMI_STS_SWSMI_TMR |
       B_ACPI_IO_SMI_STS_APM |
       B_ACPI_IO_SMI_STS_ON_SLP_EN |
       B_ACPI_IO_SMI_STS_BIOS
     );
-  IoWrite32 ((UINTN)(UINT32)(ACPI_BASE_ADDRESS + R_ACPI_IO_SMI_EN + 4), SmiSts);
+
+  Pm1Sts |=
+    (
+      B_ACPI_IO_PM1_STS_WAK |
+      B_ACPI_IO_PM1_STS_PRBTNOR |
+      B_ACPI_IO_PM1_STS_PWRBTN |
+      B_ACPI_IO_PM1_STS_GBL |
+      B_ACPI_IO_PM1_STS_TMROF
+      );
+
+  IoWrite32 ((UINTN)(UINT32)(ACPI_BASE_ADDRESS + R_ACPI_IO_SMI_STS), SmiSts);
+  IoWrite16 ((UINTN) (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_STS), (UINT16) Pm1Sts);
+
+  // Clear GPE0 STS in case some bits are set
+  IoOr32 ((UINTN)(UINT32)(ACPI_BASE_ADDRESS + R_ACPI_IO_GPE0_STS_127_96), 0);
+
 }
 
 
@@ -1136,6 +1166,7 @@ BoardInit (
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_WARN, "VBT not found %r\n", Status));
     }
+    ClearSmi ();
     if (GetPayloadId () == UEFI_PAYLOAD_ID_SIGNATURE && GetBootMode() != BOOT_ON_S3_RESUME) {
       ClearS3SaveRegion ();
       //

--- a/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017-2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017-2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -268,6 +268,8 @@ ClearSmi (
 {
   UINT32                SmiEn;
   UINT32                SmiSts;
+  UINT32                Pm1Sts;
+  UINT16                Pm1Cnt;
 
   SmiEn = IoRead32 ((UINTN)(UINT32)(ACPI_BASE_ADDRESS + R_ACPI_IO_SMI_EN));
   if (((SmiEn & B_ACPI_IO_SMI_EN_GBL_SMI) !=0) && ((SmiEn & B_ACPI_IO_SMI_EN_EOS) !=0)) {
@@ -277,18 +279,46 @@ ClearSmi (
   //
   // Clear the status before setting smi enable
   //
-  SmiSts = IoRead32 ((UINTN)(UINT32)(ACPI_BASE_ADDRESS + R_ACPI_IO_SMI_EN + 4));
+  SmiSts = IoRead32 ((UINTN)(UINT32)(ACPI_BASE_ADDRESS + R_ACPI_IO_SMI_STS));
+  Pm1Sts = IoRead32 ((UINTN)(ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_STS));
+  Pm1Cnt = IoRead16 ((UINTN)(ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_CNT));
+
+  // Clear RTC alarm and corresponding Pm1Sts only if wake-up source is RTC SMI#
+  if (((Pm1Sts & B_ACPI_IO_PM1_STS_RTC_EN) != 0) &&
+      ((Pm1Sts & B_ACPI_IO_PM1_STS_RTC) != 0) &&
+      ((Pm1Cnt & B_ACPI_IO_PM1_CNT_SCI_EN) == 0)) {
+    IoWrite8 (R_RTC_IO_INDEX, R_RTC_IO_REGC);
+    IoRead8 (R_RTC_IO_TARGET); /* RTC alarm is cleared upon read */
+    Pm1Sts |= B_ACPI_IO_PM1_STS_RTC;
+  }
+
   SmiSts |=
     (
       B_ACPI_IO_SMI_STS_SMBUS |
       B_ACPI_IO_SMI_STS_PERIODIC |
       B_ACPI_IO_SMI_STS_TCO |
+      B_ACPI_IO_SMI_STS_MCSMI |
       B_ACPI_IO_SMI_STS_SWSMI_TMR |
       B_ACPI_IO_SMI_STS_APM |
       B_ACPI_IO_SMI_STS_ON_SLP_EN |
       B_ACPI_IO_SMI_STS_BIOS
     );
-  IoWrite32 ((UINTN)(UINT32)(ACPI_BASE_ADDRESS + R_ACPI_IO_SMI_EN + 4), SmiSts);
+
+  Pm1Sts |=
+    (
+      B_ACPI_IO_PM1_STS_WAK |
+      B_ACPI_IO_PM1_STS_PRBTNOR |
+      B_ACPI_IO_PM1_STS_PWRBTN |
+      B_ACPI_IO_PM1_STS_GBL |
+      B_ACPI_IO_PM1_STS_TMROF
+      );
+
+  IoWrite32 ((UINTN)(UINT32)(ACPI_BASE_ADDRESS + R_ACPI_IO_SMI_STS), SmiSts);
+  IoWrite16 ((UINTN) (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_STS), (UINT16) Pm1Sts);
+
+  // Clear GPE0 STS in case some bits are set
+  IoOr32 ((UINTN)(UINT32)(ACPI_BASE_ADDRESS + R_ACPI_IO_GPE0_STS_127_96), 0);
+
 }
 
 
@@ -1134,6 +1164,7 @@ BoardInit (
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_WARN, "VBT not found %r\n", Status));
     }
+    ClearSmi ();
     if (GetPayloadId () == UEFI_PAYLOAD_ID_SIGNATURE && GetBootMode() != BOOT_ON_S3_RESUME) {
       ClearS3SaveRegion ();
       //

--- a/Silicon/CometlakePkg/Include/RegAccess.h
+++ b/Silicon/CometlakePkg/Include/RegAccess.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -41,6 +41,7 @@
 #include <Register/PchRegsDmi.h>
 #include <Register/PchRegsScsSd.h>
 #include <Register/RegsUsb.h>
+#include <Register/RtcRegs.h>
 
 //
 // Default Vendor ID and Subsystem ID

--- a/Silicon/CometlakePkg/Include/Register/PchRegsPmc.h
+++ b/Silicon/CometlakePkg/Include/Register/PchRegsPmc.h
@@ -1,7 +1,7 @@
 /** @file
   Register names for PCH PMC device
 
-  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -15,11 +15,17 @@
 #define V_ACPI_IO_PM1_CNT_S5                     (BIT12 | BIT11 | BIT10)
 
 #define R_ACPI_IO_PM1_STS                        0x00
+#define B_ACPI_IO_PM1_STS_RTC_EN                 BIT26
+#define B_ACPI_IO_PM1_EN_PWRBTN_EN               BIT24
+#define B_ACPI_IO_PM1_STS_GBL                    BIT21
 #define B_ACPI_IO_PM1_STS_WAK                    BIT15
 #define B_ACPI_IO_PM1_STS_PRBTNOR                BIT11
-#define B_ACPI_IO_PM1_EN_PWRBTN_EN               BIT24
+#define B_ACPI_IO_PM1_STS_RTC                    BIT10
+#define B_ACPI_IO_PM1_STS_PWRBTN                 BIT8
+#define B_ACPI_IO_PM1_STS_TMROF                  BIT0
 
 #define R_ACPI_IO_PM1_CNT                        0x04
+#define B_ACPI_IO_PM1_CNT_SCI_EN                 BIT0
 #define B_ACPI_IO_PM1_CNT_SLP_TYP                (BIT12 | BIT11 | BIT10)
 
 
@@ -27,6 +33,7 @@
 #define B_ACPI_IO_SMI_STS_SMBUS                  BIT16
 #define B_ACPI_IO_SMI_STS_PERIODIC               BIT14
 #define B_ACPI_IO_SMI_STS_TCO                    BIT13
+#define B_ACPI_IO_SMI_STS_MCSMI                  BIT11
 #define B_ACPI_IO_SMI_STS_SWSMI_TMR              BIT6
 #define B_ACPI_IO_SMI_STS_APM                    BIT5
 #define B_ACPI_IO_SMI_STS_ON_SLP_EN              BIT4
@@ -39,6 +46,8 @@
 #define B_ACPI_IO_SMI_EN_GBL_SMI                 BIT0
 
 #define R_ACPI_IO_GPE_CNTL                       0x40
+
+#define R_ACPI_IO_GPE0_STS_127_96                0x6C
 
 #define R_ACPI_IO_GPE0_EN_127_96                 0x7C
 #define B_ACPI_IO_GPE0_STS_127_96_PME_B0         BIT13

--- a/Silicon/CometlakePkg/Include/Register/RtcRegs.h
+++ b/Silicon/CometlakePkg/Include/Register/RtcRegs.h
@@ -1,0 +1,44 @@
+/** @file
+  Register names for RTC device
+
+Conventions:
+
+  - Register definition format:
+    Prefix_[GenerationName]_[ComponentName]_SubsystemName_RegisterSpace_RegisterName
+  - Prefix:
+    Definitions beginning with "R_" are registers
+    Definitions beginning with "B_" are bits within registers
+    Definitions beginning with "V_" are meaningful values within the bits
+    Definitions beginning with "S_" are register size
+    Definitions beginning with "N_" are the bit position
+  - [GenerationName]:
+    Three letter acronym of the generation is used (e.g. SKL,KBL,CNL etc.).
+    Register name without GenerationName applies to all generations.
+  - [ComponentName]:
+    This field indicates the component name that the register belongs to (e.g. PCH, SA etc.)
+    Register name without ComponentName applies to all components.
+    Register that is specific to -H denoted by "_PCH_H_" in component name.
+    Register that is specific to -LP denoted by "_PCH_LP_" in component name.
+  - SubsystemName:
+    This field indicates the subsystem name of the component that the register belongs to
+    (e.g. PCIE, USB, SATA, GPIO, PMC etc.).
+  - RegisterSpace:
+    MEM - MMIO space register of subsystem.
+    IO  - IO space register of subsystem.
+    PCR - Private configuration register of subsystem.
+    CFG - PCI configuration space register of subsystem.
+  - RegisterName:
+    Full register name.
+
+  Copyright (c) 2021 Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _REGS_RTC_H_
+#define _REGS_RTC_H_
+
+#define R_RTC_IO_INDEX                           0x70
+#define R_RTC_IO_TARGET                          0x71
+
+#define R_RTC_IO_REGC                            0x0C
+
+#endif

--- a/Silicon/CometlakevPkg/Include/RegAccess.h
+++ b/Silicon/CometlakevPkg/Include/RegAccess.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -41,6 +41,7 @@
 #include <Register/PchRegsDmi.h>
 #include <Register/PchRegsScsSd.h>
 #include <Register/RegsUsb.h>
+#include <Register/RtcRegs.h>
 
 //
 // Default Vendor ID and Subsystem ID

--- a/Silicon/CometlakevPkg/Include/Register/PchRegsPmc.h
+++ b/Silicon/CometlakevPkg/Include/Register/PchRegsPmc.h
@@ -1,7 +1,7 @@
 /** @file
   Register names for PCH PMC device
 
-  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -17,18 +17,25 @@
 #define V_ACPI_IO_PM1_CNT_S5                     (BIT12 | BIT11 | BIT10)
 
 #define R_ACPI_IO_PM1_STS                        0x00
+#define B_ACPI_IO_PM1_STS_RTC_EN                 BIT26
+#define B_ACPI_IO_PM1_EN_PWRBTN_EN               BIT24
+#define B_ACPI_IO_PM1_STS_GBL                    BIT21
 #define B_ACPI_IO_PM1_STS_WAK                    BIT15
 #define B_ACPI_IO_PM1_STS_PRBTNOR                BIT11
-#define B_ACPI_IO_PM1_EN_PWRBTN_EN               BIT24
+#define B_ACPI_IO_PM1_STS_RTC                    BIT10
+#define B_ACPI_IO_PM1_STS_PWRBTN                 BIT8
+#define B_ACPI_IO_PM1_STS_TMROF                  BIT0
 
 #define R_ACPI_IO_PM1_CNT                        0x04
+#define B_ACPI_IO_PM1_CNT_SCI_EN                 BIT0
 #define B_ACPI_IO_PM1_CNT_SLP_TYP                (BIT12 | BIT11 | BIT10)
 
 
-#define R_ACPI_IO_SMI_STS                         0x34
+#define R_ACPI_IO_SMI_STS                        0x34
 #define B_ACPI_IO_SMI_STS_SMBUS                  BIT16
 #define B_ACPI_IO_SMI_STS_PERIODIC               BIT14
 #define B_ACPI_IO_SMI_STS_TCO                    BIT13
+#define B_ACPI_IO_SMI_STS_MCSMI                  BIT11
 #define B_ACPI_IO_SMI_STS_SWSMI_TMR              BIT6
 #define B_ACPI_IO_SMI_STS_APM                    BIT5
 #define B_ACPI_IO_SMI_STS_ON_SLP_EN              BIT4
@@ -42,6 +49,8 @@
 #define B_ACPI_IO_SMI_EN_TCO                     BIT13
 
 #define R_ACPI_IO_GPE_CNTL                       0x40
+
+#define R_ACPI_IO_GPE0_STS_127_96                0x8C
 
 #define R_ACPI_IO_GPE0_EN_127_96                 0x9C
 #define B_ACPI_IO_GPE0_STS_127_96_PME_B0         BIT13

--- a/Silicon/CometlakevPkg/Include/Register/RtcRegs.h
+++ b/Silicon/CometlakevPkg/Include/Register/RtcRegs.h
@@ -1,0 +1,44 @@
+/** @file
+  Register names for RTC device
+
+Conventions:
+
+  - Register definition format:
+    Prefix_[GenerationName]_[ComponentName]_SubsystemName_RegisterSpace_RegisterName
+  - Prefix:
+    Definitions beginning with "R_" are registers
+    Definitions beginning with "B_" are bits within registers
+    Definitions beginning with "V_" are meaningful values within the bits
+    Definitions beginning with "S_" are register size
+    Definitions beginning with "N_" are the bit position
+  - [GenerationName]:
+    Three letter acronym of the generation is used (e.g. SKL,KBL,CNL etc.).
+    Register name without GenerationName applies to all generations.
+  - [ComponentName]:
+    This field indicates the component name that the register belongs to (e.g. PCH, SA etc.)
+    Register name without ComponentName applies to all components.
+    Register that is specific to -H denoted by "_PCH_H_" in component name.
+    Register that is specific to -LP denoted by "_PCH_LP_" in component name.
+  - SubsystemName:
+    This field indicates the subsystem name of the component that the register belongs to
+    (e.g. PCIE, USB, SATA, GPIO, PMC etc.).
+  - RegisterSpace:
+    MEM - MMIO space register of subsystem.
+    IO  - IO space register of subsystem.
+    PCR - Private configuration register of subsystem.
+    CFG - PCI configuration space register of subsystem.
+  - RegisterName:
+    Full register name.
+
+  Copyright (c) 2021 Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _REGS_RTC_H_
+#define _REGS_RTC_H_
+
+#define R_RTC_IO_INDEX                           0x70
+#define R_RTC_IO_TARGET                          0x71
+
+#define R_RTC_IO_REGC                            0x0C
+
+#endif


### PR DESCRIPTION
This patch clears RTC alarm when RTC is the S3 wake-up source.
Without clearing it, SMI# will be triggered once SMI_EN is set
by RestoreS3RegInfo, but no handler to clear it which results
in hang.

In addition to clearing RTC SMI#, this patch also clears other
SMI# as UEFI BIOS does.

Test method: rtcwake -m -s 15

Signed-off-by: Stanley Chang <stanley.chang@intel.com>