### PR TITLE
[ADLN] Add GPIO configuration from Cfg Data

### DIFF
--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_Gpio.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_Gpio.yaml
@@ -317,4 +317,9 @@
   - !expand { GPIO_TMPL : [ GPP_D21,  0x0350A383,  0x11152001 ] }
   - !expand { GPIO_TMPL : [ GPP_D22,  0x0350A383,  0x11162001 ] }
   - !expand { GPIO_TMPL : [ GPP_D23,  0x0350A381,  0x11172001 ] }
+  - !expand { GPIO_TMPL : [ GPP_T00,  0x0350A387,  0x81182001 ] }
+  - !expand { GPIO_TMPL : [ GPP_T01,  0x0350A387,  0x81192001 ] }
+  - !expand { GPIO_TMPL : [ GPP_T02,  0x0350A387,  0x811A2001 ] }
+  - !expand { GPIO_TMPL : [ GPP_T03,  0x0350A387,  0x811B2001 ] }
+
 

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -237,9 +237,6 @@ BoardInit (
       case BoardIdAdlPSDdr5Rvp:
         ConfigureGpio (CDATA_NO_TAG, sizeof (mGpioTablePostMemAdlPsDdr5Rvp) / sizeof (mGpioTablePostMemAdlPsDdr5Rvp[0]), (UINT8*)mGpioTablePostMemAdlPsDdr5Rvp);
         break;
-      case BoardIdAdlNDdr5Crb:
-        ConfigureGpio (CDATA_NO_TAG, sizeof (mGpioTablePostMemAdlNDdr5Crb) / sizeof (mGpioTablePostMemAdlNDdr5Crb[0]), (UINT8*)mGpioTablePostMemAdlNDdr5Crb);
-        break;
       case BoardIdAdlNLp5Rvp:
         ConfigureGpio (CDATA_NO_TAG, sizeof (mGpioTablePostMemAdlNLpddr5Rvp) / sizeof (mGpioTablePostMemAdlNLpddr5Rvp[0]), (UINT8*)mGpioTablePostMemAdlNLpddr5Rvp);
         break;

--- a/Silicon/AlderlakePkg/Include/GpioPinsVer2Lp.h
+++ b/Silicon/AlderlakePkg/Include/GpioPinsVer2Lp.h
@@ -51,8 +51,22 @@
 #define GPIO_VER2_LP_GPP_B18                 0x09000012
 #define GPIO_VER2_LP_GPP_B23                 0x09000017
 
+#define GPIO_VER2_LP_GPP_T0                  0x09010000
+#define GPIO_VER2_LP_GPP_T1                  0x09010001
 #define GPIO_VER2_LP_GPP_T2                  0x09010002
 #define GPIO_VER2_LP_GPP_T3                  0x09010003
+#define GPIO_VER2_LP_GPP_T4                  0x09010004
+#define GPIO_VER2_LP_GPP_T5                  0x09010005
+#define GPIO_VER2_LP_GPP_T6                  0x09010006
+#define GPIO_VER2_LP_GPP_T7                  0x09010007
+#define GPIO_VER2_LP_GPP_T8                  0x09010008
+#define GPIO_VER2_LP_GPP_T9                  0x09010009
+#define GPIO_VER2_LP_GPP_T10                 0x0901000A
+#define GPIO_VER2_LP_GPP_T11                 0x0901000B
+#define GPIO_VER2_LP_GPP_T12                 0x0901000C
+#define GPIO_VER2_LP_GPP_T13                 0x0901000D
+#define GPIO_VER2_LP_GPP_T14                 0x0901000E
+#define GPIO_VER2_LP_GPP_T15                 0x0901000F
 
 #define GPIO_VER2_LP_GPP_A1                  0x09020001
 #define GPIO_VER2_LP_GPP_A2                  0x09020002


### PR DESCRIPTION
Add GPP_T as part of the base cfg in order to use for
other ADL flavors like ADL PS.

Signed-off-by: Sindhura Grandhi <sindhura.grandhi@intel.com>