### PR TITLE
Fix NVMe library media info

### DIFF
--- a/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressHci.c
+++ b/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressHci.c
@@ -171,13 +171,13 @@ WriteNvmeControllerConfiguration (
     return Status;
   }
 
-  DEBUG ((DEBUG_INFO, "Cc.En: %d\n", Cc->En));
-  DEBUG ((DEBUG_INFO, "Cc.Css: %d\n", Cc->Css));
-  DEBUG ((DEBUG_INFO, "Cc.Mps: %d\n", Cc->Mps));
-  DEBUG ((DEBUG_INFO, "Cc.Ams: %d\n", Cc->Ams));
-  DEBUG ((DEBUG_INFO, "Cc.Shn: %d\n", Cc->Shn));
-  DEBUG ((DEBUG_INFO, "Cc.Iosqes: %d\n", Cc->Iosqes));
-  DEBUG ((DEBUG_INFO, "Cc.Iocqes: %d\n", Cc->Iocqes));
+  DEBUG ((DEBUG_VERBOSE, "Cc.En: %d\n", Cc->En));
+  DEBUG ((DEBUG_VERBOSE, "Cc.Css: %d\n", Cc->Css));
+  DEBUG ((DEBUG_VERBOSE, "Cc.Mps: %d\n", Cc->Mps));
+  DEBUG ((DEBUG_VERBOSE, "Cc.Ams: %d\n", Cc->Ams));
+  DEBUG ((DEBUG_VERBOSE, "Cc.Shn: %d\n", Cc->Shn));
+  DEBUG ((DEBUG_VERBOSE, "Cc.Iosqes: %d\n", Cc->Iosqes));
+  DEBUG ((DEBUG_VERBOSE, "Cc.Iocqes: %d\n", Cc->Iocqes));
 
   return EFI_SUCCESS;
 }
@@ -263,8 +263,8 @@ WriteNvmeAdminQueueAttributes (
     return Status;
   }
 
-  DEBUG ((DEBUG_INFO, "Aqa.Asqs: %d\n", Aqa->Asqs));
-  DEBUG ((DEBUG_INFO, "Aqa.Acqs: %d\n", Aqa->Acqs));
+  DEBUG ((DEBUG_VERBOSE, "Aqa.Asqs: %d\n", Aqa->Asqs));
+  DEBUG ((DEBUG_VERBOSE, "Aqa.Acqs: %d\n", Aqa->Acqs));
 
   return EFI_SUCCESS;
 }
@@ -323,7 +323,7 @@ WriteNvmeAdminSubmissionQueueBaseAddress (
     return Status;
   }
 
-  DEBUG ((DEBUG_INFO, "Asq: %lx\n", *Asq));
+  DEBUG ((DEBUG_VERBOSE, "Asq: %lx\n", *Asq));
 
   return EFI_SUCCESS;
 }
@@ -382,7 +382,7 @@ WriteNvmeAdminCompletionQueueBaseAddress (
     return Status;
   }
 
-  DEBUG ((DEBUG_INFO, "Acq: %lxh\n", *Acq));
+  DEBUG ((DEBUG_VERBOSE, "Acq: %lxh\n", *Acq));
 
   return EFI_SUCCESS;
 }
@@ -462,7 +462,7 @@ NvmeDisableController (
     Status = EFI_DEVICE_ERROR;
   }
 
-  DEBUG ((DEBUG_INFO, "NVMe controller is disabled with status [%r].\n", Status));
+  DEBUG ((DEBUG_VERBOSE, "NVMe controller is disabled with status [%r].\n", Status));
   return Status;
 }
 
@@ -537,7 +537,7 @@ NvmeEnableController (
     Status = EFI_TIMEOUT;
   }
 
-  DEBUG ((DEBUG_INFO, "NVMe controller is enabled with status [%r].\n", Status));
+  DEBUG ((DEBUG_VERBOSE, "NVMe controller is enabled with status [%r].\n", Status));
   return Status;
 }
 
