### PR TITLE
[ADL] Remove unused variable

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
@@ -705,7 +705,6 @@ PlatformUpdateAcpiGnvs (
   UINT8                    RpNum;
   UINTN                    RpDev;
   UINTN                    RpFun;
-  UINT8                    FuncIndex;
   UINT32                   Data32;
   GPIO_GROUP               GroupToGpeDwX[3];
   UINT32                   GroupDw[3];


### PR DESCRIPTION
Linux build is complaning of an unused variable,
removed that variable to fix build issues.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>