### PR TITLE
Add common GPIO payload selection CFG

### DIFF
--- a/Platform/CommonBoardPkg/CfgData/CfgData_PayloadSelection.yaml
+++ b/Platform/CommonBoardPkg/CfgData/CfgData_PayloadSelection.yaml
@@ -1,0 +1,61 @@
+## @file
+#
+#  Slim Bootloader Payload Selection CFGDATA File.
+#
+#  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+- $ACTION         :
+  page              : PLDSEL:GEN:"GPIO Payload Selection"
+- $ACTION         :
+  page              : PLDSEL
+- PLDSEL_CFG_DATA :
+  - !expand { CFGHDR_TMPL : [ PLDSEL_CFG_DATA, 0x011, 0, 0 ] }
+  - PldSelGpio      :
+    - $STRUCT         :
+      name            : GPIO pin for switching payload
+      struct          : PAYLOAD_SEL_GPIO_PIN
+      help            : >
+                        Specify GPIO PIN number to read and switch payloads
+      length          : 0x04
+    - PadGroup        :
+      name            : Pad Group
+      type            : Combo
+      option          : !include CfgData_GpioPadGroups.yaml
+      help            : >
+                        Specify GPIO Pad Group
+      condition       : $(COND_PLD_SEL_EN)
+      length          : 8bD
+      value           : 0
+    - PinNumber       :
+      name            : Pin Number
+      type            : EditNum, DEC, (0,23)
+      help            : >
+                        Specify GPIO Pin Number (0-23) on the selected Group
+      condition       : $(COND_PLD_SEL_EN)
+      length          : 8bD
+      value           : 0
+    - Enable          :
+      name            : Enable GPIO Payload Selection when PayloadId is 'AUTO'
+      type            : Combo
+      option          : $EN_DIS
+      help            : >
+                        Enable GPIO Payload Selection when PayloadId is 'AUTO'
+      length          : 1bD
+      value           : 0
+    - PinPolarity     :
+      name            : Pin Polarity
+      type            : Combo
+      option          : 0:Active High, 1:Active Low
+      help            : >
+                        GPIO Pin Polarity to trigger Payload switching
+      condition       : $(COND_PLD_SEL_EN)
+      length          : 1bD
+      value           : 0
+    - Rsvd1           :
+      name            : Reserved
+      type            : Reserved
+      length          : 14bD
+      value           : 0

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgDataDef.yaml
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgDataDef.yaml
@@ -9,6 +9,7 @@
 
 variable:
   COND_S0IX_DIS  : ($FEATURES_CFG_DATA.Features.S0ix == 0)
+  COND_PLD_SEL_EN: ($PLDSEL_CFG_DATA.PldSelGpio.Enable == 1)
 
 template:
   CFGHDR_TMPL: >
@@ -38,7 +39,6 @@ template:
   - !include Template_Gpio.yaml
 
   - !include Platform/CommonBoardPkg/CfgData/Template_BootOption.yaml
-
 
   - !include Template_Spd.yaml
 
@@ -390,52 +390,7 @@ configs:
         value        : 0x0
 
 
