### PR TITLE
[ADLN] Add TSN support

### DIFF
--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -28,6 +28,14 @@
                      Enable/disable TSN on the PCH.
       length       : 0x01
       value        : 0x0
+  - PchTsnLinkSpeed :
+      name         : TSN Link Speed
+      type         : Combo
+      option       :   0: Reserved, 1: Reserved, 2: 38.4Mhz 2.5Gbps, 3: 38.4Mhz 1Gbps
+      help         : >
+                     Set TSN Link Speed. Only applicable for ADLN
+      length       : 0x01
+      value        : 0x03
   - PchTsnMultiVcEnable :
       name         : Enable TSN Multi-VC
       type         : Combo
@@ -445,5 +453,5 @@
       length       : 0x01
       value        : 0x1
   - SiliconRsvd  :
-      length       : 0x01
+      length       : 0x00
       value        : 0x00

--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -649,6 +649,10 @@ UpdateFspConfig (
       if(SiCfgData->PchTsnEnable == 1) {
         FspsConfig->PchTsnMultiVcEnable = SiCfgData->PchTsnMultiVcEnable;
 
+          if (IsPchLp ()) {
+            FspsConfig->PchTsnLinkSpeed = SiCfgData->PchTsnLinkSpeed;
+          }
+
         TsnMacAddrBase      = NULL;
         TsnMacAddrSize      = 0;
         Status = LoadComponent (SIGNATURE_32 ('I', 'P', 'F', 'W'), SIGNATURE_32 ('T', 'M', 'A', 'C'),
@@ -660,6 +664,7 @@ UpdateFspConfig (
           FspsConfig->PchTsnMacAddressLow   = TsnSubRegion->MacConfigData.Port[0].MacAddr.U32MacAddr[0];
           FspsConfig->PchTsn1MacAddressHigh = TsnSubRegion->MacConfigData.Port[1].MacAddr.U32MacAddr[1];
           FspsConfig->PchTsn1MacAddressLow  = TsnSubRegion->MacConfigData.Port[1].MacAddr.U32MacAddr[0];
+
         } else {
           DEBUG ((DEBUG_ERROR, "TSN MAC subregion not found! %r\n", Status));
         }

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/GpioTableAdlTsn.h
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/GpioTableAdlTsn.h
@@ -26,4 +26,15 @@ GLOBAL_REMOVE_IF_UNREFERENCED GPIO_INIT_CONFIG mAdlSTsnDeviceGpioTable[] =
   {GPIO_VER4_S_GPP_S7,  { GpioPadModeNative3, GpioHostOwnDefault, GpioDirInOut,  GpioOutDefault,   GpioIntDis, GpioResetDefault,  GpioTermNone }}  //RGMII_PPS
 };
 
+GLOBAL_REMOVE_IF_UNREFERENCED GPIO_INIT_CONFIG mAdlNTsnDeviceGpioTable[] =
+{
+  // TSN Device, Same pins shared between THC Touch Panel 2
+  {GPIO_VER2_LP_GPP_F17, {GpioPadModeNative1, GpioHostOwnDefault, GpioDirOut,    GpioOutDefault,   GpioIntDis, GpioResetDefault,  GpioTermNone}},  //TSN_GMII_MDC_THC1_SPI2_RSTB
+  {GPIO_VER2_LP_GPP_F18, {GpioPadModeNative1, GpioHostOwnDefault, GpioDirInOut,  GpioOutDefault,   GpioIntDis, GpioResetDefault,  GpioTermNone}},  //TSN_GMII_MDIO_THC1_SPI2_INTB
+  {GPIO_VER2_LP_GPP_S0,  {GpioPadModeNative3, GpioHostOwnDefault, GpioDirInOut,  GpioOutDefault,   GpioIntDis, GpioResetDefault,  GpioTermNone}},  //TSN_SNDW1_CLK_RGMII_AUXTS
+  {GPIO_VER2_LP_GPP_S1,  {GpioPadModeNative3, GpioHostOwnDefault, GpioDirIn,     GpioOutDefault,   GpioIntDis, GpioResetDefault,  GpioTermNone}},  //TSN_SNDW1_DATA_RGMII_INT
+  {GPIO_VER2_LP_GPP_S2,  {GpioPadModeNative3, GpioHostOwnDefault, GpioDirOut,    GpioOutDefault,   GpioIntDis, GpioResetDefault,  GpioTermNone}},  //TSN_SNDW2_CLK_RGMII_RESET
+  {GPIO_VER2_LP_GPP_S3,  {GpioPadModeNative3, GpioHostOwnDefault, GpioDirInOut,  GpioOutDefault,   GpioIntDis, GpioResetDefault,  GpioTermNone}},  //TSNSNDW1_DATA_DMIC_CLK_B_1_RGMII_PPS
+};
+
 #endif // _ALDERLAKE_U_TSN_GPIO_TABLE_H_

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -11,7 +11,7 @@
 #include "Stage2BoardInitLib.h"
 #include "GpioTableAdlPsPostMem.h"
 #include "GpioTableAdlNPostMem.h"
-#include "GpioTableAdlSTsn.h"
+#include "GpioTableAdlTsn.h"
 #include <Library/PciePm.h>
 #include <Library/PlatformInfo.h>
 
@@ -269,6 +269,10 @@ BoardInit (
           case PLATFORM_ID_ADL_S_ADP_S_DDR4_SODIMM_CRB:
           case PLATFORM_ID_ADL_S_ADP_S_DDR5_SODIMM_CRB:
             ConfigureGpio (CDATA_NO_TAG, sizeof (mAdlSTsnDeviceGpioTable) / sizeof (mAdlSTsnDeviceGpioTable[0]), (UINT8*)mAdlSTsnDeviceGpioTable);
+            break;
+          case PLATFORM_ID_ADL_N_DDR5_CRB:
+          case PLATFORM_ID_ADL_N_LPDDR5_RVP:
+            ConfigureGpio (CDATA_NO_TAG, sizeof (mAdlNTsnDeviceGpioTable) / sizeof (mAdlNTsnDeviceGpioTable[0]), (UINT8*)mAdlNTsnDeviceGpioTable);
             break;
           default:
             DEBUG ((DEBUG_WARN, "TSN GPIO: Unrecognized BoardId 0x%X\n", GetPlatformId ()));

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -20,7 +20,7 @@
 #
 
 [Sources]
-  GpioTableAdlSTsn.h
+  GpioTableAdlTsn.h
   InterruptInit.h
   Stage2BoardInitLib.h
   Stage2BoardInitLib.c

--- a/Silicon/AlderlakePkg/Include/GpioPinsVer2Lp.h
+++ b/Silicon/AlderlakePkg/Include/GpioPinsVer2Lp.h
@@ -81,7 +81,14 @@
 #define GPIO_VER2_LP_GPD2                    0x09050002
 #define GPIO_VER2_LP_GPD7                    0x09050007
 
+#define GPIO_VER2_LP_GPP_S0                  0x09060000
+#define GPIO_VER2_LP_GPP_S1                  0x09060001
+#define GPIO_VER2_LP_GPP_S2                  0x09060002
+#define GPIO_VER2_LP_GPP_S3                  0x09060003
+#define GPIO_VER2_LP_GPP_S4                  0x09060004
 #define GPIO_VER2_LP_GPP_S5                  0x09060005
+#define GPIO_VER2_LP_GPP_S6                  0x09060006
+#define GPIO_VER2_LP_GPP_S7                  0x09060007
 
 #define GPIO_VER2_LP_GPP_H0                  0x09070000
 #define GPIO_VER2_LP_GPP_H1                  0x09070001


### PR DESCRIPTION
Unlike ADLS, TSN link speed will be coming from the Cfg data.
New TSN GPIO table needed for ADLN board.

Signed-off-by: Sindhura Grandhi <sindhura.grandhi@intel.com>