### PR TITLE
Add SMBIOS type 4 for processor info

### DIFF
--- a/BootloaderCorePkg/Library/SmbiosInitLib/SmbiosInitLib.inf
+++ b/BootloaderCorePkg/Library/SmbiosInitLib/SmbiosInitLib.inf
@@ -21,6 +21,7 @@
 [Sources]
   SmbiosTables.h
   SmbiosInitLib.c
+  SmbiosTemplate.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/BootloaderCorePkg/Library/SmbiosInitLib/SmbiosTables.h
+++ b/BootloaderCorePkg/Library/SmbiosInitLib/SmbiosTables.h
@@ -10,6 +10,16 @@
 
 #include <Library/BaseLib.h>
 #include <IndustryStandard/SmBios.h>
+#include <Register/Intel/Cpuid.h>
+#include <Register/Intel/ArchitecturalMsr.h>
+
+#define SMBIOS_STRING_UNKNOWN           "Unknown"
+#define SMBIOS_STRING_UNKNOWN_VERSION   "XXXX.XXX.XXX.XXX"
+#define SMBIOS_STRING_VENDOR            "Intel Corporation"
+#define SMBIOS_STRING_PLATFORM          "Intel Platform"
+
+#define BRAND_STRING_UNSUPPORTED        "CPU Brand String Not Supported"
+#define INTEL_CORPORATION_STRING        "Intel(R) Corporation"
 
 #define TYPE_TERMINATOR_SIZE          2     // Each Type is terminated by 0000 - 2 bytes
 #define TO_BE_FILLED                  0
@@ -25,146 +35,147 @@
 #define SMBIOS_STRING_INDEX_8         8
 #define SMBIOS_STRING_INDEX_9         9
 
+#define EfiProcessorFamilyIntelAtomProcessor    0x2B
+#define EfiProcessorFamilyIntelXeonProcessor    0xB3
 
