### PR TITLE
Enable GFX framebuffer as WC by BAR parsing

### DIFF
--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -507,7 +507,7 @@ SecStartup (
     DEBUG ((DEBUG_INIT, "PCI Enum\n"));
     Status = PciEnumeration (MemPool);
     AddMeasurePoint (0x30A0);
-
+    UpdateGraphicsHob ();
     BoardInit (PostPciEnumeration);
     AddMeasurePoint (0x30B0);
 

--- a/BootloaderCorePkg/Stage2/Stage2.h
+++ b/BootloaderCorePkg/Stage2/Stage2.h
@@ -166,4 +166,13 @@ BoardNotifyPhase (
   IN BOARD_INIT_PHASE   Phase
   );
 
+/**
+  Update graphics hobs.
+
+**/
+VOID
+UpdateGraphicsHob (
+  VOID
+  );
+
 #endif

--- a/BootloaderCorePkg/Stage2/Stage2Hob.c
+++ b/BootloaderCorePkg/Stage2/Stage2Hob.c
@@ -604,6 +604,31 @@ BuildUniversalPayloadHob (
   BuildUpldPciRootBridgeHob ();
 }
 
+/**
+  Update graphics hobs.
+
+**/
+VOID
+UpdateGraphicsHob (
+  VOID
+  )
+{
+  EFI_PEI_GRAPHICS_INFO_HOB        *GfxInfoHob;
+  EFI_PEI_GRAPHICS_DEVICE_INFO_HOB *GfxDeviceInfoHob;
+
+  // Update graphic info HOB
+  GfxInfoHob = (EFI_PEI_GRAPHICS_INFO_HOB *)GetGuidHobData (NULL, NULL, &gEfiGraphicsInfoHobGuid);
+  if (GfxInfoHob != NULL) {
+    PlatformUpdateHobInfo (&gEfiGraphicsInfoHobGuid, GfxInfoHob);
+  }
+
+  // Update graphic device info HOB
+  GfxDeviceInfoHob = (EFI_PEI_GRAPHICS_DEVICE_INFO_HOB *)GetGuidHobData (NULL, NULL, &gEfiGraphicsDeviceInfoHobGuid);
+  if (GfxDeviceInfoHob != NULL) {
+    PlatformUpdateHobInfo (&gEfiGraphicsDeviceInfoHobGuid, GfxDeviceInfoHob);
+  }
+
+}
 
 /**
   Build and update HOBs.
@@ -628,8 +653,6 @@ BuildExtraInfoHob (
   SYS_CPU_INFO                     *SysCpuInfo;
   PERFORMANCE_INFO                 *PerformanceInfo;
   OS_BOOT_OPTION_LIST              *OsBootOptionInfo;
-  EFI_PEI_GRAPHICS_INFO_HOB        *GfxInfoHob;
-  EFI_PEI_GRAPHICS_DEVICE_INFO_HOB *GfxDeviceInfoHob;
   LOADER_PLATFORM_INFO             *LoaderPlatformInfo;
   LOADER_PLATFORM_DATA             *LoaderPlatformData;
   LOADER_LIBRARY_DATA              *LoaderLibData;
@@ -656,18 +679,6 @@ BuildExtraInfoHob (
     LoaderLibData->Count = (UINT16)PcdGet32 (PcdMaxLibraryDataEntry);
     LoaderLibData->Flags = 0;
     LoaderLibData->Data  = LdrGlobal->LibDataPtr;
-  }
-
-  // Update graphic info HOB
-  GfxInfoHob = (EFI_PEI_GRAPHICS_INFO_HOB *)GetGuidHobData (NULL, NULL, &gEfiGraphicsInfoHobGuid);
-  if (GfxInfoHob != NULL) {
-    PlatformUpdateHobInfo (&gEfiGraphicsInfoHobGuid, GfxInfoHob);
-  }
-
-  // Update graphic device info HOB
-  GfxDeviceInfoHob = (EFI_PEI_GRAPHICS_DEVICE_INFO_HOB *)GetGuidHobData (NULL, NULL, &gEfiGraphicsDeviceInfoHobGuid);
-  if (GfxDeviceInfoHob != NULL) {
-    PlatformUpdateHobInfo (&gEfiGraphicsDeviceInfoHobGuid, GfxDeviceInfoHob);
   }
 
   // Update serial port hob

--- a/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -64,7 +64,8 @@ CONST PLT_DEVICE  mPlatformDevices[]= {
   {{0x00001D00}, OsBootDeviceUfs   , 0 },
   {{0x00000D02}, OsBootDeviceSpi   , 0 },
   {{0x00001500}, OsBootDeviceUsb   , 0 },
-  {{0x01000000}, OsBootDeviceMemory, 0 }
+  {{0x01000000}, OsBootDeviceMemory, 0 },
+  {{0x00000200}, PlatformDeviceGraphics, 0},
 };
 
 CONST CHAR16 *BootDeviceType[] = { L"eMMC", L"UFS", L"SPI" };

--- a/Platform/CommonBoardPkg/Include/Library/BoardSupportLib.h
+++ b/Platform/CommonBoardPkg/Include/Library/BoardSupportLib.h
@@ -176,4 +176,26 @@ SetVbtFixedMode (
   IN  UINT32     Yres
   );
 
+
+/**
+  Set framebuffer range as writecombining for performance.
+
+  @param[in]    FrameBufferBase   Framebuffer base address.
+                                  if 0, it will use framebuffer HOB to get the base.
+  @param[in]    FrameBufferSize   Framebuffer size.
+                                  if 0, it will use framebuffer HOB to get the size.
+                                  if MAX_UINT32, it will parse the PCI bar to get the size.
+
+  @retval  EFI_SUCCESS            The framebuffer cache was enabled successfully.
+           EFI_NOT_FOUND          Failed to find the required GFX controller.
+           EFI_UNSUPPORTED        The base and size cannot be supported.
+           EFI_OUT_OF_RESOURCES   No enough MTRR to use.
+**/
+EFI_STATUS
+EFIAPI
+SetFrameBufferWriteCombining (
+  IN  EFI_PHYSICAL_ADDRESS   FrameBufferBase,
+  IN  UINT32                 FrameBufferSize
+  );
+
 #endif

--- a/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardGraphicsCache.c
+++ b/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardGraphicsCache.c
@@ -1,0 +1,189 @@
+/** @file
+
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MtrrLib.h>
+#include <Library/IoLib.h>
+#include <Library/PcdLib.h>
+#include <Library/BootloaderCoreLib.h>
+#include <Guid/GraphicsInfoHob.h>
+#include <Guid/OsBootOptionGuid.h>
+#include <Register/Intel/Cpuid.h>
+#include <Register/Intel/ArchitecturalMsr.h>
+#include <IndustryStandard/Pci30.h>
+
+#define  MTRR_CACHE_WRITE_COMBINING  1
+
+/**
+  Set framebuffer range as writecombining for performance.
+
+  @param[in]    FrameBufferBase   Framebuffer base address.
+                                  if 0, it will use framebuffer HOB to get the base.
+  @param[in]    FrameBufferSize   Framebuffer size.
+                                  if 0, it will use framebuffer HOB to get the size.
+                                  if MAX_UINT32, it will parse the PCI bar to get the size.
+
+  @retval  EFI_SUCCESS            The framebuffer cache was enabled successfully.
+  @retval  EFI_NOT_FOUND          Failed to find the required GFX controller.
+  @retval  EFI_UNSUPPORTED        The base and size cannot be supported.
+  @retval  EFI_OUT_OF_RESOURCES   No enough MTRR to use.
+
+  **/
+EFI_STATUS
+EFIAPI
+SetFrameBufferWriteCombining (
+  IN  EFI_PHYSICAL_ADDRESS   FrameBufferBase,
+  IN  UINT32                 FrameBufferSize
+  )
+{
+  UINT8              CmdVal;
+  UINT32             BarVal;
+  UINT32             MsrIdx;
+  UINT32             MsrMax;
+  UINT32             Data;
+  UINTN              GfxPciBase;
+  UINT64             FbSize;
+  INTN               SizeBit;
+  INTN               BaseBit;
+  UINT32             VidDid;
+  UINT32             Offset;
+  UINT32             BarIndex;
+  BOOLEAN            Found;
+  MSR_IA32_MTRRCAP_REGISTER          MsrCap;
+  MSR_IA32_MTRR_PHYSMASK_REGISTER    MsrMask;
+  MSR_IA32_MTRR_PHYSBASE_REGISTER    MsrBase;
+  CPUID_VIR_PHY_ADDRESS_SIZE_EAX     VirPhyAddressSize;
+  EFI_PEI_GRAPHICS_DEVICE_INFO_HOB  *GfxDevHob;
+  EFI_PEI_GRAPHICS_INFO_HOB         *GfxInfoHob;
+
+  // If FrameBufferSize is MAX_UINT32, try to parse the PCI bar to get the size
+  if (FrameBufferSize == MAX_UINT32) {
+    GfxDevHob = (EFI_PEI_GRAPHICS_DEVICE_INFO_HOB *)GetGuidHobData (NULL, NULL, &gEfiGraphicsDeviceInfoHobGuid);
+    if (GfxDevHob == NULL) {
+      DEBUG ((DEBUG_VERBOSE, "Failed to find GFX device info HOB\n"));
+      return EFI_NOT_FOUND;
+    }
+    if (GfxDevHob->BarIndex >= PCI_MAX_BAR) {
+      DEBUG ((DEBUG_VERBOSE, "Invalid GFX device PCI bar index\n"));
+      return EFI_UNSUPPORTED;
+    }
+    GfxPciBase = GetDeviceAddr (PlatformDeviceGraphics, 0);
+    if (GfxPciBase == 0) {
+      DEBUG ((DEBUG_VERBOSE, "Failed to find GFX device from platform device table\n"));
+      return EFI_NOT_FOUND;
+    }
+
+    // Parse the PCI bar size
+    // Only need to parse lower 32bit since Framebuffer is less than 4GB
+    GfxPciBase = TO_MM_PCI_ADDRESS (GfxPciBase);
+    VidDid = MmioRead32 (GfxPciBase);
+    if (VidDid != (UINT32)((GfxDevHob->DeviceId << 16) + GfxDevHob->VendorId)) {
+      DEBUG ((DEBUG_VERBOSE, "GFX device VID/DID mismatch\n"));
+      return EFI_NOT_FOUND;
+    }
+
+    // Detect logic bar index
+    BarIndex = 0;
+    for (Offset = 0x10, BarIndex = 0; Offset <= 0x24 && BarIndex < PCI_MAX_BAR; BarIndex++) {
+      if (BarIndex == GfxDevHob->BarIndex) {
+        Found = TRUE;
+        break;
+      }
+      BarVal = MmioRead32 (GfxPciBase + BarIndex);
+      if (BarVal > 0) {
+        if (((BarVal & BIT0) == 0) && ((BarVal & BIT2) != 0)) {
+          // 64bit bar
+          Offset += 4;
+        }
+      }
+      Offset += 4;
+    }
+    if (!Found) {
+      DEBUG ((DEBUG_VERBOSE, "GFX bar index is invalid\n"));
+      return EFI_NOT_FOUND;
+    }
+
+    CmdVal = MmioRead8  (GfxPciBase + PCI_COMMAND_OFFSET);
+    BarVal = MmioRead32 (GfxPciBase + Offset);
+    MmioWrite8  (GfxPciBase + PCI_COMMAND_OFFSET, 0);
+    MmioWrite32 (GfxPciBase + Offset, MAX_UINT32);
+    Data = MmioRead32 (GfxPciBase + Offset) & ~(SIZE_4KB - 1);
+    MmioWrite32 (GfxPciBase + Offset, BarVal);
+    MmioWrite8  (GfxPciBase + PCI_COMMAND_OFFSET, CmdVal);
+    DEBUG ((DEBUG_VERBOSE, "GFX BAR old value 0x%08x, new value 0x%08x\n", BarVal, Data));
+
+    // Calculate bar size
+    SizeBit = LowBitSet32 (Data);
+    if (SizeBit < 0) {
+      // The size is greater than 4GB
+      DEBUG ((DEBUG_VERBOSE, "GFX BAR size is greater than 4GB\n"));
+      return EFI_UNSUPPORTED;
+    }
+    FrameBufferSize = 1 << SizeBit;
+    DEBUG ((DEBUG_VERBOSE, "GFX framebuffer BAR size 0x%08x @ BAR%d\n", FrameBufferSize, GfxDevHob->BarIndex));
+  }
+
+  // If FrameBufferBase or FrameBufferSize is 0, try to use Framebuffer HOB to get base and size.
+  if ((FrameBufferBase == 0) || (FrameBufferSize == 0)) {
+    GfxInfoHob = (EFI_PEI_GRAPHICS_INFO_HOB *)GetGuidHobData (NULL, NULL, &gEfiGraphicsInfoHobGuid);
+    if (GfxInfoHob == NULL) {
+      DEBUG ((DEBUG_VERBOSE, "Failed to find GFX info HOB\n"));
+      return EFI_NOT_FOUND;
+    }
+    if (FrameBufferBase == 0) {
+      FrameBufferBase = GfxInfoHob->FrameBufferBase;
+    }
+    if (FrameBufferSize == 0) {
+      FrameBufferSize = GfxInfoHob->FrameBufferSize;
+    }
+    DEBUG ((DEBUG_VERBOSE, "Use framebuffer 0x%llx, size 0x%x\n", FrameBufferBase, FrameBufferSize));
+  }
+
+  // FrameBufferSize needs to be power of 2, if not, round up
+  SizeBit = HighBitSet32 (FrameBufferSize);
+  if (FrameBufferSize != LShiftU64 (1, SizeBit)) {
+    SizeBit++;
+    FbSize = LShiftU64 (1, SizeBit);
+  } else {
+    FbSize = FrameBufferSize;
+  }
+
+  // FrameBufferBase needs to be aligned at the size, at least 4KB
+  BaseBit = LowBitSet64 (FrameBufferBase);
+  if ((SizeBit < 12) || (SizeBit > BaseBit)) {
+    DEBUG ((DEBUG_VERBOSE, "Framebuffer base and size are not aligned\n"));
+    return EFI_UNSUPPORTED;
+  }
+
+  // Find a free MTRR pair
+  MsrCap.Uint64 = AsmReadMsr64 (MSR_IA32_MTRRCAP);
+  MsrMax = MSR_IA32_MTRR_PHYSBASE0 + 2 * MsrCap.Bits.VCNT;
+  for (MsrIdx = MSR_IA32_MTRR_PHYSBASE0; MsrIdx < MsrMax; MsrIdx += 2) {
+     MsrMask.Uint64 = AsmReadMsr64 (MsrIdx + 1);
+     if (MsrMask.Bits.V == 0) {
+       break;
+     }
+  }
+  if (MsrIdx == MsrMax) {
+    DEBUG ((DEBUG_VERBOSE, "Failed to find free MTRR to set GFX cache"));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // Enable Framebuffer as WC.
+  AsmCpuid (CPUID_VIR_PHY_ADDRESS_SIZE, &VirPhyAddressSize.Uint32, NULL, NULL, NULL);
+  MsrBase.Uint64    = FrameBufferBase;
+  MsrBase.Bits.Type = MTRR_CACHE_WRITE_COMBINING;
+  AsmWriteMsr64 (MsrIdx,  MsrBase.Uint64);
+  MsrMask.Uint64  = (~(FbSize - 1)) & (LShiftU64 (1, VirPhyAddressSize.Bits.PhysicalAddressBits) - 1);
+  MsrMask.Bits.V  = 1;
+  AsmWriteMsr64 (MsrIdx + 1, MsrMask.Uint64);
+
+  DEBUG ((DEBUG_INFO, "GFX framebuffer WC is enabled @ 0x%llx:0x%llx\n", FrameBufferBase, FbSize));
+  return EFI_SUCCESS;
+}

--- a/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.c
+++ b/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.c
@@ -161,7 +161,7 @@ PlatformNameInit (
 
 /**
   Load the configuration data blob from SPI flash into destination buffer.
-  It supports the sources:  BIOS for external Cfgdata.
+  It supports the sources: PDR, BIOS for external Cfgdata.
 
   @param[in]    Dst        Destination address to load configuration data blob.
   @param[in]    Src        Source address to load configuration data blob.

--- a/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.inf
+++ b/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.inf
@@ -15,6 +15,7 @@
 
 [Sources]
   BoardSupportLib.c
+  BoardGraphicsCache.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -23,10 +24,15 @@
   Platform/CommonBoardPkg/CommonBoardPkg.dec
   Silicon/CommonSocPkg/CommonSocPkg.dec
 
+[Guids]
+  gEfiGraphicsDeviceInfoHobGuid
+  gEfiGraphicsInfoHobGuid
+
 [LibraryClasses]
   BaseLib
 
 [Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
   gPlatformModuleTokenSpaceGuid.PcdOsBootOptionNumber
   gPlatformModuleTokenSpaceGuid.PcdCfgDataLoadSource
   gPlatformModuleTokenSpaceGuid.PcdCfgDatabaseSize

--- a/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -37,7 +37,8 @@ CONST PLT_DEVICE  mPlatformDevices[]= {
   {{0x00000300}, OsBootDeviceSd    , 0 },
   {{0x00000300}, OsBootDeviceNvme  , 0 },
   {{0x00000400}, OsBootDeviceUsb   , 0 },
-  {{0x01000000}, OsBootDeviceMemory, 0 }
+  {{0x01000000}, OsBootDeviceMemory, 0 },
+  {{0x00000000}, PlatformDeviceGraphics, 0},
 };
 
 /**

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -466,6 +466,13 @@ BoardInit (
     }
     break;
 
+  case PostPciEnumeration:
+    Status = SetFrameBufferWriteCombining (0, MAX_UINT32);
+    if (EFI_ERROR(Status)) {
+      DEBUG ((DEBUG_INFO, "Failed to set GFX framebuffer as WC\n"));
+    }
+    break;
+
   case PrePayloadLoading:
     // Hide TSEG
     PciOr8 (PCI_LIB_ADDRESS(0, 0, 0, MCH_ESMRAMC), MCH_ESMRAMC_T_EN);
@@ -675,6 +682,8 @@ UpdateFrameBufferDeviceInfo (
     GfxDeviceInfo->VendorId = PciRead16 (PCI_LIB_ADDRESS (0, Dev, 0, 0));
     GfxDeviceInfo->DeviceId = PciRead16 (PCI_LIB_ADDRESS (0, Dev, 0, 2));
   }
+
+  SetDeviceAddr (PlatformDeviceGraphics, 0, (0 << 16) | (Dev << 8) | 0);
 }
 
 /**

--- a/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -48,7 +48,8 @@ CONST PLT_DEVICE  mPlatformDevices[]= {
   {{0x01000000}, OsBootDeviceMemory, 0 },
   {{0x00010000}, OsBootDeviceNvme  , 0 },
   {{0x00020000}, OsBootDeviceNvme  , 1 },
-  {{0x00050000}, OsBootDeviceNvme  , 2 }
+  {{0x00050000}, OsBootDeviceNvme  , 2 },
+  {{0x00000200}, PlatformDeviceGraphics, 0},
 };
 
 VOID

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1000,6 +1000,10 @@ BoardInit (
     }
     break;
   case PostPciEnumeration:
+    Status = SetFrameBufferWriteCombining (0, MAX_UINT32);
+    if (EFI_ERROR(Status)) {
+      DEBUG ((DEBUG_INFO, "Failed to set GFX framebuffer as WC\n"));
+    }
     if (GetBootMode() == BOOT_ON_S3_RESUME) {
       ClearSmi ();
       RestoreS3RegInfo (FindS3Info (S3_SAVE_REG_COMM_ID));


### PR DESCRIPTION
In order to improve the UEFI payload display performance, it is
desirable to have the framebuffer as write-combining for cache
attribute. This patch added a common API to enable this and it
enabled the GFX framebuffer cache for QEMU and TGL. Other
platforms still need porting.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>