### PR TITLE
[UPX] Disable malfunctioned USB2 port

### DIFF
--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1317,9 +1317,9 @@ UpdateFspConfig (
   }
 
   if (PlatformId == PLATFORM_ID_UPXTREME) {
-    // Workaround for USB issue on port 8, it does not respond to USB enumeration.
+    // Workaround for USB issue on port 10, it does not respond to USB enumeration.
     // Disable this port for now
-    FspsUpd->FspsConfig.PortUsb20Enable[7] = 0;
+    FspsUpd->FspsConfig.PortUsb20Enable[9] = FALSE;
   }
 
   Length = GetPchXhciMaxUsb3PortNum ();


### PR DESCRIPTION
On UPX, one USB2 port does not respond properly during PCI enumeration.
It needs to be disabled.  The current SBL code disabled the wrong port.
It should be port 10 (USB2 index 9).

Signed-off-by: Maurice Ma <maurice.ma@intel.com>