### PR TITLE
[EHL] Fix IBECC error injection

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -875,6 +875,8 @@ RtcInit (
   Bar     = MmioRead32 (MM_PCI_ADDRESS (0, PCI_DEVICE_NUMBER_PCH_PMC, PCI_FUNCTION_NUMBER_PCH_PMC, R_PMC_CFG_BASE)) & ~0x0F;
   PmConf1 = MmioRead8 (Bar + R_PMC_PWRM_GEN_PMCON_B);
 
+  RtcRead (R_RTC_IO_REGA);
+
   if ((PmConf1 & B_PMC_PWRM_GEN_PMCON_B_RTC_PWR_STS) != 0) {
     DEBUG ((DEBUG_INFO, "Initialize RTC with default values\n"));
     RtcWrite (R_RTC_IO_REGA, 0x66);

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1093,11 +1093,14 @@ UpdateFspConfig (
   FSP_S_CONFIG       *Fspscfg;
   SILICON_CFG_DATA   *SiCfgData;
   POWER_CFG_DATA     *PowerCfgData;
+  MEMORY_CFG_DATA    *MemCfgData;
   UINT8              SaDisplayConfigTable[17] = { 0 };
 
   FspsUpd    = (FSPS_UPD *)FspsUpdPtr;
   Fspscfg     = &FspsUpd->FspsConfig;
   SiCfgData = (SILICON_CFG_DATA *)FindConfigDataByTag (CDATA_SILICON_TAG);
+  MemCfgData = (MEMORY_CFG_DATA *)FindConfigDataByTag (CDATA_MEMORY_TAG);
+
   if (SiCfgData == NULL) {
     DEBUG ((DEBUG_INFO, "Failed to find Silicon CFG!\n"));
   }
@@ -1601,7 +1604,13 @@ UpdateFspConfig (
 
   if (mPchSciSupported) {
     Fspscfg->IsFusaSupported = 0x1;
-    Fspscfg->IehMode = 0x1;
+    if (MemCfgData != NULL) {
+        if (MemCfgData->IbeccErrorInj != 0x1){
+            Fspscfg->IehMode = 0x1;
+        } else {
+            Fspscfg->IehMode = 0x0;
+        }
+    }
     //
     // PchPse*Enable UPDs should be set to to 0x2 for
     // host ownership; set to 1 for PSE ownership.


### PR DESCRIPTION
Only enabled IehMode when IBECC error injection is disabled
Iehmode will cause failure in IBECC error injection test

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>