### PR TITLE
Add a PCD to set RTCM RSVD SIZE

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -252,6 +252,8 @@
   gPlatformCommonLibTokenSpaceGuid.PcdCompSignHashAlg             | $(SIGN_HASH_TYPE)
   gPlatformModuleTokenSpaceGuid.PcdFastBootEnabled                | $(ENABLE_FAST_BOOT)
 
+  gPayloadTokenSpaceGuid.PcdRtcmRsvdSize                        | $(RTCM_RSVD_SIZE)
+
 
 [PcdsPatchableInModule]
   gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel   | 0x8000004F

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -260,6 +260,8 @@ class BaseBoard(object):
         self.KEYH_SVN              = 0
         self.CFGDATA_SVN           = 0
 
+        self.RTCM_RSVD_SIZE        = 0xFF000
+
         for key, value in list(kwargs.items()):
             setattr(self, '%s' % key, value)
 

--- a/PayloadPkg/OsLoader/ExtraModSupport.c
+++ b/PayloadPkg/OsLoader/ExtraModSupport.c
@@ -8,7 +8,7 @@
 #include "OsLoader.h"
 
 #define  RTCM_HEAP_SIZE       0x10000
-#define  RTCM_RSVD_SIZE       0xFF000
+#define  RTCM_RSVD_SIZE       FixedPcdGet32 (PcdRtcmRsvdSize)
 #define  MOD_DEF_HEAP_SIZE    0x10000
 #define  MOD_DEF_RSVD_SIZE    0x04000
 

--- a/PayloadPkg/OsLoader/OsLoader.inf
+++ b/PayloadPkg/OsLoader/OsLoader.inf
@@ -110,6 +110,7 @@
   gPayloadTokenSpaceGuid.PcdGrubBootCfgEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdContainerBootEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashMask
+  gPayloadTokenSpaceGuid.PcdRtcmRsvdSize
 
 [Depex]
   TRUE

--- a/PayloadPkg/PayloadPkg.dec
+++ b/PayloadPkg/PayloadPkg.dec
@@ -43,3 +43,6 @@
   gPayloadTokenSpaceGuid.PcdGrubBootCfgEnabled   | FALSE    | BOOLEAN | 0x2001000
   gPayloadTokenSpaceGuid.PcdCsmeUpdateEnabled    | FALSE    | BOOLEAN | 0x2001002
   gPayloadTokenSpaceGuid.PcdPayloadModuleEnabled | FALSE    | BOOLEAN | 0x2001003
+
+[PcdsFixedAtBuild]
+  gPayloadTokenSpaceGuid.PcdRtcmRsvdSize      | 0x00000000 | UINT32 | 0x30001000


### PR DESCRIPTION
If the number of cores are more and the RTCM is
required to support HyperThreading, then it needs
more reserved size, preferably 511 pages instead of
current 255 pages.

So, add a FixedPcd and let each platform override
the default 255 pages value to whatever is required.

Signed-off-by: Sai T <sai.kiran.talamudupula@intel.com>