### PR TITLE
Print code bytes around eip/rip when taking a fatal exception

### DIFF
--- a/BootloaderCorePkg/Library/CpuExceptionLib/Ia32/CpuExceptionHandler.c
+++ b/BootloaderCorePkg/Library/CpuExceptionLib/Ia32/CpuExceptionHandler.c
@@ -39,6 +39,8 @@ CommonExceptionHandler (
   }
 
   DEBUG ((DEBUG_ERROR, "Exception #%d from 0x%04X:0x%08X !!!\n", ExceptionType, Ptr[1], Ptr[0]));
+  DumpHex(0, Ptr[0] - 32, 64, (UINT8 *)(Ptr[0] - 32));
+
   CpuHalt (NULL);
 }
 

--- a/BootloaderCorePkg/Library/CpuExceptionLib/X64/CpuExceptionHandler.c
+++ b/BootloaderCorePkg/Library/CpuExceptionLib/X64/CpuExceptionHandler.c
@@ -39,6 +39,8 @@ CommonExceptionHandler (
   }
 
   DEBUG ((DEBUG_ERROR, "Exception #%d from 0x%04X:0x%08X !!!\n", ExceptionType, (UINT32)Ptr[1], (UINT32)Ptr[0]));
+  DumpHex(0, Ptr[0] - 32, 64, (UINT8 *)(Ptr[0] - 32));
+
   CpuHalt (NULL);
 }
 


### PR DESCRIPTION
When we die due to a fatal exception, we get a debug message that
looks like this:

	Exception #6 from 0x0020:0x000729A1 !!!

This message by itself is not incredibly useful for figuring out
which code caused the exception.

This patch borrows an idea from the Linux kernel, and extends the
exception information with a dump of the opcode bytes around the
instruction pointer, which means that the exception debug message
will now look like this:

	Exception #6 from 0x0020:0x000729A1 !!!
	Code: 89 E0 B9 40 00 00 00 48 8D 15 E3 12 00 00 E8 4D E0 FF FF 41 B8 00 00 07 00 B9 40 00 00 00 48 8D 15 E9 12 00 00 E8 36 E0 FF FF <0F> 0B E8 7D E5 FF FF BA 01 00 00 00 4C 8D 8C 24 90 00 00 00 4C 8D

The byte marked as <0F> indicates the byte that the instruction pointer
points to, and we additionally print a number of prologue and epilogue
bytes, with more prologue bytes than epilogue bytes, according to the
reasoning used by and documented in the Linux kernel tree:

	https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kernel/dumpstack.c?h=v5.15#n100

Tested by inserting a UD2 instruction into Stage1A and verifying on
qemu ia32 and on qemu x64 that the right information is printed.

Signed-off-by: Lennert Buytenhek <buytenh@arista.com>