### PR TITLE
Fix HelloWorld payload build issue

### DIFF
--- a/PayloadPkg/PayloadPkg.dsc
+++ b/PayloadPkg/PayloadPkg.dsc
@@ -45,6 +45,7 @@
   SerialPortLib | BootloaderCommonPkg/Library/SerialPortLib/SerialPortLib.inf
   DebugLib | BootloaderCommonPkg/Library/BootloaderDebugLib/BootloaderDebugLib.inf
   PcdLib | BootloaderCommonPkg/Library/PcdLib/PcdLib.inf
+  RegisterFilterLib|MdePkg/Library/RegisterFilterLibNull/RegisterFilterLibNull.inf
   ConsoleInLib | BootloaderCommonPkg/Library/ConsoleInLib/ConsoleInLib.inf
   ConsoleOutLib | BootloaderCommonPkg/Library/ConsoleOutLib/ConsoleOutLib.inf
   GraphicsLib | BootloaderCommonPkg/Library/GraphicsLib/GraphicsLib.inf


### PR DESCRIPTION
This patch fixed the HelloWorld payload build failure after the EDK2
code sync up. It was caused by missing RegisterFilterLib class instance.

It fixed #1455.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>