### PR TITLE
SBL clean up to split core private data out

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -15,6 +15,9 @@
 [Includes]
   Include
 
+[Includes.Common.Private]
+  IncludePrivate
+
 [Guids]
   gPlatformModuleTokenSpaceGuid            = { 0x69d13bf0, 0xaf91, 0x4d96, { 0xaa, 0x9f, 0x21, 0x84, 0xc5, 0xce, 0x3b, 0xc0 } }
 

--- a/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
+++ b/BootloaderCorePkg/Include/Library/BootloaderCoreLib.h
@@ -1,139 +1,14 @@
 /** @file
 
-  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
 #ifndef _BOOTLOADER_CORE_LIB_H_
 #define _BOOTLOADER_CORE_LIB_H_
+
 #include <Library/BootloaderCommonLib.h>
-#include <Library/CryptoLib.h>
-#include <Guid/FlashMapInfoGuid.h>
-
-#define  MPLD_SIGNATURE               SIGNATURE_32 ('$', 'P', 'L', 'D')
-#define  MVBT_SIGNATURE               SIGNATURE_32 ('$', 'M', 'V', 'B')
-#define  IS_MULTI_PAYLOAD(x)          (*(UINT32 *)(x) == MPLD_SIGNATURE)
-
-#define  IS_FLASH_SPACE(x)            (((x) >= PcdGet32 (PcdFlashBaseAddress)) && \
-                                      ((x) <= PcdGet32 (PcdFlashBaseAddress) + PcdGet32 (PcdFlashSize) - 1))
-
-#define  GET_STAGE_MODULE_ENTRY(x)    (STAGE_ENTRY) (UINTN)((STAGE_HDR *)(UINTN)(x))->Entry
-#define  GET_STAGE_MODULE_BASE(x)     (STAGE_ENTRY) (UINTN)((STAGE_HDR *)(UINTN)(x))->Base
-
-#define  PCD_GET32_WITH_ADJUST(x)     GetAdjustedPcdBase (PcdGet32 (x))
-
-typedef  VOID   (EFIAPI *STAGE_ENTRY)   (VOID *Params);
-
-typedef  VOID   (EFIAPI *PAYLOAD_ENTRY) (VOID *HobList, VOID *Params);
-
-#pragma pack(1)
-
-#define  STAGE_IDT_ENTRY_COUNT        34
-#define  STAGE_GDT_ENTRY_COUNT        7
-
-#define  PLATFORM_NAME_SIZE           8
-
-typedef enum {
-  EnumBufFlashMap,
-  EnumBufVerInfo,
-  EnumBufHashStore,
-  EnumBufLibData,
-  EnumBufService,
-  EnumBufPcdData,
-  EnumBufPlatData,
-  EnumBufCfgData,
-  EnumBufCtnList,
-  EnumBufLogBuf,
-  EnumBufMax
-} BUF_INFO_ID;
-
-typedef struct {
-  UINT64        LdrGlobal;
-  IA32_IDT_GATE_DESCRIPTOR  IdtTable[STAGE_IDT_ENTRY_COUNT];
-} STAGE_IDT_TABLE;
-
-typedef struct {
-  IA32_SEGMENT_DESCRIPTOR   GdtTable[STAGE_GDT_ENTRY_COUNT];
-} STAGE_GDT_TABLE;
-
-typedef struct {
-  UINT32        Entry;
-  UINT32        Base;
-} STAGE_HDR;
-
-typedef struct {
-  UINT32        CarBase;
-  UINT32        CarTop;
-  UINT64        TimeStamp;
-  struct _STATUS {
-    UINT32      CpuBist           :  1;
-    UINT32      StackOutOfRange   :  1;
-    UINT32      RsvdBits          : 30;
-    UINT32      RsvdBits2         : 32;
-  } Status;
-} STAGE1A_ASM_PARAM;
-
-typedef struct {
-  VOID         *SrcBase;
-  VOID         *DstBase;
-  UINT32        AllocLen;
-  UINT32        CopyLen;
-} BUF_INFO;
-
-typedef struct {
-  UINT32        CarBase;
-  UINT32        CarTop;
-  UINT32        Stage1BBase;
-  UINT32        AllocDataBase;
-  UINT32        AllocDataLen;
-  BUF_INFO      BufInfo[EnumBufMax];
-} STAGE1A_PARAM;
-
-typedef struct {
-  UINT32        PayloadBase;
-  UINT32        CfgDataAddr;
-  UINT8         ConfigDataHashValid;
-  UINT8         ConfigDataHash[HASH_DIGEST_MAX];
-  UINT8         KeyHashManifestHashValid;
-  UINT8         KeyHashManifestHash[HASH_DIGEST_MAX];
-} STAGE1B_PARAM;
-
-typedef struct {
-  UINT32        PayloadBase;
-  UINT32        PayloadActualLength;
-  UINT32        Stage2ExeBase;
-} STAGE2_PARAM;
-
-typedef struct {
-  UINT32        Signature;
-  UINT8         EntryNum;
-  UINT8         Reserved[3];
-} VBT_MB_HDR;
-
-typedef struct {
-  UINT32        ImageId;
-  UINT32        Length;
-  UINT8         Data[];
-} VBT_ENTRY_HDR;
-
-typedef struct {
-  UINT32        AcpiTop;
-  UINT32        AcpiBase;
-  UINT32        AcpiGnvs;
-  UINT8         BootMediaType;
-  UINT8         BootPartition;
-} S3_DATA;
-
-typedef enum {
-  EnumMemInfoTom,     // Total system memory size
-  EnumMemInfoTolum,   // Top of low usable memory
-  EnumMemInfoTouum,   // Top of upper usable memory
-  EnumMemInfoTodplm,  // Top of DMA protected low memory
-  EnumMemInfoMax
-} MEM_INFO_TYPE;
-
-#pragma pack()
 
 //
 // These MACRO definations should be used only after feature config data is set in stage1b.
@@ -142,112 +17,15 @@ typedef enum {
 #define ACPI_ENABLED()           (FeaturePcdGet (PcdAcpiEnabled) && ACPI_FEATURE_ENABLED())
 #define MEASURED_BOOT_ENABLED()  (FeaturePcdGet (PcdMeasuredBootEnabled) && (GetFeatureCfg() & FEATURE_MEASURED_BOOT) && ACPI_FEATURE_ENABLED())
 
-/*
-          Reserved MEM
-  +------------------------------+  Top of Low MEM
-  |       SOC Reserved MEM       |
-  +------------------------------+  Top of usable MEM Base
-  |       FSP Reserved MEM       |
-  +------------------------------+  FSP Reserved MEM Base
-  |       LDR Reserved MEM       |
-  +------------------------------+  LDR Reserved MEM Base
-  |         ACPI NVS MEM         |
-  +------------------------------+  ACPI NVS MEM Base
-  |       ACPI Reclaim MEM       |
-  +------------------------------+  ACPI Reclaim MEM Base
-  |       PLD Reserved MEM       |
-  +------------------------------+  PLD Reserved MEM Base
-  |         DMA Buffer           |
-  +------------------------------+  DMA Buffer MEM Base
-  |          PLD Heap            |
-  +------------------------------+  PLD Heap MEM Base
-  |          PLD Stack           |
-  +------------------------------+  PLD Stack MEM Base
+#define PCD_GET32_WITH_ADJUST(x)  GetAdjustedPcdBase (PcdGet32 (x))
 
-        Loader Reserved MEM
-  +------------------------------+  FSP Reserved MEM Base
-  |       LDR Stack (Down)       |
-  |                              |
-  |         LDR HOB (Up)         |
-  +------------------------------+  MemPoolEnd (Fixed)
-  |                              |
-  |   Permanant MEM Pool (Down)  |
-  |                              |
-  +------------------------------+  MemPoolCurrTop (Moving down)
-  |                              |
-  +------------------------------+  MemPoolCurrBottom (Moving up)
-  |                              |
-  |   Temporary MEM Pool (Up)    |
-  |                              |
-  +------------------------------+  MemPoolStart (Fixed)
-*/
-
-#define  LDR_GDATA_SIGNATURE     SIGNATURE_32('L', 'D', 'R', 'G')
-
-typedef struct {
-  UINT32            Signature;
-  UINT16            PlatformId;
-  UINT16            PlatformBomId;
-  UINT32            SocSku;
-  UINT8             BootMode;
-  UINT8             LoaderStage;
-  UINT8             CurrentBootPartition;
-  UINT8             ResetReason;
-  UINT32            StackTop;
-  UINT32            MemPoolEnd;
-  UINT32            MemPoolStart;
-  UINT32            MemPoolCurrTop;
-  UINT32            MemPoolCurrBottom;
-  UINT32            PayloadId;
-  UINT32            DebugPrintErrorLevel;
-  UINT8             DebugPortIdx;
-  UINT8             Padding[3];
-  UINT64            MemoryInfo[EnumMemInfoMax];
-  VOID             *FspHobList;
-  VOID             *LdrHobList;
-  VOID             *FlashMapPtr;
-  VOID             *VerInfoPtr;
-  VOID             *HashStorePtr;
-  VOID             *LibDataPtr;
-  VOID             *ServicePtr;
-  VOID             *PcdDataPtr;
-  VOID             *PlatDataPtr;
-  VOID             *CfgDataPtr;
-  VOID             *LogBufPtr;
-  VOID             *DeviceTable;
-  VOID             *ContainerList;
-  VOID             *S3DataPtr;
-  VOID             *DebugDataPtr;
-  VOID             *DmaBufferPtr;
-  UINT8             PlatformName[PLATFORM_NAME_SIZE];
-  UINT32            LdrFeatures;
-  BL_PERF_DATA      PerfData;
-  UINT32            CarBase;
-  UINT32            CarSize;
-  UINT32            MemPoolMaxUsed;
-} LOADER_GLOBAL_DATA;
-
-/**
-  This function sets the Loader global data pointer.
-
-  @param[in] LoaderData    Fsp global data pointer.
-
-**/
-VOID
-EFIAPI
-SetLoaderGlobalDataPointer (
-  IN LOADER_GLOBAL_DATA   *LoaderData
-  );
-
-/**
-  This function gets the Loader global data pointer.
-
-**/
-LOADER_GLOBAL_DATA *
-EFIAPI
-GetLoaderGlobalDataPointer (
-  VOID
-  );
+typedef enum {
+  EnumMemInfoTom,     // Total system memory size
+  EnumMemInfoTolum,   // Top of low usable memory
+  EnumMemInfoTouum,   // Top of upper usable memory
+  EnumMemInfoTodplm,  // Top of DMA protected low memory
+  EnumMemInfoMax
+} MEM_INFO_TYPE;
 
 /**
   Returns the pointer to the Fsp HOB list.
@@ -393,6 +171,31 @@ UINT32
 EFIAPI
 GetSocSku (
   VOID
+  );
+
+/**
+  Returns the debug print error level mask for the current module.
+
+  @return  Debug print error level mask for the current module.
+
+**/
+UINT32
+EFIAPI
+GetDebugErrorLevel (
+  VOID
+  );
+
+
+/**
+  Sets the global debug print error level mask fpr the entire platform.
+
+  @param   ErrorLevel     Global debug print error level.
+
+**/
+VOID
+EFIAPI
+SetDebugErrorLevel (
+  UINT32  ErrorLevel
   );
 
 /**
@@ -586,16 +389,6 @@ SetFeatureCfg (
   );
 
 /**
-  This function clears FSP Hob Data and pointer.
-
-**/
-VOID
-EFIAPI
-ClearFspHob (
-  VOID
-  );
-
-/**
   This function retrieves the Version Information pointer.
 
   @retval    Version Information pointer address.
@@ -604,6 +397,16 @@ ClearFspHob (
 VOID *
 EFIAPI
 GetVerInfoPtr (
+  VOID
+  );
+
+/**
+  This function clears FSP Hob Data and pointer.
+
+**/
+VOID
+EFIAPI
+ClearFspHob (
   VOID
   );
 

