### PR TITLE
[EHL] Enable Gbe TSN config in yaml

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -1867,11 +1867,49 @@
                      When FALSE, it disables Timed GPIO 1.
       length       : 1b
       value        : 0x0
+  - PchTsnGbeSgmiiEnable :
+      name         : PCH TSN SGMII Support
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     Enable/disable PCH TSN SGMII support 0=Disable 1=Enable
+      length       : 1b
+      value        : 0x1
+  - PseTsnGbe0SgmiiEnable :
+      name         : PSE TSN 0 SGMII Support
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     Enable/disable PSE TSN 0 SGMII support 0=Disable 1=Enable
+      length       : 1b
+      value        : 0x00
+  - PseTsnGbe1SgmiiEnable :
+      name         : PSE TSN 1 SGMII Support
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     Enable/disable PSE TSN 1 SGMII support 0=Disable 1=Enable
+      length       : 1b
+      value        : 0x00
+  - PseTsnGbe0PhyInterfaceType :
+      name         : PSE TSN 0 Phy Interface Type
+      type         : EditNum, HEX, (0x00,0x3)
+      help         : >
+                     Set PSE TSN 0 Phy Interface Type 0: Not Connected, 1: RGMII, 2: SGMII, 3:SGMII+
+      length       : 2b
+      value        : 0x01
+  - PseTsnGbe1PhyInterfaceType :
+      name         : PSE TSN 1 Phy Interface Type
+      type         : EditNum, HEX, (0x00,0x3)
+      help         : >
+                     Set PSE TSN 1 Phy Interface Type 0: Not Connected, 1: RGMII, 2: SGMII, 3:SGMII+
+      length       : 2b
+      value        : 0x01
   - Dummy        :
       name         : SaPostMemTestRsvd
       type         : Combo
       option       : $EN_DIS
       help         : >
                      Reserved for SA Post-Mem Test
-      length       : 22b
+      length       : 15b
       value        : 0x0

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1523,13 +1523,24 @@ UpdateFspConfig (
     // PCH_TSN_CONFIG
     Fspscfg->PchTsnEnable         = SiCfgData->PchTsnEnable;
     Fspscfg->PchTsnGbeLinkSpeed   = SiCfgData->TsnLinkSpeed;
-    Fspscfg->PchTsnGbeSgmiiEnable    = 1;
+    Fspscfg->PchTsnGbeSgmiiEnable = (UINT8)SiCfgData->PchTsnGbeSgmiiEnable;
 
     // PSE_TSN_CONFIG
-    Fspscfg->PseTsnGbeSgmiiEnable[0] = 0;
-    Fspscfg->PseTsnGbeSgmiiEnable[1] = 0;
-    Fspscfg->PseTsnGbePhyInterfaceType[0]    = 1;
-    Fspscfg->PseTsnGbePhyInterfaceType[1]    = 1;
+    Fspscfg->PseTsnGbeSgmiiEnable[0]         = (UINT8)SiCfgData->PseTsnGbe0SgmiiEnable;
+    Fspscfg->PseTsnGbeSgmiiEnable[1]         = (UINT8)SiCfgData->PseTsnGbe1SgmiiEnable;
+    Fspscfg->PseTsnGbePhyInterfaceType[0]    = (UINT8)SiCfgData->PseTsnGbe0PhyInterfaceType;
+    Fspscfg->PseTsnGbePhyInterfaceType[1]    = (UINT8)SiCfgData->PseTsnGbe1PhyInterfaceType;
+    DEBUG ((DEBUG_VERBOSE, "------------------------------------------PCH and PSE TSN CONFIG----------------------------------------\n"));
+    DEBUG ((DEBUG_VERBOSE, "Fspscfg->TsnConfigBase: 0x%x\n",Fspscfg->TsnConfigBase));
+    DEBUG ((DEBUG_VERBOSE, "Fspscfg->TsnConfigSize: 0x%x\n",Fspscfg->TsnConfigSize));
+    DEBUG ((DEBUG_VERBOSE, "Fspscfg->PchTsnEnable: 0x%x\n",Fspscfg->PchTsnEnable));
+    DEBUG ((DEBUG_VERBOSE, "Fspscfg->PchTsnGbeLinkSpeed: 0x%x\n",Fspscfg->PchTsnGbeLinkSpeed));
+    DEBUG ((DEBUG_VERBOSE, "Fspscfg->PchTsnGbeSgmiiEnable: 0x%x\n",Fspscfg->PchTsnGbeSgmiiEnable));
+    DEBUG ((DEBUG_VERBOSE, "Fspscfg->PseTsnGbeSgmiiEnable[0]: 0x%x\n",Fspscfg->PseTsnGbeSgmiiEnable[0]));
+    DEBUG ((DEBUG_VERBOSE, "Fspscfg->PseTsnGbeSgmiiEnable[1]: 0x%x\n",Fspscfg->PseTsnGbeSgmiiEnable[1]));
+    DEBUG ((DEBUG_VERBOSE, "Fspscfg->PseTsnGbePhyInterfaceType[0]: 0x%x\n",Fspscfg->PseTsnGbePhyInterfaceType[0]));
+    DEBUG ((DEBUG_VERBOSE, "Fspscfg->PseTsnGbePhyInterfaceType[1]: 0x%x\n",Fspscfg->PseTsnGbePhyInterfaceType[1]));
+    DEBUG ((DEBUG_VERBOSE, "------------------------------------------------END-----------------------------------------------------\n"));
 
     // AMT_ME_CONFIG
     Fspscfg->AmtEnabled           = SiCfgData->AmtEnabled;


### PR DESCRIPTION
Enable Gbe TSN config in silicon yaml file below:
- PchTsnGbeSgmiiEnable
- PseTsnGbeSgmiiEnable
- PseTsnGbePhyInterfaceType

Signed-off-by: Kok Tong Ong <kok.tong.ong@intel.com>