### PR TITLE
Add PCD to let platform control the ACPI processor ID base

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -135,6 +135,9 @@
 
   gPlatformModuleTokenSpaceGuid.PcdVerifiedBootStage1B    | FALSE      | BOOLEAN| 0x200000D0
 
+  # ACPI processor ID base value
+  gPlatformModuleTokenSpaceGuid.PcdAcpiProcessorIdBase    |  1         | UINT32 | 0x200000D8
+
   gPlatformModuleTokenSpaceGuid.PcdCpuMaxLogicalProcessorNumber | 16   | UINT32 | 0x200000E0
   gPlatformModuleTokenSpaceGuid.PcdMaxServiceNumber       | 8          | UINT32 | 0x200000E1
   gPlatformModuleTokenSpaceGuid.PcdSeedListBufferSize     | 0x00000400 | UINT32 | 0x200000E2
@@ -147,6 +150,7 @@
   # Use this PCD for the potential code change related with boot performance
   # NOTE: some features might be disabled when ENABLE_FAST_BOOT is set.
   gPlatformModuleTokenSpaceGuid.PcdFastBootEnabled        |  FALSE     | BOOLEAN| 0x200000F2
+
 
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   #

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -223,8 +223,9 @@
   gPlatformModuleTokenSpaceGuid.PcdCfgDataLoadSource      | $(CFGDATA_REGION_TYPE)
   gPlatformModuleTokenSpaceGuid.PcdCfgDatabaseSize        | $(CFG_DATABASE_SIZE)
 
-  gPlatformModuleTokenSpaceGuid.PcdHashStoreSize             | $(HASH_STORE_SIZE)
+  gPlatformModuleTokenSpaceGuid.PcdHashStoreSize          | $(HASH_STORE_SIZE)
 
+  gPlatformModuleTokenSpaceGuid.PcdAcpiProcessorIdBase    | $(ACPI_PROCESSOR_ID_BASE)
   gPlatformModuleTokenSpaceGuid.PcdCpuMaxLogicalProcessorNumber | $(CPU_MAX_LOGICAL_PROCESSOR_NUMBER)
 
   gPlatformCommonLibTokenSpaceGuid.PcdConsoleInDeviceMask  | $(CONSOLE_IN_DEVICE_MASK)

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
@@ -373,7 +373,7 @@ UpdateMadt (
     for (Index = 0; Index < SysCpuInfo->CpuCount; Index++) {
       LocalX2Apic[Index].Type             = EFI_ACPI_5_0_PROCESSOR_LOCAL_X2APIC;
       LocalX2Apic[Index].Length           = sizeof (EFI_ACPI_5_0_PROCESSOR_LOCAL_X2APIC_STRUCTURE);
-      LocalX2Apic[Index].AcpiProcessorUid = Index + 1;
+      LocalX2Apic[Index].AcpiProcessorUid = Index + PcdGet32 (PcdAcpiProcessorIdBase);
       LocalX2Apic[Index].X2ApicId         = SysCpuInfo->CpuInfo[Index].ApicId;
       LocalX2Apic[Index].Flags            = 1;
     }
@@ -384,7 +384,7 @@ UpdateMadt (
     for (Index = 0; Index < SysCpuInfo->CpuCount; Index++) {
       LocalApic[Index].Type             = EFI_ACPI_5_0_PROCESSOR_LOCAL_APIC;
       LocalApic[Index].Length           = sizeof (EFI_ACPI_5_0_PROCESSOR_LOCAL_APIC_STRUCTURE);
-      LocalApic[Index].AcpiProcessorId  = (UINT8)Index + 1;
+      LocalApic[Index].AcpiProcessorId  = (UINT8)(Index + PcdGet32 (PcdAcpiProcessorIdBase));
       LocalApic[Index].ApicId           = (UINT8)SysCpuInfo->CpuInfo[Index].ApicId;
       LocalApic[Index].Flags            = 1;
     }
@@ -643,7 +643,7 @@ AcpiInit (
       if (!EFI_ERROR(Status)) {
         if (UpdateRdstXsdt == 1) {
           Signature = Table->Signature;
-          DEBUG ((DEBUG_INFO, "Publish ACPI table: %a\n", &Signature));
+          DEBUG ((DEBUG_INFO, "Publish ACPI table: %a @ 0x%08X\n", &Signature, (UINT32)(UINTN)Current));
           RsdtEntry[XsdtIndex]   = (UINT32) (UINTN)Current;
           XsdtEntry[XsdtIndex++] = (UINT64) (UINTN)Current;
         }

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
@@ -64,3 +64,4 @@
   gPlatformModuleTokenSpaceGuid.PcdSplashEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdCpuX2ApicEnabled
   gPlatformModuleTokenSpaceGuid.PcdAcpiTableTemplatePtr
+  gPlatformModuleTokenSpaceGuid.PcdAcpiProcessorIdBase

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -132,6 +132,7 @@ class BaseBoard(object):
 
         self.PCI_EXPRESS_BASE       = 0xE0000000
         self.ACPI_PM_TIMER_BASE     = 0x0408
+        self.ACPI_PROCESSOR_ID_BASE = 1
         self.USB_KB_POLLING_TIMEOUT = 1
 
         self.VERIFIED_BOOT_STAGE_1B   = 0x0

--- a/Platform/ElkhartlakeBoardPkg/BoardConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/BoardConfig.py
@@ -39,6 +39,7 @@ class Board(BaseBoard):
         self.PCI_IO_BASE          = 0x00002000
         self.PCI_MEM32_BASE       = 0x80000000
         self.ACPI_PM_TIMER_BASE   = 0x1808
+        self.ACPI_PROCESSOR_ID_BASE = 0
 
         self.FLASH_BASE_ADDRESS   = 0xFF000000
         self.FLASH_BASE_SIZE      = (self.FLASH_LAYOUT_START - self.FLASH_BASE_ADDRESS)

--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -51,7 +51,8 @@ class Board(BaseBoard):
             self.SUPPORT_ARI          = 1
             self.SUPPORT_SR_IOV       = 1
 
-        self.ACPI_PM_TIMER_BASE   = 0x1808
+        self.ACPI_PROCESSOR_ID_BASE = 0
+        self.ACPI_PM_TIMER_BASE     = 0x1808
         self.LOADER_ACPI_RECLAIM_MEM_SIZE = 0x000090000
 
         self.FLASH_BASE_ADDRESS   = 0xFF000000


### PR DESCRIPTION
This patch added PcdAcpiProcessorIdBase to allow platform to
customize the processor ID start base within MADT APIC entry.
Current EHL and TGL declared PR00 processor object in ACPI
with unique ID value 0, but other projects used vlaue 1
instead. This patch will help fix this issue.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>