### PR TITLE
Add UpdateMemoryInfo implementation for all open platforms

### DIFF
--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -590,6 +590,7 @@ SecStartup2 (
   // Print memory top info
   DEBUG ((DEBUG_INFO, "Memory Tolum @ 0x%llx\n", GetMemoryInfo (EnumMemInfoTolum)));
   DEBUG ((DEBUG_INFO, "Memory Touum @ 0x%llx\n", GetMemoryInfo (EnumMemInfoTouum)));
+  DEBUG ((DEBUG_INFO, "Memory Tom   @ 0x%llx\n", GetMemoryInfo (EnumMemInfoTom)));
 
   // Switch to memory-based stack and continue execution at ContinueFunc
   StackTop  = LdrGlobal->StackTop - (sizeof (STAGE2_PARAM) + sizeof (STAGE1B_PARAM) + 0x40);

--- a/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -34,6 +34,7 @@
 #include <Library/HeciLib.h>
 #include <Library/BootloaderCommonLib.h>
 #include <Library/BoardSupportLib.h>
+#include <Library/SocInitLib.h>
 #include <FspmUpd.h>
 #include <GpioDefines.h>
 #include <PlatformBase.h>
@@ -959,6 +960,7 @@ LoadExternalConfigData (
   Get the reset reason from the PMC registers.
 **/
 VOID
+EFIAPI
 UpdateResetReason (
   VOID
   )
@@ -1865,6 +1867,7 @@ BoardInit (
     EarlyPcieLinkUp ();
     break;
   case PostMemoryInit:
+    UpdateMemoryInfo ();
     break;
   case PreTempRamExit:
     break;

--- a/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -653,6 +653,7 @@ DEBUG_CODE_END();
     GpioInit (PlatformId);
   case PostMemoryInit:
     DEBUG ((DEBUG_INFO, "PostMemoryInit called\n"));
+    UpdateMemoryInfo ();
     break;
   case PreTempRamExit:
     break;

--- a/Platform/CometlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CometlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -736,6 +736,7 @@ DEBUG_CODE_END();
     GpioConfigurePads (sizeof (mGpioTableCmlS82Ddr4PreMem) / sizeof (GPIO_INIT_CONFIG), mGpioTableCmlS82Ddr4PreMem );
   case PostMemoryInit:
     DEBUG ((DEBUG_INFO, "PostMemoryInit called\n"));
+    UpdateMemoryInfo ();
     break;
   case PreTempRamExit:
     break;

--- a/Platform/CometlakevBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CometlakevBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -746,6 +746,7 @@ DEBUG_CODE_END();
     GpioConfigurePads (sizeof (mGpioTableCmlS82Ddr4PreMem) / sizeof (GPIO_INIT_CONFIG), mGpioTableCmlS82Ddr4PreMem );
   case PostMemoryInit:
     DEBUG ((DEBUG_INFO, "PostMemoryInit called\n"));
+    UpdateMemoryInfo ();
     break;
   case PreTempRamExit:
     break;

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -21,6 +21,7 @@
 #include <IndustryStandard/Pci30.h>
 #include <Library/BootloaderCoreLib.h>
 #include <Library/BoardSupportLib.h>
+#include <Library/SocInitLib.h>
 #include <PchAccess.h>
 #include <RegAccess.h>
 #include <Library/CryptoLib.h>
@@ -1151,6 +1152,7 @@ DEBUG_CODE_END();
     // Clear the DISB bit after completing DRAM Initialization Sequence
     //
     MmioAnd32 (PmcBase + R_PMC_PWRM_GEN_PMCON_A, 0);
+    UpdateMemoryInfo ();
     break;
   case PreTempRamExit:
     break;

--- a/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -25,6 +25,7 @@
 #include <Library/BootloaderCoreLib.h>
 #include <Library/BoardSupportLib.h>
 #include <Library/PciCf8Lib.h>
+#include <Library/SocInitLib.h>
 #include <FspmUpd.h>
 #include <BlCommon.h>
 #include <PlatformBase.h>
@@ -226,6 +227,7 @@ BoardInit (
     if (FspHob != NULL) {
       DumpFspResourceHob (FspHob);
     }
+    UpdateMemoryInfo ();
     break;
 
   case PreMemoryInit:

--- a/Silicon/ApollolakePkg/Include/SaRegs.h
+++ b/Silicon/ApollolakePkg/Include/SaRegs.h
@@ -296,4 +296,12 @@
 #define  TSEG                   0xb8    // TSEG base
 #define  BGSM                   0xb4    // Base GTT Stolen Memory
 
+//  This 64 bit register defines the Top of Upper Usable DRAM.
+#define R_SA_TOUUD              (0xa8)
+#define B_SA_TOUUD_MASK         (0x7ffff00000ULL)
+
+//  This register contains the Top of low memory address.
+#define R_SA_TOLUD              (0xbc)
+#define B_SA_TOLUD_MASK         (0xfff00000)
+
 #endif

--- a/Silicon/ApollolakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/ApollolakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -8,6 +8,7 @@
 
 #include <PiPei.h>
 #include <Library/IoLib.h>
+#include <Library/BootloaderCoreLib.h>
 #include <RegAccess.h>
 
 /**
@@ -19,4 +20,35 @@ EnableCodeExecution (
 )
 {
   AsmWriteMsr32 (0x120, 0x100);
+}
+
+/**
+ Update memory map related info using SOC registers.
+
+ **/
+VOID
+EFIAPI
+UpdateMemoryInfo (
+  VOID
+)
+{
+  UINT32  Tolum;
+  UINT64  Touum;
+  UINT64  Tom;
+
+  // Update system memory info using SOC specific registers
+  Tolum  = PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOLUD));
+  Tolum &= B_SA_TOLUD_MASK;
+  SetMemoryInfo (EnumMemInfoTolum,  Tolum);
+
+  Touum  = PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOUUD));
+  Touum += LShiftU64 (PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOUUD + 4)), 32);
+  Touum &= B_SA_TOUUD_MASK;
+  if (Touum < SIZE_4GB) {
+    Touum = SIZE_4GB;
+  }
+  SetMemoryInfo (EnumMemInfoTouum,  Touum);
+
+  Tom = Tolum + (Touum - SIZE_4GB);
+  SetMemoryInfo (EnumMemInfoTom, Tom);
 }