-  - $ACTION      :
-      page         : PIDSEL:PLT:"Payload Selection GPIO"
-  - PLATFORM_CFG_DATA :
-    - !expand { CFGHDR_TMPL : [ PLATFORM_CFG_DATA, 0x280, 0, 0 ] }
-    - PayloadSelGpio :
-      - $STRUCT      :
-          name         : GPIO pin for switching payload
-          struct       : PAYLOAD_SEL_GPIO_PIN
-          length       : 0x02
-      - PinGroup     :
-          name         : Pin Group
-          type         : Combo
-          option       : >
-                         0x00:GPP_A, 0x01:GPP_B, 0x02:GPP_C, 0x03:GPP_D, 0x04:GPP_E, 0x05:GPP_F, 0x06:GPP_G, 0x07:GPP_H,
-                         0x08:GPP_I, 0x09:GPP_J, 0x0A:GPP_K, 0x11:GPP_R, 0x12:GPP_S, 0x13:GPP_T, 0x14:GPP_U,
-                         0x19:GPD
-          condition    : ($PLATFORM_CFG_DATA.PayloadSelGpio.Enable > 0)
-          help         : >
-                         Specify GPIO Group Number
-          length       : 7bW
-          value        : 0
-      - Enable       :
-          name         : Payload Selection Pin Enable
-          type         : Combo
-          option       : $EN_DIS
-          help         : >
-                         Enable/Disable this pin for payload selection between OsLoader and UEFI.
-          order        : 0000.0000
-          length       : 1bW
-          value        : 0
-      - PinNumber    :
-          name         : Pin Number
-          type         : Combo
-          option       : >
-                         0:0, 1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8, 9:9,
-                         10:10, 11:11, 12:12, 13:13, 14:14, 15:15, 16:16, 17:17,
-                         18:18, 19:19, 20:20, 21:21, 22:22, 23:23
-          length       : 8bW
-          value        : 0
-          condition    : ($PLATFORM_CFG_DATA.PayloadSelGpio.Enable > 0)
-          help         : >
-                         Specify GPIO Pin Number
-    - Dummy        :
-        length       : 0x02
-        value        : 0x0
-
+  - !include Platform/CommonBoardPkg/CfgData/CfgData_PayloadSelection.yaml
 
   - !include CfgData_Features.yaml
 

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_GpioPadGroups.yaml
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_GpioPadGroups.yaml
@@ -1,0 +1,12 @@
+## @file
+#
+#  Slim Bootloader CFGDATA Tiger Lake GPIO pad groups.
+#
+#  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+>
+0x00:GPP_A, 0x01:GPP_B, 0x02:GPP_C, 0x03:GPP_D, 0x04:GPP_E, 0x05:GPP_F, 0x06:GPP_G, 0x07:GPP_H,
+0x08:GPP_I, 0x09:GPP_J, 0x0A:GPP_K, 0x11:GPP_R, 0x12:GPP_S, 0x13:GPP_T, 0x14:GPP_U, 0x19:GPD

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglh_Ddr4.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglh_Ddr4.dlt
@@ -44,10 +44,9 @@ BOOT_OPTION_CFG_DATA_5.HwPart_5                             | 255
 
 
 # PCH H :  GPIO_VER2_H_GPP_F10
-PLATFORM_CFG_DATA.PayloadSelGpio.Enable                     | 1
-PLATFORM_CFG_DATA.PayloadSelGpio.PinGroup                   | 5
-PLATFORM_CFG_DATA.PayloadSelGpio.PinNumber                  | 10
-
+PLDSEL_CFG_DATA.PldSelGpio.Enable                           | 1
+PLDSEL_CFG_DATA.PldSelGpio.PadGroup                         | 5
+PLDSEL_CFG_DATA.PldSelGpio.PinNumber                        | 10
 
 # GPIO Group GPP_A: TGL-H has 15. 15-23 should be skipped.
 GPIO_CFG_DATA.GpioPinConfig0_GPP_A00                        | 0x0350A383

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_Ddr4.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_Ddr4.dlt
@@ -33,9 +33,9 @@ MEMORY_CFG_DATA.DmaControlGuarantee                         | 1
 SILICON_CFG_DATA.PortUsb20Enable.Usb2Port1                  | 0
 
 # PCH LP :  GPIO_VER2_LP_GPP_B15
-PLATFORM_CFG_DATA.PayloadSelGpio.Enable                     | 1
-PLATFORM_CFG_DATA.PayloadSelGpio.PinGroup                   | 1
-PLATFORM_CFG_DATA.PayloadSelGpio.PinNumber                  | 15
+PLDSEL_CFG_DATA.PldSelGpio.Enable                           | 1
+PLDSEL_CFG_DATA.PldSelGpio.PadGroup                         | 1
+PLDSEL_CFG_DATA.PldSelGpio.PinNumber                        | 15
 
 #
 # By default use Osloader Payload, set to "UEFI" to select UEFI payload.

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_DdrLp4.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_DdrLp4.dlt
@@ -28,9 +28,9 @@ MEMORY_CFG_DATA.SpdDataSel130                               | 1
 SILICON_CFG_DATA.PortUsb20Enable.Usb2Port1                  | 0
 
 # PCH LP :  GPIO_VER2_LP_GPP_B15
