### PR TITLE
[ADLS] Disable S0ix by default

### DIFF
--- a/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr4.dlt
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr4.dlt
@@ -15,7 +15,7 @@
 PLATFORMID_CFG_DATA.PlatformId           | 0x0017
 PLAT_NAME_CFG_DATA.PlatformName          | 'ADL_S'
 GEN_CFG_DATA.PayloadId                   | 'AUTO'
-FEATURES_CFG_DATA.Features.S0ix          | 0x1
+FEATURES_CFG_DATA.Features.S0ix          | 0x0
 
 #
 # This GPIO maps to the SW7C1 4-block DIP switch's 3rd switch.

--- a/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr4_Sodimm.dlt
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr4_Sodimm.dlt
@@ -15,7 +15,7 @@
 PLATFORMID_CFG_DATA.PlatformId           | 0x0018
 PLAT_NAME_CFG_DATA.PlatformName          | 'AdlSSdm4'
 GEN_CFG_DATA.PayloadId                   | 'AUTO'
-FEATURES_CFG_DATA.Features.S0ix          | 0x1
+FEATURES_CFG_DATA.Features.S0ix          | 0x0
 #
 # This GPIO maps to the SW7C1 4-block DIP switch's 3rd switch.
 # If the switch is ON then OS Loader will be used, if OFF UEFI PLD

--- a/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr5.dlt
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr5.dlt
@@ -16,7 +16,7 @@
 PLATFORMID_CFG_DATA.PlatformId           | 0x001B
 PLAT_NAME_CFG_DATA.PlatformName          | 'ADL_S'
 GEN_CFG_DATA.PayloadId                   | 'AUTO'
-FEATURES_CFG_DATA.Features.S0ix          | 0x1
+FEATURES_CFG_DATA.Features.S0ix          | 0x0
 
 #
 # This GPIO maps to the SW7C1 4-block DIP switch's 3rd switch.

--- a/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr5_Sodimm.dlt
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr5_Sodimm.dlt
@@ -16,7 +16,7 @@
 PLATFORMID_CFG_DATA.PlatformId           | 0x001C
 PLAT_NAME_CFG_DATA.PlatformName          | 'AdlSSdm5'
 GEN_CFG_DATA.PayloadId                   | 'AUTO'
-FEATURES_CFG_DATA.Features.S0ix          | 0x1
+FEATURES_CFG_DATA.Features.S0ix          | 0x0
 #
 # This GPIO maps to the SW7C1 4-block DIP switch's 3rd switch.
 # If the switch is ON then OS Loader will be used, if OFF UEFI PLD


### PR DESCRIPTION
When S0ix feature is enabled, some controllers are disabled
and ethernet/lan is one of them. Hence, disable by default so
that other controllers can be enabled by default.


Signed-off-by: Sindhura Grandhi <sindhura.grandhi@intel.com>