### PR TITLE
Enable BIOS region update in single shot

### DIFF
--- a/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
+++ b/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
@@ -71,6 +71,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define CREATOR_REV_INTEL           0x20090903
 #define ACPI_FWST_OEM_REV           0x00001000
 
+#define CAPSULE_FLAG_FORCE_BIOS_UPDATE    BIT31
+
 typedef enum {
   TopSwapSet,
   TopSwapClear
@@ -156,7 +158,7 @@ typedef struct {
   UINT32                      Version;
   EFI_GUID                    UpdateImageTypeId;
   UINT8                       UpdateImageIndex;
-  UINT8                       reserved_bytes[3];
+  UINT8                       ReservedBytes[3];
   UINT32                      UpdateImageSize;
   UINT32                      UpdateVendorCodeSize;
   UINT64                      UpdateHardwareInstance;

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
@@ -1,13 +1,16 @@
 /** @file
   The header file for internal firmware update definitions.
 
-  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
 #ifndef __INTERNAL_FIRMWARE_UPDATE_LIB_H__
 #define __INTERNAL_FIRMWARE_UPDATE_LIB_H__
+
+#include <Uefi/UefiBaseType.h>
+#include <Library/ResetSystemLib.h>
 
 /**
   Update a region block.
@@ -137,6 +140,19 @@ AfterUpdateEnforceFwUpdatePolicy (
  );
 
 /**
+  Perform full BIOS region update.
+
+  @param[in] ImageHdr       Pointer to fw mgmt capsule Image header
+
+  @retval  EFI_SUCCESS      Update successful.
+  @retval  other            error occurred during firmware update
+**/
+EFI_STATUS
+UpdateFullBiosRegion (
+  IN EFI_FW_MGMT_CAP_IMAGE_HEADER  *ImageHdr
+  );
+
+/**
   Perform system Firmware update.
 
   This function will update SBL or Configuration data alone.
@@ -202,4 +218,16 @@ CheckSblConfigDataSvn (
   IN   FIRMWARE_UPDATE_POLICY         FwPolicy,
   OUT  UINT8                         *SvnStatus
   );
+
+/**
+  Reboot platform.
+
+  @param[in]  ResetType   Cold, Warm or Shutdown
+
+**/
+VOID
+Reboot (
+  IN  EFI_RESET_TYPE        ResetType
+  );
+
 #endif


### PR DESCRIPTION
Sometimes it is helpful if SBL can support firmware update from
SBL FW to UEFI FW, or update from incompatible SBL flash layout.
This will need SBL to write full BIOS region without using
redundant partition. To support this, a special capsule image
flag is added to indicate this special update. Please note, this
update might be very risky. This is only for development purpose.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>