### PR TITLE
[RPLS] Update big core number default value

### DIFF
--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_Memory.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_Memory.yaml
@@ -285,7 +285,7 @@
         help         : >
                        Number of active big cores(Depends on Number of big cores). Default 0xFF means to active all system supported big cores. <b>0xFF- Active all big cores</b>; 0- Disable all big cores; 1- 1; 2- 2; 3- 3;
         length       : 0x0001
-        value        : 0x8
+        value        : 0xFF
   - FClkFrequency :
       name         : Processor Early Power On Configuration FCLK setting
       type         : Combo


### PR DESCRIPTION
The default big core number was set to 8, it has to be overridden if
the CPU number is not 8. Had better set to 0xFF to all active big cores.
Also it mentioned the default value is 0xFF in the help message.

Signed-off-by: Guo Dong <guo.dong@intel.com>