### PR TITLE
Enhance firmware update to handle different BIOS region size

### DIFF
--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
@@ -65,7 +65,6 @@
   gPayloadTokenSpaceGuid.PcdPayloadHobList
   gPlatformCommonLibTokenSpaceGuid.PcdAcpiPmTimerBase
   gPayloadTokenSpaceGuid.PcdFwUpdStatusBase
-  gPayloadTokenSpaceGuid.PcdRsvdRegionBase
   gPlatformCommonLibTokenSpaceGuid.PcdLowestSupportedFwVer
   gPayloadTokenSpaceGuid.PcdCsmeUpdateEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdCompSignHashAlg

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
@@ -230,4 +230,14 @@ Reboot (
   IN  EFI_RESET_TYPE        ResetType
   );
 
+/**
+  Retrieve the SBL rom image offset within BIOS region.
+
+  @retval  The SBL rom image offset within BIOS region
+**/
+UINT32
+GetRomImageOffsetInBiosRegion (
+  VOID
+  );
+
 #endif

--- a/PayloadPkg/PayloadPkg.dec
+++ b/PayloadPkg/PayloadPkg.dec
@@ -38,7 +38,6 @@
 
 [PcdsPatchableInModule]
   gPayloadTokenSpaceGuid.PcdFwUpdStatusBase   | 0x00000000 | UINT32 | 0x10001005
-  gPayloadTokenSpaceGuid.PcdRsvdRegionBase    | 0x00000000 | UINT32 | 0x10001006
 
 [PcdsFeatureFlag]
   gPayloadTokenSpaceGuid.PcdGrubBootCfgEnabled   | FALSE    | BOOLEAN | 0x2001000


### PR DESCRIPTION
Current SBL FWU code assumes the SBL ROM image size is the same as
the BIOS region size defined in the SPI descriptor. It is used to
calculate the offset for flash write and erase. However, the SBL
ROM image size could be smaller than BIOS region size, in this case
the offsets are all wrong. This patch addressed this issue.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>