### PR TITLE
[TGL] Restore AUTO payload-switching behavior

### DIFF
--- a/Platform/CommonBoardPkg/CfgData/CfgData_PayloadSelection.yaml
+++ b/Platform/CommonBoardPkg/CfgData/CfgData_PayloadSelection.yaml
@@ -2,7 +2,7 @@
 #
 #  Slim Bootloader Payload Selection CFGDATA File.
 #
-#  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -51,6 +51,7 @@
       option          : 0:Active High, 1:Active Low
       help            : >
                         GPIO Pin Polarity to trigger Payload switching
+                        When pin polarity matches the value, OS Loader will be used. Otherwise, UEFI Payload is selected.
       condition       : $(COND_PLD_SEL_EN)
       length          : 1bD
       value           : 0

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglh_Ddr4.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglh_Ddr4.dlt
@@ -2,7 +2,7 @@
 #
 #  Platform Configuration Delta File.
 #
-#  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -39,12 +39,6 @@ SILICON_CFG_DATA.PchDmiAspmCtrl                             | 2
 SILICON_CFG_DATA.PchLegacyIoLowLatency                      | 1
 
 BOOT_OPTION_CFG_DATA_5.HwPart_5                             | 255
-
-
-# PCH H :  GPIO_VER2_H_GPP_F10
-PLDSEL_CFG_DATA.PldSelGpio.Enable                           | 1
-PLDSEL_CFG_DATA.PldSelGpio.PadGroup                         | 5
-PLDSEL_CFG_DATA.PldSelGpio.PinNumber                        | 10
 
 # GPIO Group GPP_A: TGL-H has 15. 15-23 should be skipped.
 GPIO_CFG_DATA.GpioPinConfig0_GPP_A00                        | 0x0350A383
@@ -565,4 +559,10 @@ GPIO_CFG_DATA.GpioPinConfig1_GPD11.GPIOSkip_GPD11           | 1           # TGL-
 #
 GEN_CFG_DATA.PayloadId                                      | 'AUTO'
 GPIO_CFG_DATA.GpioPinConfig0_GPP_F10.GPIODirection_GPP_F10  | 11
+# PCH H :  GPIO_VER2_H_GPP_F10
+PLDSEL_CFG_DATA.PldSelGpio.Enable                           | 1
+PLDSEL_CFG_DATA.PldSelGpio.PadGroup                         | 5
+PLDSEL_CFG_DATA.PldSelGpio.PinNumber                        | 10
+PLDSEL_CFG_DATA.PldSelGpio.PinPolarity                      | 1
+
 SILICON_CFG_DATA.PchHdaEnable                               | 0x00

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_Ddr4.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_Ddr4.dlt
@@ -32,11 +32,6 @@ MEMORY_CFG_DATA.DmaControlGuarantee                         | 1
 
 SILICON_CFG_DATA.PortUsb20Enable.Usb2Port1                  | 0
 
-# PCH LP :  GPIO_VER2_LP_GPP_B15
-PLDSEL_CFG_DATA.PldSelGpio.Enable                           | 1
-PLDSEL_CFG_DATA.PldSelGpio.PadGroup                         | 1
-PLDSEL_CFG_DATA.PldSelGpio.PinNumber                        | 15
-
 #
 # By default use Osloader Payload, set to "UEFI" to select UEFI payload.
 #
@@ -49,4 +44,10 @@ PLDSEL_CFG_DATA.PldSelGpio.PinNumber                        | 15
 #
 GEN_CFG_DATA.PayloadId                                      | 'AUTO'
 GPIO_CFG_DATA.GpioPinConfig0_GPP_B15.GPIODirection_GPP_B15  | 0xB
+# PCH LP :  GPIO_VER2_LP_GPP_B15
+PLDSEL_CFG_DATA.PldSelGpio.Enable                           | 1
+PLDSEL_CFG_DATA.PldSelGpio.PadGroup                         | 1
+PLDSEL_CFG_DATA.PldSelGpio.PinNumber                        | 15
+PLDSEL_CFG_DATA.PldSelGpio.PinPolarity                      | 1
+
 SILICON_CFG_DATA.PchHdaEnable                               | 0x00

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_DdrLp4.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Int_Tglu_DdrLp4.dlt
@@ -27,10 +27,6 @@ MEMORY_CFG_DATA.SpdDataSel130                               | 1
 
 SILICON_CFG_DATA.PortUsb20Enable.Usb2Port1                  | 0
 
-# PCH LP :  GPIO_VER2_LP_GPP_B15
-PLDSEL_CFG_DATA.PldSelGpio.Enable                           | 1
-PLDSEL_CFG_DATA.PldSelGpio.PadGroup                         | 1
-PLDSEL_CFG_DATA.PldSelGpio.PinNumber                        | 15
 
 #
 # By default use Osloader Payload, set to "UEFI" to select UEFI payload.
@@ -44,4 +40,10 @@ PLDSEL_CFG_DATA.PldSelGpio.PinNumber                        | 15
 #
 GEN_CFG_DATA.PayloadId                                      | 'AUTO'
 GPIO_CFG_DATA.GpioPinConfig0_GPP_B15.GPIODirection_GPP_B15  | 0xB
+# PCH LP :  GPIO_VER2_LP_GPP_B15
+PLDSEL_CFG_DATA.PldSelGpio.Enable                           | 1
+PLDSEL_CFG_DATA.PldSelGpio.PadGroup                         | 1
+PLDSEL_CFG_DATA.PldSelGpio.PinNumber                        | 15
+PLDSEL_CFG_DATA.PldSelGpio.PinPolarity                      | 1
+
 SILICON_CFG_DATA.PchHdaEnable                               | 0x00

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -729,7 +729,7 @@ UpdatePayloadId (
 
   PldSelCfgData = (PLDSEL_CFG_DATA *)FindConfigDataByTag (CDATA_PLDSEL_TAG);
   if ((PldSelCfgData != NULL) && (PldSelCfgData->PldSelGpio.Enable != 0)) {
-    PayloadSelGpioPad = GpioGroupPinToPad (PldSelCfgData->PldSelGpio.PadGroup,  PldSelCfgData->PldSelGpio.PinNumber);
+    PayloadSelGpioPad = GpioGroupPinToPad (PldSelCfgData->PldSelGpio.PadGroup, PldSelCfgData->PldSelGpio.PinNumber);
     if (PayloadSelGpioPad == 0) {
       Status = EFI_ABORTED;
     } else {


### PR DESCRIPTION
Previous commit fe6cf3272 unexpectedly changed the AUTO payload-switching behavior.
This patch restores the behavior to the original design.

Verified: TGL-UP3 RVP

Signed-off-by: Stanley Chang <stanley.chang@intel.com>