### PR TITLE
[ADL] Update VBT binary before silicon init

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -509,6 +509,13 @@ UpdateFspConfig (
     DEBUG ((DEBUG_INFO, "Frame Buffer Enabled\n"));
     FspsConfig->GraphicsConfigPtr = (UINT32)GetVbtAddress ();
     VbtPtr = (VBIOS_VBT_STRUCTURE*)(UINTN)(FspsConfig->GraphicsConfigPtr);
+    //
+    // Update VBT for the board
+    //
+    Status = UpdateVbt (VbtPtr);
+    if (EFI_ERROR(Status)) {
+      DEBUG ((DEBUG_ERROR, "Could not update VBT\n"));
+    }
     FspsConfig->PeiGraphicsPeimInit = 1;
     if (VbtPtr != NULL) {
       FspsConfig->VbtSize = ((VbtPtr->HeaderVbtSize) & (UINT32)~(0x1FF)) + 0x200;

--- a/Silicon/AlderlakePkg/Include/Library/IgdOpRegionLib.h
+++ b/Silicon/AlderlakePkg/Include/Library/IgdOpRegionLib.h
@@ -33,4 +33,17 @@ IgdOpRegionInit (
   void
   );
 
+/**
+  Update VBT data in Igd Op Region.
+
+  @param[in] VbtTablePtr      Pointer to VBT_TABLE_DATA
+
+  @retval    EFI_SUCCESS      VBT data was returned.
+  @exception EFI_ABORTED      Intel VBT not found.
+**/
+EFI_STATUS
+UpdateVbt (
+  IN VOID   *VbtTablePtr
+  );
+
 #endif


### PR DESCRIPTION
Graphics driver in FSP Silicon init is expecting
board related changes for VBT, so moved UpdateVbt
function call before Silicon Init.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>