--- a/BootloaderCorePkg/Include/Library/StageLib.h
+++ b/BootloaderCorePkg/Include/Library/StageLib.h
@@ -7,6 +7,8 @@
 
 #ifndef _STAGE_LIB_H_
 
+#include <BootloaderCoreGlobal.h>
+
 /**
   Load IDT table for current processor.
 

--- a/BootloaderCorePkg/IncludePrivate/BootloaderCoreGlobal.h
+++ b/BootloaderCorePkg/IncludePrivate/BootloaderCoreGlobal.h
@@ -1,0 +1,222 @@
+/** @file
+  Common header file for Bootloader Core global data structures.
+
+  Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _BOOTLOADER_CORE_GLOBAL_H_
+#define _BOOTLOADER_CORE_GLOBAL_H_
+
+#include <Library/BootloaderCoreLib.h>
+
+#define  MPLD_SIGNATURE               SIGNATURE_32 ('$', 'P', 'L', 'D')
+#define  IS_MULTI_PAYLOAD(x)          (*(UINT32 *)(x) == MPLD_SIGNATURE)
+
+#define  IS_FLASH_SPACE(x)            (((x) >= PcdGet32 (PcdFlashBaseAddress)) && \
+                                      ((x) <= PcdGet32 (PcdFlashBaseAddress) + PcdGet32 (PcdFlashSize) - 1))
+
+#define  GET_STAGE_MODULE_ENTRY(x)    (STAGE_ENTRY) (UINTN)((STAGE_HDR *)(UINTN)(x))->Entry
+#define  GET_STAGE_MODULE_BASE(x)     (STAGE_ENTRY) (UINTN)((STAGE_HDR *)(UINTN)(x))->Base
+
+typedef  VOID   (EFIAPI *STAGE_ENTRY)   (VOID *Params);
+
+typedef  VOID   (EFIAPI *PAYLOAD_ENTRY) (VOID *HobList, VOID *Params);
+
+#pragma pack(1)
+
+#define  STAGE_IDT_ENTRY_COUNT        34
+#define  STAGE_GDT_ENTRY_COUNT        7
+
+#define  PLATFORM_NAME_SIZE           8
+
+typedef enum {
+  EnumBufFlashMap,
+  EnumBufVerInfo,
+  EnumBufHashStore,
+  EnumBufLibData,
+  EnumBufService,
+  EnumBufPcdData,
+  EnumBufPlatData,
+  EnumBufCfgData,
+  EnumBufCtnList,
+  EnumBufLogBuf,
+  EnumBufMax
+} BUF_INFO_ID;
+
+typedef struct {
+  UINT64        LdrGlobal;
+  IA32_IDT_GATE_DESCRIPTOR  IdtTable[STAGE_IDT_ENTRY_COUNT];
+} STAGE_IDT_TABLE;
+
+typedef struct {
+  IA32_SEGMENT_DESCRIPTOR   GdtTable[STAGE_GDT_ENTRY_COUNT];
+} STAGE_GDT_TABLE;
+
+typedef struct {
+  UINT32        Entry;
+  UINT32        Base;
+} STAGE_HDR;
+
+typedef struct {
+  UINT32        CarBase;
+  UINT32        CarTop;
+  UINT64        TimeStamp;
+  struct _STATUS {
+    UINT32      CpuBist           :  1;
+    UINT32      StackOutOfRange   :  1;
+    UINT32      RsvdBits          : 30;
+    UINT32      RsvdBits2         : 32;
+  } Status;
+} STAGE1A_ASM_PARAM;
+
+typedef struct {
+  VOID         *SrcBase;
+  VOID         *DstBase;
+  UINT32        AllocLen;
+  UINT32        CopyLen;
+} BUF_INFO;
+
+typedef struct {
+  UINT32        CarBase;
+  UINT32        CarTop;
+  UINT32        Stage1BBase;
+  UINT32        AllocDataBase;
+  UINT32        AllocDataLen;
+  BUF_INFO      BufInfo[EnumBufMax];
+} STAGE1A_PARAM;
+
+typedef struct {
+  UINT32        PayloadBase;
+  UINT32        CfgDataAddr;
+  UINT8         ConfigDataHashValid;
+  UINT8         ConfigDataHash[HASH_DIGEST_MAX];
+  UINT8         KeyHashManifestHashValid;
+  UINT8         KeyHashManifestHash[HASH_DIGEST_MAX];
+} STAGE1B_PARAM;
+
+typedef struct {
+  UINT32        PayloadBase;
+  UINT32        PayloadActualLength;
+  UINT32        Stage2ExeBase;
+} STAGE2_PARAM;
+
+typedef struct {
+  UINT32        AcpiTop;
+  UINT32        AcpiBase;
+  UINT32        AcpiGnvs;
+  UINT8         BootMediaType;
+  UINT8         BootPartition;
+} S3_DATA;
+
+#pragma pack()
+
+/*
+          Reserved MEM
+  +------------------------------+  Top of Low MEM
+  |       SOC Reserved MEM       |
+  +------------------------------+  Top of usable MEM Base
+  |       FSP Reserved MEM       |
+  +------------------------------+  FSP Reserved MEM Base
+  |       LDR Reserved MEM       |
+  +------------------------------+  LDR Reserved MEM Base
+  |         ACPI NVS MEM         |
+  +------------------------------+  ACPI NVS MEM Base
+  |       ACPI Reclaim MEM       |
+  +------------------------------+  ACPI Reclaim MEM Base
+  |       PLD Reserved MEM       |
+  +------------------------------+  PLD Reserved MEM Base
+  |         DMA Buffer           |
+  +------------------------------+  DMA Buffer MEM Base
+  |          PLD Heap            |
+  +------------------------------+  PLD Heap MEM Base
+  |          PLD Stack           |
+  +------------------------------+  PLD Stack MEM Base
+
+        Loader Reserved MEM
+  +------------------------------+  FSP Reserved MEM Base
+  |       LDR Stack (Down)       |
+  |                              |
+  |         LDR HOB (Up)         |
+  +------------------------------+  MemPoolEnd (Fixed)
+  |                              |
+  |   Permanant MEM Pool (Down)  |
+  |                              |
+  +------------------------------+  MemPoolCurrTop (Moving down)
+  |                              |
+  +------------------------------+  MemPoolCurrBottom (Moving up)
+  |                              |
+  |   Temporary MEM Pool (Up)    |
+  |                              |
+  +------------------------------+  MemPoolStart (Fixed)
+*/
+
+#define  LDR_GDATA_SIGNATURE     SIGNATURE_32('L', 'D', 'R', 'G')
+
+typedef struct {
+  UINT32            Signature;
+  UINT16            PlatformId;
+  UINT16            PlatformBomId;
+  UINT32            SocSku;
+  UINT8             BootMode;
+  UINT8             LoaderStage;
+  UINT8             CurrentBootPartition;
+  UINT8             ResetReason;
+  UINT32            StackTop;
+  UINT32            MemPoolEnd;
+  UINT32            MemPoolStart;
+  UINT32            MemPoolCurrTop;
+  UINT32            MemPoolCurrBottom;
+  UINT32            PayloadId;
+  UINT32            DebugPrintErrorLevel;
+  UINT8             DebugPortIdx;
+  UINT8             Padding[3];
+  UINT64            MemoryInfo[EnumMemInfoMax];
+  VOID             *FspHobList;
+  VOID             *LdrHobList;
+  VOID             *FlashMapPtr;
+  VOID             *VerInfoPtr;
+  VOID             *HashStorePtr;
+  VOID             *LibDataPtr;
+  VOID             *ServicePtr;
+  VOID             *PcdDataPtr;
+  VOID             *PlatDataPtr;
+  VOID             *CfgDataPtr;
+  VOID             *LogBufPtr;
+  VOID             *DeviceTable;
+  VOID             *ContainerList;
+  VOID             *S3DataPtr;
+  VOID             *DebugDataPtr;
+  VOID             *DmaBufferPtr;
+  UINT8             PlatformName[PLATFORM_NAME_SIZE];
+  UINT32            LdrFeatures;
+  BL_PERF_DATA      PerfData;
+  UINT32            CarBase;
+  UINT32            CarSize;
+  UINT32            MemPoolMaxUsed;
+} LOADER_GLOBAL_DATA;
+
+/**
+  This function sets the Loader global data pointer.
+
+  @param[in] LoaderData    Fsp global data pointer.
+
+**/
+VOID
+EFIAPI
+SetLoaderGlobalDataPointer (
+  IN LOADER_GLOBAL_DATA   *LoaderData
+  );
+
+/**
+  This function gets the Loader global data pointer.
+
+**/
+LOADER_GLOBAL_DATA *
+EFIAPI
+GetLoaderGlobalDataPointer (
+  VOID
+  );
+
+#endif

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
@@ -23,6 +23,7 @@
 #include <Library/MpInitLib.h>
 #include <Library/FirmwareUpdateLib.h>
 #include <Guid/BootLoaderVersionGuid.h>
