### PR TITLE
[TGL] Enable PCIe PM features

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -1,7 +1,7 @@
 ## @file
 # Provides bootloader driver related package definitions.
 #
-# Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2022, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -225,3 +225,4 @@
   gPlatformModuleTokenSpaceGuid.PcdEnableSetup            | FALSE      | BOOLEAN | 0x20000213
   gPlatformModuleTokenSpaceGuid.PcdLegacyEfSegmentEnabled | TRUE       | BOOLEAN | 0x20000214
   gPlatformModuleTokenSpaceGuid.PcdEnableDts              | FALSE      | BOOLEAN | 0x20000215
+  gPlatformModuleTokenSpaceGuid.PcdEnablePciePm           | FALSE      | BOOLEAN | 0x20000222

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -1,7 +1,7 @@
 ## @file
 # Provides driver and definitions to build bootloader.
 #
-# Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2022, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -335,6 +335,7 @@
   gPlatformModuleTokenSpaceGuid.PcdEnableSetup            | $(ENABLE_SBL_SETUP)
   gPayloadTokenSpaceGuid.PcdPayloadModuleEnabled          | $(ENABLE_PAYLOD_MODULE)
   gPlatformModuleTokenSpaceGuid.PcdEnableDts              | $(ENABLE_DTS)
+  gPlatformModuleTokenSpaceGuid.PcdEnablePciePm           | $(ENABLE_PCIE_PM)
 
 !ifdef $(S3_DEBUG)
   gPlatformModuleTokenSpaceGuid.PcdS3DebugEnabled         | $(S3_DEBUG)

--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -1,7 +1,7 @@
 ## @file
 # This file is used to provide board specific image information.
 #
-#  Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2018 - 2022, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -73,6 +73,7 @@ class Board(BaseBoard):
         self.ENABLE_FRAMEBUFFER_INIT    = 1
         # 1: To read ambient temperature at boot time 0: Disable the feature
         self.ENABLE_DTS           = 1
+        self.ENABLE_PCIE_PM       = 1
         self.ENABLE_FAST_BOOT     = 0
         self.HAVE_FUSA            = 1
         # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)
@@ -292,6 +293,17 @@ class Board(BaseBoard):
 
         if self.BUILD_CSME_UPDATE_DRIVER:
             dsc['LibraryClasses.%s' % self.BUILD_ARCH].append ('MeFwUpdateLib|Silicon/$(PCH_PKG_NAME)/Library/MeFwUpdateLib/MeFwUpdateLib.inf')
+
+        if self.ENABLE_PCIE_PM:
+            lib = [
+                'PciePm|Silicon/$(PCH_PKG_NAME)/Library/PciePm/PciePm.inf',
+                'PciExpressHelpersLib|Silicon/$(PCH_PKG_NAME)/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.inf',
+                'BasePcieHelperLib|Silicon/$(PCH_PKG_NAME)/Library/BasePcieHelperLib/BasePcieHelperLib.inf',
+                'PcieClientRpLib|Silicon/$(PCH_PKG_NAME)/Library/PcieClientRpLib/PcieClientRpLib.inf'
+            ]
+            dsc['LibraryClasses.%s' % self.BUILD_ARCH].extend (lib)
+        else:
+            dsc['LibraryClasses.%s' % self.BUILD_ARCH].append ('PciePm|Silicon/CommonSocPkg/Library/PciePmNull/PciePmNull.inf')
 
         dsc['PcdsFeatureFlag.%s' % self.BUILD_ARCH] = [
             'gPlatformTigerLakeTokenSpaceGuid.PcdFusaEnabled | $(HAVE_FUSA)'

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -83,6 +83,8 @@
 #include <Library/WatchDogTimerLib.h>
 #include "Dts.h"
 #include "SerialIo.h"
+#include <Library/PciePm.h>
+#include <Library/PlatformInfo.h>
 #include <Library/PlatformHookLib.h>
 
 
@@ -949,6 +951,9 @@ BoardInit (
     }
     break;
   case PostPciEnumeration:
+    if (FeaturePcdGet (PcdEnablePciePm)) {
+      PciePmConfig ();
+    }
     Status = SetFrameBufferWriteCombining (0, MAX_UINT32);
     if (EFI_ERROR(Status)) {
       DEBUG ((DEBUG_INFO, "Failed to set GFX framebuffer as WC\n"));
@@ -1661,6 +1666,10 @@ UpdateFspConfig (
       FspsConfig->SerialIoUartDmaEnable[Index]       = 1;
       FspsConfig->SerialIoUartDbg2[Index]            = 0;
     }
+  }
+
+  if (FeaturePcdGet (PcdEnablePciePm)) {
+    StoreRpConfig (FspsConfig);
   }
 }
 

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -70,6 +70,7 @@
   TccLib
   SmbiosInitLib
   WatchDogTimerLib
+  PciePm
 
 [Guids]
   gOsConfigDataGuid
@@ -110,4 +111,5 @@
   gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled
   gPlatformModuleTokenSpaceGuid.PcdAcpiTableTemplatePtr
   gPlatformModuleTokenSpaceGuid.PcdEnableDts
+  gPlatformModuleTokenSpaceGuid.PcdEnablePciePm
   gPlatformModuleTokenSpaceGuid.PcdPciResourceMem64Base

--- a/Silicon/CommonSocPkg/Include/Library/PciExpressHelpersLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/PciExpressHelpersLib.h
@@ -1,0 +1,172 @@
+/** @file
+  Header file for PCI Express helpers library
+
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _PCI_EXPRESS_HELPERS_LIB_H_
+#define _PCI_EXPRESS_HELPERS_LIB_H_
+
+#include <Library/PcieRpLib.h>
+
+typedef enum {
+  TpoScale2us,
+  TpoScale10us,
+  TpoScale100us,
+  TpoScaleMax
+} T_PO_SCALE;
+//
+// This structure keeps segment:bus:device:function coordinates of a PCIe device
+// in a single variable. PcieCap is offset to PCI Express capabilities.
+//
+typedef struct {
+  UINT32 Seg : 8;
+  UINT32 Bus : 8;
+  UINT32 Dev : 5;
+  UINT32 Func : 3;
+  UINT32 PcieCap : 8;
+} SBDF;
+
+/*
+  Converts Tpower_on from value:scale notation to microseconds
+
+  @param[in] TpoScale   T power on scale
+  @param[in] TpoValue   T power on value
+
+  @retval    number of microseconds
+*/
+UINT32
+TpoToUs (
+  UINT32 TpoScale,
+  UINT32 TpoValue
+  );
+
+/**
+PCIe controller Sku.
+**/
+
+typedef enum {
+  EnumPchPcie = 0,
+  EnumiTbtPcie = 1,
+  EnumCpuPcie = 2,
+  EnumPciSkuMax = 3
+} PCI_SKU;
+
+/*
+  Initializes the following features in rootport and devices behind it:
+  Maximum Payload Size (generic)
+  Rootport packet split (proprietary)
+  EonOfInterrupt forwarding (proprietary)
+  Common Clock Configuration (generic)
+
+  Generic: any code written according to PCIE Express base specification can do that.
+  Proprietary: code uses registers and features that are specific to Intel silicon
+  and probably only this Reference Code knows how to handle that.
+
+  If OEM implemented generic feature enabling in his platform code or trusts Operating System
+  to do it, then those features can be deleted from here.
+
+  CCC requires link retrain, which takes a while. CCC must happen before L0s/L1 programming.
+  If there was guarantee no code would access PCI while links retrain, it would be possible to skip this waiting
+
+  @param[in] RpSegment  address of rootport on PCIe
+  @param[in] RpBus      address of rootport on PCIe
+  @param[in] RpDevice   address of rootport on PCIe
+  @param[in] RpFunction address of rootport on PCIe
+  @param[in] BusMin     minimum Bus number that can be assigned below this rootport
+  @param[in] BusMax     maximum Bus number that can be assigned below this rootport
+*/
+VOID
+RootportDownstreamConfiguration (
+  UINT8                     RpSegment,
+  UINT8                     RpBus,
+  UINT8                     RpDevice,
+  UINT8                     RpFunction,
+  UINT8                     BusMin,
+  UINT8                     BusMax,
+  PCI_SKU                   PciSku
+  );
+
+/*
+  Configures the following power-management related features in rootport and devices behind it:
+  LTR limit (generic)
+  LTR override (proprietary)
+  Clock Power Management (generic)
+  L1 substates (generic except for the override table)
+  L1.LOW substate (proprietary)
+  L0s and L1 (generic)
+
+  Generic: any code written according to PCIE Express base specification can do that.
+  Proprietary: code uses registers and features that are specific to Intel silicon
+  and probably only this Reference Code knows how to handle that.
+
+  If OEM implemented generic feature enabling in his platform code or trusts Operating System
+  to do it, then those features can be deleted from here.
+
+  @param[in] RpSegment                address of rootport on PCIe
+  @param[in] RpBus                    address of rootport on PCIe
+  @param[in] RpDevice                 address of rootport on PCIe
+  @param[in] RpFunction               address of rootport on PCIe
+  @param[in] BusMin                   minimal Bus number that can be assigned below this rootport
+  @param[in] BusMax                   maximum Bus number that can be assigned below this rootport
+  @param[in] PcieRpCommonConfig       a pointer to Pcie Root Port Common Config
+  @param[in] AspmOverrideTableSize    size of override array
+  @param[in] AspmOverrideTable        array of device that need exceptions in configuration
+*/
+VOID
+RootportDownstreamPmConfiguration (
+  UINT8                               RpSegment,
+  UINT8                               RpBus,
+  UINT8                               RpDevice,
+  UINT8                               RpFunction,
+  UINT8                               BusMin,
+  UINT8                               BusMax,
+  PCIE_ROOT_PORT_COMMON_CONFIG        *PcieRpCommonConfig,
+  UINT32                              AspmOverrideTableSize,
+  PCH_PCIE_DEVICE_OVERRIDE            *AspmOverrideTable
+  );
+
+typedef struct {
+  UINT32 MaxSnoopLatencyValue         : 10;
+  UINT32 MaxSnoopLatencyScale         : 3;
+  UINT32 MaxNoSnoopLatencyValue       : 10;
+  UINT32 MaxNoSnoopLatencyScale       : 3;
+  UINT32 Reserved                     : 6;
+} LTR_LIMIT;
+
+/**
+  Checks if given PCI device is capable of Latency Tolerance Reporting
+
+  @param[in] Sbdf            device's segment:bus:device:function coordinates
+
+  @retval TRUE if yes
+**/
+BOOLEAN
+IsLtrCapable (
+  SBDF Sbdf
+  );
+
+/**
+  Returns combination of two LTR override values
+  The resulting LTR override separately chooses stricter limits for snoop and nosnoop
+
+  @param[in] LtrA      LTR override values to be combined
+  @param[in] LtrB      LTR override values to be combined
+
+  @retval LTR override value
+**/
+LTR_OVERRIDE
+CombineLtr (
+  LTR_OVERRIDE LtrA,
+  LTR_OVERRIDE LtrB
+  );
+
+/**
+  Extended Virtual Channel Configuration
+**/
+typedef struct {
+  UINT16 CapOffset;
+  UINT8  ExtVcCount;
+} MULTI_VC_SUPPORT;
+
+#endif // _PCI_EXPRESS_HELPERS_LIB_H_

--- a/Silicon/CommonSocPkg/Include/Library/PcieHelperLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/PcieHelperLib.h
@@ -1,0 +1,173 @@
+/** @file
+  Header file for PCI Express helpers base library
+
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _PCIE_HELPER_LIB_H_
+#define _PCIE_HELPER_LIB_H_
+
+#include <PcieRegs.h>
+#include <Library/PciSegmentLib.h>
+#include <Uefi/UefiBaseType.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <IndustryStandard/Pci.h>
+
+/**
+  Find the Offset to a given Capabilities ID
+  CAPID list:
+    0x01 = PCI Power Management Interface
+    0x04 = Slot Identification
+    0x05 = MSI Capability
+    0x10 = PCI Express Capability
+
+  @param[in] DeviceBase           device's base address
+  @param[in] CapId                CAPID to search for
+
+  @retval 0                       CAPID not found
+  @retval Other                   CAPID found, Offset of desired CAPID
+**/
+UINT8
+PcieBaseFindCapId (
+  IN UINT64  DeviceBase,
+  IN UINT8   CapId
+  );
+
+/**
+  Find the Offset to a given Capabilities ID
+  CAPID list:
+    0x01 = PCI Power Management Interface
+    0x04 = Slot Identification
+    0x05 = MSI Capability
+    0x10 = PCI Express Capability
+
+  @param[in] Segment              Pci Segment Number
+  @param[in] Bus                  Pci Bus Number
+  @param[in] Device               Pci Device Number
+  @param[in] Function             Pci Function Number
+  @param[in] CapId                CAPID to search for
+
+  @retval 0                       CAPID not found
+  @retval Other                   CAPID found, Offset of desired CAPID
+**/
+UINT8
+PcieFindCapId (
+  IN UINT8   Segment,
+  IN UINT8   Bus,
+  IN UINT8   Device,
+  IN UINT8   Function,
+  IN UINT8   CapId
+  );
+
+/**
+  Search and return the offset of desired Pci Express Capability ID
+  CAPID list:
+    0x0001 = Advanced Error Reporting Capability
+    0x0002 = Virtual Channel Capability
+    0x0003 = Device Serial Number Capability
+    0x0004 = Power Budgeting Capability
+
+  @param[in] DeviceBase           device base address
+  @param[in] CapId                Extended CAPID to search for
+
+  @retval 0                       CAPID not found, this includes situation where device doesn't exist
+  @retval Other                   CAPID found, Offset of desired CAPID
+**/
+UINT16
+PcieBaseFindExtendedCapId (
+  IN UINT64  DeviceBase,
+  IN UINT16  CapId
+  );
+
+/**
+  Search and return the offset of desired Pci Express Capability ID
+  CAPID list:
+    0x0001 = Advanced Error Rreporting Capability
+    0x0002 = Virtual Channel Capability
+    0x0003 = Device Serial Number Capability
+    0x0004 = Power Budgeting Capability
+
+  @param[in] Segment              Pci Segment Number
+  @param[in] Bus                  Pci Bus Number
+  @param[in] Device               Pci Device Number
+  @param[in] Function             Pci Function Number
+  @param[in] CapId                Extended CAPID to search for
+
+  @retval 0                       CAPID not found
+  @retval Other                   CAPID found, Offset of desired CAPID
+**/
+UINT16
+PcieFindExtendedCapId (
+  IN UINT8   Segment,
+  IN UINT8   Bus,
+  IN UINT8   Device,
+  IN UINT8   Function,
+  IN UINT16  CapId
+  );
+
+/*
+  Checks device's Slot Clock Configuration
+
+  @param[in] Base            device's base address
+  @param[in] PcieCapOffset   devices Pci express capability list register offset
+
+  @retval TRUE when device device uses slot clock, FALSE otherwise
+*/
+BOOLEAN
+GetScc (
+  UINT64    Base,
+  UINT8     PcieCapOffset
+  );
+
+/*
+  Sets Common Clock Configuration bit for given device.
+  @param[in] PcieCapOffset   devices Pci express capability list register offset
+  @param[in] Base            device's base address
+*/
+VOID
+EnableCcc (
+  UINT64    Base,
+  UINT8     PcieCapOffset
+  );
+
+/*
+  Retrains link behind given device.
+  It only makes sense to call it for downstream ports.
+  If called for upstream port nothing will happen, it won't enter infinite loop.
+
+  @param[in] Base                 device's base address
+  @param[in] PcieCapOffset        devices Pci express capability list register offset
+  @param[boolean] WaitUnitlDone   when TRUE, function waits until link has retrained
+*/
+VOID
+RetrainLink (
+  UINT64  Base,
+  UINT8   PcieCapOffset,
+  BOOLEAN WaitUntilDone
+  );
+
+/*
+  Checks if device at given address exists
+
+  @param[in] Base            device's base address
+
+  @retval TRUE when device exists; FALSE otherwise
+*/
+BOOLEAN
+IsDevicePresent (
+  UINT64 Base
+  );
+
+/*
+  Checks if device is a multifunction device
+
+  @param[in] Base            device's base address
+
+  @retval TRUE if multifunction; FALSE otherwise
+*/
+BOOLEAN
+IsMultifunctionDevice (
+  UINT64 Base
+  );
+#endif // _PCIE_HELPER_LIB_H_

--- a/Silicon/CommonSocPkg/Include/Library/PciePm.h
+++ b/Silicon/CommonSocPkg/Include/Library/PciePm.h
@@ -1,0 +1,33 @@
+/** @file
+  Header file for Pcie PM (power management control). Platform can provide
+  an implementation.
+
+  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _PCIE_PM_H_
+#define _PCIE_PM_H_
+
+/**
+  Store Root Port Config based on FSP-s UPDs
+
+  @param[in]  FspsConfig       The pointer to FSP-S Config
+
+**/
+VOID
+EFIAPI
+StoreRpConfig (
+  VOID  *FspsConfig
+);
+
+
+/**
+  Config PCIE power management settings
+**/
+VOID
+EFIAPI
+PciePmConfig (
+  VOID
+);
+
+#endif // _PCIE_PM_H_

--- a/Silicon/CommonSocPkg/Include/Library/PlatformInfo.h
+++ b/Silicon/CommonSocPkg/Include/Library/PlatformInfo.h
@@ -1,0 +1,33 @@
+/** @file
+  Header file for Platform Info. Platform can provide an implementation.
+
+  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _PLATFORM_INFO_H_
+#define _PLATFORM_INFO_H_
+
+#include <CpuRegs.h>
+
+/**
+  Get CPU Family ID
+
+  @retval CPU Family ID
+**/
+CPU_FAMILY
+EFIAPI
+GetCpuFamily (
+  VOID
+);
+
+/**
+  Get Maximum CPU Pcie Root Port Number
+
+  @retval Maximum CPU Pcie Root Port Number
+**/
+UINT8
+GetMaxCpuPciePortNum (
+  VOID
+);
+
+#endif // _PLATFORM_INFO_H_

--- a/Silicon/CommonSocPkg/Library/PciePmNull/PciePmNull.c
+++ b/Silicon/CommonSocPkg/Library/PciePmNull/PciePmNull.c
@@ -1,0 +1,35 @@
+/** @file
+  This file implements default PCIe PM interfaces
+
+  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#include <Uefi.h>
+
+/**
+  Store Root Port Config based on FSP-s UPDs
+
+  @param[in]  FspsConfig       The pointer to FSP-S Config
+
+**/
+VOID
+EFIAPI
+StoreRpConfig (
+  VOID        *FspsConfig
+)
+{
+  return;
+}
+
+/**
+  Config PCIE power management settings
+**/
+VOID
+EFIAPI
+PciePmConfig (
+  VOID
+)
+{
+  return;
+}
+

--- a/Silicon/CommonSocPkg/Library/PciePmNull/PciePmNull.inf
+++ b/Silicon/CommonSocPkg/Library/PciePmNull/PciePmNull.inf
@@ -1,0 +1,28 @@
+## @file
+#
+# Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010017
+  BASE_NAME                      = PciePm
+  FILE_GUID                      = c69bfb95-be8f-41df-8fef-eca5727fbb81
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = PciePm
+
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+
+[Sources]
+  PciePmNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec

