### PR TITLE
Check fit header entry location

### DIFF
--- a/Silicon/CommonSocPkg/Library/BootGuardLibCBnT/BootGuardLibCBnT.inf
+++ b/Silicon/CommonSocPkg/Library/BootGuardLibCBnT/BootGuardLibCBnT.inf
@@ -44,3 +44,4 @@
 
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
+  gPlatformModuleTokenSpaceGuid.PcdTopSwapRegionSize

--- a/Silicon/CommonSocPkg/Library/BootGuardLibCBnT/BootGuardTpmEventLogLib.c
+++ b/Silicon/CommonSocPkg/Library/BootGuardLibCBnT/BootGuardTpmEventLogLib.c
@@ -512,7 +512,15 @@ FindFitEntryData (
   UINT32                         Index;
 
   FitTableOffset = *(UINT64 *)(UINTN)(BASE_4GB - 0x40);
+  // Fit table is located in Top Swap region.
+  // Adding check to validate Fit entry location
+  if ((FitTableOffset < (BASE_4GB - PcdGet32 (PcdTopSwapRegionSize)))  ||  (FitTableOffset >  BASE_4GB)) {
+    DEBUG ((DEBUG_INFO, "FitTableOffset 0x%x is not valid \n", FitTableOffset));
+    return NULL;
+  }
+
   FitEntry = (FIRMWARE_INTERFACE_TABLE_ENTRY *)(UINTN)FitTableOffset;
+
   if (FitEntry != NULL) {
     if (FitEntry[0].Address != *(UINT64 *)"_FIT_   ") {
       return NULL;


### PR DESCRIPTION
For bootguard event log fit header location is retrieved
from fit pointer. Added a condition to check the FIT header
range to fix KW error.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>