+#include <BootloaderCoreGlobal.h>
 #include "AcpiInitLibInternal.h"
 
 STATIC
@@ -185,7 +186,6 @@ AcpiTableUpdate (
   UINT32                            Size;
   UINT32                            EntryNum;
   EFI_STATUS                        Status;
-  LOADER_GLOBAL_DATA               *LdrGlobal;
   S3_DATA                          *S3Data;
   UINT32                            AcpiMax;
 
@@ -199,9 +199,7 @@ AcpiTableUpdate (
   RsdtEntry = (UINT32 *) ((UINT8 *)Rsdt + sizeof (EFI_ACPI_DESCRIPTION_HEADER));
   XsdtEntry = (UINT64 *) ((UINT8 *)Xsdt + sizeof (EFI_ACPI_DESCRIPTION_HEADER));
   EntryNum  = (Rsdt->Length - sizeof (EFI_ACPI_DESCRIPTION_HEADER)) / sizeof (UINT32);
-
-  LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer();
-  S3Data    = (S3_DATA *)LdrGlobal->S3DataPtr;
+  S3Data    = (S3_DATA *) GetS3DataPtr();
   Current   = (UINT8 *)(UINTN)S3Data->AcpiTop;
   AcpiMax   = S3Data->AcpiBase + PcdGet32 (PcdLoaderAcpiReclaimSize);
 

--- a/BootloaderCorePkg/Library/BootloaderCoreLib/BootloaderArch.c
+++ b/BootloaderCorePkg/Library/BootloaderCoreLib/BootloaderArch.c
@@ -7,7 +7,7 @@
 
 #include <PiPei.h>
 #include <Library/PcdLib.h>
-#include <Library/BootloaderCoreLib.h>
+#include <BootloaderCoreGlobal.h>
 
 /**
   This function sets the Loader global data pointer.

--- a/BootloaderCorePkg/Library/BootloaderCoreLib/BootloaderCoreLib.c
+++ b/BootloaderCorePkg/Library/BootloaderCoreLib/BootloaderCoreLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2016 - 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -10,8 +10,8 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/HobLib.h>
-#include <Library/BootloaderCoreLib.h>
 #include <Guid/FlashMapInfoGuid.h>
+#include <BootloaderCoreGlobal.h>
 
 /**
   This function retrieves current boot mode.
@@ -344,6 +344,37 @@ GetDebugPort (
   return GetLoaderGlobalDataPointer()->DebugPortIdx;
 }
 
+
+/**
+  Returns the debug print error level mask for the current module.
+
+  @return  Debug print error level mask for the current module.
+
+**/
+UINT32
+EFIAPI
+GetDebugErrorLevel (
+  VOID
+  )
+{
+  return ((LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer())->DebugPrintErrorLevel;
+}
+
+
+/**
+  Sets the global debug print error level mask fpr the entire platform.
+
+  @param   ErrorLevel     Global debug print error level.
+
+**/
+VOID
+EFIAPI
+SetDebugErrorLevel (
+  UINT32  ErrorLevel
+  )
+{
+  ((LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer())->DebugPrintErrorLevel = ErrorLevel;
+}
 
 /**
   This function sets current platform BOM id.

--- a/BootloaderCorePkg/Library/BootloaderLib/BootloaderLib.c
+++ b/BootloaderCorePkg/Library/BootloaderLib/BootloaderLib.c
@@ -9,10 +9,10 @@
 #include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLogBufferLib.h>
-#include <Library/BootloaderCoreLib.h>
 #include <Library/SecureBootLib.h>
 #include <Library/HobLib.h>
 #include <Library/PcdLib.h>
+#include <BootloaderCoreGlobal.h>
 
 /**
   Returns the pointer to the Flash Map.

--- a/BootloaderCorePkg/Library/DebugDataLib/DebugDataLib.c
+++ b/BootloaderCorePkg/Library/DebugDataLib/DebugDataLib.c
@@ -6,7 +6,7 @@
 **/
 
 #include <Library/DebugDataLib.h>
-
+#include <BootloaderCoreGlobal.h>
 
 /**
   Allocate Memory for Debug Test Cases.

--- a/BootloaderCorePkg/Library/DebugPrintErrorLevelLib/DebugPrintErrorLevelLib.c
+++ b/BootloaderCorePkg/Library/DebugPrintErrorLevelLib/DebugPrintErrorLevelLib.c
@@ -24,7 +24,7 @@ GetDebugPrintErrorLevel (
   VOID
   )
 {
-  return ((LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer())->DebugPrintErrorLevel;
+  return GetDebugErrorLevel ();
 }
 
 /**
@@ -42,6 +42,6 @@ SetDebugPrintErrorLevel (
   UINT32  ErrorLevel
   )
 {
-  ((LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer())->DebugPrintErrorLevel = ErrorLevel;
+  SetDebugErrorLevel (ErrorLevel);
   return TRUE;
 }

--- a/BootloaderCorePkg/Library/MemoryAllocationLib/MemoryAllocationLib.c
+++ b/BootloaderCorePkg/Library/MemoryAllocationLib/MemoryAllocationLib.c
@@ -12,7 +12,7 @@
 #include <Library/MemoryAllocationLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
-#include <Library/BootloaderCoreLib.h>
+#include <BootloaderCoreGlobal.h>
 
 #define   POOL_MIN_ALIGNMENT    0x10
 

--- a/BootloaderCorePkg/Library/StageLib/StageLib.c
+++ b/BootloaderCorePkg/Library/StageLib/StageLib.c
@@ -9,9 +9,9 @@
 #include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/BlMemoryAllocationLib.h>
-#include <Library/BootloaderCoreLib.h>
 #include <Library/CpuExceptionLib.h>
 #include <Library/PagingLib.h>
+#include <BootloaderCoreGlobal.h>
 
 /**
   Load IDT table for current processor.

--- a/Platform/CommonBoardPkg/Include/Library/BoardSupportLib.h
+++ b/Platform/CommonBoardPkg/Include/Library/BoardSupportLib.h
@@ -11,6 +11,20 @@
 #include <Guid/OsBootOptionGuid.h>
 #include <Library/FirmwareUpdateLib.h>
 
+#define  MVBT_SIGNATURE               SIGNATURE_32 ('$', 'M', 'V', 'B')
+
+typedef struct {
+  UINT32        Signature;
+  UINT8         EntryNum;
+  UINT8         Reserved[3];
+} VBT_MB_HDR;
+
+typedef struct {
+  UINT32        ImageId;
+  UINT32        Length;
+  UINT8         Data[];
+} VBT_ENTRY_HDR;
+
 /**
   A function pointer to get relative power number in mW
 


### PR DESCRIPTION
This patch moved SBL core private data strctures and definitions
into a private header file so that other packages cannot refer
to the private structures.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>