### PR TITLE
HelloWorld: Use ConsolePrint to simplify code and fix GCC build

### DIFF
--- a/PayloadPkg/HelloWorld/HelloWorld.c
+++ b/PayloadPkg/HelloWorld/HelloWorld.c
@@ -22,8 +22,6 @@ PayloadMain (
   )
 {
   UINT8      Key;
-  CHAR8      Message[64];
-  UINTN      Len;
 
   DEBUG ((DEBUG_INFO, "\n\n==================== Hello World ====================\n\n"));
 
@@ -32,8 +30,7 @@ PayloadMain (
     if (ConsolePoll ()) {
       if (ConsoleRead (&Key, 1) > 0) {
         if ((Key >= 0x20) && (Key < 0x7F)) {
-          Len = AsciiSPrint (Message, sizeof (Message), "Key '%c' pressed !\n", Key);
-          ConsoleWrite (Message, Len);
+          ConsolePrint("Key '%c' pressed !\n", Key);
         }
       }
     }


### PR DESCRIPTION
This compiles, but I'm having some other problems which mean that I haven't been able to test the result yet.

I suspect that the automated checks will complain about the length of the quoted compiler output in the commit message. I can't really fix that without making the output unreadable or removing it altogether.