### PR TITLE
Fix GPIO CFGDATA database overriding issue

### DIFF
--- a/Silicon/CommonSocPkg/Library/GpioLib/GpioInit.c
+++ b/Silicon/CommonSocPkg/Library/GpioLib/GpioInit.c
@@ -610,25 +610,21 @@ FillGpioTable (
 
 )
 {
-  UINT32             *GpioItem;
-  GPIO_PAD            GpioPad;
-  UINT8              *TableData;
+  GPIO_PAD           *GpioPad;
+  UINT8              *GpioData;
+  UINT8              *GpioCfg;
 
-  TableData = ((UINT8 *)GpioCfgHdr) + GpioCfgHdr->HeaderSize;
+  GpioData  = ((UINT8 *)GpioCfgHdr) + GpioCfgHdr->HeaderSize + Offset;
+  GpioCfg   = GpioTable + sizeof(GPIO_PAD);
+  GpioPad   = (GPIO_PAD *) GpioTable;
+  CopyMem (GpioCfg, GpioData, GpioCfgHdr->ItemSize);
 
   //
   // Get the DW and extract PadInfo
   //
-  GpioItem = (UINT32 *) (TableData + Offset);
-  GpioGetGpioPadFromCfgDw (GpioItem, &GpioPad);
+  GpioGetGpioPadFromCfgDw ((UINT32 *)GpioCfg, GpioPad);
 
-  //
-  // Copy PadInfo(PinOffset), DW0, DW1
-  //
-  CopyMem (GpioTable, (VOID *)&GpioPad, sizeof(GPIO_PAD));
-  GpioTable += sizeof(GPIO_PAD);
-  CopyMem (GpioTable, GpioItem, GpioCfgHdr->ItemSize);
-  GpioTable += GpioCfgHdr->ItemSize;
+  GpioTable += (sizeof(GPIO_PAD) + GpioCfgHdr->ItemSize);
 
   return GpioTable;
 }


### PR DESCRIPTION
Current GPIO programming code in CommonSocPkg will override the
CFGDATA database. It tried to zero out the GPIO group ID and pad
ID from the GPIO CFGDATA entry. But it should only be applied to
the copied new entry, not the original entry in CFGDATA database.
This patch fixed this isue.
It fixed #1382.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>