### PR TITLE
Build SMM HOBs for universal payload

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -149,6 +149,15 @@
   #     0x0002    - RSA_PSS.<BR>
   gPlatformCommonLibTokenSpaceGuid.PcdCompSignSchemeSupportedMask      |        0x03| UINT8 | 0x20000704
 
+  ## This PCD indicates which SMM HOBs to build
+  #     BIT0    - If it set it would support SMM variable related HOBs using old format.<BR>
+  #               Old HOB format refer these file headers: SmmInformationGuid.h, LoaderPlatformInfoGuid.h
+  #               FlashMapInfoGuid.h, DeviceTableHobGuid.h
+  #     BIT1    - If it set it would support SMM variable related HOBs using new format.<BR>
+  #               New HOB format refer these file headers: SmmS3CommunicationInfoGuid.h, SpiFlashInfoGuid.h
+  #               SmmRegisterInfoGuid.h and NvVariableInfoGuid.h
+  gPlatformCommonLibTokenSpaceGuid.PcdBuildSmmHobs                     |        0x03| UINT8 | 0x20000705
+
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   # For patchable PCDs, try to set the default as none-zero
   # It is to prevent it from being put into BSS section, thus cause patching issue

--- a/BootloaderCommonPkg/Include/Guid/NvVariableInfoGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/NvVariableInfoGuid.h
@@ -1,0 +1,24 @@
+/** @file
+  This file defines the hob structure for the SPI flash variable info.
+
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef NV_VARIABLE_INFO_GUID_H_
+#define NV_VARIABLE_INFO_GUID_H_
+
+//
+// NV variable hob info GUID
+//
+extern EFI_GUID gNvVariableInfoGuid;
+
+typedef struct {
+  UINT8                  Revision;
+  UINT8                  Reserved[3];
+  UINT32                 VariableStoreBase;
+  UINT32                 VariableStoreSize;
+} NV_VARIABLE_INFO;
+
+#endif

--- a/BootloaderCommonPkg/Include/Guid/SmmRegisterInfoGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/SmmRegisterInfoGuid.h
@@ -1,0 +1,48 @@
+/** @file
+  This file defines the SMM info hob structure.
+
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SMM_REGISTER_INFO_GUID_H_
+#define SMM_REGISTER_INFO_GUID_H_
+
+#include <IndustryStandard/Acpi.h>
+
+///
+/// SMM Information GUID
+///
+extern EFI_GUID gSmmRegisterInfoGuid;
+
+///
+/// Reuse ACPI definition
+/// AddressSpaceId(0xC0-0xFF) is defined by OEM for MSR and other spaces
+///
+typedef EFI_ACPI_3_0_GENERIC_ADDRESS_STRUCTURE  PLD_GENERIC_ADDRESS;
+
+#define REGISTER_ID_SMI_GBL_EN         1
+#define REGISTER_ID_SMI_GBL_EN_LOCK    2
+#define REGISTER_ID_SMI_EOS            3
+#define REGISTER_ID_SMI_APM_EN         4
+#define REGISTER_ID_SMI_APM_STS        5
+
+#pragma pack(1)
+typedef struct {
+  UINT64                Id;
+  UINT64                Value;
+  PLD_GENERIC_ADDRESS   Address;
+} PLD_GENERIC_REGISTER;
+
+typedef struct {
+  UINT16                Revision;
+  UINT16                Reserved;
+  UINT32                Count;
+  PLD_GENERIC_REGISTER  Registers[0];
+} PLD_SMM_REGISTERS;
+
+
+#pragma pack()
+
+#endif

--- a/BootloaderCommonPkg/Include/Guid/SmmS3CommunicationInfoGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/SmmS3CommunicationInfoGuid.h
@@ -1,0 +1,54 @@
+/** @file
+  This file defines the SMM S3 communication hob structure.
+
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SMM_S3_COMMUNICATION_GUID_H_
+#define SMM_S3_COMMUNICATION_GUID_H_
+
+extern EFI_GUID gPldS3CommunicationGuid;
+
+#pragma pack(1)
+
+typedef struct {
+  EFI_SMRAM_DESCRIPTOR  CommBuffer;
+  BOOLEAN               PldAcpiS3Enable;
+} PLD_S3_COMMUNICATION;
+
+///
+/// The information below is used for communication between bootloader and payload.
+/// It is used to save/store some registers in S3 path
+///
+/// This region exists only when gEfiAcpiVariableGuid HOB exist.
+/// when PLD_S3_COMMUNICATION.PldAcpiS3Enable is false, the communication buffer is defined as below.
+///
+
+typedef struct {
+  UINT32             ApicId;
+  UINT32             SmmBase;
+} CPU_SMMBASE;
+
+typedef struct {
+  UINT8              SwSmiData;
+  UINT8              SwSmiTriggerValue;
+  UINT16             Reserved;
+  UINT32             CpuCount;
+  CPU_SMMBASE        SmmBase[0];
+} SMM_S3_INFO;
+
+//
+// Payload would save this structure to S3 communication area in normal boot.
+// In S3 path, bootloader need restore SMM base and writie IO port 0xB2 with SwSmiTriggerValue
+// to trigger SMI to let payload to restore S3.
+//
+typedef struct {
+  EFI_HOB_GUID_TYPE  Header;
+  SMM_S3_INFO        S3Info;
+} PLD_TO_BL_SMM_INFO;
+
+#pragma pack()
+
+#endif

--- a/BootloaderCommonPkg/Include/Guid/SpiFlashInfoGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/SpiFlashInfoGuid.h
@@ -1,0 +1,38 @@
+/** @file
+  This file defines the hob structure for the SPI flash variable info.
+
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SPI_FLASH_INFO_GUID_H_
+#define SPI_FLASH_INFO_GUID_H_
+
+#include <IndustryStandard/Acpi.h>
+//
+// SPI Flash infor hob GUID
+//
+extern EFI_GUID gSpiFlashInfoGuid;
+
+//
+// Set this bit if platform need disable SMM write protection when writing flash
+// in SMM mode using this method:  -- AsmWriteMsr32 (0x1FE, MmioRead32 (0xFED30880) | BIT0);
+//
+#define FLAGS_SPI_DISABLE_SMM_WRITE_PROTECT     BIT0
+
+//
+// Reuse ACPI definition
+//
+typedef EFI_ACPI_3_0_GENERIC_ADDRESS_STRUCTURE PLD_GENERIC_ADDRESS;
+#define SPACE_ID_PCI_CONFIGURATION              EFI_ACPI_3_0_PCI_CONFIGURATION_SPACE
+#define REGISTER_BIT_WIDTH_DWORD                EFI_ACPI_3_0_DWORD
+
+typedef struct {
+  UINT8                        Revision;
+  UINT8                        Reserved;
+  UINT16                       Flags;
+  PLD_GENERIC_ADDRESS          SpiAddress;
+} SPI_FLASH_INFO;
+
+#endif

--- a/BootloaderCorePkg/Include/Library/S3SaveRestoreLib.h
+++ b/BootloaderCorePkg/Include/Library/S3SaveRestoreLib.h
@@ -8,6 +8,7 @@
 #ifndef _S3_SAVE_RESTORE_LIB_H_
 #define _S3_SAVE_RESTORE_LIB_H_
 
+#include <Guid/SmmS3CommunicationInfoGuid.h>
 
 #define BL_PLD_COMM_SIG       SIGNATURE_32('B', 'P', 'C', 'O')
 
@@ -79,11 +80,6 @@ typedef struct {
   BL_PLD_COMM_HDR S3SaveHdr;
   REG_INFO        RegInfo[];
 } S3_SAVE_REG;
-
-typedef struct {
-  UINT32  ApicId;
-  UINT32  SmmBase;
-} CPU_SMMBASE;
 
 typedef struct {
   BL_PLD_COMM_HDR SmmBaseHdr;

--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
@@ -60,3 +60,4 @@
   gPlatformModuleTokenSpaceGuid.PcdSmmRebaseMode
   gPlatformModuleTokenSpaceGuid.PcdFuncCpuInitHook
   gPlatformCommonLibTokenSpaceGuid.PcdCpuX2ApicEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdBuildSmmHobs

--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLibInternal.h
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLibInternal.h
@@ -24,6 +24,7 @@
 #include <Library/BootloaderCoreLib.h>
 #include <Library/S3SaveRestoreLib.h>
 #include <Register/Intel/ArchitecturalMsr.h>
+#include <Guid/SmmS3CommunicationInfoGuid.h>
 
 #define   AP_BUFFER_ADDRESS        0x38000
 #define   AP_BUFFER_SIZE           0x8000

--- a/BootloaderCorePkg/Library/S3SaveRestoreLib/S3SaveRestoreLib.inf
+++ b/BootloaderCorePkg/Library/S3SaveRestoreLib/S3SaveRestoreLib.inf
@@ -35,3 +35,6 @@
 
 [Guids]
   gSmmInformationGuid
+
+[Pcd]
+  gPlatformCommonLibTokenSpaceGuid.PcdBuildSmmHobs

--- a/BootloaderCorePkg/Stage2/Stage2.h
+++ b/BootloaderCorePkg/Stage2/Stage2.h
@@ -66,7 +66,11 @@
 #include <Library/SmbiosInitLib.h>
 #include <Library/UniversalPayloadLib.h>
 #include <VerInfo.h>
-
+#include <Guid/SmramMemoryReserve.h>
+#include <Guid/SmmRegisterInfoGuid.h>
+#include <Guid/SpiFlashInfoGuid.h>
+#include <Guid/NvVariableInfoGuid.h>
+#include <Guid/SmmS3CommunicationInfoGuid.h>
 
 
 #define UIMAGE_FIT_MAGIC               (0x56190527)

--- a/BootloaderCorePkg/Stage2/Stage2.inf
+++ b/BootloaderCorePkg/Stage2/Stage2.inf
@@ -98,6 +98,11 @@
   gUniversalPayloadSmbiosTableGuid
   gUniversalPayloadSerialPortInfoGuid
   gUniversalPayloadExtraDataGuid
+  gPldSmmRegisterInfoGuid
+  gEfiSmmSmramMemoryGuid
+  gSpiFlashInfoGuid
+  gNvVariableInfoGuid
+  gPldS3CommunicationGuid
 
 [Pcd]
   gPlatformCommonLibTokenSpaceGuid.PcdMaxLibraryDataEntry
@@ -139,6 +144,6 @@
   gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashMask
   gPlatformModuleTokenSpaceGuid.PcdSmmRebaseMode
   gPlatformModuleTokenSpaceGuid.PcdAcpiTablesRsdp
-
+  gPlatformCommonLibTokenSpaceGuid.PcdBuildSmmHobs
 [Depex]
   TRUE

--- a/MdePkg/Include/Guid/SmramMemoryReserve.h
+++ b/MdePkg/Include/Guid/SmramMemoryReserve.h
@@ -1,0 +1,45 @@
+/** @file
+  This is a special GUID extension Hob to describe SMRAM memory regions.
+
+  This file defines:
+  * the GUID used to identify the GUID HOB for reserving SMRAM regions.
+  * the data structure of SMRAM descriptor to describe SMRAM candidate regions
+  * values of state of SMRAM candidate regions
+  * the GUID specific data structure of HOB for reserving SMRAM regions.
+
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Revision Reference:
+  GUIDs defined in PI SPEC version 1.5.
+
+**/
+
+#ifndef _SMRAM_MEMORY_RESERVE_H_
+#define _SMRAM_MEMORY_RESERVE_H_
+
+#define EFI_SMM_SMRAM_MEMORY_GUID \
+  { \
+    0x6dadf1d1, 0xd4cc, 0x4910, {0xbb, 0x6e, 0x82, 0xb1, 0xfd, 0x80, 0xff, 0x3d } \
+  }
+
+/**
+* The GUID extension hob is to describe SMRAM memory regions supported by the platform.
+**/
+typedef struct {
+  ///
+  /// Designates the number of possible regions in the system
+  /// that can be usable for SMRAM.
+  ///
+  UINT32                NumberOfSmmReservedRegions;
+  ///
+  /// Used throughout this protocol to describe the candidate
+  /// regions for SMRAM that are supported by this platform.
+  ///
+  EFI_SMRAM_DESCRIPTOR  Descriptor[1];
+} EFI_SMRAM_HOB_DESCRIPTOR_BLOCK;
+
+extern EFI_GUID gEfiSmmSmramMemoryGuid;
+
+#endif
+


### PR DESCRIPTION
UEFI payload built from open sourced EDK2 supports SMM variable now.
So build the required HOBs to work with EDK2.
This patch just changed the common SBL code, so there is no platform
change required.

Signed-off-by: Guo Dong <guo.dong@intel.com>