### PR TITLE
fix the wrong sblopen_dir value in StitchLoader.py and StitchIfwi.py

### DIFF
--- a/Platform/AlderlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/AlderlakeBoardPkg/Script/StitchIfwi.py
@@ -1,7 +1,7 @@
 ## @ StitchIfwi.py
 #  This is a python stitching script for Slim Bootloader ADL build
 #
-# Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved. <BR>
+# Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved. <BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -29,9 +29,11 @@ sys.dont_write_bytecode = True
 # sign_bin_flag can be set to false to avoid signing process. Applicable for Btg profile 0
 sign_bin_flag = True
 
-sblopen_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../../../../', 'SblOpen')
+sblopen_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../'))
 if not os.path.exists (sblopen_dir):
     sblopen_dir = os.getenv('SBL_SOURCE', '')
+if not os.path.exists (sblopen_dir):
+    raise  Exception("Please set env 'SBL_SOURCE' to SBL open source root folder")
 
 sys.path.append (os.path.join(sblopen_dir, "BootloaderCorePkg" , "Tools"))
 
@@ -93,12 +95,6 @@ def replace_component (ifwi_src_path, flash_path, file_path, comp_alg, pri_key, 
         container_file = os.path.join(work_dir, 'Temp', 'CTN_%s.bin') % comp_name
         gen_file_from_object (container_file, ifwi_bin[replace_comp.offset:replace_comp.offset + replace_comp.length])
         comp_file     = os.path.join(work_dir, file_path)
-        sblopen_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../../../../', 'SblOpen')
-        if not os.path.exists (sblopen_dir):
-            sblopen_dir = os.getenv('SBL_SOURCE', '')
-
-        if not os.path.exists (sblopen_dir):
-           raise  Exception("Please set env 'SBL_SOURCE' to SBL open source root folder")
 
         if os.name == 'nt':
             tool_bin_dir  = os.path.join(sblopen_dir, "BaseTools", "Bin", "Win32")

--- a/Platform/AlderlakeBoardPkg/Script/StitchLoader.py
+++ b/Platform/AlderlakeBoardPkg/Script/StitchLoader.py
@@ -1,7 +1,7 @@
 ## @ StitchLoader.py
-#  This is a python stitching script for Slim Bootloader WHL/CFL build
+#  This is a python stitching script for Slim Bootloader ADL build
 #
-# Copyright (c) 2019, Intel Corporation. All rights reserved. <BR>
+# Copyright (c) 2019 - 2022, Intel Corporation. All rights reserved. <BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -12,7 +12,7 @@ from   ctypes import *
 from   functools import reduce
 
 sys.dont_write_bytecode = True
-sblopen_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../../../../', 'SblOpen')
+sblopen_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../'))
 if not os.path.exists (sblopen_dir):
     sblopen_dir = os.getenv('SBL_SOURCE', '')
 sys.path.append (os.path.join(sblopen_dir, "BootloaderCorePkg" , "Tools"))

--- a/Platform/ApollolakeBoardPkg/Script/StitchLoader.py
+++ b/Platform/ApollolakeBoardPkg/Script/StitchLoader.py
@@ -1,7 +1,7 @@
 ## @ StitchLoader.py
 #  This is a python stitching script for Slim Bootloader APL build
 #
-# Copyright (c) 2018, Intel Corporation. All rights reserved. <BR>
+# Copyright (c) 2018 - 2022, Intel Corporation. All rights reserved. <BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -18,7 +18,11 @@ from subprocess  import check_output
 from functools import reduce
 
 sys.dont_write_bytecode = True
-sys.path.append (os.path.join(os.getenv('SBL_SOURCE', ''), 'BootloaderCorePkg' , 'Tools'))
+sblopen_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../'))
+if not os.path.exists (sblopen_dir):
+    sblopen_dir = os.getenv('SBL_SOURCE', '')
+sys.path.append (os.path.join(sblopen_dir, 'BootloaderCorePkg' , 'Tools'))
+
 try:
     from   IfwiUtility   import *
 except ImportError:

--- a/Platform/CoffeelakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/CoffeelakeBoardPkg/Script/StitchIfwi.py
@@ -1,7 +1,7 @@
 ## @ StitchIfwi.py
 #  This is a python stitching script for Slim Bootloader WHL/CFL build
 #
-# Copyright (c) 2019 - 2020, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2019 - 2022, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -22,6 +22,12 @@ from   ctypes  import *
 from   StitchLoader import *
 from   subprocess   import call
 sys.dont_write_bytecode = True
+
+sblopen_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../'))
+if not os.path.exists (sblopen_dir):
+    sblopen_dir = os.getenv('SBL_SOURCE', '')
+if not os.path.exists (sblopen_dir):
+    raise  Exception("Please set env 'SBL_SOURCE' to SBL open source root folder")
 
 btg_profile_values = [\
                     "Boot Guard Profile 0 - No_FVME",\
@@ -342,12 +348,6 @@ def replace_component (ifwi_src_path, flash_path, file_path, comp_alg, pri_key):
         container_file = os.path.join(work_dir, 'CTN_%s.bin') % comp_name
         gen_file_from_object (container_file, ifwi_bin[replace_comp.offset:replace_comp.offset + replace_comp.length])
         comp_file     = os.path.join(work_dir, file_path)
-        sblopen_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../../../../', 'SblOpen')
-        if not os.path.exists (sblopen_dir):
-            sblopen_dir = os.getenv('SBL_SOURCE', '')
-
-        if not os.path.exists (sblopen_dir):
-           raise  Exception("Please set env 'SBL_SOURCE' to SBL open source root folder")
 
         if os.name == 'nt':
             tool_bin_dir  = os.path.join(sblopen_dir, "BaseTools", "Bin", "Win32")

--- a/Platform/CoffeelakeBoardPkg/Script/StitchLoader.py
+++ b/Platform/CoffeelakeBoardPkg/Script/StitchLoader.py
@@ -1,7 +1,7 @@
 ## @ StitchLoader.py
 #  This is a python stitching script for Slim Bootloader WHL/CFL build
 #
-# Copyright (c) 2019, Intel Corporation. All rights reserved. <BR>
+# Copyright (c) 2019 - 2022, Intel Corporation. All rights reserved. <BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -12,7 +12,11 @@ from   ctypes import *
 from   functools import reduce
 
 sys.dont_write_bytecode = True
-sys.path.append (os.path.join(os.getenv('SBL_SOURCE', ''), "BootloaderCorePkg" , "Tools"))
+sblopen_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../'))
+if not os.path.exists (sblopen_dir):
+    sblopen_dir = os.getenv('SBL_SOURCE', '')
+sys.path.append (os.path.join(sblopen_dir, "BootloaderCorePkg" , "Tools"))
+
 try:
     from   IfwiUtility import *
 except ImportError:

--- a/Platform/CometlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/CometlakeBoardPkg/Script/StitchIfwi.py
@@ -1,7 +1,7 @@
 ## @ StitchIfwi.py
 #  This is a python stitching script for Slim Bootloader CML build
 #
-# Copyright (c) 2020, Intel Corporation. All rights reserved. <BR>
+# Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved. <BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -22,6 +22,12 @@ from   ctypes  import *
 from   subprocess   import call #nosec
 from   StitchLoader import *
 sys.dont_write_bytecode = True
+
+sblopen_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../'))
+if not os.path.exists (sblopen_dir):
+    sblopen_dir = os.getenv('SBL_SOURCE', '')
+if not os.path.exists (sblopen_dir):
+    raise  Exception("Please set env 'SBL_SOURCE' to SBL open source root folder")
 
 btg_profile_values = [\
                     "Boot Guard Profile 0 - No_FVME",\
@@ -400,12 +406,6 @@ def replace_component (ifwi_src_path, flash_path, file_path, comp_alg, pri_key):
         container_file = os.path.join(work_dir, 'CTN_%s.bin') % comp_name
         gen_file_from_object (container_file, ifwi_bin[replace_comp.offset:replace_comp.offset + replace_comp.length])
         comp_file     = os.path.join(work_dir, file_path)
-        sblopen_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../../../../', 'SblOpen')
-        if not os.path.exists (sblopen_dir):
-            sblopen_dir = os.getenv('SBL_SOURCE', '')
-
-        if not os.path.exists (sblopen_dir):
-           raise  Exception("Please set env 'SBL_SOURCE' to SBL open source root folder")
 
         if os.name == 'nt':
             tool_bin_dir  = os.path.join(sblopen_dir, "BaseTools", "Bin", "Win32")

--- a/Platform/CometlakeBoardPkg/Script/StitchLoader.py
+++ b/Platform/CometlakeBoardPkg/Script/StitchLoader.py
@@ -1,7 +1,7 @@
 ## @ StitchLoader.py
 #  This is a python stitching script for Slim Bootloader CML build
 #
-# Copyright (c) 2020, Intel Corporation. All rights reserved. <BR>
+# Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved. <BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -12,7 +12,11 @@ from   ctypes import *
 from   functools import reduce
 
 sys.dont_write_bytecode = True
-sys.path.append (os.path.join(os.getenv('SBL_SOURCE', ''), "BootloaderCorePkg" , "Tools"))
+sblopen_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../'))
+if not os.path.exists (sblopen_dir):
+    sblopen_dir = os.getenv('SBL_SOURCE', '')
+sys.path.append (os.path.join(sblopen_dir, "BootloaderCorePkg" , "Tools"))
+
 try:
     from   IfwiUtility import *
 except ImportError:

--- a/Platform/CometlakevBoardPkg/Script/StitchIfwi.py
+++ b/Platform/CometlakevBoardPkg/Script/StitchIfwi.py
@@ -1,7 +1,7 @@
 ## @ StitchIfwi.py
 #  This is a python stitching script for Slim Bootloader CMLV build
 #
-# Copyright (c) 2020, Intel Corporation. All rights reserved. <BR>
+# Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved. <BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -22,6 +22,12 @@ from   ctypes  import *
 from   subprocess   import call # nosec
 from   StitchLoader import *
 sys.dont_write_bytecode = True
+
+sblopen_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../'))
+if not os.path.exists (sblopen_dir):
+    sblopen_dir = os.getenv('SBL_SOURCE', '')
+if not os.path.exists (sblopen_dir):
+    raise  Exception("Please set env 'SBL_SOURCE' to SBL open source root folder")
 
 btg_profile_values = [\
                     "Boot Guard Profile 0 - No_FVME",\
@@ -400,12 +406,6 @@ def replace_component (ifwi_src_path, flash_path, file_path, comp_alg, pri_key):
         container_file = os.path.join(work_dir, 'CTN_%s.bin') % comp_name
         gen_file_from_object (container_file, ifwi_bin[replace_comp.offset:replace_comp.offset + replace_comp.length])
         comp_file     = os.path.join(work_dir, file_path)
-        sblopen_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../../../../', 'SblOpen')
-        if not os.path.exists (sblopen_dir):
-            sblopen_dir = os.getenv('SBL_SOURCE', '')
-
-        if not os.path.exists (sblopen_dir):
-           raise  Exception("Please set env 'SBL_SOURCE' to SBL open source root folder")
 
         if os.name == 'nt':
             tool_bin_dir  = os.path.join(sblopen_dir, "BaseTools", "Bin", "Win32")

--- a/Platform/CometlakevBoardPkg/Script/StitchLoader.py
+++ b/Platform/CometlakevBoardPkg/Script/StitchLoader.py
@@ -1,7 +1,7 @@
 ## @ StitchLoader.py
 #  This is a python stitching script for Slim Bootloader CMLV build
 #
-# Copyright (c) 2019, Intel Corporation. All rights reserved. <BR>
+# Copyright (c) 2019 - 2022, Intel Corporation. All rights reserved. <BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -12,7 +12,11 @@ from   ctypes import *
 from   functools import reduce
 
 sys.dont_write_bytecode = True
-sys.path.append (os.path.join(os.getenv('SBL_SOURCE', ''), "BootloaderCorePkg" , "Tools"))
+sblopen_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../'))
+if not os.path.exists (sblopen_dir):
+    sblopen_dir = os.getenv('SBL_SOURCE', '')
+sys.path.append (os.path.join(sblopen_dir, "BootloaderCorePkg" , "Tools"))
+
 try:
     from   IfwiUtility import *
 except ImportError:
@@ -21,18 +25,18 @@ except ImportError:
     raise  ImportError(err_msg)
 
 extra_usage_txt = \
-"""This script creates a new Whiskeylake/Cometlake Slim Bootloader IFWI image basing
+"""This script creates a new Cometlake Slim Bootloader IFWI image basing
 on an existing IFWI base image.  Please note, this stitching method will work
 only if Boot Guard in the base image is not enabled, and the silicon is not
 fused with Boot Guard enabled.
 Please follow steps below:
-  1.  Download an existing Whiskeylake/Cometlake UEFI IFWI image associated
+  1.  Download an existing Cometlake UEFI IFWI image associated
       with the target platform.
       Alternatively, the original IFWI image from the onboard SPI flash can be
       read out as the base image too.
   2.  Build Slim Bootloader source tree.
       The generated Slim Bootloader binary is located at:
-      $(WORKSPACE)/Outputs/cml/SlimBootloader.bin
+      $(WORKSPACE)/Outputs/cmlv/SlimBootloader.bin
   3.  Stitch to create a new IFWI image.
       EX:
       python StitchLoader.py -i CMLV_UEFI_IFWI.bin -s SlimBootloader.bin -o CMLV_SBL_IFWI.bin

--- a/Platform/ElkhartlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/ElkhartlakeBoardPkg/Script/StitchIfwi.py
@@ -1,7 +1,7 @@
 ## @ StitchIfwi.py
 #  This is a python stitching script for Slim Bootloader EHL build
 #
-# Copyright (c) 2019 - 2021, Intel Corporation. All rights reserved. <BR>
+# Copyright (c) 2019 - 2022, Intel Corporation. All rights reserved. <BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -27,6 +27,12 @@ sys.dont_write_bytecode = True
 
 # sign_bin_flag can be set to false to avoid signing process. Applicable for Btg profile 0
 sign_bin_flag = True
+
+sblopen_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../'))
+if not os.path.exists (sblopen_dir):
+    sblopen_dir = os.getenv('SBL_SOURCE', '')
+if not os.path.exists (sblopen_dir):
+    raise  Exception("Please set env 'SBL_SOURCE' to SBL open source root folder")
 
 def gen_xml_file(stitch_dir, stitch_cfg_file, btg_profile, plt_params_list, platform, tpm):
     print ("Generating xml file .........")
@@ -80,12 +86,6 @@ def replace_component (ifwi_src_path, flash_path, file_path, comp_alg, pri_key, 
         container_file = os.path.join(work_dir, 'CTN_%s.bin') % comp_name
         gen_file_from_object (container_file, ifwi_bin[replace_comp.offset:replace_comp.offset + replace_comp.length])
         comp_file     = os.path.join(work_dir, file_path)
-        sblopen_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../../../../', 'SblOpen')
-        if not os.path.exists (sblopen_dir):
-            sblopen_dir = os.getenv('SBL_SOURCE', '')
-
-        if not os.path.exists (sblopen_dir):
-           raise  Exception("Please set env 'SBL_SOURCE' to SBL open source root folder")
 
         if os.name == 'nt':
             tool_bin_dir  = os.path.join(sblopen_dir, "BaseTools", "Bin", "Win32")

--- a/Platform/ElkhartlakeBoardPkg/Script/StitchLoader.py
+++ b/Platform/ElkhartlakeBoardPkg/Script/StitchLoader.py
@@ -1,7 +1,7 @@
 ## @ StitchLoader.py
 #  This is a python stitching script for Slim Bootloader EHL build
 #
-# Copyright (c) 2019, Intel Corporation. All rights reserved. <BR>
+# Copyright (c) 2019 - 2022, Intel Corporation. All rights reserved. <BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -12,7 +12,7 @@ from   ctypes import *
 from   functools import reduce
 
 sys.dont_write_bytecode = True
-sblopen_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../../../../', 'SblOpen')
+sblopen_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../'))
 if not os.path.exists (sblopen_dir):
     sblopen_dir = os.getenv('SBL_SOURCE', '')
 sys.path.append (os.path.join(sblopen_dir, "BootloaderCorePkg" , "Tools"))

--- a/Platform/TigerlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/TigerlakeBoardPkg/Script/StitchIfwi.py
@@ -1,7 +1,7 @@
 ## @ StitchIfwi.py
 #  This is a python stitching script for Slim Bootloader TGL build
 #
-# Copyright (c) 2019, Intel Corporation. All rights reserved. <BR>
+# Copyright (c) 2019 - 2022, Intel Corporation. All rights reserved. <BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -28,6 +28,12 @@ sys.dont_write_bytecode = True
 
 # sign_bin_flag can be set to false to avoid signing process. Applicable for Btg profile 0
 sign_bin_flag = True
+
+sblopen_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../'))
+if not os.path.exists (sblopen_dir):
+    sblopen_dir = os.getenv('SBL_SOURCE', '')
+if not os.path.exists (sblopen_dir):
+    raise  Exception("Please set env 'SBL_SOURCE' to SBL open source root folder")
 
 def gen_xml_file(stitch_dir, stitch_cfg_file, btg_profile, plt_params_list, platform, tpm):
     print ("Generating xml file .........")
@@ -78,12 +84,6 @@ def replace_component (ifwi_src_path, flash_path, file_path, comp_alg, pri_key):
         container_file = os.path.join(work_dir, 'CTN_%s.bin') % comp_name
         gen_file_from_object (container_file, ifwi_bin[replace_comp.offset:replace_comp.offset + replace_comp.length])
         comp_file     = os.path.join(work_dir, file_path)
-        sblopen_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../../../../', 'SblOpen')
-        if not os.path.exists (sblopen_dir):
-            sblopen_dir = os.getenv('SBL_SOURCE', '')
-
-        if not os.path.exists (sblopen_dir):
-           raise  Exception("Please set env 'SBL_SOURCE' to SBL open source root folder")
 
         if os.name == 'nt':
             tool_bin_dir  = os.path.join(sblopen_dir, "BaseTools", "Bin", "Win32")

--- a/Platform/TigerlakeBoardPkg/Script/StitchLoader.py
+++ b/Platform/TigerlakeBoardPkg/Script/StitchLoader.py
@@ -1,7 +1,7 @@
 ## @ StitchLoader.py
-#  This is a python stitching script for Slim Bootloader WHL/CFL build
+#  This is a python stitching script for Slim Bootloader TGL build
 #
-# Copyright (c) 2019, Intel Corporation. All rights reserved. <BR>
+# Copyright (c) 2019 - 2022, Intel Corporation. All rights reserved. <BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -12,7 +12,7 @@ from   ctypes import *
 from   functools import reduce
 
 sys.dont_write_bytecode = True
-sblopen_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../../../../', 'SblOpen')
+sblopen_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../'))
 if not os.path.exists (sblopen_dir):
     sblopen_dir = os.getenv('SBL_SOURCE', '')
 sys.path.append (os.path.join(sblopen_dir, "BootloaderCorePkg" , "Tools"))


### PR DESCRIPTION
This patch fixed the warning "the imp module is deprecated in
favour of importlib." This patch can reduce the chance of setting
SBL_SOURCE when the SBL root directory is not named as "SblOpen"
or when the scripts are run from the path other than the SBL root
directory. Also note that os.path.abspath() returns the absolute
path relative to the current working directory instead of the real
path of __file__. So in StitchIfwi.py, sblopen_dir was incorrect
since the working directory had been changed before calling stitch().

Signed-off-by: Vincent Chen <vincent.chen@intel.com>