### PR TITLE
[TGL] Fix UpdateFspConfig() early return issue

### DIFF
--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1423,21 +1423,20 @@ UpdateFspConfig (
       if (RegionType < FlashRegionMax) {
         if (RegionType != FlashRegionBios) {
           Status = GetComponentInfo (FLASH_MAP_SIG_SPI_IAS1, &SpiIasBase, NULL);
-          if (EFI_ERROR (Status)) {
-            return;
-          }
-          SpiIasBase &= 0xFFFF;
-          Status = SpiGetRegionAddress (RegionType, &BaseAddress, &TotalSize);
           if (!EFI_ERROR (Status)) {
-            if ((PcdGet32 (PcdSpiIasImage1RegionSize) + PcdGet32 (PcdSpiIasImage2RegionSize)) <= TotalSize) {
-              IasProtected = TRUE;
-              FspsConfig->PchWriteProtectionEnable[PrIndex] = TRUE;
-              FspsConfig->PchReadProtectionEnable[PrIndex]  = FALSE;
-              FspsConfig->PchProtectedRangeBase[PrIndex]    = (UINT16) ((BaseAddress + SpiIasBase) >> 12);
-              FspsConfig->PchProtectedRangeLimit[PrIndex]   = (UINT16) ((BaseAddress + SpiIasBase +
-                                                          PcdGet32 (PcdSpiIasImage1RegionSize) +
-                                                          PcdGet32 (PcdSpiIasImage2RegionSize) - 1) >> 12);
-              PrIndex++;
+            SpiIasBase &= 0xFFFF;
+            Status = SpiGetRegionAddress (RegionType, &BaseAddress, &TotalSize);
+            if (!EFI_ERROR (Status)) {
+              if ((PcdGet32 (PcdSpiIasImage1RegionSize) + PcdGet32 (PcdSpiIasImage2RegionSize)) <= TotalSize) {
+                IasProtected = TRUE;
+                FspsConfig->PchWriteProtectionEnable[PrIndex] = TRUE;
+                FspsConfig->PchReadProtectionEnable[PrIndex]  = FALSE;
+                FspsConfig->PchProtectedRangeBase[PrIndex]    = (UINT16) ((BaseAddress + SpiIasBase) >> 12);
+                FspsConfig->PchProtectedRangeLimit[PrIndex]   = (UINT16) ((BaseAddress + SpiIasBase +
+                                                            PcdGet32 (PcdSpiIasImage1RegionSize) +
+                                                            PcdGet32 (PcdSpiIasImage2RegionSize) - 1) >> 12);
+                PrIndex++;
+              }
             }
           }
         } else {


### PR DESCRIPTION
On TGL  UpdateFspConfig() funciton in Stage2BoardInitLib.c has code
path to return early, it will skip all remaining UPD initialization.
The code should always continue the flow to finish the whole
function. This patch fixed this issue.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>