### PR TITLE
Enhance SerialPortLib to handle debug output during PCI enumeration

### DIFF
--- a/BootloaderCommonPkg/Library/SerialPortLib/SerialPortLib.c
+++ b/BootloaderCommonPkg/Library/SerialPortLib/SerialPortLib.c
@@ -59,13 +59,15 @@ SerialPortReadRegister (
   UINTN    Base;
 
   Base   = (UINTN) GetSerialPortBase ();
-  Offset = GetSerialPortStrideSize () * Offset;
   if (Base == 0) {
-    Data = 0;
-  } else if (Base < 0x10000) {
-    Data = IoRead8 (Base + Offset);
+    Data = (Offset == LSR_OFFSET) ? LSR_TXRDY : 0;
   } else {
-    Data = MmioRead8 (Base + Offset);
+    Offset = GetSerialPortStrideSize () * Offset;
+    if (Base < 0x10000) {
+      Data = IoRead8 (Base + Offset);
+    } else {
+      Data = MmioRead8 (Base + Offset);
+    }
   }
   return Data;
 }


### PR DESCRIPTION
If there is DEBUG output during PCI enumeration, it could cause SBL
hang due to invalid PCI bar resource. In this case, SBL will force
to return 0 for any serial port register read. And it might cause
dead loop because of LSR_TXRDY bit polling in SerialPortWrite().
To avoid this potential dead loop, it is required to set LSR_TXRDY
bit for LSR_OFFSET register read if the PCI resource is invalid.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>