### PR TITLE
Profile Max Used Heap size at runtime

### DIFF
--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -215,6 +215,7 @@ typedef struct {
   BL_PERF_DATA      PerfData;
   UINT32            CarBase;
   UINT32            CarSize;
+  UINT32            MemPoolMaxUsed;
 } LOADER_GLOBAL_DATA;
 
 /**

--- a/BootloaderCorePkg/Library/MemoryAllocationLib/MemoryAllocationLib.c
+++ b/BootloaderCorePkg/Library/MemoryAllocationLib/MemoryAllocationLib.c
@@ -27,8 +27,14 @@ InternalUpdateMemPoolTop (
   )
 {
   LOADER_GLOBAL_DATA  *LdrGlobal;
+  UINT32               PoolUsed;
 
   LdrGlobal = GetLoaderGlobalDataPointer();
+  PoolUsed = (LdrGlobal->MemPoolEnd - Top) +
+              (LdrGlobal->MemPoolCurrBottom - LdrGlobal->MemPoolStart);
+  if (LdrGlobal->MemPoolMaxUsed < PoolUsed) {
+    LdrGlobal->MemPoolMaxUsed = PoolUsed;
+  }
   ASSERT (Top >= LdrGlobal->MemPoolCurrBottom);
   LdrGlobal->MemPoolCurrTop = Top;
 }
@@ -44,8 +50,14 @@ InternalUpdateMemPoolBottom (
   )
 {
   LOADER_GLOBAL_DATA  *LdrGlobal;
+  UINT32               PoolUsed;
 
   LdrGlobal = GetLoaderGlobalDataPointer();
+  PoolUsed = (LdrGlobal->MemPoolEnd - LdrGlobal->MemPoolCurrTop) +
+              (Bottom - LdrGlobal->MemPoolStart);
+  if (LdrGlobal->MemPoolMaxUsed < PoolUsed) {
+    LdrGlobal->MemPoolMaxUsed = PoolUsed;
+  }
   ASSERT (LdrGlobal->MemPoolCurrTop >= Bottom);
   LdrGlobal->MemPoolCurrBottom = Bottom;
 }

--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -463,6 +463,7 @@ SecStartup (
   LdrGlobal->MemPoolStart          = StackTop;
   LdrGlobal->MemPoolCurrTop        = LdrGlobal->MemPoolEnd;
   LdrGlobal->MemPoolCurrBottom     = LdrGlobal->MemPoolStart;
+  LdrGlobal->MemPoolMaxUsed        = 0;
   LdrGlobal->DebugPrintErrorLevel  = 0;
   LdrGlobal->PerfData.PerfIndex    = 2;
   LdrGlobal->PerfData.FreqKhz      = GetTimeStampFrequency ();

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -446,6 +446,7 @@ SecStartup2 (
   LdrGlobal->MemPoolStart      = MemPoolStart;
   LdrGlobal->MemPoolCurrTop    = MemPoolCurrTop;
   LdrGlobal->MemPoolCurrBottom = MemPoolStart;
+  LdrGlobal->MemPoolMaxUsed    = 0;
   LdrGlobal->MemUsableTop      = (UINT32)(FspReservedMemBase + FspReservedMemSize);
 
   if (FeaturePcdGet (PcdDmaProtectionEnabled)) {
@@ -644,9 +645,11 @@ ContinueFunc (
            ));
   DEBUG ((
            DEBUG_INFO,
-           "Stage1 heap: 0x%X (0x%X used)\n",
+           "Stage1 heap: 0x%X (0x%X used, 0x%x max used)\n",
            PcdGet32 (PcdStage1DataSize),
-           OldLdrGlobal->MemPoolEnd - OldLdrGlobal->MemPoolCurrTop
+           (OldLdrGlobal->MemPoolEnd - OldLdrGlobal->MemPoolCurrTop) +
+           (OldLdrGlobal->MemPoolCurrBottom - OldLdrGlobal->MemPoolStart),
+           OldLdrGlobal->MemPoolMaxUsed
            ));
   DEBUG_CODE_END ();
 

--- a/BootloaderCorePkg/Stage2/Stage2Support.c
+++ b/BootloaderCorePkg/Stage2/Stage2Support.c
@@ -136,10 +136,12 @@ PrintStackHeapInfo (
 
   DEBUG ((
            DEBUG_INFO,
-           "Stage2 heap: 0x%X (0x%X used, 0x%X free)\n",
+           "Stage2 heap: 0x%X (0x%X used, 0x%X free, 0x%x max used)\n",
            LdrGlobal->MemPoolEnd - LdrGlobal->MemPoolStart,
-           LdrGlobal->MemPoolEnd - LdrGlobal->MemPoolCurrTop,
-           LdrGlobal->MemPoolCurrTop - LdrGlobal->MemPoolStart
+           (LdrGlobal->MemPoolEnd - LdrGlobal->MemPoolCurrTop) +
+           (LdrGlobal->MemPoolCurrBottom - LdrGlobal->MemPoolStart),
+           LdrGlobal->MemPoolCurrTop - LdrGlobal->MemPoolCurrBottom,
+           LdrGlobal->MemPoolMaxUsed
            ));
 }
 


### PR DESCRIPTION
This records the maximum usage of heap at runtime. The Stage1/2 heap
sometimes reaches OUT OF RESOURCE even if it looks there is enough
usable space in the heap. This is because AllocateTemporaryMemory()
sometime exceeds the heap boundary. ex) IppCryptoLib
This would help identify proper heap size required in each stages.

Signed-off-by: Aiden Park <aiden.park@intel.com>