### PR TITLE
Use Universal Payload hobs for serial port info

### DIFF
--- a/PayloadPkg/Library/PlatformHookLib/PlatformHookLib.inf
+++ b/PayloadPkg/Library/PlatformHookLib/PlatformHookLib.inf
@@ -28,7 +28,7 @@
   BootloaderCommonPkg/BootloaderCommonPkg.dec
 
 [Guids]
-  gLoaderSerialPortInfoGuid
+  gUniversalPayloadSerialPortInfoGuid
 
 [Pcd]
   gPlatformCommonLibTokenSpaceGuid.PcdSerialUseMmio         ## PRODUCES
@@ -37,3 +37,4 @@
   gPlatformCommonLibTokenSpaceGuid.PcdSerialRegisterStride  ## PRODUCES
   gPlatformCommonLibTokenSpaceGuid.PcdSerialClockRate       ## PRODUCES
   gPayloadTokenSpaceGuid.PcdPayloadHobList        ## PRODUCES
+


### PR DESCRIPTION
Universal Payload defined new HOBs for serial port information.
This patch switched to use the new hob instead of the old one to
retrieve serial port information.

Signed-off-by: Maurice Ma <maurice.ma@intel.com>