### PR TITLE
Improve XHCI library timeout polling mechanism

### DIFF
--- a/BootloaderCommonPkg/Library/XhciLib/XhcPeim.c
+++ b/BootloaderCommonPkg/Library/XhciLib/XhcPeim.c
@@ -169,17 +169,22 @@ XhcPeiWaitOpRegBit (
   IN UINT32             Timeout
   )
 {
-  UINT64                Index;
+  EFI_STATUS            Status;
+  UINT64                EndTimeStamp;
 
-  for (Index = 0; Index < Timeout * XHC_1_MILLISECOND; Index++) {
+  EndTimeStamp = ReadTimeStamp() + \
+                 MicroSecondToTimeStampTick (Timeout * XHC_1_MILLISECOND);
+
+  Status = EFI_TIMEOUT;
+  while (ReadTimeStamp() < EndTimeStamp) {
     if (XHC_REG_BIT_IS_SET (Xhc, Offset, Bit) == WaitToSet) {
-      return EFI_SUCCESS;
+      Status = EFI_SUCCESS;
+      break;
     }
-
     MicroSecondDelay (XHC_1_MICROSECOND);
   }
 
-  return EFI_TIMEOUT;
+  return Status;
 }
 
 /**

--- a/BootloaderCommonPkg/Library/XhciLib/XhcPeim.h
+++ b/BootloaderCommonPkg/Library/XhciLib/XhcPeim.h
@@ -1,7 +1,7 @@
 /** @file
 Private Header file for Usb Host Controller PEIM
 
-Copyright (c) 2014 - 2016, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2014 - 2021, Intel Corporation. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -21,6 +21,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/IoLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/IoMmuLib.h>
+#include <Library/TimeStampLib.h>
 
 typedef struct _PEI_XHC_DEV PEI_XHC_DEV;
 typedef struct _USB_DEV_CONTEXT USB_DEV_CONTEXT;

--- a/BootloaderCommonPkg/Library/XhciLib/XhciLib.inf
+++ b/BootloaderCommonPkg/Library/XhciLib/XhciLib.inf
@@ -43,3 +43,4 @@
   BaseMemoryLib
   MemoryAllocationLib
   IoMmuLib
+  TimeStampLib


### PR DESCRIPTION
Current XHCI library does a big loop to poll the status of a
USB command execution. In each loop it will delay 1us until
it completes or reachs the timeout. When the loop is very big,
the accumulated 1us delay together will be shifted far beyond
the original timeout requested. This is because of the inaccuracy
of the 1us delay provided by ACPI timer library. This patch
addressed this issue by checking the actual executed time rather
than looping with delay.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>