### PR TITLE
FWU: support OEM key revocation together with BIOS/CSME update

### DIFF
--- a/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
+++ b/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
@@ -1,7 +1,7 @@
 /** @file
 The header file for firmware update library.
 
-Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -39,7 +39,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define FW_UPDATE_SIG_LENGTH    256
 
 #define MAX_FILE_LEN            16
-#define MAX_FW_COMPONENTS       3
+#define MAX_FW_COMPONENTS       6
 #define MAX_FW_FAILED_RETRY     3
 
 #define CAPSULE_FLAGS_CFG_DATA  BIT0

--- a/Platform/AlderlakeBoardPkg/AcpiTables/Fwst/Fwst.aslc
+++ b/Platform/AlderlakeBoardPkg/AcpiTables/Fwst/Fwst.aslc
@@ -1,7 +1,7 @@
 /** @file
   Structure definition for the ACPI BDAT Table
 
-  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -31,6 +31,33 @@ EFI_FWST_ACPI_DESCRIPTION_TABLE FwstTable = {
     EFI_SYSTEM_RESOURCE_TABLE_FIRMWARE_RESOURCE_VERSION,
   },
   {{
+    { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  },
+  {
+    { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  },
+  {
+    { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  },
+  {
     { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
     0,
     0,

--- a/Platform/CoffeelakeBoardPkg/AcpiTables/Fwst/Fwst.aslc
+++ b/Platform/CoffeelakeBoardPkg/AcpiTables/Fwst/Fwst.aslc
@@ -1,7 +1,7 @@
 /** @file
   Structure definition for the ACPI BDAT Table
 
-  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -32,6 +32,33 @@ EFI_FWST_ACPI_DESCRIPTION_TABLE FwstTable = {
     EFI_SYSTEM_RESOURCE_TABLE_FIRMWARE_RESOURCE_VERSION,
   },
   {{
+    { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  },
+  {
+    { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  },
+  {
+    { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  },
+  {
     { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
     0,
     0,

--- a/Platform/CometlakeBoardPkg/AcpiTables/Fwst/Fwst.aslc
+++ b/Platform/CometlakeBoardPkg/AcpiTables/Fwst/Fwst.aslc
@@ -1,7 +1,7 @@
 /** @file
   Structure definition for the ACPI BDAT Table
 
-  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -32,6 +32,33 @@ EFI_FWST_ACPI_DESCRIPTION_TABLE FwstTable = {
     EFI_SYSTEM_RESOURCE_TABLE_FIRMWARE_RESOURCE_VERSION,
   },
   {{
+    { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  },
+  {
+    { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  },
+  {
+    { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  },
+  {
     { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
     0,
     0,

--- a/Platform/CometlakevBoardPkg/AcpiTables/Fwst/Fwst.aslc
+++ b/Platform/CometlakevBoardPkg/AcpiTables/Fwst/Fwst.aslc
@@ -1,7 +1,7 @@
 /** @file
   Structure definition for the ACPI BDAT Table
 
-  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -32,6 +32,33 @@ EFI_FWST_ACPI_DESCRIPTION_TABLE FwstTable = {
     EFI_SYSTEM_RESOURCE_TABLE_FIRMWARE_RESOURCE_VERSION,
   },
   {{
+    { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  },
+  {
+    { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  },
+  {
+    { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  },
+  {
     { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
     0,
     0,

--- a/Platform/ElkhartlakeBoardPkg/AcpiTables/Fwst/Fwst.aslc
+++ b/Platform/ElkhartlakeBoardPkg/AcpiTables/Fwst/Fwst.aslc
@@ -1,7 +1,7 @@
 /** @file
   Structure definition for the ACPI BDAT Table
 
-  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -32,6 +32,33 @@ EFI_FWST_ACPI_DESCRIPTION_TABLE FwstTable = {
     EFI_SYSTEM_RESOURCE_TABLE_FIRMWARE_RESOURCE_VERSION,
   },
   {
+   {
+    { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+   },
+   {
+    { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+   },
+   {
+    { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+   },
    {
     { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
     0,

--- a/Platform/TigerlakeBoardPkg/AcpiTables/Fwst/Fwst.aslc
+++ b/Platform/TigerlakeBoardPkg/AcpiTables/Fwst/Fwst.aslc
@@ -1,7 +1,7 @@
 /** @file
   Structure definition for the ACPI BDAT Table
 
-  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -32,6 +32,33 @@ EFI_FWST_ACPI_DESCRIPTION_TABLE FwstTable = {
     EFI_SYSTEM_RESOURCE_TABLE_FIRMWARE_RESOURCE_VERSION,
   },
   {{
+    { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  },
+  {
+    { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  },
+  {
+    { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  },
+  {
     { 0, 0, 0, { 0, 0, 0, 0, 0, 0, 0, 0 } },
     0,
     0,


### PR DESCRIPTION
The steps of OEM key revocation are:
  1. Replace OEM KM (signed with key2) by updating CSME
  2. Replace BIOS region (signed with key2)
  3. Reboot with new BIOS region (to make key1 inactive)
  4. Revoke key1

Before this patch, it requires 2 firmware updates and 2 capsules for
step 1~2 and step 4 respectively. The patch combines them into a single
update/capsule.

To implement the feature, the patch:
  1. Double max # of payloads to allow CSME/CSMD/BIOS/CMDI update
     in one capsule image.
  2. Prevent from failing update of a critical component.
     e.g., if step 1(CSME) fails, step 2(BIOS) should be skipped

Verified cases:

 Case 1: Capsule having CSMD/CSMD/BIOS/CMDI.
         Expectation: successful

    $ python BootloaderCorePkg/Tools/GenCapsuleFirmware.py \
      -p CSME FWUpdate.bin \
      -p CSMD CsmeUpdateDriver.efi \
      -p BIOS new_BiosRegion.bin \
      -p CMDI cmdi.txt \
      ...(skip)

 Case 2: Capsule having CSME/BIOS/CMDI but no CSMD.
         Expectation: no update

 Case 3: Inject fault flow (no partition switch after first flash),
         Capsule having CSME/CSMD/BIOS/CMDI.
         Expectation: no CMDI update

Verification: EHL CRB

Signed-off-by: Stanley Chang <stanley.chang@intel.com>