### PR TITLE
PrepareBuildComponentBin: Avoid network access if commit is already available

### DIFF
--- a/BootloaderCorePkg/Tools/PrepareBuildComponentBin.py
+++ b/BootloaderCorePkg/Tools/PrepareBuildComponentBin.py
@@ -36,7 +36,16 @@ def CloneRepo (clone_dir, driver_inf):
             Fatal ('Failed to clone repo to directory %s !' % clone_dir)
         print ('Done\n')
     else:
-        print ('Update the repo ...')
+        # If the repository already exists, then try to check out the correct
+        # revision without going to the network
+        print ('Attempting to check out specified version ... %s' % commit)
+        cmd = 'git checkout %s' % commit
+        ret = subprocess.call(cmd.split(' '), cwd=clone_dir)
+        if ret == 0:
+            print ('Done\n')
+            return clone_dir
+
+        print ('Specified version not available. Update the repo ...')
         cmd = 'git fetch origin'
         ret = subprocess.call(cmd.split(' '), cwd=clone_dir)
         if ret:


### PR DESCRIPTION
It may be necessary to build Slimbootloader in situations where Internet
access is not available, or where it is important to ensure that there
is also a local copy of the build dependencies.

It's possible for the correct repositories to be cloned into the right
places outside the Slimbootloader build system. However,
PrepareBuildComponentBin previously insisted on attempting to
fetch from the remote repository every time.

If the .git directory exists, let's first try to check out the required
commit and only if that fails attempt to fetch.

This means that it's possible to stop the Slimbootloader build system
accessing the Internet by arranging for the correct repositories to be
cloned in the right places beforehand and setting the https_proxy
environment variables to unresolvable names to avoid accidental use.

Signed-off-by: Mike Crowe <mac@mcrowe.com>