### PR TITLE
[TGL][EHL] Fix GetFwCap HECI communication issue

### DIFF
--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -367,12 +367,23 @@ class GitDiffCheck:
         '.patch',
         '.pem',
         '.makefile',
-        '.lib'
+        '.lib',
+        '.txt',
+        '.ini',
+        '.app',
+        '.common',
+        '.template',
+        '.rule',
+        'Makefile',
+        'GNUmakefile',
         )
+
 
     def check_added_line(self, line):
         f_name, f_ext = os.path.splitext(self.filename)
         if f_ext in self.skip_check_file_types:
+            return
+        if f_ext == '' and (os.path.basename(f_name) in self.skip_check_file_types):
             return
 
         eol = ''
@@ -388,6 +399,7 @@ class GitDiffCheck:
                                   line)
         if '\t' in line:
             self.added_line_error('Tab character used', line)
+
         if len(stripped) < len(line):
             self.added_line_error('Trailing whitespace found', line)
 

--- a/Silicon/ElkhartlakePkg/Library/HeciInitLib/HeciCore.c
+++ b/Silicon/ElkhartlakePkg/Library/HeciInitLib/HeciCore.c
@@ -1468,8 +1468,8 @@ HeciGetFwCapsSkuMsg (
   // Allocate MsgGenGetFwVersion data structure
   //
   MsgGenGetFwCapsSku->MkhiHeader.Data               = 0;
-  MsgGenGetFwCapsSku->MkhiHeader.Fields.GroupId     = 0x03;
-  MsgGenGetFwCapsSku->MkhiHeader.Fields.Command     = 0x02;
+  MsgGenGetFwCapsSku->MkhiHeader.Fields.GroupId     = MKHI_FWCAPS_GROUP_ID;
+  MsgGenGetFwCapsSku->MkhiHeader.Fields.Command     = FWCAPS_GET_RULE_CMD;
   MsgGenGetFwCapsSku->MkhiHeader.Fields.IsResponse  = 0x0;
   MsgGenGetFwCapsSku->Data.RuleId                   = 0x0;
   Length = sizeof (GET_FW_CAPSKU);
@@ -1488,28 +1488,24 @@ HeciGetFwCapsSkuMsg (
       BIOS_FIXED_HOST_ADDR,
       0x7
       );
+  if (!EFI_ERROR (Status)) {
+    Length = sizeof (GET_FW_CAPS_SKU_ACK);
+    Status = HeciReceive (
+        HECI1_DEVICE,
+        BLOCKING,
+        (UINT32 *)MsgGenGetFwCapsSkuAck,
+        &Length
+        );
+  }
 
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "FWCAPS:Send Error from Heci=%d \n", Status));
+    DEBUG ((DEBUG_INFO, "FWCAPS: Received Error from Heci: %r\n", Status));
     return Status;
   }
 
-  DEBUG ((DEBUG_INFO, "FWCAPS: EHL Though HECI\n"));
-  Length = sizeof (GET_FW_CAPS_SKU_ACK_DATA);
-  Status = HeciReceive (
-      HECI1_DEVICE,
-      BLOCKING,
-      (UINT32 *)MsgGenGetFwCapsSkuAck,
-      &Length
-      );
-
-
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_INFO, "FWCAPS: Received Error from Heci=%d \n", Status));
-    return Status;
-  }
   return EFI_SUCCESS;
 }
