### PR TITLE
Move DSO update/check to TccLib

### DIFF
--- a/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
+++ b/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
@@ -48,6 +48,7 @@
   BootGuardLib
   BoardSupportLib
   WatchDogTimerLib
+  TccLib
 
 [Guids]
 

--- a/Silicon/CommonSocPkg/Include/Library/TccLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/TccLib.h
@@ -28,4 +28,31 @@ UpdateAcpiRtctTable (
   IN EFI_ACPI_DESCRIPTION_HEADER *RtctTable
   );
 
+/**
+  Check if the TCC DSO is a bad binary by checking its signature.
+
+  @retval TRUE     TCC DSO was marked as a bad binary
+  @retval FALSE    TCC DSO was not found or not marked as a bad binary
+
+ */
+BOOLEAN
+EFIAPI
+IsMarkedBadDso (
+  VOID
+  );
+
+/**
+  Mark TCC DSO as a bad binary by changing its signature to 0.
+
+  @retval EFI_SUCCESS
+  @retval EFI_NOT_FOUND          Unable to find IPFW/TCCT
+  @retval Others                 Errors during SPI operations
+
+ */
+EFI_STATUS
+EFIAPI
+InvalidateBadDso (
+  VOID
+  );
+
 #endif

--- a/Silicon/CommonSocPkg/Library/TccLib/TccLib.inf
+++ b/Silicon/CommonSocPkg/Library/TccLib/TccLib.inf
@@ -34,6 +34,8 @@
   DebugLib
   HobLib
   BootloaderCoreLib
+  SpiFlashLib
+  ContainerLib
 
 [Guids]
   gTccRtctHobGuid


### PR DESCRIPTION
IsMarkedBadDso and InvalidateBadDso would be required for all
the platforms that support TCC. And the implementation is also
common, so just move them to common TccLib.
Also updated the implementation to remove SPI flash erase for
InvalidateBadDso().

Signed-off-by: Guo Dong <guo.dong@intel.com>