### PR TITLE
[CFL][CML] Fix board hook call sequence issue

### DIFF
--- a/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -651,6 +651,7 @@ DEBUG_CODE_END();
     break;
   case PreMemoryInit:
     GpioInit (PlatformId);
+    break;
   case PostMemoryInit:
     DEBUG ((DEBUG_INFO, "PostMemoryInit called\n"));
     UpdateMemoryInfo ();

--- a/Platform/CometlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CometlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -734,6 +734,7 @@ DEBUG_CODE_END();
     break;
   case PreMemoryInit:
     GpioConfigurePads (sizeof (mGpioTableCmlS82Ddr4PreMem) / sizeof (GPIO_INIT_CONFIG), mGpioTableCmlS82Ddr4PreMem );
+    break;
   case PostMemoryInit:
     DEBUG ((DEBUG_INFO, "PostMemoryInit called\n"));
     UpdateMemoryInfo ();

--- a/Platform/CometlakevBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/CometlakevBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -744,6 +744,7 @@ DEBUG_CODE_END();
     break;
   case PreMemoryInit:
     GpioConfigurePads (sizeof (mGpioTableCmlS82Ddr4PreMem) / sizeof (GPIO_INIT_CONFIG), mGpioTableCmlS82Ddr4PreMem );
+    break;
   case PostMemoryInit:
     DEBUG ((DEBUG_INFO, "PostMemoryInit called\n"));
     UpdateMemoryInfo ();


### PR DESCRIPTION
On CFL and CML, the board hook PostMemoryInit was called before
FspMemoryInit API. This should be called afterwards instead.

This patch fixed this issue. It is because of missing "break"
statement. It fixed #1435.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>