### PR TITLE
[EHL] Read SecCapability from Mbp Data HOB as priority

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Security.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Security.yaml
@@ -2,7 +2,7 @@
 #
 #  Slim Bootloader CFGDATA Option File.
 #
-#  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -21,5 +21,5 @@
       help         : >
                      Enable/Disable Platform Security Discovery (PSD)
       length       : 0x04
-      value        : 0x0
+      value        : 0x1
 

--- a/Silicon/ElkhartlakePkg/Library/PsdLib/PsdLib.inf
+++ b/Silicon/ElkhartlakePkg/Library/PsdLib/PsdLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2018 - 2020 Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2018 - 2022 Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 #
@@ -55,7 +55,7 @@ ConfigDataLib
 BootGuardLib
 
 [Guids]
-
+  gMeBiosPayloadHobGuid
 
 [Pcd]
 gPlatformModuleTokenSpaceGuid.PcdAcpiTablesAddress


### PR DESCRIPTION
Found PSDS ACPI table reporting incorrect value
and fix by referring the BIOS method to retrieve
right value. Also Enable Platform Security Discovery.

Verify on CRB platform.

Signed-off-by: Randy Lin <randy.lin@intel.com>