### PR TITLE
[CFL] Increase PAYLOAD size

### DIFF
--- a/Platform/CoffeelakeBoardPkg/BoardConfig.py
+++ b/Platform/CoffeelakeBoardPkg/BoardConfig.py
@@ -120,7 +120,7 @@ class Board(BaseBoard):
         self.STAGE1_DATA_SIZE     = 0x00014000
 
         self.PAYLOAD_EXE_BASE     = 0x00B00000
-        self.PAYLOAD_SIZE         = 0x00028000
+        self.PAYLOAD_SIZE         = 0x00029000
         if len(self._PAYLOAD_NAME.split(';')) > 1:
             self.UEFI_VARIABLE_SIZE = 0x00040000
         else:


### PR DESCRIPTION
Seems some recent patches may have added additional
size to OS Loader and now the internal pre-commit build
test in Jenkins is failing due to not enough space
for PAYLOAD. Other platforms are also using 29000h
so might be best to increase the CFL value as well.

Signed-off-by: James Gutbub <james.gutbub@intel.com>