### PR TITLE
Add print for bootable USB device name

### DIFF
--- a/BootloaderCommonPkg/Include/Library/UsbBusLib.h
+++ b/BootloaderCommonPkg/Include/Library/UsbBusLib.h
@@ -30,4 +30,19 @@ UsbEnumBus (
   USB_IO_CALLBACK                        UsbIoCb
   );
 
+/**
+  Retrieve the concatenated manufacturer and product string for a given USB device.
+
+  @param[in]  UsbIo for a USB device.
+
+  @retval     The constant manufacturer and product string.
+              NULL if UsbIo is not valid.
+**/
+CONST
+CHAR16 *
+EFIAPI
+GetUsbDeviceNameString (
+  IN PEI_USB_IO_PPI  *UsbIo
+  );
+
 #endif

--- a/BootloaderCommonPkg/Library/UsbBusLib/UsbPeim.c
+++ b/BootloaderCommonPkg/Library/UsbBusLib/UsbPeim.c
@@ -204,6 +204,8 @@ PeiHubEnumeration (
         NewPeiUsbDevice->Tier             = (UINT8) (PeiUsbDevice->Tier + 1);
         NewPeiUsbDevice->IsHub            = 0x0;
         NewPeiUsbDevice->DownStreamPortNo = 0x0;
+        NewPeiUsbDevice->Port             = (UINT8)Index;
+        NewPeiUsbDevice->Parent           = &PeiUsbDevice->UsbIoPpi;
 
         if (((PortStatus.PortChangeStatus & USB_PORT_STAT_C_RESET) == 0) ||
             ((PortStatus.PortStatus & (USB_PORT_STAT_CONNECTION | USB_PORT_STAT_ENABLE)) == 0)) {
@@ -432,6 +434,8 @@ PeiUsbEnumeration (
         PeiUsbDevice->Usb2HcPpi         = Usb2HcPpi;
         PeiUsbDevice->IsHub             = 0x0;
         PeiUsbDevice->DownStreamPortNo  = 0x0;
+        PeiUsbDevice->Port              = Index;
+        PeiUsbDevice->Parent            = NULL;
 
         if (((PortStatus.PortChangeStatus & USB_PORT_STAT_C_RESET) == 0) ||
             ((PortStatus.PortStatus & (USB_PORT_STAT_CONNECTION | USB_PORT_STAT_ENABLE)) == 0)) {
@@ -591,6 +595,10 @@ PeiConfigureUsbDevice (
   EFI_STATUS                  Status;
   PEI_USB_IO_PPI              *UsbIoPpi;
   UINT8                       Retry;
+  UINT8                       StrLoop;
+  UINT32                      StrOffset;
+  UINT32                      WcharCnt;
+  EFI_USB_STRING_DESCRIPTOR  *StringDescriptor;
 
   UsbIoPpi = &PeiUsbDevice->UsbIoPpi;
   Status   = EFI_SUCCESS;
@@ -657,6 +665,32 @@ PeiConfigureUsbDevice (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "PeiUsbGetDescriptor First Failed\n"));
     return Status;
+  }
+
+  //
+  // Get manufacturer and product name string
+  //
+  PeiUsbDevice->ProductName[0] = 0;
+  for (StrLoop = 0; StrLoop < 2; StrLoop++) {
+    Status = PeiUsbGetDescriptor (
+               PeiServices,
+               UsbIoPpi,
+               (USB_DT_STRING << 8) |
+                 ((StrLoop == 0) ? DeviceDescriptor.StrManufacturer : DeviceDescriptor.StrProduct),
+               0x0409,
+               (UINT16) sizeof (PeiUsbDevice->ConfigurationData),
+               PeiUsbDevice->ConfigurationData
+               );
+    if (!EFI_ERROR (Status)) {
+      StringDescriptor = (EFI_USB_STRING_DESCRIPTOR *)PeiUsbDevice->ConfigurationData;
+      StrOffset = OFFSET_OF(EFI_USB_STRING_DESCRIPTOR, String);
+      if (StringDescriptor->Length > StrOffset) {
+        WcharCnt = ARRAY_SIZE(PeiUsbDevice->ProductName) - 1;
+        StrnCatS (PeiUsbDevice->ProductName, WcharCnt,
+                  StringDescriptor->String,  (StringDescriptor->Length - StrOffset) / sizeof(CHAR16));
+        StrCatS  (PeiUsbDevice->ProductName, WcharCnt, L" ");
+      }
+    }
   }
 
   //
@@ -1197,4 +1231,38 @@ UsbDeinitDevice (
   FreePages (PeiUsbDev, MemPages);
 
   return EFI_SUCCESS;
+}
+
+
+/**
+  Retrieve the concatenated manufacturer and product string for a given USB device.
+
+  @param[in]  UsbIo for a USB device.
+
+  @retval     The constant manufacturer and product string.
+              NULL if UsbIo is not valid.
+
+**/
+CONST
+CHAR16 *
+EFIAPI
+GetUsbDeviceNameString (
+  IN PEI_USB_IO_PPI  *UsbIo
+  )
+{
+  PEI_USB_IO_PPI   *This;
+  PEI_USB_DEVICE   *PeiUsbDev;
+
+  if (UsbIo == NULL) {
+    return NULL;
+  }
+
+  This = (PEI_USB_IO_PPI *)UsbIo;
+  PeiUsbDev = PEI_USB_DEVICE_FROM_THIS (This);
+
+  if (PeiUsbDev->ProductName[0] == 0) {
+    return NULL;
+  } else {
+    return PeiUsbDev->ProductName;
+  }
 }

--- a/BootloaderCommonPkg/Library/UsbBusLib/UsbPeim.h
+++ b/BootloaderCommonPkg/Library/UsbBusLib/UsbPeim.h
@@ -34,7 +34,10 @@
 #define MAX_ENDPOINT              16
 
 #define PEI_USB_DEVICE_SIGNATURE  SIGNATURE_32 ('U', 's', 'b', 'D')
-typedef struct {
+
+typedef struct _PEI_USB_DEVICE  PEI_USB_DEVICE;
+
+struct _PEI_USB_DEVICE {
   UINTN                         Signature;
   PEI_USB_IO_PPI                UsbIoPpi;
   EFI_PEI_PPI_DESCRIPTOR        UsbIoPpiList;
@@ -44,9 +47,11 @@ typedef struct {
   UINT8                         DeviceSpeed;
   UINT8                         IsHub;
   UINT8                         DownStreamPortNo;
+  UINT8                         Port;
   UINTN                         AllocateAddress;
   PEI_USB_HOST_CONTROLLER_PPI   *UsbHcPpi;
   PEI_USB2_HOST_CONTROLLER_PPI  *Usb2HcPpi;
+  CHAR16                        ProductName[128];
   UINT8                         ConfigurationData[1024];
   EFI_USB_CONFIG_DESCRIPTOR     *ConfigDesc;
   EFI_USB_INTERFACE_DESCRIPTOR  *InterfaceDesc;
@@ -55,7 +60,8 @@ typedef struct {
   EFI_USB_ENDPOINT_DESCRIPTOR   *EndpointDescList[MAX_INTERFACE][MAX_ENDPOINT];
   EFI_USB2_HC_TRANSACTION_TRANSLATOR Translator;
   UINT8                          Tier;
-} PEI_USB_DEVICE;
+  PEI_USB_IO_PPI                *Parent;
+};
 
 #define PEI_USB_DEVICE_FROM_THIS(a) CR (a, PEI_USB_DEVICE, UsbIoPpi, PEI_USB_DEVICE_SIGNATURE)
 

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -170,7 +170,7 @@ class BaseBoard(object):
         self.ENABLE_CSME_UPDATE    = 0
         self.ENABLE_EMMC_HS400     = 1
         self.ENABLE_DMA_PROTECTION = 0
-        self.ENABLE_MULTI_USB_BOOT_DEV = 0
+        self.ENABLE_MULTI_USB_BOOT_DEV = 1
         self.ENABLE_SBL_SETUP      = 0
         self.ENABLE_PAYLOD_MODULE  = 0
         self.ENABLE_FAST_BOOT      = 0


### PR DESCRIPTION
When multiple USB mass storage devices are connected to the
target, it is not clear to the end user which one is selected
for boot. This patch added code to print the USB mass storage
device manufacturer and product name string. In this way, it
is easier for the end user to identify specific USB device.

It can also be used to determine the HwPart field for USB boot
option. HwPart for USB boot option is mapped to the USB mass
storage device index detected on the platform. BTW, to allow
boot from multiple USB mass storage devices, the optoin
ENABLE_MULTI_USB_BOOT_DEV needs to be enabled in BoardConfig.py.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>