### PR TITLE
[EHL] Enable WDT for TCC

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/BoardConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/BoardConfig.py
@@ -235,7 +235,8 @@ class Board(BaseBoard):
             'SmbusLib|Silicon/CommonSocPkg/Library/SmbusLib/SmbusLib.inf',
             'PsdLib|Silicon/$(SILICON_PKG_NAME)/Library/PsdLib/PsdLib.inf',
             'HeciInitLib|Silicon/$(SILICON_PKG_NAME)/Library/HeciInitLib/HeciInitLib.inf',
-            'MeExtMeasurementLib|Silicon/$(SILICON_PKG_NAME)/Library/MeExtMeasurementLib/MeExtMeasurementLib.inf'
+            'MeExtMeasurementLib|Silicon/$(SILICON_PKG_NAME)/Library/MeExtMeasurementLib/MeExtMeasurementLib.inf',
+            'WatchDogTimerLib|Silicon/CommonSocPkg/Library/WatchDogTimerLib/WatchDogTimerLib.inf',
         ]
 
         if self.BUILD_CSME_UPDATE_DRIVER:

--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Tcc_Feature.dlt
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Tcc_Feature.dlt
@@ -33,3 +33,6 @@ BOOT_OPTION_CFG_DATA_2.ImageType_2 | 0x1E        #USB
 #BOOT_OPTION_CFG_DATA_11.ImageType_11 | 0x1E     #NVME
 #BOOT_OPTION_CFG_DATA_14.ImageType_14 | 0x1E     #UFS1
 #BOOT_OPTION_CFG_DATA_17.ImageType_17 | 0x1E     #UFS2
+
+#Enable Wdt
+MEMORY_CFG_DATA.WdtDisableAndLock | 0

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -41,6 +41,8 @@
 #include <Register/PmcRegs.h>
 #include <GpioConfig.h>
 #include <Library/GpioLib.h>
+#include <Library/WatchDogTimerLib.h>
+#include <Library/TccLib.h>
 
 CONST PLT_DEVICE  mPlatformDevices[]= {
   {{0x00001700}, OsBootDeviceSata  , 0 },
@@ -177,6 +179,11 @@ TccModePreMemConfig (
     return EFI_NOT_FOUND;
   }
 
+  if (GetBootMode() == BOOT_ON_FLASH_UPDATE) {
+    DEBUG ((DEBUG_INIT, "In FW update flow. Donot apply DSO settings\n"));
+    TccCfgData->TccTuning = 0;
+  }
+
   // TCC related memory settings
   DEBUG ((DEBUG_INFO, "Tcc is enabled, Setting memory config.\n"));
   FspmUpd->FspmConfig.TccModeEnablePreMem    = 1;
@@ -193,19 +200,30 @@ TccModePreMemConfig (
   FspmUpd->FspmConfig.DsoTuningEnPreMem      = TccCfgData->TccTuning;
   FspmUpd->FspmConfig.TccErrorLogEnPreMem    = TccCfgData->TccErrorLog;
 
-  // Load TCC stream config from container
-  TccStreamBase = NULL;
-  TccStreamSize = 0;
-  Status = LoadComponent (SIGNATURE_32 ('I', 'P', 'F', 'W'), SIGNATURE_32 ('T', 'C', 'C', 'T'),
-                          (VOID **)&TccStreamBase, &TccStreamSize);
-  if (EFI_ERROR (Status) || (TccStreamSize < sizeof(TCC_STREAM_CONFIGURATION))) {
-    DEBUG ((DEBUG_INFO, "Load TCC Stream %r, size = 0x%x\n", Status, TccStreamSize));
-  } else {
-    FspmUpd->FspmConfig.TccStreamCfgBasePreMem = (UINT32)(UINTN)TccStreamBase;
-    FspmUpd->FspmConfig.TccStreamCfgSizePreMem = TccStreamSize;
-    DEBUG ((DEBUG_INFO, "Load TCC stream @0x%p, size = 0x%x\n", TccStreamBase, TccStreamSize));
+  if (IsMarkedBadDso ()) {
+    DEBUG ((DEBUG_INFO, "Incorrect TCC tuning parameters. Platform rebooted with default values.\n"));
+    FspmUpd->FspmConfig.TccStreamCfgStatusPreMem = 1;
+  } else if (IsWdtFlagsSet(WDT_FLAG_TCC_DSO_IN_PROGRESS) && IsWdtTimeout()) {
+    DEBUG ((DEBUG_ERROR, "Incorrect TCC tuning parameters. Platform rebooted with default values.\n"));
+    WdtClearScratchpad (WDT_FLAG_TCC_DSO_IN_PROGRESS);
+    FspmUpd->FspmConfig.TccStreamCfgStatusPreMem = 1;
+    InvalidateBadDso ();
+  } else if (TccCfgData->TccTuning != 0) {
+    // Setup Watch dog timer
+    WdtReloadAndStart (WDT_TIMEOUT_TCC_DSO, WDT_FLAG_TCC_DSO_IN_PROGRESS);
 
-    if (TccCfgData->TccTuning != 0) {
+    // Load TCC stream config from container
+    TccStreamBase = NULL;
+    TccStreamSize = 0;
+    Status = LoadComponent (SIGNATURE_32 ('I', 'P', 'F', 'W'), SIGNATURE_32 ('T', 'C', 'C', 'T'),
+                            (VOID **)&TccStreamBase, &TccStreamSize);
+    if (EFI_ERROR (Status) || (TccStreamSize < sizeof(TCC_STREAM_CONFIGURATION))) {
+      DEBUG ((DEBUG_INFO, "Load TCC Stream %r, size = 0x%x\n", Status, TccStreamSize));
+    } else {
+      FspmUpd->FspmConfig.TccStreamCfgBasePreMem = (UINT32)(UINTN)TccStreamBase;
+      FspmUpd->FspmConfig.TccStreamCfgSizePreMem = TccStreamSize;
+      DEBUG ((DEBUG_INFO, "Load TCC stream @0x%p, size = 0x%x\n", TccStreamBase, TccStreamSize));
+
       StreamConfig = (TCC_STREAM_CONFIGURATION *) TccStreamBase;
       PolicyConfig = (BIOS_SETTINGS *) &StreamConfig->BiosSettings;
 

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
@@ -45,6 +45,8 @@
   BoardSupportLib
   SmbusLib
   PchSciLib
+  WatchDogTimerLib
+  TccLib
 
 [Guids]
 

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -61,6 +61,7 @@
   PsdLib
   MeExtMeasurementLib
   TccLib
+  WatchDogTimerLib
 
 [Guids]
   gOsConfigDataGuid


### PR DESCRIPTION
When some settings from DSO caused system hang,
the WDT would cause the system reboot.
And in the next boot, SBL would use the default
setting by not apply the DSO values.

Verify on EHL CRB.

Signed-off-by: Aiman Rosli <muhammad.aiman.rosli@intel.com>