### PR TITLE
[CML] Update FSP, UCODE and platform version since MR1 is released

### DIFF
--- a/Platform/CometlakeBoardPkg/BoardConfig.py
+++ b/Platform/CometlakeBoardPkg/BoardConfig.py
@@ -26,7 +26,7 @@ class Board(BaseBoard):
 
         self.VERINFO_IMAGE_ID          = 'SB_CML'
         self.VERINFO_PROJ_MAJOR_VER    = 1
-        self.VERINFO_PROJ_MINOR_VER    = 0
+        self.VERINFO_PROJ_MINOR_VER    = 1
         self.VERINFO_SVN               = 1
         self.VERINFO_BUILD_DATE        = time.strftime("%m/%d/%Y")
         self.LOWEST_SUPPORTED_FW_VER   = ((self.VERINFO_PROJ_MAJOR_VER << 8) + self.VERINFO_PROJ_MINOR_VER)

--- a/Platform/CometlakeBoardPkg/Script/StitchIfwiConfig.py
+++ b/Platform/CometlakeBoardPkg/Script/StitchIfwiConfig.py
@@ -60,6 +60,7 @@ def get_bpmgen2_params_change_list ():
       ('BpmSigPrivKey',         r'Bpmgen2\keys\bpm_privkey_2048.pem'),
       ('BpmKeySizeBits',        '2048'),
       ('BpmSigHashAlgID',       '0x0B:SHA256'),
+      ('VTD_BAR',               '0x00000000FED91000'),
       ])
     return params_change_list
 

--- a/Platform/CometlakevBoardPkg/BoardConfig.py
+++ b/Platform/CometlakevBoardPkg/BoardConfig.py
@@ -26,7 +26,7 @@ class Board(BaseBoard):
 
         self.VERINFO_IMAGE_ID          = 'SB_CML'
         self.VERINFO_PROJ_MAJOR_VER    = 1
-        self.VERINFO_PROJ_MINOR_VER    = 0
+        self.VERINFO_PROJ_MINOR_VER    = 1
         self.VERINFO_SVN               = 1
         self.VERINFO_BUILD_DATE        = time.strftime("%m/%d/%Y")
         self.LOWEST_SUPPORTED_FW_VER   = ((self.VERINFO_PROJ_MAJOR_VER << 8) + self.VERINFO_PROJ_MINOR_VER)

--- a/Platform/CometlakevBoardPkg/Script/StitchIfwiConfig.py
+++ b/Platform/CometlakevBoardPkg/Script/StitchIfwiConfig.py
@@ -60,6 +60,7 @@ def get_bpmgen2_params_change_list ():
       ('BpmSigPrivKey',         r'Bpmgen2\keys\bpm_privkey_2048.pem'),
       ('BpmKeySizeBits',        '2048'),
       ('BpmSigHashAlgID',       '0x0B:SHA256'),
+      ('VTD_BAR',               '0x00000000FED91000'),
       ])
     return params_change_list
 

--- a/Silicon/CometlakePkg/FspBin/FspBin.inf
+++ b/Silicon/CometlakePkg/FspBin/FspBin.inf
@@ -11,11 +11,11 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = 2263d48a006d8653df1fc742c3f7d5ffd6b75d68
+  COMMIT  = b24086682cb08da0c9b7a1c975da460f39ffd314
 
 [UserExtensions.SBL."CopyList"]
-  CometLakeFspBinPkg/CometLakeS/FSP.fd                 : Silicon/CometlakePkg/FspBin/FspDbg.bin
-  CometLakeFspBinPkg/CometLakeS/FSP.fd                 : Silicon/CometlakePkg/FspBin/FspRel.bin
+  CometLakeFspBinPkg/CometLakeS/Fsp.fd                 : Silicon/CometlakePkg/FspBin/FspDbg.bin
+  CometLakeFspBinPkg/CometLakeS/Fsp.fd                 : Silicon/CometlakePkg/FspBin/FspRel.bin
   CometLakeFspBinPkg/CometLakeS/Fsp.bsf                : Silicon/CometlakePkg/FspBin/Fsp.bsf
   CometLakeFspBinPkg/CometLakeS/Include/FspInfoHob.h   : Silicon/CometlakePkg/Include/FspInfoHob.h
   CometLakeFspBinPkg/CometLakeS/Include/FspUpd.h       : Silicon/CometlakePkg/Include/FspUpd.h

--- a/Silicon/CometlakePkg/Microcode/Microcode.inf
+++ b/Silicon/CometlakePkg/Microcode/Microcode.inf
@@ -14,15 +14,13 @@
   VERSION_STRING       = 1.0
 
 [Sources]
- m22A0653_000000CC.mcb  # CML G1-Step
- m22A0655_000000CA.mcb
+ m22A0653_000000EA.mcb  # CML G1-Step
+ m22A0655_000000EC.mcb  # CML Q0-Step
 
 [UserExtensions.SBL."CloneRepo"]
   REPO  = https://github.com/tianocore/edk2-non-osi.git
