### PR TITLE
Add boot from multiple USB devices

### DIFF
--- a/Platform/TigerlakeBoardPkg/CfgData/CfgDataExt_Upx11.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgDataExt_Upx11.dlt
@@ -44,6 +44,7 @@ GEN_CFG_DATA.PayloadId                                      | 0
 # BOOT_OPTION_CFG_DATA_0 is USB boot
 # Allow to boot from USB partition 0 and FAT filesystem by default
 BOOT_OPTION_CFG_DATA_0.SwPart_0                             | 0
+BOOT_OPTION_CFG_DATA_0.HwPart_0                             | 0xff
 BOOT_OPTION_CFG_DATA_0.FsType_0                             | 0
 BOOT_OPTION_CFG_DATA_0.BootFlags_0                          | 0
 


### PR DESCRIPTION
When multiple USB devices are attached, current SBL will try to
boot the device with index specified by HwPart in the boot option.
However, it is hard to determine the USB device index order since
it depends on which port the device is connected to. Instead, for
USB devices, SBL can try to boot from each of them until the boot
image is loaded successfully or all USB devices have been tried out.
This patch added this support.

To enable this feature, it is required to set the USB boot option
HwPart to 0xFF.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>