### PR TITLE
Resolve KW possible NULL refs in ElfLib

### DIFF
--- a/BootloaderCommonPkg/Library/ElfLib/Elf32Lib.c
+++ b/BootloaderCommonPkg/Library/ElfLib/Elf32Lib.c
@@ -86,6 +86,9 @@ RelocateElf32Sections  (
     CurPtr  = CurPtr + Elf32Hdr->e_shentsize;
     if ((Rel32Shdr->sh_type == SHT_REL) || (Rel32Shdr->sh_type == SHT_RELA)) {
       Sec32Shdr = GetElf32SectionByIndex (ElfCt->FileBase, Rel32Shdr->sh_info);
+      if (Sec32Shdr == NULL) {
+        continue;
+      }
       if (!IsTextShdr(Sec32Shdr) && !IsDataShdr(Sec32Shdr)) {
         continue;
       }

--- a/BootloaderCommonPkg/Library/ElfLib/Elf64Lib.c
+++ b/BootloaderCommonPkg/Library/ElfLib/Elf64Lib.c
@@ -87,6 +87,9 @@ RelocateElf64Sections  (
     CurPtr  = CurPtr + Elf64Hdr->e_shentsize;
     if ((Rel64Shdr->sh_type == SHT_REL) || (Rel64Shdr->sh_type == SHT_RELA)) {
       Sec64Shdr = GetElf64SectionByIndex (ElfCt->FileBase, Rel64Shdr->sh_info);
+      if (Sec64Shdr == NULL) {
+        continue;
+      }
       if (!IsTextShdr(Sec64Shdr) && !IsDataShdr(Sec64Shdr)) {
         continue;
       }


### PR DESCRIPTION
KW scan reported a couple errors regarding
Sec*Shdr value, need to check if they are
NULL before using these values.

Signed-off-by: James Gutbub <james.gutbub@intel.com>