### PR TITLE
[TGL] Fix UART0 access

### DIFF
--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/SerialIo.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/SerialIo.c
@@ -1,0 +1,52 @@
+/** @file
+
+  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/DebugLib.h>
+#include <FspsUpd.h>
+#include <Library/PchInfoLib.h>
+#include <PlatformData.h>
+#include <PchAccess.h>
+#include <PchLimits.h>
+#include "SerialIo.h"
+
+/**
+  Update Serial IO for FSP-S UPD
+
+  @param  FspsConfig            The pointer to the FSP-S UPD to be updated.
+**/
+VOID
+EFIAPI
+SerialIoPostMemConfig (
+  FSP_S_CONFIG  *FspsConfig
+)
+{
+  UINT8               DebugPort;
+
+  DebugPort = GetDebugPort ();
+  if (DebugPort < PCH_MAX_SERIALIO_UART_CONTROLLERS) {
+    // Inform FSP to skip debug UART init
+    FspsConfig->SerialIoDebugUartNumber = DebugPort;
+    FspsConfig->SerialIoUartMode[DebugPort] = 0x4;
+  } else if (S0IX_STATUS() == 1) {  // legacy UART
+    FspsConfig->SerialIoUartMode[2] = 1;  // Force UART to PCI mode to enable OS to have full control
+  }
+
+  // Two instants of UART0 in TGL PCH: GPP_C8 to GPP_C11 and GPP_F0 to GPP_F3, while the second
+  // instant can be used by CNVI.
+  if (IsPchLp ()) {
+    FspsConfig->SerialIoUartRxPinMuxPolicy[0] = GPIO_VER2_LP_MUXING_SERIALIO_UART0_RXD_GPP_C8;
+    FspsConfig->SerialIoUartTxPinMuxPolicy[0] = GPIO_VER2_LP_MUXING_SERIALIO_UART0_TXD_GPP_C9;
+    FspsConfig->SerialIoUartRtsPinMuxPolicy[0] = GPIO_VER2_LP_MUXING_SERIALIO_UART0_RTS_GPP_C10;
+    FspsConfig->SerialIoUartCtsPinMuxPolicy[0] = GPIO_VER2_LP_MUXING_SERIALIO_UART0_CTS_GPP_C11;
+  } else if (IsPchH ()) {
+    FspsConfig->SerialIoUartRxPinMuxPolicy[0] = GPIO_VER2_H_MUXING_SERIALIO_UART0_RXD_GPP_C8;
+    FspsConfig->SerialIoUartTxPinMuxPolicy[0] = GPIO_VER2_H_MUXING_SERIALIO_UART0_TXD_GPP_C9;
+    FspsConfig->SerialIoUartRtsPinMuxPolicy[0] = GPIO_VER2_H_MUXING_SERIALIO_UART0_RTS_GPP_C10;
+    FspsConfig->SerialIoUartCtsPinMuxPolicy[0] = GPIO_VER2_H_MUXING_SERIALIO_UART0_CTS_GPP_C11;
+  } else {
+    DEBUG ((DEBUG_ERROR, "Unsupported PCH to initialize GPIO pins for UART0\n"));
+  }
+}

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/SerialIo.h
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/SerialIo.h
@@ -1,0 +1,21 @@
+/** @file
+  Header file for SerialIo
+
+  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _SERIAL_IO_H_
+#define _SERIAL_IO_H_
+
+/**
+  Update Serial IO for FSP-S UPD
+
+  @param  FspsConfig            The pointer to the FSP-S UPD to be updated.
+**/
+VOID
+EFIAPI
+SerialIoPostMemConfig (
+  FSP_S_CONFIG  *FspsConfig
+);
+
+#endif // _SERIAL_IO_H

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-# Copyright (c) 2008 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2008 - 2022, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -31,6 +31,8 @@
   LowPowerSupport.h
   Dts.h
   Dts.c
