### PR TITLE
Fix HelloWorld payload build issue

### DIFF
--- a/PayloadPkg/PayloadPkg.dsc
+++ b/PayloadPkg/PayloadPkg.dsc
@@ -64,6 +64,7 @@
   LitePeCoffLib|BootloaderCommonPkg/Library/LitePeCoffLib/LitePeCoffLib.inf
   DebugAgentLib|BootloaderCommonPkg/Library/DebugAgentLib/DebugAgentLibNull.inf
   TimerLib|BootloaderCommonPkg/Library/AcpiTimerLib/AcpiTimerLib.inf
+  DebugPortLib|BootloaderCommonPkg/Library/DebugPortLib/DebugPortLibNull.inf
 
 [PcdsPatchableInModule]
   gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel         | 0x8000004F


### PR DESCRIPTION
This patch fixed SBL HelloWorld payload build failure.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>