--- a/Silicon/TigerlakePchPkg/Include/Library/PchPcieRpConfig.h
+++ b/Silicon/TigerlakePchPkg/Include/Library/PchPcieRpConfig.h
@@ -1,0 +1,271 @@
+/** @file
+  PCH Pcie root port policy
+
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _PCH_PCIERP_CONFIG_H_
+#define _PCH_PCIERP_CONFIG_H_
+
+#include <PchLimits.h>
+#include <PcieConfig.h>
+
+#define PCIE_RP_CONFIG_REVISION 1
+#define PCIE_RP_PREMEM_CONFIG_REVISION 1
+#define PCIE_RP_DXE_CONFIG_REVISION 1
+
+#pragma pack (push,1)
+
+#define PCIE_LINK_EQ_COEFFICIENTS_MAX 10
+#define PCIE_LINK_EQ_PRESETS_MAX 11
+
+typedef enum {
+  PchPcieOverrideDisabled             = 0,
+  PchPcieL1L2Override                 = 0x01,
+  PchPcieL1SubstatesOverride          = 0x02,
+  PchPcieL1L2AndL1SubstatesOverride   = 0x03,
+  PchPcieLtrOverride                  = 0x04
+} PCH_PCIE_OVERRIDE_CONFIG;
+
+/**
+  PCIe device table entry entry
+
+  The PCIe device table is being used to override PCIe device ASPM settings.
+  To take effect table consisting of such entries must be instelled as PPI
+  on gPchPcieDeviceTablePpiGuid.
+  Last entry VendorId must be 0.
+**/
+typedef struct {
+  UINT16  VendorId;                    ///< The vendor Id of Pci Express card ASPM setting override, 0xFFFF means any Vendor ID
+  UINT16  DeviceId;                    ///< The Device Id of Pci Express card ASPM setting override, 0xFFFF means any Device ID
+  UINT8   RevId;                       ///< The Rev Id of Pci Express card ASPM setting override, 0xFF means all steppings
+  UINT8   BaseClassCode;               ///< The Base Class Code of Pci Express card ASPM setting override, 0xFF means all base class
+  UINT8   SubClassCode;                ///< The Sub Class Code of Pci Express card ASPM setting override, 0xFF means all sub class
+  UINT8   EndPointAspm;                ///< Override device ASPM (see: PCH_PCIE_ASPM_CONTROL)
+                                       ///< Bit 1 must be set in OverrideConfig for this field to take effect
+  UINT16  OverrideConfig;              ///< The override config bitmap (see: PCH_PCIE_OVERRIDE_CONFIG).
+  /**
+    The L1Substates Capability Offset Override. (applicable if bit 2 is set in OverrideConfig)
+    This field can be zero if only the L1 Substate value is going to be override.
+  **/
+  UINT16  L1SubstatesCapOffset;
+  /**
+    L1 Substate Capability Mask. (applicable if bit 2 is set in OverrideConfig)
+    Set to zero then the L1 Substate Capability [3:0] is ignored, and only L1s values are override.
+    Only bit [3:0] are applicable. Other bits are ignored.
+  **/
+  UINT8   L1SubstatesCapMask;
+  /**
+    L1 Substate Port Common Mode Restore Time Override. (applicable if bit 2 is set in OverrideConfig)
+    L1sCommonModeRestoreTime and L1sTpowerOnScale can have a valid value of 0, but not the L1sTpowerOnValue.
+    If L1sTpowerOnValue is zero, all L1sCommonModeRestoreTime, L1sTpowerOnScale, and L1sTpowerOnValue are ignored,
+    and only L1SubstatesCapOffset is override.
+  **/
+  UINT8   L1sCommonModeRestoreTime;
+  /**
+    L1 Substate Port Tpower_on Scale Override. (applicable if bit 2 is set in OverrideConfig)
+    L1sCommonModeRestoreTime and L1sTpowerOnScale can have a valid value of 0, but not the L1sTpowerOnValue.
+    If L1sTpowerOnValue is zero, all L1sCommonModeRestoreTime, L1sTpowerOnScale, and L1sTpowerOnValue are ignored,
+    and only L1SubstatesCapOffset is override.
+  **/
+  UINT8   L1sTpowerOnScale;
+  /**
+    L1 Substate Port Tpower_on Value Override. (applicable if bit 2 is set in OverrideConfig)
+    L1sCommonModeRestoreTime and L1sTpowerOnScale can have a valid value of 0, but not the L1sTpowerOnValue.
+    If L1sTpowerOnValue is zero, all L1sCommonModeRestoreTime, L1sTpowerOnScale, and L1sTpowerOnValue are ignored,
+    and only L1SubstatesCapOffset is override.
+  **/
+  UINT8   L1sTpowerOnValue;
+
+  /**
+    SnoopLatency bit definition
+    Note: All Reserved bits must be set to 0
+
+    BIT[15]     - When set to 1b, indicates that the values in bits 9:0 are valid
+                  When clear values in bits 9:0 will be ignored
+    BITS[14:13] - Reserved
+    BITS[12:10] - Value in bits 9:0 will be multiplied with the scale in these bits
+                  000b - 1 ns
+                  001b - 32 ns
+                  010b - 1024 ns
+                  011b - 32,768 ns
+                  100b - 1,048,576 ns
+                  101b - 33,554,432 ns
+                  110b - Reserved
+                  111b - Reserved
+    BITS[9:0]   - Snoop Latency Value. The value in these bits will be multiplied with
+                  the scale in bits 12:10
+
+    This field takes effect only if bit 3 is set in OverrideConfig.
+  **/
+  UINT16  SnoopLatency;
+  /**
+    NonSnoopLatency bit definition
+    Note: All Reserved bits must be set to 0
+
+    BIT[15]     - When set to 1b, indicates that the values in bits 9:0 are valid
+                  When clear values in bits 9:0 will be ignored
+    BITS[14:13] - Reserved
+    BITS[12:10] - Value in bits 9:0 will be multiplied with the scale in these bits
+                  000b - 1 ns
+                  001b - 32 ns
+                  010b - 1024 ns
+                  011b - 32,768 ns
+                  100b - 1,048,576 ns
+                  101b - 33,554,432 ns
+                  110b - Reserved
+                  111b - Reserved
+    BITS[9:0]   - Non Snoop Latency Value. The value in these bits will be multiplied with
+                  the scale in bits 12:10
+
+    This field takes effect only if bit 3 is set in OverrideConfig.
+  **/
+  UINT16  NonSnoopLatency;
+
+  /**
+    Forces LTR override to be permanent
+    The default way LTR override works is:
+      rootport uses LTR override values provided by BIOS until connected device sends an LTR message, then it will use values from the message
+    This settings allows force override of LTR mechanism. If it's enabled, then:
+      rootport will use LTR override values provided by BIOS forever; LTR messages sent from connected device will be ignored
+  **/
+  UINT8  ForceLtrOverride;
+  UINT8  Reserved[3];
+} PCH_PCIE_DEVICE_OVERRIDE;
+
+///
+/// The values before AutoConfig match the setting of PCI Express Base Specification 1.1, please be careful for adding new feature
+///
+typedef enum {
+  PchPcieAspmDisabled,
+  PchPcieAspmL0s,
+  PchPcieAspmL1,
+  PchPcieAspmL0sL1,
+  PchPcieAspmAutoConfig,
+  PchPcieAspmMax
+} PCH_PCIE_ASPM_CONTROL;
+
+/**
+  Refer to PCH EDS for the PCH implementation values corresponding
+  to below PCI-E spec defined ranges
+**/
+typedef enum {
+  PchPcieL1SubstatesDisabled,
+  PchPcieL1SubstatesL1_1,
+  PchPcieL1SubstatesL1_1_2,
+  PchPcieL1SubstatesMax
+} PCH_PCIE_L1SUBSTATES_CONTROL;
+
+enum PCH_PCIE_MAX_PAYLOAD {
+  PchPcieMaxPayload128 = 0,
+  PchPcieMaxPayload256,
+  PchPcieMaxPayloadMax
+};
+
+typedef enum {
+  PcieLinkHardwareEq = 0,  ///< Hardware is responsible for performing coefficient/preset search.
+  PcieLinkFixedEq          ///< No coefficient/preset search is performed. Fixed values are used.
+} PCIE_LINK_EQ_METHOD;
+
+typedef enum {
+  PcieLinkEqPresetMode = 0,   ///< Use presets during PCIe link equalization
+  PcieLinkEqCoefficientMode   ///< Use coefficients during PCIe link equalization
+} PCIE_LINK_EQ_MODE;
+
+typedef struct {
+  UINT32  PreCursor;    ///< Pre-cursor coefficient
+  UINT32  PostCursor;   ///< Post-cursor coefficient
+} PCIE_LINK_EQ_COEFFICIENTS;
+
+/**
+  PCIe Link EQ Platform Settings
+**/
+typedef struct {
+  UINT8                      PcieLinkEqMethod;               ///< Tells BIOS which link EQ method should be used for this port. Please refer to PCIE_LINK_EQ_METHOD for details of supported methods. Default: PcieLinkHardwareEq
+  UINT8                      PcieLinkEqMode;                 ///< Tells BIOS which mode should be used for PCIe link EQ. Please refer to PCIE_LINK_EQ_MODE for details of supported modes. Default: depends on SoC
+  /**
+    Specifies if BIOS should perform local transmitter override during phase 2 of EQ process.
+    If enabled value in Ph2LocalTransmitterOverridePreset must be valid.
+    <b>0: Disabled</b>; 1: Enabled
+  **/
+  UINT8                      LocalTransmitterOverrideEnable;
+  /**
+    Tells BIOS how many presets/coefficients should be used during link EQ.
+    Entries in the Ph3CoefficientsList or Ph3PresetList(depending on chosen mode) need to be valid up to the number specified in this field.
+  **/
+  UINT8                      Ph3NumberOfPresetsOrCoefficients;
+
+  PCIE_LINK_EQ_COEFFICIENTS  Ph3CoefficientsList[PCIE_LINK_EQ_COEFFICIENTS_MAX];  ///< List of the PCIe coefficients to be used during equalization process. Only valid if PcieLinkEqMode is PcieLinkEqCoefficientMode
+  UINT32                     Ph3PresetList[PCIE_LINK_EQ_PRESETS_MAX];             ///< List of the PCIe preset values to be used during equalization process. Only valid if PcieLinkEqMode is PcieLinkEqPresetMode
+  UINT32                     Ph1DownstreamPortTransmitterPreset;  ///< Specifies the value of the downstream port transmitter preset to be used during phase 1 of the equalization process. Will be applied to all lanes
+  UINT32                     Ph1UpstreamPortTransmitterPreset;    ///< Specifies the value of the upstream port transmitter preset to be used during phase 1 of the equalization process. Will be applied to all lanes
+  /**
+    Specifies the preset that should be used during local transmitter override during phase 2 of EQ process.
+    Used only if LocalTransmitterOverrideEnable is TRUE. Will be applied to all PCIe lanes of the root port.
+    Valid up to the PCIE_LINK_EQ_PRESET_MAX value. <b>Default: 0<\b>
+  **/
+  UINT32                     Ph2LocalTransmitterOverridePreset;
+} PCIE_LINK_EQ_PLATFORM_SETTINGS;
+
+#define PCH_PCIE_NO_SUCH_CLOCK 0xFF
+
+typedef enum {
+  PchClockUsagePchPcie0      = 0,
+  PchClockUsagePchPcie1      = 1,
+  PchClockUsagePchPcie2      = 2,
+  PchClockUsagePchPcie3      = 3,
+  PchClockUsagePchPcie4      = 4,
+  PchClockUsagePchPcie5      = 5,
+  PchClockUsagePchPcie6      = 6,
+  PchClockUsagePchPcie7      = 7,
+  PchClockUsagePchPcie8      = 8,
+  PchClockUsagePchPcie9      = 9,
+  PchClockUsagePchPcie10     = 10,
+  PchClockUsagePchPcie11     = 11,
+  PchClockUsagePchPcie12     = 12,
+  PchClockUsagePchPcie13     = 13,
+  PchClockUsagePchPcie14     = 14,
+  PchClockUsagePchPcie15     = 15,
+  PchClockUsagePchPcie16     = 16,
+  PchClockUsagePchPcie17     = 17,
+  PchClockUsagePchPcie18     = 18,
+  PchClockUsagePchPcie19     = 19,
+  PchClockUsagePchPcie20     = 20,
+  PchClockUsagePchPcie21     = 21,
+  PchClockUsagePchPcie22     = 22,
+  PchClockUsagePchPcie23     = 23,
+  /**
+    Quantity of PCH and CPU PCIe ports, as well as their encoding in this enum, may change between
+    silicon generations and series. Do not assume that PCH port 0 will be always encoded by 0.
+    Instead, it is recommended to use (PchClockUsagePchPcie0 + PchPortIndex) style to be forward-compatible
+  **/
+  PchClockUsageCpuPcie0      = 0x40,
+  PchClockUsageCpuPcie1      = 0x41,
+  PchClockUsageCpuPcie2      = 0x42,
+  PchClockUsageCpuPcie3      = 0x43,
+
+  PchClockUsageLan           = 0x70,
+  PchClockUsageUnspecified   = 0x80, ///< In use for a purpose not listed above
+  PchClockUsageNotUsed       = 0xFF
+} PCH_PCIE_CLOCK_USAGE;
+
+/**
+  PCH_PCIE_CLOCK describes PCIe source clock generated by PCH.
+**/
+typedef struct {
+  UINT8   Usage;        ///< Purpose of given clock (see PCH_PCIE_CLOCK_USAGE). Default: Unused, 0xFF
+  UINT8   ClkReq;       ///< ClkSrc - ClkReq mapping. Default: 1:1 mapping with Clock numbers
+  UINT8   RsvdBytes[2]; ///< Reserved byte
+} PCH_PCIE_CLOCK;
+
+/**
+  The PCH_PCI_EXPRESS_ROOT_PORT_CONFIG describe the feature and capability of each PCH PCIe root port.
+**/
+typedef struct {
+  PCIE_ROOT_PORT_COMMON_CONFIG  PcieRpCommonConfig; ///an instance of Pcie Common Config
+} PCH_PCIE_ROOT_PORT_CONFIG;
+
+
+#pragma pack (pop)
+
+#endif // _PCH_PCIERP_CONFIG_H_

--- a/Silicon/TigerlakePchPkg/Include/Library/PchPcieRpLib.h
+++ b/Silicon/TigerlakePchPkg/Include/Library/PchPcieRpLib.h
@@ -1,0 +1,123 @@
+/** @file
+  Header file for PchPcieRpLib.
+
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _PCH_PCIERP_LIB_H_
+#define _PCH_PCIERP_LIB_H_
+
+#include <Library/PchPcrLib.h>
+
+/**
+  PCIe controller bifurcation configuration.
+**/
+typedef enum {
+  PcieBifurcationDefault = 0,
+  PcieBifurcation4x1,
+  PcieBifurcation1x2_2x1,
+  PcieBifurcation2x2,
+  PcieBifurcation1x4,
+  PcieBifurcation4x2,
+  PcieBifurcation1x4_2x2,
+  PcieBifurcation2x2_1x4,
+  PcieBifurcation2x4,
+  PcieBifurcation1x8,
+  PcieBifurcationUnknown,
+  PcieBifurcationMax
+} PCIE_BIFURCATION_CONFIG;
+
+/**
+  This function returns PID according to PCIe controller index
+
+  @param[in] ControllerIndex     PCIe controller index
+
+  @retval PCH_SBI_PID    Returns PID for SBI Access
+**/
+PCH_SBI_PID
+PchGetPcieControllerSbiPid (
+  IN UINT32  ControllerIndex
+  );
+
+/**
+  This function returns PID according to Root Port Number
+
+  @param[in] RpIndex     Root Port Index (0-based)
+
+  @retval PCH_SBI_PID    Returns PID for SBI Access
+**/
+PCH_SBI_PID
+GetRpSbiPid (
+  IN UINTN  RpIndex
+  );
+
+/**
+  Get Pch Pcie Root Port Device and Function Number by Root Port physical Number
+
+  @param[in]  RpNumber            Root port physical number. (0-based)
+  @param[out] RpDev               Return corresponding root port device number.
+  @param[out] RpFun               Return corresponding root port function number.
+
+  @retval EFI_SUCCESS
+**/
+EFI_STATUS
+EFIAPI
+GetPchPcieRpDevFun (
+  IN  UINTN   RpNumber,
+  OUT UINTN   *RpDev,
+  OUT UINTN   *RpFun
+  );
+
+/**
+  Get Root Port physical Number by Pch Pcie Root Port Device and Function Number
+
+  @param[in]  RpDev                 Root port device number.
+  @param[in]  RpFun                 Root port function number.
+  @param[out] RpNumber              Return corresponding physical Root Port index (0-based)
+
+  @retval     EFI_SUCCESS           Physical root port is retrieved
+  @retval     EFI_INVALID_PARAMETER RpDev and/or RpFun are invalid
+  @retval     EFI_UNSUPPORTED       Root port device and function is not assigned to any physical root port
+**/
+EFI_STATUS
+EFIAPI
+GetPchPcieRpNumber (
+  IN  UINTN   RpDev,
+  IN  UINTN   RpFun,
+  OUT UINTN   *RpNumber
+  );
+
+/**
+  Gets pci segment base address of PCIe root port.
+
+  @param RpIndex    Root Port Index (0 based)
+  @return PCIe port base address.
+**/
+UINT64
+PchPcieBase (
+  IN  UINT32   RpIndex
+  );
+
+/**
+  Determines whether L0s is supported on current stepping.
+
+  @return TRUE if L0s is supported, FALSE otherwise
+**/
+BOOLEAN
+PchIsPcieL0sSupported (
+  VOID
+  );
+
+/**
+  Some early PCH steppings require Native ASPM to be disabled due to hardware issues:
+   - RxL0s exit causes recovery
+   - Disabling PCIe L0s capability disables L1
+  Use this function to determine affected steppings.
+
+  @return TRUE if Native ASPM is supported, FALSE otherwise
+**/
+BOOLEAN
+PchIsPcieNativeAspmSupported (
+  VOID
+  );
+#endif // _PCH_PCIERP_LIB_H_

--- a/Silicon/TigerlakePchPkg/Include/Library/PcieRpLib.h
+++ b/Silicon/TigerlakePchPkg/Include/Library/PcieRpLib.h
@@ -1,0 +1,95 @@
+/** @file
+  Header file for PCH PCI Express helpers library
+
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _PCIE_RP_LIB_
+#define _PCIE_RP_LIB_
+
+#include <PcieConfig.h>
+
+typedef struct {
+  UINT32 MaxSnoopLatencyValue         : 10;
+  UINT32 MaxSnoopLatencyScale         : 3;
+  UINT32 MaxSnoopLatencyRequirement   : 1;
+  UINT32 MaxNoSnoopLatencyValue       : 10;
+  UINT32 MaxNoSnoopLatencyScale       : 3;
+  UINT32 MaxNoSnoopLatencyRequirement : 1;
+  UINT32 ForceOverride                : 1;
+} LTR_OVERRIDE;
+
+/**
+  Get PCIe port number for enabled Root Port.
+
+  @param[in] RpBase    Root Port pci segment base address
+
+  @retval Root Port number (1 based)
+**/
+UINT32
+PciePortNum (
+  IN     UINT64  RpBase
+  );
+
+/**
+  Get PCIe root port index
+  @param[in] RpBase    Root Port pci segment base address
+  @return Root Port index (0 based)
+**/
+UINT32
+PciePortIndex (
+  IN     UINT64  RpBase
+  );
+
+/**
+  This function checks whether PHY lane power gating is enabled on the port.
+
+  @param[in] RpBase                 Root Port base address
+
+  @retval TRUE                      PHY power gating is enabled
+  @retval FALSE                     PHY power gating disabled
+**/
+BOOLEAN
+PcieIsPhyLanePgEnabled (
+  IN     UINT64  RpBase
+  );
+
+/**
+  Configures Root Port packet split.
+
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+  @param[in] Mps                            maximum packet size
+**/
+VOID
+ConfigureRpPacketSplit (
+  UINT64 RpBase,
+  UINT8  Mps
+  );
+
+/**
+  Configures LTR override in Root Port's proprietary registers.
+
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+  @param[in] LtrConfig                      Root Port LTR configuration
+  @param[in] AspmOverride                   combination of LTR override values from all devices under this Root Port
+**/
+VOID
+ConfigureRpLtrOverride (
+  UINT64           RpBase,
+  UINT32           DevNum,
+  LTR_OVERRIDE     *TreeLtr,
+  PCIE_LTR_CONFIG  *LtrConfig
+  );
+
+/**
+  Configures proprietary parts of L1 substates configuration in Root Port
+
+  @param[in] RpSbdf       segment:bus:device:function coordinates of Root Port
+  @param[in] LtrCapable   TRUE if Root Port is LTR capable
+**/
+VOID
+L1ssProprietaryConfiguration (
+  UINT64  RpBase,
+  BOOLEAN LtrCapable
+  );
+#endif

