### PR TITLE
[ADLN] Changes required for ADLN FSP Sync

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/BoardSaConfigPreMem.h
+++ b/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/BoardSaConfigPreMem.h
@@ -100,6 +100,28 @@ GLOBAL_REMOVE_IF_UNREFERENCED const UINT8 mTestSDdr5RowDisplayDdiConfig3[16] = {
 //
 // Display DDI Config 3: DP + DP
 //
+GLOBAL_REMOVE_IF_UNREFERENCED const UINT8 mAdlNddr5CrbRowDisplayDdiConfig[16] = {
+  DdiPortEdp,         // DDI Port A Config : DdiPortDisabled = No LFP is Connected, DdiPortEdp = eDP, DdiPortMipiDsi = MIPI DSI
+  DdiPortDisabled,    // DDI Port B Config : DdiPortDisabled = No LFP is Connected, DdiPortEdp = eDP, DdiPortMipiDsi = MIPI DSI
+  DdiHpdDisable,      // DDI Port A HPD    : DdiHpdDisable = Disable, DdiHpdEnable = Enable HPD
+  DdiHpdEnable,       // DDI Port B HPD    : DdiHpdDisable = Disable, DdiHpdEnable = Enable HPD
+  DdiHpdDisable,      // DDI Port C HPD    : DdiHpdDisable = Disable, DdiHpdEnable = Enable HPD
+  DdiHpdDisable,      // DDI Port 1 HPD    : DdiHpdDisable = Disable, DdiHpdEnable = Enable HPD
+  DdiHpdEnable,       // DDI Port 2 HPD    : DdiHpdDisable = Disable, DdiHpdEnable = Enable HPD
+  DdiHpdDisable,      // DDI Port 3 HPD    : DdiHpdDisable = Disable, DdiHpdEnable = Enable HPD
+  DdiHpdDisable,      // DDI Port 4 HPD    : DdiHpdDisable = Disable, DdiHpdEnable = Enable HPD
+  DdiDisable,         // DDI Port A DDC    : DdiDisable = Disable, DdiDdcEnable = Enable DDC
+  DdiDdcEnable,       // DDI Port B DDC    : DdiDisable = Disable, DdiDdcEnable = Enable DDC
+  DdiDisable,         // DDI Port C DDC    : DdiDisable = Disable, DdiDdcEnable = Enable DDC
+  DdiDisable,         // DDI Port 1 DDC    : DdiDisable = Disable, DdiDdcEnable = Enable DDC
+  DdiDdcEnable,       // DDI Port 2 DDC    : DdiDisable = Disable, DdiDdcEnable = Enable DDC
+  DdiDisable,         // DDI Port 3 DDC    : DdiDisable = Disable, DdiDdcEnable = Enable DDC
+  DdiDisable          // DDI Port 4 DDC    : DdiDisable = Disable, DdiDdcEnable = Enable DDC
+};
+
+//
+// Display DDI Config 3: DP + DP
+//
 GLOBAL_REMOVE_IF_UNREFERENCED const UINT8 mAdlNLpddr5RowDisplayDdiConfig[16] = {
   DdiPortEdp,         // DDI Port A Config : DdiPortDisabled = No LFP is Connected, DdiPortEdp = eDP, DdiPortMipiDsi = MIPI DSI
   DdiPortDisabled,    // DDI Port B Config : DdiPortDisabled = No LFP is Connected, DdiPortEdp = eDP, DdiPortMipiDsi = MIPI DSI

--- a/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -521,6 +521,10 @@ UpdateFspConfig (
     // DP + DP
     CopyMem(SaDisplayConfigTable, (VOID *)(UINTN)mTestSDdr5RowDisplayDdiConfig3, sizeof(mTestSDdr5RowDisplayDdiConfig3));
     break;
+  case PLATFORM_ID_ADL_N_DDR5_CRB:
+    // DP + DP
+    CopyMem(SaDisplayConfigTable, (VOID *)(UINTN)mAdlNddr5CrbRowDisplayDdiConfig, sizeof(mAdlNddr5CrbRowDisplayDdiConfig));
+    break;
   case PLATFORM_ID_ADL_N_LPDDR5_RVP:
     // DP + DP
     CopyMem(SaDisplayConfigTable, (VOID *)(UINTN)mAdlNLpddr5RowDisplayDdiConfig, sizeof(mAdlNLpddr5RowDisplayDdiConfig));
@@ -590,16 +594,11 @@ UpdateFspConfig (
         break;
       case PLATFORM_ID_ADL_N_DDR5_CRB:
         Fspmcfg->CpuPcieRpEnableMask = 0x0;
-        Fspmcfg->DdiPortAConfig = 0x1;
-        Fspmcfg->DdiPortBHpd = 0x1;
-        Fspmcfg->DdiPort1Hpd = 0x1;
-        Fspmcfg->DdiPort2Hpd = 0x1;
-        Fspmcfg->DdiPortBDdc = 0x1;
-        Fspmcfg->DdiPort1Ddc = 0x1;
-        Fspmcfg->DdiPort2Ddc = 0x1;
         Fspmcfg->DmiHweq = 0x2;
         Fspmcfg->Lp5CccConfig = 0xff;
         Fspmcfg->SkipCpuReplacementCheck = 0x0;
+        Fspmcfg->FirstDimmBitMaskEcc = 0x0;
+        Fspmcfg->Lp5BankMode = 0x0;
         break;
       case PLATFORM_ID_ADL_N_LPDDR5_RVP:
         Fspmcfg->DmiHweq = 0x2;

--- a/Platform/AlderlakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
@@ -49,6 +49,27 @@ FSPT_UPD TempRamInitParams = {
     .CodeRegionSize         = CODE_REGION_SIZE,
     .Reserved               = {0},
   },
+  .FsptConfig = {
+    .PcdSerialIoUartDebugEnable = 1,
+    .PcdSerialIoUartNumber      = FixedPcdGet32 (PcdDebugPortNumber) < PCH_MAX_SERIALIO_UART_CONTROLLERS ? \
+                                    FixedPcdGet32 (PcdDebugPortNumber) : 2,
+    .PcdSerialIoUartMode        = 4, // SerialIoUartSkipInit, let SBL init UART
+#ifdef PLATFORM_ADLN
+    .PcdSerialIoUartPowerGating = 1,
+#endif
+    .PcdSerialIoUartBaudRate    = 115200,
+    .PcdPciExpressBaseAddress   = FixedPcdGet32 (PcdPciMmcfgBase),
+    .PcdPciExpressRegionLength  = 0x10000000,
+    .PcdSerialIoUartParity      = 1, // NoParity
+    .PcdSerialIoUartDataBits    = 8,
+    .PcdSerialIoUartStopBits    = 1,
+    .PcdSerialIoUartAutoFlow    = 0,
+    .PcdSerialIoUartRxPinMux    = 0,
+    .PcdSerialIoUartTxPinMux    = 0,
+    .PcdSerialIoUartRtsPinMux   = 0,
+    .PcdSerialIoUartCtsPinMux   = 0,
+    .PcdLpcUartDebugEnable      = 1,
+  },
   .UpdTerminator = 0x55AA,
 };
 

--- a/Silicon/AlderlakePkg/Library/IgdOpRegionLib/GopConfigLib.h
+++ b/Silicon/AlderlakePkg/Library/IgdOpRegionLib/GopConfigLib.h
@@ -14,13 +14,17 @@
 #define ChildStruct_MAX                       10         ///< Maximum number of child structures in VBT
 #define CompressionStruct_MAX                 16         ///< Maximum number of compression parameter structures in VBT.
 #define NO_DEVICE                             0x00      ///< Defines a null display class.
+#define DISPLAY_PORT_ONLY                     0x68C6    ///< Defines a display class of Integrated Display Port Only
 #define DISPLAY_PORT_HDMI_DVI_COMPATIBLE      0x60D6    ///< Defines a display class of Integrated DisplayPort with HDMI/DVI Compatible
 #define HDMI_DVI                              0x60D2    ///< Defines a display class of Integrated HDMI/DVI
+#define AUX_CHANNEL_A                         0x40
 #define AUX_CHANNEL_B                         0x10
 #define AUX_CHANNEL_C                         0x20
 #define AUX_CHANNEL_E                         0x50
 #define HDMI_B                                0x01      ///< Defines a output port HDMI-B
 #define HDMI_D                                0x03      ///< Defines a output port HDMI-D
+#define HDMI_G                                0x10      ///< Defines a output port HDMI-G (TCP-2)
+#define DISPLAY_PORT_A                        0x0A      ///< Defines a output port DisplayPort A
 #define DISPLAY_PORT_B                        0x07      ///< Defines a output port DisplayPort B
 #define DISPLAY_PORT_C                        0x08      ///< Defines a output port DisplayPort C
 #define DISPLAY_PORT_D                        0x09      ///< Defines a output port DisplayPort D

--- a/Silicon/AlderlakePkg/Library/IgdOpRegionLib/IgdOpRegionLib.c
+++ b/Silicon/AlderlakePkg/Library/IgdOpRegionLib/IgdOpRegionLib.c
@@ -130,6 +130,43 @@ AdlNLpddr5GopVbtSpecificUpdate (
 }
 
 /**
+  GOP VBT update for ADL N Ddr5 Edp + DP
+
+  @param[in]  ChildStructPtr  - CHILD_STRUCT
+
+**/
+VOID
+EFIAPI
+AdlNddr5GopVbtSpecificUpdate (
+  IN CHILD_STRUCT **ChildStructPtr
+)
+{
+  DEBUG ((DEBUG_INFO,"Update VBT for ADL-N LPDDR5\n"));
+  // Disabling DDI-A (LFP1)
+  ChildStructPtr[0]->DeviceClass          = NO_DEVICE;
+  // Disabling DDI-B (LFP2)
+  ChildStructPtr[1]->DeviceClass          = NO_DEVICE;
+  // Enabling HDMI on DDI-B
+  ChildStructPtr[2]->DeviceClass          = HDMI_DVI;
+  ChildStructPtr[2]->DVOPort              = HDMI_B;
+  // Enabling HDMI on DDI-1 (TCP-2)
+  ChildStructPtr[4]->DeviceClass          = HDMI_DVI;
+  ChildStructPtr[4]->DVOPort              = HDMI_G;
+  ChildStructPtr[4]->Flags_2.Bits.DpAltModeOverTypeCEnabled   = 0x0;
+  ChildStructPtr[4]->Flags_2.Bits.TbtAltModeOverTypeCEnabled  = 0x0;
+  // Disabling EFP4
+  ChildStructPtr[5]->DeviceClass          = NO_DEVICE;
+  // Disabling EFP5
+  ChildStructPtr[6]->DeviceClass          = NO_DEVICE;
+  // Enabling DP on DDI-A (EFP6)
+  ChildStructPtr[7]->DeviceClass          = DISPLAY_PORT_ONLY;
+  ChildStructPtr[7]->DVOPort              = DISPLAY_PORT_A;
+  ChildStructPtr[7]->AUX_Channel          = AUX_CHANNEL_A;
+  ChildStructPtr[7]->Flags_2.Bits.DpAltModeOverTypeCEnabled   = 0x0;
+  ChildStructPtr[7]->Flags_2.Bits.TbtAltModeOverTypeCEnabled  = 0x0;
+}
+
+/**
   GOP VBT update for ADL S DDR4
 
   @param[in]  ChildStructPtr  - CHILD_STRUCT
@@ -260,7 +297,7 @@ UpdateVbt (
     break;
   case PLATFORM_ID_ADL_N_DDR5_CRB:
     DEBUG((DEBUG_INFO, "UpdateVbt: BoardIdAdlNDdr5 .....\n"));
-    GopVbtSpecificUpdate = (GOP_VBT_SPECIFIC_UPDATE)(UINTN)&AdlGopVbtSpecificUpdateNull;
+    GopVbtSpecificUpdate = (GOP_VBT_SPECIFIC_UPDATE)(UINTN)&AdlNddr5GopVbtSpecificUpdate;
     break;
   case PLATFORM_ID_ADL_N_LPDDR5_RVP:
     DEBUG((DEBUG_INFO, "UpdateVbt: BoardIdAdlNLpddr5 .....\n"));


### PR DESCRIPTION
This patch added changes required for ADLN FSP Sync and
also did the following

1) Added SA config for DDR5 CRB
2) Initialized VBT to enable 2 HDMI and a DP port
3) Moved FSPM config to delta file

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>