### PR TITLE
[TGL] add TCO Timer control option

### DIFF
--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -263,6 +263,14 @@
                      Enable/disable Timed GPIO1    0- Disable; 1- Enable.
       length       : 0x01
       value        : 0x0
+  - EnableTcoTimer :
+      name         : Enable TCO Timer
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     Enable/disable TCO Timer    0- Disable; 1- Enable.
+      length       : 0x01
+      value        : 0x0
   - EcEnable     :
       name         : Enable EC Device
       type         : Combo
@@ -315,5 +323,5 @@
     - !expand { USB_PORT_TMPL : [ 2, 14 ] }
     - !expand { USB_PORT_TMPL : [ 2, 15 ] }
   - Dummy        :
-      length       : 0x3
+      length       : 0x2
       value        : 0x0

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1610,6 +1610,7 @@ UpdateFspConfig (
   FspsConfig->UsbTcPortEn = 0xf;
 
   if (SiCfgData != NULL) {
+    FspsConfig->EnableTcoTimer   = SiCfgData->EnableTcoTimer;
     FspsConfig->EnableTimedGpio0 = SiCfgData->EnableTimedGpio0;
     FspsConfig->EnableTimedGpio1 = SiCfgData->EnableTimedGpio1;
     FspsConfig->XdciEnable       = SiCfgData->XdciEnable;


### PR DESCRIPTION
This patch adds control option for TCO timer.

Use case: the control option shall be enabled when Linux hw watchdog driver (iTCO) is enabled.

Verified: TGL-UP3 RVP

Signed-off-by: Stanley Chang <stanley.chang@intel.com>