### PR TITLE
[EHL] Fix Kernel DMA driver cannot be registed issue

### DIFF
--- a/Silicon/ElkhartlakePkg/Include/PseConfig.h
+++ b/Silicon/ElkhartlakePkg/Include/PseConfig.h
@@ -1,7 +1,7 @@
 /** @file
   PSE policy
 
-  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 #ifndef _PSE_CONFIG_H_
@@ -11,6 +11,12 @@
 #define PSE_CONFIG_REVISION 1
 
 #pragma pack (push,1)
+
+typedef enum {
+  NONE_OWNED = 0,
+  PSE_OWNED  = 1,
+  HOST_OWNED = 2
+} PSE_IP_OWNERSHIP;
 
 typedef enum {
   NONTGPIO,


### PR DESCRIPTION
EHL DMA controllers are hidden at PSF level in reference code,
DMA controllers are reported as ACPI devices if ownership is Host.
So should not check DMA PCI header for DSDT table patching.
Update the change follow EHL reference code.

Signed-off-by: Gavin Xue <gavin.xue@intel.com>