### PR TITLE
FWU: fix infinite fwu caused by a/b update failure

### DIFF
--- a/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
+++ b/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
@@ -40,6 +40,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define MAX_FILE_LEN            16
 #define MAX_FW_COMPONENTS       3
+#define MAX_FW_FAILED_RETRY     3
 
 #define CAPSULE_FLAGS_CFG_DATA  BIT0
 
@@ -109,7 +110,8 @@ typedef struct {
   UINT16                Length;
   UINT8                 CapsuleSig[FW_UPDATE_SIG_LENGTH];
   UINT8                 StateMachine;
-  UINT8                 Reserved[7];
+  UINT8                 RetryCount;
+  UINT8                 Reserved[6];
 } FW_UPDATE_STATUS;
 
 typedef struct {


### PR DESCRIPTION
In A/B update, after FWU updates partition B, it switches to and boots with partition B. If boot fails because of anything wrong with the update, CSME will switch back to booting with partition A.

Before this patch, unfortunately, the EnforceFwUpdatePolicy will immediately try to boot again with partition B, which results in an infinite FWU loop:

  try B -> failed -> boot A -> try B -> failed ...
  (Same for initial with "try A" scheme)

This patch adds a retry count field in FW_UPDATE_STATUS.
Using retry count field to determine if retry also reaches a max times. If so, stop the loop.

To simplify the implementation for SPI, the retry count field is implemented as continuous 1 (ONE) of a bit array.

Test scenarios:
  Case 1. update bios region. Expectation: PASS
  Case 2. update non-bios region. Expectation: PASS
  Case 3. Inject fault flow (no partition switch after first flash), and update bios region. Expectation: Stop retry after few times.

Verify: EHL RVP

Signed-off-by: Stanley Chang <stanley.chang@intel.com>