### PR TITLE
Update BtgSign tool

### DIFF
--- a/Platform/CommonBoardPkg/Script/BtgSign.py
+++ b/Platform/CommonBoardPkg/Script/BtgSign.py
@@ -21,7 +21,8 @@ import xml.etree.ElementTree as ET
 from   xml.dom import minidom
 from   ctypes  import *
 from   subprocess   import call
-from   StitchLoader import *
+from   CommonUtility import *
+from   IfwiUtility   import *
 
 SIGNING_KEY = {
     # Key Id                                | Key File Name |


### PR DESCRIPTION
Currently StitchLoader.py is under platform package, and
the common tool BtgSign.py should not depend on that tool.
And BtgSign.py indeed doesn't depend on it, so just update
it to make it could work without StitchLoader.py.

Signed-off-by: Guo Dong <guo.dong@intel.com>