### PR TITLE
FWU: reset the system after CSME firmware update

### DIFF
--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -1081,7 +1081,7 @@ ApplyFwImage (
       CsmeUpdateInData = InitCsmeUpdInputData();
       if (CsmeUpdateInData != NULL) {
         Status = UpdateCsme(CapImage, CapImageSize, CsmeUpdateInData, ImageHdr);
-        *ResetRequired = FALSE;
+        *ResetRequired = TRUE;
       }
     }
     break;


### PR DESCRIPTION
This patch is to support OEM root key revocation feature.
When the firmware update is done processing CSME payload
containing OEM KM with revocation extension, the system
needs to reset for the changes to take effect. Otherwise,
the following CMDI {OEMKEYREVOCATION} command will fail.

Signed-off-by: Vincent Chen <vincent.chen@intel.com>