### PR TITLE
[TGL] Update FSP and platform version since MR5 is released

### DIFF
--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -25,7 +25,7 @@ class Board(BaseBoard):
 
         self.VERINFO_IMAGE_ID       = 'SBL_TGL'
         self.VERINFO_PROJ_MAJOR_VER = 1
-        self.VERINFO_PROJ_MINOR_VER = 4
+        self.VERINFO_PROJ_MINOR_VER = 5
         self.VERINFO_SVN            = 1
         self.VERINFO_BUILD_DATE     = time.strftime("%m/%d/%Y")
 

--- a/Silicon/TigerlakePkg/FspBin/FspBin.inf
+++ b/Silicon/TigerlakePkg/FspBin/FspBin.inf
@@ -11,7 +11,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = 04ad3cd76f87f44a8e632db60cecd82e881ca081
+  COMMIT  = 48d4c23f957548311345fa463494e7ffbed4ae35
 
 [UserExtensions.SBL."CopyList"]
   TigerLakeFspBinPkg/TGL_IOT/Fsp.fd                    : Silicon/TigerlakePkg/FspBin/FspDbg.bin


### PR DESCRIPTION
- update FSP version to IoT FSP 4391_03 (0A.00.66.13)
- update TGL platform version to 1.5

Signed-off-by: Vincent Chen <vincent.chen@intel.com>