### PR TITLE
[TGL] Disable s0ix on TGLU RVP

### DIFF
--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_Ddr4.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_Ddr4.dlt
@@ -2,7 +2,7 @@
 #
 #  Platform Configuration Delta File.
 #
-#  Copyright (c) 2019 - 2021, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2019 - 2022, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -11,8 +11,8 @@
 PLATFORMID_CFG_DATA.PlatformId                              | 0x0001
 PLAT_NAME_CFG_DATA.PlatformName                             | 'TGLU_DDR'
 
-# Enable S0ix by default
-FEATURES_CFG_DATA.Features.S0ix                             | 0x1
+# Disable S0ix by default
+FEATURES_CFG_DATA.Features.S0ix                             | 0x0
 
 MEMORY_CFG_DATA.DqsMapCpu2DramMc0Ch1                        | {0, 1}
 MEMORY_CFG_DATA.DqsMapCpu2DramMc0Ch3                        | {0, 1}

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_DdrLp4.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_DdrLp4.dlt
@@ -2,7 +2,7 @@
 #
 #  Platform Configuration Delta File.
 #
-#  Copyright (c) 2019 - 2021, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2019 - 2022, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -12,8 +12,8 @@
 PLATFORMID_CFG_DATA.PlatformId                              | 0x0003
 PLAT_NAME_CFG_DATA.PlatformName                             | 'TGLU_LP4'
 
-# Enable S0ix by default
-FEATURES_CFG_DATA.Features.S0ix                             | 0x1
+# Disable S0ix by default
+FEATURES_CFG_DATA.Features.S0ix                             | 0x0
 
 MEMORY_CFG_DATA.SpdAddressTable                             | {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 MEMORY_CFG_DATA.SpdDataSel000                               | 1


### PR DESCRIPTION
s0ix feature enabling flag also turn off some FSP configs
so that default SBL image can't detect the onboard Lan
and type c devices.

Signed-off-by: Randy Lin <randy.lin@intel.com>