--- a/Silicon/ApollolakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.inf
+++ b/Silicon/ApollolakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.inf
@@ -25,6 +25,7 @@
 [Packages]
   MdePkg/MdePkg.dec
   BootloaderCorePkg/BootloaderCorePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
   Silicon/ApollolakePkg/ApollolakePkg.dec
 
 [LibraryClasses]

--- a/Silicon/CoffeelakePkg/Include/Register/SaRegs.h
+++ b/Silicon/CoffeelakePkg/Include/Register/SaRegs.h
@@ -68,4 +68,17 @@ typedef struct {
 #define  TSEG                                       0xB8
 #define  BGSM                                       0xB4
 
+//  This Register contains the size of physical memory.
+#define R_SA_TOM         (0xa0)
+#define B_SA_TOM_MASK    (0x7ffff00000ULL)
+
+//  This 64 bit register defines the Top of Upper Usable DRAM.
+#define R_SA_TOUUD       (0xa8)
+#define B_SA_TOUUD_MASK  (0x7ffff00000ULL)
+
+
+//  This register contains the Top of low memory address.
+#define R_SA_TOLUD       (0xbc)
+#define B_SA_TOLUD_MASK  (0xfff00000)
+
 #endif

--- a/Silicon/CoffeelakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/CoffeelakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -10,6 +10,8 @@
 #include <Library/BaseLib.h>
 #include <Library/IoLib.h>
 #include <Library/PciLib.h>
+#include <Library/BootloaderCoreLib.h>
+#include <RegAccess.h>
 
 VOID
 EnableCodeExecution (
@@ -17,4 +19,38 @@ EnableCodeExecution (
 )
 {
 
+}
+
+/**
+ Update memory map related info using SOC registers.
+
+ **/
+VOID
+EFIAPI
+UpdateMemoryInfo (
+  VOID
+)
+{
+  UINT32  Tolum;
+  UINT64  Touum;
+  UINT64  Tom;
+
+  // Update system memory info using SOC specific registers
+
+  Tom  = PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOM));
+  Tom += LShiftU64 (PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOM + 4)), 32);
+  Tom &= B_SA_TOM_MASK;
+  SetMemoryInfo (EnumMemInfoTom,  Tom);
+
+  Tolum  = PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOLUD));
+  Tolum &= B_SA_TOLUD_MASK;
+  SetMemoryInfo (EnumMemInfoTolum,  Tolum);
+
+  Touum  = PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOUUD));
+  Touum += LShiftU64 (PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOUUD + 4)), 32);
+  Touum &= B_SA_TOUUD_MASK;
+  if (Touum < SIZE_4GB) {
+    Touum = SIZE_4GB;
+  }
+  SetMemoryInfo (EnumMemInfoTouum,  Touum);
 }

