### PR TITLE
[ADL] Configure MTRR to enable full flash region cache

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
@@ -13,6 +13,7 @@
 #include <Library/PlatformHookLib.h>
 #include <Library/BootloaderCoreLib.h>
 #include <PchAccess.h>
+#include <CpuRegs.h>
 #include <FsptUpd.h>
 #include <PlatformData.h>
 #include <Library/GpioLib.h>
@@ -132,8 +133,12 @@ BoardInit (
   IN  BOARD_INIT_PHASE  InitPhase
   )
 {
-  UINT8             DebugPort;
-  GPIO_INIT_CONFIG  *UartGpioTable;
+  UINT8                     DebugPort;
+  GPIO_INIT_CONFIG          *UartGpioTable;
+  UINT32                    MsrIdx;
+  UINT32                    ImgLen;
+  UINT32                    AdjLen;
+  UINT64                    MskLen;
 
   switch (InitPhase) {
   case PostTempRamInit:
@@ -152,11 +157,30 @@ BoardInit (
 
     PlatformHookSerialPortInitialize ();
     SerialPortInitialize ();
+
+    // Enlarge the code cache region to cover full flash for non-BootGuard case only
+    if ((AsmReadMsr64(MSR_BOOT_GUARD_SACM_INFO) & B_BOOT_GUARD_SACM_INFO_NEM_ENABLED) == 0) {
+      // FSP-T does not allow to enable full flash code cache due to cache size restriction.
+      // Here, MTRR is patched to enable full flash region cache to avoid performance penalty.
+      // However, the SBL code flow should ensure only limited flash regions will be accessed
+      // before FSP TempRamExit() is called. The combined DATA and CODE cache size should satisfy
+      // the BWG requirement.
+      MskLen = (AsmReadMsr64(MSR_CACHE_VARIABLE_MTRR_BASE + 1) | (SIZE_4GB - 1)) + 1;
+      MsrIdx = MSR_CACHE_VARIABLE_MTRR_BASE + 1 * 2;
+      ImgLen = PcdGet32(PcdFlashSize);
+      AdjLen = GetPowerOfTwo32(ImgLen);
+      if (ImgLen > AdjLen) {
+        AdjLen <<= 1;
+      }
+      AsmWriteMsr64(MsrIdx, (SIZE_4GB - AdjLen) | CACHE_WRITEPROTECTED);
+      AsmWriteMsr64(MsrIdx + 1, (MskLen - AdjLen) | B_CACHE_MTRR_VALID);
+    }
     break;
   default:
     break;
   }
 }
+
 
 /**
   Get size of Platform Specific Data

--- a/Silicon/AlderlakePkg/Include/CpuRegs.h
+++ b/Silicon/AlderlakePkg/Include/CpuRegs.h
@@ -26,6 +26,9 @@
 #define MSR_PACKAGE_POWER_SKU                                         0x614
 
 
+#define MSR_BOOT_GUARD_SACM_INFO                                      0x0000013A
+#define B_BOOT_GUARD_SACM_INFO_NEM_ENABLED                            BIT0
+
 ///
 /// Local APIC definitions
 ///
@@ -36,6 +39,11 @@
 #define CPUID_FULL_FAMILY_MODEL                     0x0FFF0FF0
 #define CPUID_FULL_FAMILY_MODEL_ALDERLAKE_DT_HALO   0x00090670
 #define CPUID_FULL_FAMILY_MODEL_ALDERLAKE_MOBILE    0x000906A0
+
+#define CACHE_WRITEPROTECTED            5
+
+#define MSR_CACHE_VARIABLE_MTRR_BASE                                  0x200
+#define B_CACHE_MTRR_VALID                                            BIT11
 
 #ifndef SLE_FLAG
 #ifndef STALL_ONE_MICRO_SECOND


### PR DESCRIPTION
FSPT doesn't allow to enable full flash code cache.
Bootloader configures MTRR in non BTG cases to avoid
performance penalty.

This fixes the ADL boot from BP1 partition.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>