### PR TITLE
[ADLS] Fix Tcc issue caused due to incorrect UPD setting.

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -387,6 +387,10 @@ TccModePostMemConfig (
     FspsUpd->FspsConfig.TccCacheCfgBase = (UINT32)(UINTN)TccCacheconfigBase;
     FspsUpd->FspsConfig.TccCacheCfgSize = TccCacheconfigSize;
     DEBUG ((DEBUG_INFO, "Load Tcc Cache @0x%p, size = 0x%x\n", TccCacheconfigBase, TccCacheconfigSize));
+
+    if (IsPchS ()) {
+      FspsUpd->FspsConfig.TccMode = 1;
+    }
   }
 
   // Load Tcc Crl binary from container


### PR DESCRIPTION
Some of the RTCT table entries werent populated due to this
missing UPD setting. Hence, assigning it to the correct value.

TEST= Verified the fix on ADLS board.

Signed-off-by: Sindhura Grandhi <sindhura.grandhi@intel.com>