### PR TITLE
[WIP] [ADLPS] Process GPIO from Cfg Data

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/GpioTableAdlPsPostMem.h
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/GpioTableAdlPsPostMem.h
@@ -23,7 +23,7 @@ GLOBAL_REMOVE_IF_UNREFERENCED GPIO_INIT_CONFIG mGpioTablePostMemAdlPsDdr5Rvp[] =
   {GPIO_VER2_LP_GPP_A14,  {GpioPadModeGpio,       GpioHostOwnAcpi,       GpioDirOut,        GpioOutLow,        GpioIntDefault,          GpioPlatformReset,     GpioTermNone} },//X4_SLOT_PWREN
   {GPIO_VER2_LP_GPP_F10,  {GpioPadModeGpio,       GpioHostOwnAcpi,       GpioDirOut,        GpioOutHigh,       GpioIntDefault,          GpioPlatformReset,     GpioTermNone} },//X4_Slot_RESET
    //WLAN
-  {GPIO_VER2_LP_GPP_A13,  {GpioPadModeGpio,       GpioHostOwnDefault,    GpioDirIn,         GpioOutHigh,       GpioIntDefault,          GpioPlatformReset,     GpioTermNone} },//BT_RF_KILL_N
+  {GPIO_VER2_LP_GPP_A13,  {GpioPadModeGpio,       GpioHostOwnDefault,    GpioDirOut,        GpioOutHigh,       GpioIntDefault,          GpioPlatformReset,     GpioTermNone} },//BT_RF_KILL_N
   {GPIO_VER2_LP_GPP_H2,   {GpioPadModeGpio,       GpioHostOwnAcpi,       GpioDirOut,        GpioOutHigh,       GpioIntDefault,          GpioPlatformReset,     GpioTermNone} },//WLAN_RST_N
   //M.2 PCH SSD
   {GPIO_VER2_LP_GPP_D16,  {GpioPadModeGpio,       GpioHostOwnAcpi,       GpioDirOut,        GpioOutHigh,       GpioIntDefault,          GpioPlatformReset,     GpioTermNone} },//M2_PCH_SSD_PWREN
@@ -49,25 +49,22 @@ GLOBAL_REMOVE_IF_UNREFERENCED GPIO_INIT_CONFIG mGpioTablePostMemAdlPsDdr5Rvp[] =
   {GPIO_VER2_LP_GPP_A11,  {GpioPadModeGpio,       GpioHostOwnDefault,    GpioDirOut,        GpioOutHigh,       GpioIntDefault,            GpioPlatformReset,     GpioTermNone} },  //EC_SLP_S0_CS_N
   {GPIO_VER2_LP_GPP_E7,   {GpioPadModeGpio,       GpioHostOwnAcpi,       GpioDirInInv,      GpioOutDefault,    GpioIntSmi|GpioIntLevel,   GpioPlatformReset,     GpioTermNone} },  //GPPC_E7_EC_SMI_N
 
-  //DNX/DDIA DDC
-  {GPIO_VER2_LP_GPP_E23,  {GpioPadModeGpio,       GpioHostOwnDefault,    GpioDirOut,        GpioOutHigh,       GpioIntDefault,           GpioPlatformReset,     GpioTermNone} },//DNX_IN_PROG
-
   //HDMI Input Detect and Wake
   {GPIO_VER2_LP_GPP_H9,   {GpioPadModeGpio,       GpioHostOwnAcpi,       GpioDirInInv,      GpioOutDefault,     GpioIntSci|GpioIntEdge,     GpioHostDeepReset,     GpioTermNone,  GpioPadConfigUnlock } },//CRD2_HDMI_WAKE_N
   {GPIO_VER2_LP_GPD7,     {GpioPadModeGpio,       GpioHostOwnAcpi,       GpioDirInInv,      GpioOutDefault,     GpioIntSci|GpioIntEdge,     GpioHostDeepReset,     GpioTermNone,  GpioPadConfigUnlock} },//CRD1_HDMI_WAKE_N
 
   //TouchPad
-  {GPIO_VER2_LP_GPP_A15,  {GpioPadModeGpio,       GpioHostOwnGpio,       GpioDirInInv,      GpioOutDefault,    GpioIntApic|GpioIntEdge,  GpioPlatformReset,     GpioTermNone} },// TCH_PAD_INT_N
+  {GPIO_VER2_LP_GPP_A15,  {GpioPadModeGpio, GpioHostOwnGpio, GpioDirInInv,  GpioOutDefault,GpioIntEdge|GpioIntApic,GpioPlatformReset,  GpioTermNone,  GpioPadConfigUnlock  }},  //TCH_PAD_INT_N
 
   //Touch PNL2 /TSN
   {GPIO_VER2_LP_GPP_F17,  {GpioPadModeGpio,         GpioHostOwnAcpi,     GpioDirOut,        GpioOutHigh,       GpioIntDefault,          GpioPlatformReset,     GpioTermNone} },//GSPI1_CS_CVF
   {GPIO_VER2_LP_GPP_F18,  {GpioPadModeGpio,         GpioHostOwnGpio,     GpioDirInInv,      GpioOutDefault,    GpioIntApic|GpioIntEdge, GpioPlatformReset,     GpioTermNone} },//GSPI1_CS_CVF
 
   //WLAN/Flash Dec/ sec /ISH SNSR HDR/EC/MECC
