### PR TITLE
[ADLP] Enable S0ix feature

### DIFF
--- a/Platform/AlderlakeBoardPkg/AcpiTables/Dsdt/HostBus.asl
+++ b/Platform/AlderlakeBoardPkg/AcpiTables/Dsdt/HostBus.asl
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -750,7 +750,7 @@ Scope(\_SB.PC00)
   //
   Device(PEG2) {
     Method (_ADR, 0) {
-      Store (0x00010001, local0) // Initialize the Address with hardcoded value
+      Store (0x00060002, local0) // Initialize the Address with hardcoded value
       If (CondRefOf (\_SB.PC00.PEG2.CPRA)) {
         Store (\_SB.PC00.PEG2.CPRA (), local0)
       }

--- a/Platform/AlderlakeBoardPkg/AcpiTables/Dsdt/Pep.asl
+++ b/Platform/AlderlakeBoardPkg/AcpiTables/Dsdt/Pep.asl
@@ -1,7 +1,7 @@
 /** @file
   ACPI uPEP Support
 
-  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -13,6 +13,10 @@ External(\_SB.PC00.DPOF)
 External(\_SB.PC00.LPCB.H_EC.ECNT, MethodObj)
 External(\_SB.PC00.LPCB.HPET.TCN1)
 External(\_SB.PC00.SPIF.SPIS)
+External(SPCO,MethodObj)
+External(\_SB.PC00.RP08.DL23, MethodObj)
+External(\_SB.PC00.RP08.L23D, MethodObj)
+External (TMCS, IntObj)
 
 External(THCE) // TCSS XHCI Device Enable
 External(TDCE) // TCSS XDCI Device Enable
@@ -1017,6 +1021,9 @@ Scope(\_SB)
           }
         }
 
+        Name(RSTG, Package() {0, 0})
+        Name(PWRG, Package() {0, 0})
+
         // resiliency phase entry (deep standby entry)
         Store (1, Local0) // Display All Monitor off flag
         ADBG (Concatenate ("All Monitor off flag(default): ", ToHexString (Local0)))
@@ -1027,6 +1034,20 @@ Scope(\_SB)
             // standby state with very limited SW activities
             \_SB.PC00.SPIF.SPIS() // Clear SPI Synchronous SMI Status bit
             Store(0x0000000000000000, \_SB.PC00.LPCB.HPET.TCN1)
+            \_SB.PC00.RP08.DL23()
+            Store(0x90C000A, Index(RSTG, 0))
+            Store(0x0, Index(RSTG, 1))
+            Store(0x9020016, Index(PWRG, 0))
+            Store(0x0, Index(PWRG, 1))
+            \PIN.ON(RSTG)
+            \_SB.PSD3 (1)
+            If(CondRefOf(TMCS)) {
+              SPCX(7, 0, TMCS)
+            } Else {
+              SPCO(7, 0)
+            }
+            \PIN.OFF (PWRG)
+            \_SB.SHPO (0, 0)
             \GUAM(1) // 0x01 - Power State Standby (CS Resiliency Entry)
           }
 
@@ -1068,6 +1089,22 @@ Scope(\_SB)
           If(LEqual(S0ID, 1)) { //S0ID: >=1: CS 0: non-CS
             // call method specific to CS platforms when the system is in a
             // standby state with very limited SW activities
+            Store(0x90C000A, Index(RSTG, 0))
+            Store(0x0, Index(RSTG, 1))
+            Store(0x9020016, Index(PWRG, 0))
+            Store(0x0, Index(PWRG, 1))
+            \_SB.SHPO (0, 1)
+            \_SB.CAGS (0)
+            \_SB.PSD0 (1)
+            \PIN.ON (PWRG)
+            Sleep (PEP0)
+            If(CondRefOf(TMCS)) {
+              SPCX(7, 1, TMCS)
+            } Else {
+              SPCO(7, 1)
+            }
+            \PIN.OFF (RSTG)
+            \_SB.PC00.RP08.L23D()
             \GUAM(0) // 0x00 - Power State On (CS Resiliency Exit)
           }
           If (\ECON) {

--- a/Platform/AlderlakeBoardPkg/AcpiTables/SaSsdt/CpuPcieRp.asl
+++ b/Platform/AlderlakeBoardPkg/AcpiTables/SaSsdt/CpuPcieRp.asl
@@ -1,7 +1,7 @@
 /** @file
   This file contains the CPU PCIe Root Port configuration
 
-  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -161,7 +161,7 @@ Scope (\_SB.PC00.PEG2) {
     If (LNotEqual(\PPA2,0)) {
       Return (\PPA2)
     } Else {
-      Return (0x00010001)
+      Return (0x00060002)
     }
   }
 

--- a/Platform/AlderlakeBoardPkg/AcpiTables/Ssdt/PcieRpGenericPcieDeviceRtd3.asl
+++ b/Platform/AlderlakeBoardPkg/AcpiTables/Ssdt/PcieRpGenericPcieDeviceRtd3.asl
@@ -1,7 +1,7 @@
 /**@file
   PCIe Root Port Generic PCIE Device Rtd3 file.
 
-  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -57,7 +57,7 @@
   {
 
     If (CondRefOf (RD3C)) {
-      If (LEqual (RD3C, 0x02)) {
+      If (LEqual (RD3C, 0x01)) {
         Return (0x4)
       }
     }
@@ -268,7 +268,7 @@
     // Check if D3 Cold is supported for PCIE RP.
     //
     If (CondRefOf (RD3C)) {
-      If (LNotEqual (RD3C, 0x02)) {
+      If (LNotEqual (RD3C, 0)) {
         Return (0)
       }
     }

--- a/Platform/AlderlakeBoardPkg/AcpiTables/Ssdt/PcieRpSsdStorageRtd3Hook.asl
+++ b/Platform/AlderlakeBoardPkg/AcpiTables/Ssdt/PcieRpSsdStorageRtd3Hook.asl
@@ -1,7 +1,7 @@
 /**@file
   ACPI RTD3 Hook SSDT Library for Generic Pcie Rp with End Point as M.2 SSD/Storage Device.
 
-  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -19,7 +19,7 @@
   {
 
     If (CondRefOf (^^RD3C)) {
-      If (LEqual (^^RD3C, 0x02)) {
+      If (LEqual (^^RD3C, 0x01)) {
         Return (0x4)
       }
     }

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -907,6 +907,9 @@ PlatformUpdateAcpiGnvs (
   PchNvs->PchUsb2PortCount = (UINT8) GetPchUsb2MaxPhysicalPortNum ();
   PchNvs->PchUsb3PortCount = (UINT8) GetPchXhciMaxUsb3PortNum ();
 
+  PchNvs->ClkreqIpcCmdSupported = 1;
+  PchNvs->HybridStorageCpuRpLocation = 0xFF;
+
   //Platform NVS Init
   PlatformNvs->ApicEnable                   = 1;
   PlatformNvs->PlatformId = (UINT8) GetPlatformId ();
@@ -1053,6 +1056,49 @@ PlatformUpdateAcpiGnvs (
     PlatformNvs->PcieSlot1PowerEnableGpio = GPIO_VER4_S_GPP_E1;
     PlatformNvs->PcieSlot2RpNumber = 5;
     break;
+  case PLATFORM_ID_ADL_P_DDR5_RVP:
+    PlatformNvs->PcieSlot1WakeGpio = 0;
+    PlatformNvs->PcieSlot1PowerEnableGpio = GPIO_VER2_LP_GPP_A22;
+    PlatformNvs->PcieSlot1PowerEnableGpioPolarity = 0;
+    PlatformNvs->PcieSlot1RstGpio = GPIO_VER2_LP_GPP_F10;
+    PlatformNvs->PcieSlot1RpNumber = 8;
+    PlatformNvs->PcieSlot2WakeGpio = 0;
+    PlatformNvs->PcieSlot2PowerEnableGpio = 0;
+    PlatformNvs->PcieSlot2PowerEnableGpioPolarity = 0;
+    PlatformNvs->PcieSlot2RstGpio = 0;
+    PlatformNvs->PcieSlot2RpNumber = 0;
+    PlatformNvs->PcieSlot3WakeGpio = 0;
+    PlatformNvs->PcieSlot3PowerEnableGpio = 0;
+    PlatformNvs->PcieSlot3PowerEnableGpioPolarity = 0;
+    PlatformNvs->PcieSlot3RstGpio = 0;
+    PlatformNvs->PcieSlot3RpNumber = 0;
+    PlatformNvs->M2Ssd2PowerEnableGpio = GPIO_VER2_LP_GPP_D14;
+    PlatformNvs->M2Ssd2RstGpio = GPIO_VER2_LP_GPP_F20;
+    PlatformNvs->M2Ssd3PowerEnableGpio = GPIO_VER2_LP_GPP_C2;
+    PlatformNvs->PchM2SsdPowerEnableGpio = GPIO_VER2_LP_GPP_D16;
+    PlatformNvs->PchM2SsdRstGpio = GPIO_VER2_LP_GPP_H0;
+    PlatformNvs->PchM2Ssd2PowerEnableGpio = 0;
+    PlatformNvs->PchM2Ssd2PowerEnableGpioPolarity = 0;
+    PlatformNvs->PchM2Ssd2RstGpio = 0;
+    PlatformNvs->PchM2Ssd3PowerEnableGpio = 0;
+    PlatformNvs->PchM2Ssd3PowerEnableGpioPolarity = 0;
+    PlatformNvs->PchM2Ssd3RstGpio = 0;
+    PlatformNvs->SataPortPowerEnableGpio = 0;
+    PlatformNvs->SataPortPowerEnableGpioPolarity = 0;
+    PlatformNvs->PegSlot1PwrEnableGpioNo = 0;
+    PlatformNvs->PegSlot1PwrEnableGpioPolarity = 0;
+    PlatformNvs->PegSlot1RstGpioNo = 0;
+    PlatformNvs->PegSlot1WakeGpioPin = GPIO_VER2_LP_GPP_A20;
+    PlatformNvs->PegSlot1RootPort = 0;
+    PlatformNvs->PegSlot2PwrEnableGpioNo = 0;
+    PlatformNvs->PegSlot2PwrEnableGpioPolarity = 0;
+    PlatformNvs->PegSlot2RstGpioNo = 0;
+    PlatformNvs->PegSlot2RstGpioPolarity = 0;
+    PlatformNvs->PegSlot2WakeGpioPin = 0;
+    PlatformNvs->PegSlot2RootPort = 0;
+    PlatformNvs->WlanWakeGpio = GPIO_VER2_LP_GPP_D13;
+    PlatformNvs->WlanRootPortNumber = 5;
+    PlatformNvs->PL1LimitCSValue = 0x1194;
 
   default:
     DEBUG ((DEBUG_ERROR, "Could not find PlatformNvs settings for PlatformId 0x%X!\n", GetPlatformId ()));
@@ -1072,6 +1118,11 @@ PlatformUpdateAcpiGnvs (
   PlatformNvs->Rtd3Config0 = 0x0;
   PlatformNvs->Rtd3Config1 = 0x0;
   PlatformNvs->StorageRtd3Support = 0x1;
+
+  PlatformNvs->Rp08D3ColdDisable = 0x0;
+  PlatformNvs->Rp08D3ColdSupport = 0x0;
+  PlatformNvs->Rp08WakeReworkDone = 0x0;
+
   //CPU NVS Init
   UpdateCpuNvs (CpuNvs);
 


### PR DESCRIPTION
This patch enable S0ix feature in ADLP
1. Ported correct NVS value for ADLP.
2. Ported ACPI value refer to BIOS.
3. Implemented workaround for RP08.

Verified: ADL-P RVP

Signed-off-by: jinjhuli <jin.jhu.lim@intel.com>