### PR TITLE
FWU: support capsule file placed in non-FAT FS

### DIFF
--- a/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
+++ b/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
@@ -1,7 +1,7 @@
 /** @file
   This file contains the implementation of FirmwareUpdateLib library.
 
-  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -301,7 +301,11 @@ LoadCapsuleImage (
     goto Done;
   }
 
-  Status = InitFileSystem (CapsuleInfo->SwPart, EnumFileSystemTypeFat, HwPartHandle, &FsHandle);
+  if (CapsuleInfo->FsType >= EnumFileSystemMax) {
+    Status = InitFileSystem (CapsuleInfo->SwPart, EnumFileSystemTypeAuto, HwPartHandle, &FsHandle);
+  } else {
+    Status = InitFileSystem (CapsuleInfo->SwPart, CapsuleInfo->FsType, HwPartHandle, &FsHandle);
+  }
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_INFO, "No partitions found, Status = %r\n", Status));
     goto Done;


### PR DESCRIPTION
This patch fixes the support of a capsule file placed in a filesystem
whose fs type is specified by CAPSULE_INFO_CFG_DATA.FsType.

Verify method:
  1. Set disk/partition CAPSULE_INFO_CFG_DATA to a volume of ext2 fs
  2. Set CAPSULE_INFO_CFG_DATA.FsType = 2 (AUTO)
  3. Place FwuImage.bin to the volume
  4. Run firmware update test

Verified: EHL CRB

Signed-off-by: Stanley Chang <stanley.chang@intel.com>