### PR TITLE
[ADL] Fix HsPhyInit failure

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -333,9 +333,11 @@ BoardInit (
     Status = PcdSet32S (PcdFuncCpuInitHook, (UINT32)(UINTN) PlatformCpuInit);
 
     if (PcdGetBool (PcdFastBootEnabled) == FALSE) {
-      Status = HsPhyLoadAndInit ();
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_WARN, "HsPhyInit failure, %r\n", Status));
+      if (IsPchS ()) {
+        Status = HsPhyLoadAndInit ();
+        if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_WARN, "HsPhyInit failure, %r\n", Status));
+        }
       }
     }
 


### PR DESCRIPTION
HsPhy feature is only applicable for ADLS and not for others.
Adding a condition to apply only for it.

Signed-off-by: Sindhura Grandhi <sindhura.grandhi@intel.com>