### PR TITLE
[TGL] Fix S0ix issues

### DIFF
--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Tcc_Feature.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Tcc_Feature.dlt
@@ -8,6 +8,8 @@
 ##
 #
 
+FEATURES_CFG_DATA.Features.S0ix   | 0
+
 # Enable TCC config data
 TCC_CFG_DATA.TccEnable   | 1
 TCC_CFG_DATA.TccTuning   | 1

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Tsn_Feature.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Tsn_Feature.dlt
@@ -8,6 +8,8 @@
 ##
 #
 
+FEATURES_CFG_DATA.Features.S0ix   | 0
+
 SILICON_CFG_DATA.PchTsnEnable     | 1
 
 SILICON_CFG_DATA.PchTsnLinkSpeed  | 3

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1363,9 +1363,8 @@ UpdateFspConfig (
     // Inform FSP to skip debug UART init
     FspsConfig->SerialIoDebugUartNumber = DebugPort;
     FspsConfig->SerialIoUartMode[DebugPort] = 0x4;
-    if (S0IX_STATUS() == 1) {
-      FspsConfig->SerialIoUartMode[DebugPort] = 1;    // Force UART to PCI mode to enable OS to have full control
-    }
+  } else if (S0IX_STATUS() == 1) {  // legacy UART
+    FspsConfig->SerialIoUartMode[2] = 1;  // Force UART to PCI mode to enable OS to have full control
   }
 
   //
@@ -1713,10 +1712,6 @@ UpdateFspConfig (
 
     // PCH SERIAL_UART_CONFIG
     for (Index = 0; Index < GetPchMaxSerialIoUartControllersNum (); Index++) {
-      FspsConfig->SerialIoUartParity[Index]          = 1;
-      FspsConfig->SerialIoUartDataBits[Index]        = 0x8;
-      FspsConfig->SerialIoUartStopBits[Index]        = 1;
-      FspsConfig->SerialIoUartAutoFlow[Index]        = 1;
       FspsConfig->SerialIoUartPowerGating[Index]     = 2;
       FspsConfig->SerialIoUartDmaEnable[Index]       = 1;
       FspsConfig->SerialIoUartDbg2[Index]            = 0;


### PR DESCRIPTION
This patch fixes three S0ix issues:

    1. a regression caused by commit 20889 where the
       FspsConfig->SerialIoUartMode missed configuring for legacy UART

    2. failed s0ix when assigning uart port2 as debug port: root caused
       by Maurice. He pointed out that several uart properties should
       not be reset
       This fixed #1314.

    3. conflict with TCC/TSN: In TGL, S0ix should be disabled when either
       TCC or TSN is enabled. If s0ix is enabled, the patch checks TCC/TSN
       enabling status and forces turning off S0ix if TCC/TSN is enabled.

Signed-off-by: Stanley Chang <stanley.chang@intel.com>