### PR TITLE
[EHL] Revert the WA for POSC issue Pt2

### DIFF
--- a/BootloaderCorePkg/IncludePrivate/BootloaderCoreGlobal.h
+++ b/BootloaderCorePkg/IncludePrivate/BootloaderCoreGlobal.h
@@ -168,7 +168,6 @@ typedef struct {
   UINT32            MemPoolStart;
   UINT32            MemPoolCurrTop;
   UINT32            MemPoolCurrBottom;
-  UINT32            MemUsableTop;
   UINT32            PayloadId;
   UINT32            DebugPrintErrorLevel;
   UINT8             DebugPortIdx;


### PR DESCRIPTION
Missing of removal MemUsableTop in the data structure
Revert the WA for POSC issue in commit below:
9cd53b6

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>