### PR TITLE
[EHL] Update FSP version since MR3 is released

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -965,7 +965,7 @@ FspUpdatePsePolicy (
   Fspscfg->PchPseOobEnabled       = 0;
   Fspscfg->PchPseWoLEnabled       = 1;
   Fspscfg->PchPseAicEnabled       = (UINT8)SiCfgData->PchPseAicEnabled;
-
+  Fspscfg->CpuTempSensorReadEnable= 1;
   //Fspscfg->PseJtagEnabled       = 0;
   //Fspscfg->PseJtagPinMux        = 0;
 

--- a/Silicon/ElkhartlakePkg/FspBin/FspBin.inf
+++ b/Silicon/ElkhartlakePkg/FspBin/FspBin.inf
@@ -11,7 +11,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = ccf7f35c13770174078a0492e0d95bb0afa806cb
+  COMMIT  = 72266f6523286fb3494f5b2553ace612d1dc95c4
 
 [UserExtensions.SBL."CopyList"]
   ElkhartLakeFspBinPkg/FspBin/FSPRel.bin               : Silicon/ElkhartlakePkg/FspBin/FspDbg.bin


### PR DESCRIPTION
Also set the CpuTempSensorReadEnable = 1
It was renamed from PchCpuTempSensorEnable
and removed in commit 44faa431c97

Signed-off-by: Randy Lin <randy.lin@intel.com>