### PR TITLE
[Common] Filename prompt issue fix in OSL shell

### DIFF
--- a/BootloaderCommonPkg/Library/ShellLib/CmdBoot.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdBoot.c
@@ -592,13 +592,13 @@ ShellCommandBootFunc (
       if (EFI_ERROR (Status)) {
         goto ExitBootCmd;
       }
-      if ((CurrOption->BootFlags & BOOT_FLAGS_PREOS) != 0){
+      if ((BootOption.BootFlags & BOOT_FLAGS_PREOS) != 0){
         Status = GetBootFileInfo (Shell, Buffer, sizeof (Buffer), &BootOption, CurrOption, LoadImageTypePreOs);
         if (EFI_ERROR (Status)) {
           goto ExitBootCmd;
         }
       }
-      if ((CurrOption->BootFlags & BOOT_FLAGS_EXTRA) != 0){
+      if ((BootOption.BootFlags & BOOT_FLAGS_EXTRA) != 0){
         Status = GetBootFileInfo (Shell, Buffer, sizeof (Buffer), &BootOption, CurrOption, LoadImageTypeExtra0);
         if (EFI_ERROR (Status)) {
           goto ExitBootCmd;


### PR DESCRIPTION
When user disabled PRE_OS in bootflag with boot->idx
command in OSL shell but shell still prompt user to
enter PREOS image file path, This is due to the system
check the existing boot option list instead of the
boot option that user currently updating.

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>