### PR TITLE
[EHL] Add FiaLaneReversalEnable FSP-M config

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Memory.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Memory.yaml
@@ -1405,6 +1405,13 @@
                      Disclaimer- Warning- This must NOT be enabled for production!!! Enabling Error Injection allows attackers who have access to the Host Operating System to inject IBECC errors that can cause unintended # memory corruption and enable the leak of security data in the BIOS stolen memory regions.
       length       : 0x01
       value        : 0x00
+  - FiaLaneReversalEnable :
+      name         : FIA Lane Reversal Enable/Disable config mask
+      type         : EditNum, HEX, (0x0,0xFF)
+      help         : >
+                     Set 0x10 for M.2 NVME storage support on J4U1.
+      length       : 0x2
+      value        : 0x0
   - Dummy        :
-      length       : 0x4
+      length       : 0x2
       value        : 0x0

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -580,7 +580,8 @@ UpdateFspConfig (
       Fspmcfg->IbeccProtectedRegionBase[Index]   = MemCfgData->IbeccProtectedRegionBase[Index];
       Fspmcfg->IbeccProtectedRegionMask[Index]   = MemCfgData->IbeccProtectedRegionMask[Index];
     }
-
+    // FIA Lane Reversal setting
+    Fspmcfg->FiaLaneReversalEnable              = MemCfgData->FiaLaneReversalEnable;
     // Debug Config
     Fspmcfg->DciEn                        = 1;
     Fspmcfg->DciModphyPg                  = 0;
@@ -645,6 +646,7 @@ UpdateFspConfig (
       DEBUG ((DEBUG_INFO, "PchTraceHubMode = %x\n",        Fspmcfg->PchTraceHubMode));
       DEBUG ((DEBUG_INFO, "PchTraceHubMemReg0Size = %x\n", Fspmcfg->PchTraceHubMemReg0Size));
       DEBUG ((DEBUG_INFO, "PchTraceHubMemReg1Size = %x\n", Fspmcfg->PchTraceHubMemReg1Size));
+      DEBUG ((DEBUG_INFO, "FiaLaneReversalEnable = %x\n", Fspmcfg->FiaLaneReversalEnable));
   }
 
   // IGD config data


### PR DESCRIPTION
For enabling the M.2 SATA devcie in CRB,
The FiaLaneReversalEnable value is 16 in CfgData_Memory.yaml.

Signed-off-by: Randy Lin <randy.lin@intel.com>