### PR TITLE
Move paging table build from OsLoader to Stage2

### DIFF
--- a/BootloaderCommonPkg/Include/Library/PagingLib.h
+++ b/BootloaderCommonPkg/Include/Library/PagingLib.h
@@ -110,6 +110,8 @@ UnmapMemoryRange (
   @param[in] RequestedAddressBits   If RequestedAddressBits is in valid range
                                     (MIN_ADDR_BITS < RequestedAddressBits < PhysicalAddressBits),
                                     paging table will cover the requested physical address range only.
+                                    When RequestedAddressBits is 0, it will build the address range
+                                    that the CPU can support.
 
   @retval    EFI_SUCCESS            Page table was created successfully.
   @retval    EFI_OUT_OF_RESOURCES   Failed to allocate page buffer
@@ -212,6 +214,18 @@ IsLongModeEnabled (
 BOOLEAN
 EFIAPI
 IsLongModeSupported (
+  VOID
+  );
+
+/**
+  Get physical address bits.
+
+  @return Physical address bits.
+
+**/
+UINT8
+EFIAPI
+GetPhysicalAddressBits (
   VOID
   );
 

--- a/BootloaderCommonPkg/Library/PagingLib/PagingLib.c
+++ b/BootloaderCommonPkg/Library/PagingLib/PagingLib.c
@@ -15,7 +15,7 @@
 #define IS_PD_SET     (((Address & 0xFFF) & IA32_PG_PD) == IA32_PG_PD)
 #define PD_SET_ADDR   (Address & ~(0xFFFF))
 #define PD_UNSET_ADDR (Address & ~(0xFFF))
-#define MIN_ADDR_BITS 32
+#define MIN_ADDR_BITS 36
 
 /**
   The function will check if 5-level paging is needed
@@ -71,8 +71,8 @@ IsPage1GSupport (
   @return Physical address bits.
 
 **/
-STATIC
 UINT8
+EFIAPI
 GetPhysicalAddressBits (
   VOID
   )
@@ -297,6 +297,8 @@ Create4GbPageTables (
   @param[in] RequestedAddressBits   If RequestedAddressBits is in valid range
                                     (MIN_ADDR_BITS < RequestedAddressBits < PhysicalAddressBits),
                                     paging table will cover the requested physical address range only.
+                                    When RequestedAddressBits is 0, it will build the address range
+                                    that the CPU can support.
 
   @retval    EFI_SUCCESS            Page table was created successfully.
   @retval    EFI_OUT_OF_RESOURCES   Failed to allocate page buffer
@@ -324,6 +326,10 @@ CreateIdentityMappingPageTables (
   UINTN             Cr0;
 
   PhysicalAddressBits = GetPhysicalAddressBits ();
+  if (RequestedAddressBits == 0) {
+    RequestedAddressBits = PhysicalAddressBits;
+  }
+
   Page1GSupport       = IsPage1GSupport ();
   Page5LevelSupport   = Is5LevelPagingNeeded ();
   DEBUG ((DEBUG_INFO, "RequestedAddressBits=%u PhysicalAddressBits=%u 5LevelPaging=%u 1GPage=%u\n",

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -405,6 +405,11 @@ SecStartup (
   // Deallocate temporary memory used by previous stage
   FreeTemporaryMemory (NULL);
 
+  if (IS_X64) {
+    // Build full physical space 1:1 mapping page table
+    CreateIdentityMappingPageTables (0);
+  }
+
   // Init all services
   InitializeService ();
 

--- a/BootloaderCorePkg/Stage2/Stage2Hob.c
+++ b/BootloaderCorePkg/Stage2/Stage2Hob.c
@@ -494,7 +494,6 @@ BuildUniversalPayloadHob (
   UNIVERSAL_PAYLOAD_SERIAL_PORT_INFO  *PldSerialPortInfo;
   UNIVERSAL_PAYLOAD_ACPI_TABLE        *AcpiHob;
   UNIVERSAL_PAYLOAD_SMBIOS_TABLE      *SmbiosHob;
-  UINT32                               RegEax;
   UINT8                                PhysicalAddressBits;
 
   // Memory resource hob
@@ -537,13 +536,7 @@ BuildUniversalPayloadHob (
   }
 
   // Build CPU memory space and IO space hob
-  AsmCpuid (0x80000000, &RegEax, NULL, NULL, NULL);
-  if (RegEax >= 0x80000008) {
-    AsmCpuid (0x80000008, &RegEax, NULL, NULL, NULL);
-    PhysicalAddressBits = (UINT8) RegEax;
-  } else {
-    PhysicalAddressBits  = 36;
-  }
+  PhysicalAddressBits = GetPhysicalAddressBits ();
   BuildCpuHob (PhysicalAddressBits, 16);
 
   // Build PCI root bridge hob

--- a/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
+++ b/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
@@ -193,11 +193,6 @@ SecStartup (
   UINT32                    StackBase;
   UINT32                    StackSize;
   LOADER_PLATFORM_INFO      *LoaderPlatformInfo;
-  PCI_ROOT_BRIDGE_INFO_HOB  *RootBridgeInfoHob;
-  UINT64                    MaxResLimit;
-  UINT64                    ResLimit;
-  UINT8                     Count;
-  UINT8                     Index;
 
   TimeStamp = ReadTimeStamp ();
 
@@ -206,26 +201,6 @@ SecStartup (
 
   // DEBUG will be available after PayloadInit ()
   DEBUG ((DEBUG_INIT, "\nPayload startup\n"));
-
-  RootBridgeInfoHob = (PCI_ROOT_BRIDGE_INFO_HOB *)GetGuidHobData (NULL, NULL, &gLoaderPciRootBridgeInfoGuid);
-  if (RootBridgeInfoHob != NULL) {
-    MaxResLimit = BASE_4GB;
-    for (Count = 0; Count < RootBridgeInfoHob->Count; Count++) {
-      for (Index = 0; Index < PCI_MAX_BAR; Index++) {
-        if (((Index + 1) == PciBarTypeMem64) || ((Index + 1) == PciBarTypePMem64)) {
-          ResLimit = RootBridgeInfoHob->Entry[Count].Resource[Index].ResBase
-                   + RootBridgeInfoHob->Entry[Count].Resource[Index].ResLength;
-          MaxResLimit = MAX (MaxResLimit, ResLimit);
-        }
-      }
-    }
-
-    // Only create paging in X64 mode
-    if (IS_X64 && (MaxResLimit > BASE_4GB)) {
-      Index = (UINT8)HighBitSet64 (MaxResLimit - 1);
-      CreateIdentityMappingPageTables (Index + 1);
-    }
-  }
 
   // Copy libraries data
   GuidHob = GetNextGuidHob (&gLoaderLibraryDataGuid, (VOID *)(UINTN)PcdGet32 (PcdPayloadHobList));


### PR DESCRIPTION
Current SBL will build full address paging table supported by CPU
only at the beginning of the OsLoader. It is better to move it to
Stage2 so that all payloads can have the full range address support
in x64 mode. It also allows Stage2 platform code to access 64bit
PCI resource.  This patch addressed this issue.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>