### PR TITLE
Adjust debug message in USB libraries

### DIFF
--- a/BootloaderCommonPkg/Library/UsbInitLib/UsbInitLib.c
+++ b/BootloaderCommonPkg/Library/UsbInitLib/UsbInitLib.c
@@ -61,6 +61,7 @@ DeinitUsbDevices (
     return EFI_NOT_FOUND;
   }
 
+  DEBUG ((DEBUG_INFO, "Deinit USB controller\n"));
   Status = UsbDeinitCtrl (mUsbInit.UsbHostHandle);
 
   UsbDeInitBot ();

--- a/BootloaderCommonPkg/Library/XhciLib/XhcPeim.c
+++ b/BootloaderCommonPkg/Library/XhciLib/XhcPeim.c
@@ -723,7 +723,7 @@ XhcPeiControlTransfer (
         // Don't support multi-TT feature for super speed hub now.
         //
         MTT = 0;
-        DEBUG ((DEBUG_ERROR, "XHCI: Don't support multi-TT feature for Hub now. (force to disable MTT)\n"));
+        DEBUG ((DEBUG_INFO, "XHCI: Don't support multi-TT feature for Hub now. (force to disable MTT)\n"));
       } else {
         MTT = 0;
       }

--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -511,7 +511,7 @@ PrintStackHeapInfo (
     StackBot = DetectUsedStackBottom (StackTop, PcdGet32 (PcdPayloadStackSize));
     DEBUG ((
              DEBUG_INFO,
-             "Payload stack: 0x%X (0x%X used)\n\n",
+             "Payload stack: 0x%X (0x%X used)\n",
              PcdGet32 (PcdPayloadStackSize),
              StackTop - StackBot
              ));


### PR DESCRIPTION
This patch adjusted the following debug message for USB libraries:
  - For SBL, since mutli-TT is not utilized, it should not be
    classified as error message. It is changed to be DEBUG_INFO now.
  - Added DeInit debug print for USB so that it tells the USB
    resources are de-allocated.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>