### PR TITLE
[TGL] fix KW issue

### DIFF
--- a/Silicon/TigerlakePchPkg/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.c
+++ b/Silicon/TigerlakePchPkg/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.c
@@ -477,7 +477,7 @@ GetOverrideL1ssCapsOffset (
     if (((Override->Table[Index].OverrideConfig & PchPcieL1SubstatesOverride) == PchPcieL1SubstatesOverride) &&
         (Override->Table[Index].VendorId == VendorId) &&
         (Override->Table[Index].DeviceId == DeviceId) &&
-        (Override->Table[Index].RevId == Revision || Override->Table[Index].RevId == 0xFFFF)) {
+        (Override->Table[Index].RevId == Revision || Override->Table[Index].RevId == 0xFF)) {
       return Override->Table[Index].L1SubstatesCapOffset;
     }
   }


### PR DESCRIPTION
KW reported the expression 'Override->Table[Index].RevId'
can never reach the value '0xFFFF', where RevId is of type UINT8

Signed-off-by: Vincent Chen <vincent.chen@intel.com>