### PR TITLE
[ADL] Fix ADL build errors

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.h
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.h
@@ -235,31 +235,6 @@ GetCpuStepping(
   );
 
 /**
-  Return CPU Sku
-
-  @param[in]  UINT32             CpuFamilyModel
-  @param[in]  UINT16             CpuDid
-
-  @retval     UINT8              CPU Sku
-**/
-UINT8
-GetCpuSkuInfo (
-  IN UINT32 CpuFamilyModel,
-  IN UINT16 CpuDid
-  );
-
-/**
-  Return CPU Sku
-
-  @retval UINT8              CPU Sku
-**/
-UINT8
-EFIAPI
-GetCpuSku (
-  VOID
-  );
-
-/**
   Return CPU Family ID
 
   @retval CPU_FAMILY              CPU Family ID

--- a/Silicon/AlderlakePkg/Include/Library/CpuPcieHsPhyInitLib.h
+++ b/Silicon/AlderlakePkg/Include/Library/CpuPcieHsPhyInitLib.h
@@ -39,4 +39,29 @@ HsPhyLoadAndInit (
   VOID
   );
 
+/**
+  Return CPU Sku
+
+  @param[in]  UINT32             CpuFamilyModel
+  @param[in]  UINT16             CpuDid
+
+  @retval     UINT8              CPU Sku
+**/
+UINT8
+GetCpuSkuInfo (
+  IN UINT32 CpuFamilyModel,
+  IN UINT16 CpuDid
+  );
+
+/**
+  Return CPU Sku
+
+  @retval UINT8              CPU Sku
+**/
+UINT8
+EFIAPI
+GetCpuSku (
+  VOID
+  );
+
 #endif

--- a/Silicon/AlderlakePkg/Library/PciePm/PciePm.c
+++ b/Silicon/AlderlakePkg/Library/PciePm/PciePm.c
@@ -14,6 +14,7 @@
 #include <Library/PchPciBdfLib.h>
 #include <Library/PchPcieRpConfig.h>
 #include <Library/PciExpressHelpersLib.h>
+#include <Library/CpuPcieHsPhyInitLib.h>
 #include <Library/PchInfoLib.h>
 #include <PcieRegs.h>
 #include <PchAccess.h>


### PR DESCRIPTION
With latest changes for S0ix, PciePm is expecting GetCpuSku and
GetCpuSkuInfo function declaration in header files. Added these
declarations in CpuPcieHsPhyInitLib header file

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>