### PR TITLE
Resolve VS2015x86 compile issue

### DIFF
--- a/BootloaderCommonPkg/Library/TimeStampLib/TimeStampLib.c
+++ b/BootloaderCommonPkg/Library/TimeStampLib/TimeStampLib.c
@@ -35,15 +35,15 @@ GetTimeStampFrequency (
   VOID
   )
 {
-  UINT8  Ratio;
+  UINT32  Ratio;
 
-  Ratio = (UINT8)((UINT32)AsmReadMsr64 (0xCE) >> 8);
+  Ratio = ((UINT32)AsmReadMsr64 (0xCE) >> 8) & 0xFF;
   if (Ratio == 0) {
     // This might be QEMU case
     Ratio = 8;
   }
   // Ratio * 100000
-  return (UINT32)(Ratio * 100000);
+  return (Ratio * 100000);
 }
 
 /**


### PR DESCRIPTION
When trying to build tgl target with
VS2015x86 there is some error reported:

TimeStampLib.lib(TimeStampLib.obj) : error LNK2001: unresolved external symbol __allmul
FirmwareUpdate.dll : fatal error LNK1120: 1 unresolved externals

This patch resolves the issue by removing
the UINT8 casting.

Signed-off-by: James Gutbub <james.gutbub@intel.com>