### PR TITLE
Allow uCode Padding to Occur on Inner Source Platforms

### DIFF
--- a/BootloaderCorePkg/Tools/PrepareBuildComponentBin.py
+++ b/BootloaderCorePkg/Tools/PrepareBuildComponentBin.py
@@ -220,18 +220,6 @@ def BuildFspBins (fsp_dir, sbl_dir, fsp_inf, silicon_pkg_name, flag):
 
     CopyFileList (copy_list, fsp_dir, sbl_dir)
 
-def DoAddPaddingData(File, SlotSize):
-  with open(File, "rb") as fd:
-    Binary = fd.read()
-    if len(Binary) > SlotSize:
-      print (("Microcode patch %s is larger than slot size(%d)\n") % (File, SlotSize))
-      assert (False)
-    elif len(Binary) < SlotSize:
-      Binary = Binary + b'\xff' * (SlotSize - len(Binary))
-
-  with open(File, "wb") as fd:
-    fd.write(Binary)
-
 def Main():
 
     if len(sys.argv) < 4:
@@ -255,19 +243,8 @@ def Main():
     else:
         CopyBins (fsp_repo_dir, sbl_dir, fsp_inf)
 
-    microcode_dir = os.path.join(sbl_dir, 'Silicon', silicon_pkg_name, 'Microcode')
-    microcode_inf = os.path.join(microcode_dir, 'Microcode.inf')
+    microcode_inf = os.path.join(sbl_dir, 'Silicon', silicon_pkg_name, 'Microcode', 'Microcode.inf')
     CopyBins (ucode_repo_dir, sbl_dir, microcode_inf)
-
-    # Pad all microcode files in directory
-    microcode_pattern = os.path.join(microcode_dir, "*.mcb")
-    microcode_bins = glob.glob(microcode_pattern)
-
-    # Add microcode padding, if slotting
-    if len(sys.argv) > 4:
-        ucode_slot_size = int(sys.argv[4])
-        for microcode_bin in microcode_bins:
-            DoAddPaddingData (microcode_bin, ucode_slot_size)
 
     return 0
 


### PR DESCRIPTION
While attempting uCode capsule update on ADL-N and RPL-S, it was noticed that solution provided as part of #1569 does not consider platforms which have not yet been migrated into SBL open source. This patch adds that consideration.