### PR TITLE
Append ACPI rsdp parameter only for old Linux boot protocol

### DIFF
--- a/BootloaderCommonPkg/Library/LinuxLib/LinuxLib.c
+++ b/BootloaderCommonPkg/Library/LinuxLib/LinuxLib.c
@@ -332,12 +332,16 @@ UpdateLinuxBootParams (
   GuidHob = GetFirstGuidHob (&gLoaderSystemTableInfoGuid);
   if (GuidHob != NULL) {
     SystemTableInfo = (SYSTEM_TABLE_INFO *)GET_GUID_HOB_DATA (GuidHob);
-    if (AsciiStrStr ((CHAR8 *)(UINTN)Bp->Hdr.CmdLinePtr, (CHAR8 *)ACPI_RSDP_CMDLINE_STR) == NULL) {
-      AsciiSPrint (ParamValue, sizeof (ParamValue), " %a0x%lx", ACPI_RSDP_CMDLINE_STR, SystemTableInfo->AcpiTableBase);
-      AsciiStrCatS ((CHAR8 *)(UINTN)Bp->Hdr.CmdLinePtr, CMDLINE_LENGTH_MAX, ParamValue);
-      Bp->Hdr.CmdlineSize = (UINT32)AsciiStrLen ((CHAR8 *)(UINTN)Bp->Hdr.CmdLinePtr);
-    }
     Bp->AcpiRsdpAddr = SystemTableInfo->AcpiTableBase;
+    if (Bp->Hdr.Version < 0x020E) {
+      // Bp.AcpiRsdpAddr was only added in Linux boot protocol 2.14
+      // For old version, just append "acpi_rsdp=" instead.
+      if (AsciiStrStr ((CHAR8 *)(UINTN)Bp->Hdr.CmdLinePtr, (CHAR8 *)ACPI_RSDP_CMDLINE_STR) == NULL) {
+        AsciiSPrint (ParamValue, sizeof (ParamValue), " %a0x%lx", ACPI_RSDP_CMDLINE_STR, SystemTableInfo->AcpiTableBase);
+        AsciiStrCatS ((CHAR8 *)(UINTN)Bp->Hdr.CmdLinePtr, CMDLINE_LENGTH_MAX, ParamValue);
+        Bp->Hdr.CmdlineSize = (UINT32)AsciiStrLen ((CHAR8 *)(UINTN)Bp->Hdr.CmdLinePtr);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Current SBL will always append "acpi_rsdp=" as part of the command
line for Linux boot. However, since acpi_rsdp_addr was added in
boot parameter for Linux boot protocol 2.14 and later, it is only
required to do this for old boot protocol. This patch implemented
this.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>