### PR TITLE
[EHL] Refine the PSE FW stitch logic

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/BoardConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/BoardConfig.py
@@ -76,10 +76,7 @@ class Board(BaseBoard):
             self.SIIPFW_SIZE += self.POSC_SIZE
 
         bins = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'Binaries')
-        if os.path.exists(os.path.join(bins, 'PseFw.bin')):
-            self.ENABLE_PSEFW_LOADING = 1
-        else:
-            self.ENABLE_PSEFW_LOADING = 0
+        self.ENABLE_PSEFW_LOADING = 1
 
         if self.ENABLE_PSEFW_LOADING:
             self.PSEF_SIZE = 0x00030000

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -953,6 +953,9 @@ FspUpdatePsePolicy (
     if (MEASURED_BOOT_ENABLED() && (GetBootMode() != BOOT_ON_S3_RESUME)) {
       TpmHashAndExtendPcrEventLog (0, (UINT8 *)SiipRegionBase, SiipRegionSize, EV_EFI_PLATFORM_FIRMWARE_BLOB, sizeof("PSEF Firmware"), (UINT8 *)"PSEF Firmware");
     }
+  } else {
+    DEBUG ((DEBUG_ERROR, "PSE is enabled but missing PSE FW !! %r\n", Status));
+    return;
   }
 
   DEBUG ((DEBUG_INFO, "Load PSE firmware @ %p:0x%X - %r\n", SiipRegionBase, SiipRegionSize, Status));
@@ -1561,9 +1564,9 @@ UpdateFspConfig (
     // PCH_8254_CONFIG
     Fspscfg->Enable8254ClockGating      = SiCfgData->Enable8254ClockGating;
     Fspscfg->Enable8254ClockGatingOnS3  = SiCfgData->Enable8254ClockGatingOnS3;
-
-    FspUpdatePsePolicy(FspsUpd, SiCfgData);
-
+    if (MemCfgData != NULL && MemCfgData->PchPseEnable) {
+      FspUpdatePsePolicy(FspsUpd, SiCfgData);
+    }
     // SA Post CONFIG
     Fspscfg->RenderStandby        = SiCfgData->RenderStandby;
     Fspscfg->PmSupport            = SiCfgData->PmSupport;


### PR DESCRIPTION
PSE is enabled by default.
During SBL building, it will check the existence of PSE FW binary.
If it is missing in binaries folder, the PSEF won't be appended in
container list and cause StitchIFWI script fail if it try to update.

Signed-off-by: Randy Lin <randy.lin@intel.com>