@@ -821,7 +821,7 @@ NvmeControllerInit (
   }
 
   if (Private->Cap.Css != 0x01) {
-    DEBUG ((DEBUG_INFO, "NvmeControllerInit: the controller doesn't support NVMe command set\n"));
+    DEBUG ((DEBUG_VERBOSE, "NvmeControllerInit: the controller doesn't support NVMe command set\n"));
     return EFI_UNSUPPORTED;
   }
 
@@ -879,15 +879,15 @@ NvmeControllerInit (
   Private->SqBuffer[2]        = (NVME_SQ *) (UINTN) (Private->Buffer + 4 * EFI_PAGE_SIZE);
   Private->CqBuffer[2]        = (NVME_CQ *) (UINTN) (Private->Buffer + 5 * EFI_PAGE_SIZE);
 
-  DEBUG ((DEBUG_INFO, "Private->Buffer = [%016X]\n", (UINT64) (UINTN)Private->Buffer));
-  DEBUG ((DEBUG_INFO, "Admin     Submission Queue size (Aqa.Asqs) = [%08X]\n", Aqa.Asqs));
-  DEBUG ((DEBUG_INFO, "Admin     Completion Queue size (Aqa.Acqs) = [%08X]\n", Aqa.Acqs));
-  DEBUG ((DEBUG_INFO, "Admin     Submission Queue (SqBuffer[0]) = [%016X]\n", Private->SqBuffer[0]));
-  DEBUG ((DEBUG_INFO, "Admin     Completion Queue (CqBuffer[0]) = [%016X]\n", Private->CqBuffer[0]));
-  DEBUG ((DEBUG_INFO, "Sync  I/O Submission Queue (SqBuffer[1]) = [%016X]\n", Private->SqBuffer[1]));
-  DEBUG ((DEBUG_INFO, "Sync  I/O Completion Queue (CqBuffer[1]) = [%016X]\n", Private->CqBuffer[1]));
-  DEBUG ((DEBUG_INFO, "Async I/O Submission Queue (SqBuffer[2]) = [%016X]\n", Private->SqBuffer[2]));
-  DEBUG ((DEBUG_INFO, "Async I/O Completion Queue (CqBuffer[2]) = [%016X]\n", Private->CqBuffer[2]));
+  DEBUG ((DEBUG_VERBOSE, "Private->Buffer = [%016X]\n", (UINT64) (UINTN)Private->Buffer));
+  DEBUG ((DEBUG_VERBOSE, "Admin     Submission Queue size (Aqa.Asqs) = [%08X]\n", Aqa.Asqs));
+  DEBUG ((DEBUG_VERBOSE, "Admin     Completion Queue size (Aqa.Acqs) = [%08X]\n", Aqa.Acqs));
+  DEBUG ((DEBUG_VERBOSE, "Admin     Submission Queue (SqBuffer[0]) = [%016X]\n", Private->SqBuffer[0]));
+  DEBUG ((DEBUG_VERBOSE, "Admin     Completion Queue (CqBuffer[0]) = [%016X]\n", Private->CqBuffer[0]));
+  DEBUG ((DEBUG_VERBOSE, "Sync  I/O Submission Queue (SqBuffer[1]) = [%016X]\n", Private->SqBuffer[1]));
+  DEBUG ((DEBUG_VERBOSE, "Sync  I/O Completion Queue (CqBuffer[1]) = [%016X]\n", Private->CqBuffer[1]));
+  DEBUG ((DEBUG_VERBOSE, "Async I/O Submission Queue (SqBuffer[2]) = [%016X]\n", Private->SqBuffer[2]));
+  DEBUG ((DEBUG_VERBOSE, "Async I/O Completion Queue (CqBuffer[2]) = [%016X]\n", Private->CqBuffer[2]));
 
   //
   // Program admin queue attributes.
@@ -950,18 +950,18 @@ NvmeControllerInit (
   Sn[20] = 0;
   CopyMem (Mn, Private->ControllerData->Mn, sizeof (Private->ControllerData->Mn));
   Mn[40] = 0;
-  DEBUG ((DEBUG_INFO, " == NVME IDENTIFY CONTROLLER DATA ==\n"));
-  DEBUG ((DEBUG_INFO, "    PCI VID   : 0x%x\n", Private->ControllerData->Vid));
-  DEBUG ((DEBUG_INFO, "    PCI SSVID : 0x%x\n", Private->ControllerData->Ssvid));
-  DEBUG ((DEBUG_INFO, "    SN        : %a\n",   Sn));
-  DEBUG ((DEBUG_INFO, "    MN        : %a\n",   Mn));
-  DEBUG ((DEBUG_INFO, "    FR        : 0x%x\n", * ((UINT64 *)Private->ControllerData->Fr)));
-  DEBUG ((DEBUG_INFO, "    RAB       : 0x%x\n", Private->ControllerData->Rab));
-  DEBUG ((DEBUG_INFO, "    IEEE      : 0x%x\n", * (UINT32 *)Private->ControllerData->Ieee_oui));
-  DEBUG ((DEBUG_INFO, "    AERL      : 0x%x\n", Private->ControllerData->Aerl));
-  DEBUG ((DEBUG_INFO, "    SQES      : 0x%x\n", Private->ControllerData->Sqes));
-  DEBUG ((DEBUG_INFO, "    CQES      : 0x%x\n", Private->ControllerData->Cqes));
-  DEBUG ((DEBUG_INFO, "    NN        : 0x%x\n", Private->ControllerData->Nn));
+  DEBUG ((DEBUG_VERBOSE, " == NVME IDENTIFY CONTROLLER DATA ==\n"));
+  DEBUG ((DEBUG_VERBOSE, "    PCI VID   : 0x%x\n", Private->ControllerData->Vid));
+  DEBUG ((DEBUG_VERBOSE, "    PCI SSVID : 0x%x\n", Private->ControllerData->Ssvid));
+  DEBUG ((DEBUG_VERBOSE, "    SN        : %a\n",   Sn));
+  DEBUG ((DEBUG_VERBOSE, "    MN        : %a\n",   Mn));
+  DEBUG ((DEBUG_VERBOSE, "    FR        : 0x%x\n", * ((UINT64 *)Private->ControllerData->Fr)));
+  DEBUG ((DEBUG_VERBOSE, "    RAB       : 0x%x\n", Private->ControllerData->Rab));
+  DEBUG ((DEBUG_VERBOSE, "    IEEE      : 0x%x\n", * (UINT32 *)Private->ControllerData->Ieee_oui));
+  DEBUG ((DEBUG_VERBOSE, "    AERL      : 0x%x\n", Private->ControllerData->Aerl));
+  DEBUG ((DEBUG_VERBOSE, "    SQES      : 0x%x\n", Private->ControllerData->Sqes));
+  DEBUG ((DEBUG_VERBOSE, "    CQES      : 0x%x\n", Private->ControllerData->Cqes));
+  DEBUG ((DEBUG_VERBOSE, "    NN        : 0x%x\n", Private->ControllerData->Nn));
 
   //
   // Create two I/O completion queues.

--- a/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressPassthru.c
+++ b/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressPassthru.c
@@ -3,7 +3,7 @@
   NVM Express specification.
 
   (C) Copyright 2014 Hewlett-Packard Development Company, L.P.<BR>
-  Copyright (c) 2013 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2013 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -250,7 +250,7 @@ NvmeCreatePrpList (
              Mapping
              );
   if (EFI_ERROR(Status) || (*PrpListHost == NULL)) {
-    DEBUG ((DEBUG_ERROR, "NvmeCreatePrpList: create PrpList failure!\n"));
+    DEBUG ((DEBUG_VERBOSE, "NvmeCreatePrpList: create PrpList failure!\n"));
     goto EXIT;
   }
 
@@ -467,7 +467,7 @@ NvmExpressPassThru (
   //
   ASSERT (Sq->Psdt == 0);
   if (Sq->Psdt != 0) {
-    DEBUG ((DEBUG_ERROR, "NvmExpressPassThru: doesn't support SGL mechanism\n"));
+    DEBUG ((DEBUG_VERBOSE, "NvmExpressPassThru: doesn't support SGL mechanism\n"));
     return EFI_UNSUPPORTED;
   }
 


### PR DESCRIPTION
Current NVMe library reports hardcoded block size 512 and block num
512. It is incorrect. This patch fixed it.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>