### PR TITLE
[ADL] Remove RTC logic in payload switching

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/MiscInit.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/MiscInit.c
@@ -49,38 +49,6 @@ UpdatePayloadId (
   }
 
   //
-  // Use CMOS offset 0x20 (use as magic check) and 0x21 (payloadId) for payload detection.
-  //
-  // Read CMOS offset 20 value
-  IoWrite8 (CMOS_EXTENDED_ADDREG, CMOS_EXTENDED_OFFSET_20);
-  CmosData = IoRead8 (CMOS_EXTENDED_DATAREG);
-  DEBUG ((DEBUG_INFO, "CMOS boot Magic [0x%x]\n", CmosData));
-
-  if (CmosData == CMOS_VALUE_SWITCH_PLD) {
-    // Read payload target
-    IoWrite8 (CMOS_EXTENDED_ADDREG, CMOS_EXTENDED_OFFSET_21);
-    CmosData  = IoRead8 (CMOS_EXTENDED_DATAREG);
-    DEBUG ((DEBUG_INFO, "CMOS boot target [0x%x]\n", CmosData));
-
-    switch (CmosData) {
-      case 0:
-        SetPayloadId (0);
-        break;
-      case 1:
-        SetPayloadId (UEFI_PAYLOAD_ID_SIGNATURE);
-        break;
-      case 2:
-        SetPayloadId (LINX_PAYLOAD_ID_SIGNATURE);
-        break;
-      default:
-       SetPayloadId (0);
-       break;
-    }
-
-    return;
-  }
-
-  //
   // Switch payloads based on configured GPIO pin
   //
   PldSelCfgData = (PLDSEL_CFG_DATA *)FindConfigDataByTag (CDATA_PLDSEL_TAG);

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.h
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.h
@@ -127,12 +127,6 @@
 #define ATOM_MODULE_ID_1            0x8
 #define ATOM_MODULE_ID_2            0x9
 
-#define CMOS_EXTENDED_ADDREG        0x74
-#define CMOS_EXTENDED_DATAREG       0x75
-#define CMOS_EXTENDED_OFFSET_20     0x20
-#define CMOS_EXTENDED_OFFSET_21     0x21
-#define CMOS_VALUE_SWITCH_PLD       0x5A
-
 /**
   Time spent in the Package C-State.  It is given in units compatible to P1 clock frequency (Guaranteed / Maximum Core Non-Turbo Frequency).
   This time will be updated by PCODE only after the C-State exit (the update of this register has lower priority than actually ensuring that the C-State exit occurs).


### PR DESCRIPTION
Removed RTC logic, it is problematic and should not be used,
all other platforms are not using this logic and
we should remove this from the code

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>