### PR TITLE
[TGL][EHL] Fix regression for Flash descriptor lock

### DIFF
--- a/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
+++ b/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
@@ -387,6 +387,28 @@ BootMediaWrite (
   OUT    UINT8                   *Buffer
   );
 
+
+/**
+  This function writes blocks to the SPI device based on flash region type.
+
+  @param[in] FlashRegionType      The Flash Region type for flash cycle which is listed in the Descriptor.
+  @param[in]  Address             The block address in the FlashRegionAll to read from on the SPI.
+  @param[in]  ByteCount           Size of the Buffer in bytes.
+  @param[out] Buffer              Pointer to caller-allocated buffer containing the data received during the SPI cycle.
+
+  @retval EFI_SUCCESS             Write completes successfully.
+  @retval others                  Device error, the command aborts abnormally.
+
+**/
+EFI_STATUS
+EFIAPI
+BootMediaWriteByType (
+  IN     FLASH_REGION_TYPE  FlashRegionType,
+  IN     UINT64             Address,
+  IN     UINT32             ByteCount,
+  OUT    UINT8              *Buffer
+  );
+
 /**
   Erase the data on the BootMedia.
 

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.c
@@ -113,7 +113,7 @@ BootMediaReadByType (
 }
 
 /**
-  This function writes blocks from the SPI device.
+  This function writes blocks to the SPI device.
 
   @param[in]   Address            The block address in the FlashRegionAll to read from on the SPI.
   @param[in]   ByteCount          Size of the Buffer in bytes.
@@ -133,6 +133,31 @@ BootMediaWrite (
 {
   return mFwuSpiService->SpiWrite (FlashRegionBios, (UINT32)Address, ByteCount, Buffer);
 }
+
+/**
+  This function writes blocks to the SPI device based on flash region type.
+
+  @param[in] FlashRegionType      The Flash Region type for flash cycle which is listed in the Descriptor.
+  @param[in]  Address             The block address in the FlashRegionAll to read from on the SPI.
+  @param[in]  ByteCount           Size of the Buffer in bytes.
+  @param[out] Buffer              Pointer to caller-allocated buffer containing the data received during the SPI cycle.
+
+  @retval EFI_SUCCESS             Write completes successfully.
+  @retval others                  Device error, the command aborts abnormally.
+
+**/
+EFI_STATUS
+EFIAPI
+BootMediaWriteByType (
+  IN     FLASH_REGION_TYPE  FlashRegionType,
+  IN     UINT64             Address,
+  IN     UINT32             ByteCount,
+  OUT    UINT8              *Buffer
+  )
+{
+  return mFwuSpiService->SpiWrite (FlashRegionType, (UINT32)Address, ByteCount, Buffer);
+}
+
 
 /**
   This function erases blocks from the SPI device.

--- a/Silicon/ElkhartlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/ElkhartlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -450,7 +450,7 @@ SetFlashDescriptorLock (
     //
     // Write to flash descriptor master access region
     //
-    Status = BootMediaReadByType (FlashRegionDescriptor, (UINT32) B_FLASH_FMBA, sizeof(FlashDescMasterAccess), (UINT8 *) FlashDescMasterAccess);
+    Status = BootMediaWriteByType (FlashRegionDescriptor, (UINT32) B_FLASH_FMBA, sizeof(FlashDescMasterAccess), (UINT8 *) FlashDescMasterAccess);
     if (EFI_ERROR (Status)) {
       DEBUG((DEBUG_ERROR, "SPI Lock write failed 0x%x\n", Status));
     }

--- a/Silicon/TigerlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/TigerlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -459,7 +459,7 @@ SetFlashDescriptorLock (
     //
     // Write to flash descriptor master access region
     //
-    Status = BootMediaReadByType (FlashRegionDescriptor, (UINT32) B_FLASH_FMBA, sizeof(FlashDescMasterAccess), (UINT8 *) FlashDescMasterAccess);
+    Status = BootMediaWriteByType (FlashRegionDescriptor, (UINT32) B_FLASH_FMBA, sizeof(FlashDescMasterAccess), (UINT8 *) FlashDescMasterAccess);
     if (EFI_ERROR (Status)) {
       DEBUG((DEBUG_ERROR, "SPI Lock write failed 0x%x\n", Status));
     }


### PR DESCRIPTION
Add BootMediaWriteByType and use for flash descriptor
update.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>