### PR TITLE
[ADL] Update BDF for UFS device

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -71,9 +71,9 @@ CONST PLT_DEVICE mPlatformDevices[] = {
   {
     .Dev = {
       .PciDev = {
-        .PciFunctionNumber  = 0,
+        .PciFunctionNumber  = 5,
         .PciDeviceNumber    = 18,
-        .PciBusNumber       = 5,
+        .PciBusNumber       = 0,
         .IsMmioDevice       = 0
       }
     },
@@ -83,9 +83,9 @@ CONST PLT_DEVICE mPlatformDevices[] = {
   {
     .Dev = {
       .PciDev = {
-        .PciFunctionNumber  = 0,
+        .PciFunctionNumber  = 7,
         .PciDeviceNumber    = 18,
-        .PciBusNumber       = 7,
+        .PciBusNumber       = 0,
         .IsMmioDevice       = 0
       }
     },


### PR DESCRIPTION
This patch fixed BDF for UFS device, bus number and function
number are improperly ported and this patch fixed the issue.

Signed-off-by: Raghava Gudla <raghava.gudla@intel.com>