### PR TITLE
[ADLPS] Disable SCI for hibernate issue

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/GpioTableAdlPsPostMem.h
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/GpioTableAdlPsPostMem.h
@@ -1,7 +1,7 @@
 /** @file
   AlderLake PS RVP GPIO definition table for Post-Memory Initialization
 
-  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -64,10 +64,10 @@ GLOBAL_REMOVE_IF_UNREFERENCED GPIO_INIT_CONFIG mGpioTablePostMemAdlPsDdr5Rvp[] =
   {GPIO_VER2_LP_GPP_F18,  {GpioPadModeGpio,         GpioHostOwnGpio,     GpioDirInInv,      GpioOutDefault,    GpioIntApic|GpioIntEdge, GpioPlatformReset,     GpioTermNone} },//GSPI1_CS_CVF
 
   //WLAN/Flash Dec/ sec /ISH SNSR HDR/EC/MECC
-  {GPIO_VER2_LP_GPP_D13,  {GpioPadModeGpio,       GpioHostOwnAcpi,       GpioDirInInv,      GpioOutDefault,     GpioIntSci|GpioIntLevel, GpioHostDeepReset,     GpioTermNone,  GpioPadConfigUnlock} },//WIFI_WAKE_N
+  {GPIO_VER2_LP_GPP_D13,  {GpioPadModeGpio,       GpioHostOwnAcpi,       GpioDirInInv,      GpioOutDefault,     GpioIntDis,              GpioHostDeepReset,     GpioTermNone,  GpioPadConfigUnlock} },//WIFI_WAKE_N
 
   //UART_BT_WAKE_N
-  {GPIO_VER2_LP_GPP_E0,   {GpioPadModeGpio,       GpioHostOwnAcpi,       GpioDirInInv,      GpioOutDefault,      GpioIntSci|GpioIntLevel, GpioHostDeepReset,     GpioTermNone,  GpioPadConfigUnlock} },//UART_BT_WAKE_N
+  {GPIO_VER2_LP_GPP_E0,   {GpioPadModeGpio,       GpioHostOwnAcpi,       GpioDirInInv,      GpioOutDefault,      GpioIntDis,              GpioHostDeepReset,     GpioTermNone,  GpioPadConfigUnlock} },//UART_BT_WAKE_N
   //WLAN/ SPI TPM HDR
   {GPIO_VER2_LP_GPP_E3,   {GpioPadModeGpio,       GpioHostOwnDefault,    GpioDirOut,        GpioOutHigh,       GpioIntDefault,            GpioPlatformReset,     GpioTermNone} },//WIFI_RF_KILL_N
   //WWAN/LPC TPM HDR


### PR DESCRIPTION
SCI storm is happening for GPIO pins D13 and E00.
Disable them as not needed.

Signed-off-by: jinjhuli <jin.jhu.lim@intel.com>