--- a/Silicon/TigerlakePchPkg/Include/PchPcieRpInfo.h
+++ b/Silicon/TigerlakePchPkg/Include/PchPcieRpInfo.h
@@ -1,0 +1,16 @@
+/** @file
+  Pcie Root Port info header
+
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef _PCH_PCIERP_INFO_H_
+#define _PCH_PCIERP_INFO_H_
+
+//
+// Number of PCIe ports per PCIe controller
+//
+#define PCH_PCIE_CONTROLLER_PORTS                     4u
+
+#endif

--- a/Silicon/TigerlakePchPkg/Include/PcieConfig.h
+++ b/Silicon/TigerlakePchPkg/Include/PcieConfig.h
@@ -1,0 +1,217 @@
+/** @file
+  PCIe Config Block
+
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _PCIE_CONFIG_H_
+#define _PCIE_CONFIG_H_
+#include <CpuPcieInfo.h>
+
+#define PCIE_CONFIG_REVISION  3
+/*
+<b>Revision 2< / b>:
+FomsCp - Deprecated
+<b>Revision 3< / b>:
+Added PCIE_EQ_PARAM  HwEqGen3CoeffList for all CPU_PCIE_MAX_ROOT_PORTS
+Added PCIE_EQ_PARAM  HwEqGen4CoeffList for all CPU_PCIE_MAX_ROOT_PORTS
+Added PCIE_EQ_PARAM  HwEqGen5CoeffList for all CPU_PCIE_MAX_ROOT_PORTS
+*/
+
+extern EFI_GUID gPcieConfigGuid;
+
+#pragma pack (push,1)
+
+enum PCIE_COMPLETION_TIMEOUT {
+  PcieCompletionTO_Default,
+  PcieCompletionTO_50_100us,
+  PcieCompletionTO_1_10ms,
+  PcieCompletionTO_16_55ms,
+  PcieCompletionTO_65_210ms,
+  PcieCompletionTO_260_900ms,
+  PcieCompletionTO_1_3P5s,
+  PcieCompletionTO_4_13s,
+  PcieCompletionTO_17_64s,
+  PcieCompletionTO_Disabled
+};
+
+enum PCIE_SPEED {
+  PcieAuto,
+  PcieGen1,
+  PcieGen2,
+  PcieGen3,
+  PcieGen4
+};
+
+/**
+  Represent lane specific PCIe Gen3 equalization parameters.
+**/
+typedef struct {
+  UINT8   Cm;                 ///< Coefficient C-1
+  UINT8   Cp;                 ///< Coefficient C+1
+  UINT8   Rsvd0[2];           ///< Reserved bytes
+} PCIE_EQ_PARAM;
+
+typedef struct {
+  UINT16  LtrMaxSnoopLatency;                     ///< <b>(Test)</b> Latency Tolerance Reporting, Max Snoop Latency.
+  UINT16  LtrMaxNoSnoopLatency;                   ///< <b>(Test)</b> Latency Tolerance Reporting, Max Non-Snoop Latency.
+  UINT8   SnoopLatencyOverrideMode;               ///< <b>(Test)</b> Latency Tolerance Reporting, Snoop Latency Override Mode.
+  UINT8   SnoopLatencyOverrideMultiplier;         ///< <b>(Test)</b> Latency Tolerance Reporting, Snoop Latency Override Multiplier.
+  UINT16  SnoopLatencyOverrideValue;              ///< <b>(Test)</b> Latency Tolerance Reporting, Snoop Latency Override Value.
+  UINT8   NonSnoopLatencyOverrideMode;            ///< <b>(Test)</b> Latency Tolerance Reporting, Non-Snoop Latency Override Mode.
+  UINT8   NonSnoopLatencyOverrideMultiplier;      ///< <b>(Test)</b> Latency Tolerance Reporting, Non-Snoop Latency Override Multiplier.
+  UINT16  NonSnoopLatencyOverrideValue;           ///< <b>(Test)</b> Latency Tolerance Reporting, Non-Snoop Latency Override Value.
+  UINT8   LtrConfigLock;                          ///< <b>0: Disable</b>; 1: Enable.
+  UINT8   ForceLtrOverride;
+  UINT16  RsvdByte1;
+} PCIE_LTR_CONFIG;
+
+
+/**
+  Specifies the form factor that the slot
+  implements. For custom form factors that
+  do not require any special handling please
+  set PcieFormFactorOther.
+**/
+typedef enum {
+  PcieFormFactorOther = 0,
+  PcieFormFactorCem,
+  PcieFormFactorMiniPci,
+  PcieFormFactorM2,
+  PcieFormFactorOcuLink,
+  PcieFormFactorExpressModule, // Also known as Server IO module(SIOM)
+  PcieFormFactorExpressCard,
+  PcieFormFactorU2 // Also known as SF-8639
+} PCIE_FORM_FACTOR;
+
+//Note: This structure will be expanded to hold all common PCIe policies between SA and PCH RootPort
+typedef struct {
+  UINT32  HotPlug                         :  1;   ///< Indicate whether the root port is hot plug available. <b>0: Disable</b>; 1: Enable.
+  UINT32  PmSci                           :  1;   ///< Indicate whether the root port power manager SCI is enabled. 0: Disable; <b>1: Enable</b>.
+  UINT32  TransmitterHalfSwing            :  1;   ///< Indicate whether the Transmitter Half Swing is enabled. <b>0: Disable</b>; 1: Enable.
+  UINT32  AcsEnabled                      :  1;   ///< Indicate whether the ACS is enabled. 0: Disable; <b>1: Enable</b>.
+  //
+  // Error handlings
+  //
+  UINT32  AdvancedErrorReporting          :  1;   ///< Indicate whether the Advanced Error Reporting is enabled. <b>0: Disable</b>; 1: Enable.
+  UINT32  UnsupportedRequestReport        :  1;   ///< Indicate whether the Unsupported Request Report is enabled. <b>0: Disable</b>; 1: Enable.
+  UINT32  FatalErrorReport                :  1;   ///< Indicate whether the Fatal Error Report is enabled. <b>0: Disable</b>; 1: Enable.
+  UINT32  NoFatalErrorReport              :  1;   ///< Indicate whether the No Fatal Error Report is enabled. <b>0: Disable</b>; 1: Enable.
+  UINT32  CorrectableErrorReport          :  1;   ///< Indicate whether the Correctable Error Report is enabled. <b>0: Disable</b>; 1: Enable.
+  UINT32  SystemErrorOnFatalError         :  1;   ///< Indicate whether the System Error on Fatal Error is enabled. <b>0: Disable</b>; 1: Enable.
+  UINT32  SystemErrorOnNonFatalError      :  1;   ///< Indicate whether the System Error on Non Fatal Error is enabled. <b>0: Disable</b>; 1: Enable.
+  UINT32  SystemErrorOnCorrectableError   :  1;   ///< Indicate whether the System Error on Correctable Error is enabled. <b>0: Disable</b>; 1: Enable.
+  /**
+    Max Payload Size supported, Default <b>128B</b>, see enum CPU_PCIE_MAX_PAYLOAD
+    Changes Max Payload Size Supported field in Device Capabilities of the root port.
+  **/
+  UINT32  MaxPayload                      :  2;
+  UINT32  DpcEnabled                      :  1;   ///< Downstream Port Containment. 0: Disable; <b>1: Enable</b>
+  UINT32  RpDpcExtensionsEnabled          :  1;   ///< RP Extensions for Downstream Port Containment. 0: Disable; <b>1: Enable</b>
+  /**
+    Indicates how this root port is connected to endpoint. 0: built-in device; <b>1: slot</b>
+    Built-in is incompatible with hotplug-capable ports.
+  **/
+  UINT32  SlotImplemented                 :  1;
+  UINT32  PtmEnabled                      :  1;   ///< Enables PTM capability
+  UINT32  SlotPowerLimitScale             :  2;   ///< <b>(Test)</b> Specifies scale used for slot power limit value. Leave as 0 to set to default. Default is <b>zero</b>.
+  UINT32  SlotPowerLimitValue             : 12;   //< <b>(Test)</b> Specifies upper limit on power supplies by slot. Leave as 0 to set to default. Default is <b>zero</b>.
+  /**
+    Probe CLKREQ# signal before enabling CLKREQ# based power management.
+    Conforming device shall hold CLKREQ# low until CPM is enabled. This feature attempts
+    to verify CLKREQ# signal is connected by testing pad state before enabling CPM.
+    In particular this helps to avoid issues with open-ended PCIe slots.
+    This is only applicable to non hot-plug ports.
+    <b>0: Disable</b>; 1: Enable.
+  **/
+  UINT32  ClkReqDetect                    :  1;
+  /**
+    Set if the slot supports manually operated retention latch.
+  **/
+  UINT32  MrlSensorPresent                :  1;
+  UINT32  RelaxedOrder                    :  1;
+  UINT32  NoSnoop                         :  1;
+  UINT32  RsvdBits0                       : 28;   ///< Reserved bits.
+  /**
+    PCIe Gen3 Equalization Phase 3 Method (see CPU_PCIE_EQ_METHOD).
+    0: DEPRECATED, hardware equalization; <b>1: hardware equalization</b>; 4: Fixed Coefficients
+  **/
+  UINT8   Gen3EqPh3Method;
+  UINT8   PhysicalSlotNumber;                     ///< Indicates the slot number for the root port. Default is the value as root port index.
+  UINT8   CompletionTimeout;                      ///< The completion timeout configuration of the root port (see: CPU_PCIE_COMPLETION_TIMEOUT). Default is <b>PchPcieCompletionTO_Default</b>.
+  //
+  // Power Management
+  //
+  UINT8   Aspm;                                   ///< The ASPM configuration of the root port (see: CPU_PCIE_ASPM_CONTROL). Default is <b>PchPcieAspmAutoConfig</b>.
+  UINT8   L1Substates;                            ///< The L1 Substates configuration of the root port (see: CPU_PCIE_L1SUBSTATES_CONTROL). Default is <b>PchPcieL1SubstatesL1_1_2</b>.
+  UINT8   LtrEnable;                              ///< Latency Tolerance Reporting Mechanism. <b>0: Disable</b>; 1: Enable.
+  UINT8   EnableCpm;                              ///< Enables Clock Power Management; even if disabled, CLKREQ# signal can still be controlled by L1 PM substates mechanism
+  UINT8   PcieSpeed;                              ///< Contains speed of PCIe bus (see: PCIE_SPEED)
+  /**
+  <b>(Test)</b>
+  Forces LTR override to be permanent
+  The default way LTR override works is:
+  rootport uses LTR override values provided by BIOS until connected device sends an LTR message, then it will use values from the message
+  This settings allows force override of LTR mechanism. If it's enabled, then:
+  rootport will use LTR override values provided by BIOS forever; LTR messages sent from connected device will be ignored
+  **/
+  PCIE_LTR_CONFIG               PcieRpLtrConfig;            ///< <b>(Test)</b> Latency Tolerance Reporting Policies including LTR limit and Override
+    /**
+    The number of milliseconds reference code will wait for link to exit Detect state for enabled ports
+    before assuming there is no device and potentially disabling the port.
+    It's assumed that the link will exit detect state before root port initialization (sufficient time
+    elapsed since PLTRST de-assertion) therefore default timeout is zero. However this might be useful
+    if device power-up seqence is controlled by BIOS or a specific device requires more time to detect.
+    In case of non-common clock enabled the default timout is 15ms.
+    <b>Default: 0</b>
+  **/
+  UINT16  DetectTimeoutMs;
+  UINT8   FormFactor; // Please check PCIE_FORM_FACTOR for supported values
+  UINT8   Reserved;
+} PCIE_ROOT_PORT_COMMON_CONFIG;
+
+/**
+  PCIe Common Config
+  @note This structure will be expanded to hold all common PCIe policies between SA and PCH
+**/
+typedef struct {
+  ///
+  /// This member describes whether Peer Memory Writes are enabled on the platform. <b>0: Disable</b>; 1: Enable.
+  ///
+  UINT32  EnablePeerMemoryWrite          :  1;
+  /**
+    RpFunctionSwap allows BIOS to use root port function number swapping when root port of function 0 is disabled.
+    A PCIE device can have higher functions only when Function0 exists. To satisfy this requirement,
+    BIOS will always enable Function0 of a device that contains more than 0 enabled root ports.
+    - <b>Enabled: One of enabled root ports get assigned to Function0.</b>
+      This offers no guarantee that any particular root port will be available at a specific DevNr:FuncNr location
+    - Disabled: Root port that corresponds to Function0 will be kept visible even though it might be not used.
+      That way rootport - to - DevNr:FuncNr assignment is constant. This option will impact ports 1, 9, 17.
+      NOTE: This option will not work if ports 1, 9, 17 are fused or configured for RST PCIe storage or disabled through policy
+            In other words, it only affects ports that would become hidden because they have no device connected.
+      NOTE: Disabling function swap may have adverse impact on power management. This option should ONLY
+            be used when each one of root ports 1, 9, 17:
+        - is configured as PCIe and has correctly configured ClkReq signal, or
+        - does not own any mPhy lanes (they are configured as SATA or USB)
+  **/
+  UINT32  RpFunctionSwap                   :  1;
+  /**
+    Compliance Test Mode shall be enabled when using Compliance Load Board.
+    <b>0: Disable</b>, 1: Enable
+  **/
+  UINT32  ComplianceTestMode               :  1;
+  UINT32  RsvdBits0                        : 29;   ///< Reserved bits
+  ///
+  /// List of coefficients used during equalization (applicable to both software and hardware EQ)
+  /// Deprecated Policy
+  ///
+  PCIE_EQ_PARAM                    HwEqGen3CoeffList[PCIE_HWEQ_COEFFS_MAX];
+} PCIE_COMMON_CONFIG;
+
+typedef struct {
+  PCIE_EQ_PARAM                            HwEqGen3CoeffList[CPU_PCIE_MAX_ROOT_PORTS][PCIE_HWEQ_COEFFS_MAX];
+  PCIE_EQ_PARAM                            HwEqGen4CoeffList[CPU_PCIE_MAX_ROOT_PORTS][PCIE_HWEQ_COEFFS_MAX];
+} PCIE_COMMON_CONFIG2;
+
+#pragma pack (pop)
+#endif // _PCIE_CONFIG_H_

--- a/Silicon/TigerlakePchPkg/Include/PcieRegs.h
+++ b/Silicon/TigerlakePchPkg/Include/PcieRegs.h
@@ -10,7 +10,7 @@
     Definitions beginning with "S_" are register sizes
     Definitions beginning with "N_" are the bit position
 
-  Copyright (c) 2014 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 #ifndef _PCIE_REGS_H_
@@ -21,40 +21,126 @@
 //
 // PCI type 0 Header
 //
-
+#define R_PCI_BCC_OFFSET                          0x0B
 #define R_PCI_BAR0_OFFSET                         0x10
 
+//
+// PCI type 1 Header
+//
+#define R_PCI_BRIDGE_BNUM                         0x18 ///< Bus Number Register
+#define B_PCI_BRIDGE_BNUM_SBBN                    0x00FF0000 ///< Subordinate Bus Number
+#define B_PCI_BRIDGE_BNUM_SCBN                    0x0000FF00 ///< Secondary Bus Number
 
 //
 // PCI Express Capability List Register (CAPID:10h)
 //
+#define R_PCIE_XCAP_OFFSET                        0x02 ///< PCI Express Capabilities Register (Offset 02h)
+#define B_PCIE_XCAP_DT                            (BIT7 | BIT6 | BIT5 | BIT4) ///< Device/Port Type
+#define N_PCIE_XCAP_DT                            4
+
+#define R_PCIE_DCAP_OFFSET                        0x04 ///< Device Capabilities Register (Offset 04h)
+#define B_PCIE_DCAP_RBER                          BIT15 ///< Role-Based Error Reporting
+#define B_PCIE_DCAP_E1AL                          (BIT11 | BIT10 | BIT9) ///< Endpoint L1 Acceptable Latency
+#define N_PCIE_DCAP_E1AL                          9
+#define B_PCIE_DCAP_E0AL                          (BIT8 | BIT7 | BIT6) ///< Endpoint L0s Acceptable Latency
+#define N_PCIE_DCAP_E0AL                          6
+#define B_PCIE_DCAP_MPS                           (BIT2 | BIT1 | BIT0) ///< Max_Payload_Size Supported
+
+#define R_PCIE_DCTL_OFFSET                        0x08 ///< Device Control Register (Offset 08h)
+#define B_PCIE_DCTL_MPS                           (BIT7 | BIT6 | BIT5) ///< Max_Payload_Size
+#define N_PCIE_DCTL_MPS                           5
+
+#define R_PCIE_LCAP_OFFSET                        0x0C ///< Link Capabilities Register (Offset 0Ch)
+#define B_PCIE_LCAP_CPM                           BIT18 ///< Clock Power Management
+#define B_PCIE_LCAP_EL1                           (BIT17 | BIT16 | BIT15) ///< L1 Exit Latency
+#define N_PCIE_LCAP_EL1                           15
+#define B_PCIE_LCAP_EL0                           (BIT14 | BIT13 | BIT12) ///< L0s Exit Latency
+#define N_PCIE_LCAP_EL0                           12
+#define B_PCIE_LCAP_APMS_L0S                      BIT10
+#define B_PCIE_LCAP_APMS_L1                       BIT11
+#define B_PCIE_LCAP_MLS                           (BIT3 | BIT2 | BIT1 | BIT0) ///< Max Link Speed
+#define V_PCIE_LCAP_MLS_GEN3                      3
+#define V_PCIE_LCAP_MLS_GEN4                      4
+
+#define R_PCIE_LCTL_OFFSET                        0x10 ///< Link Control Register (Offset 10h)
+#define B_PCIE_LCTL_ECPM                          BIT8 ///< Enable Clock Power Management
+#define B_PCIE_LCTL_CCC                           BIT6 ///< Common Clock Configuration
+#define B_PCIE_LCTL_RL                            BIT5 ///< Retrain Link
+#define B_PCIE_LCTL_ASPM                          (BIT1 | BIT0) ///< Active State Power Management (ASPM) Control
+#define V_PCIE_LCTL_ASPM_L0S                      1
+#define V_PCIE_LCTL_ASPM_L1                       2
+#define V_PCIE_LCTL_ASPM_L0S_L1                   3
+
+#define R_PCIE_LSTS_OFFSET                        0x12 ///< Link Status Register (Offset 12h)
+#define B_PCIE_LSTS_LA                            BIT13 ///< Data Link Layer Link Active
+#define B_PCIE_LSTS_SCC                           BIT12 ///< Slot Clock Configuration
+#define B_PCIE_LSTS_LT                            BIT11 ///< Link Training
+#define B_PCIE_LSTS_NLW                           0x03F0 ///< Negotiated Link Width
+#define N_PCIE_LSTS_NLW                           4
+#define B_PCIE_LSTS_CLS                           0x000F ///< Current Link Speed
+
+#define R_PCIE_SLCAP_OFFSET                       0x14 ///< Slot Capabilities Register (Offset 14h)
+#define B_PCIE_SLCAP_HPC                          BIT6       ///< Hot-Plug Capable
+
 #define R_PCIE_SLSTS_OFFSET                       0x1A ///< Slot Status Register (Offset 1Ah)
 #define B_PCIE_SLSTS_PDS                          BIT6 ///< Presence Detect State
+
+#define R_PCIE_DCAP2_OFFSET                       0x24 ///< Device Capabilities 2 Register (Offset 24h)
+#define B_PCIE_DCAP2_LTRMS                        BIT11 ///< LTR Mechanism Supported
+
+#define R_PCIE_DCTL2_OFFSET                       0x28 ///< Device Control 2 Register (Offset 28h)
+#define B_PCIE_DCTL2_LTREN                        BIT10 ///< LTR Mechanism Enable
+
+#define B_PCIE_LCTL2_TLS                          (BIT3 | BIT2 | BIT1 | BIT0) ///< Target Link Speed
+
+//
+// Latency Tolerance Reporting Extended Capability Registers (CAPID:0018h)
+//
+#define R_PCIE_LTRECH_CID                         0x0018
+
+#define R_PCIE_LTRECH_MSLR_OFFSET                 0x04
+#define N_PCIE_LTRECH_MSLR_VALUE                  0
+#define N_PCIE_LTRECH_MSLR_SCALE                  10
+
+#define R_PCIE_LTRECH_MNSLR_OFFSET                0x06
+#define N_PCIE_LTRECH_MNSLR_VALUE                 0
+#define N_PCIE_LTRECH_MNSLR_SCALE                 10
+
+//
+// Secondary PCI Express Extended Capability Header (CAPID:0019h)
+//
+#define R_PCIE_EX_LCTL3_OFFSET                    0x04 ///< Link Control 3 Register
+#define B_PCIE_EX_LCTL3_PE                        BIT0 ///< Perform Equalization
 
 //
 // L1 Sub-States Extended Capability Register (CAPID:001Eh)
 //
-#define  B_PCIE_EX_L1SCAP_PTV                     0x00F80000 //< Port Tpower_on value
-#define  N_PCIE_EX_L1SCAP_PTV                     19
-#define  B_PCIE_EX_L1SCAP_PTPOS                   0x00030000 //< Port Tpower_on scale
-#define  N_PCIE_EX_L1SCAP_PTPOS                   16
-#define  B_PCIE_EX_L1SCAP_CMRT                    0x0000FF00 //< Common Mode Restore time
-#define  N_PCIE_EX_L1SCAP_CMRT                    8
-#define  V_PCIE_EX_L1SCAP_PTPOS_2us               0
-#define  V_PCIE_EX_L1SCAP_PTPOS_10us              1
-#define  V_PCIE_EX_L1SCAP_PTPOS_100us             2
-#define  B_PCIE_EX_L1SCAP_L1SSES                  BIT5 ///< CLKREQ Acceleration Supported
-#define  B_PCIE_EX_L1SCAP_L1PSS                   BIT4 ///< L1 PM substates supported
-#define  B_PCIE_EX_L1SCAP_AL1SS                   BIT3 ///< ASPM L1.1 supported
-#define  B_PCIE_EX_L1SCAP_AL12S                   BIT2 ///< ASPM L1.2 supported
-#define  B_PCIE_EX_L1SCAP_PPL11S                  BIT1 ///< PCI-PM L1.1 supported
-#define  B_PCIE_EX_L1SCAP_PPL12S                  BIT0 ///< PCI-PM L1.2 supported
+#define V_PCIE_EX_L1S_CID                        0x001E ///< Capability ID
+#define R_PCIE_EX_L1SCAP_OFFSET                  0x04 ///< L1 Sub-States Capabilities
+#define B_PCIE_EX_L1SCAP_PTV                     0x00F80000 //< Port Tpower_on value
+#define N_PCIE_EX_L1SCAP_PTV                     19
+#define B_PCIE_EX_L1SCAP_PTPOS                   0x00030000 //< Port Tpower_on scale
+#define N_PCIE_EX_L1SCAP_PTPOS                   16
+#define B_PCIE_EX_L1SCAP_CMRT                    0x0000FF00 //< Common Mode Restore time
+#define N_PCIE_EX_L1SCAP_CMRT                    8
+#define B_PCIE_EX_L1SCAP_L1PSS                   BIT4 ///< L1 PM substates supported
+#define B_PCIE_EX_L1SCAP_AL1SS                   BIT3 ///< ASPM L1.1 supported
+#define B_PCIE_EX_L1SCAP_AL12S                   BIT2 ///< ASPM L1.2 supported
+#define B_PCIE_EX_L1SCAP_PPL11S                  BIT1 ///< PCI-PM L1.1 supported
+#define B_PCIE_EX_L1SCAP_PPL12S                  BIT0 ///< PCI-PM L1.2 supported
+#define R_PCIE_EX_L1SCTL1_OFFSET                 0x08 ///< L1 Sub-States Control 1
+#define B_PCIE_EX_L1SCTL1_L1SSEIE                BIT4
+#define N_PCIE_EX_L1SCTL1_L12LTRTLSV             29
+#define N_PCIE_EX_L1SCTL1_L12LTRTLV              16
+#define R_PCIE_EX_L1SCTL2_OFFSET                 0x0C ///< L1 Sub-States Control 2
+#define N_PCIE_EX_L1SCTL2_POWT                   3
 
 //
 // PTM Extended Capability Register (CAPID:001Fh)
 //
-#define  B_PCIE_EX_PTMCAP_PTMRC                   BIT2 ///< PTM Root Capable
-#define  B_PCIE_EX_PTMCAP_PTMRSPC                 BIT1 ///< PTM Responder Capable
+#define V_PCIE_EX_PTM_CID                         0x001F ///< Capability ID
+#define R_PCIE_EX_PTMCAP_OFFSET                   0x04 ///< PTM Capabilities
+#define R_PCIE_EX_PTMCTL_OFFSET                   0x08 ///< PTM Control Register
 
 //
 // Base Address Offset
@@ -62,5 +148,9 @@
 #define B_PCI_BAR_MEMORY_TYPE_MASK                (BIT1 | BIT2)
 #define B_PCI_BAR_MEMORY_TYPE_64                  BIT2
 
+//
+// PCI Express Extended Capability Header
+//
+#define R_PCIE_CFG_EXCAP_OFFSET                   0x100
 
 #endif

--- a/Silicon/TigerlakePchPkg/Include/Register/PchPcieRpRegs.h
+++ b/Silicon/TigerlakePchPkg/Include/Register/PchPcieRpRegs.h
@@ -17,7 +17,6 @@
   - [ComponentName]:
     This field indicates the component name that the register belongs to (e.g. PCH, SA etc.)
     Register name without ComponentName applies to all components.
-    Register that is specific to -H denoted by "_PCH_H_" in component name.
     Register that is specific to -LP denoted by "_PCH_LP_" in component name.
   - SubsystemName:
     This field indicates the subsystem name of the component that the register belongs to
@@ -30,70 +29,69 @@
   - RegisterName:
     Full register name.
 
-  Copyright (c) 1999 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 #ifndef _PCH_REGS_PCIE_RP_H_
 #define _PCH_REGS_PCIE_RP_H_
 
+#define R_PCH_PCIE_CFG_CLIST                          0x40
+#define R_PCH_PCIE_CFG_LCAP                           (R_PCH_PCIE_CFG_CLIST + R_PCIE_LCAP_OFFSET)
+#define N_PCH_PCIE_CFG_LCAP_PN                        24
+#define R_PCH_PCIE_CFG_LCTL                           (R_PCH_PCIE_CFG_CLIST + R_PCIE_LCTL_OFFSET)
+#define R_PCH_PCIE_CFG_LSTS                           (R_PCH_PCIE_CFG_CLIST + R_PCIE_LSTS_OFFSET)
+#define R_PCH_PCIE_CFG_SLCAP                          (R_PCH_PCIE_CFG_CLIST + R_PCIE_SLCAP_OFFSET)
+#define R_PCH_PCIE_CFG_SLSTS                          (R_PCH_PCIE_CFG_CLIST + R_PCIE_SLSTS_OFFSET)
+
+#define R_PCH_PCIE_CFG_MPC2                           0xD4
+#define B_PCH_PCIE_CFG_MPC2_EOIFD                     BIT1
 
 #define R_PCH_PCIE_CFG_MPC                            0xD8
+#define S_PCH_PCIE_CFG_MPC                            4
+#define B_PCH_PCIE_CFG_MPC_PMCE                       BIT31
+#define B_PCH_PCIE_CFG_MPC_HPME                       BIT1
+#define N_PCH_PCIE_CFG_MPC_HPME                       1
+
 #define R_PCH_PCIE_CFG_SMSCS                          0xDC
+#define S_PCH_PCIE_CFG_SMSCS                          4
+#define B_PCH_PCIE_CFG_SMSCS_PMCS                     BIT31
+#define N_PCH_PCIE_CFG_SMSCS_LERSMIS                  5
+#define N_PCH_PCIE_CFG_SMSCS_HPLAS                    4
+#define N_PCH_PCIE_CFG_SMSCS_HPPDM                    1
+
 #define R_PCH_PCIE_CFG_SPR                            0xE0
 #define R_PCH_PCIE_CFG_RPPGEN                         0xE2
 
+//CES.RE, CES.BT, CES.BD
 
-//
-//PCI Express Extended Capability Registers
-//
-
-#ifndef PCH_ICL
-#define R_PCH_PCIE_CFG_EX_ACSECH                      0x140 ///< ACS Extended Capability Header
-#else
-#define R_PCH_PCIE_CFG_EX_ACSECH                      0x220 ///< ACS Extended Capability Header
-#endif
-
-
-#ifndef PCH_ICL
-#define R_PCH_PCIE_CFG_EX_SPEECH                      0x220 ///< Secondary PCI Express Extended Capability Header
-#else
 #define R_PCH_PCIE_CFG_EX_SPEECH                      0xA30 ///< Secondary PCI Express Extended Capability Header
-#endif
+#define R_PCH_PCIE_CFG_EX_LCTL3                       (R_PCH_PCIE_CFG_EX_SPEECH + R_PCIE_EX_LCTL3_OFFSET)
 
-#ifndef PCH_ICL
-#define R_PCH_PCIE_CFG_EX_DPCECH                      0x250 ///< Downstream Port Containment
-#else
-#define R_PCH_PCIE_CFG_EX_DPCECH                      0xA00 ///< Downstream Port Containment
-#endif
+#define R_PCH_PCIE_CFG_LTROVR                         0x400
+#define B_PCH_PCIE_CFG_LTROVR_LTRNSROVR               BIT31 ///< LTR Non-Snoop Requirement Bit Override
+#define B_PCH_PCIE_CFG_LTROVR_LTRSROVR                BIT15 ///< LTR Snoop Requirement Bit Override
 
