### PR TITLE
Add RxRaw field to Gpio config template

### DIFF
--- a/Platform/CoffeelakeBoardPkg/CfgData/Template_CfgData.yaml
+++ b/Platform/CoffeelakeBoardPkg/CfgData/Template_CfgData.yaml
@@ -191,10 +191,16 @@ GPIO_TMPL: >
                        - OutputStateUnlock = Leave Pad output control unlocked, PadUnlock = Leave both Pad configuration and output control unlocked
         condition    :  $(COND_GPIO_SKIP)
         length       : 4b
+    - RxRaw_$(1) :
+        name         : RxRaw
+        type         : Combo
+        option       : 0x0:Default, 0x1:NoOverride, 0x3:RxDrive 1 internally
+        help         : > This bit determines if the selected pad state is being overridden to '1'.
+        length       : 2b
     - Reserved1_$(1) :
         name         : Reserved1
         type         : Reserved
-        length       : 3b
+        length       : 1b
     - PadNum_$(1)  :
         name         : PadNum
         type         : Reserved

--- a/Platform/CometlakeBoardPkg/CfgData/Template_CfgData.yaml
+++ b/Platform/CometlakeBoardPkg/CfgData/Template_CfgData.yaml
@@ -381,14 +381,20 @@ GPIO_TMPL: >
         condition    : $GPIO_CFG_DATA.GpioPinConfig1_$(1).GPIOSkip_$(1) == 0
 
         length       : 4b
-
+    - RxRaw_$(1) :
+        name         : RxRaw
+        type         : Combo
+        option       : 0x0:Default, 0x1:NoOverride, 0x3:RxDrive 1 internally
+        help         : >
+                        This bit determines if the selected pad state is being overridden to '1'.
+        length       : 2b
     - Reserved1_$(1) :
 
         name         : Reserved1
 
         type         : Reserved
 
-        length       : 3b
+        length       : 1b
 
     - PadNum_$(1)  :
 

--- a/Platform/CometlakevBoardPkg/CfgData/Template_CfgData.yaml
+++ b/Platform/CometlakevBoardPkg/CfgData/Template_CfgData.yaml
@@ -190,10 +190,16 @@ GPIO_TMPL: >
                        - OutputStateUnlock = Leave Pad output control unlocked, PadUnlock = Leave both Pad configuration and output control unlocked
         condition    : $GPIO_CFG_DATA.GpioPinConfig1_$(1).GPIOSkip_$(1) == 0
         length       : 4b
+    - RxRaw_$(1) :
+        name         : RxRaw
+        type         : Combo
+        option       : 0x0:Default, 0x1:NoOverride, 0x3:RxDrive 1 internally
+        help         : > This bit determines if the selected pad state is being overridden to '1'.
+        length       : 2b
     - Reserved1_$(1) :
         name         : Reserved1
         type         : Reserved
-        length       : 3b
+        length       : 1b
     - PadNum_$(1)  :
         name         : PadNum
         type         : Reserved

--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgDataDef.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgDataDef.yaml
@@ -140,10 +140,16 @@ template:
                          - OutputStateUnlock = Leave Pad output control unlocked, PadUnlock = Leave both Pad configuration and output control unlocked
           condition    : $GPIO_CFG_DATA.GpioPinConfig1_$(1)$(2).GPIOSkip_$(1)$(2) == 0
           length       : 4b
+      - RxRaw_$(1)$(2) :
+          name         : RxRaw
+          type         : Combo
+          option       : 0x0:Default, 0x1:NoOverride, 0x3:RxDrive 1 internally
+          help         : > This bit determines if the selected pad state is being overridden to '1'.
+          length       : 2b
       - Reserved1_$(1)$(2) :
           name         : Reserved1
           type         : Reserved
-          length       : 3b
+          length       : 1b
       - PadNum_$(1)$(2)  :
           name         : PadNum
           type         : Reserved

--- a/Platform/TigerlakeBoardPkg/CfgData/Template_Gpio.yaml
+++ b/Platform/TigerlakeBoardPkg/CfgData/Template_Gpio.yaml
@@ -126,10 +126,16 @@ GPIO_TMPL: >
                        - OutputStateUnlock = Leave Pad output control unlocked, PadUnlock = Leave both Pad configuration and output control unlocked
         condition    : $GPIO_CFG_DATA.GpioPinConfig1_$(1)$(2).GPIOSkip_$(1)$(2) == 0
         length       : 4b
+    - RxRaw_$(1)$(2) :
+          name         : RxRaw
+          type         : Combo
+          option       : 0x0:Default, 0x1:NoOverride, 0x3:RxDrive 1 internally
+          help         : > This bit determines if the selected pad state is being overridden to '1'.
+          length       : 2b
     - Reserved1_$(1)$(2) :
         name         : Reserved1
         type         : Reserved
-        length       : 3b
+        length       : 1b
     - PadNum_$(1)$(2)  :
         name         : PadNum
         type         : Reserved


### PR DESCRIPTION
Current GpioLib uses 2 bits from OtherSettings to
configure RxRaw field in GPIO PAD CFG DWORD 0. But
Gpio config templates are missing the option to configure
this feature. This patch adds the option in template.

Signed-off-by: Sai T <sai.kiran.talamudupula@intel.com>