-PLATFORM_CFG_DATA.PayloadSelGpio.Enable                     | 1
-PLATFORM_CFG_DATA.PayloadSelGpio.PinGroup                   | 1
-PLATFORM_CFG_DATA.PayloadSelGpio.PinNumber                  | 15
+PLDSEL_CFG_DATA.PldSelGpio.Enable                           | 1
+PLDSEL_CFG_DATA.PldSelGpio.PadGroup                         | 1
+PLDSEL_CFG_DATA.PldSelGpio.PinNumber                        | 15
 
 #
 # By default use Osloader Payload, set to "UEFI" to select UEFI payload.

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -713,7 +713,7 @@ UpdatePayloadId (
   UINT32             PayloadSelGpioData;
   UINT32             PayloadSelGpioPad;
   GEN_CFG_DATA      *GenCfgData;
-  PLATFORM_CFG_DATA *PlatCfgData;
+  PLDSEL_CFG_DATA   *PldSelCfgData;
 
   GenCfgData = (GEN_CFG_DATA *)FindConfigDataByTag (CDATA_GEN_TAG);
   if (GenCfgData == NULL) {
@@ -724,9 +724,9 @@ UpdatePayloadId (
     return;
   }
 
-  PlatCfgData = (PLATFORM_CFG_DATA *)FindConfigDataByTag (CDATA_PLATFORM_TAG);
-  if ((PlatCfgData != NULL) && (PlatCfgData->PayloadSelGpio.Enable != 0)) {
-    PayloadSelGpioPad = GpioGroupPinToPad (PlatCfgData->PayloadSelGpio.PinGroup,  PlatCfgData->PayloadSelGpio.PinNumber);
+  PldSelCfgData = (PLDSEL_CFG_DATA *)FindConfigDataByTag (CDATA_PLDSEL_TAG);
+  if ((PldSelCfgData != NULL) && (PldSelCfgData->PldSelGpio.Enable != 0)) {
+    PayloadSelGpioPad = GpioGroupPinToPad (PldSelCfgData->PldSelGpio.PadGroup,  PldSelCfgData->PldSelGpio.PinNumber);
     if (PayloadSelGpioPad == 0) {
       Status = EFI_ABORTED;
     } else {
@@ -735,12 +735,12 @@ UpdatePayloadId (
     }
 
     if (!EFI_ERROR (Status)) {
-      if (PayloadSelGpioData == 1) {
-        SetPayloadId (0);
-        DEBUG ((DEBUG_INFO, "Update PayloadId to OS Loader\n"));
-      } else {
+      if (PayloadSelGpioData != PldSelCfgData->PldSelGpio.PinPolarity) {
         SetPayloadId (UEFI_PAYLOAD_ID_SIGNATURE);
         DEBUG ((DEBUG_INFO, "Update PayloadId to UEFI\n"));
+      } else {
+        SetPayloadId (0);
+        DEBUG ((DEBUG_INFO, "Update PayloadId to OS Loader\n"));
       }
     } else {
       DEBUG ((DEBUG_ERROR, "Invalid GPIO pin for Payload Select\n"));


### PR DESCRIPTION
GPIO payload selection settings can be made
into a platform optional common config. This
will ensure that the options display the same
across all platforms which add support for
the GPIO payload selection feature. Each
platform will need to include the
CfgData_PayloadSelection.yaml and needs to
create their own CfgData_GpioPadGroups.yaml
to provide the list of GPIO pad groups to
select from.

Signed-off-by: James Gutbub <james.gutbub@intel.com>