### PR TITLE
[TGL] Fix infinite reset loop caused by bad DSO

### DIFF
--- a/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -108,13 +108,15 @@ TccModePreMemConfig (
     DEBUG ((DEBUG_INFO, "S0ix is turned off when TCC is enabled\n"));
   }
 
-  if (IsWdtFlagsSet(WDT_FLAG_TCC_DSO) && IsWdtTimeout()) {
-    DEBUG ((DEBUG_INFO, "Incorrect TCC tuning parameters. Platform rebooted with default values.\n"));
-    WdtClearFlags (WDT_FLAG_TCC_DSO);
+  if (IsWdtFlagsSet(WDT_FLAG_TCC_BAD_DSO) ||
+      (IsWdtFlagsSet(WDT_FLAG_TCC_DSO_IN_PROGRESS) && IsWdtTimeout())) {
+    DEBUG ((DEBUG_ERROR, "Incorrect TCC tuning parameters. Platform rebooted with default values.\n"));
+    WdtClearScratchpad (WDT_FLAG_TCC_DSO_IN_PROGRESS);
+    WdtSetScratchpad (WDT_FLAG_TCC_BAD_DSO);
     FspmUpd->FspmConfig.TccStreamCfgStatusPreMem = 1;
   } else if (TccCfgData->TccTuning != 0) {
     // Setup Watch dog timer
-    WdtReloadAndStart (WDT_TIMEOUT_TCC_DSO, WDT_FLAG_TCC_DSO);
+    WdtReloadAndStart (WDT_TIMEOUT_TCC_DSO, WDT_FLAG_TCC_DSO_IN_PROGRESS);
 
     // Load TCC stream config from container
     TccStreamBase = NULL;

--- a/Silicon/CommonSocPkg/Include/Library/WatchDogTimerLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/WatchDogTimerLib.h
@@ -8,9 +8,9 @@
 #ifndef WATCH_DOG_TIMBER_LIB_H_
 #define WATCH_DOG_TIMBER_LIB_H_
 
-#define  WDT_TIMEOUT_TCC_DSO   200          // 200 seconds
-#define  WDT_FLAG_TCC_DSO      BIT17
-#define  WDT_FLAG_MASK         BIT17
+#define  WDT_TIMEOUT_TCC_DSO           200    // 200 seconds
+#define  WDT_FLAG_TCC_DSO_IN_PROGRESS  BIT17
+#define  WDT_FLAG_TCC_BAD_DSO          BIT18
 
 
 /**
@@ -44,14 +44,26 @@ WdtDisable (
 
 
 /**
-  Clear WDT timer flags.
+  Clear WDT flags in scratchpad
 
-  @param[in] Flags             The timer flags that would be cleared.
+  @param[in] Flags             The scratchpad flags that would be cleared.
 
 **/
 VOID
 EFIAPI
-WdtClearFlags (
+WdtClearScratchpad (
+  IN  UINT32  Flags
+  );
+
+/**
+  Set WDT flags in scratchpad
+
+  @param[in] Flags             The scratchpad flags that would be set.
+
+**/
+VOID
+EFIAPI
+WdtSetScratchpad (
   IN  UINT32  Flags
   );
 


### PR DESCRIPTION
This patch solves an infinite reset loop issue caused by bad DSO with the scenario:
- After platform reset (due to WDT timeout), FSPm asks for another reset, but before that, WDT_FLAG_TCC_DSO is already cleaned. As a result, in the thrid reset, stage1B will have no idea about the DSO is corrupted and it continues boot with Tcc Tuning flow, which causes WDT timeout reset again.

This patch introduces a WDT_FLAG_TCC_BAD_DSO flag in WDT scrachpad (bit 18). The flag is a marker that is set when a bad DSO is detected. The new booting flow for "bad DSO" case if Tcc_Tuning enabled will be:
  - 1st boot: (after fwupdate)
      - TCC_DSO and WDT set by stage1b and stage2
      - FSP hangs and trigger WDT reset
  - 2nd boot:
      - Stage1b detects "bad DSO" because of WDT and TCC_DSO.
      - It clears TCC_DSO and WDT.
      - Then, it sets TCC_BAD_DSO.
      - Then it continues boot that will skip Tcc Tuning (because of TCC_DSO unset)
  - 3rd boot:
      - Stage1b detects "bad DSO" because of TCC_BAD_DSO
      - It continues boot that will skip Tcc Tuning (because of TCC_DSO unset)

The patch does not remove the 200-sec abnormal boot-up symptom because the symptom is noticeable to user. So user can be aware of something wrong (bad DSO).

The "bad DSO" flag will be clear before fwupdate, so a fwupdate with a correct DSO can solve the 200 sec abnormal boot up time.
