### PR TITLE
Sync up MTRR for MP before boot

### DIFF
--- a/BootloaderCommonPkg/Include/Library/MtrrLib.h
+++ b/BootloaderCommonPkg/Include/Library/MtrrLib.h
@@ -11,6 +11,93 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <PiPei.h>
 
+//
+// The semantics of below macro is MAX_MTRR_NUMBER_OF_VARIABLE_MTRR, the real number can be read out from MTRR_CAP register.
+//
+#define  MTRR_NUMBER_OF_VARIABLE_MTRR  32
+
+#define  MTRR_NUMBER_OF_FIXED_MTRR     11
+
+//
+// Structure to describe a fixed MTRR
+//
+typedef struct {
+  UINT32  Msr;
+  UINT32  BaseAddress;
+  UINT32  Length;
+} FIXED_MTRR;
+
+//
+// Structure to hold base and mask pair for variable MTRR register
+//
+typedef struct _MTRR_VARIABLE_SETTING_ {
+  UINT64    Base;
+  UINT64    Mask;
+} MTRR_VARIABLE_SETTING;
+
+//
+// Array for variable MTRRs
+//
+typedef struct _MTRR_VARIABLE_SETTINGS_ {
+  MTRR_VARIABLE_SETTING   Mtrr[MTRR_NUMBER_OF_VARIABLE_MTRR];
+} MTRR_VARIABLE_SETTINGS;
+
+//
+// Array for fixed MTRRs
+//
+typedef  struct  _MTRR_FIXED_SETTINGS_ {
+  UINT64       Mtrr[MTRR_NUMBER_OF_FIXED_MTRR];
+} MTRR_FIXED_SETTINGS;
+
+//
+// Structure to hold all MTRRs
+//
+typedef struct _MTRR_SETTINGS_ {
+  MTRR_FIXED_SETTINGS       Fixed;
+  MTRR_VARIABLE_SETTINGS    Variables;
+} MTRR_SETTINGS;
+
+/**
+  This function gets the content in all MTRRs (variable and fixed)
+
+  @param[out]  MtrrSetting   A buffer to hold all MTRRs content.
+
+  @retval  EFI_INVALID_PARAMETER   MtrrSetting is NULL.
+           EFI_OUT_OF_RESOURCES    Insufficient space to save all MTRR values.
+           EFI_SUCCESS             MTRR values were retrieved successfully.
+**/
+EFI_STATUS
+EFIAPI
+GetCpuMtrrs (
+  OUT MTRR_SETTINGS                *MtrrSetting
+  );
+
+/**
+  This function sets all MTRRs (variable and fixed)
+
+  @param[in]  MtrrSetting   A buffer to hold all MTRRs content.
+
+  @retval  EFI_INVALID_PARAMETER   MtrrSetting is NULL.
+           EFI_SUCCESS             MTRR values were programmed successfully.
+**/
+EFI_STATUS
+EFIAPI
+SetCpuMtrrs (
+  IN MTRR_SETTINGS                *MtrrSetting
+  );
+
+/**
+  Worker function returns the variable MTRR count for the CPU.
+
+  @return Variable MTRR count
+
+**/
+UINT32
+EFIAPI
+GetVariableMtrrCount (
+  VOID
+  );
+
 /**
   Print MTRR settings.
 

--- a/BootloaderCommonPkg/Library/MtrrLib/MtrrLib.inf
+++ b/BootloaderCommonPkg/Library/MtrrLib/MtrrLib.inf
@@ -21,6 +21,7 @@
 
 [Sources]
   MtrrLib.c
+  MtrrSync.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/BootloaderCommonPkg/Library/MtrrLib/MtrrSync.c
+++ b/BootloaderCommonPkg/Library/MtrrLib/MtrrSync.c
@@ -1,0 +1,197 @@
+/** @file
+  MTRR related functions.
+
+Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+#include <Register/Intel/Cpuid.h>
+#include <Register/Intel/ArchitecturalMsr.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MtrrLib.h>
+#include <Library/DebugLib.h>
+
+//
+// This table defines the offset, base and length of the fixed MTRRs
+//
+CONST FIXED_MTRR  mMtrrLibFixedMtrrTable[] = {
+  {
+    MSR_IA32_MTRR_FIX64K_00000,
+    0,
+    SIZE_64KB
+  },
+  {
+    MSR_IA32_MTRR_FIX16K_80000,
+    0x80000,
+    SIZE_16KB
+  },
+  {
+    MSR_IA32_MTRR_FIX16K_A0000,
+    0xA0000,
+    SIZE_16KB
+  },
+  {
+    MSR_IA32_MTRR_FIX4K_C0000,
+    0xC0000,
+    SIZE_4KB
+  },
+  {
+    MSR_IA32_MTRR_FIX4K_C8000,
+    0xC8000,
+    SIZE_4KB
+  },
+  {
+    MSR_IA32_MTRR_FIX4K_D0000,
+    0xD0000,
+    SIZE_4KB
+  },
+  {
+    MSR_IA32_MTRR_FIX4K_D8000,
+    0xD8000,
+    SIZE_4KB
+  },
+  {
+    MSR_IA32_MTRR_FIX4K_E0000,
+    0xE0000,
+    SIZE_4KB
+  },
+  {
+    MSR_IA32_MTRR_FIX4K_E8000,
+    0xE8000,
+    SIZE_4KB
+  },
+  {
+    MSR_IA32_MTRR_FIX4K_F0000,
+    0xF0000,
+    SIZE_4KB
+  },
+  {
+    MSR_IA32_MTRR_FIX4K_F8000,
+    0xF8000,
+    SIZE_4KB
+  }
+};
+
+
+/**
+  Worker function returns the variable MTRR count for the CPU.
+
+  @return Variable MTRR count
+
+**/
+UINT32
+EFIAPI
+GetVariableMtrrCount (
+  VOID
+  )
+{
+  MSR_IA32_MTRRCAP_REGISTER MtrrCap;
+
+  MtrrCap.Uint64 = AsmReadMsr64 (MSR_IA32_MTRRCAP);
+  return MtrrCap.Bits.VCNT;
+}
+
+/**
+  This function gets the content in all MTRRs (variable and fixed)
+
+  @param[out]  MtrrSetting   A buffer to hold all MTRRs content.
+
+  @retval  EFI_INVALID_PARAMETER   MtrrSetting is NULL.
+           EFI_OUT_OF_RESOURCES    Insufficient space to save all MTRR values.
+           EFI_SUCCESS             MTRR values were retrieved successfully.
+**/
+EFI_STATUS
+EFIAPI
+GetCpuMtrrs (
+  OUT MTRR_SETTINGS                *MtrrSetting
+  )
+{
+  UINT32                   Index;
+  UINT32                   MsrIdx;
+  UINT32                   VariableMtrrCount;
+  MTRR_FIXED_SETTINGS     *FixedSettings;
+  MTRR_VARIABLE_SETTINGS  *VariableSettings;
+
+  if (MtrrSetting == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (MtrrSetting, sizeof(MTRR_SETTINGS));
+
+  FixedSettings = &MtrrSetting->Fixed;
+  for (Index = 0; Index < MTRR_NUMBER_OF_FIXED_MTRR; Index++) {
+    FixedSettings->Mtrr[Index] =
+      AsmReadMsr64 (mMtrrLibFixedMtrrTable[Index].Msr);
+  }
+
+  VariableMtrrCount = GetVariableMtrrCount ();
+  if (VariableMtrrCount > ARRAY_SIZE (VariableSettings->Mtrr)) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  VariableSettings = &MtrrSetting->Variables;
+  for (Index = 0; Index < VariableMtrrCount; Index++) {
+    MsrIdx = MSR_IA32_MTRR_PHYSBASE0 + (Index << 1);
+    VariableSettings->Mtrr[Index].Base = AsmReadMsr64 (MsrIdx);
+    VariableSettings->Mtrr[Index].Mask = AsmReadMsr64 (MsrIdx + 1);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This function sets all MTRRs (variable and fixed)
+
+  @param[in]  MtrrSetting   A buffer to hold all MTRRs content.
+
+  @retval  EFI_INVALID_PARAMETER   MtrrSetting is NULL.
+           EFI_SUCCESS             MTRR values were programmed successfully.
+**/
+EFI_STATUS
+EFIAPI
+SetCpuMtrrs (
+  IN MTRR_SETTINGS                *MtrrSetting
+  )
+{
+  UINT32                   Index;
+  UINT32                   MsrIdx;
+  UINT32                   VariableMtrrCount;
+  UINT64                   Value;
+  MTRR_FIXED_SETTINGS     *FixedSettings;
+  MTRR_VARIABLE_SETTINGS  *VariableSettings;
+
+  if (MtrrSetting == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  FixedSettings = &MtrrSetting->Fixed;
+  for (Index = 0; Index < MTRR_NUMBER_OF_FIXED_MTRR; Index++) {
+    MsrIdx = mMtrrLibFixedMtrrTable[Index].Msr;
+    Value  = AsmReadMsr64 (MsrIdx);
+    if (Value != FixedSettings->Mtrr[Index]) {
+      AsmWriteMsr64 (MsrIdx, Value);
+    }
+  }
+
+  VariableMtrrCount = GetVariableMtrrCount ();
+  VariableMtrrCount = MIN (VariableMtrrCount, ARRAY_SIZE (VariableSettings->Mtrr));
+  VariableSettings  = &MtrrSetting->Variables;
+  for (Index = 0; Index < VariableMtrrCount; Index++) {
+    MsrIdx = MSR_IA32_MTRR_PHYSBASE0 + (Index << 1);
+    Value  = AsmReadMsr64 (MsrIdx);
+    if (Value != VariableSettings->Mtrr[Index].Base) {
+      AsmWriteMsr64 (MsrIdx, VariableSettings->Mtrr[Index].Base);
+    }
+    Value  = AsmReadMsr64 (MsrIdx + 1);
+    if (Value != VariableSettings->Mtrr[Index].Mask) {
+      AsmWriteMsr64 (MsrIdx + 1, VariableSettings->Mtrr[Index].Mask);
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+

--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
@@ -47,6 +47,7 @@
   SynchronizationLib
   SortLib
   ExtraBaseLib
+  MtrrLib
 
 [Guids]
 

--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLibInternal.h
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLibInternal.h
@@ -20,6 +20,7 @@
 #include <Library/MemoryAllocationLib.h>
 #include <Library/BootloaderCommonLib.h>
 #include <Library/MpInitLib.h>
+#include <Library/MtrrLib.h>
 #include <Library/ExtraBaseLib.h>
 #include <Library/BootloaderCoreLib.h>
 #include <Library/S3SaveRestoreLib.h>


### PR DESCRIPTION
SBL might change MTRR to enable framebuffer cache. Current code
only handles BSP MTRR programming, and it is necessary to sync
up the MTRR programming for all APs as well. This patch added
a function to sync up MTRRs for all APs.

Please note, this MTRR sync up is a simplified version for SBL
case since SBL will only add new MTRRs for GFX framebuffer.
To do a full generic MTRRs sync up, it is required to flush cache,
reload TLB, etc. And it will come with some performance impacts.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>