### PR TITLE
Add SMBIOS type 19 - memory array mapped address

### DIFF
--- a/BootloaderCorePkg/Include/Library/FspSupportLib.h
+++ b/BootloaderCorePkg/Include/Library/FspSupportLib.h
@@ -47,6 +47,22 @@ GetFspReservedMemoryFromGuid (
   );
 
 /**
+  This function retrieves a top of low and high memory address.
+
+  @param  HobListPtr    A HOB list pointer.
+  @param  TopOfHighMem  A pointer to receive the top of high memory.
+
+  @retval              Top of low memory.
+
+**/
+UINT32
+EFIAPI
+GetSystemTopOfMemeory (
+  CONST VOID     *HobListPtr,
+  UINT64         *TopOfHighMem  OPTIONAL
+  );
+
+/**
   This function traverses each memory resource hob type and calls the handler.
 
   @param  HobListPtr         A HOB list pointer.

--- a/BootloaderCorePkg/Library/FspSupportLib/FspSupportLib.c
+++ b/BootloaderCorePkg/Library/FspSupportLib/FspSupportLib.c
@@ -79,6 +79,58 @@ GetFspReservedMemoryFromGuid (
 }
 
 /**
+  This function retrieves a top of low and high memory address.
+
+  @param  HobListPtr    A HOB list pointer.
+  @param  TopOfHighMem  A pointer to receive the top of high memory.
+
+  @retval              Top of low memory.
+
+**/
+UINT32
+EFIAPI
+GetSystemTopOfMemeory (
+  CONST VOID     *HobListPtr,
+  UINT64         *TopOfHighMem  OPTIONAL
+  )
+{
+  EFI_PEI_HOB_POINTERS    Hob;
+  UINT32                  Tolm;
+  UINT64                  Tohm;
+  EFI_PHYSICAL_ADDRESS    EndAddr;
+
+  // Get the HOB list for processing
+  Hob.Raw = (VOID *)HobListPtr;
+
+  // Collect memory ranges
+  Tolm = 0;
+  Tohm = SIZE_4GB;
+  while (!END_OF_HOB_LIST (Hob)) {
+    if (Hob.Header->HobType == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+      if (Hob.ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) {
+        EndAddr = Hob.ResourceDescriptor->PhysicalStart + Hob.ResourceDescriptor->ResourceLength;
+        if (EndAddr < SIZE_4GB) {
+          if (EndAddr > Tolm) {
+            Tolm = (UINT32) EndAddr;
+          }
+        } else {
+          if (EndAddr > Tohm) {
+            Tohm = EndAddr;
+          }
+        }
+      }
+    }
+    Hob.Raw = GET_NEXT_HOB (Hob);
+  }
+
+  if (TopOfHighMem != NULL) {
+    *TopOfHighMem = Tohm;
+  }
+
+  return Tolm;
+}
+
+/**
   This function traverses each memory resource hob type and calls the handler.
 
   @param  HobListPtr         A HOB list pointer.


### PR DESCRIPTION
Current UEFI payload showed 0 KB RAM size in setup screen because
of missing SMBIOS memory type information. This patch added SMBIOS
type 19 to provide memory array mapped address information. With
this change, UEFI setup screen can show correct memory size.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>