### PR TITLE
[TGL] Enable PCI 64bit resource in X64 build

### DIFF
--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -255,7 +255,7 @@ class BaseBoard(object):
         self.HASH_STORE_SIZE       = 0x400  #Hash store size to be allocated in bootloader
 
         self.PCI_MEM64_BASE        = 0
-        self.BUILD_ARCH            = 'IA32'
+        self.BUILD_ARCH            = ''
         self.KEYH_SVN              = 0
         self.CFGDATA_SVN           = 0
 

--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -42,6 +42,15 @@ class Board(BaseBoard):
         self.PCI_MEM32_BASE       = 0x80000000
         self.PCI_MEM64_BASE       = 0x1000000000
 
+        if self.BUILD_ARCH == 'X64':
+            # Assign Mem64/PMem64 PCI resources except for Bus0
+            self._PCI_ENUM_DOWNGRADE_MEM64  = 0
+            self._PCI_ENUM_DOWNGRADE_PMEM64 = 0
+            # Downgrade all devices on bus 0 but iGFX
+            self._PCI_ENUM_DOWNGRADE_BUS0   = 2
+            self.SUPPORT_ARI          = 1
+            self.SUPPORT_SR_IOV       = 1
+
         self.ACPI_PM_TIMER_BASE   = 0x1808
         self.LOADER_ACPI_RECLAIM_MEM_SIZE = 0x000090000
 

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -977,10 +977,12 @@ BoardInit (
       }
       if (FspGfxHob != NULL) {
         DEBUG ((DEBUG_INFO, "FspGfxHob->FrameBufferBase = 0x%lx\n", FspGfxHob->FrameBufferBase));
-        PciWrite8 (PCI_LIB_ADDRESS(SA_IGD_BUS, SA_IGD_DEV, SA_IGD_FUN_0, PCI_COMMAND_OFFSET), \
-                   EFI_PCI_COMMAND_MEMORY_SPACE | EFI_PCI_COMMAND_BUS_MASTER);
+        PciWrite32 (PCI_LIB_ADDRESS(SA_IGD_BUS, SA_IGD_DEV, SA_IGD_FUN_0, 0x1C), \
+                   (UINT32)RShiftU64 (FspGfxHob->FrameBufferBase, 32));
         PciWrite32 (PCI_LIB_ADDRESS(SA_IGD_BUS, SA_IGD_DEV, SA_IGD_FUN_0, 0x18), \
                    (UINT32)FspGfxHob->FrameBufferBase);
+        PciWrite8 (PCI_LIB_ADDRESS(SA_IGD_BUS, SA_IGD_DEV, SA_IGD_FUN_0, PCI_COMMAND_OFFSET), \
+                   EFI_PCI_COMMAND_MEMORY_SPACE | EFI_PCI_COMMAND_BUS_MASTER);
       } else {
         DEBUG ((DEBUG_ERROR, "FspGfxHob is not available\n"));
       }
@@ -1892,8 +1894,12 @@ UpdateFrameBufferInfo (
   OUT  EFI_PEI_GRAPHICS_INFO_HOB   *GfxInfo
 )
 {
+  UINT64  GfxBar;
+
   if (PcdGetBool (PcdIntelGfxEnabled)) {
-    GfxInfo->FrameBufferBase = PciRead32 (PCI_LIB_ADDRESS (SA_IGD_BUS, SA_IGD_DEV, SA_IGD_FUN_0, 0x18)) & 0xFFFFFF00;
+    GfxBar  = LShiftU64 (PciRead32 (PCI_LIB_ADDRESS (SA_IGD_BUS, SA_IGD_DEV, SA_IGD_FUN_0, 0x1C)), 32);
+    GfxBar += (PciRead32 (PCI_LIB_ADDRESS (SA_IGD_BUS, SA_IGD_DEV, SA_IGD_FUN_0, 0x18)) & 0xFFFFFF00);
+    GfxInfo->FrameBufferBase = (PHYSICAL_ADDRESS) GfxBar;
   }
 }
 


### PR DESCRIPTION
This patch enabled several config options for TGL x64 build so that
64 bit PCI resource can be allocated properly. As part of it, the
related GFX bar read/write has been extended to handle 64bit address.

This has been tested on UPX i11 board. X64 SBL can boot to Ubuntu
properly.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>