### PR TITLE
Add new Constant type for CFGDATA

### DIFF
--- a/BootloaderCorePkg/Tools/ConfigEditor.py
+++ b/BootloaderCorePkg/Tools/ConfigEditor.py
@@ -1014,7 +1014,7 @@ class application(tkinter.Frame):
             widget = custom_table(parent, col_hdr, bins)
 
         else:
-            if itype and itype not in ["Reserved"]:
+            if itype and itype not in ["Reserved", "Constant"]:
                 print ("WARNING: Type '%s' is invalid for '%s' !" % (itype, item['path']))
 
         if widget:

--- a/BootloaderCorePkg/Tools/SblSetup.py
+++ b/BootloaderCorePkg/Tools/SblSetup.py
@@ -2062,7 +2062,7 @@ def rebuild_cfgs (cfg_win, pages, page_id):
                 tabel1.show()
                 rc.adjust (0, rc.h + 1, 0, 0)
 
-        elif itype == 'Reserved':
+        elif itype in ['Reserved', 'Constant']:
             pass
 
         else:


### PR DESCRIPTION
There are CFGDATA item that needs to be generated into DLT file,
but not to be displayed in ConfigEditor. The current "Reserved"
type prevents the item from being displayed in ConfigEditor,
but also prevents it from being generated in a DLT file. The new
"Constant" type is introduced here to resolve this issue. Item
with "Constant" type will not be displayed in ConfigEditor, but
will be generated in the DLT file.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>