-SMBIOS_TABLE_TYPE0    mBiosInfo = {
-  {                                         // Hdr
-    SMBIOS_TYPE_BIOS_INFORMATION,           /// Hdr.Type
-    sizeof (SMBIOS_TABLE_TYPE0),            /// Hdr.Length
-    0                                       /// Hdr.Handle
-  },
-  SMBIOS_STRING_INDEX_1,                    // Vendor
-  SMBIOS_STRING_INDEX_2,                    // BiosVersion
-  0x0000,                                   // BiosSegment
-  SMBIOS_STRING_INDEX_3,                    // BiosReleaseDate
-  0,                                        // BiosSize
-  {                                         // BiosCharacteristics
-    0,                                      ///< Bit 0-1  Reserved1                         :2
-    0,                                      ///< Bit 02 - Unknown                           :1
-    0,                                      ///< Bit 03 - BiosCharacteristicsNotSupported   :1
-    0,                                      ///< Bit 04 - IsaIsSupported                    :1
-    0,                                      ///< Bit 05 - McaIsSupported                    :1
-    0,                                      ///< Bit 06 - EisaIsSupported                   :1
-    1,                                      ///< Bit 07 - PciIsSupported                    :1
-    0,                                      ///< Bit 08 - PcmciaIsSupported                 :1
-    0,                                      ///< Bit 09 - PlugAndPlayIsSupported            :1
-    0,                                      ///< Bit 10 - ApmIsSupported                    :1
-    1,                                      ///< Bit 11 - BiosIsUpgradable                  :1
-    1,                                      ///< Bit 12 - BiosShadowingAllowed              :1
-    0,                                      ///< Bit 13 - VLVesaIsSupported                 :1
-    0,                                      ///< Bit 14 - EscdSupportIsAvailable            :1
-    1,                                      ///< Bit 15 - BootFromCdIsSupported             :1
-    1,                                      ///< Bit 16 - SelectableBootIsSupported         :1
-    0,                                      ///< Bit 17 - RomBiosIsSocketed                 :1
-    0,                                      ///< Bit 18 - BootFromPcmciaIsSupported         :1
-    1,                                      ///< Bit 19 - EDDSpecificationIsSupported       :1
-    0,                                      ///< Bit 20 - JapaneseNecFloppyIsSupported      :1
-    0,                                      ///< Bit 21 - JapaneseToshibaFloppyIsSupported  :1
-    0,                                      ///< Bit 22 - Floppy525_360IsSupported          :1
-    0,                                      ///< Bit 23 - Floppy525_12IsSupported           :1
-    0,                                      ///< Bit 24 - Floppy35_720IsSupported           :1
-    0,                                      ///< Bit 25 - Floppy35_288IsSupported           :1
-    1,                                      ///< Bit 26 - PrintScreenIsSupported            :1
-    1,                                      ///< Bit 27 - Keyboard8042IsSupported           :1
-    1,                                      ///< Bit 28 - SerialIsSupported                 :1
-    1,                                      ///< Bit 29 - PrinterIsSupported                :1
-    0,                                      ///< Bit 30 - CgaMonoIsSupported                :1
-    0,                                      ///< Bit 31 - NecPc98                           :1
-    0                                       ///< Bit 32-63 - Reserved for BIOS/System Vendor :32
-  },
-  {                                         // BiosCharacteristicsExtensionBytes
+typedef struct {
+  CHAR8  *String;
+  UINT16  Family;
+} PROCESSOR_FAMILY_FIELD;
+
+///
+/// This data record refer
+/// length.
+///
+typedef enum {
+  EfiProcessorOther    = 1,
+  EfiProcessorUnknown  = 2,
+  EfiCentralProcessor  = 3,
+  EfiMathProcessor     = 4,
+  EfiDspProcessor      = 5,
+  EfiVideoProcessor    = 6
+} EFI_PROCESSOR_TYPE_DATA;
+
+typedef struct {
+  UINT32                            ProcessorSteppingId:4;
+  UINT32                            ProcessorModel:     4;
+  UINT32                            ProcessorFamily:    4;
+  UINT32                            ProcessorType:      2;
+  UINT32                            ProcessorReserved1: 2;
+  UINT32                            ProcessorXModel:    4;
+  UINT32                            ProcessorXFamily:   8;
+  UINT32                            ProcessorReserved2: 4;
+} EFI_PROCESSOR_SIGNATURE;
+
+
+///
+/// Inconsistent with specification here:
+/// The name of third field in ProcSubClass specification 0.9 is LogicalProcessorCount.
+/// Keep it unchanged for backward compatibility.
+///
+typedef struct {
+  UINT32                            ProcessorBrandIndex    :8;
+  UINT32                            ProcessorClflush       :8;
+  UINT32                            ProcessorReserved      :8;
+  UINT32                            ProcessorDfltApicId    :8;
+} EFI_PROCESSOR_MISC_INFO;
+
+typedef struct {
+  UINT32                            ProcessorFpu:       1;
+  UINT32                            ProcessorVme:       1;
+  UINT32                            ProcessorDe:        1;
+  UINT32                            ProcessorPse:       1;
+  UINT32                            ProcessorTsc:       1;
+  UINT32                            ProcessorMsr:       1;
+  UINT32                            ProcessorPae:       1;
+  UINT32                            ProcessorMce:       1;
+  UINT32                            ProcessorCx8:       1;
+  UINT32                            ProcessorApic:      1;
+  UINT32                            ProcessorReserved1: 1;
+  UINT32                            ProcessorSep:       1;
+  UINT32                            ProcessorMtrr:      1;
+  UINT32                            ProcessorPge:       1;
+  UINT32                            ProcessorMca:       1;
+  UINT32                            ProcessorCmov:      1;
+  UINT32                            ProcessorPat:       1;
+  UINT32                            ProcessorPse36:     1;
+  UINT32                            ProcessorPsn:       1;
+  UINT32                            ProcessorClfsh:     1;
+  UINT32                            ProcessorReserved2: 1;
+  UINT32                            ProcessorDs:        1;
+  UINT32                            ProcessorAcpi:      1;
+  UINT32                            ProcessorMmx:       1;
+  UINT32                            ProcessorFxsr:      1;
+  UINT32                            ProcessorSse:       1;
+  UINT32                            ProcessorSse2:      1;
+  UINT32                            ProcessorSs:        1;
+  UINT32                            ProcessorReserved3: 1;
+  UINT32                            ProcessorTm:        1;
+  UINT32                            ProcessorReserved4: 2;
+} EFI_PROCESSOR_FEATURE_FLAGS;
+
+///
+/// This structure provides a calculation for base-10 representations.
+///
+/// Not consistent with PI 1.2 Specification.
+/// This data type is not defined in the PI 1.2 Specification, but is
+/// required by several of the other data structures in this file.
+///
+typedef struct {
+  ///
+  /// The INT16 number by which to multiply the base-2 representation.
+  ///
+  INT16                            Value;
+  ///
+  /// The INT16 number by which to raise the base-2 calculation.
+  ///
+  INT16                            Exponent;
+} EFI_EXP_BASE10_DATA;
+
+///
+/// This data record refers to the unique ID that identifies a set of processors. This data record is 16
+/// bytes in length. The data in this structure is processor specific and reserved values can be defined
+/// for future use. The consumer of this data should not make any assumption and should use this data
+/// with respect to the processor family defined in the Family record number.
+///
+typedef struct {
+  ///
+  /// Identifies the processor.
+  ///
+  EFI_PROCESSOR_SIGNATURE           Signature;
+  ///
+  /// Provides additional processor information.
+  ///
+  EFI_PROCESSOR_MISC_INFO           MiscInfo;
+  ///
+  /// Reserved for future use.
+  ///
+  UINT32                            Reserved;
+  ///
+  /// Provides additional processor information.
+  ///
+  EFI_PROCESSOR_FEATURE_FLAGS       FeatureFlags;
+} EFI_PROCESSOR_ID_DATA;
+
+
+///
+/// This data record refers to the core voltage of the processor being defined. The unit of measurement
+/// of this data record is in volts.
+///
+typedef EFI_EXP_BASE10_DATA         EFI_PROCESSOR_VOLTAGE_DATA;
+
+extern  SMBIOS_TABLE_TYPE0    mBiosInfo;
+extern  SMBIOS_TABLE_TYPE1    mSystemInfo;
+extern  SMBIOS_TABLE_TYPE2    mBaseBoardInfo;
+extern  SMBIOS_TABLE_TYPE4    mProcessorInfo;
+extern  SMBIOS_TABLE_TYPE19   mMemArrayMappedAddr;
+
 /**
-  MISC_BIOS_CHARACTERISTICS_EXTENSION.BiosReserved
-  1, Bit 0 - AcpiIsSupported                    :1
-  1, Bit 1 - UsbLegacyIsSupported               :1
-  0, Bit 2 - AgpIsSupported                     :1
-  0, Bit 3 - I20BootIsSupported                 :1
-  1, Bit 4 - Ls120BootIsSupported               :1
-  1, Bit 5 - AtapiZipDriveBootIsSupported       :1
-  0, Bit 6 - Boot1394IsSupported                :1
-  0, Bit 7 - SmartBatteryIsSupported            :1
+  This function builds required processor info SMBIOS type.
 **/
-   (UINT8)(BIT0 | BIT1 | BIT4 | BIT5),
-/**
-  MISC_BIOS_CHARACTERISTICS_EXTENSION.SystemReserved
-  1, Bit 0 - BiosBootSpecIsSupported            :1
-  1, Bit 1 - FunctionKeyNetworkBootIsSupported  :1
-  1, Bit 2 - TargetContentDistributionEnabled   :1
-  1, Bit 3 - UefiSpecificationSupported         :1
-  0, Bit 4 - VirtualMachineSupported            :1
-  0, Bit 5-7 - ExtensionByte2Reserved           :3
-**/
-    (UINT8)(BIT0 | BIT1 | BIT2 | BIT3)
-  },
-  0x0,                                      // System BIOS Major Release
-  0x1,                                      // System BIOS Minor Release
-  0xFF,                                     // Embedded controller firmware major Release
-  0xFF                                      // Embedded controller firmware minor Release
-};
-
-
-//
-// Static (possibly build generated) System Manufacturer data.
-//
-SMBIOS_TABLE_TYPE1    mSystemInfo = {
-  {                                             // Hdr
-    SMBIOS_TYPE_SYSTEM_INFORMATION,             /// Hdr.Type
-    sizeof (SMBIOS_TABLE_TYPE1),                /// Hdr.Size
-    0                                           /// Hdr.Handle
-  },
-  SMBIOS_STRING_INDEX_1,                        // SystemManufactrurer
-  SMBIOS_STRING_INDEX_2,                        // SystemProductName
-  SMBIOS_STRING_INDEX_3,                        // SystemVersion
-  SMBIOS_STRING_INDEX_4,                        // SystemSerialNumber
-  {                                             // SystemUuid
-    0x00000000, 0x0000, 0x0000, { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }
-  },
-  SystemWakeupTypeOther,                        // SystemWakeupType
-  SMBIOS_STRING_INDEX_5,                        // SystemSKUNumber
-  SMBIOS_STRING_INDEX_6                         // SystemFamily
-};
-
-
-//
-// Static (possibly build generated) Base Board Manufacturer data.
-//
-SMBIOS_TABLE_TYPE2    mBaseBoardInfo = {
-  {                                             // Hdr
-    SMBIOS_TYPE_BASEBOARD_INFORMATION,          ///< Hdr.Type
-    sizeof (SMBIOS_TABLE_TYPE2),                ///< Hdr.Length
-    0                                           ///< Hdr.Handle
-  },
-  SMBIOS_STRING_INDEX_1,                        ///< Manufacturer
-  SMBIOS_STRING_INDEX_2,                        ///< ProductName
-  SMBIOS_STRING_INDEX_3,                        ///< Version
-  SMBIOS_STRING_INDEX_4,                        ///< SerialNumber
-  SMBIOS_STRING_INDEX_5,                        ///< AssetTag
-  {                                             // FeatureFlags
-    1,                                          ///< Bit0 Motherboard
-    0,                                          ///< Bit1 RequiresDaughterCard
-    0,                                          ///< Bit2 Removable
-    0,                                          ///< Bit3 Replaceable,
-    0,                                          ///< Bit4 HotSwappable
-    0,                                          ///< Bit5-7 Reserved
-  },
-  SMBIOS_STRING_INDEX_6,                        // LocationInChassis
-  0,                                            // ChassisHandle
-  BaseBoardTypeMotherBoard,                     // BoardType
-  0,                                            // NumberOfContainedObjectHandles
-  { 0 }                                         // ContainedObjectHandles
-};
-
-SMBIOS_TABLE_TYPE19  mMemArrayMappedAddr = {
-  {                                             // Hdr
-    SMBIOS_TYPE_MEMORY_ARRAY_MAPPED_ADDRESS,    ///< Hdr.Type
-    sizeof (SMBIOS_TABLE_TYPE19),               ///< Hdr.Length
-    0                                           ///< Hdr.Handle
-  },
-  0xFFFFFFFF,                                   // StartingAddress
-  0xFFFFFFFF,                                   // EndingAddress
-  SMBIOS_HANDLE_PI_RESERVED,                    // MemoryArrayHandle
-  1,                                            // PartitionWidth
-  0,                                            // ExtendedStartingAddress
-  0                                             // ExtendedEndingAddress
-};
+EFI_STATUS
+BuildProcessorInfo (
+  VOID
+  );
 
 #endif /* __SMBIOS_TABLES_H__ */

