### PR TITLE
[UPX] Disable trace hub debug interface by default

### DIFF
--- a/Platform/CoffeelakeBoardPkg/CfgData/CfgDataExt_Upx.dlt
+++ b/Platform/CoffeelakeBoardPkg/CfgData/CfgDataExt_Upx.dlt
@@ -458,7 +458,3 @@ GPIO_CFG_DATA.GpioPinConfig0_GPP_E22 | 0x0350A381
 GPIO_CFG_DATA.GpioPinConfig1_GPP_E22 | 0x04162001
 GPIO_CFG_DATA.GpioPinConfig0_GPP_E23 | 0x0350A281
 GPIO_CFG_DATA.GpioPinConfig1_GPP_E23 | 0x04172001
-
-MEMORY_CFG_DATA.PchTraceHubMode          | 0x2
-MEMORY_CFG_DATA.PlatformDebugConsent     | 0x1
-SILICON_CFG_DATA.DebugInterfaceEnable    | 0x1


### PR DESCRIPTION
During UP Extreme board enabling, trace hub interface was enabled
to help debug. But it should be disabled by default. This patch
fixed it.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>