### PR TITLE
Add support for PCI expansion rom resource allocation

### DIFF
--- a/BootloaderCorePkg/Library/PciEnumerationLib/InternalPciEnumerationLib.c
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/InternalPciEnumerationLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -32,14 +32,22 @@ BarExisted (
   )
 {
   UINT32              OriginalValue;
+  UINT32              AllOne;
+  UINT32              Mask;
   volatile UINT32     Value;
 
   //
   // Preserve the original value
   //
   OriginalValue = PciExpressRead32 (PciIoDevice->Address + Offset);
-  PciExpressWrite32 (PciIoDevice->Address + Offset, 0xFFFFFFFF);
-  Value = PciExpressRead32 (PciIoDevice->Address + Offset);
+  AllOne = 0xFFFFFFFF;
+  Mask   = 0xFFFFFFFF;
+  if (Offset == PCI_EXPANSION_ROM_BASE) {
+    AllOne &=  ~BIT0;
+    Mask   &= ~0x7FF;
+  }
+  PciExpressWrite32 (PciIoDevice->Address + Offset, AllOne);
+  Value = PciExpressRead32 (PciIoDevice->Address + Offset) & Mask;
   PciExpressWrite32 (PciIoDevice->Address + Offset, OriginalValue);
 
   if (BarLengthValue != NULL) {

--- a/BootloaderCorePkg/Library/PciEnumerationLib/InternalPciEnumerationLib.h
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/InternalPciEnumerationLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -75,7 +75,8 @@ typedef struct {
 
 typedef struct {
   UINT16            AllocPmemFirst  : 1;
-  UINT16            Reserved        : 15;
+  UINT16            FlagAllocRomBar : 1;
+  UINT16            Reserved        : 14;
 } PCI_ENUM_FLAG;
 
 typedef struct {

--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -2,7 +2,7 @@
 ## @ BuildUtility.py
 # Build bootloader main script
 #
-# Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2022, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -203,7 +203,8 @@ class PciEnumPolicyInfo(Structure):
         ('DowngradeBus0',           c_uint16, 2),
         ('DowngradeReserved',       c_uint16, 11),
         ('FlagAllocPmemFirst',      c_uint16, 1),
-        ('FlagReserved',            c_uint16, 15),
+        ('FlagAllocRomBar',         c_uint16, 1),
+        ('FlagReserved',            c_uint16, 14),
         ('BusScanType',             c_uint8), # 0: list, 1: range
         ('NumOfBus',                c_uint8),
         ('BusScanItems',            ARRAY(c_uint8, 0))
@@ -216,6 +217,7 @@ class PciEnumPolicyInfo(Structure):
         self.DowngradeBus0      = 1
         self.DowngradeReserved  = 0
         self.FlagAllocPmemFirst = 0
+        self.FlagAllocRomBar    = 0
         self.FlagReserved       = 0
         self.Reserved           = 0
         self.BusScanType        = 0
@@ -1230,6 +1232,7 @@ def gen_pci_enum_policy_info (policy_dict):
         policy_info.DowngradePMem64 = policy_dict['DOWNGRADE_PMEM64']
         policy_info.DowngradeBus0   = policy_dict['DOWNGRADE_BUS0']
         policy_info.FlagAllocPmemFirst  = policy_dict['FLAG_ALLOC_PMEM_FIRST']
+        policy_info.FlagAllocRomBar = policy_dict['FLAG_ALLOC_ROM_BAR']
         policy_info.BusScanType     = policy_dict['BUS_SCAN_TYPE']
         bus_scan_items              = policy_dict['BUS_SCAN_ITEMS']
 

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -868,6 +868,7 @@ class Build(object):
             'DOWNGRADE_PMEM64',
             'DOWNGRADE_BUS0',
             'FLAG_ALLOC_PMEM_FIRST',
+            'FLAG_ALLOC_ROM_BAR',
             'BUS_SCAN_TYPE',
             'BUS_SCAN_ITEMS'
         ]


### PR DESCRIPTION
Current SBL PCI enumeration does not allocate resource for PCI ROM
bar because SBL does not deal with option ROM at all. However, the
Linux kernel might expect the ROM bar resource to be allocated.
This patch introduces a static build configuration to allow support
PCI resource allocation for PCI ROM bar.

To enable this feature, please add following into the project
BoardConfig.py file:
  self._PCI_ENUM_FLAG_ALLOC_ROM_BAR = 1

By default, it will be disabled to keep the same behavior as before.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>