### PR TITLE
Fix incorrect lspci behavior for multi-function PCI device

### DIFF
--- a/BootloaderCommonPkg/Library/ShellLib/CmdPci.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdPci.c
@@ -163,6 +163,12 @@ ShellCommandPciFunc (
             }
             ShellPrint (L"\n\n");
           }
+
+          if ((Func == 0) && ((PciDev->HeaderType & HEADER_TYPE_MULTI_FUNCTION) == 0)) {
+            // Skip sub functions, this is not a multi function device
+            Func = PCI_MAX_FUNC;
+          }
+
         }
       }
     }


### PR DESCRIPTION
According to PCI spec, it is required to check the multi-function
support in PCI configuration header type before scanning next PCI
function. Current SBL does not follow this, and it caused duplicated
PCI devices listed in Shell command "lspci".  This patch fixed
this issue.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>