### PR TITLE
BuildUtility: Support GCC5_BIN prefix

### DIFF
--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -245,7 +245,8 @@ def get_gcc_info ():
     toolchain = 'GCC5'
     cmd = 'gcc'
     try:
-        ver = subprocess.check_output([cmd, '-dumpfullversion']).decode().strip()
+        prefix = os.environ.get(toolchain + '_BIN')
+        ver = subprocess.check_output([(prefix if prefix else '') + cmd, '-dumpfullversion']).decode().strip()
     except:
         ver = ''
         pass


### PR DESCRIPTION
The EDK II build tools support applying a prefix for GCC from an
environment variable (e.g. GCC5_BIN). For this to work correctly with
Slimbootloader it's also necessary to use the prefix for the version
check too.

Signed-off-by: Mike Crowe <mac@mcrowe.com>