### PR TITLE
Revert "[UPX] Disable malfunctioned USB2 port"

### DIFF
--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1308,9 +1308,9 @@ UpdateFspConfig (
   }
 
   if (PlatformId == PLATFORM_ID_UPXTREME) {
-    // Workaround for USB issue on port 10, it does not respond to USB enumeration.
+    // Workaround for USB issue on port 8, it does not respond to USB enumeration.
     // Disable this port for now
-    FspsUpd->FspsConfig.PortUsb20Enable[9] = FALSE;
+    FspsUpd->FspsConfig.PortUsb20Enable[7] = FALSE;
   }
 
   Length = GetPchXhciMaxUsb3PortNum ();


### PR DESCRIPTION
This reverts commit 1caacefeb508a41c4363e64ce45159b72f4b2f73.

The USB port that does not respond to USB bus enumeration is port 8 on
the newer UPX board. The old UPX board might have different behavior.
The original commit was valid on old UPX board only, and this patch
reverted it. Confirmed the USB error message disappeared on the new
UPX board after the reverting.

Signed-off-by: Maurice Ma <mauricemx.ma@gmail.com>