### PR TITLE
Add GpioGetStrapValue() helper function

### DIFF
--- a/Silicon/CommonSocPkg/Include/GpioConfig.h
+++ b/Silicon/CommonSocPkg/Include/GpioConfig.h
@@ -416,6 +416,8 @@ typedef struct {
 #define B_GPIO_PCR_RX_SMI_ROUTE         BIT18
 #define B_GPIO_PCR_RX_NMI_ROUTE         BIT17
 #define N_GPIO_PCR_RX_NMI_ROUTE         17
+#define B_GPIO_PCR_PINSTRAPVAL          BIT11
+#define N_GPIO_PCR_PINSTRAPVAL          11
 #define B_GPIO_PCR_TERM                 (BIT13 | BIT12 | BIT11 | BIT10)
 #define N_GPIO_PCR_TERM                 10
 #define B_GPIO_PCR_PAD_MODE             (BIT12 | BIT11 | BIT10)

--- a/Silicon/CommonSocPkg/Include/Library/GpioLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/GpioLib.h
@@ -167,6 +167,24 @@ GpioGetInputValue (
 
 
 /**
+  This procedure will get GPIO strap value
+
+  @param[in]  GpioPad             GPIO pad
+  @param[out] StrapVal            GPIO Strap value
+                                  0: Low, 1: High
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+EFIAPI
+GpioGetStrapValue (
+  IN GPIO_PAD                  GpioPad,
+  OUT UINT32                   *StrapVal
+  );
+
+
+/**
   This procedure will configure GPIO input inversion
 
   @param[in] GpioPad              GPIO pad

--- a/Silicon/CommonSocPkg/Library/GpioLib/GpioLib.c
+++ b/Silicon/CommonSocPkg/Library/GpioLib/GpioLib.c
@@ -1036,6 +1036,40 @@ GpioGetInputValue (
 }
 
 /**
+  This procedure will get GPIO strap value
+
+  @param[in] GpioPad              GPIO pad
+  @param[out] StrapVal            GPIO Strap value
+                                  0: Low, 1: High
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid GpioPad
+**/
+EFI_STATUS
+EFIAPI
+GpioGetStrapValue (
+  IN GPIO_PAD                  GpioPad,
+  OUT UINT32                   *StrapVal
+  )
+{
+  UINT32      PadCfgReg;
+
+  if (!GpioIsPadValid (GpioPad)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!GpioIsPadHostOwned (GpioPad)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  PadCfgReg = GpioReadPadCfgReg (GpioPad, 2);
+
+  *StrapVal = (PadCfgReg & B_GPIO_PCR_PINSTRAPVAL) >> N_GPIO_PCR_PINSTRAPVAL;
+
+  return EFI_SUCCESS;
+}
+
+/**
   This procedure will get GPIO IOxAPIC interrupt number
 
   @param[in]  GpioPad             GPIO pad


### PR DESCRIPTION
This patch adds a new GpioGetStrapValue() helper function which allows
reading the pin-strap value of GPIO pins.  This is useful for reading
the value of hard straps or of BOARD_ID pins or of other GPIOs for
which the input buffer may be disabled, as the pin-strap value bit is
valid even when a pin's input buffer has been disabled.

Signed-off-by: Lennert Buytenhek <buytenh@arista.com>