### PR TITLE
[EHL] Enabled AC Split Lock

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1605,9 +1605,6 @@ UpdateFspConfig (
     Fspscfg->PchUnlockGpioPads   = 0x0;
   }
 
-  // W/A for Yocto boot issue
-  Fspscfg->AcSplitLock = 0x0;
-
   PowerCfgData = (POWER_CFG_DATA *) FindConfigDataByTag (CDATA_POWER_TAG);
   if (PowerCfgData == NULL) {
     DEBUG ((DEBUG_ERROR, "Missing power Cfg Data!\n"));


### PR DESCRIPTION
Removal of disabling AcSplitLock FSP UPD.
The FSP UPD is commented out due to the Yocto hang
issue previously which no longer occured.

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>