+
 
 /**
   Check for Spi Protection Mode

--- a/Silicon/ElkhartlakePkg/Library/HeciInitLib/MkhiMsgs.h
+++ b/Silicon/ElkhartlakePkg/Library/HeciInitLib/MkhiMsgs.h
@@ -36,6 +36,11 @@ typedef union {
 #define MKHI_MCA_GROUP_ID     0x0A
 #define MKHI_GEN_GROUP_ID     0xFF
 
+///
+/// Defines for FWCAPS_GROUP Command
+///
+#define FWCAPS_GET_RULE_CMD               0x02
+
 #define IAFW_DNX_REQ_CLEAR    0x02
 
 ///
@@ -209,8 +214,12 @@ typedef struct {
   UINT32        RuleID;
   UINT8         RuleDataLen;
   MEFWCAPS_SKU  FWCap;
-  UINT8         Reseved[3];
 } GET_FW_CAPS_SKU_ACK_DATA;
+
+typedef struct {
+  MKHI_MESSAGE_HEADER       MKHIHeader;
+  GET_FW_CAPS_SKU_ACK_DATA  Data;
+} GET_FW_CAPS_SKU_ACK;
 
 ///
 /// Get/Set Local FW Update
@@ -459,7 +468,6 @@ typedef union {
   ARB_SVN_GET_INFO       Request;
   ARB_SVN_GET_INFO_ACK   Response;
 } ARB_SVN_GET_INFO_BUFFER;
-
 
 ///
 /// OEM Key Revocation

--- a/Silicon/ElkhartlakePkg/Library/PsdLib/PsdLib.c
+++ b/Silicon/ElkhartlakePkg/Library/PsdLib/PsdLib.c
@@ -116,10 +116,9 @@ GetSecCapability (
   UINT32    *SecCapability
   )
 {
-
   EFI_STATUS                 Status;
   GET_FW_CAPSKU              MsgGenGetFwCapsSku;
-  GET_FW_CAPS_SKU_ACK_DATA   MsgGenGetFwCapsSkuAck;
+  GET_FW_CAPS_SKU_ACK        MsgGenGetFwCapsSkuAck;
 
   if(SecCapability == NULL) {
     DEBUG ((DEBUG_ERROR, "GetSecCapability Failed Status=0x%x\n",EFI_INVALID_PARAMETER));
@@ -130,8 +129,7 @@ GetSecCapability (
   if (EFI_ERROR(Status)) {
     return Status;
   }
-  *SecCapability = MsgGenGetFwCapsSkuAck.FWCap.Data;
-
+  *SecCapability = MsgGenGetFwCapsSkuAck.Data.FWCap.Data;
   return EFI_SUCCESS;
 }
 

--- a/Silicon/TigerlakePchPkg/Library/HeciInitLib/MkhiMsgs.h
+++ b/Silicon/TigerlakePchPkg/Library/HeciInitLib/MkhiMsgs.h
@@ -31,9 +31,15 @@ typedef union {
 /// Defines for GroupID
 ///
 #define MKHI_CBM_GROUP_ID     0x00
+#define MKHI_FWCAPS_GROUP_ID  0x03
 #define MKHI_HMRFPO_GROUP_ID  0x05
 #define MKHI_MCA_GROUP_ID     0x0A
 #define MKHI_GEN_GROUP_ID     0xFF
+
+///
+/// Defines for FWCAPS_GROUP Command
+///
+#define FWCAPS_GET_RULE_CMD   0x02
 
 #define IAFW_DNX_REQ_CLEAR    0x02
 
@@ -203,9 +209,12 @@ typedef struct {
   UINT32        RuleID;
   UINT8         RuleDataLen;
   MEFWCAPS_SKU  FWCap;
-  UINT8         Reseved[3];
 } GET_FW_CAPS_SKU_ACK_DATA;
 
+typedef struct {
+  MKHI_MESSAGE_HEADER       MKHIHeader;
+  GET_FW_CAPS_SKU_ACK_DATA  Data;
+} GET_FW_CAPS_SKU_ACK;
 
 ///
 /// Get/Set Local FW Update

--- a/Silicon/TigerlakePkg/Library/PsdLib/PsdLib.c
+++ b/Silicon/TigerlakePkg/Library/PsdLib/PsdLib.c
@@ -118,7 +118,7 @@ GetSecCapability (
 {
   EFI_STATUS                 Status;
   GET_FW_CAPSKU              MsgGenGetFwCapsSku;
-  GET_FW_CAPS_SKU_ACK_DATA   MsgGenGetFwCapsSkuAck;
+  GET_FW_CAPS_SKU_ACK        MsgGenGetFwCapsSkuAck;
 
   if(SecCapability == NULL) {
     DEBUG ((DEBUG_ERROR, "GetSecCapability Failed Status=0x%x\n",EFI_INVALID_PARAMETER));
@@ -129,7 +129,7 @@ GetSecCapability (
   if (EFI_ERROR(Status)) {
     return Status;
   }
-  *SecCapability = MsgGenGetFwCapsSkuAck.FWCap.Data;
+  *SecCapability = MsgGenGetFwCapsSkuAck.Data.FWCap.Data;
   return EFI_SUCCESS;
 }
 


### PR DESCRIPTION
On TGL and EHL, to get FW capability, it will send GetFwCaps
command. However, the ACK buffer structure is used incorrectly.
It should use GET_FW_CAPS_SKU_ACK rather than
GET_FW_CAPS_SKU_ACK_DATA. This patch fixed it.

It fixed #1401.

Signed-off-by: Ma <maurice.ma@intel.com>