### PR TITLE
[ADL] Expose Timed GPIO to OS

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
@@ -1195,5 +1195,11 @@ PlatformUpdateAcpiGnvs (
       PlatformNvs->LowPowerS0Idle = PlatformData->PlatformFeatures.TccLowPowerS0Idle;
     }
   }
+
+    // Expose Timed GPIO to OS through Nvs variables
+    if (SiCfgData != NULL) {
+        PchNvs->EnableTimedGpio0 = (UINT8)SiCfgData->EnableTimedGpio0;
+        PchNvs->EnableTimedGpio1 = (UINT8)SiCfgData->EnableTimedGpio1;
+    }
 }
 


### PR DESCRIPTION
This patch assigns Timed GPIO Cfg Data to the NVS variables
in order for the OS to load this driver.

Signed-off-by: Sindhura Grandhi <sindhura.grandhi@intel.com>