--- a/BootloaderCorePkg/Library/SmbiosInitLib/SmbiosTemplate.c
+++ b/BootloaderCorePkg/Library/SmbiosInitLib/SmbiosTemplate.c
@@ -1,0 +1,153 @@
+/** @file
+
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+#include "SmbiosTables.h"
+
+
+SMBIOS_TABLE_TYPE0    mBiosInfo = {
+  {                                         // Hdr
+    SMBIOS_TYPE_BIOS_INFORMATION,           /// Hdr.Type
+    sizeof (SMBIOS_TABLE_TYPE0),            /// Hdr.Length
+    0                                       /// Hdr.Handle
+  },
+  SMBIOS_STRING_INDEX_1,                    // Vendor
+  SMBIOS_STRING_INDEX_2,                    // BiosVersion
+  0x0000,                                   // BiosSegment
+  SMBIOS_STRING_INDEX_3,                    // BiosReleaseDate
+  0,                                        // BiosSize
+  {                                         // BiosCharacteristics
+    0,                                      ///< Bit 0-1  Reserved1                         :2
+    0,                                      ///< Bit 02 - Unknown                           :1
+    0,                                      ///< Bit 03 - BiosCharacteristicsNotSupported   :1
+    0,                                      ///< Bit 04 - IsaIsSupported                    :1
+    0,                                      ///< Bit 05 - McaIsSupported                    :1
+    0,                                      ///< Bit 06 - EisaIsSupported                   :1
+    1,                                      ///< Bit 07 - PciIsSupported                    :1
+    0,                                      ///< Bit 08 - PcmciaIsSupported                 :1
+    0,                                      ///< Bit 09 - PlugAndPlayIsSupported            :1
+    0,                                      ///< Bit 10 - ApmIsSupported                    :1
+    1,                                      ///< Bit 11 - BiosIsUpgradable                  :1
+    1,                                      ///< Bit 12 - BiosShadowingAllowed              :1
+    0,                                      ///< Bit 13 - VLVesaIsSupported                 :1
+    0,                                      ///< Bit 14 - EscdSupportIsAvailable            :1
+    1,                                      ///< Bit 15 - BootFromCdIsSupported             :1
+    1,                                      ///< Bit 16 - SelectableBootIsSupported         :1
+    0,                                      ///< Bit 17 - RomBiosIsSocketed                 :1
+    0,                                      ///< Bit 18 - BootFromPcmciaIsSupported         :1
+    1,                                      ///< Bit 19 - EDDSpecificationIsSupported       :1
+    0,                                      ///< Bit 20 - JapaneseNecFloppyIsSupported      :1
+    0,                                      ///< Bit 21 - JapaneseToshibaFloppyIsSupported  :1
+    0,                                      ///< Bit 22 - Floppy525_360IsSupported          :1
+    0,                                      ///< Bit 23 - Floppy525_12IsSupported           :1
+    0,                                      ///< Bit 24 - Floppy35_720IsSupported           :1
+    0,                                      ///< Bit 25 - Floppy35_288IsSupported           :1
+    1,                                      ///< Bit 26 - PrintScreenIsSupported            :1
+    1,                                      ///< Bit 27 - Keyboard8042IsSupported           :1
+    1,                                      ///< Bit 28 - SerialIsSupported                 :1
+    1,                                      ///< Bit 29 - PrinterIsSupported                :1
+    0,                                      ///< Bit 30 - CgaMonoIsSupported                :1
+    0,                                      ///< Bit 31 - NecPc98                           :1
+    0                                       ///< Bit 32-63 - Reserved for BIOS/System Vendor :32
+  },
+  {                                         // BiosCharacteristicsExtensionBytes
+/**
+  MISC_BIOS_CHARACTERISTICS_EXTENSION.BiosReserved
+  1, Bit 0 - AcpiIsSupported                    :1
+  1, Bit 1 - UsbLegacyIsSupported               :1
+  0, Bit 2 - AgpIsSupported                     :1
+  0, Bit 3 - I20BootIsSupported                 :1
+  1, Bit 4 - Ls120BootIsSupported               :1
+  1, Bit 5 - AtapiZipDriveBootIsSupported       :1
+  0, Bit 6 - Boot1394IsSupported                :1
+  0, Bit 7 - SmartBatteryIsSupported            :1
+**/
+   (UINT8)(BIT0 | BIT1 | BIT4 | BIT5),
+/**
+  MISC_BIOS_CHARACTERISTICS_EXTENSION.SystemReserved
+  1, Bit 0 - BiosBootSpecIsSupported            :1
+  1, Bit 1 - FunctionKeyNetworkBootIsSupported  :1
+  1, Bit 2 - TargetContentDistributionEnabled   :1
+  1, Bit 3 - UefiSpecificationSupported         :1
+  0, Bit 4 - VirtualMachineSupported            :1
+  0, Bit 5-7 - ExtensionByte2Reserved           :3
+**/
+    (UINT8)(BIT0 | BIT1 | BIT2 | BIT3)
+  },
+  0x0,                                      // System BIOS Major Release
+  0x1,                                      // System BIOS Minor Release
+  0xFF,                                     // Embedded controller firmware major Release
+  0xFF                                      // Embedded controller firmware minor Release
+};
+
+
+//
+// Static (possibly build generated) System Manufacturer data.
+//
+SMBIOS_TABLE_TYPE1    mSystemInfo = {
+  {                                             // Hdr
+    SMBIOS_TYPE_SYSTEM_INFORMATION,             /// Hdr.Type
+    sizeof (SMBIOS_TABLE_TYPE1),                /// Hdr.Size
+    0                                           /// Hdr.Handle
+  },
+  SMBIOS_STRING_INDEX_1,                        // SystemManufactrurer
+  SMBIOS_STRING_INDEX_2,                        // SystemProductName
+  SMBIOS_STRING_INDEX_3,                        // SystemVersion
+  SMBIOS_STRING_INDEX_4,                        // SystemSerialNumber
+  {                                             // SystemUuid
+    0x00000000, 0x0000, 0x0000, { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }
+  },
+  SystemWakeupTypeOther,                        // SystemWakeupType
+  SMBIOS_STRING_INDEX_5,                        // SystemSKUNumber
+  SMBIOS_STRING_INDEX_6                         // SystemFamily
+};
+
+
+//
+// Static (possibly build generated) Base Board Manufacturer data.
+//
+SMBIOS_TABLE_TYPE2    mBaseBoardInfo = {
+  {                                             // Hdr
+    SMBIOS_TYPE_BASEBOARD_INFORMATION,          ///< Hdr.Type
+    sizeof (SMBIOS_TABLE_TYPE2),                ///< Hdr.Length
+    0                                           ///< Hdr.Handle
+  },
+  SMBIOS_STRING_INDEX_1,                        ///< Manufacturer
+  SMBIOS_STRING_INDEX_2,                        ///< ProductName
+  SMBIOS_STRING_INDEX_3,                        ///< Version
+  SMBIOS_STRING_INDEX_4,                        ///< SerialNumber
+  SMBIOS_STRING_INDEX_5,                        ///< AssetTag
+  {                                             // FeatureFlags
+    1,                                          ///< Bit0 Motherboard
+    0,                                          ///< Bit1 RequiresDaughterCard
+    0,                                          ///< Bit2 Removable
+    0,                                          ///< Bit3 Replaceable,
+    0,                                          ///< Bit4 HotSwappable
+    0,                                          ///< Bit5-7 Reserved
+  },
+  SMBIOS_STRING_INDEX_6,                        // LocationInChassis
+  0,                                            // ChassisHandle
+  BaseBoardTypeMotherBoard,                     // BoardType
+  0,                                            // NumberOfContainedObjectHandles
+  { 0 }                                         // ContainedObjectHandles
+};
+
+
+SMBIOS_TABLE_TYPE19  mMemArrayMappedAddr = {
+  {                                             // Hdr
+    SMBIOS_TYPE_MEMORY_ARRAY_MAPPED_ADDRESS,    ///< Hdr.Type
+    sizeof (SMBIOS_TABLE_TYPE19),               ///< Hdr.Length
+    0                                           ///< Hdr.Handle
+  },
+  0xFFFFFFFF,                                   // StartingAddress
+  0xFFFFFFFF,                                   // EndingAddress
+  SMBIOS_HANDLE_PI_RESERVED,                    // MemoryArrayHandle
+  1,                                            // PartitionWidth
+  0,                                            // ExtendedStartingAddress
+  0                                             // ExtendedEndingAddress
+};
+


### PR DESCRIPTION
This patch added required SMBIOS type 4 for processor info.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>