--- a/Silicon/CoffeelakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.inf
+++ b/Silicon/CoffeelakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.inf
@@ -24,6 +24,7 @@
 [Packages]
   MdePkg/MdePkg.dec
   BootloaderCorePkg/BootloaderCorePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
   Silicon/CoffeelakePkg/CoffeelakePkg.dec
 
 [LibraryClasses]

--- a/Silicon/CometlakePkg/Include/Register/SaRegs.h
+++ b/Silicon/CometlakePkg/Include/Register/SaRegs.h
@@ -44,4 +44,17 @@ typedef struct {
 #define  TSEG                                       0xB8
 #define  BGSM                                       0xB4
 
+//  This Register contains the size of physical memory.
+#define R_SA_TOM         (0xa0)
+#define B_SA_TOM_MASK    (0x7ffff00000ULL)
+
+//  This 64 bit register defines the Top of Upper Usable DRAM.
+#define R_SA_TOUUD       (0xa8)
+#define B_SA_TOUUD_MASK  (0x7ffff00000ULL)
+
+
+//  This register contains the Top of low memory address.
+#define R_SA_TOLUD       (0xbc)
+#define B_SA_TOLUD_MASK  (0xfff00000)
+
 #endif

--- a/Silicon/CometlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/CometlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -10,6 +10,8 @@
 #include <Library/BaseLib.h>
 #include <Library/IoLib.h>
 #include <Library/PciLib.h>
+#include <Library/BootloaderCoreLib.h>
+#include <RegAccess.h>
 
 VOID
 EnableCodeExecution (
@@ -17,4 +19,38 @@ EnableCodeExecution (
 )
 {
 
+}
+
+/**
+ Update memory map related info using SOC registers.
+
+ **/
+VOID
+EFIAPI
+UpdateMemoryInfo (
+  VOID
+)
+{
+  UINT32  Tolum;
+  UINT64  Touum;
+  UINT64  Tom;
+
+  // Update system memory info using SOC specific registers
+
+  Tom  = PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOM));
+  Tom += LShiftU64 (PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOM + 4)), 32);
+  Tom &= B_SA_TOM_MASK;
+  SetMemoryInfo (EnumMemInfoTom,  Tom);
+
+  Tolum  = PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOLUD));
+  Tolum &= B_SA_TOLUD_MASK;
+  SetMemoryInfo (EnumMemInfoTolum,  Tolum);
+
+  Touum  = PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOUUD));
+  Touum += LShiftU64 (PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOUUD + 4)), 32);
+  Touum &= B_SA_TOUUD_MASK;
+  if (Touum < SIZE_4GB) {
+    Touum = SIZE_4GB;
+  }
+  SetMemoryInfo (EnumMemInfoTouum,  Touum);
 }

--- a/Silicon/CometlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.inf
+++ b/Silicon/CometlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.inf
@@ -24,6 +24,7 @@
 [Packages]
   MdePkg/MdePkg.dec
   BootloaderCorePkg/BootloaderCorePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
   Silicon/CometlakePkg/CometlakePkg.dec
 
 [LibraryClasses]

