### PR TITLE
[QEMU] Fix AUTO boot option index

### DIFF
--- a/BootloaderCommonPkg/Include/Guid/OsBootOptionGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/OsBootOptionGuid.h
@@ -14,6 +14,7 @@
 
 #define MAX_FILE_PATH_LEN          16
 #define MAX_EXTRA_IMAGE_NUM        4
+#define MAX_BOOT_OPTION_ENTRY      32
 
 #define BOOT_FLAGS_MISC            BIT0
 #define BOOT_FLAGS_CRASH_OS        BIT1

--- a/Platform/CommonBoardPkg/CfgData/CfgData_Common.yaml
+++ b/Platform/CommonBoardPkg/CfgData/CfgData_Common.yaml
@@ -62,7 +62,7 @@
   - CurrentBoot  :
       name         : Current Boot Option
       type         : Combo
-      option       : 16:AUTO, 0:0, 1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8, 9:9, 10:10, 11:11, 10:10, 11:11, 12:12, 13:13, 14:14, 15:15
+      option       : 31:AUTO, 0:0, 1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8, 9:9, 10:10, 11:11, 10:10, 11:11, 12:12, 13:13, 14:14, 15:15
       help         : >
                      Set the current boot option. It indicates the boot option index (0-15) to be tried first on the boot flow.
                      AUTO allows platform to set current boot option using platform specific policy.

--- a/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.c
+++ b/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.c
@@ -124,7 +124,7 @@ FillBootOptionListFromCfgData (
   GenCfgData = (GEN_CFG_DATA *)FindConfigDataByTag (CDATA_GEN_TAG);
   if (GenCfgData != NULL) {
     OsBootOptionList->CurrentBoot = GenCfgData->CurrentBoot;
-    if (OsBootOptionList->CurrentBoot != MAX_BOOT_OPTION_CFGDATA_ENTRY) {
+    if (OsBootOptionList->CurrentBoot != MAX_BOOT_OPTION_ENTRY - 1) {
       if (OsBootOptionList->CurrentBoot >= OsBootOptionList->OsBootOptionCount) {
         OsBootOptionList->CurrentBoot = 0;
       }

--- a/Platform/QemuBoardPkg/CfgData/CfgDataExt_Brd1.dlt
+++ b/Platform/QemuBoardPkg/CfgData/CfgDataExt_Brd1.dlt
@@ -16,6 +16,6 @@ PLATFORMID_CFG_DATA.PlatformId | 1
 PLAT_NAME_CFG_DATA.PlatformName            | 'QEMU_01'
 
 GEN_CFG_DATA.PayloadId                     | 'AUTO'
-GEN_CFG_DATA.CurrentBoot                   | 16
+GEN_CFG_DATA.CurrentBoot                   | 31
 
 !include CfgDataExt_Inc.dlt

--- a/Platform/QemuBoardPkg/CfgData/CfgDataExt_QSP.dlt
+++ b/Platform/QemuBoardPkg/CfgData/CfgDataExt_QSP.dlt
@@ -16,6 +16,6 @@ PLATFORMID_CFG_DATA.PlatformId | 2
 PLAT_NAME_CFG_DATA.PlatformName            | 'QSP'
 
 GEN_CFG_DATA.PayloadId                     | 'AUTO'
-GEN_CFG_DATA.CurrentBoot                   | 16
+GEN_CFG_DATA.CurrentBoot                   | 31
 
 !include CfgDataExt_Inc.dlt

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -441,7 +441,7 @@ UpdateOsBootMediumInfo (
 
   FillBootOptionListFromCfgData (OsBootOptionList);
 
-  if (OsBootOptionList->CurrentBoot == MAX_BOOT_OPTION_CFGDATA_ENTRY) {
+  if (OsBootOptionList->CurrentBoot == MAX_BOOT_OPTION_ENTRY - 1) {
     //
     // Read boot order, it is passed in by QEMU command
     //   QEMU boot order (a=1 c=2 d=3 n=4 at CMOS 0x3D)


### PR DESCRIPTION
On SBL, it can support boot option selection through QEMU command line
"-boot order" parameter. However, it does not work anymore. It was
because of the MAX_BOOT_OPTION_CFGDATA_ENTRY adjustment in other commit.
This patch decoupled internal boot option index with the CFGDATA boot
option index so that it does not have impacts on each other. With this
change, QEMU boot option can be altered through command line again.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>