### PR TITLE
[TGL] Fix x64 builds

### DIFF
--- a/Silicon/TigerlakePchPkg/Library/HeciInitLib/HeciPeiDxe.c
+++ b/Silicon/TigerlakePchPkg/Library/HeciInitLib/HeciPeiDxe.c
@@ -565,6 +565,7 @@ HeciGetOemKeyStatus(
   @retval EFI_DEVICE_ERROR        HECI Device error, command aborts abnormally
 **/
 EFI_STATUS
+EFIAPI
 HeciRevokeOemKey (
   VOID
   )


### PR DESCRIPTION
This PR fixes the following error for x64 TGL builds, observed on gcc 11.2 (Ubuntu 22.04).

```
Silicon/TigerlakePchPkg/Library/HeciInitLib/HeciPeiDxe.c:568:1: error: conflicting types for ‘HeciRevokeOemKey’; have ‘EFI_STATUS(void)’ {aka ‘long long unsigned int(void)’}
  568 | HeciRevokeOemKey (
      | ^~~~~~~~~~~~~~~~
In file included from Silicon/TigerlakePchPkg/Library/HeciInitLib/HeciPeiDxe.c:12:
Silicon/TigerlakePchPkg/Include/Library/HeciInitLib.h:391:1: note: previous declaration of ‘HeciRevokeOemKey’ with type ‘EFI_STATUS(void)’ {aka ‘long long unsigned int(void)’}
  391 | HeciRevokeOemKey (
      | ^~~~~~~~~~~~~~~~
make: *** [GNUmakefile:306: Build/BootloaderCorePkg/RELEASE_GCC5/X64/Silicon/TigerlakePchPkg/Library/HeciInitLib/HeciInitLib/OUTPUT/HeciPeiDxe.obj] Error 1
```