### PR TITLE
Enhance Ext2 filesystem library

### DIFF
--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.c
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.c
@@ -646,6 +646,11 @@ Ext2SbValidate (
     goto Exit;
   }
 
+  if (Ext2Fs->Ext2FsRev == E2FS_REV0) {
+    Ext2Fs->Ext2FsFirstInode = 11;
+    Ext2Fs->Ext2FsInodeSize  = 128;
+  }
+
   if (RExt2Fs != NULL) {
     E2FS_SBLOAD ((VOID *)Ext2Fs, RExt2Fs);
   }


### PR DESCRIPTION
For EXT2 filesystem revision 0, there are some fixed fields in the
super block structure according to the documentation. The code should
always use those fixed values for safe regardless of the value inside
the image.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>