### PR TITLE
[UPX i11] Clear boot flags in the default USB boot option

### DIFF
--- a/Platform/TigerlakeBoardPkg/CfgData/CfgDataExt_Upx11.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgDataExt_Upx11.dlt
@@ -45,6 +45,7 @@ GEN_CFG_DATA.PayloadId                                      | 0
 # Allow to boot from USB partition 0 and FAT filesystem by default
 BOOT_OPTION_CFG_DATA_0.SwPart_0                             | 0
 BOOT_OPTION_CFG_DATA_0.FsType_0                             | 0
+BOOT_OPTION_CFG_DATA_0.BootFlags_0                          | 0
 
 GPIO_CFG_DATA.GpioPinConfig0_GPP_A00        | 0x0550A381
 GPIO_CFG_DATA.GpioPinConfig1_GPP_A00        | 0x02002001


### PR DESCRIPTION
By default, the boot option 0 has mender OS boot flag set, and it causes
"root=" to be appended to the Linux boot command line. For Ubuntu OS,
it will cause the wrong root fs parameter and prevent it from booting.
This patch fixed this issue.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>