+#define R_PCH_PCIE_CFG_LTROVR2                        0x404
+#define B_PCH_PCIE_CFG_LTROVR2_FORCE_OVERRIDE         BIT3 ///< LTR Force Override Enable
+#define B_PCH_PCIE_CFG_LTROVR2_LOCK                   BIT2 ///< LTR Override Lock
+#define B_PCH_PCIE_CFG_LTROVR2_LTRNSOVREN             BIT1 ///< LTR Non-Snoop Override Enable
+#define B_PCH_PCIE_CFG_LTROVR2_LTRSOVREN              BIT0 ///< LTR Snoop Override Enable
 
 #define R_PCH_PCIE_CFG_PCIEPMECTL                     0x420
+#define B_PCH_PCIE_CFG_PCIEPMECTL_DLSULPPGE           BIT30
+#define B_PCH_PCIE_CFG_PCIEPMECTL_L1LE                BIT17
+#define B_PCH_PCIE_CFG_PCIEPMECTL_L1FSOE              BIT0
 
-
+#define R_PCH_PCIE_CFG_EQCFG1                         0x450
+#define S_PCH_PCIE_CFG_EQCFG1                         4
+#define N_PCH_PCIE_CFG_EQCFG1_LERSMIE                 21
 
 //
 // PCIE PCRs (PID:SPA SPB SPC SPD SPE SPF)
 //
 #define R_SPX_PCR_PCD                         0                       ///< Port configuration and disable
 #define B_SPX_PCR_PCD_RP1FN                   (BIT2 | BIT1 | BIT0)    ///< Port 1 Function Number
-#define B_SPX_PCR_PCD_RP1CH                   BIT3                    ///< Port 1 config hide
-#define B_SPX_PCR_PCD_RP2FN                   (BIT6 | BIT5 | BIT4)    ///< Port 2 Function Number
-#define B_SPX_PCR_PCD_RP2CH                   BIT7                    ///< Port 2 config hide
-#define B_SPX_PCR_PCD_RP3FN                   (BIT10 | BIT9 | BIT8)   ///< Port 3 Function Number
-#define B_SPX_PCR_PCD_RP3CH                   BIT11                   ///< Port 3 config hide
-#define B_SPX_PCR_PCD_RP4FN                   (BIT14 | BIT13 | BIT12) ///< Port 4 Function Number
-#define B_SPX_PCR_PCD_RP4CH                   BIT15                   ///< Port 4 config hide
 #define S_SPX_PCR_PCD_RP_FIELD                4                       ///< 4 bits for each RP FN
-#define B_SPX_PCR_PCD_P1D                     BIT16                   ///< Port 1 disable
-#define B_SPX_PCR_PCD_P2D                     BIT17                   ///< Port 2 disable
-#define B_SPX_PCR_PCD_P3D                     BIT18                   ///< Port 3 disable
-#define B_SPX_PCR_PCD_P4D                     BIT19                   ///< Port 4 disable
-#define B_SPX_PCR_PCD_SRL                     BIT31                   ///< Secured Register Lock
 
 
-#define R_PCH_PCIE_CFG_MPC                            0xD8
-#define R_PCH_PCIE_CFG_SPR                            0xE0
-#define R_PCH_PCIE_CFG_RPPGEN                         0xE2
-#define R_PCH_PCIE_CFG_PCIEPMECTL                     0x420
-#define R_PCH_PCIE_CFG_SMSCS                          0xDC
 #endif

--- a/Silicon/TigerlakePchPkg/Include/Register/PcieSipRegs.h
+++ b/Silicon/TigerlakePchPkg/Include/Register/PcieSipRegs.h
@@ -1,0 +1,45 @@
+/** @file
+  Register names for PCIe SIP specific registers
+
+  Conventions:
+
+  - Register definition format:
+  Prefix_[GenerationName]_[ComponentName]_SubsystemName_RegisterSpace_RegisterName
+  - Prefix:
+  Definitions beginning with "R_" are registers
+  Definitions beginning with "B_" are bits within registers
+  Definitions beginning with "V_" are meaningful values within the bits
+  Definitions beginning with "S_" are register size
+  Definitions beginning with "N_" are the bit position
+  - [GenerationName]:
+  Three letter acronym of the generation is used (e.g. SKL,KBL,CNL etc.).
+  Register name without GenerationName applies to all generations.
+  - [ComponentName]:
+  This field indicates the component name that the register belongs to (e.g. PCH, SA etc.)
+  Register name without ComponentName applies to all components.
+  Register that is specific to -LP denoted by "_PCH_LP_" in component name.
+  - SubsystemName:
+  This field indicates the subsystem name of the component that the register belongs to
+    (e.g. PCIE, USB, SATA, GPIO, PMC etc.).
+  - RegisterSpace:
+  MEM - MMIO space register of subsystem.
+  IO  - IO space register of subsystem.
+  PCR - Private configuration register of subsystem.
+  CFG - PCI configuration space register of subsystem.
+  - RegisterName:
+  Full register name.
+
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef _PCIE_SIP_RP_REGS_H_
+#define _PCIE_SIP_RP_REGS_H_
+
+#include <PcieRegs.h>
+
+#define R_PCIE_CFG_CCFG                               0xD0
+#define B_PCIE_CFG_CCFG_UNRS                          (BIT6 | BIT5 | BIT4)
+#define N_PCIE_CFG_CCFG_UNRS                          4
+
+#endif

--- a/Silicon/TigerlakePchPkg/Library/BasePcieHelperLib/BasePcieHelperLib.c
+++ b/Silicon/TigerlakePchPkg/Library/BasePcieHelperLib/BasePcieHelperLib.c
@@ -1,0 +1,315 @@
+/** @file
+  This file contains routines that support PCI Express initialization
+
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#include <Library/PcieHelperLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <PcieRegs.h>
+
+#define ASPM_L1_NO_LIMIT 0xFF
+#define LINK_RETRAIN_WAIT_TIME 1000 // microseconds
+
+/**
+  Finds the Offset to a given Capabilities ID
+  Each capability has an ID and a pointer to next Capability, so they form a linked list.
+  This function walks the list of Capabilities present in device's pci cfg. If requested capability
+  can be found, its offset is returned.
+  If the capability can't be found or if device doesn't exist, function returns 0
+  CAPID list:
+    0x01 = PCI Power Management Interface
+    0x04 = Slot Identification
+    0x05 = MSI Capability
+    0x10 = PCI Express Capability
+
+  @param[in] DeviceBase           device's base address
+  @param[in] CapId                CAPID to search for
+
+  @retval 0                       CAPID not found (this includes situation where device doesn't exit)
+  @retval Other                   CAPID found, Offset of desired CAPID
+**/
+UINT8
+PcieBaseFindCapId (
+  IN UINT64  DeviceBase,
+  IN UINT8   CapId
+  )
+{
+  UINT8  CapHeaderOffset;
+  UINT8  CapHeaderId;
+  UINT16 Data16;
+  //
+  // We do not explicitly check if device exists to save time and avoid unnecessary PCI access
+  // If the device doesn't exist, check for CapHeaderId != 0xFF will fail and function will return offset 0
+  //
+  if ((PciSegmentRead8 (DeviceBase + PCI_PRIMARY_STATUS_OFFSET) & EFI_PCI_STATUS_CAPABILITY) == 0x00) {
+    ///
+    /// Function has no capability pointer
+    ///
+    return 0;
+  } else {
+    ///
+    /// Check the header layout to determine the Offset of Capabilities Pointer Register
+    ///
+    if ((PciSegmentRead8 (DeviceBase + PCI_HEADER_TYPE_OFFSET) & HEADER_LAYOUT_CODE) == (HEADER_TYPE_CARDBUS_BRIDGE)) {
+      ///
+      /// If CardBus bridge, start at Offset 0x14
+      ///
+      CapHeaderOffset = EFI_PCI_CARDBUS_BRIDGE_CAPABILITY_PTR;
+    } else {
+      ///
+      /// Otherwise, start at Offset 0x34
+      ///
+      CapHeaderOffset = PCI_CAPBILITY_POINTER_OFFSET;
+    }
+    ///
+    /// Get Capability Header, A pointer value of 00h is used to indicate the last capability in the list.
+    ///
+    CapHeaderId     = 0;
+    CapHeaderOffset = PciSegmentRead8 (DeviceBase + CapHeaderOffset) & ((UINT8) ~(BIT0 | BIT1));
+    while (CapHeaderOffset != 0 && CapHeaderId != 0xFF) {
+      Data16 = PciSegmentRead16 (DeviceBase + CapHeaderOffset);
+      CapHeaderId = (UINT8)(Data16 & 0xFF);
+      if (CapHeaderId == CapId) {
+        if (CapHeaderOffset > PCI_MAXLAT_OFFSET) {
+          ///
+          /// Return valid capability offset
+          ///
+          return CapHeaderOffset;
+        } else {
+          ASSERT ((FALSE));
+          return 0;
+        }
+      }
+      ///
+      /// Each capability must be DWORD aligned.
+      /// The bottom two bits of all pointers (including the initial pointer at 34h) are reserved
+      /// and must be implemented as 00b although software must mask them to allow for future uses of these bits.
+      ///
+      CapHeaderOffset = (UINT8)(Data16 >> 8);
+    }
+    return 0;
+  }
+}
+
+/**
+  Find the Offset to a given Capabilities ID
+  CAPID list:
+    0x01 = PCI Power Management Interface
+    0x04 = Slot Identification
+    0x05 = MSI Capability
+    0x10 = PCI Express Capability
+
+  @param[in] Segment              Pci Segment Number
+  @param[in] Bus                  Pci Bus Number
+  @param[in] Device               Pci Device Number
+  @param[in] Function             Pci Function Number
+  @param[in] CapId                CAPID to search for
+
+  @retval 0                       CAPID not found
+  @retval Other                   CAPID found, Offset of desired CAPID
+**/
+UINT8
+PcieFindCapId (
+  IN UINT8   Segment,
+  IN UINT8   Bus,
+  IN UINT8   Device,
+  IN UINT8   Function,
+  IN UINT8   CapId
+  )
+{
+  UINT64 DeviceBase;
+
+  DeviceBase = PCI_SEGMENT_LIB_ADDRESS (Segment, Bus, Device, Function, 0);
+  return PcieBaseFindCapId (DeviceBase, CapId);
+}
+
+/**
+  Search and return the offset of desired Pci Express Capability ID
+  CAPID list:
+    0x0001 = Advanced Error Reporting Capability
+    0x0002 = Virtual Channel Capability
+    0x0003 = Device Serial Number Capability
+    0x0004 = Power Budgeting Capability
+
+  @param[in] DeviceBase           device base address
+  @param[in] CapId                Extended CAPID to search for
+
+  @retval 0                       CAPID not found, this includes situation where device doesn't exist
+  @retval Other                   CAPID found, Offset of desired CAPID
+**/
+UINT16
+PcieBaseFindExtendedCapId (
+  IN UINT64  DeviceBase,
+  IN UINT16  CapId
+  )
+{
+  UINT16  CapHeaderOffset;
+  UINT16  CapHeaderId;
+  ///
+  /// Start to search at Offset 0x100
+  /// Get Capability Header, A pointer value of 00h is used to indicate the last capability in the list.
+  ///
+  CapHeaderId     = 0;
+  CapHeaderOffset = R_PCIE_CFG_EXCAP_OFFSET;
+  while (CapHeaderOffset != 0 && CapHeaderId != MAX_UINT16) {
+    CapHeaderId = PciSegmentRead16 (DeviceBase + CapHeaderOffset);
+    if (CapHeaderId == CapId) {
+      return CapHeaderOffset;
+    }
+    ///
+    /// Each capability must be DWORD aligned.
+    /// The bottom two bits of all pointers are reserved and must be implemented as 00b
+    /// although software must mask them to allow for future uses of these bits.
+    ///
+    CapHeaderOffset = (PciSegmentRead16 (DeviceBase + CapHeaderOffset + 2) >> 4) & ((UINT16) ~(BIT0 | BIT1));
+  }
+
+  return 0;
+}
+
+/**
+  Search and return the offset of desired Pci Express Capability ID
+  CAPID list:
+    0x0001 = Advanced Error Reporting Capability
+    0x0002 = Virtual Channel Capability
+    0x0003 = Device Serial Number Capability
+    0x0004 = Power Budgeting Capability
+
+  @param[in] Segment              Pci Segment Number
+  @param[in] Bus                  Pci Bus Number
+  @param[in] Device               Pci Device Number
+  @param[in] Function             Pci Function Number
+  @param[in] CapId                Extended CAPID to search for
+
+  @retval 0                       CAPID not found, this includes situation where device doesn't exist
+  @retval Other                   CAPID found, Offset of desired CAPID
+**/
+UINT16
+PcieFindExtendedCapId (
+  IN UINT8   Segment,
+  IN UINT8   Bus,
+  IN UINT8   Device,
+  IN UINT8   Function,
+  IN UINT16  CapId
+  )
+{
+  UINT64  DeviceBase;
+
+  DeviceBase = PCI_SEGMENT_LIB_ADDRESS (Segment, Bus, Device, Function, 0);
+  return PcieBaseFindExtendedCapId (DeviceBase, CapId);
+}
+
+/**
+  Checks if PCI device at given address exists
+
+  @param[in] Base            device's base address
+
+  @retval TRUE if exists
+**/
+BOOLEAN
+IsDevicePresent (
+  UINT64 Base
+  )
+{
+  if (PciSegmentRead16 (Base) == 0xFFFF) {
+    return FALSE;
+  }
+  return TRUE;
+}
+
+/**
+  Checks if device is a multifunction device
+  Besides comparing Multifunction bit (BIT7) it checks if contents of HEADER_TYPE register
+  make sense (header != 0xFF) to prevent false positives when called on devices which do not exist
+
+  @param[in] Base            device's base address
+
+  @retval TRUE if multifunction; FALSE otherwise
+**/
+BOOLEAN
+IsMultifunctionDevice (
+  UINT64 Base
+  )
+{
+  UINT8 HeaderType;
+  HeaderType = PciSegmentRead8(Base + PCI_HEADER_TYPE_OFFSET);
+  if ((HeaderType == 0xFF) || ((HeaderType & HEADER_TYPE_MULTI_FUNCTION) == 0)) {
+    return FALSE;
+  }
+  return TRUE;
+}
+
+/**
+  Checks device's Slot Clock Configuration
+
+  @param[in] Base            device's base address
+  @param[in] PcieCapOffset   devices Pci express capability list register offset
+
+  @retval TRUE when device uses slot clock, FALSE otherwise
+**/
+BOOLEAN
+GetScc (
+  UINT64    Base,
+  UINT8     PcieCapOffset
+  )
+{
+  return !!(PciSegmentRead16 (Base + PcieCapOffset + R_PCIE_LSTS_OFFSET) & B_PCIE_LSTS_SCC);
+}
+
+/**
+  Sets Common Clock Configuration bit for given device.
+
+  @param[in] PcieCapOffset   devices Pci express capability list register offset
+  @param[in] Base            device's base address
+**/
+VOID
+EnableCcc (
+  UINT64    Base,
+  UINT8     PcieCapOffset
+  )
+{
+  PciSegmentOr8 (Base + PcieCapOffset + R_PCIE_LCTL_OFFSET, B_PCIE_LCTL_CCC);
+}
+
+/**
+  Retrains link behind given device.
+  It only makes sense to call it for downstream ports. If called for upstream port nothing will happen.
+  If WaitUntilDone is TRUE function will wait until link retrain had finished, otherwise it will return immediately.
+  Link must finish retrain before software can access the device on the other side. If it's not going to access it
+  then considerable time can be saved by not waiting here.
+
+  @param[in] Base             device's base address
+  @param[in] PcieCapOffset    devices Pci express capability list register offset
+  @param[in] WaitUntilDone    when TRUE, function waits until link has retrained
+**/
+VOID
+RetrainLink (
+  UINT64  Base,
+  UINT8   PcieCapOffset,
+  BOOLEAN WaitUntilDone
+  )
+{
+  UINT16 LinkTraining;
+  UINT32 TimeoutUs;
+
+  TimeoutUs = LINK_RETRAIN_WAIT_TIME;
+  //
+  // Before triggering link retrain make sure it's not already retraining. Otherwise
+  // settings recently entered in LCTL register might go unnoticed
+  //
+  do {
+    LinkTraining = (PciSegmentRead16 (Base + PcieCapOffset + R_PCIE_LSTS_OFFSET) & B_PCIE_LSTS_LT);
+    TimeoutUs--;
+  } while (LinkTraining && (TimeoutUs != 0));
+
+  PciSegmentOr8 (Base + PcieCapOffset + R_PCIE_LCTL_OFFSET, B_PCIE_LCTL_RL);
+
+  TimeoutUs = LINK_RETRAIN_WAIT_TIME;
+  if (WaitUntilDone) {
+    do {
+      LinkTraining = (PciSegmentRead16 (Base + PcieCapOffset + R_PCIE_LSTS_OFFSET) & B_PCIE_LSTS_LT);
+      TimeoutUs--;
+    } while (LinkTraining && (TimeoutUs != 0));
+  }
+}

--- a/Silicon/TigerlakePchPkg/Library/BasePcieHelperLib/BasePcieHelperLib.inf
+++ b/Silicon/TigerlakePchPkg/Library/BasePcieHelperLib/BasePcieHelperLib.inf
@@ -1,0 +1,37 @@
+## @file
+# Component description file for the BasePcieHelperLib
+#
+#  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+
+[Defines]
+INF_VERSION = 0x00010017
+BASE_NAME = BasePcieHelperLib
+FILE_GUID = 568F5812-A9A8-4A4A-AD4D-471DD5F0BC11
+VERSION_STRING = 1.0
+MODULE_TYPE = BASE
+LIBRARY_CLASS = BasePcieHelperLib
+#
+# The following information is for reference only and not required by the build tools.
+#
+# VALID_ARCHITECTURES = IA32 X64 IPF EBC
+#
+
+
+
+[LibraryClasses]
+DebugLib
+PciSegmentLib
+
+
+[Packages]
+MdePkg/MdePkg.dec
+Silicon/CommonSocPkg/CommonSocPkg.dec
+Silicon/TigerlakePchPkg/TigerlakePchPkg.dec
+
+[Sources]
+BasePcieHelperLib.c
+

