### PR TITLE
[TGL] Disable Intel HD Audio (Azalia)

### DIFF
--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglh_Ddr4.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglh_Ddr4.dlt
@@ -568,3 +568,4 @@ GPIO_CFG_DATA.GpioPinConfig1_GPD11.GPIOSkip_GPD11           | 1           # TGL-
 #
 GEN_CFG_DATA.PayloadId                                      | 'AUTO'
 GPIO_CFG_DATA.GpioPinConfig0_GPP_F10.GPIODirection_GPP_F10  | 11
+SILICON_CFG_DATA.PchHdaEnable                               | 0x00

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_Ddr4.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_Ddr4.dlt
@@ -49,3 +49,4 @@ PLATFORM_CFG_DATA.PayloadSelGpio.PinNumber                  | 15
 #
 GEN_CFG_DATA.PayloadId                                      | 'AUTO'
 GPIO_CFG_DATA.GpioPinConfig0_GPP_B15.GPIODirection_GPP_B15  | 0xB
+SILICON_CFG_DATA.PchHdaEnable                               | 0x00

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_DdrLp4.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_DdrLp4.dlt
@@ -44,3 +44,4 @@ PLATFORM_CFG_DATA.PayloadSelGpio.PinNumber                  | 15
 #
 GEN_CFG_DATA.PayloadId                                      | 'AUTO'
 GPIO_CFG_DATA.GpioPinConfig0_GPP_B15.GPIODirection_GPP_B15  | 0xB
+SILICON_CFG_DATA.PchHdaEnable                               | 0x00


### PR DESCRIPTION
 1. HD Audio and TSN share pins. These are mutually exclusive features.
 2. RVP board should be reworked to support legacy HD Audio mode.

Signed-off-by: Randy Lin <randy.lin@intel.com>