### PR TITLE
[ADLS] Fix build error

### DIFF
--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlS.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlS.py
@@ -33,7 +33,7 @@ class Board(BaseBoard):
         self.BOARD_PKG_NAME       = 'AlderlakeBoardPkg'
         self.SILICON_PKG_NAME     = 'AlderlakePkg'
         self.FSP_IMAGE_ID         = 'ADLI-FSP'
-        self._EXTRA_INC_PATH      = ['Silicon/AlderlakePkg/Adls/FspBin']
+        self._EXTRA_INC_PATH      = ['Silicon/AlderlakePkg/Adls/Include']
         self._FSP_PATH_NAME       =  'Silicon/AlderlakePkg/Adls/FspBin'
         self.MICROCODE_INF_FILE   = 'Silicon/AlderlakePkg/Microcode/Microcode.inf'
         self.ACPI_TABLE_INF_FILE  = 'Platform/AlderlakeBoardPkg/AcpiTables/AcpiTables.inf'


### PR DESCRIPTION
Match the FSP include path from Board Config to that of
FspBin inf file so it fixes the build issue.

Signed-off-by: Sindhura Grandhi <sindhura.grandhi@intel.com>