### PR TITLE
Add BootToShell configuration item

### DIFF
--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -1367,6 +1367,7 @@ PayloadMain (
       BootShell    = FALSE;
     } else {
       if (OsBootOptionList->BootToShell != 0) {
+        ShellTimeout = (UINTN)PcdGet16 (PcdPlatformBootTimeOut);
         BootShell    = TRUE;
       } else if (DebugCodeEnabled ()) {
         ShellTimeout = (UINTN)PcdGet16 (PcdPlatformBootTimeOut);
@@ -1419,7 +1420,7 @@ PayloadMain (
       }
     }
 
-    if (DebugCodeEnabled () && (OsBootOptionList->RestrictedBoot == 0)) {
+    if ((DebugCodeEnabled () || (OsBootOptionList->BootToShell != 0)) && (OsBootOptionList->RestrictedBoot == 0)) {
       // Restricted boot should not fall back to shell
       RunShell (0);
     } else {

--- a/Platform/CommonBoardPkg/CfgData/CfgData_Common.yaml
+++ b/Platform/CommonBoardPkg/CfgData/CfgData_Common.yaml
@@ -2,7 +2,7 @@
 #
 #  Slim Bootloader Platform CFGDATA Option File.
 #
-#  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -68,4 +68,15 @@
                      AUTO allows platform to set current boot option using platform specific policy.
       length       : 0x01
       value        : 0
-
+  - BootToShell :
+      name         : Boot to OsLoader shell
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     By default OsLoader payload shell is only available in debug build. Enable BootToShell will make OsLoader Payload
+                     have same behavior with debug build in the release build.
+      length       : 0x01
+      value        : 0
+  - Dummy        :
+      length       : 0x3
+      value        : 0x0

--- a/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.c
+++ b/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2019 - 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -127,6 +127,7 @@ FillBootOptionListFromCfgData (
   GenCfgData = (GEN_CFG_DATA *)FindConfigDataByTag (CDATA_GEN_TAG);
   if (GenCfgData != NULL) {
     OsBootOptionList->CurrentBoot = GenCfgData->CurrentBoot;
+    OsBootOptionList->BootToShell = (GenCfgData->BootToShell == 0)?0:1;
     if (OsBootOptionList->CurrentBoot != MAX_BOOT_OPTION_ENTRY - 1) {
       if (OsBootOptionList->CurrentBoot >= OsBootOptionList->OsBootOptionCount) {
         OsBootOptionList->CurrentBoot = 0;


### PR DESCRIPTION
By default OsLoader payload shell is only available in debug build.
In some case customer also wants to have shell in release build.
So add a BootToShell configuration item to enable shell in release build.
By default BootToShell is set to 0. When it is set to 1 the shell behavior
would be same in release and debug build.

NOTE: user could add this line in platform dlt file to set BootToShell.
GEN_CFG_DATA.BootToShell  |1

Signed-off-by: Guo Dong <guo.dong@intel.com>