### PR TITLE
[QEMU] Add UEFI universal payload test case

### DIFF
--- a/Platform/QemuBoardPkg/Script/TestCases/firmware_update.py
+++ b/Platform/QemuBoardPkg/Script/TestCases/firmware_update.py
@@ -283,7 +283,7 @@ def main():
         output.extend(lines)
 
     # Try final normal boot
-    lines = run_qemu(bios_img, fwu_dir, True if fwu_mode != 0 else False, 3)
+    lines = run_qemu(bios_img, fwu_dir, True if fwu_mode != 0 else False, timeout = 3)
     output.extend(lines)
 
     # check test result

--- a/Platform/QemuBoardPkg/Script/TestCases/test_base.py
+++ b/Platform/QemuBoardPkg/Script/TestCases/test_base.py
@@ -16,6 +16,17 @@ import zipfile
 import urllib.request
 from   threading import Timer
 
+def get_tool_dir (sbl_dir):
+    if os.name == 'nt':
+        return os.path.join(sbl_dir, 'BaseTools', 'Bin', 'Win32')
+    else:
+        return os.path.join(sbl_dir, 'BaseTools', 'BinWrappers', 'PosixLike')
+
+def get_file_data (file, mode = 'rb'):
+    return open(file, mode).read()
+
+def gen_file_from_object (file, object, mode='b'):
+    open (file, 'w' + mode).write(object)
 
 def unzip_file (zip_file, tgt_dir):
     with zipfile.ZipFile(zip_file, 'r') as zip_ref:
@@ -33,7 +44,7 @@ def create_dirs (dirs):
             os.mkdir (dir_name)
 
 
-def run_qemu (bios_img, fwu_path, fwu_mode=False, timeout=0):
+def run_qemu (bios_img, fwu_path, fwu_mode=False, boot_order='', timeout=0):
     if os.name == 'nt':
         path = r"C:\Program Files\qemu\qemu-system-x86_64"
     else:
@@ -43,7 +54,7 @@ def run_qemu (bios_img, fwu_path, fwu_mode=False, timeout=0):
         "-cpu", "max", "-serial", "mon:stdio",
         "-m", "256M", "-drive",
         "id=mydrive,if=none,format=raw,file=fat:rw:%s" % fwu_path, "-device",
-        "ide-hd,drive=mydrive", "-boot", "order=d%s" % ('an' if fwu_mode else ''),
+        "ide-hd,drive=mydrive", "-boot", "order=d%s" % ('an' if fwu_mode else boot_order),
         "-no-reboot", "-drive", "file=%s,if=pflash,format=raw" % bios_img
     ]
 

--- a/Platform/QemuBoardPkg/Script/TestCases/uefi_upld_boot.py
+++ b/Platform/QemuBoardPkg/Script/TestCases/uefi_upld_boot.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+## @ uefi_upld_boot.py
+#
+# Test UEFI universal payload on QEMU
+#
+# Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+import os
+import sys
+import shutil
+from   test_base import *
+
+def get_check_lines ():
+    lines = [
+              "===== Intel Slim Bootloader STAGE1A =====",
+              "===== Intel Slim Bootloader STAGE1B =====",
+              "===== Intel Slim Bootloader STAGE2 ======",
+              "Universal Payload UEFI",
+              "Jump to payload",
+              "[Bds]Booting UEFI Shell",
+              "any other key to continue.",
+            ]
+    return lines
+
+def usage():
+    print("usage:\n  python %s bios_image os_image_dir\n" % sys.argv[0])
+    print("  bios_image  :  QEMU Slim Bootloader firmware image.")
+    print("                 This image can be generated through the normal Slim Bootloader build process.")
+    print("  os_image_dir:  Directory containing bootable OS image.")
+    print("                 This image can be generated using GenContainer.py tool.")
+    print("")
+
+
+def main():
+    if sys.version_info.major < 3:
+        print ("This script needs Python3 !")
+        return -1
+
+    if len(sys.argv) != 3:
+        usage()
+        return -2
+
+    bios_img = sys.argv[1]
+    os_dir   = sys.argv[2]
+
+    print("Universal UEFI payload boot test for Slim BootLoader")
+
+    tmp_dir = os.path.dirname(os_dir) + '/temp'
+    create_dirs ([tmp_dir, os_dir])
+
+    # download and unzip UEFI payload image
+    local_file = tmp_dir + '/UefiUpld.zip'
+    download_url (
+        'https://github.com/slimbootloader/slimbootloader/files/7317829/UefiUpld.zip',
+        local_file
+    )
+    unzip_file (local_file, tmp_dir)
+
+    # Create new EPAYLOAD and replace it in SlimBootloader.bin
+    layout = ',\n'.join ([
+                 "( 'EPLD', 'EPAYLOAD.bin'  , 'NORMAL'  , 'RSA3072_PSS_SHA2_384'  , 'KEY_ID_CONTAINER_RSA3072'      , 0x10      , 0         , 0x0       )",
+                 "( 'UEFI', 'UefiUpld.elf'  , 'Lzma'    , 'SHA2_384'              , ''                              , 0x10      , 0         , 0x0       )"
+               ])
+    gen_file_from_object (tmp_dir + '/epld.txt', layout, '')
+    sbl_dir = os.getcwd()
+    os.environ['SBL_KEY_DIR'] = os.path.join (sbl_dir, '..', 'SblKeys')
+    os.chdir (tmp_dir)
+    cmds = [sys.executable, sbl_dir + '/BootloaderCorePkg/Tools/GenContainer.py', 'create',  '-l', 'epld.txt', '-td', get_tool_dir(sbl_dir)]
+    run_process (cmds)
+    cmds = [sys.executable, sbl_dir + '/BootloaderCorePkg/Tools/IfwiUtility.py', 'replace',  '-i', os.path.join(sbl_dir, bios_img), '-f', 'EPAYLOAD.bin', '-p', 'IFWI/BIOS/NRD/EPLD']
+    run_process (cmds)
+    os.chdir (sbl_dir)
+
+    # run QEMU boot with timeout
+    output = []
+    lines = run_qemu(bios_img, os_dir, boot_order = 'ba', timeout = 8)
+    output.extend(lines)
+
+    # check test result
+    ret = check_result (output, get_check_lines())
+
+    print ('UEFI Universal Payload boot test %s !\n' % ('PASSED' if ret == 0 else 'FAILED'))
+
+    return ret
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/Platform/QemuBoardPkg/Script/qemu_test.py
+++ b/Platform/QemuBoardPkg/Script/qemu_test.py
@@ -36,7 +36,8 @@ def main():
     # run test cases
     test_cases = [
       ('firmware_update.py',  [tst_img, fwu_dir]),
-      ('linux_boot.py'     ,  [tst_img, img_dir])
+      ('linux_boot.py'     ,  [tst_img, img_dir]),
+      ('uefi_upld_boot.py' ,  [tst_img, img_dir]),
     ]
 
     for test_file, test_args in test_cases:


### PR DESCRIPTION
This patch added UEFI universal payload boot test on QEMU.
It fixed #1332.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>