### PR TITLE
[TGL] Support individual TSN ports Enable/Disable

### DIFF
--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -2,7 +2,7 @@
 #
 #  Slim Bootloader CFGDATA Option File.
 #
-#  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -54,13 +54,12 @@
       value        : 0x1
   - PchTsnEnable :
       name         : Enable PCH TSN
-      type         : Combo
-      option       : $EN_DIS
+      type         : EditNum, HEX, (0x00,0xFFFF)
       condition    : $(COND_S0IX_DIS)
       help         : >
-                     Enable/disable TSN on the PCH.
-      length       : 0x01
-      value        : 0x0
+                     Enable/disable TSN Ports on the PCH.
+      length       : 0x02
+      value        : { 0x0, 0x0 }
   - PchTsnLinkSpeed :
       name         : TSN Link Speed
       type         : Combo
@@ -323,5 +322,5 @@
     - !expand { USB_PORT_TMPL : [ 2, 14 ] }
     - !expand { USB_PORT_TMPL : [ 2, 15 ] }
   - Dummy        :
-      length       : 0x2
+      length       : 0x1
       value        : 0x0

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_Tsn_Feature.dlt
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_Tsn_Feature.dlt
@@ -2,7 +2,7 @@
 #
 #  TSN feature Configuration Delta File.
 #
-#  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -10,7 +10,7 @@
 
 FEATURES_CFG_DATA.Features.S0ix   | 0
 
-SILICON_CFG_DATA.PchTsnEnable     | 1
+SILICON_CFG_DATA.PchTsnEnable     | {1, 1}
 
 SILICON_CFG_DATA.PchTsnLinkSpeed  | 3
 

--- a/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2008 - 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2008 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -255,7 +255,7 @@ UpdateFspConfig (
   // Need enable VTd if TSN is enabled
   SiCfgData = (SILICON_CFG_DATA *)FindConfigDataByTag (CDATA_SILICON_TAG);
   if (SiCfgData != NULL) {
-    if (SiCfgData->PchTsnEnable == 1) {
+    if (SiCfgData->PchTsnEnable[0] || SiCfgData->PchTsnEnable[1]) {
       DEBUG ((DEBUG_INFO, "TSN is enabled\n"));
       PlatformData->PlatformFeatures.VtdEnable = 1;
     }
@@ -521,7 +521,7 @@ UpdateFspConfig (
     PLAT_FEAT.S0ixEnable = FeaturesCfgData->Features.S0ix;
 
     // S0ix is disabled if TSN is enabled.
-    if ((PLAT_FEAT.S0ixEnable == 1) && (SiCfgData != NULL) && (SiCfgData->PchTsnEnable == 1)) {
+    if ((PLAT_FEAT.S0ixEnable == 1) && (SiCfgData != NULL) && (SiCfgData->PchTsnEnable[0] || SiCfgData->PchTsnEnable[1])) {
       PLAT_FEAT.S0ixEnable = 0;
       DEBUG ((DEBUG_INFO, "S0ix is turned off when TSN is enabled\n"));
     }

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -880,7 +880,7 @@ BoardInit (
     SiCfgData = (SILICON_CFG_DATA *)FindConfigDataByTag (CDATA_SILICON_TAG);
     if (SiCfgData != NULL) {
       // Configure TSN GPIO table if TSN is enabled.
-      if (SiCfgData->PchTsnEnable == 1) {
+      if (SiCfgData->PchTsnEnable[0] || SiCfgData->PchTsnEnable[1]) {
         switch (GetPlatformId ()) {
           case BoardIdTglHDdr4SODimm:
           case 0x0F:
@@ -1513,10 +1513,10 @@ UpdateFspConfig (
     TsnMacAddrBase      = NULL;
     TsnMacAddrSize      = 0;
 
-    FspsConfig->PchTsnEnable    = SiCfgData->PchTsnEnable;
+    CopyMem (FspsConfig->PchTsnEnable, SiCfgData->PchTsnEnable, sizeof(SiCfgData->PchTsnEnable));
     FspsConfig->PchTsnLinkSpeed = SiCfgData->PchTsnLinkSpeed;
 
-    if(SiCfgData->PchTsnEnable == 1) {
+    if (SiCfgData->PchTsnEnable[0] || SiCfgData->PchTsnEnable[1]) {
       FspsConfig->PchTsnMultiVcEnable = SiCfgData->PchTsnMultiVcEnable;
       Status = LoadComponent (SIGNATURE_32 ('I', 'P', 'F', 'W'), SIGNATURE_32 ('T', 'M', 'A', 'C'),
                               (VOID **)&TsnMacAddrBase, &TsnMacAddrSize);
@@ -1549,7 +1549,7 @@ UpdateFspConfig (
     FspsConfig->CpuUsb3OverCurrentPin[1] = 0x1;
     FspsConfig->CpuUsb3OverCurrentPin[2] = 0x2;
     FspsConfig->CpuUsb3OverCurrentPin[3] = 0x3;
-    if ((SiCfgData != NULL) && (SiCfgData->PchTsnEnable)) {
+    if ((SiCfgData != NULL) && (SiCfgData->PchTsnEnable[0] || SiCfgData->PchTsnEnable[1])) {
       FspsConfig->Usb2OverCurrentPin[1] = 0xff;
       FspsConfig->Usb2OverCurrentPin[4] = 0xff;
       FspsConfig->Usb3OverCurrentPin[1] = 0xff;
@@ -1658,7 +1658,8 @@ UpdateFspConfig (
     FspsConfig->D3HotEnable = 0;
     FspsConfig->D3ColdEnable = 1;
     FspsConfig->PchLanEnable = 0;
-    FspsConfig->PchTsnEnable = 0;
+    FspsConfig->PchTsnEnable[0] = 0;
+    FspsConfig->PchTsnEnable[1] = 0;
     FspsConfig->XdciEnable = 0;
 
     // PCH SERIAL_UART_CONFIG
@@ -2675,7 +2676,7 @@ PlatformUpdateAcpiGnvs (
 
   // TSN
   SiCfgData = (SILICON_CFG_DATA *)FindConfigDataByTag (CDATA_SILICON_TAG);
-  if ((SiCfgData != NULL) && (SiCfgData->PchTsnEnable)) {
+  if ((SiCfgData != NULL) && (SiCfgData->PchTsnEnable[0] || SiCfgData->PchTsnEnable[1])) {
     PlatformNvs->TsnPcsEnabled  = 1;
   }
 


### PR DESCRIPTION
New FSP (from 0A.00.66.12) supports switching TSN GbE ports
Enable/Disable individually. SBL requires CfgData change
accordingly to avoid build errors.

Signed-off-by: Vincent Chen <vincent.chen@intel.com>