+  SerialIo.h
+  SerialIo.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/Silicon/TigerlakePchPkg/Include/GpioPinsVer2H.h
+++ b/Silicon/TigerlakePchPkg/Include/GpioPinsVer2H.h
@@ -1,7 +1,7 @@
 /** @file
   GPIO pins for TGL-PCH-H,
 
-  Copyright (c) 2017 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 #ifndef _GPIO_PINS_VER2_H_H_
@@ -48,23 +48,31 @@
 /// require GpioPad as argument. Encoding used here
 /// has all information required by library functions
 ///
-#define GPIO_VER2_H_GPP_A0                   0x08000000
-#define GPIO_VER2_H_GPP_A1                   0x08000001
-#define GPIO_VER2_H_GPP_A2                   0x08000002
-#define GPIO_VER2_H_GPP_A3                   0x08000003
-#define GPIO_VER2_H_GPP_A4                   0x08000004
-#define GPIO_VER2_H_GPP_A5                   0x08000005
-#define GPIO_VER2_H_GPP_A6                   0x08000006
-#define GPIO_VER2_H_GPP_A7                   0x08000007
-#define GPIO_VER2_H_GPP_A8                   0x08000008
-#define GPIO_VER2_H_GPP_A9                   0x08000009
-#define GPIO_VER2_H_GPP_A10                  0x0800000A
-#define GPIO_VER2_H_GPP_A11                  0x0800000B
-#define GPIO_VER2_H_GPP_A12                  0x0800000C
-#define GPIO_VER2_H_GPP_A13                  0x0800000D
-#define GPIO_VER2_H_GPP_A14                  0x0800000E
-#define GPIO_VER2_H_SPI0_CLK_LOOPBK          0x0800000F
-#define GPIO_VER2_H_ESPI_CLK_LOOPBK          0x08000010
+#define GPIO_VER2_H_SPI0_IO_2                0x08000000
+#define GPIO_VER2_H_SPI0_IO_3                0x08000001
+#define GPIO_VER2_H_SPI0_MOSI_IO_0           0x08000002
+#define GPIO_VER2_H_SPI0_MISO_IO_1           0x08000003
+#define GPIO_VER2_H_SPI0_TPM_CSB             0x08000004
+#define GPIO_VER2_H_SPI0_FLASH_0_CSB         0x08000005
+#define GPIO_VER2_H_SPI0_FLASH_1_CSB         0x08000006
+#define GPIO_VER2_H_SPI0_CLK                 0x08000007
+#define GPIO_VER2_H_GPP_A0                   0x08000008
+#define GPIO_VER2_H_GPP_A1                   0x08000009
+#define GPIO_VER2_H_GPP_A2                   0x0800000A
+#define GPIO_VER2_H_GPP_A3                   0x0800000B
+#define GPIO_VER2_H_GPP_A4                   0x0800000C
+#define GPIO_VER2_H_GPP_A5                   0x0800000D
+#define GPIO_VER2_H_GPP_A6                   0x0800000E
+#define GPIO_VER2_H_GPP_A7                   0x0800000F
+#define GPIO_VER2_H_GPP_A8                   0x08000010
+#define GPIO_VER2_H_GPP_A9                   0x08000011
+#define GPIO_VER2_H_GPP_A10                  0x08000012
+#define GPIO_VER2_H_GPP_A11                  0x08000013
+#define GPIO_VER2_H_GPP_A12                  0x08000014
+#define GPIO_VER2_H_GPP_A13                  0x08000015
+#define GPIO_VER2_H_GPP_A14                  0x08000016
+#define GPIO_VER2_H_SPI0_CLK_LOOPBK          0x08000017
+#define GPIO_VER2_H_ESPI_CLK_LOOPBK          0x08000018
 
 #define GPIO_VER2_H_GPP_R0                   0x08010000
 #define GPIO_VER2_H_GPP_R1                   0x08010001
@@ -472,7 +480,13 @@
 // If certain signal is not listed below it means that it can be enabled
 // only on a single pad and musing setting is not needed.
 //
-#define GPIO_VER2_H_MUXING_SERIALIO_UART0_RXD_GPP_C8         (GPIO_NATIVE_PAD_DEF (GPIO_VER2_H_GPP_C8,  1, GPIO_FUNCTION_SERIAL_IO_UART_RX(0)))
-#define GPIO_VER2_H_MUXING_SERIALIO_UART0_RXD_GPP_J3         (GPIO_NATIVE_PAD_DEF (GPIO_VER2_H_GPP_J3,  2, GPIO_FUNCTION_SERIAL_IO_UART_RX(0)))
+#define GPIO_VER2_H_MUXING_SERIALIO_UART0_RXD_GPP_C8         0x18050208
+#define GPIO_VER2_H_MUXING_SERIALIO_UART0_RXD_GPP_J3         0x280E0203
+#define GPIO_VER2_H_MUXING_SERIALIO_UART0_TXD_GPP_C9         0x18051209
+#define GPIO_VER2_H_MUXING_SERIALIO_UART0_TXD_GPP_J4         0x280E1204
+#define GPIO_VER2_H_MUXING_SERIALIO_UART0_RTS_GPP_C10        0x1805220A
+#define GPIO_VER2_H_MUXING_SERIALIO_UART0_RTS_GPP_J2         0x280E2202
+#define GPIO_VER2_H_MUXING_SERIALIO_UART0_CTS_GPP_C11        0x1805320B
+#define GPIO_VER2_H_MUXING_SERIALIO_UART0_CTS_GPP_J5         0x280E3205
 
 #endif // _GPIO_PINS_VER2_H_H_

--- a/Silicon/TigerlakePchPkg/Include/Pins/GpioPinsVer2H.h
+++ b/Silicon/TigerlakePchPkg/Include/Pins/GpioPinsVer2H.h
@@ -1,7 +1,7 @@
 /** @file
   GPIO pins for TGL-PCH-H,
 
-  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 #ifndef _GPIO_PINS_VER2_H_H_
@@ -48,6 +48,13 @@
 /// require GpioPad as argument. Encoding used here
 /// has all information required by library functions
 ///
+#define GPIO_VER2_H_SPI0_IO_2                0x08000000
+#define GPIO_VER2_H_SPI0_IO_3                0x08000001
+#define GPIO_VER2_H_SPI0_MOSI_IO_0           0x08000002
+#define GPIO_VER2_H_SPI0_MISO_IO_1           0x08000003
+#define GPIO_VER2_H_SPI0_TPM_CSB             0x08000004
+#define GPIO_VER2_H_SPI0_FLASH_0_CSB         0x08000005
+#define GPIO_VER2_H_SPI0_FLASH_1_CSB         0x08000006
 #define GPIO_VER2_H_SPI0_CLK                 0x08000007
 #define GPIO_VER2_H_GPP_A0                   0x08000008
 #define GPIO_VER2_H_GPP_A1                   0x08000009
@@ -475,5 +482,11 @@
 //
 #define GPIO_VER2_H_MUXING_SERIALIO_UART0_RXD_GPP_C8         0x18050208
 #define GPIO_VER2_H_MUXING_SERIALIO_UART0_RXD_GPP_J3         0x280E0203
+#define GPIO_VER2_H_MUXING_SERIALIO_UART0_TXD_GPP_C9         0x18051209
+#define GPIO_VER2_H_MUXING_SERIALIO_UART0_TXD_GPP_J4         0x280E1204
+#define GPIO_VER2_H_MUXING_SERIALIO_UART0_RTS_GPP_C10        0x1805220A
+#define GPIO_VER2_H_MUXING_SERIALIO_UART0_RTS_GPP_J2         0x280E2202
+#define GPIO_VER2_H_MUXING_SERIALIO_UART0_CTS_GPP_C11        0x1805320B
+#define GPIO_VER2_H_MUXING_SERIALIO_UART0_CTS_GPP_J5         0x280E3205
 
 #endif // _GPIO_PINS_VER2_H_H_


### PR DESCRIPTION
This patch fixes no activity on UART0 pins when enabling it for serial
communication.

In TGL, there are two UART0 instances while the one (GPP_F0 to GPP_F4)
is shared with CNVI. This patch enables GPP_C8~C11 as the UART0 instance
to reduce the conflict with CNVI.

This patch also fixes the GPIO pins definition for TGL-H and moves
serial io initialization code to SerialIo.c to simplfy Stage2BoardInitLib.c.

Test: TGL-UP3 RVP and TGL-H RVP

Signed-off-by: Stanley Chang <stanley.chang@intel.com>