### PR TITLE
StitchIfwi: Indicate failure through exit status

### DIFF
--- a/Platform/AlderlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/AlderlakeBoardPkg/Script/StitchIfwi.py
@@ -196,15 +196,15 @@ def main():
     if args.work_dir == '':
         print ("Please specify stitch work directory")
         print ('%s' % stitch_cfg_file.extra_usage_txt)
-        return 0
+        return 1
 
     if args.btg_profile in ["vm","fvme"] and args.tpm == "none":
         print ("ERROR: Choose appropriate Tpm type for BootGuard profile 3 and 5")
-        return 0
+        return 1
 
     plt_params_list = get_para_list (args.option.split(';'))
     if not stitch_cfg_file.check_parameter(plt_params_list):
-        exit (0)
+        exit (1)
 
     print ("Executing stitch.......")
     curr_dir = os.getcwd()

--- a/Platform/CoffeelakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/CoffeelakeBoardPkg/Script/StitchIfwi.py
@@ -512,7 +512,7 @@ def main():
     if args.stitch_dir == '':
         print ("Please specify stitch work directory")
         print ('%s' % stitch_cfg_file.extra_usage_txt)
-        return 0
+        return 1
 
     sku_dict = stitch_cfg_file.get_platform_sku()
     if len (sku_dict) == 1 and args.platform == '':
@@ -523,16 +523,16 @@ def main():
         print ("Invalid sku (%s), Please provide valid sku:" % args.platform)
         for sku in sku_dict :
             print (" %s - 'For %s'" % (sku, sku_dict[sku]))
-        return 0
+        return 1
 
     if args.btg_profile in ["vm","fvme"] and args.tpm == "none":
         print ("ERROR: Choose appropriate Tpm type for BootGuard profile 3 and 5")
-        return 0
+        return 1
 
     if args.clean:
         shutil.rmtree(os.path.join(stitch_dir, 'Temp'), ignore_errors=True)
         print ("Cleaning completed successfully !\n")
-        return 0
+        return 1
 
     print ("Executing stitch.......")
     curr_dir = os.getcwd()

--- a/Platform/CometlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/CometlakeBoardPkg/Script/StitchIfwi.py
@@ -479,13 +479,13 @@ def main():
     if args.work_dir == '':
         print ("Please specify stitch work directory")
         print ('%s' % stitch_cfg_file.extra_usage_txt)
-        return 0
+        return 1
     if args.platform == '' or args.platform not in stitch_cfg_file.get_platform_sku():
         print ("Please specify platform from the list: %s" % stitch_cfg_file.get_platform_sku().keys())
-        return 0
+        return 1
     if args.btg_profile in ["vm","fvme"] and args.tpm == "none":
         print ("ERROR: Choose appropriate Tpm type for BootGuard profile 3 and 5")
-        return 0
+        return 1
 
     print ("Executing stitch.......")
     curr_dir = os.getcwd()

--- a/Platform/CometlakevBoardPkg/Script/StitchIfwi.py
+++ b/Platform/CometlakevBoardPkg/Script/StitchIfwi.py
@@ -480,13 +480,13 @@ def main():
     if args.work_dir == '':
         print ("Please specify stitch work directory")
         print ('%s' % stitch_cfg_file.extra_usage_txt)
-        return 0
+        return 1
     if args.platform == '' or args.platform not in stitch_cfg_file.get_platform_sku():
         print ("Please specify platform from the list: %s" % stitch_cfg_file.get_platform_sku().keys())
-        return 0
+        return 1
     if args.btg_profile in ["vm","fvme"] and args.tpm == "none":
         print ("ERROR: Choose appropriate Tpm type for BootGuard profile 3 and 5")
-        return 0
+        return 1
 
     print ("Executing stitch.......")
     curr_dir = os.getcwd()

--- a/Platform/ElkhartlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/ElkhartlakeBoardPkg/Script/StitchIfwi.py
@@ -203,18 +203,18 @@ def main():
     if args.work_dir == '':
         print ("Please specify stitch work directory")
         print ('%s' % stitch_cfg_file.extra_usage_txt)
-        return 0
+        return 1
 
     sku_dict = stitch_cfg_file.get_platform_sku()
     if args.platform == '' or args.platform not in sku_dict:
         print ("Invalid sku (%s), Please provide valid sku:" % args.platform)
         for sku in sku_dict :
             print (" %s - 'For %s'" % (sku, sku_dict[sku]))
-        return 0
+        return 1
 
     if args.btg_profile in ["vm","fvme"] and args.tpm == "none":
         print ("ERROR: Choose appropriate Tpm type for BootGuard profile 3 and 5")
-        return 0
+        return 1
 
     plt_params_list = get_para_list (args.option.split(';'))
     if not stitch_cfg_file.check_parameter(plt_params_list):

--- a/Platform/TigerlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/TigerlakeBoardPkg/Script/StitchIfwi.py
@@ -180,7 +180,7 @@ def main():
     if args.work_dir == '':
         print ("Please specify stitch work directory")
         print ('%s' % stitch_cfg_file.extra_usage_txt)
-        return 0
+        return 1
 
     sku_dict = stitch_cfg_file.get_platform_sku()
     if len (sku_dict) == 1 and args.platform == '':
@@ -191,15 +191,15 @@ def main():
         print ("Invalid sku (%s), Please provide valid sku:" % args.platform)
         for sku in sku_dict :
             print (" %s - 'For %s'" % (sku, sku_dict[sku]))
-        return 0
+        return 1
 
     if args.btg_profile in ["vm","fvme"] and args.tpm == "none":
         print ("ERROR: Choose appropriate Tpm type for BootGuard profile 3 and 5")
-        return 0
+        return 1
 
     plt_params_list = get_para_list (args.option.split(';'))
     if not stitch_cfg_file.check_parameter(plt_params_list):
-        exit (0)
+        exit (1)
 
     print ("Executing stitch.......")
     curr_dir = os.getcwd()


### PR DESCRIPTION
When run as part of an automated system it's important to ensure that
any failure is reported to the calling process. Writing an error message
and then exiting indicating success leads to difficult-to-diagnose
problems.