### PR TITLE
[X64] Fix invalid 1st timestamp at reset vector

### DIFF
--- a/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Main.asm
+++ b/BootloaderCorePkg/Stage1A/Ia32/Vtf0/Main.asm
@@ -98,11 +98,23 @@ FspApiSuccess:
     mov     ebp, ecx
     mov     esp, edx
 
+    ;
+    ; Save time stamp to stack
+    ;
+    push    esi
+    push    edi
+
     ; Create page tables
     ;   ECX: Page base
     mov     eax, ADDR_OF(BuildPatchData)
     add     ecx, dword [eax + 0x00]
     OneTimeCall  PreparePagingTable
+
+    ;
+    ; Restore time stamp from stack
+    ;
+    pop     edi
+    pop     esi
 
     ;
     ; Set CR3 now that the paging structures are available


### PR DESCRIPTION
The timestamp value is saved in edi:esi at reset vector in X64, but
PreparePagingTable is using esi and makes 1st timestamp value invalid.

This saves/restores edi:esi before/after PreparePagingTable to keep
proper timestamp value at reset vector.

Signed-off-by: Aiden Park <aiden.park@intel.com>