### PR TITLE
[CMLV] Fix wrong value of PchMaxPciePort

### DIFF
--- a/Silicon/CometlakevPkg/Library/PchInfoLib/PchInfoLibCmlv.c
+++ b/Silicon/CometlakevPkg/Library/PchInfoLib/PchInfoLibCmlv.c
@@ -260,7 +260,7 @@ GetPchMaxPciePortNum (
   if (IsPchLp ()) {
     return 16;
   } else {
-    return 24;
+    return 20;
   }
 }
 


### PR DESCRIPTION
According to H410 PCH EDS data, it should be 20.

Signed-off-by: Randy Lin <randy.lin@intel.com>