### PR TITLE
Support different CPU sort method

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -146,6 +146,10 @@
   gPlatformModuleTokenSpaceGuid.PcdSeedListBufferSize     | 0x00000400 | UINT32 | 0x200000E2
 
   gPlatformModuleTokenSpaceGuid.PcdSmbiosTablesSize       |     0x1000 | UINT16 | 0x200000E3
+  # 0: Sort the CPU according to their thread distances
+  # 1: Sort the CPU based on CPU APIC ID in ascending order
+  # 2: Sort the CPU based on CPU APIC ID in descending order
+  gPlatformModuleTokenSpaceGuid.PcdCpuSortMethod          |     0      | UINT32 | 0x200000E4
 
   # Size of the Hash store allocated in bootloader
   gPlatformModuleTokenSpaceGuid.PcdHashStoreSize          | 0x00000200 | UINT32 | 0x200000F1

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -230,6 +230,7 @@
 
   gPlatformModuleTokenSpaceGuid.PcdAcpiProcessorIdBase    | $(ACPI_PROCESSOR_ID_BASE)
   gPlatformModuleTokenSpaceGuid.PcdCpuMaxLogicalProcessorNumber | $(CPU_MAX_LOGICAL_PROCESSOR_NUMBER)
+  gPlatformModuleTokenSpaceGuid.PcdCpuSortMethod          | $(CPU_SORT_METHOD)
 
   gPlatformCommonLibTokenSpaceGuid.PcdConsoleInDeviceMask  | $(CONSOLE_IN_DEVICE_MASK)
   gPlatformCommonLibTokenSpaceGuid.PcdConsoleOutDeviceMask | $(CONSOLE_OUT_DEVICE_MASK)

--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -54,6 +54,7 @@
 
 [FixedPcd]
   gPlatformModuleTokenSpaceGuid.PcdCpuMaxLogicalProcessorNumber
+  gPlatformModuleTokenSpaceGuid.PcdCpuSortMethod
 
 [Pcd]
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegBase

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -186,6 +186,7 @@ class BaseBoard(object):
         self.BUILD_CSME_UPDATE_DRIVER    = 0
 
         self.CPU_MAX_LOGICAL_PROCESSOR_NUMBER = 16
+        self.CPU_SORT_METHOD       = 0
 
         self.ACM_SIZE              = 0
         self.DIAGNOSTICACM_SIZE    = 0


### PR DESCRIPTION
Different use case might want to have a different CPU order.
e.g. P-core first or E-core first.
This patch adds an option to help user sort CPU.

platform could add "self.CPU_SORT_METHOD  = value" to
BoardConfig.py to override the default value.

Signed-off-by: Guo Dong <guo.dong@intel.com>