### PR TITLE
[Common] Fix CSME update build issue

### DIFF
--- a/BootloaderCommonPkg/Library/BootloaderDebugLib/BootloaderDebugLib.inf
+++ b/BootloaderCommonPkg/Library/BootloaderDebugLib/BootloaderDebugLib.inf
@@ -38,6 +38,7 @@
   PrintLib
   BaseLib
   DebugPrintErrorLevelLib
+  BootloaderCommonLib
 
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdDebugClearMemoryValue          ## CONSUMES


### PR DESCRIPTION
There is unresolved external symbol build issue with
BUILD_CSME_UPDATE_DRIVER enabled in BoardConfig.
By adding the BootloaderCommonLib in BootloaderDebugLib
inf file will address this issue.

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>