### PR TITLE
Add cache flush on warm reset for SBL shell

### DIFF
--- a/BootloaderCommonPkg/Library/ResetSystemLib/ResetSystemLib.c
+++ b/BootloaderCommonPkg/Library/ResetSystemLib/ResetSystemLib.c
@@ -1,7 +1,7 @@
 /** @file
   Reset System Library
 
-  Copyright (c) 2006 - 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -51,6 +51,8 @@ ResetWarm (
   VOID
   )
 {
+  // In case of memory persistency across warm reset, need to flush the cache.
+  AsmWbinvd ();
   IoWrite8 ((UINTN) R_RST_CNT, V_RST_CNT_HARDSTARTSTATE);
   IoWrite8 ((UINTN) R_RST_CNT, V_RST_CNT_HARDRESET);
 }


### PR DESCRIPTION
In some cases, the memory needs to keep consistent across a warm
reset. When warm reset is triggered, it might still have modified
cacheline that has not been flushed to memory yet. The patch added
WBINVD to flush cache before the warm reset.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>