### PR TITLE
Add USB command timeout control

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -1,7 +1,7 @@
 ## @file
 # Provides bootloader driver related package definitions.
 #
-# Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2022, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -119,6 +119,9 @@
 
   # USB keyboard polling timeout in milliseconds
   gPlatformCommonLibTokenSpaceGuid.PcdUsbKeyboardPollingTimeout   | 0x00000001 | UINT32 | 0x20000440
+
+  # USB command timeout in milliseconds
+  gPlatformCommonLibTokenSpaceGuid.PcdUsbCmdTimeout               |     0x1000 | UINT16 | 0x20000441
 
   # Options to limit framebuffer console size (it will be centered if smaller than screen resolution)
   gPlatformCommonLibTokenSpaceGuid.PcdFrameBufferMaxConsoleWidth  | 0xFFFFFFFF | UINT32 | 0x20000501

--- a/BootloaderCommonPkg/Library/UsbBlockIoLib/PeiAtapi.c
+++ b/BootloaderCommonPkg/Library/UsbBlockIoLib/PeiAtapi.c
@@ -1,7 +1,7 @@
 /** @file
 Pei USB ATATPI command implementations.
 
-Copyright (c) 1999 - 2017, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 1999 - 2022, Intel Corporation. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -56,7 +56,7 @@ PeiUsbInquiry (
              &Idata,
              36,
              EfiUsbDataIn,
-             2000
+             PcdGet16 (PcdUsbCmdTimeout)
              );
 
   if (EFI_ERROR (Status)) {
@@ -111,7 +111,7 @@ PeiUsbTestUnitReady (
              NULL,
              0,
              EfiUsbNoData,
-             2000
+             PcdGet16 (PcdUsbCmdTimeout)
              );
 
   if (EFI_ERROR (Status)) {
@@ -179,7 +179,7 @@ PeiUsbRequestSense (
                (VOID *) Ptr,
                sizeof (ATAPI_REQUEST_SENSE_DATA),
                EfiUsbDataIn,
-               2000
+               PcdGet16 (PcdUsbCmdTimeout)
                );
 
     //
@@ -255,7 +255,7 @@ PeiUsbReadCapacity (
              (VOID *) &Data,
              sizeof (ATAPI_READ_CAPACITY_DATA),
              EfiUsbDataIn,
-             2000
+             PcdGet16 (PcdUsbCmdTimeout)
              );
 
   if (EFI_ERROR (Status)) {
@@ -313,7 +313,7 @@ PeiUsbReadFormattedCapacity (
              (VOID *) &FormatData,
              sizeof (ATAPI_READ_FORMAT_CAPACITY_DATA),
              EfiUsbDataIn,
-             2000
+             PcdGet16 (PcdUsbCmdTimeout)
              );
 
   if (EFI_ERROR (Status)) {

--- a/BootloaderCommonPkg/Library/UsbBlockIoLib/UsbBlockIoLib.inf
+++ b/BootloaderCommonPkg/Library/UsbBlockIoLib/UsbBlockIoLib.inf
@@ -1,7 +1,7 @@
 ## @file
 # Description file for the USB block I/O library.
 #
-# Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2018 - 2022, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -48,4 +48,5 @@
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdUsbTransferTimeoutValue  ## CONSUMES
   gPlatformCommonLibTokenSpaceGuid.PcdMultiUsbBootDeviceEnabled ## CONSUMES
+  gPlatformCommonLibTokenSpaceGuid.PcdUsbCmdTimeout ## CONSUMES
 

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -248,6 +248,7 @@
 
   gPlatformCommonLibTokenSpaceGuid.PcdSeedListEnabled     | $(HAVE_SEED_LIST)
   gPlatformCommonLibTokenSpaceGuid.PcdUsbKeyboardPollingTimeout | $(USB_KB_POLLING_TIMEOUT)
+  gPlatformCommonLibTokenSpaceGuid.PcdUsbCmdTimeout             | $(USB_CMD_TIMEOUT)
   gPlatformCommonLibTokenSpaceGuid.PcdLowestSupportedFwVer      | $(LOWEST_SUPPORTED_FW_VER)
 
   gPlatformCommonLibTokenSpaceGuid.PcdIppHashLibSupportedMask    | $(IPP_HASH_LIB_SUPPORTED_MASK)

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -134,6 +134,7 @@ class BaseBoard(object):
         self.ACPI_PM_TIMER_BASE     = 0x0408
         self.ACPI_PROCESSOR_ID_BASE = 1
         self.USB_KB_POLLING_TIMEOUT = 1
+        self.USB_CMD_TIMEOUT        = 0x1000
 
         self.VERIFIED_BOOT_STAGE_1B   = 0x0
         self.BOOT_MEDIA_SUPPORT_MASK  = 0xFFFFFFFF


### PR DESCRIPTION
A USB disk behind a hub may take longer time to respond command.
Prior to the patch, a magic 2000 ms is set. This patch introduces a python control (USB_CMD_TIMEOUT) for customizing the timeout if need. The patch also extends the default timeout to 0x1000 (4096) ms.

This patch does not impact booting time when a platform boots with a good-conditioning usb disk, because the timeout only takes effect when a disk does not respond to a USB inquiry for a long time.

Verified: Ehl RVP

Signed-off-by: Stanley Chang <stanley.chang@intel.com>