### PR TITLE
[EHL] WA for POSC issue

### DIFF
--- a/BootloaderCorePkg/IncludePrivate/BootloaderCoreGlobal.h
+++ b/BootloaderCorePkg/IncludePrivate/BootloaderCoreGlobal.h
@@ -158,7 +158,6 @@ typedef struct {
   UINT32            Signature;
   UINT16            PlatformId;
   UINT16            PlatformBomId;
-  UINT32            SocSku;
   UINT8             BootMode;
   UINT8             LoaderStage;
   UINT8             CurrentBootPartition;
@@ -168,11 +167,11 @@ typedef struct {
   UINT32            MemPoolStart;
   UINT32            MemPoolCurrTop;
   UINT32            MemPoolCurrBottom;
+  UINT32            MemUsableTop;
   UINT32            PayloadId;
   UINT32            DebugPrintErrorLevel;
   UINT8             DebugPortIdx;
   UINT8             Padding[3];
-  UINT64            MemoryInfo[EnumMemInfoMax];
   VOID             *FspHobList;
   VOID             *LdrHobList;
   VOID             *FlashMapPtr;
@@ -195,6 +194,8 @@ typedef struct {
   UINT32            CarBase;
   UINT32            CarSize;
   UINT32            MemPoolMaxUsed;
+  UINT64            MemoryInfo[EnumMemInfoMax];
+  UINT32            SocSku;
 } LOADER_GLOBAL_DATA;
 
 /**


### PR DESCRIPTION
Rearrange SBL Global Data Structure for POSC
issue workaround. This is due to the POSC accessing
SBL Global Data and it get corrupted when SBL rearrange
or restructure the data structure.

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>