### PR TITLE
KW fix for un-initialized buffer

### DIFF
--- a/BootloaderCommonPkg/Library/XhciLib/XhciSched.c
+++ b/BootloaderCommonPkg/Library/XhciLib/XhciSched.c
@@ -2,7 +2,7 @@
 PEIM to produce gPeiUsb2HostControllerPpiGuid based on gPeiUsbControllerPpiGuid
 which is used to enable recovery function from USB Drivers.
 
-Copyright (c) 2014 - 2017, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2014 - 2022, Intel Corporation. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -2835,6 +2835,7 @@ XhcPeiInitSched (
   UINT32                Index;
   UINTN                 *ScratchEntryMap;
   EFI_STATUS            Status;
+  ScratchBuf = NULL;
 
   //
   // Initialize memory management.


### PR DESCRIPTION
[KW] A buffer is not initialized before being passed as
an argument. Initializing it to null
Signed-off-by: Kalp Parikh <kalp.parikh@intel.com>