### PR TITLE
[QEMU] Enable SMBIOS support

### DIFF
--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -60,6 +60,7 @@ class Board(BaseBoard):
         self.ENABLE_GRUB_CONFIG       = 1
         self.ENABLE_LINUX_PAYLOAD     = 1
         self.ENABLE_CRYPTO_SHA_OPT    = 0
+        self.ENABLE_SMBIOS            = 1
 
         # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)
         self.ENABLE_SMM_REBASE        = 2

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -262,6 +262,127 @@ EmuGraphicsInit (
   return Status;
 }
 
+/**
+  Add a Smbios type string into a buffer
+
+**/
+STATIC
+EFI_STATUS
+AddSmbiosTypeString (
+  SMBIOS_TYPE_STRINGS  *Dest,
+  UINT8                 Type,
+  UINT8                 Index,
+  CHAR8                *String
+  )
+{
+  UINTN   Length;
+
+  Dest->Type    = Type;
+  Dest->Idx     = Index;
+  if (String != NULL) {
+    Length = AsciiStrLen (String);
+
+    Dest->String  = (CHAR8 *)AllocateZeroPool (Length + 1);
+    if (Dest->String == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+    CopyMem (Dest->String, String, Length);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Initialize necessary information for Smbios
+
+  @retval EFI_SUCCESS             Initialized necessary information successfully
+  @retval EFI_OUT_OF_RESOURCES    Failed to allocate memory for Smbios info
+
+**/
+EFI_STATUS
+InitializeSmbiosInfo (
+  VOID
+  )
+{
+  CHAR8                 TempStrBuf[SMBIOS_STRING_MAX_LENGTH];
+  UINT16                Index;
+  UINTN                 Length;
+  SMBIOS_TYPE_STRINGS  *TempSmbiosStrTbl;
+  BOOT_LOADER_VERSION  *VerInfoTbl;
+  VOID                 *SmbiosStringsPtr;
+
+  Index             = 0;
+  TempSmbiosStrTbl  = (SMBIOS_TYPE_STRINGS *) AllocateTemporaryMemory (0);
+  VerInfoTbl    = GetVerInfoPtr ();
+
+  //
+  // SMBIOS_TYPE_BIOS_INFORMATION
+  //
+  AddSmbiosTypeString (&TempSmbiosStrTbl[Index++], SMBIOS_TYPE_BIOS_INFORMATION,
+    1, "Intel Corporation");
+  if (VerInfoTbl != NULL) {
+    AsciiSPrint (TempStrBuf, sizeof (TempStrBuf),
+      "SB_QEMU.%03d.%03d.%03d.%03d.%05d.%c\0",
+      VerInfoTbl->ImageVersion.CoreMajorVersion,
+      VerInfoTbl->ImageVersion.CoreMinorVersion,
+      VerInfoTbl->ImageVersion.ProjMajorVersion,
+      VerInfoTbl->ImageVersion.ProjMinorVersion,
+      VerInfoTbl->ImageVersion.BuildNumber,
+      VerInfoTbl->ImageVersion.BldDebug ? 'D' : 'R');
+  } else {
+    AsciiSPrint (TempStrBuf, sizeof (TempStrBuf), "%a", "Unknown");
+  }
+  AddSmbiosTypeString (&TempSmbiosStrTbl[Index++], SMBIOS_TYPE_BIOS_INFORMATION,
+    2, TempStrBuf);
+  AddSmbiosTypeString (&TempSmbiosStrTbl[Index++], SMBIOS_TYPE_BIOS_INFORMATION,
+    3, __DATE__);
+
+  //
+  // SMBIOS_TYPE_SYSTEM_INFORMATION
+  //
+  AddSmbiosTypeString (&TempSmbiosStrTbl[Index++], SMBIOS_TYPE_SYSTEM_INFORMATION,
+    1, "Intel Corporation");
+  AddSmbiosTypeString (&TempSmbiosStrTbl[Index++], SMBIOS_TYPE_SYSTEM_INFORMATION,
+    2, "QEMU Virtual Platform");
+  AddSmbiosTypeString (&TempSmbiosStrTbl[Index++], SMBIOS_TYPE_SYSTEM_INFORMATION,
+    3, "0.1");
+  AddSmbiosTypeString (&TempSmbiosStrTbl[Index++], SMBIOS_TYPE_SYSTEM_INFORMATION,
+    4, "System Serial Number");
+  AddSmbiosTypeString (&TempSmbiosStrTbl[Index++], SMBIOS_TYPE_SYSTEM_INFORMATION,
+    5, "System SKU Number");
+  AddSmbiosTypeString (&TempSmbiosStrTbl[Index++], SMBIOS_TYPE_SYSTEM_INFORMATION,
+    6, "Virtual System");
+
+  //
+  // SMBIOS_TYPE_BASEBOARD_INFORMATION
+  //
+  AddSmbiosTypeString (&TempSmbiosStrTbl[Index++], SMBIOS_TYPE_BASEBOARD_INFORMATION,
+    1, "Intel Corporation");
+  AsciiSPrint (TempStrBuf, sizeof (TempStrBuf), "%8a (ID:%02X)", GetPlatformName(), GetPlatformId ());
+  AddSmbiosTypeString (&TempSmbiosStrTbl[Index++], SMBIOS_TYPE_BASEBOARD_INFORMATION,
+    2, TempStrBuf);
+  AddSmbiosTypeString (&TempSmbiosStrTbl[Index++], SMBIOS_TYPE_BASEBOARD_INFORMATION,
+    3, "1");
+  AddSmbiosTypeString (&TempSmbiosStrTbl[Index++], SMBIOS_TYPE_BASEBOARD_INFORMATION,
+    4, "Board Serial Number");
+
+  //
+  // SMBIOS_TYPE_END_OF_TABLE
+  //
+  AddSmbiosTypeString (&TempSmbiosStrTbl[Index++], SMBIOS_TYPE_END_OF_TABLE,
+    0, NULL);
+
+  Length = sizeof (SMBIOS_TYPE_STRINGS) * Index;
+  SmbiosStringsPtr = AllocatePool (Length);
+  if (SmbiosStringsPtr == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+  CopyMem (SmbiosStringsPtr, TempSmbiosStrTbl, Length);
+  (VOID) PcdSet32S (PcdSmbiosStringsPtr, (UINT32)(UINTN)SmbiosStringsPtr);
+  (VOID) PcdSet16S (PcdSmbiosStringsCnt, Index);
+
+  return EFI_SUCCESS;
+}
 
 
 /**
@@ -333,6 +454,10 @@ BoardInit (
     break;
 
   case PostSiliconInit:
+    // Initialize Smbios Info
+    if (FeaturePcdGet (PcdSmbiosEnabled)) {
+      InitializeSmbiosInfo ();
+    }
     // Open TSEG so that MpInit can do SMM rebasing if required
     PciAnd8 (PCI_LIB_ADDRESS(0, 0, 0, MCH_ESMRAMC), (UINT8)~MCH_ESMRAMC_T_EN);
     PciAndThenOr8 (PCI_LIB_ADDRESS(0, 0, 0, MCH_SMRAM), (UINT8)~MCH_SMRAM_D_CLOSE, MCH_SMRAM_D_OPEN);

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -43,6 +43,7 @@
   VariableLib
   BoardSupportLib
   GraphicsInitLib
+  SmbiosInitLib
 
 [Guids]
   gReservedMemoryResourceHobTsegGuid
@@ -65,3 +66,6 @@
   gPlatformModuleTokenSpaceGuid.PcdStage1BXip
   gPlatformModuleTokenSpaceGuid.PcdEnableSetup
   gPlatformModuleTokenSpaceGuid.PcdAcpiTableTemplatePtr
+  gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsPtr
+  gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsCnt
+  gPlatformModuleTokenSpaceGuid.PcdSmbiosEnabled

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLibInternal.h
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLibInternal.h
@@ -29,6 +29,8 @@
 #include <Library/GraphicsInitLib.h>
 #include <Library/HobLib.h>
 #include <Library/PlatformHookLib.h>
+#include <Library/SmbiosInitLib.h>
+#include <Library/PrintLib.h>
 #include <Guid/GraphicsInfoHob.h>
 #include <Guid/SystemTableInfoGuid.h>
 #include <Guid/SerialPortInfoGuid.h>


### PR DESCRIPTION
This patch enable SMBIOS support for QEMU. It allows to test SMBIOS
on QEMU platform.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>