### PR TITLE
Update VBT patching by dynamically locating block

### DIFF
--- a/Silicon/CommonSocPkg/Include/Library/IgdOpRegionLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/IgdOpRegionLib.h
@@ -11,13 +11,15 @@
     VBT:        Video BIOS Table (OEM customizable data)
     IPU:        Image Processing Unit
 
-  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
 #ifndef _IGD_OP_REGION_LIB_H_
 #define _IGD_OP_REGION_LIB_H_
+
+#define VBT_BLK_ID_GENERAL2_INFO              2
 
 #pragma pack(1)
 
@@ -305,6 +307,22 @@ EFI_STATUS
 EFIAPI
 IgdOpRegionInit (
   IN IGD_OP_PLATFORM_INFO *PlatformInfo
+  );
+
+/**
+  Locate a VBT block within VBT bianry by its block ID.
+
+  @param[in] VbtBuf     VBT binary buffer pointer.
+  @param[in] BlockId    A VBT block ID to locate.
+
+  @retval    NULL       Not found.
+             Others     The pointer to the block header.
+**/
+UINT8 *
+EFIAPI
+LocateVbtBlockById (
+  IN  UINT8     *VbtBuf,
+  IN  UINT8      BlockId
   );
 
 #endif


### PR DESCRIPTION
Current VBT patching uses a static big structure VBT_TABLE_DATA to
parse the VBT data. It is not reliable because the sub structures
within VBT_TABLE_DATA might change between different revision. A
better solution is to look through each block data using the common
block header info. It can provide better back compatibility.  This
patch implemented this.

It fixed #1504.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>