-  {GPIO_VER2_LP_GPP_D13,  {GpioPadModeGpio,       GpioHostOwnAcpi,       GpioDirInInv,      GpioOutDefault,     GpioIntSci|GpioIntLevel, GpioHostDeepReset,     GpioTermNone,  GpioPadConfigUnlock} },//WIFI_WAKE_N
+  {GPIO_VER2_LP_GPP_D13,  {GpioPadModeGpio,       GpioHostOwnAcpi,       GpioDirInInv,      GpioOutDefault,     GpioIntDis, GpioHostDeepReset,     GpioTermNone,  GpioPadConfigUnlock} },//WIFI_WAKE_N
 
   //UART_BT_WAKE_N
-  {GPIO_VER2_LP_GPP_E0,   {GpioPadModeGpio,       GpioHostOwnAcpi,       GpioDirInInv,      GpioOutDefault,      GpioIntSci|GpioIntLevel, GpioHostDeepReset,     GpioTermNone,  GpioPadConfigUnlock} },//UART_BT_WAKE_N
+  {GPIO_VER2_LP_GPP_E0,   {GpioPadModeGpio,       GpioHostOwnAcpi,       GpioDirInInv,      GpioOutDefault,      GpioIntDis, GpioHostDeepReset,     GpioTermNone,  GpioPadConfigUnlock} },//UART_BT_WAKE_N
   //WLAN/ SPI TPM HDR
   {GPIO_VER2_LP_GPP_E3,   {GpioPadModeGpio,       GpioHostOwnDefault,    GpioDirOut,        GpioOutHigh,       GpioIntDefault,            GpioPlatformReset,     GpioTermNone} },//WIFI_RF_KILL_N
   //WWAN/LPC TPM HDR

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -9,7 +9,6 @@
 #include <PlatformData.h>
 #include <Library/MeExtMeasurementLib.h>
 #include "Stage2BoardInitLib.h"
-#include "GpioTableAdlPsPostMem.h"
 #include "GpioTableAdlNPostMem.h"
 #include "GpioTableAdlTsn.h"
 #include <Library/PciePm.h>
@@ -285,9 +284,6 @@ BoardInit (
   case PreSiliconInit:
     EnableLegacyRegions ();
     switch (GetPlatformId ()) {
-      case BoardIdAdlPSDdr5Rvp:
-        ConfigureGpio (CDATA_NO_TAG, sizeof (mGpioTablePostMemAdlPsDdr5Rvp) / sizeof (mGpioTablePostMemAdlPsDdr5Rvp[0]), (UINT8*)mGpioTablePostMemAdlPsDdr5Rvp);
-        break;
       case BoardIdAdlNLp5Rvp:
         ConfigureGpio (CDATA_NO_TAG, sizeof (mGpioTablePostMemAdlNLpddr5Rvp) / sizeof (mGpioTablePostMemAdlNLpddr5Rvp[0]), (UINT8*)mGpioTablePostMemAdlNLpddr5Rvp);
         break;

--- a/Silicon/CommonSocPkg/Library/GpioLib/GpioInit.c
+++ b/Silicon/CommonSocPkg/Library/GpioLib/GpioInit.c
@@ -309,7 +309,6 @@ GpioConfigurePch (
         ASSERT (FALSE);
         return EFI_INVALID_PARAMETER;
       }
-      DEBUG_CODE_END ();
 
       ZeroMem (PadCfgDwReg, sizeof (PadCfgDwReg));
       ZeroMem (PadCfgDwRegMask, sizeof (PadCfgDwRegMask));
@@ -363,7 +362,7 @@ GpioConfigurePch (
         &GpioData->GpioConfig,
         GroupDwData
         );
-
+      DEBUG_CODE_END ();
       //Move to next item
       Index++;
     }


### PR DESCRIPTION
- Updated GPIO table to match BIOS PV ER3 release.
- Disable SCI for D13 and E00.
- Process the GPIO table from dlt file instead
of the hard-coded table. The mGpioTablePostMemAdlPsDdr5Rvp
is only for reference purposes.
- Move DEBUG CODE END to later part of the GPIO function in
order to add GPIO prints when required.

Signed-off-by: Sindhura Grandhi <sindhura.grandhi@intel.com>