### PR TITLE
[ADLS] Resolve reboot issue on DDR4 board

### DIFF
--- a/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr4.dlt
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr4.dlt
@@ -50,6 +50,7 @@ MEMORY_CFG_DATA.TcssDma1En | 0x1
 MEMORY_CFG_DATA.PchHdaAudioLinkHdaEnable   | 0x1
 MEMORY_CFG_DATA.PchHdaAudioLinkDmicEnable  | {0x1, 0x1}
 MEMORY_CFG_DATA.PchHdaDspEnable            | 0x1
+MEMORY_CFG_DATA.DmiMaxLinkSpeed            | 0x0
 
 PLDSEL_CFG_DATA.PldSelGpio.Enable      | 1
 PLDSEL_CFG_DATA.PldSelGpio.PadGroup    | 5


### PR DESCRIPTION
This patch fixes the hang seen during a reboot cmd on ADLS DDR4 board.
Setting the DmiMaxLinkSpeed to Auto mode.

Signed-off-by: Sindhura Grandhi <sindhura.grandhi@intel.com>