### PR TITLE
[TGL] Update FSP/VBT/UCODE/platform version since MR6 is released

### DIFF
--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -25,7 +25,7 @@ class Board(BaseBoard):
 
         self.VERINFO_IMAGE_ID       = 'SBL_TGL'
         self.VERINFO_PROJ_MAJOR_VER = 1
-        self.VERINFO_PROJ_MINOR_VER = 5
+        self.VERINFO_PROJ_MINOR_VER = 6
         self.VERINFO_SVN            = 1
         self.VERINFO_BUILD_DATE     = time.strftime("%m/%d/%Y")
 

--- a/Silicon/TigerlakePkg/FspBin/FspBin.inf
+++ b/Silicon/TigerlakePkg/FspBin/FspBin.inf
@@ -1,7 +1,7 @@
 ## @file
 #  File to describe FSP repo information
 #
-#  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -11,7 +11,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = 48d4c23f957548311345fa463494e7ffbed4ae35
+  COMMIT  = 6f5ae9679e662353bc5570a1bc89e137e262155f
 
 [UserExtensions.SBL."CopyList"]
   TigerLakeFspBinPkg/TGL_IOT/Fsp.fd                    : Silicon/TigerlakePkg/FspBin/FspDbg.bin
@@ -24,3 +24,4 @@
   TigerLakeFspBinPkg/TGL_IOT/Include/MemInfoHob.h      : Silicon/TigerlakePkg/Include/MemInfoHob.h
   TigerLakeFspBinPkg/TGL_IOT/SampleCode/Vbt/Vbt.bin    : Platform/TigerlakeBoardPkg/VbtBin/Vbt.dat
   TigerLakeFspBinPkg/TGL_IOT/SampleCode/Vbt/Vbt.json   : Platform/TigerlakeBoardPkg/VbtBin/Vbt.json
+  FSP_License.pdf                                      : Platform/TigerlakeBoardPkg/FspBin/FSP_License.pdf

--- a/Silicon/TigerlakePkg/Microcode/Microcode.inf
+++ b/Silicon/TigerlakePkg/Microcode/Microcode.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2019 - 2021, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2019 - 2022, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 #
@@ -14,14 +14,14 @@
   VERSION_STRING       = 1.0
 
 [Sources]
-  m_80_806c1_0000009a.mcb
+  m_80_806c1_000000a4.mcb
   m_c2_806d1_0000003c.mcb
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
-  COMMIT = 411cbc8e0ebb22374b7b26f14881d1013bd9fcb8
+  COMMIT = b587cd64ac87bde380b113a32867ff5dc2ef3fb7
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/TigerLake/m_80_806c1_0000009a.pdb  : Silicon/TigerlakePkg/Microcode/m_80_806c1_0000009a.mcb
+  Microcode/TigerLake/m_80_806c1_000000a4.pdb  : Silicon/TigerlakePkg/Microcode/m_80_806c1_000000a4.mcb
   Microcode/TigerLake/m_c2_806d1_0000003c.pdb  : Silicon/TigerlakePkg/Microcode/m_c2_806d1_0000003c.mcb
 


### PR DESCRIPTION
- update FSP version to IoT FSP 5143_01_MR6 (0A.00.7B.31)
- update VBT version to IoT FSP 5143_01_MR6 (250)
- update TGLU microcode version to A4
- update TGL platform version to 1.6

Signed-off-by: Vincent Chen <vincent.chen@intel.com>