### PR TITLE
Add FS load Shell command

### DIFF
--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -163,7 +163,6 @@ class Board(BaseBoard):
         self.VARIABLE_SIZE        = 0x00002000
         self.SBLRSVD_SIZE         = 0x00001000
         self.FWUPDATE_SIZE        = 0x00020000 if self.ENABLE_FWU else 0
-        self.OS_LOADER_FD_SIZE    = 0x0004F000
         self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.TOP_SWAP_SIZE        = 0x080000


### PR DESCRIPTION
This patch adds "fs load" command to SBL shell so that it can be
used to load a file from boot media into memory. It also supports
loading file at specified memory address.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>