### PR TITLE
[TGL] Fix MRC full training issue on warm reset flow

### DIFF
--- a/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -759,12 +759,12 @@ BoardInit (
   IN  BOARD_INIT_PHASE  InitPhase
 )
 {
-  UINTN                 PmcBase;
+  UINTN                 PmcMmioBase;
   PLT_DEVICE_TABLE      *PltDeviceTable;
   UINT8                 BoardId;
   SILICON_CFG_DATA      *SiCfgData;
 
-  PmcBase = MM_PCI_ADDRESS (0, PCI_DEVICE_NUMBER_PCH_PMC, PCI_FUNCTION_NUMBER_PCH_PMC, 0);
+  PmcMmioBase = PCH_PWRM_BASE_ADDRESS;
 
   switch (InitPhase) {
   case PreConfigInit:
@@ -820,8 +820,7 @@ DEBUG_CODE_END();
     // Set the DISB bit in PCH (DRAM Initialization Scratchpad Bit)
     // prior to starting DRAM Initialization Sequence.
     //
-    MmioOr32 (PmcBase + R_PCH_PMC_GEN_PMCON_A, B_PCH_PMC_GEN_PMCON_A_DISB);
-
+    MmioOr32 (PmcMmioBase + R_PMC_PWRM_GEN_PMCON_A, B_PCH_PMC_GEN_PMCON_A_DISB);
     switch (GetPlatformId ()) {
       case BoardIdTglHDdr4SODimm:
       case 0xF:
@@ -833,14 +832,12 @@ DEBUG_CODE_END();
         ConfigureGpio (CDATA_NO_TAG, sizeof (mGpioTablePreMemTglUDdr4) / sizeof (mGpioTablePreMemTglUDdr4[0]), (UINT8*)mGpioTablePreMemTglUDdr4);
         break;
     }
-
     break;
   case PostMemoryInit:
     //
     // Clear the DISB bit after completing DRAM Initialization Sequence
     //
-    MmioAnd32 (PmcBase + R_PCH_PMC_GEN_PMCON_A, 0);
-
+    MmioAnd32 (PmcMmioBase + R_PMC_PWRM_GEN_PMCON_A, (UINT32)~B_PCH_PMC_GEN_PMCON_A_DISB);
     break;
   case PreTempRamExit:
     break;

--- a/Silicon/TigerlakePchPkg/Include/Register/PchRegsPmc.h
+++ b/Silicon/TigerlakePchPkg/Include/Register/PchRegsPmc.h
@@ -34,7 +34,6 @@
 #define PCI_FUNCTION_NUMBER_PCH_PMC                         2
 
 #define B_PCH_PMC_PM_DATA_BAR                               0xFFFFC000
-#define R_PCH_PMC_GEN_PMCON_A                               0xA0
 #define B_PCH_PMC_GEN_PMCON_A_DISB                          BIT23
 
 //


### PR DESCRIPTION
On TGL warm reset flow, current MRC will always do full MRC training.
It is because of wrong PMC rigster was used in platform code to set
and clear the MRC scratch pad bit.

This fixed #1346.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>