### PR TITLE
Gpio data convert improvements

### DIFF
--- a/Platform/AlderlakeBoardPkg/Script/GpioDataConfig.py
+++ b/Platform/AlderlakeBoardPkg/Script/GpioDataConfig.py
@@ -1,0 +1,63 @@
+## @ GpioDataConfig.py
+#  This is a Gpio config script for Slim Bootloader
+#
+# Copyright (c) 2022, Intel Corporation. All rights reserved. <BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+
+#
+# The index for a group has to match implementation
+# in a platform specific Gpio library.
+#
+
+grp_info_lp = {
+    # Grp     Index
+    'GPP_B' : [ 0x0],
+    'GPP_T' : [ 0x1],
+    'GPP_A' : [ 0x2],
+    'GPP_R' : [ 0x3],
+    'GPP_S' : [ 0x6],
+    'GPP_H' : [ 0x7],
+    'GPP_D' : [ 0x8],
+    'GPP_U' : [ 0x9],
+    'GPP_C' : [ 0xB],
+    'GPP_F' : [ 0xC],
+    'GPP_E' : [ 0xE],
+}
+
+grp_info_s = {
+    # Grp     Index
+    'GPP_I' : [ 0x0],
+    'GPP_R' : [ 0x1],
+    'GPP_J' : [ 0x2],
+    'GPP_B' : [ 0x5],
+    'GPP_G' : [ 0x6],
+    'GPP_H' : [ 0x7],
+    'GPP_A' : [ 0xA],
+    'GPP_C' : [ 0xB],
+    'GPP_S' : [ 0xD],
+    'GPP_E' : [ 0xE],
+    'GPP_K' : [ 0xF],
+    'GPP_F' : [ 0x10],
+    'GPP_D' : [ 0x11],
+}
+
+def get_grp_info(pch_series):
+    if pch_series not in ['s', 'p']:
+        raise Exception ('Invalid pch series passed')
+    else:
+        if pch_series == 's':
+            return grp_info_s
+        elif pch_series == 'p':
+            return grp_info_lp
+
+def rxraw_override_cfg():
+    return True
+
+def vir_to_phy_grp():
+    return True
+
+def plat_name():
+    return 'adl'

--- a/Platform/ElkhartlakeBoardPkg/Script/GpioDataConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/Script/GpioDataConfig.py
@@ -12,27 +12,31 @@
 # in a platform specific Gpio library.
 #
 
-def get_grp_info():
-    grp_info ={
-      # Grp     Index
-      'GPP_A' : [ 0xB],
-      'GPP_B' : [ 0x0],
-      'GPP_C' : [ 0xD],
-      'GPP_D' : [ 0x5],
-      'GPP_E' : [ 0x10],
-      'GPP_F' : [ 0xE],
-      'GPP_G' : [ 0x2],
-      'GPP_H' : [ 0x4],
-      'GPP_R' : [ 0x12],
-      'GPP_S' : [ 0xA],
-      'GPP_T' : [ 0x1],
-      'GPP_U' : [ 0x6],
-      'GPP_V' : [ 0x3],
-      'GPPD'  : [ 0x8],
-    }
-    return grp_info
+grp_info_def ={
+    # Grp     Index
+    'GPP_A' : [ 0xB],
+    'GPP_B' : [ 0x0],
+    'GPP_C' : [ 0xD],
+    'GPP_D' : [ 0x5],
+    'GPP_E' : [ 0x10],
+    'GPP_F' : [ 0xE],
+    'GPP_G' : [ 0x2],
+    'GPP_H' : [ 0x4],
+    'GPP_R' : [ 0x12],
+    'GPP_S' : [ 0xA],
+    'GPP_T' : [ 0x1],
+    'GPP_U' : [ 0x6],
+    'GPP_V' : [ 0x3],
+    'GPPD'  : [ 0x8],
+}
+
+def get_grp_info(pch_series):
+    return grp_info_def
 
 def rxraw_override_cfg():
+    return True
+
+def vir_to_phy_grp():
     return True
 
 def plat_name():

--- a/Platform/TigerlakeBoardPkg/Script/GpioDataConfig.py
+++ b/Platform/TigerlakeBoardPkg/Script/GpioDataConfig.py
@@ -14,30 +14,36 @@
 
 grp_info_lp = {
     # Grp     Index
-    'GPP_A' : [ 0x0],
-    'GPP_B' : [ 0x1],
-    'GPP_C' : [ 0x2],
-    'GPP_D' : [ 0x3],
-    'GPP_E' : [ 0x4],
-    'GPP_F' : [ 0x5],
-    'GPP_G' : [ 0x6],
-    'GPP_H' : [ 0x7],
+    'GPP_B' : [ 0x0],
+    'GPP_T' : [ 0x1],
+    'GPP_A' : [ 0x2],
+    'GPP_R' : [ 0x3],
+    'GPP_S' : [ 0x5],
+    'GPP_H' : [ 0x6],
+    'GPP_D' : [ 0x7],
+    'GPP_U' : [ 0x8],
+    'GPP_C' : [ 0xA],
+    'GPP_F' : [ 0xB],
+    'GPP_E' : [ 0xC],
 }
 
 grp_info_h = {
     # Grp     Index
-    'GPP_A' : [ 0x0],
-    'GPP_B' : [ 0x1],
-    'GPP_C' : [ 0x2],
-    'GPP_D' : [ 0x3],
-    'GPP_E' : [ 0x4],
-    'GPP_F' : [ 0x5],
-    'GPP_G' : [ 0x6],
-    'GPP_H' : [ 0x7],
-    'GPP_I' : [ 0x8],
-    'GPP_J' : [ 0x9],
-    'GPP_K' : [ 0xA],
+    'GPP_A' : [ 0x1],
+    'GPP_R' : [ 0x2],
+    'GPP_B' : [ 0x3],
+    'GPP_D' : [ 0x4],
+    'GPP_C' : [ 0x5],
+    'GPP_S' : [ 0x6],
+    'GPP_G' : [ 0x7],
+    'GPP_E' : [ 0x9],
+    'GPP_F' : [ 0xA],
+    'GPP_H' : [ 0xB],
+    'GPP_K' : [ 0xC],
+    'GPP_J' : [ 0xD],
+    'GPP_I' : [ 0xE],
 }
+
 
 def get_grp_info(pch_series):
     if pch_series not in ['lp', 'h']:
@@ -55,4 +61,4 @@ def vir_to_phy_grp():
     return False
 
 def plat_name():
-    return 'cfl'
+    return 'tgl'


### PR DESCRIPTION
Pass in a pch_series param to GpioDataConvert tool
to fetch the correct gpio group info for a platform
based on the pch series.

The tool expects the platform specific config file to
implement a function vir_to_phy_grp () that returns
a BOOL value based on:

If vir_to_phy_grp = False, SBL's config has A->0, B->1 etc. mapping.
And GpioSiLib.c or GpioInitLib.c corresponding libraries will map
this virtual group #s to real physical group #s (if not same).

If vir_to_phy_grp = True, SBL's config has A->G1, B->G2 etc.
physical mapping directly, so the GpioLib library uses this as is.

GpioDataConfig.py file was added for ADL platform.

Signed-off-by: Sai T <sai.kiran.talamudupula@intel.com>