### PR TITLE
[EHL] Enhance GPIO convert tool

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/Script/GpioDataConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/Script/GpioDataConfig.py
@@ -1,0 +1,39 @@
+## @ GpioDataConfig.py
+#  This is a Gpio config script for Slim Bootloader
+#
+# Copyright (c) 2022, Intel Corporation. All rights reserved. <BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+
+#
+# The index for a group has to match implementation
+# in a platform specific Gpio library.
+#
+
+def get_grp_info():
+    grp_info ={
+      # Grp     Index
+      'GPP_A' : [ 0xB],
+      'GPP_B' : [ 0x0],
+      'GPP_C' : [ 0xD],
+      'GPP_D' : [ 0x5],
+      'GPP_E' : [ 0x10],
+      'GPP_F' : [ 0xE],
+      'GPP_G' : [ 0x2],
+      'GPP_H' : [ 0x4],
+      'GPP_R' : [ 0x12],
+      'GPP_S' : [ 0xA],
+      'GPP_T' : [ 0x1],
+      'GPP_U' : [ 0x6],
+      'GPP_V' : [ 0x3],
+      'GPPD'  : [ 0x8],
+    }
+    return grp_info
+
+def rxraw_override_cfg():
+    return True
+
+def plat_name():
+    return 'ehl'


### PR DESCRIPTION
This patch enhanced GPIO convert tool so that it can handle the
new GPIO template format.

EX:
  To convert GPIO from YAML format to CSV format:
  python Platform\CommonBoardPkg\Tools\GpioDataConvert.py -cf
         Platform\ElkhartlakeBoardPkg\Script\GpioDataConfig.py -if
         Platform\ElkhartlakeBoardPkg\CfgData\CfgData_Gpio.yaml
	 -of csv -o gpio.csv

  To convert GPIO from CSV to YAML format:
  python Platform\CommonBoardPkg\Tools\GpioDataConvert.py -cf
         Platform\ElkhartlakeBoardPkg\Script\GpioDataConfig.py -if
         gpio.csv -of yaml -o gpio.yaml -t new

Signed-off-by: Maurice Ma <maurice.ma@intel.com>