--- a/Silicon/CometlakevPkg/Include/Register/SaRegs.h
+++ b/Silicon/CometlakevPkg/Include/Register/SaRegs.h
@@ -44,4 +44,17 @@ typedef struct {
 #define  TSEG                                       0xB8
 #define  BGSM                                       0xB4
 
+//  This Register contains the size of physical memory.
+#define R_SA_TOM         (0xa0)
+#define B_SA_TOM_MASK    (0x7ffff00000ULL)
+
+//  This 64 bit register defines the Top of Upper Usable DRAM.
+#define R_SA_TOUUD       (0xa8)
+#define B_SA_TOUUD_MASK  (0x7ffff00000ULL)
+
+
+//  This register contains the Top of low memory address.
+#define R_SA_TOLUD       (0xbc)
+#define B_SA_TOLUD_MASK  (0xfff00000)
+
 #endif

--- a/Silicon/CometlakevPkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/CometlakevPkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -10,6 +10,8 @@
 #include <Library/BaseLib.h>
 #include <Library/IoLib.h>
 #include <Library/PciLib.h>
+#include <Library/BootloaderCoreLib.h>
+#include <RegAccess.h>
 
 VOID
 EnableCodeExecution (
@@ -17,4 +19,38 @@ EnableCodeExecution (
 )
 {
 
+}
+
+/**
+ Update memory map related info using SOC registers.
+
+ **/
+VOID
+EFIAPI
+UpdateMemoryInfo (
+  VOID
+)
+{
+  UINT32  Tolum;
+  UINT64  Touum;
+  UINT64  Tom;
+
+  // Update system memory info using SOC specific registers
+
+  Tom  = PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOM));
+  Tom += LShiftU64 (PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOM + 4)), 32);
+  Tom &= B_SA_TOM_MASK;
+  SetMemoryInfo (EnumMemInfoTom,  Tom);
+
+  Tolum  = PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOLUD));
+  Tolum &= B_SA_TOLUD_MASK;
+  SetMemoryInfo (EnumMemInfoTolum,  Tolum);
+
+  Touum  = PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOUUD));
+  Touum += LShiftU64 (PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOUUD + 4)), 32);
+  Touum &= B_SA_TOUUD_MASK;
+  if (Touum < SIZE_4GB) {
+    Touum = SIZE_4GB;
+  }
+  SetMemoryInfo (EnumMemInfoTouum,  Touum);
 }

--- a/Silicon/CometlakevPkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.inf
+++ b/Silicon/CometlakevPkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.inf
@@ -24,6 +24,7 @@
 [Packages]
   MdePkg/MdePkg.dec
   BootloaderCorePkg/BootloaderCorePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
   Silicon/CommonSocPkg/CommonSocPkg.dec
   Silicon/CometlakevPkg/CometlakevPkg.dec
 

--- a/Silicon/ElkhartlakePkg/Include/Register/SaRegsHostBridge.h
+++ b/Silicon/ElkhartlakePkg/Include/Register/SaRegsHostBridge.h
@@ -101,11 +101,20 @@
 #define B_SA_GGC_GGMS_MASK    (0xc0)
 #define V_SA_GGC_GGMS_8MB     3
 
-///
-/// Description:
-///  This register contains the Top of low memory address.
-///
-#define R_SA_TOLUD (0xbc)
+
+//  This Register contains the size of physical memory.
+#define R_SA_TOM         (0xa0)
+#define B_SA_TOM_MASK    (0x7ffff00000ULL)
+
+//  This 64 bit register defines the Top of Upper Usable DRAM.
+#define R_SA_TOUUD       (0xa8)
+#define B_SA_TOUUD_MASK  (0x7ffff00000ULL)
+
+
+//  This register contains the Top of low memory address.
+#define R_SA_TOLUD       (0xbc)
+#define B_SA_TOLUD_MASK  (0xfff00000)
+
 
 #define R_SA_MC_CAPID0_A_OFFSET    0xE4
 

