### PR TITLE
[EHL] Increase Fwupdate payload size

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/BoardConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/BoardConfig.py
@@ -152,7 +152,7 @@ class Board(BaseBoard):
         else:
             self.UEFI_VARIABLE_SIZE = 0x00001000
         self.SBLRSVD_SIZE         = 0x00001000
-        self.FWUPDATE_SIZE        = 0x0001A000 if self.ENABLE_FWU else 0
+        self.FWUPDATE_SIZE        = 0x0001B000 if self.ENABLE_FWU else 0
 
         self.TOP_SWAP_SIZE        = 0x080000
         self.REDUNDANT_SIZE       = 0x360000


### PR DESCRIPTION
This patch increased fwupdate payload size to 0x1B000 to resolve
build issue.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>