### PR TITLE
Enable Grahpics Console during firmware update

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -414,6 +414,7 @@
   PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf {
     <PcdsFixedAtBuild>
       gPlatformCommonLibTokenSpaceGuid.PcdDebugOutputDeviceMask  | $(DEBUG_OUTPUT_DEVICE_MASK)
+      gPlatformCommonLibTokenSpaceGuid.PcdConsoleOutDeviceMask   | ($(CONSOLE_OUT_DEVICE_MASK) + 0x02)
     <LibraryClasses>
       MemoryAllocationLib     | BootloaderCommonPkg/Library/FullMemoryAllocationLib/FullMemoryAllocationLib.inf
       PayloadEntryLib         | PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.inf

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
@@ -50,6 +50,7 @@
   ContainerLib
   StringSupportLib
   BootOptionLib
+  TimerLib
 
 [Guids]
   gLoaderMemoryMapInfoGuid
@@ -60,6 +61,7 @@
   gFlashMapInfoGuid
   gBootLoaderVersionFileGuid
   gBootLoaderVersionGuid
+  gEfiGraphicsInfoHobGuid
 
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
@@ -69,6 +71,9 @@
   gPlatformCommonLibTokenSpaceGuid.PcdLowestSupportedFwVer
   gPayloadTokenSpaceGuid.PcdCsmeUpdateEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdCompSignHashAlg
+  gPlatformCommonLibTokenSpaceGuid.PcdConsoleOutDeviceMask
+  gPlatformCommonLibTokenSpaceGuid.PcdFrameBufferMaxConsoleWidth
+  gPlatformCommonLibTokenSpaceGuid.PcdFrameBufferMaxConsoleHeight
 
 [Depex]
   TRUE

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.c
@@ -19,6 +19,8 @@
 #include <Library/DecompressLib.h>
 #include <Library/ConfigDataLib.h>
 #include <Library/LiteFvLib.h>
+#include <Library/ConsoleOutLib.h>
+#include <Library/TimerLib.h>
 #include "FirmwareUpdateHelper.h"
 #include <Service/SpiFlashService.h>
 
@@ -425,16 +427,16 @@ UpdateBootRegion (
         UpdateBlockSize = SIZE_64KB;
       }
     }
-    DEBUG ((DEBUG_INIT, "Updating 0x%08llx, Size:0x%05x\n", UpdateAddress, UpdateBlockSize));
+    ConsolePrint ("Updating 0x%08llx, Size:0x%06x\n", UpdateAddress, UpdateBlockSize);
     Status = UpdateRegionBlock (UpdateAddress, Buffer, UpdateBlockSize);
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "\nFailed! Address=0x%08llx, Status = %r\n", UpdateAddress, Status));
+      ConsolePrint ("\nFailed at address 0x%08llx, status: %r\n", UpdateAddress, Status);
       return Status;
     }
     UpdateAddress += UpdateBlockSize;
     Buffer        += UpdateBlockSize;
     UpdatedSize   += UpdateBlockSize;
-    DEBUG ((DEBUG_INIT, "\nFinished   %3d%%\n", (WrittenSize + UpdatedSize) * 100 / TotalSize));
+    ConsolePrint ("\nFinished   %3d%%\n", (WrittenSize + UpdatedSize) * 100 / TotalSize);
   }
 
   return EFI_SUCCESS;
@@ -1052,7 +1054,8 @@ Reboot (
   IN  EFI_RESET_TYPE        ResetType
   )
 {
-  DEBUG ((DEBUG_INFO, "Reset required to proceed with the firmware update.\n\n"));
+  ConsolePrint("Reset required to proceed.\n\n");
+  MicroSecondDelay (3000000);
   ResetSystem (ResetType);
   CpuDeadLoop ();
 }

--- a/Platform/QemuBoardPkg/Script/TestCases/firmware_update.py
+++ b/Platform/QemuBoardPkg/Script/TestCases/firmware_update.py
@@ -72,7 +72,7 @@ def  get_check_lines (bp = 0, mode = 0):
               "===========Read Capsule Image============",
               "Boot from partition %s, update partition %s" % (bp_ab[0], bp_ab[1]),
               "Finished   100%",
-              "Reset required to proceed with the firmware update"
+              "Reset required to proceed"
               ])
     return lines
 


### PR DESCRIPTION
This patch enables graphics console when entering FWU payload.
FWU progress will show on both graphics console and serial port.

Signed-off-by: kokweich <kok.wei.chan@intel.com>