### PR TITLE
[ADLPS] Enable S0ix feature

### DIFF
--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_Power.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_Power.yaml
@@ -1078,6 +1078,13 @@
                      TurboRatioLimitRatio[7-0] will pair with TurboRatioLimitNumCore[7-0] to determine the active core ranges for each frequency point.
       length       : 0x08
       value        : {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+  - TurboRatioLimitNumCore :
+      name         : Turbo Ratio Limit Num Core array
+      type         : EditNum, HEX, (0x00, 0xFFFFFFFF)
+      help         : >
+                     TurboRatioLimitNumCore[7-0] will pair with TurboRatioLimitRatio[7-0] to determine the active core ranges for each frequency point.
+      length       : 0x08
+      value        : {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
   - AtomTurboRatioLimitRatio :
       name         : Turbo Ratio Limit Ratio array
       type         : EditNum, HEX, (0x00,0xFFFFFFFFFFFFFFFF)

--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -771,6 +771,7 @@ UpdateFspConfig (
       FspsConfig->EnableItbm = 0;
       FspsConfig->EnableTimedGpio0 = 0;
       FspsConfig->EnableTimedGpio1 = 0;
+      FspsConfig->PchLanEnable = 0x0;
       ZeroMem (FspsConfig->PchIshI2cEnable, sizeof (FspsConfig->PchIshI2cEnable));
       ZeroMem (FspsConfig->PchIshGpEnable, sizeof (FspsConfig->PchIshGpEnable));
       DEBUG ((DEBUG_INFO, "Stage 2 S0ix config applied.\n"));
@@ -925,6 +926,7 @@ UpdateFspConfig (
     // Cpu power related settings
     for (Index = 0; Index < TURBO_RATIO_LIMIT_ARRAY_SIZE; Index++) {
       FspsConfig->TurboRatioLimitRatio[Index] = PowerCfgData->TurboRatioLimitRatio[Index];
+      FspsConfig->TurboRatioLimitNumCore[Index] = PowerCfgData->TurboRatioLimitNumCore[Index];
       FspsConfig->AtomTurboRatioLimitRatio[Index] = PowerCfgData->AtomTurboRatioLimitRatio[Index];
       FspsConfig->AtomTurboRatioLimitNumCore[Index] = PowerCfgData->AtomTurboRatioLimitNumCore[Index];
     }

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
@@ -1052,6 +1052,7 @@ PlatformUpdateAcpiGnvs (
     PlatformNvs->PcieSlot2RpNumber = 5;
     break;
   case PLATFORM_ID_ADL_P_DDR5_RVP:
+  case PLATFORM_ID_ADL_PS_DDR5_RVP:
     PlatformNvs->PcieSlot1WakeGpio = 0;
     PlatformNvs->PcieSlot1PowerEnableGpio = GPIO_VER2_LP_GPP_A22;
     PlatformNvs->PcieSlot1PowerEnableGpioPolarity = 0;

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/CpuInfoLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/CpuInfoLib.c
@@ -86,6 +86,16 @@ GetCpuSkuInfo (
         case V_SA_DEVICE_ID_MB_ULT_4:    // AlderLake P (2(f)+4(f)+GT)
         case V_SA_DEVICE_ID_MB_ULT_5:    // AlderLake P (2+8+GT)
         case V_SA_DEVICE_ID_MB_ULT_6:    // AlderLake P (2+4(f)+GT)
+        case V_SA_DEVICE_ID_MB_ULT_7:    // AlderLake P (4+4(f)+GT)
+        case V_SA_DEVICE_ID_MB_ULT_8:    // AlderLake P (1+4+GT) SA DID
+        case V_SA_DEVICE_ID_MB_ULT_9:    // AlderLake P (1+8+GT) SA DID
+        case V_SA_DEVICE_ID_MB_ULT_10:   // AlderLake P (6+6+GT) SA DID
+        case V_SA_DEVICE_ID_MB_ULT_11:   //< AlderLake PS (2+8+GT) SA DID
+        case V_SA_DEVICE_ID_MB_ULT_12:   //< AlderLake PS (6+8+GT) SA DID
+        case V_SA_DEVICE_ID_MB_ULT_13:    //< AlderLake PS (4+8+GT) SA DID
+        case V_SA_DEVICE_ID_MB_ULT_14:    //< AlderLake PS (2+4+GT) SA DID
+        case V_SA_DEVICE_ID_MB_ULT_15:    //< AlderLake PS (4+4+GT) SA DID
+        case V_SA_DEVICE_ID_MB_ULT_16:    //< AlderLake PS (1+4+GT) SA DID
           CpuType  = EnumCpuUlt;
           SkuFound = TRUE;
           break;

--- a/Silicon/AlderlakePkg/Include/Register/SaRegsHostBridge.h
+++ b/Silicon/AlderlakePkg/Include/Register/SaRegsHostBridge.h
@@ -72,6 +72,16 @@
 #define V_SA_DEVICE_ID_MB_ULT_4   0x4609   ///< AlderLake P (2(f)+4(f)+GT) SA DID
 #define V_SA_DEVICE_ID_MB_ULT_5   0x4601   ///< AlderLake P (2+8+GT) SA DID
 #define V_SA_DEVICE_ID_MB_ULT_6   0x4661   ///< AlderLake P (6+8+2) SA DID
+#define V_SA_DEVICE_ID_MB_ULT_7    0x4629   ///< AlderLake P (4+4+1) SA DID
+#define V_SA_DEVICE_ID_MB_ULT_8    0x4619   ///< AlderLake P (1+4+GT) SA DID
+#define V_SA_DEVICE_ID_MB_ULT_9    0x4659   ///< AlderLake P (1+8+GT) SA DID
+#define V_SA_DEVICE_ID_MB_ULT_10   0x4645   ///< AlderLake P (6+6+GT) SA DID
+#define V_SA_DEVICE_ID_MB_ULT_11   0x4603   ///< AlderLake PS (2+8+GT) SA DID
+#define V_SA_DEVICE_ID_MB_ULT_12   0x4643   ///< AlderLake PS (6+8+GT) SA DID
+#define V_SA_DEVICE_ID_MB_ULT_13   0x4627   ///< AlderLake PS (4+8+GT) SA DID
+#define V_SA_DEVICE_ID_MB_ULT_14   0x460B   ///< AlderLake PS (2+4+GT) SA DID
+#define V_SA_DEVICE_ID_MB_ULT_15   0x464B   ///< AlderLake PS (4+4+GT) SA DID
+#define V_SA_DEVICE_ID_MB_ULT_16   0x467B   ///< AlderLake PS (1+4+GT) SA DID
 /**
  <b>Description</b>:
   This is the base address for the PCI Express Egress Port MMIO Configuration space.  There is no physical memory within this 4KB window that can be addressed.  The 4KB reserved by this register does not alias to any PCI 2.3 compliant memory mapped space.  On reset, the EGRESS port MMIO configuration space is disabled and must be enabled by writing a 1 to PXPEPBAREN [Dev 0, offset 40h, bit 0].


### PR DESCRIPTION
This patch enable S0ix feature in ADLPS

1. Disabled PCH LAN.
2. Added ADLPS FSPS UPD update.
3. Added ADLPS NVS value update.
4. Added ADLPS CPU SKU Device ID.

Verified: ADL-PS RVP

Signed-off-by: jinjhuli <jin.jhu.lim@intel.com>