-  COMMIT= 9369fc86378bc13383e0544e55dec4bf0e65a412
+  COMMIT= bf2ba5e5136bfe5efe6052fb565d8597bcbeec17
 
 [UserExtensions.SBL."CopyList"]
-  Silicon/Intel/CometlakeSiliconBinPkg/Microcode/m22A0653_000000CC.mcb  : Silicon/CometlakePkg/Microcode/m22A0653_000000CC.mcb
-  Silicon/Intel/CometlakeSiliconBinPkg/Microcode/m22A0655_000000CA.mcb  : Silicon/CometlakePkg/Microcode/m22A0655_000000CA.mcb
-
-
+  Silicon/Intel/CometlakeSiliconBinPkg/Microcode/m22A0653_000000EA.mcb  : Silicon/CometlakePkg/Microcode/m22A0653_000000EA.mcb
+  Silicon/Intel/CometlakeSiliconBinPkg/Microcode/m22A0655_000000EC.mcb  : Silicon/CometlakePkg/Microcode/m22A0655_000000EC.mcb

--- a/Silicon/CometlakevPkg/FspBin/FspBin.inf
+++ b/Silicon/CometlakevPkg/FspBin/FspBin.inf
@@ -11,11 +11,11 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = 2263d48a006d8653df1fc742c3f7d5ffd6b75d68
+  COMMIT  = b24086682cb08da0c9b7a1c975da460f39ffd314
 
 [UserExtensions.SBL."CopyList"]
-  CometLakeFspBinPkg/CometLakeV/FSP.fd                 : Silicon/CometlakevPkg/FspBin/FspDbg.bin
-  CometLakeFspBinPkg/CometLakeV/FSP.fd                 : Silicon/CometlakevPkg/FspBin/FspRel.bin
+  CometLakeFspBinPkg/CometLakeV/Fsp.fd                 : Silicon/CometlakevPkg/FspBin/FspDbg.bin
+  CometLakeFspBinPkg/CometLakeV/Fsp.fd                 : Silicon/CometlakevPkg/FspBin/FspRel.bin
   CometLakeFspBinPkg/CometLakeV/Fsp.bsf                : Silicon/CometlakevPkg/FspBin/Fsp.bsf
   CometLakeFspBinPkg/CometLakeV/Include/FspInfoHob.h   : Silicon/CometlakevPkg/Include/FspInfoHob.h
   CometLakeFspBinPkg/CometLakeV/Include/FspUpd.h       : Silicon/CometlakevPkg/Include/FspUpd.h

--- a/Silicon/CometlakevPkg/Microcode/Microcode.inf
+++ b/Silicon/CometlakevPkg/Microcode/Microcode.inf
@@ -14,13 +14,13 @@
   VERSION_STRING       = 1.0
 
 [Sources]
- m22A0653_000000CC.mcb  # CML G1-Step
- m22A0655_000000CA.mcb
+ m22A0653_000000EA.mcb  # CML G1-Step
+ m22A0655_000000EC.mcb  # CML Q0-Step
 
 [UserExtensions.SBL."CloneRepo"]
   REPO  = https://github.com/tianocore/edk2-non-osi.git
-  COMMIT= 9369fc86378bc13383e0544e55dec4bf0e65a412
+  COMMIT= bf2ba5e5136bfe5efe6052fb565d8597bcbeec17
 
 [UserExtensions.SBL."CopyList"]
-  Silicon/Intel/CometlakeSiliconBinPkg/Microcode/m22A0653_000000CC.mcb  : Silicon/CometlakevPkg/Microcode/m22A0653_000000CC.mcb
-  Silicon/Intel/CometlakeSiliconBinPkg/Microcode/m22A0655_000000CA.mcb  : Silicon/CometlakevPkg/Microcode/m22A0655_000000CA.mcb
+  Silicon/Intel/CometlakeSiliconBinPkg/Microcode/m22A0653_000000EA.mcb  : Silicon/CometlakevPkg/Microcode/m22A0653_000000EA.mcb
+  Silicon/Intel/CometlakeSiliconBinPkg/Microcode/m22A0655_000000EC.mcb  : Silicon/CometlakevPkg/Microcode/m22A0655_000000EC.mcb


### PR DESCRIPTION
- FSP:
  * 09.03.7B.20 for CML-S
  * 09.01.7B.20 for CML-V
  * bpmgen2_params: set VTD_BAR to 0xFED91000
- Microcode:
  * m22A0653_000000EA.mcb  # G1-Step
  * m22A0655_000000EC.mcb  # Q0-Step
- update CML platform version to 1.1

Signed-off-by: Vincent Chen <vincent.chen@intel.com>