--- a/Silicon/ElkhartlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/ElkhartlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -14,6 +14,7 @@
 #include <Library/DebugLib.h>
 #include <Library/BoardInitLib.h>
 #include <MemInfoHob.h>
+#include <RegAccess.h>
 
 #define  TCO_STS_2ND_TIMEOUT      BIT1
 
@@ -130,4 +131,38 @@ UpdateResetReason (
     ResetReason |= ResetWarm;
   }
   SetResetReason (ResetReason);
+}
+
+/**
+ Update memory map related info using SOC registers.
+
+ **/
+VOID
+EFIAPI
+UpdateMemoryInfo (
+  VOID
+)
+{
+  UINT32  Tolum;
+  UINT64  Touum;
+  UINT64  Tom;
+
+  // Update system memory info using SOC specific registers
+
+  Tom  = PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOM));
+  Tom += LShiftU64 (PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOM + 4)), 32);
+  Tom &= B_SA_TOM_MASK;
+  SetMemoryInfo (EnumMemInfoTom,  Tom);
+
+  Tolum  = PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOLUD));
+  Tolum &= B_SA_TOLUD_MASK;
+  SetMemoryInfo (EnumMemInfoTolum,  Tolum);
+
+  Touum  = PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOUUD));
+  Touum += LShiftU64 (PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOUUD + 4)), 32);
+  Touum &= B_SA_TOUUD_MASK;
+  if (Touum < SIZE_4GB) {
+    Touum = SIZE_4GB;
+  }
+  SetMemoryInfo (EnumMemInfoTouum,  Touum);
 }

--- a/Silicon/ElkhartlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.inf
+++ b/Silicon/ElkhartlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.inf
@@ -24,6 +24,7 @@
 
 [Packages]
   MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
   BootloaderCorePkg/BootloaderCorePkg.dec
   Silicon/ElkhartlakePkg/ElkhartlakePkg.dec
   BootloaderCommonPkg/BootloaderCommonPkg.dec

--- a/Silicon/QemuSocPkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/QemuSocPkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -9,7 +9,7 @@
 #include <Library/IoLib.h>
 #include <Library/PciLib.h>
 #include <RegAccess.h>
-
+#include <Library/BootloaderCoreLib.h>
 
 /**
   Enables the execution by writing to the MSR.
@@ -17,6 +17,18 @@
 VOID
 EFIAPI
 EnableCodeExecution (
+  VOID
+)
+{
+}
+
+/**
+ Update memory map related info using SOC registers.
+
+ **/
+VOID
+EFIAPI
+UpdateMemoryInfo (
   VOID
 )
 {

--- a/Silicon/QemuSocPkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.inf
+++ b/Silicon/QemuSocPkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.inf
@@ -24,6 +24,7 @@
 
 [Packages]
   MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
   BootloaderCorePkg/BootloaderCorePkg.dec
   Silicon/QemuSocPkg/QemuSocPkg.dec
 

--- a/Silicon/TigerlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/TigerlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -162,5 +162,8 @@ UpdateMemoryInfo (
   Touum  = PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOUUD));
   Touum += LShiftU64 (PciRead32 (PCI_LIB_ADDRESS(SA_MC_BUS, SA_MC_DEV, SA_MC_FUN, R_SA_TOUUD + 4)), 32);
   Touum &= B_SA_TOUUD_MASK;
+  if (Touum < SIZE_4GB) {
+    Touum = SIZE_4GB;
+  }
   SetMemoryInfo (EnumMemInfoTouum,  Touum);
 }

--- a/Silicon/TigerlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.inf
+++ b/Silicon/TigerlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.inf
@@ -24,10 +24,10 @@
 
 [Packages]
   MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
   BootloaderCorePkg/BootloaderCorePkg.dec
   Silicon/TigerlakePchPkg/TigerlakePchPkg.dec
   Silicon/TigerlakePkg/TigerlakePkg.dec
-  BootloaderCommonPkg/BootloaderCommonPkg.dec
 
 [LibraryClasses]
   BaseLib


### PR DESCRIPTION
This patch implemented SOC specific hook to update the memory
map info through UpdateMemoryInfo() API.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>