### PR TITLE
[EHL] Update FSP/VBT/UCODE/platform version since MR4 is released

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/BoardConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/BoardConfig.py
@@ -26,7 +26,7 @@ class Board(BaseBoard):
         # VERINFO_PROJ_MAJOR_VER: 1 PV Quality release
         # VERINFO_PROJ_MINOR_VER: 0: PV  1: MR1  2: MR2 etc.
         self.VERINFO_PROJ_MAJOR_VER = 1
-        self.VERINFO_PROJ_MINOR_VER = 3
+        self.VERINFO_PROJ_MINOR_VER = 4
         self.VERINFO_SVN          = 1
         self.VERINFO_BUILD_DATE   = time.strftime("%m/%d/%Y")
         self.LOWEST_SUPPORTED_FW_VER = ((self.VERINFO_PROJ_MAJOR_VER << 8) + self.VERINFO_PROJ_MINOR_VER)

--- a/Silicon/ElkhartlakePkg/FspBin/FspBin.inf
+++ b/Silicon/ElkhartlakePkg/FspBin/FspBin.inf
@@ -11,7 +11,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = 72266f6523286fb3494f5b2553ace612d1dc95c4
+  COMMIT  = 751a02a2d3236bfebc3928928ec361c3956476e9
 
 [UserExtensions.SBL."CopyList"]
   ElkhartLakeFspBinPkg/FspBin/FSPRel.bin               : Silicon/ElkhartlakePkg/FspBin/FspDbg.bin

--- a/Silicon/ElkhartlakePkg/Microcode/Microcode.inf
+++ b/Silicon/ElkhartlakePkg/Microcode/Microcode.inf
@@ -14,11 +14,11 @@
   VERSION_STRING       = 1.0
 
 [Sources]
-  m0190661_00000015.mcb
+  m0190661_00000016.mcb
 
 [UserExtensions.SBL."CloneRepo"]
   REPO  = https://github.com/tianocore/edk2-non-osi.git
-  COMMIT= 3aad93ea6ac0d601d779be7ff4a2d61798cf9056
+  COMMIT= 6996a45d7f4014fd4aa0f1eb4cbe97d8a3c5957a
 
 [UserExtensions.SBL."CopyList"]
-  Silicon/Intel/ElkhartlakeSiliconBinPkg/Microcode/m0190661_00000015.mcb  : Silicon/ElkhartlakePkg/Microcode/m0190661_00000015.mcb
+  Silicon/Intel/ElkhartlakeSiliconBinPkg/Microcode/m0190661_00000016.mcb  : Silicon/ElkhartlakePkg/Microcode/m0190661_00000016.mcb


### PR DESCRIPTION
- update FSP version to MR4 FSP (09.04.25.11)
- update VBT version to MR4 FSP (244)
- update microcode version to 16
- update EHL platform version to 1.4

Signed-off-by: Vincent Chen <vincent.chen@intel.com>