### PR TITLE
[UPX i11] Enable Ubuntu boot support

### DIFF
--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -66,6 +66,9 @@ class Board(BaseBoard):
         # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)
         self.ENABLE_SMM_REBASE     = 2
 
+        # Allow boot through GRUB config
+        self.ENABLE_GRUB_CONFIG   = 1
+
         if self.HAVE_FIT_TABLE:
             self.FIT_ENTRY_MAX_NUM  = 10
 
@@ -184,7 +187,7 @@ class Board(BaseBoard):
         if self.NON_REDUNDANT_SIZE < Non_Redundant_Components_Size:
             raise Exception ('Non redundant region size 0x%x is smaller than required components size 0x%x!' % (self.NON_REDUNDANT_SIZE, Non_Redundant_Components_Size))
 
-        self.PLD_HEAP_SIZE        = 0x04000000
+        self.PLD_HEAP_SIZE        = 0x08000000
         self.PLD_STACK_SIZE       = 0x00020000
         self.PLD_RSVD_MEM_SIZE    = 0x00500000
 

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgDataExt_Upx11.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgDataExt_Upx11.dlt
@@ -31,6 +31,7 @@ MEMORY_CFG_DATA.PcieClkSrcUsage                             | { 0x80, 0x80, 0x80
 
 SILICON_CFG_DATA.PcieRpAspm                                 | { 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x4, 0x4, 0x4, 0x4, 0x4, 0x4, 0x4, 0x4, 0x4, 0x4, 0x4, 0x4, 0x4, 0x4}
 SILICON_CFG_DATA.PcieRpL1Substates                          | { 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2, 0x2, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1}
+
 SILICON_CFG_DATA.EcEnable                                   | 0
 
 # UPX i11 USB2 port 8 does not respond to USB command, so disable it
@@ -39,6 +40,11 @@ SILICON_CFG_DATA.PortUsb20Enable.Usb2Port8                  | 0
 FEATURES_CFG_DATA.Features.FusaEnable                       | 0
 
 GEN_CFG_DATA.PayloadId                                      | 0
+
+# BOOT_OPTION_CFG_DATA_0 is USB boot
+# Allow to boot from USB partition 0 and FAT filesystem by default
+BOOT_OPTION_CFG_DATA_0.SwPart_0                             | 0
+BOOT_OPTION_CFG_DATA_0.FsType_0                             | 0
 
 GPIO_CFG_DATA.GpioPinConfig0_GPP_A00        | 0x0550A381
 GPIO_CFG_DATA.GpioPinConfig1_GPP_A00        | 0x02002001


### PR DESCRIPTION
Ubuntu 20.04.3 can support TGL platform. However, current SBL won't
be able to boot without changes. It is caused by following issues:
 - GRUB CFG support is not enabled by default
 - Payload heap is too small to load the full INITRD image
 - USB boot option is set to boot from partition 1 and EXT2 filesystem.

This patch addressed above issues. It has been tested on UPX i11.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>