--- a/Silicon/TigerlakePchPkg/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.c
+++ b/Silicon/TigerlakePchPkg/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.c
@@ -1,0 +1,1525 @@
+/** @file
+  This file contains routines that support PCI Express initialization
+
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#include "PciExpressHelpersLibrary.h"
+#include <Library/BaseMemoryLib.h>
+#include <Library/PcieHelperLib.h>
+#include <Library/PchPciBdfLib.h>
+#include <Library/PcieRpLib.h>
+#include <PchPcieRpInfo.h>
+#include <CpuPcieInfo.h>
+#include <Register/PchPcieRpRegs.h>
+
+#define ASPM_L1_NO_LIMIT 0xFF
+#define ASPM_L0s_NO_LIMIT 0x7
+#define LINK_RETRAIN_WAIT_TIME 1000 // microseconds
+
+typedef union {
+  struct {
+    UINT32  RequesterCapable       : 1;
+    UINT32  ResponderCapable       : 1;
+    UINT32  RootCapable            : 1;
+    UINT32  Reserved               : 5;
+    UINT32  LocalClockGranularity  : 8;
+    UINT32  Reserved2              : 16;
+  } Bits;
+  UINT32  Uint32;
+} PTM_CAPS;
+
+typedef union {
+  struct {
+    UINT32 Enable                 : 1;
+    UINT32 RootSelect             : 1;
+    UINT32 Reserved               : 6;
+    UINT32 EffectiveGranularity   : 8;
+    UINT32 Reserved2              : 16;
+  } Bits;
+  UINT32  Uint32;
+} PTM_CTRL;
+
+typedef struct {
+  UINT32                          Size;
+  const PCH_PCIE_DEVICE_OVERRIDE* Table;
+} OVERRIDE_TABLE;
+
+typedef enum {
+  DevTypePci,
+  DevTypePcieEndpoint,
+  DevTypePcieUpstream,
+  DevTypePcieDownstream,
+  DevTypeMax
+} PCI_DEV_TYPE;
+
+//
+// This structure keeps in one place all data relevant to enabling L0s and L1.
+// L0s latencies are encoded in the same way as in hardware registers. The only operation
+// that will be performed on them is comparison
+// L1 latencies are decoded to microseconds, because they will be used in subtractions and additions
+//
+typedef struct {
+  UINT32  L0sSupported          : 1;
+  UINT32  L1Supported           : 1;
+  UINT32  L0sAcceptableLatency  : 3; // encoded as in hardware register
+  UINT32  L1AcceptableLatencyUs : 8; // decoded to microseconds
+  UINT32  LinkL0sExitLatency    : 3; // encoded as in hardware register
+  UINT32  LinkL1ExitLatencyUs   : 8; // decoded to microseconds
+} ASPM_CAPS;
+
+typedef struct {
+  UINT32     AspmL11  : 1;
+  UINT32     AspmL12  : 1;
+  UINT32     PmL11    : 1;
+  UINT32     PmL12    : 1;
+  UINT32     Cmrt     : 8; // Common Mode Restore Time
+  UINT32     TpoScale : 2; // T power_on scale
+  UINT32     TpoValue : 6; // T power_on value
+} L1SS_CAPS;
+
+#define MAX_SBDF_TABLE_SIZE 50 //arbitrary table size; big enough to accomodate even full length TBT chain.
+
+typedef struct {
+  UINT32 Count;
+  SBDF   Entry [MAX_SBDF_TABLE_SIZE];
+} SBDF_TABLE;
+
+/**
+  Converts device's segment:bus:device:function coordinates to flat address
+
+  @param[in] Sbdf   device's segment:bus:device:function coordinates
+
+  @retval    address of device's PCI cfg space
+**/
+STATIC
+UINT64
+SbdfToBase (
+  SBDF Sbdf
+  )
+{
+  return PCI_SEGMENT_LIB_ADDRESS (Sbdf.Seg, Sbdf.Bus, Sbdf.Dev, Sbdf.Func, 0);
+}
+
+/*
+  Converts Tpower_on from value:scale notation to microseconds
+
+  @param[in] TpoScale   T power on scale
+  @param[in] TpoValue   T power on value
+
+  @retval    number of microseconds
+*/
+UINT32
+TpoToUs (
+  UINT32 TpoScale,
+  UINT32 TpoValue
+  )
+{
+  static const UINT8 TpoScaleMultiplier[] = {2, 10, 100};
+
+  ASSERT (TpoScale < TpoScaleMax);
+  if (TpoScale >= TpoScaleMax) {
+    return 0;
+  }
+  return (TpoScaleMultiplier[TpoScale] * TpoValue);
+}
+
+/**
+  Enables LTR feature in given device
+
+  @param[in] Sbdf            device's segment:bus:device:function coordinates
+**/
+STATIC
+VOID
+EnableLtr (
+  SBDF Sbdf
+  )
+{
+  if (Sbdf.PcieCap == 0) {
+    return;
+  }
+  PciSegmentOr32 (SbdfToBase (Sbdf) + Sbdf.PcieCap + R_PCIE_DCTL2_OFFSET, B_PCIE_DCTL2_LTREN);
+}
+
+/**
+  Returns information about type of device.
+
+  @param[out] Sbdf            device's segment:bus:device:function coordinates
+
+  @retval     one of: not a PCIe device (legacy PCI), PCIe endpoint, PCIe upstream port or PCIe downstream port (including rootport)
+**/
+STATIC
+PCI_DEV_TYPE
+GetDeviceType (
+  SBDF Sbdf
+  )
+{
+  UINT8 DeviceType;
+
+  if (Sbdf.PcieCap == 0) {
+    return DevTypePci;
+  }
+  DeviceType = (UINT8) ((PciSegmentRead16 (SbdfToBase (Sbdf) + Sbdf.PcieCap + R_PCIE_XCAP_OFFSET) & B_PCIE_XCAP_DT) >> N_PCIE_XCAP_DT);
+  if (DeviceType == PCIE_DEVICE_PORT_TYPE_UPSTREAM_PORT) {
+    return DevTypePcieUpstream;
+  } else if (DeviceType == PCIE_DEVICE_PORT_TYPE_DOWNSTREAM_PORT || DeviceType == PCIE_DEVICE_PORT_TYPE_ROOT_PORT) {
+    return DevTypePcieDownstream;
+  } else {
+    return DevTypePcieEndpoint;
+  }
+}
+
+/**
+  Initializes Dev:Func numbers for use in FindNextPcieChild or FindNextLegalSbdf functions.
+
+  @param[out] Sbdf            device's segment:bus:device:function coordinates
+**/
+STATIC
+VOID
+InitChildFinder (
+  OUT SBDF *Sbdf
+  )
+{
+  //
+  // Initialize Dev/Func to maximum values, so that when FindNextLegalSbdf ()
+  // is called on those input parameters, it will return 1st legal address (Dev 0 Func 0).
+  //
+  Sbdf->Dev = PCI_MAX_DEVICE;
+  Sbdf->Func = PCI_MAX_FUNC;
+}
+
+/**
+  Checks the device is a bridge and has non-zero secondary bus number assigned.
+  If so, it returns TRUE and initializes ChildSbdf with such values that
+  allow searching for devices on the secondary bus.
+  ChildSbdf will be mangled even if this function returns FALSE.
+
+  Legal bus assignment is assumed. This function doesn't check subordinate bus numbers of
+  the the device it was called on or any bridges between it and root complex
+
+  @param[in]  Sbdf       device's segment:bus:device:function coordinates
+  @param[out] ChildSbdf  SBDF initialized in such way that calling FindNextPcieChild( ) on it will find all children devices
+
+  @retval TRUE if device is a bridge and has a bus behind it; FALSE otherwise
+**/
+STATIC
+BOOLEAN
+HasChildBus (
+  SBDF   Sbdf,
+  SBDF   *ChildSbdf
+  )
+{
+  UINT32 Data32;
+  UINT64 Base;
+  UINT8  SecondaryBus;
+
+  ChildSbdf->Seg = Sbdf.Seg;
+  InitChildFinder (ChildSbdf);
+
+  Base = SbdfToBase (Sbdf);
+
+  if (PciSegmentRead8 (Base + R_PCI_BCC_OFFSET) != PCI_CLASS_BRIDGE) {
+    DEBUG ((DEBUG_INFO, "HasChildBus%02:%02:%02: no\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+    return FALSE;
+  }
+  Data32 = PciSegmentRead32 (Base + PCI_BRIDGE_PRIMARY_BUS_REGISTER_OFFSET);
+  SecondaryBus = (UINT8)((Data32 & B_PCI_BRIDGE_BNUM_SCBN) >> 8);
+  ChildSbdf->Bus = SecondaryBus;
+  if (SecondaryBus == 0) {
+    DEBUG ((DEBUG_INFO, "HasChildBus%02x:%02x:%02x: no\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+    return FALSE;
+  } else {
+    DEBUG ((DEBUG_INFO, "HasChildBus%02x:%02x:%02x: yes, %x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func, SecondaryBus));
+    return TRUE;
+  }
+}
+
+/**
+  Sets LTR limit in a device.
+
+  @param[in] Base            device's base address
+  @param[in] Ltr             LTR limit
+**/
+STATIC
+VOID
+SetLtrLimit (
+  UINT64    Base,
+  LTR_LIMIT Ltr
+  )
+{
+  UINT16 LtrCapOffset;
+  UINT16 Data16;
+
+  LtrCapOffset = PcieBaseFindExtendedCapId (Base, R_PCIE_LTRECH_CID);
+  if (LtrCapOffset == 0) {
+    return;
+  }
+  Data16 = (UINT16)((Ltr.MaxSnoopLatencyValue << N_PCIE_LTRECH_MSLR_VALUE) | (Ltr.MaxSnoopLatencyScale << N_PCIE_LTRECH_MSLR_SCALE));
+  PciSegmentWrite16(Base + LtrCapOffset + R_PCIE_LTRECH_MSLR_OFFSET, Data16);
+
+  Data16 = (UINT16)((Ltr.MaxNoSnoopLatencyValue << N_PCIE_LTRECH_MNSLR_VALUE) | (Ltr.MaxNoSnoopLatencyScale << N_PCIE_LTRECH_MNSLR_SCALE));
+  PciSegmentWrite16(Base + LtrCapOffset + R_PCIE_LTRECH_MNSLR_OFFSET, Data16);
+}
+
+/**
+  Checks if device at given address exists and is a PCI Express device.
+  PCI express devices are distinguished from PCI by having Capability ID 0x10
+  If the device is PCI express then its SDBF structure gets updated with pointer to
+  the PCIe Capability. This is an optimization feature. It greatly decreases the number
+  of bus accesses, since most features configured by this library depend on registers
+  whose location is relative to PCIe capability.
+
+  @param[in,out] Sbdf   on entry, segment:bus:device:function coordinates
+                        on exit, PcieCap offset is updated
+
+  @retval               TRUE when PCIe device exists; FALSE if it's not PCIe or there's no device at all
+**/
+STATIC
+BOOLEAN
+IsPcieDevice (
+  SBDF *Sbdf
+  )
+{
+  UINT8 PcieCapOffset;
+  UINT64         Base;
+
+  Base = SbdfToBase(*Sbdf);
+
+  if (PciSegmentRead16 (Base) == 0xFFFF) {
+    return FALSE;
+  }
+
+
+  PcieCapOffset = PcieBaseFindCapId (Base, EFI_PCI_CAPABILITY_ID_PCIEXP);
+  if (PcieCapOffset == 0) {
+    DEBUG ((DEBUG_INFO, "IsPcieDevice %02x:%02x:%02x - legacy\n", Sbdf->Bus, Sbdf->Dev, Sbdf->Func));
+    return FALSE;
+  } else {
+    Sbdf->PcieCap = PcieCapOffset;
+    DEBUG ((DEBUG_INFO, "IsPcieDevice %02x:%02x:%02x - yes\n", Sbdf->Bus, Sbdf->Dev, Sbdf->Func));
+    return TRUE;
+  }
+}
+
+/**
+  Returns TRUE and Dev:Func numbers where a PCIe device could legally be located, or FALSE if there
+  no such coordinates left.
+
+  Segment and Bus fields of SBDF structure are input only and determine which bus will be scanned.
+  This function should be called in a while() loop. It replaces the less efficient method of
+  using nested FOR loops that iterate over all device and function numbers. It is optimized for
+  the amount of bus access. If function0 doesn't exist or doesn't have Multifunction bit set,
+  then higher function numbers are skipped. If parent of this bus is a downstream port, then
+  Device numbers 1-31 get skipped too (there can be only Dev0 behind downstream ports)
+  If device/function number == 0x1F/0x7, this function returns first possible address, that is 0:0
+  Any other device number means Dev:Func contain address of last found child device
+  and this function should search for next one
+
+  @param[in]     ParentDevType  type of bridge who's partent of this bus
+  @param[in,out] Sbdf           On entry: location returned previously from this function
+                                          Dev:Func value of 1F:07 means search should start from the beginning
+                                On exit:  if legal Dev:Func combination was found, that Dev:Func is returned
+                                          otherwise, Dev:Func are initialized to 1F:07 for convenience
+
+  @retval TRUE when next legal Dev:Func address was found; FALSE otherwise
+**/
+STATIC
+BOOLEAN
+FindNextLegalSbdf (
+  IN     PCI_DEV_TYPE ParentDevType,
+  IN OUT SBDF         *Sbdf
+  )
+{
+  UINT8  MaxDev;
+  UINT64 Func0Base;
+
+  if (ParentDevType == DevTypePcieEndpoint) {
+    return FALSE;
+  }
+  if (ParentDevType == DevTypePcieUpstream) {
+    MaxDev = PCI_MAX_DEVICE;
+  } else {
+    MaxDev = 0;
+  }
+  Func0Base = PCI_SEGMENT_LIB_ADDRESS (Sbdf->Seg, Sbdf->Bus, Sbdf->Dev, 0, 0);
+  if ((Sbdf->Dev == PCI_MAX_DEVICE) && Sbdf->Func == PCI_MAX_FUNC) {
+    Sbdf->Dev = 0;
+    Sbdf->Func = 0;
+    return TRUE;
+  } else if ((Sbdf->Func == PCI_MAX_FUNC) || (Sbdf->Func == 0 && !IsMultifunctionDevice (Func0Base))) {
+  //
+  // if it's the last function of a device, then return Func0 of new device or FALSE in case there are no more devices
+  //
+    if (Sbdf->Dev == MaxDev) {
+      InitChildFinder (Sbdf);
+      return FALSE;
+    }
+    (Sbdf->Dev)++;
+    Sbdf->Func = 0;
+    return TRUE;
+  } else {
+    (Sbdf->Func)++;
+    return TRUE;
+  }
+}
+
+/**
+  Finds next PCIe (not legacy PCI) device behind given device
+  If device/function number == 0x1F/0x7, this function searches for children from scratch
+  Any other device number means Dev:Func contain address of last found child device
+  and this function should search for next one
+
+  @param[in]     ParentDevType  type of bridge who's partent of this bus
+  @param[in,out] Sbdf           On entry: location returned previously from this function
+                                          Dev:Func value of 0x1F:0x07 means search should start from the beginning
+                                On exit:  if PCIe device was found, its SBDF coordinates are returned
+                                          otherwise, Dev:Func are initialized to 0x1F:0x07 for convenience
+  @retval TRUE when next PCIe device was found; FALSE otherwise
+**/
+BOOLEAN
+FindNextPcieChild (
+  IN     PCI_DEV_TYPE ParentDevType,
+  IN OUT SBDF   *Sbdf
+  )
+{
+  while ( FindNextLegalSbdf (ParentDevType, Sbdf)) {
+    if (IsPcieDevice (Sbdf)) {
+      return TRUE;
+    }
+  }
+  return FALSE;
+}
+
+/**
+  Checks if given device supports Clock Power Management
+
+  @param[in] Sbdf     segment:bus:device:function coordinates of a device
+
+  @retval TRUE when device supports it, FALSE otherwise
+**/
+STATIC
+BOOLEAN
+IsCpmSupported (
+  SBDF Sbdf
+  )
+{
+  return !!(PciSegmentRead32 (SbdfToBase (Sbdf) + Sbdf.PcieCap + R_PCIE_LCAP_OFFSET) & B_PCIE_LCAP_CPM);
+}
+
+/**
+  Sets Enable Clock Power Management bit for given device
+
+  @param[in] Sbdf            segment:bus:device:function coordinates of a device
+**/
+STATIC
+VOID
+EnableCpm (
+  SBDF Sbdf
+  )
+{
+  PciSegmentOr16 (SbdfToBase (Sbdf) + Sbdf.PcieCap + R_PCIE_LCTL_OFFSET, B_PCIE_LCTL_ECPM);
+}
+
+/**
+  Checks if given device is an IoAPIC
+
+  @param[in] Base            device's base address
+
+  @retval TRUE if it's an IoAPIC
+**/
+BOOLEAN
+IsIoApicDevice (
+  UINT64 Base
+  )
+{
+  UINT8 BaseClassCode;
+  UINT8 SubClassCode;
+  UINT8 ProgInterface;
+
+  BaseClassCode = PciSegmentRead8 (Base + PCI_CLASSCODE_OFFSET + 2);
+  SubClassCode  = PciSegmentRead8 (Base + PCI_CLASSCODE_OFFSET + 1);
+  ProgInterface = PciSegmentRead8 (Base + PCI_CLASSCODE_OFFSET);
+  if ((BaseClassCode == PCI_CLASS_SYSTEM_PERIPHERAL) &&
+      (SubClassCode == PCI_SUBCLASS_PIC) &&
+      ((ProgInterface == PCI_IF_APIC_CONTROLLER) ||
+       (ProgInterface == PCI_IF_APIC_CONTROLLER2))) {
+    return TRUE;
+  }
+  return FALSE;
+}
+
+/**
+  There are some devices which support L1 substates, but due to silicon bugs the corresponding register
+  cannot be found by scanning PCIe capabilities. This function checks list of such devices and if one
+  is found, returns its L1ss capability register offset
+
+  @param[in] Base       base address of device
+  @param[in] Override   table of devices that need override
+
+  @retval               offset to L1ss capability register
+**/
+UINT16
+GetOverrideL1ssCapsOffset (
+  UINT64         Base,
+  OVERRIDE_TABLE *Override
+  )
+{
+  UINT16 DeviceId;
+  UINT16 VendorId;
+  UINT8  Revision;
+  UINT32 Index;
+
+  VendorId = PciSegmentRead16 (Base + PCI_VENDOR_ID_OFFSET);
+  DeviceId = PciSegmentRead16 (Base + PCI_DEVICE_ID_OFFSET);
+  Revision = PciSegmentRead8  (Base + PCI_REVISION_ID_OFFSET);
+
+  for (Index = 0; Index < Override->Size; Index++) {
+    if (((Override->Table[Index].OverrideConfig & PchPcieL1SubstatesOverride) == PchPcieL1SubstatesOverride) &&
+        (Override->Table[Index].VendorId == VendorId) &&
+        (Override->Table[Index].DeviceId == DeviceId) &&
+        (Override->Table[Index].RevId == Revision || Override->Table[Index].RevId == 0xFFFF)) {
+      return Override->Table[Index].L1SubstatesCapOffset;
+    }
+  }
+  return 0;
+}
+
+/**
+  There are some devices whose implementation of L1 substates is partially broken. This function checks
+  list of such devices and if one is found, overrides their L1ss-related capabilities
+
+  @param[in]     Base       base address of device
+  @param[in]     Override   table of devices that need override
+  @param[in,out] L1ss       on entry, capabilities read from register; on exit, capabilities modified according ot override table
+**/
+STATIC
+VOID
+OverrideL1ssCaps (
+  UINT64         Base,
+  OVERRIDE_TABLE *Override,
+  L1SS_CAPS      *L1ss
+  )
+{
+  UINT16 DeviceId;
+  UINT16 VendorId;
+  UINT8  Revision;
+  UINT32 Index;
+
+  VendorId = PciSegmentRead16 (Base + PCI_VENDOR_ID_OFFSET);
+  DeviceId = PciSegmentRead16 (Base + PCI_DEVICE_ID_OFFSET);
+  Revision = PciSegmentRead8  (Base + PCI_REVISION_ID_OFFSET);
+
+  for (Index = 0; Index < Override->Size; Index++) {
+    if (((Override->Table[Index].OverrideConfig & PchPcieL1SubstatesOverride) == PchPcieL1SubstatesOverride) &&
+        (Override->Table[Index].VendorId == VendorId) &&
+        (Override->Table[Index].DeviceId == DeviceId) &&
+        (Override->Table[Index].RevId == Revision || Override->Table[Index].RevId == 0xFF)) {
+
+      L1ss->PmL12   &= !!(Override->Table[Index].L1SubstatesCapMask & B_PCIE_EX_L1SCAP_PPL12S);
+      L1ss->PmL11   &= !!(Override->Table[Index].L1SubstatesCapMask & B_PCIE_EX_L1SCAP_PPL11S);
+      L1ss->AspmL12 &= !!(Override->Table[Index].L1SubstatesCapMask & B_PCIE_EX_L1SCAP_AL12S);
+      L1ss->AspmL11 &= !!(Override->Table[Index].L1SubstatesCapMask & B_PCIE_EX_L1SCAP_AL1SS);
+      if (Override->Table[Index].L1sTpowerOnValue != 0) {
+        L1ss->Cmrt = Override->Table[Index].L1sCommonModeRestoreTime;
+        L1ss->TpoScale = Override->Table[Index].L1sTpowerOnScale;
+        L1ss->TpoValue = Override->Table[Index].L1sTpowerOnValue;
+      }
+      return;
+    }
+  }
+}
+
+/**
+  Returns L1 sub states capabilities of a device
+
+  @param[in] Base   base address of a device
+
+  @retval L1SS_CAPS structure filled with device's capabilities
+**/
+STATIC
+L1SS_CAPS
+GetL1ssCaps (
+  UINT64         Base,
+  OVERRIDE_TABLE *Override
+  )
+{
+  L1SS_CAPS Capabilities = {0};
+  UINT16    PcieCapOffset;
+  UINT32    CapsRegister;
+
+  PcieCapOffset = GetOverrideL1ssCapsOffset (Base, Override);
+  if (PcieCapOffset == 0) {
+    PcieCapOffset = PcieBaseFindExtendedCapId (Base, V_PCIE_EX_L1S_CID);
+  }
+  if (PcieCapOffset == 0) {
+    return Capabilities;
+  }
+  CapsRegister = PciSegmentRead32 (Base + PcieCapOffset + R_PCIE_EX_L1SCAP_OFFSET);
+  if (CapsRegister & B_PCIE_EX_L1SCAP_L1PSS) {
+    //
+    // Skip L1.1 checking since some device only indecate L1.2 support.
+    // [1604452805]
+    //
+    Capabilities.PmL11 = !!(CapsRegister & B_PCIE_EX_L1SCAP_PPL11S);
+    Capabilities.PmL12 = !!(CapsRegister & B_PCIE_EX_L1SCAP_PPL12S);
+    Capabilities.AspmL12 = !!(CapsRegister & B_PCIE_EX_L1SCAP_AL12S);
+    Capabilities.AspmL11 = !!(CapsRegister & B_PCIE_EX_L1SCAP_AL1SS);
+    Capabilities.Cmrt = (CapsRegister & B_PCIE_EX_L1SCAP_CMRT) >> N_PCIE_EX_L1SCAP_CMRT;
+    Capabilities.TpoValue = (CapsRegister & B_PCIE_EX_L1SCAP_PTV) >> N_PCIE_EX_L1SCAP_PTV;
+    Capabilities.TpoScale = (CapsRegister & B_PCIE_EX_L1SCAP_PTPOS) >> N_PCIE_EX_L1SCAP_PTPOS;
+  }
+  OverrideL1ssCaps (Base, Override, &Capabilities);
+  return Capabilities;
+}
+
+/**
+  Returns combination of two sets of L1 substate capabilities
+  Given feature is supported by the link only if both sides support it
+  Time parameters for link (Cmrt and Tpo) depend on the bigger value between two sides
+
+  @param[in] L1ssA      L1 substate capabilities of first device
+  @param[in] L1ssB      L1 substate capabilities of second device
+
+  @retval Link's L1 substate capabilities
+**/
+STATIC
+L1SS_CAPS
+CombineL1ss (
+  L1SS_CAPS L1ssA,
+  L1SS_CAPS L1ssB
+  )
+{
+  L1SS_CAPS Combined;
+
+  Combined.PmL12 = L1ssA.PmL12 && L1ssB.PmL12;
+  Combined.PmL11 = L1ssA.PmL11 && L1ssB.PmL11;
+  Combined.AspmL12 = L1ssA.AspmL12 && L1ssB.AspmL12;
+  Combined.AspmL11 = L1ssA.AspmL11 && L1ssB.AspmL11;
+  Combined.Cmrt = MAX (L1ssA.Cmrt, L1ssB.Cmrt);
+  if (TpoToUs (L1ssA.TpoScale, L1ssA.TpoValue) > TpoToUs (L1ssB.TpoScale, L1ssB.TpoValue)) {
+    Combined.TpoScale = L1ssA.TpoScale;
+    Combined.TpoValue = L1ssA.TpoValue;
+  } else {
+    Combined.TpoScale = L1ssB.TpoScale;
+    Combined.TpoValue = L1ssB.TpoValue;
+  }
+  return Combined;
+}
+
+/**
+  Configures L1 substate feature in a device
+
+  @param[in] Sbdf     segment:bus:device:function coordinates of a device
+  @param[in] L1ss     configuration to be programmed
+  @param[in] Override table of devices that require special handling
+**/
+STATIC
+VOID
+SetL1ss (
+  SBDF           Sbdf,
+  L1SS_CAPS      L1ss,
+  OVERRIDE_TABLE *Override,
+  BOOLEAN   IsCpuPcie
+
+  )
+{
+  UINT16    PcieCapOffset;
+  UINT32    Ctrl1Register;
+  UINT32    Ctrl2Register;
+  UINT64    Base;
+
+  Base = SbdfToBase(Sbdf);
+  Ctrl1Register = 0;
+  Ctrl2Register = 0;
+
+  PcieCapOffset = GetOverrideL1ssCapsOffset (Base, Override);
+  if (PcieCapOffset == 0) {
+    PcieCapOffset = PcieBaseFindExtendedCapId (Base, V_PCIE_EX_L1S_CID);
+  }
+  if (PcieCapOffset == 0) {
+    return;
+  }
+
+  Ctrl1Register |= (L1ss.PmL12 ? B_PCIE_EX_L1SCAP_PPL12S : 0);
+  Ctrl1Register |= (L1ss.PmL11 ? B_PCIE_EX_L1SCAP_PPL11S : 0);
+  Ctrl1Register |= (L1ss.AspmL12 ? B_PCIE_EX_L1SCAP_AL12S : 0);
+  Ctrl1Register |= (L1ss.AspmL11 ? B_PCIE_EX_L1SCAP_AL1SS : 0);
+  if ((GetDeviceType (Sbdf) == DevTypePcieDownstream)) {
+    Ctrl1Register |= (L1ss.Cmrt << N_PCIE_EX_L1SCAP_CMRT);
+  }
+  ///
+  /// BWG 1.3 Section 5.5.7.6 LTR Threshold Latency
+  /// Set L1.2 LTR threshold using formula (TpoToUs (L1ss.TpoScale, L1ss.TpoValue) + L1ss.Cmrt + 10)
+  ///
+  Ctrl1Register |= ((TpoToUs (L1ss.TpoScale, L1ss.TpoValue) + L1ss.Cmrt + 10) << N_PCIE_EX_L1SCTL1_L12LTRTLV);
+  Ctrl1Register |= (2 << N_PCIE_EX_L1SCTL1_L12LTRTLSV);
+
+  Ctrl2Register |= (L1ss.TpoScale);
+  Ctrl2Register |= (L1ss.TpoValue << N_PCIE_EX_L1SCTL2_POWT);
+  //
+  // Set CLKREQ Acceleration Interrupt Enable
+  //
+  Ctrl1Register |= B_PCIE_EX_L1SCTL1_L1SSEIE;
+  PciSegmentWrite32 (Base + PcieCapOffset + R_PCIE_EX_L1SCTL1_OFFSET, 0);
+  PciSegmentWrite32 (Base + PcieCapOffset + R_PCIE_EX_L1SCTL2_OFFSET, Ctrl2Register);
+  PciSegmentWrite32 (Base + PcieCapOffset + R_PCIE_EX_L1SCTL1_OFFSET, Ctrl1Register);
+}
+
+/**
+  Converts L1 latency from enumerated register value to microseconds
+
+  @param[in] L1Latency     latency value retrieved from register; see PCIE specification for encoding
+
+  @retval    L1 latency converted to microseconds
+**/
+UINT32
+L1LatencyToUs (
+  UINT32 L1Latency
+  )
+{
+  if (L1Latency < 7) {
+    return 1 * (BIT0 << L1Latency);
+  } else {
+    return ASPM_L1_NO_LIMIT;
+  }
+}
+
+/**
+  Modifies L1 latency by provided value
+
+  @param[in] Aspm     Structure that contains ASPM capabilities of a link, including L1 acceptable latency
+  @param[in] Value    Value, in microseconds, to be added to L1 acceptable latency. Can be negative.
+
+  @retval             Aspm structure with modified L1 acceptable latency
+**/
+STATIC
+ASPM_CAPS
+PatchL1AcceptableLatency (
+  ASPM_CAPS Aspm,
+  INT8      Value
+  )
+{
+  if (Aspm.L1AcceptableLatencyUs != ASPM_L1_NO_LIMIT) {
+    if (Value > 0) {
+      Aspm.L1AcceptableLatencyUs += Value;
+    } else {
+      if (Aspm.L1AcceptableLatencyUs > (UINT32)(-1*Value)) {
+        Aspm.L1AcceptableLatencyUs = Aspm.L1AcceptableLatencyUs + Value;
+      } else {
+        Aspm.L1AcceptableLatencyUs = 0;
+      }
+    }
+  }
+  return Aspm;
+}
+
+/**
+  Reads ASPM capabilities of a device
+
+  @param[in] Sbdf segment:bus:device:function coordinates of a device
+
+  @retval           structure containing device's ASPM capabilities
+**/
+STATIC
+ASPM_CAPS
+GetAspmCaps (
+  SBDF   Sbdf
+  )
+{
+
+  UINT32    LinkCapRegister;
+  UINT32    DevCapRegister;
+  UINT64    Base;
+  ASPM_CAPS Aspm = {0};
+
+  Base = SbdfToBase (Sbdf);
+
+  LinkCapRegister = PciSegmentRead32 (Base + Sbdf.PcieCap + R_PCIE_LCAP_OFFSET);
+  DevCapRegister = PciSegmentRead32 (Base + Sbdf.PcieCap + R_PCIE_DCAP_OFFSET);
+
+  ///
+  /// Check endpoint for pre-1.1 devices based on the Role based Error Reporting Capability bit. Don't report L0s support for old devices
+  ///
+  if (DevCapRegister & B_PCIE_DCAP_RBER) {
+    Aspm.L0sSupported = !!(LinkCapRegister & B_PCIE_LCAP_APMS_L0S);
+  }
+  Aspm.L1Supported = !!(LinkCapRegister & B_PCIE_LCAP_APMS_L1);
+
+  Aspm.LinkL0sExitLatency = (LinkCapRegister & B_PCIE_LCAP_EL0) >> N_PCIE_LCAP_EL0;
+  Aspm.LinkL1ExitLatencyUs = L1LatencyToUs( (LinkCapRegister & B_PCIE_LCAP_EL1) >> N_PCIE_LCAP_EL1);
+
+  if (GetDeviceType (Sbdf) == DevTypePcieEndpoint) {
+    Aspm.L0sAcceptableLatency = (DevCapRegister & B_PCIE_DCAP_E0AL) >> N_PCIE_DCAP_E0AL;
+    Aspm.L1AcceptableLatencyUs = L1LatencyToUs( (DevCapRegister & B_PCIE_DCAP_E1AL) >> N_PCIE_DCAP_E1AL);
+    DEBUG ((DEBUG_INFO, "GetAspmCaps %02x:%02x:%02x L0s%c %d:%d L1%c %d:%d\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func,
+                                                                           Aspm.L0sSupported?'+':'-', Aspm.LinkL0sExitLatency, Aspm.L0sAcceptableLatency,
+                                                                           Aspm.L1Supported?'+':'-', Aspm.LinkL1ExitLatencyUs, Aspm.L1AcceptableLatencyUs));
+  } else {
+    Aspm.L0sAcceptableLatency = ASPM_L0s_NO_LIMIT;
+    Aspm.L1AcceptableLatencyUs = ASPM_L1_NO_LIMIT;
+    DEBUG ((DEBUG_INFO, "GetAspmCaps %02x:%02x:%02x L0s%c %d:x L1%c %d:x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func,
+                                                                           Aspm.L0sSupported?'+':'-', Aspm.LinkL0sExitLatency,
+                                                                           Aspm.L1Supported?'+':'-', Aspm.LinkL1ExitLatencyUs));
+  }
+  return Aspm;
+}
+
+/**
+  Get ASPM L0s and L1 override of given device.
+
+  @param[in] Sbdf                Segment,Bus,Device,Function address of currently visited PCIe device
+  @param[in,out] MyAspm          Current device's ASPM capabilities structure
+  @param[in] Override            Pch Pcie devices OverrideTable
+**/
+STATIC
+VOID
+GetOverrideAspm (
+  SBDF           Sbdf,
+  ASPM_CAPS      *MyAspm,
+  OVERRIDE_TABLE *Override
+  )
+{
+  UINT16      DeviceId;
+  UINT16      VendorId;
+  UINT8       Revision;
+  UINT32      Index;
+  UINT64      Base;
+
+  Base = SbdfToBase (Sbdf);
+
+  VendorId = PciSegmentRead16 (Base + PCI_VENDOR_ID_OFFSET);
+  DeviceId = PciSegmentRead16 (Base + PCI_DEVICE_ID_OFFSET);
+  Revision = PciSegmentRead8  (Base + PCI_REVISION_ID_OFFSET);
+
+  for (Index = 0; Index < Override->Size; Index++) {
+    if (((Override->Table[Index].OverrideConfig & PchPcieL1L2Override) == PchPcieL1L2Override) &&
+        (Override->Table[Index].VendorId == VendorId) &&
+        (Override->Table[Index].DeviceId == DeviceId) &&
+        (Override->Table[Index].RevId == Revision || Override->Table[Index].RevId == 0xFF)) {
+      DEBUG ((DEBUG_INFO, "GetOverrideAspm %02x:%02x:%02x, original L0sSupported = 0x%x, L1Supported = 0x%x\n",
+              Sbdf.Bus, Sbdf.Dev, Sbdf.Func, MyAspm->L0sSupported, MyAspm->L1Supported));
+      if (MyAspm->L0sSupported) {
+        //
+        // If L0s is supported in capability, apply platform override.
+        //
+        MyAspm->L0sSupported = Override->Table[Index].EndPointAspm & BIT0;
+      }
+      if (MyAspm->L1Supported) {
+        //
+        // If L1 is supported in capability, apply platform override.
+        //
+        MyAspm->L1Supported = (Override->Table[Index].EndPointAspm & BIT1) >> 1;
+      }
+      DEBUG ((DEBUG_INFO, "GetOverrideAspm %02x:%02x:%02x, override L0sSupported = 0x%x, L1Supported = 0x%x\n",
+              Sbdf.Bus, Sbdf.Dev, Sbdf.Func, MyAspm->L0sSupported, MyAspm->L1Supported));
+    }
+  }
+}
+
+/**
+  Combines ASPM capabilities of two devices on both ends of a link to determine link's ASPM capabilities
+
+  @param[in] AspmA, AspmB  ASPM capabilities of two devices
+
+  @retval    ASPM_CAPS structure containing combined ASPM capabilities
+**/
+STATIC
+ASPM_CAPS
+CombineAspm (
+  ASPM_CAPS AspmA,
+  ASPM_CAPS AspmB,
+  BOOLEAN   DownstreamPort
+  )
+{
+  ASPM_CAPS Combined;
+
+  if (DownstreamPort) {
+    //
+    // When combining ASPM in downstream ports, combination must reflect state of link just below
+    // and consider all acceptable latencies of all endpoints anywhere down below that port
+    //
+    Combined.L0sSupported = AspmA.L0sSupported & AspmB.L0sSupported;
+    Combined.L1Supported = AspmA.L1Supported & AspmB.L1Supported;
+    Combined.LinkL0sExitLatency = MAX (AspmA.LinkL0sExitLatency, AspmB.LinkL0sExitLatency);
+    Combined.LinkL1ExitLatencyUs = MAX (AspmA.LinkL1ExitLatencyUs, AspmB.LinkL1ExitLatencyUs);
+    Combined.L0sAcceptableLatency = MIN (AspmA.L0sAcceptableLatency, AspmB.L0sAcceptableLatency);
+    Combined.L1AcceptableLatencyUs = MIN (AspmA.L1AcceptableLatencyUs, AspmB.L1AcceptableLatencyUs);
+  } else {
+    //
+    // When combining ASPM in switch upstream ports,
+    // Supported and ExitLatency must only reflect capabilities of upstream port itself
+    // But acceptable latencies must consider all endpoints anywhere below
+    //
+    Combined.L0sSupported = AspmA.L0sSupported;
+    Combined.L1Supported = AspmA.L1Supported;
+    Combined.LinkL0sExitLatency = AspmA.LinkL0sExitLatency;
+    Combined.LinkL1ExitLatencyUs = AspmA.LinkL1ExitLatencyUs;
+    Combined.L0sAcceptableLatency = MIN (AspmA.L0sAcceptableLatency, AspmB.L0sAcceptableLatency);
+    Combined.L1AcceptableLatencyUs = MIN (AspmA.L1AcceptableLatencyUs, AspmB.L1AcceptableLatencyUs);
+  }
+  DEBUG ((DEBUG_INFO, "CombineAspm %x:%x -> %x\n", AspmA.L1AcceptableLatencyUs, AspmB.L1AcceptableLatencyUs, Combined.L1AcceptableLatencyUs));
+  return Combined;
+}
+
+/**
+  Checks if L1 can be enabled on given link, according to ASPM parameters of that link
+
+  @param[in] Aspm            set of parameters describing this link and endpoint devices below it
+
+  @retval    TRUE if L1 can be enabled
+**/
+STATIC
+BOOLEAN
+IsL1Allowed (
+  ASPM_CAPS Aspm
+  )
+{
+  return (Aspm.L1Supported && (Aspm.L1AcceptableLatencyUs >= Aspm.LinkL1ExitLatencyUs));
+}
+
+/**
+  Checks if L0s can be enabled on given link, according to ASPM parameters of that link
+
+  @param[in] Aspm            set of parameters describing this link and endpoint devices below it
+
+  @retval    TRUE if L0s can be enabled
+**/
+STATIC
+BOOLEAN
+IsL0sAllowed (
+  ASPM_CAPS Aspm
+  )
+{
+  return (Aspm.L0sSupported && (Aspm.L0sAcceptableLatency >= Aspm.LinkL0sExitLatency));
+}
+
+/**
+  Enables L0s and L1 for given port, if possible.
+  L0s/L1 can be enabled if it's supported on both sides of a link and if link's latency doesn't exceed
+  acceptable latency of any endpoint below this link
+
+  @param[in] Base            device's base address
+  @param[in] Aspm            set of parameters describing this link and endpoint devices below it
+**/
+STATIC
+VOID
+SetAspm (
+  SBDF      Sbdf,
+  ASPM_CAPS Aspm
+  )
+{
+  UINT16 DataOr;
+
+  DataOr = 0;
+  if (IsL0sAllowed (Aspm)) {
+    DataOr |= V_PCIE_LCTL_ASPM_L0S;
+  }
+  if (IsL1Allowed (Aspm)) {
+    DataOr |= V_PCIE_LCTL_ASPM_L1;
+  }
+  DEBUG ((DEBUG_INFO, "SetAspm on %02x:%02x:%02x to %d\n", Sbdf.Bus,Sbdf.Dev,Sbdf.Func, DataOr));
+  PciSegmentAndThenOr16 (SbdfToBase (Sbdf) + Sbdf.PcieCap + R_PCIE_LCTL_OFFSET, (UINT16)~B_PCIE_LCTL_ASPM, DataOr);
+}
+
+/**
+  Adds device entry to a list of devices.
+
+  @param[in,out] Table    array of devices
+  @param[in]     Sbdf     segment:bus:device:function coordinates of device to be added to table
+**/
+STATIC
+VOID
+AddToDeviceTable (
+  SBDF_TABLE *Table,
+  SBDF       Sbdf
+  )
+{
+  if (Table->Count < MAX_SBDF_TABLE_SIZE) {
+    Table->Entry[Table->Count++] = Sbdf;
+  } else {
+    ASSERT (FALSE);
+  }
+}
+
+/**
+  Remove device entry from a list and clear its bus assignment
+
+  @param[in,out] Table    array of devices
+**/
+STATIC
+VOID
+ClearBusFromTable (
+  SBDF_TABLE *Table
+  )
+{
+  while (Table->Count > 0) {
+    PciSegmentWrite32 (SbdfToBase (Table->Entry[Table->Count - 1]) + PCI_BRIDGE_PRIMARY_BUS_REGISTER_OFFSET, 0);
+    Table->Count--;
+  }
+}
+
+/**
+  Attempts to assign secondary and subordinate bus numbers to uninitialized bridges in PCIe tree
+  If the device is a bridge and already has bus numbers assigned, they won't be changed
+  Otherwise new bus number will be assigned below this bridge.
+  This function can be called from SMM, where BIOS must not modify bus numbers to prevent
+  conflict with OS enumerator. To prevent this, this function returns list of bridges whose
+  bus numbers were changed. All devices from that list must have buses cleared afterwards.
+
+  @param[in] Sbdf                segment:bus:device:function coordinates of device to be added to table
+  @param[in] MinBus              minimum Bus number that can be assigned below this port
+  @param[in] MaxBus              maximum Bus number that can be assigned below this port
+  @param[in] BridgeCleanupList   list of bridges where bus numbers were modified
+
+  @retval    maximum bus number assigned anywhere below this device
+**/
+STATIC
+UINT8
+RecursiveBusAssignment (
+  SBDF       Sbdf,
+  UINT8      MinBus,
+  UINT8      MaxBus,
+  SBDF_TABLE *BridgeCleanupList
+  )
+{
+  UINT64  Base;
+  SBDF    ChildSbdf;
+  PCI_DEV_TYPE DevType;
+  UINT32  Data32;
+  UINT8   BelowBus;
+  UINT8   SecondaryBus;
+  UINT8   SubordinateBus;
+
+  ChildSbdf.Seg = Sbdf.Seg;
+  InitChildFinder (&ChildSbdf);
+  Base = SbdfToBase (Sbdf);
+
+  //
+  // On way down:
+  //   assign secondary bus, then increase it by one before stepping down; temporarily assign max subordinate bus
+  // On way up:
+  //   fix subordinate bus assignment to equal max bus number assigned anywhere below; return that number
+  //
+  DevType = GetDeviceType (Sbdf);
+  if ((Sbdf.Bus >= MaxBus) || (DevType == DevTypePcieEndpoint) || (DevType == DevTypePci)) {
+    return (UINT8) Sbdf.Bus;
+  } else  {
+    Data32 = PciSegmentRead32 (Base + PCI_BRIDGE_PRIMARY_BUS_REGISTER_OFFSET);
+    SecondaryBus = (UINT8)((Data32 & B_PCI_BRIDGE_BNUM_SCBN) >> 8);
+    SubordinateBus = (UINT8)((Data32 & B_PCI_BRIDGE_BNUM_SBBN) >> 16);
+    if (SecondaryBus != 0) {
+      ChildSbdf.Bus = SecondaryBus;
+      MinBus = SecondaryBus + 1;
+      DEBUG ((DEBUG_INFO, "RecursiveBusAssignmentP %x:%x:%x -> %x,%x,%x \n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func, Sbdf.Bus, MinBus, SubordinateBus));
+      while (FindNextPcieChild (DevType, &ChildSbdf)) {
+        BelowBus = RecursiveBusAssignment (ChildSbdf, MinBus, SubordinateBus, BridgeCleanupList);
+        MinBus = BelowBus + 1;
+      }
+      return SubordinateBus;
+    } else {
+      Data32 = Sbdf.Bus + (MinBus << 8) + (MaxBus << 16);
+      PciSegmentWrite32(Base + PCI_BRIDGE_PRIMARY_BUS_REGISTER_OFFSET, Data32);
+      AddToDeviceTable (BridgeCleanupList, Sbdf);
+      DEBUG ((DEBUG_INFO, "RecursiveBusAssignmentE %x:%x:%x -> %x,%x,%x \n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func, Sbdf.Bus, MinBus, MaxBus));
+      BelowBus = MinBus;
+      ChildSbdf.Bus = MinBus;
+      MinBus++;
+      while (FindNextPcieChild (DevType, &ChildSbdf)) {
+        BelowBus = RecursiveBusAssignment (ChildSbdf, MinBus, MaxBus, BridgeCleanupList);
+        MinBus = BelowBus + 1;
+      }
+      Data32  &= ~B_PCI_BRIDGE_BNUM_SBBN;
+      Data32 |= (BelowBus << 16);
+      PciSegmentWrite32 (Base + PCI_BRIDGE_PRIMARY_BUS_REGISTER_OFFSET, Data32);
+      DEBUG ((DEBUG_INFO, "RecursiveBusAssignmentL %x:%x:%x -> %x,%x,%x \n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func, Sbdf.Bus, (Data32&0xFF00)>>8, BelowBus));
+      return BelowBus;
+    }
+  }
+}
+
+/**
+  Enables L0s and/or L1 for PCIE links in the hierarchy below
+  L0s/L1 can be enabled when both sides of a link support it and link latency is smaller than acceptable latency
+  ASPM of a given link is independend from any other link (except 1ms L1 adjustment, read below), so it's possible to
+  have a hierarchy when RP link has no ASPM but links below do.
+
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+  @param[in] Depth                          How many links there are between this port and root complex
+  @param[in] Override                       Pch Pcie devices OverrideTable
+
+  @retval structure that describes acceptable latencies of all endpoints below plus ASPM parameters of last link
+**/
+STATIC
+ASPM_CAPS
+RecursiveAspmConfiguration (
+  SBDF           Sbdf,
+  UINT8          Depth,
+  OVERRIDE_TABLE *Override
+  )
+{
+  SBDF         ChildSbdf;
+  ASPM_CAPS    MyAspm;
+  ASPM_CAPS    ChildAspm;
+  PCI_DEV_TYPE DevType;
+
+  DEBUG ((DEBUG_INFO, "RecursiveAspmConfiguration %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+
+  //
+  // On way down:
+  //   pass number of links traversed; increase it per upstream port visited (not endpoint)
+  // On way up:
+  //   EndPoint: read Acceptable Latencies; subtract Depth From L1AcceptableLat to account for "1us per switch additional delay"
+  //   Downstreamport: AND L0s/L1 caps; calculate LinkLatency; enable L0s/L1 if supported and if acceptable latency is bigger than link latency;
+  //     if L1 not enabled, add back 1us to Acceptable Latency to cancel earlier Depth subtraction
+  //   UpstreamPort: calculate minimum of below Acceptable Latencies; return that, with upper link's Latency and L0s/L1 support
+  //
+  DevType = GetDeviceType(Sbdf);
+  if (DevType == DevTypePcieUpstream) {
+    Depth++;
+  }
+  MyAspm = GetAspmCaps (Sbdf);
+  //
+  // Get ASPM L0s and L1 override
+  //
+  if (Override != NULL) {
+    GetOverrideAspm (Sbdf, &MyAspm, Override);
+  }
+  if (DevType == DevTypePcieEndpoint) {
+    //
+    // Every switch between endpoint and CPU introduces 1us additional latency on L1 exit. This is reflected by
+    // subtracting 1us per switch from endpoint's acceptable L1 latency.
+    // In case L1 doesn't get enabled in one of switches, that 1us will be added back.
+    // This calculation is not precise. It ignores that some switches' added delay may be shadowed by
+    // other links' exit latency. But it guarantees that acceptable latency won't be exceeded and is simple
+    // enough to perform in a single iteration without backtracking.
+    //
+    return PatchL1AcceptableLatency (MyAspm, (-1 * Depth));
+  }
+  if (HasChildBus (Sbdf, &ChildSbdf)) {
+    while (FindNextPcieChild (DevType, &ChildSbdf)) {
+      ChildAspm = RecursiveAspmConfiguration (ChildSbdf, Depth, Override);
+      MyAspm = CombineAspm (MyAspm, ChildAspm, (DevType == DevTypePcieDownstream));
+    }
+    if (DevType == DevTypePcieDownstream) {
+      SetAspm (Sbdf, MyAspm);
+      //
+      // ASPM config must be consistent across all functions of a device. That's why there's while loop.
+      //
+      while (FindNextPcieChild (DevType, &ChildSbdf)) {
+        SetAspm (ChildSbdf, MyAspm);
+      }
+      if (!IsL1Allowed (MyAspm)) {
+        MyAspm = PatchL1AcceptableLatency (MyAspm, 1);
+      }
+    }
+  }
+  return MyAspm;
+}
+
+/**
+  Enables L1 substates for PCIE links in the hierarchy below
+  L1.1 / L1.2 can be enabled if both sides of a link support it.
+
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+
+  @retval  structure that describes L1ss capabilities of the device
+**/
+STATIC
+L1SS_CAPS
+RecursiveL1ssConfiguration (
+  SBDF           Sbdf,
+  OVERRIDE_TABLE *Override
+  )
+{
+  UINT64  Base;
+  SBDF    ChildSbdf;
+  L1SS_CAPS CombinedCaps;
+  L1SS_CAPS ChildCaps;
+  PCI_DEV_TYPE DevType;
+  BOOLEAN   IsCpuPcie;
+  UINT32    DevNum;
+
+  IsCpuPcie = FALSE;
+
+  DEBUG ((DEBUG_INFO, "RecursiveL1ssConfiguration %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+
+  Base = SbdfToBase (Sbdf);
+  DevNum = Sbdf.Dev;
+  if (DevNum == SA_PEG0_DEV_NUM || DevNum == SA_PEG3_DEV_NUM) {
+    IsCpuPcie = TRUE;
+  }
+  //
+  // On way down:
+  //   do nothing
+  // On way up:
+  //   In downstream ports, combine L1ss capabilities of that port and device behind it, then enable L1.1 and/or L1.2 if possible
+  //   Return L1ss capabilities
+  //
+  if (HasChildBus (Sbdf, &ChildSbdf)) {
+    DevType = GetDeviceType (Sbdf);
+    while (FindNextPcieChild (DevType, &ChildSbdf)) {
+      ChildCaps = RecursiveL1ssConfiguration (ChildSbdf, Override);
+      if (DevType == DevTypePcieDownstream && ChildSbdf.Func == 0) {
+        CombinedCaps = CombineL1ss (GetL1ssCaps (Base, Override), ChildCaps);
+        SetL1ss (Sbdf, CombinedCaps, Override, IsCpuPcie);
+        SetL1ss (ChildSbdf, CombinedCaps, Override, IsCpuPcie);
+      }
+    }
+  }
+  return GetL1ssCaps (Base, Override);
+}
+
+/**
+  Sets Enable Clock Power Management bit for devices that support it.
+  A device supports CPM only if all function of this device report CPM support.
+  Downstream ports never report CPM capability, so it's only relevant for upstream ports.
+  When this function executes on upstream component, it will check CPM & set ECPM of downstream component
+  When this function executes on downstream component, all devices below it are guaranteed to
+  return CPM=0 so it will do nothing
+
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+
+  @retval TRUE = this device supports CPM, FALSE = it doesn't
+**/
+STATIC
+BOOLEAN
+RecursiveCpmConfiguration (
+  SBDF       Sbdf
+  )
+{
+  SBDF         ChildSbdf;
+  BOOLEAN      ChildCpm;
+  PCI_DEV_TYPE DevType;
+
+  DEBUG ((DEBUG_INFO, "RecursiveCpmConfiguration %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+
+  ChildCpm = FALSE;
+
+  if (HasChildBus (Sbdf, &ChildSbdf)) {
+    ChildCpm = TRUE;
+    DevType = GetDeviceType (Sbdf);
+    while (FindNextPcieChild (DevType, &ChildSbdf)) {
+      ChildCpm &= RecursiveCpmConfiguration (ChildSbdf);
+    }
+    if (ChildCpm) {
+      while (FindNextPcieChild (DevType, &ChildSbdf)) {
+        EnableCpm (ChildSbdf);
+      }
+    }
+  }
+  return IsCpmSupported (Sbdf);
+}
+
+/**
+  Configures Latency Tolerance Reporting in given device and in PCIe tree below it.
+  This function configures Maximum LTR and enables LTR mechanism. It visits devices using depth-first search
+  and skips branches behind devices which do not support LTR.
+  Maximum LTR:
+    This function will set LTR's upper bound for every visited device. Max LTR value is provided as a parameter
+  Enable LTR:
+    LTR should be enabled top-to-bottom in every visited device that supports LTR. This function does not
+    iterate down behind devices with no LTR support. In effect, LTR will be enabled in given device if that device
+    and all devices above it on the way to RootComplex do support LTR.
+
+  This function expects that bridges have bus numbers already configured
+
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+  @param[in] LtrLimit                       Ltr to be programmed to every endpoint
+
+  @retval MaxLTR programmed in this device
+**/
+STATIC
+VOID
+RecursiveLtrConfiguration (
+  SBDF       Sbdf,
+  LTR_LIMIT  LtrLimit
+  )
+{
+  UINT64  Base;
+  SBDF    ChildSbdf;
+  PCI_DEV_TYPE DevType;
+
+  DEBUG ((DEBUG_INFO, "RecursiveLtrConfiguration %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+
+  Base = SbdfToBase(Sbdf);
+
+  if (!IsLtrCapable (Sbdf)) {
+    DEBUG ((DEBUG_INFO, "Not LtrCapable %02x:%02x:%02x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+    return;
+  }
+  EnableLtr (Sbdf);
+  if (HasChildBus (Sbdf, &ChildSbdf)) {
+    DevType = GetDeviceType (Sbdf);
+    while (FindNextPcieChild (DevType, &ChildSbdf)) {
+      RecursiveLtrConfiguration (ChildSbdf, LtrLimit);
+    }
+  }
+  SetLtrLimit (Base, LtrLimit);
+}
+
+/**
+  Checks if given PCI device is capable of Latency Tolerance Reporting
+
+  @param[in] Sbdf            device's segment:bus:device:function coordinates
+
+  @retval TRUE if yes
+**/
+BOOLEAN
+IsLtrCapable (
+  SBDF Sbdf
+  )
+{
+  if (Sbdf.PcieCap == 0) {
+    return FALSE;
+  }
+  return !!(PciSegmentRead32 (SbdfToBase (Sbdf) + Sbdf.PcieCap + R_PCIE_DCAP2_OFFSET) & B_PCIE_DCAP2_LTRMS);
+}
+
+/**
+  Returns combination of two LTR override values
+  The resulting LTR override separately chooses stricter limits for snoop and nosnoop
+
+  @param[in] LtrA      LTR override values to be combined
+  @param[in] LtrB      LTR override values to be combined
+
+  @retval LTR override value
+**/
+LTR_OVERRIDE
+CombineLtr (
+  LTR_OVERRIDE LtrA,
+  LTR_OVERRIDE LtrB
+  )
+{
+  UINT64        DecodedLatencyA;
+  UINT64        DecodedLatencyB;
+  LTR_OVERRIDE  Result;
+  static UINT32 ScaleEncoding [8] = {1, 32, 1024, 32768, 1048576, 33554432, 0, 0};
+
+  ZeroMem (&Result, sizeof (LTR_OVERRIDE));
+  DecodedLatencyA = ScaleEncoding[LtrA.MaxSnoopLatencyScale] * LtrA.MaxSnoopLatencyValue;
+  DecodedLatencyB = ScaleEncoding[LtrB.MaxSnoopLatencyScale] * LtrB.MaxSnoopLatencyValue;
+  if ((!LtrB.MaxSnoopLatencyRequirement) || ((DecodedLatencyA < DecodedLatencyB) && LtrA.MaxSnoopLatencyRequirement)) {
+    Result.MaxSnoopLatencyValue       = LtrA.MaxSnoopLatencyValue;
+    Result.MaxSnoopLatencyScale       = LtrA.MaxSnoopLatencyScale;
+    Result.MaxSnoopLatencyRequirement = LtrA.MaxSnoopLatencyRequirement;
+  } else {
+    Result.MaxSnoopLatencyValue       = LtrB.MaxSnoopLatencyValue;
+    Result.MaxSnoopLatencyScale       = LtrB.MaxSnoopLatencyScale;
+    Result.MaxSnoopLatencyRequirement = LtrB.MaxSnoopLatencyRequirement;
+  }
+  DecodedLatencyA = ScaleEncoding[LtrA.MaxNoSnoopLatencyScale] * LtrA.MaxNoSnoopLatencyValue;
+  DecodedLatencyB = ScaleEncoding[LtrB.MaxNoSnoopLatencyScale] * LtrB.MaxNoSnoopLatencyValue;
+  if ((!LtrB.MaxNoSnoopLatencyRequirement) || ((DecodedLatencyA < DecodedLatencyB) && LtrA.MaxNoSnoopLatencyRequirement)) {
+    Result.MaxNoSnoopLatencyValue       = LtrA.MaxNoSnoopLatencyValue;
+    Result.MaxNoSnoopLatencyScale       = LtrA.MaxNoSnoopLatencyScale;
+    Result.MaxNoSnoopLatencyRequirement = LtrA.MaxNoSnoopLatencyRequirement;
+  } else {
+    Result.MaxNoSnoopLatencyValue       = LtrB.MaxNoSnoopLatencyValue;
+    Result.MaxNoSnoopLatencyScale       = LtrB.MaxNoSnoopLatencyScale;
+    Result.MaxNoSnoopLatencyRequirement = LtrB.MaxNoSnoopLatencyRequirement;
+  }
+  if (LtrA.ForceOverride || LtrB.ForceOverride) {
+    Result.ForceOverride = TRUE;
+  }
+  DEBUG ((DEBUG_INFO, "CombineLtr: A(V%d S%d E%d : V%d S%d E%d, F%d)\n",
+    LtrA.MaxSnoopLatencyValue, LtrA.MaxSnoopLatencyScale, LtrA.MaxSnoopLatencyRequirement,
+    LtrA.MaxNoSnoopLatencyValue, LtrA.MaxNoSnoopLatencyScale, LtrA.MaxNoSnoopLatencyRequirement,
+    LtrA.ForceOverride
+    ));
+  DEBUG ((DEBUG_INFO, "          : B(V%d S%d E%d : V%d S%d E%d, F%d)\n",
+    LtrB.MaxSnoopLatencyValue, LtrB.MaxSnoopLatencyScale, LtrB.MaxSnoopLatencyRequirement,
+    LtrB.MaxNoSnoopLatencyValue, LtrB.MaxNoSnoopLatencyScale, LtrB.MaxNoSnoopLatencyRequirement,
+    LtrB.ForceOverride
+    ));
+  DEBUG ((DEBUG_INFO, "          : R(V%d S%d E%d : V%d S%d E%d, F%d)\n",
+    Result.MaxSnoopLatencyValue, Result.MaxSnoopLatencyScale, Result.MaxSnoopLatencyRequirement,
+    Result.MaxNoSnoopLatencyValue, Result.MaxNoSnoopLatencyScale, Result.MaxNoSnoopLatencyRequirement,
+    Result.ForceOverride
+    ));
+  return Result;
+}
+
+/**
+  Returns LTR override value for given device
+  The value is extracted from Device Override table. If the device is not found,
+  the returned value will have Requirement bits clear
+
+  @param[in] Base            device's base address
+  @param[in] Override        device override table
+
+  @retval LTR override value
+**/
+LTR_OVERRIDE
+GetOverrideLtr (
+  UINT64         Base,
+  OVERRIDE_TABLE *Override
+  )
+{
+  UINT16       DevId;
+  UINT16       VenId;
+  UINT16       RevId;
+  UINT32       Index;
+  LTR_OVERRIDE ReturnValue = {0};
+
+  VenId = PciSegmentRead16 (Base + PCI_VENDOR_ID_OFFSET);
+  DevId = PciSegmentRead16 (Base + PCI_DEVICE_ID_OFFSET);
+  RevId = PciSegmentRead16 (Base + PCI_REVISION_ID_OFFSET);
+
+  for (Index = 0; Index < Override->Size; Index++) {
+    if (((Override->Table[Index].OverrideConfig & PchPcieLtrOverride) == PchPcieLtrOverride) &&
+        (Override->Table[Index].VendorId == VenId) &&
+        ((Override->Table[Index].DeviceId == DevId) || (Override->Table[Index].DeviceId == 0xFFFF)) &&
+        ((Override->Table[Index].RevId == RevId) || (Override->Table[Index].RevId == 0xFF))) {
+      if (Override->Table[Index].SnoopLatency & 0x8000) {
+        ReturnValue.MaxSnoopLatencyRequirement = 1;
+        ReturnValue.MaxSnoopLatencyValue = Override->Table[Index].SnoopLatency & 0x3FF;
+        ReturnValue.MaxSnoopLatencyScale = (Override->Table[Index].SnoopLatency & 0x1C00) >> 10;
+      }
+      if (Override->Table[Index].NonSnoopLatency & 0x8000) {
+        ReturnValue.MaxNoSnoopLatencyRequirement = 1;
+        ReturnValue.MaxNoSnoopLatencyValue = Override->Table[Index].NonSnoopLatency & 0x3FF;
+        ReturnValue.MaxNoSnoopLatencyScale = (Override->Table[Index].NonSnoopLatency & 0x1C00) >> 10;
+      }
+      ReturnValue.ForceOverride = Override->Table[Index].ForceLtrOverride;
+      break;
+    }
+  }
+  return ReturnValue;
+}
+
+/**
+  In accordance with PCIe spec, devices with no LTR support are considered to have no LTR requirements
+  which means infinite latency tolerance. This was found to cause problems with HID and Audio devices without LTR
+  support placed behind PCIe switches with LTR support, as Switch's upstream link would be allowed to enter L1.2
+  and cause large latency downstream. To work around such issues and to fix some devices with broken
+  LTR reporting, Device Override table was introduced.
+  This function scans PCIe tree for devices mentioned in override table and calculates the strictest
+  LTR requirement between them. That value will be programmed into rootport's LTR override register
+
+  This function expects that bridges have bus numbers already configured
+
+  @param[in] BusLimit                       maximum Bus number that can be assigned below this port
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+  @param[in] AspmOverride                   Device specific ASPM policy override items
+
+  @retval MaxLTR programmed in this device
+**/
+LTR_OVERRIDE
+RecursiveLtrOverrideCheck (
+  SBDF           Sbdf,
+  OVERRIDE_TABLE *AspmOverride
+  )
+{
+  UINT64       Base;
+  SBDF         ChildSbdf;
+  LTR_OVERRIDE MyLtrOverride;
+  LTR_OVERRIDE ChildLtr;
+  PCI_DEV_TYPE DevType;
+
+  DEBUG ((DEBUG_INFO, "RecursiveLtrOverrideCheck %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+
+  Base = SbdfToBase(Sbdf);
+
+  MyLtrOverride = GetOverrideLtr (Base, AspmOverride);
+  if (HasChildBus (Sbdf, &ChildSbdf)) {
+    DevType = GetDeviceType (Sbdf);
+    while (FindNextPcieChild (DevType, &ChildSbdf)) {
+      ChildLtr = RecursiveLtrOverrideCheck (ChildSbdf, AspmOverride);
+      MyLtrOverride = CombineLtr (MyLtrOverride, ChildLtr);
+    }
+  }
+  return MyLtrOverride;
+}
+
+/**
+  Configures the following power-management related features in rootport and devices behind it:
+  LTR limit (generic)
+  LTR override (proprietary)
+  Clock Power Management (generic)
+  L1 substates (generic except for the override table)
+  L1.LOW substate (proprietary)
+  L0s and L1 (generic)
+
+  Generic: any code written according to PCIE Express base specification can do that.
+  Proprietary: code uses registers and features that are specific to Intel silicon
+  and probably only this Reference Code knows how to handle that.
+
+  If OEM implemented generic feature enabling in his platform code or trusts Operating System
+  to do it, then those features can be deleted from here.
+
+  @param[in] RpSegment                address of rootport on PCIe
+  @param[in] RpBus                    address of rootport on PCIe
+  @param[in] RpDevice                 address of rootport on PCIe
+  @param[in] RpFunction               address of rootport on PCIe
+  @param[in] BusLimit                 maximum Bus number that can be assigned below this rootport
+  @param[in] PcieRpLtrConfig          address of LTR Policy struct
+  @param[in] PcieRpCommonConfig       address of Common PCIe Policy struct
+  @param[in] AspmOverrideTableSize    size of override array
+  @param[in] AspmOverrideTable        array of device that need exceptions in configuration
+**/
+VOID
+RootportDownstreamPmConfiguration (
+  UINT8                               RpSegment,
+  UINT8                               RpBus,
+  UINT8                               RpDevice,
+  UINT8                               RpFunction,
+  UINT8                               BusMin,
+  UINT8                               BusMax,
+  PCIE_ROOT_PORT_COMMON_CONFIG        *PcieRpCommonConfig,
+  UINT32                              AspmOverrideTableSize,
+  PCH_PCIE_DEVICE_OVERRIDE            *AspmOverrideTable
+  )
+{
+  LTR_LIMIT      PolicyLtr;
+  LTR_OVERRIDE   TreeLtr;
+  OVERRIDE_TABLE PmOverrideTable;
+  UINT64         RpBase;
+  SBDF           RpSbdf;
+  SBDF_TABLE     BridgeCleanupList;
+
+  RpBase = PCI_SEGMENT_LIB_ADDRESS (RpSegment, RpBus, RpDevice, RpFunction, 0);
+  if (!(IsDevicePresent (RpBase))) {
+    return;
+  }
+  PmOverrideTable.Size = AspmOverrideTableSize;
+  PmOverrideTable.Table = AspmOverrideTable;
+
+  DEBUG ((DEBUG_INFO, "RootportDownstreamPmConfiguration %x:%x\n", RpDevice, RpFunction));
+  PolicyLtr.MaxNoSnoopLatencyScale = (PcieRpCommonConfig->PcieRpLtrConfig.LtrMaxNoSnoopLatency & 0x1c00) >> 10;
+  PolicyLtr.MaxNoSnoopLatencyValue = PcieRpCommonConfig->PcieRpLtrConfig.LtrMaxNoSnoopLatency & 0x3FF;
+  PolicyLtr.MaxSnoopLatencyScale   = (PcieRpCommonConfig->PcieRpLtrConfig.LtrMaxSnoopLatency & 0x1c00) >> 10;
+  PolicyLtr.MaxSnoopLatencyValue   = PcieRpCommonConfig->PcieRpLtrConfig.LtrMaxSnoopLatency & 0x3FF;
+
+  RpSbdf.Seg = RpSegment;
+  RpSbdf.Bus = RpBus;
+  RpSbdf.Dev = RpDevice;
+  RpSbdf.Func = RpFunction;
+  RpSbdf.PcieCap = PcieBaseFindCapId (RpBase, EFI_PCI_CAPABILITY_ID_PCIEXP);
+  //
+  // This code could execute either before or after enumeration. If before, then buses would not yet be assigned to bridges,
+  // making devices deeper in the hierarchy inaccessible.
+  // RecursiveBusAssignment will scan whole PCie tree and assign bus numbers to uninitialized bridges, if there are any
+  // List of such bridges will be kept in CleanupList, so that after PM programming is done, bus numbers can brought to original state
+  //
+  BridgeCleanupList.Count = 0;
+  RecursiveBusAssignment(RpSbdf, BusMin, BusMax, &BridgeCleanupList);
+  //
+  // The 'Recursive...' functions below expect bus numbers to be already assigned
+  //
+  RecursiveLtrConfiguration (RpSbdf, PolicyLtr);
+  TreeLtr = RecursiveLtrOverrideCheck (RpSbdf, &PmOverrideTable);
+  ConfigureRpLtrOverride (RpBase, RpSbdf.Dev, &TreeLtr, &(PcieRpCommonConfig->PcieRpLtrConfig));
+  DEBUG ((DEBUG_INFO, "ConfigureRpLtrOverride %x:%x\n", RpSbdf.Dev, RpSbdf.Func));
+  if (PcieRpCommonConfig->EnableCpm) {
+    RecursiveCpmConfiguration (RpSbdf);
+  }
+  //
+  // L1 substates can be modified only when L1 is disabled, so this function must execute
+  // before Aspm configuration which enables L1
+  //
+  RecursiveL1ssConfiguration (RpSbdf, &PmOverrideTable);
+  L1ssProprietaryConfiguration (RpBase, IsLtrCapable (RpSbdf));
+  RecursiveAspmConfiguration (RpSbdf, 0, &PmOverrideTable);
+
+  ClearBusFromTable (&BridgeCleanupList);
+}

--- a/Silicon/TigerlakePchPkg/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.h
+++ b/Silicon/TigerlakePchPkg/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.h
@@ -1,0 +1,39 @@
+/** @file
+  Header file for Pci Express helps library implementation.
+
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _PCI_EXPRESS_HELPERS_LIBRARY_H_
+#define _PCI_EXPRESS_HELPERS_LIBRARY_H_
+
+#include <Uefi/UefiBaseType.h>
+#include <Library/BaseLib.h>
+#include <Library/IoLib.h>
+#include <Library/DebugLib.h>
+#include <IndustryStandard/Pci.h>
+#include <Library/PchPcieRpConfig.h>
+#include <Library/PchPcieRpLib.h>
+#include <Library/PchPcrLib.h>
+#include <Library/PchInfoLib.h>
+#include <Library/PciSegmentLib.h>
+#include <Library/TimerLib.h>
+#include <Library/PciExpressHelpersLib.h>
+#include <Library/PcieRpLib.h>
+#include <PcieRegs.h>
+#include <Register/CpuPcieRegs.h>
+#include <Register/PchPcieRpRegs.h>
+
+#define LTR_VALUE_MASK (BIT0 + BIT1 + BIT2 + BIT3 + BIT4 + BIT5 + BIT6 + BIT7 + BIT8 + BIT9)
+#define LTR_SCALE_MASK (BIT10 + BIT11 + BIT12)
+
+  #define CONFIG_WRITE_LOOP_COUNT   100000
+
+//
+// LTR related macros
+//
+#define LTR_LATENCY_VALUE(x)           ((x) & LTR_VALUE_MASK)
+#define LTR_SCALE_VALUE(x)             (((x) & LTR_SCALE_MASK) >> 10)
+#define LTR_LATENCY_NS(x)              (LTR_LATENCY_VALUE(x) * (1 << (5 * LTR_SCALE_VALUE(x))))
+
+#endif

--- a/Silicon/TigerlakePchPkg/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.inf
+++ b/Silicon/TigerlakePchPkg/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.inf
@@ -1,0 +1,43 @@
+## @file
+# Component description file for the PeiDxeSmmPciExpressHelpersLib
+#
+#  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+
+[Defines]
+  INF_VERSION = 0x00010017
+  BASE_NAME = PciExpressHelperssLib
+  FILE_GUID = 07E3F76D-6D26-419d-9053-58696A15B519
+  VERSION_STRING = 1.0
+  MODULE_TYPE = BASE
+  LIBRARY_CLASS = PciExpressHelpersLib
+#
+# The following information is for reference only and not required by the build tools.
+#
+# VALID_ARCHITECTURES = IA32 X64 IPF EBC
+#
+
+
+[LibraryClasses]
+  IoLib
+  DebugLib
+  PchPcrLib
+  PchInfoLib
+  GpioLib
+  TimerLib
+  BasePchPciBdfLib
+  BasePcieHelperLib
+  PcieClientRpLib
+
+[Packages]
+  Silicon/TigerlakePkg/TigerlakePkg.dec
+  Silicon/TigerlakePchPkg/TigerlakePchPkg.dec
+  Silicon/CommonSocPkg/CommonSocPkg.dec
+  MdePkg/MdePkg.dec
+
+[Sources]
+  PciExpressHelpersLibrary.c
+  PciExpressHelpersLibrary.h

--- a/Silicon/TigerlakePchPkg/Library/PcieClientRpLib/PcieClientRpLib.c
+++ b/Silicon/TigerlakePchPkg/Library/PcieClientRpLib/PcieClientRpLib.c
@@ -1,0 +1,212 @@
+/** @file
+  This file contains routines that support PCI Express initialization
+
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#include <Uefi/UefiBaseType.h>
+#include <IndustryStandard/Pci.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/PcieHelperLib.h>
+#include <Library/PchSbiAccessLib.h>
+#include <Library/PchPciBdfLib.h>
+#include <Library/PcieRpLib.h>
+#include <Library/PchInfoLib.h>
+#include <Library/PchPcieRpLib.h>
+#include <Register/PchPcieRpRegs.h>
+#include <Register/PcieSipRegs.h>
+#include <PcieRegs.h>
+#include <PchPcieRpInfo.h>
+#include <CpuPcieInfo.h>
+
+/**
+  Get PCIe port number for enabled port.
+  @param[in] RpBase    Root Port pci segment base address
+
+  @retval Root Port number (1 based)
+**/
+UINT32
+PciePortNum (
+  IN     UINT64  RpBase
+  )
+{
+  return PciSegmentRead32 (RpBase + R_PCH_PCIE_CFG_LCAP) >> N_PCH_PCIE_CFG_LCAP_PN;
+}
+
+/**
+  Get PCIe root port index
+
+  @param[in] RpBase    Root Port pci segment base address
+
+  @retval Root Port index (0 based)
+**/
+UINT32
+PciePortIndex (
+  IN     UINT64  RpBase
+  )
+{
+  return PciePortNum (RpBase) - 1;
+}
+
+/**
+  This function checks whether PHY lane power gating is enabled on the port.
+
+  @param[in] RpBase                 Root Port base address
+
+  @retval TRUE                      PHY power gating is enabled
+  @retval FALSE                     PHY power gating disabled
+**/
+BOOLEAN
+PcieIsPhyLanePgEnabled (
+  IN     UINT64  RpBase
+  )
+{
+  UINT32 Data32;
+
+  Data32 = PciSegmentRead32 (RpBase + R_PCH_PCIE_CFG_PCIEPMECTL);
+  return (Data32 & B_PCH_PCIE_CFG_PCIEPMECTL_DLSULPPGE) != 0;
+}
+
+/**
+  Configures Root Port packet split.
+
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+  @param[in] Mps                            maximum packet size
+**/
+VOID
+ConfigureRpPacketSplit (
+  UINT64 RpBase,
+  UINT8  Mps
+  )
+{
+  PciSegmentAndThenOr32 (RpBase + R_PCIE_CFG_CCFG, (UINT32) ~(B_PCIE_CFG_CCFG_UNRS), Mps << N_PCIE_CFG_CCFG_UNRS);
+}
+
+/**
+  Configures LTR override in Root Port's proprietary registers.
+
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+  @param[in] DevNum                         currently visited device number
+  @param[in] RpConfig                       Root Port LTR configuration
+  @param[in] AspmOverride                   combination of LTR override values from all devices under this Root Port
+**/
+VOID
+ConfigureRpLtrOverride (
+  UINT64           RpBase,
+  UINT32           DevNum,
+  LTR_OVERRIDE     *TreeLtr,
+  PCIE_LTR_CONFIG  *LtrConfig
+  )
+{
+  UINT32       OvrEn;
+  UINT32       OvrVal;
+  BOOLEAN      IsCpuPcie;
+
+  IsCpuPcie = FALSE;
+  OvrEn = 0;
+  OvrVal = 0;
+
+  if (DevNum == SA_PEG0_DEV_NUM || DevNum == SA_PEG3_DEV_NUM) {
+    IsCpuPcie = TRUE;
+  }
+
+  //
+  // LTR settings from LTROVR register only get acknowledged on rising edge of LTROVR2[1:0]
+  // If those bits were already set (that can happen on a plug-hotUnplug-hotPlug scenario),
+  // they need to be toggled
+  //
+  if (PciSegmentRead32 (RpBase + R_PCH_PCIE_CFG_LTROVR2) != 0) {
+    PciSegmentWrite32 (RpBase + R_PCH_PCIE_CFG_LTROVR2, 0);
+  }
+  //
+  // (*)LatencyOverrideMode = 0 -> no override
+  //                          1 -> override with RP policy values
+  //                          2 -> override with endpoint's override values
+  //
+
+  if (LtrConfig->ForceLtrOverride || TreeLtr->ForceOverride) {
+    OvrEn |= B_PCH_PCIE_CFG_LTROVR2_FORCE_OVERRIDE;
+  }
+  if (LtrConfig->LtrConfigLock == TRUE) {
+    OvrEn |= B_PCH_PCIE_CFG_LTROVR2_LOCK;
+  }
+
+  if (LtrConfig->SnoopLatencyOverrideMode == 1) {
+    OvrEn |= B_PCH_PCIE_CFG_LTROVR2_LTRSOVREN;
+    OvrVal |= LtrConfig->SnoopLatencyOverrideValue;
+    OvrVal |= LtrConfig->SnoopLatencyOverrideMultiplier << 10;
+    OvrVal |= B_PCH_PCIE_CFG_LTROVR_LTRSROVR;
+  } else if (LtrConfig->SnoopLatencyOverrideMode == 2) {
+    if (TreeLtr->MaxSnoopLatencyRequirement) {
+      OvrEn |= B_PCH_PCIE_CFG_LTROVR2_LTRSOVREN;
+      OvrVal |= TreeLtr->MaxSnoopLatencyValue;
+      OvrVal |= TreeLtr->MaxSnoopLatencyScale << 10;
+      OvrVal |= B_PCH_PCIE_CFG_LTROVR_LTRSROVR;
+    }
+  }
+  if (LtrConfig->NonSnoopLatencyOverrideMode == 1) {
+    OvrEn |= B_PCH_PCIE_CFG_LTROVR2_LTRNSOVREN;
+    OvrVal |= LtrConfig->NonSnoopLatencyOverrideValue << 16;
+    OvrVal |= LtrConfig->NonSnoopLatencyOverrideMultiplier << 26;
+    OvrVal |= B_PCH_PCIE_CFG_LTROVR_LTRNSROVR;
+  } else if (LtrConfig->NonSnoopLatencyOverrideMode == 2) {
+    if (TreeLtr->MaxNoSnoopLatencyRequirement) {
+      OvrEn |= B_PCH_PCIE_CFG_LTROVR2_LTRNSOVREN;
+      OvrVal |= TreeLtr->MaxNoSnoopLatencyValue << 16;
+      OvrVal |= TreeLtr->MaxNoSnoopLatencyScale << 26;
+      OvrVal |= B_PCH_PCIE_CFG_LTROVR_LTRNSROVR;
+    }
+  }
+  PciSegmentWrite32 (RpBase + R_PCH_PCIE_CFG_LTROVR, OvrVal);
+  PciSegmentWrite32 (RpBase + R_PCH_PCIE_CFG_LTROVR2, OvrEn);
+
+  DEBUG ((DEBUG_INFO, "ConfigureRpLtrOverride IsCpuPcie=%d\n", IsCpuPcie));
+  DEBUG ((DEBUG_INFO, "ConfigureRpLtrOverride %x Val %x En %x\n", RpBase, OvrVal, OvrEn));
+}
+
+/**
+  Configures proprietary parts of L1 substates configuration in Root Port
+
+  @param[in] RpSbdf       segment:bus:device:function coordinates of Root Port
+  @param[in] LtrCapable   TRUE if Root Port is LTR capable
+**/
+VOID
+L1ssProprietaryConfiguration (
+  UINT64  RpBase,
+  BOOLEAN LtrCapable
+  )
+{
+  BOOLEAN ClkreqSupported;
+  BOOLEAN L1ssEnabled;
+  UINT16  PcieCapOffset;
+  UINT32  Data32;
+  BOOLEAN L1LowSupported;
+
+  ClkreqSupported = PcieIsPhyLanePgEnabled (RpBase);
+
+  PcieCapOffset = PcieBaseFindExtendedCapId (RpBase, V_PCIE_EX_L1S_CID);
+  if (PcieCapOffset == 0) {
+    L1ssEnabled = FALSE;
+  } else {
+    Data32 = PciSegmentRead32 (RpBase + PcieCapOffset + R_PCIE_EX_L1SCTL1_OFFSET);
+    L1ssEnabled = Data32 & (B_PCIE_EX_L1SCAP_AL1SS | B_PCIE_EX_L1SCAP_AL12S | B_PCIE_EX_L1SCAP_PPL11S |B_PCIE_EX_L1SCAP_PPL12S);
+  }
+  L1LowSupported = ClkreqSupported && LtrCapable && !L1ssEnabled;
+
+  ///
+  /// If L1.SNOOZ and L1.OFF (L1 Sub-States) are not supported and per-port CLKREQ# is supported, and LTR is supported:
+  /// Enable L1.LOW by setting Dxx:Fn:420[17] = 1b
+  ///
+  if (L1LowSupported) {
+    PciSegmentOr32 (RpBase + R_PCH_PCIE_CFG_PCIEPMECTL, (UINT32) B_PCH_PCIE_CFG_PCIEPMECTL_L1LE);
+  } else {
+    PciSegmentAnd32 (RpBase + R_PCH_PCIE_CFG_PCIEPMECTL, (UINT32) ~B_PCH_PCIE_CFG_PCIEPMECTL_L1LE);
+  }
+
+  if (L1LowSupported || L1ssEnabled) {
+    ///
+    /// f.  Set Dxx:Fn:420h[0] to 1b prior to L1 enabling if any L1substate is enabled (including L1.LOW)
+    ///
+    PciSegmentOr32 (RpBase + R_PCH_PCIE_CFG_PCIEPMECTL, B_PCH_PCIE_CFG_PCIEPMECTL_L1FSOE);
+  }
+}

--- a/Silicon/TigerlakePchPkg/Library/PcieClientRpLib/PcieClientRpLib.inf
+++ b/Silicon/TigerlakePchPkg/Library/PcieClientRpLib/PcieClientRpLib.inf
@@ -1,0 +1,42 @@
+## @file
+# Component description file for the PcieClientRpLib
+#
+#  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+
+[Defines]
+  INF_VERSION = 0x00010017
+  BASE_NAME = PcieClientRpLib
+  FILE_GUID = 77EB467D-674C-4C20-A13E-381600E182C4
+  VERSION_STRING = 1.0
+  MODULE_TYPE = BASE
+  LIBRARY_CLASS = PcieRpLib
+#
+# The following information is for reference only and not required by the build tools.
+#
+# VALID_ARCHITECTURES = IA32 X64 IPF EBC
+#
+
+
+
+[LibraryClasses]
+  IoLib
+  DebugLib
+  #PchPcieRpLib
+  PchPcrLib
+  PchInfoLib
+  GpioLib
+  TimerLib
+  BasePcieHelperLib
+  BasePchPciBdfLib
+
+[Packages]
+  MdePkg/MdePkg.dec
+  Silicon/CommonSocPkg/CommonSocPkg.dec
+  Silicon/TigerlakePchPkg/TigerlakePchPkg.dec
+
+[Sources]
+  PcieClientRpLib.c

--- a/Silicon/TigerlakePchPkg/Library/PciePm/PciePm.c
+++ b/Silicon/TigerlakePchPkg/Library/PciePm/PciePm.c
@@ -1,0 +1,307 @@
+/** @file
+  This file enables PCIe PM configuration
+
+  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#include <Uefi.h>
+#include <Library/DebugLib.h>
+#include <PcieRegs.h>
+#include <Register/PchPcieRpRegs.h>
+#include <Library/PciSegmentLib.h>
+#include <Library/PcieHelperLib.h>
+#include <Library/PchPciBdfLib.h>
+#include <Library/PchPcieRpConfig.h>
+#include <Library/PciExpressHelpersLib.h>
+#include <Library/PchInfoLib.h>
+#include <PcieRegs.h>
+#include <PchAccess.h>
+#include <CpuDataStruct.h>
+#include <FspsUpd.h>
+#include <Library/PciePm.h>
+#include <Library/PlatformInfo.h>
+
+#define SA_SEG_NUM         0x00
+#define SA_MC_BUS          0x00
+
+#define PCI_CLASS_NETWORK             0x02
+#define PCI_CLASS_NETWORK_ETHERNET    0x00
+#define PCI_CLASS_NETWORK_OTHER       0x80
+
+GLOBAL_REMOVE_IF_UNREFERENCED PCH_PCIE_DEVICE_OVERRIDE mPcieDeviceTable[] = {
+  //
+  // Intel PRO/Wireless
+  //
+  { 0x8086, 0x422b, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x422c, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x4238, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x4239, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel WiMAX/WiFi Link
+  //
+  { 0x8086, 0x0082, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0085, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0083, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0084, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0086, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0087, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0088, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0089, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x008F, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0090, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel Crane Peak WLAN NIC
+  //
+  { 0x8086, 0x08AE, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x08AF, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel Crane Peak w/BT WLAN NIC
+  //
+  { 0x8086, 0x0896, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0897, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel Kelsey Peak WiFi, WiMax
+  //
+  { 0x8086, 0x0885, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0886, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel Centrino Wireless-N 105
+  //
+  { 0x8086, 0x0894, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0895, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel Centrino Wireless-N 135
+  //
+  { 0x8086, 0x0892, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0893, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel Centrino Wireless-N 2200
+  //
+  { 0x8086, 0x0890, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0891, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel Centrino Wireless-N 2230
+  //
+  { 0x8086, 0x0887, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0888, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel Centrino Wireless-N 6235
+  //
+  { 0x8086, 0x088E, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x088F, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel CampPeak 2 Wifi
+  //
+  { 0x8086, 0x08B5, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x08B6, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel WilkinsPeak 1 Wifi
+  //
+  { 0x8086, 0x08B3, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2AndL1SubstatesOverride, 0x0158, 0x0000000F, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x08B4, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2AndL1SubstatesOverride, 0x0158, 0x0000000F, 0, 0, 0, 0, 0 },
+  //
+  // Intel Wilkins Peak 2 Wifi
+  //
+  { 0x8086, 0x08B1, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2AndL1SubstatesOverride, 0x0158, 0x0000000F, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x08B2, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2AndL1SubstatesOverride, 0x0158, 0x0000000F, 0, 0, 0, 0, 0 },
+  //
+  // Intel Wilkins Peak PF Wifi
+  //
+  { 0x8086, 0x08B0, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Teton Glacier Endpoint
+  //
+  { 0x8086, 0x0975, 0xff, 0, 0, 0, PchPcieL1SubstatesOverride, 0, 0xff, 0x3C, 0, 5, 0, 0 },
+
+  //
+  // End of Table
+  //
+  { 0 }
+};
+
+GLOBAL_REMOVE_IF_UNREFERENCED PCH_PCIE_ROOT_PORT_CONFIG     mPcieRootPortConfig[PCH_MAX_PCIE_ROOT_PORTS];
+GLOBAL_REMOVE_IF_UNREFERENCED PCH_PCIE_ROOT_PORT_CONFIG     mCpuPcieRootPortConfig[CPU_PCIE_MAX_ROOT_PORTS];
+
+/**
+  Store Root Port Config based on FSP-s UPDs
+
+  @param[in]  FspsConfig       The pointer to FSP-S Config
+
+**/
+VOID
+EFIAPI
+StoreRpConfig (
+  VOID *FspsConfig
+)
+{
+  FSP_S_CONFIG  *Config;
+  UINT8         MaxPchPcieRootPorts;
+  UINT8         MaxCpuPciePorts;
+  UINT8         Index;
+
+  Config = (FSP_S_CONFIG *)FspsConfig;
+  if (Config == NULL) {
+    return;
+  }
+
+  MaxPchPcieRootPorts = GetPchMaxPciePortNum ();
+  for (Index = 0; Index < MaxPchPcieRootPorts; Index++) {
+    mPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.LtrMaxNoSnoopLatency = Config->PcieRpLtrMaxNoSnoopLatency[Index];
+    mPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.LtrMaxSnoopLatency = Config->PcieRpLtrMaxSnoopLatency[Index];
+    mPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.LtrConfigLock = Config->PcieRpLtrConfigLock[Index];
+    mPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.SnoopLatencyOverrideMode = Config->PcieRpSnoopLatencyOverrideMode[Index];
+    mPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.SnoopLatencyOverrideValue = Config->PcieRpSnoopLatencyOverrideValue[Index];
+    mPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.SnoopLatencyOverrideMultiplier = Config->PcieRpSnoopLatencyOverrideMultiplier[Index];
+    mPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.NonSnoopLatencyOverrideMode = Config->PcieRpNonSnoopLatencyOverrideMode[Index];
+    mPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.NonSnoopLatencyOverrideValue = Config->PcieRpNonSnoopLatencyOverrideValue[Index];
+    mPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.NonSnoopLatencyOverrideMultiplier = Config->PcieRpNonSnoopLatencyOverrideMultiplier[Index];
+
+    mPcieRootPortConfig[Index].PcieRpCommonConfig.EnableCpm = Config->PcieRpEnableCpm[Index];
+  }
+
+  MaxCpuPciePorts = GetMaxCpuPciePortNum();
+  for (Index = 0; Index < MaxCpuPciePorts; Index++) {
+    mCpuPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.LtrMaxNoSnoopLatency = Config->CpuPcieRpLtrMaxNoSnoopLatency[Index];
+    mCpuPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.LtrMaxSnoopLatency = Config->CpuPcieRpLtrMaxSnoopLatency[Index];
+    mCpuPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.LtrConfigLock = Config->CpuPcieRpLtrConfigLock[Index];
+    mCpuPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.SnoopLatencyOverrideMode = Config->CpuPcieRpSnoopLatencyOverrideMode[Index];
+    mCpuPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.SnoopLatencyOverrideValue = Config->CpuPcieRpSnoopLatencyOverrideValue[Index];
+    mCpuPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.SnoopLatencyOverrideMultiplier = Config->CpuPcieRpSnoopLatencyOverrideMultiplier[Index];
+    mCpuPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.NonSnoopLatencyOverrideMode = Config->CpuPcieRpNonSnoopLatencyOverrideMode[Index];
+    mCpuPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.NonSnoopLatencyOverrideValue = Config->CpuPcieRpNonSnoopLatencyOverrideValue[Index];
+    mCpuPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.NonSnoopLatencyOverrideMultiplier = Config->CpuPcieRpNonSnoopLatencyOverrideMultiplier[Index];
+
+    mCpuPcieRootPortConfig[Index].PcieRpCommonConfig.EnableCpm = Config->CpuPcieRpEnableCpm[Index];
+  }
+}
+
+/**
+  Get CPU Pcie Root Port Device and Function Number by Root Port physical Number
+
+  @param[in]  RpNumber              Root port physical number. (0-based)
+  @param[out] RpDev                 Return corresponding root port device number.
+  @param[out] RpFun                 Return corresponding root port function number.
+
+  @retval     EFI_SUCCESS           Root port device and function is retrieved
+  @retval     EFI_INVALID_PARAMETER RpNumber is invalid
+**/
+EFI_STATUS
+EFIAPI
+GetCpuPcieRpDevFun (
+  IN  UINTN   RpNumber,
+  OUT UINTN   *RpDev,
+  OUT UINTN   *RpFun
+  )
+{
+  if (RpNumber > GetMaxCpuPciePortNum ()) {
+    DEBUG ((DEBUG_ERROR, "GetCpuPcieRpDevFun invalid RpNumber %x", RpNumber));
+    ASSERT (FALSE);
+    return EFI_INVALID_PARAMETER;
+  }
+  //
+  //  For TGL - U/Y only one CPU PCIE Root port is present
+  //
+  *RpDev = 6;
+  *RpFun = 0;
+  return EFI_SUCCESS;
+}
+
+
+/**
+  Config CPU PCIE power management settings
+**/
+VOID
+CpuPciePmConfig (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      PortIndex;
+  UINT64      RpBase;
+  UINT8       MaxPciePortNum;
+  UINTN       RpDevice;
+  UINTN       RpFunction;
+  UINT8       TempRootPortBusNumMin;
+  UINT8       TempRootPortBusNumMax;
+
+  TempRootPortBusNumMin = 2;
+  TempRootPortBusNumMax = 10;
+
+  MaxPciePortNum = GetMaxCpuPciePortNum ();
+
+  for (PortIndex = 0; PortIndex < MaxPciePortNum; PortIndex++) {
+    Status = GetCpuPcieRpDevFun (PortIndex, &RpDevice, &RpFunction);
+    if (EFI_ERROR (Status)) {
+      continue;
+    }
+
+    RpBase = PCI_SEGMENT_LIB_ADDRESS (SA_SEG_NUM, SA_MC_BUS, (UINT32) RpDevice, (UINT32) RpFunction, 0);
+
+    if (PciSegmentRead16 (RpBase) != 0xFFFF) {
+      RootportDownstreamPmConfiguration (
+        SA_SEG_NUM,
+        SA_MC_BUS,
+        (UINT8)RpDevice,
+        (UINT8)RpFunction,
+        TempRootPortBusNumMin,
+        TempRootPortBusNumMax,
+        &mCpuPcieRootPortConfig[PortIndex].PcieRpCommonConfig,
+        0,
+        NULL
+      );
+    }
+  }
+}
+
+/**
+  Config PCH PCIE power management settings
+**/
+VOID
+PchPciePmConfig (
+  VOID
+  )
+{
+  UINT32  PortIndex;
+  UINT64  RpBase;
+  UINT8   MaxPciePortNum;
+  UINT8   TempRootPortBusNumMin;
+  UINT8   TempRootPortBusNumMax;
+
+  TempRootPortBusNumMin = 2;
+  TempRootPortBusNumMax = 10;
+
+  MaxPciePortNum = GetPchMaxPciePortNum ();
+
+  for (PortIndex = 0; PortIndex < MaxPciePortNum; PortIndex++) {
+    RpBase = PchPcieRpPciCfgBase (PortIndex);
+
+    if (PciSegmentRead16 (RpBase) != 0xFFFF) {
+      RootportDownstreamPmConfiguration (
+        DEFAULT_PCI_SEGMENT_NUMBER_PCH,
+        DEFAULT_PCI_BUS_NUMBER_PCH,
+        PchPcieRpDevNumber (PortIndex),
+        PchPcieRpFuncNumber (PortIndex),
+        TempRootPortBusNumMin,
+        TempRootPortBusNumMax,
+        &mPcieRootPortConfig[PortIndex].PcieRpCommonConfig,
+        ARRAY_SIZE (mPcieDeviceTable) - 1,
+        mPcieDeviceTable
+      );
+
+    }
+  }
+}
+
+/**
+  Config PCIE power management settings
+**/
+VOID
+EFIAPI
+PciePmConfig (
+  VOID
+)
+{
+  CpuPciePmConfig ();
+  PchPciePmConfig ();
+}
+

--- a/Silicon/TigerlakePchPkg/Library/PciePm/PciePm.inf
+++ b/Silicon/TigerlakePchPkg/Library/PciePm/PciePm.inf
@@ -1,0 +1,38 @@
+## @file
+#
+# Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010017
+  BASE_NAME                      = PciePm
+  FILE_GUID                      = 868ba60c-b140-48e4-8029-687934c36117
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = PciePm
+
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[LibraryClasses]
+  SerialPortLib
+  BaseLib
+  DebugLib
+  PciExpressHelpersLib
+
+[Sources]
+  PciePm.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  IntelFsp2Pkg/IntelFsp2Pkg.dec
+  Silicon/TigerlakePchPkg/TigerlakePchPkg.dec
+  Silicon/CommonSocPkg/CommonSocPkg.dec
+  Silicon/TigerlakePkg/TigerlakePkg.dec
+

--- a/Silicon/TigerlakePkg/Include/Register/CpuPcieRegs.h
+++ b/Silicon/TigerlakePkg/Include/Register/CpuPcieRegs.h
@@ -1,0 +1,24 @@
+/** @file
+  This file contains definitions of  PCIe Configuration
+
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef _CPU_PCIE_REGS_H_
+#define _CPU_PCIE_REGS_H_
+
+#define  R_PCIE_LCAP                              0x4C
+#define  R_PCIE_LCTL                              0x50
+#define  R_PCIE_LSTS                              0x52
+#define  R_PCIE_SLCAP                             0x54
+#define  R_PCIE_SLSTS                             0x5A
+#define  R_PCIE_LCTL2                             0x70
+#define  R_PCIE_MPC                               0xD8
+#define  B_PCIE_MPC_HPME                          BIT1
+#define  R_PCIE_PGTHRES                           0x5C0
+#define  B_PCIE_PGTHRES_L1PGLTREN                 BIT0
+#define  R_PCIE_LCTL3                             0xA34
+#define  B_PCIE_LCTL3_PE                          BIT0
+
+#endif


### PR DESCRIPTION
The patch enables PCIe PM features by,
    1. Store Root Port configuration before FSP-s.
    2. Configure Pcie RP in PostPciEnumeration with the stored RP config.

The feature is controlled by ENABLE_PCIE_PM and the corresponding PcdEnablePciePm

The implementation is silicon-dependent, because of registers definition.
The PciePmNull component is a generic implementation. This patch also implements PciePm for TGL.

Verified: TGL-U RVP

Signed-off-by: Stanley Chang <stanley.chang@intel.com>