### PR TITLE
[ADLN] Gpio Cfg data from dlt file

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/GpioTableAdlNPostMem.h
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/GpioTableAdlNPostMem.h
@@ -71,7 +71,8 @@ GLOBAL_REMOVE_IF_UNREFERENCED GPIO_INIT_CONFIG mGpioTablePostMemAdlNDdr5Crb[] =
   {GPIO_VER2_LP_GPD2,      {GpioPadModeGpio, GpioHostOwnAcpi, GpioDirInInv, GpioOutDefault,   GpioIntEdge,               GpioHostDeepReset,  GpioTermNone, GpioPadConfigUnlock}},  // this is needed to be in NF mode1 FOX_WAKE_N. Set to SCI based on the setup option
 
   // PWR BTN GPIO
-  {GPIO_VER2_LP_GPP_H19,   {GpioPadModeGpio, GpioHostOwnGpio, GpioDirInInv, GpioOutDefault,   GpioIntEdge|GpioIntSci,    GpioPlatformReset,  GpioTermNone,  GpioPadConfigUnlock  }},  // PWRBTN_GPIO_N
+//  {GPIO_VER2_LP_GPP_H19,   {GpioPadModeGpio, GpioHostOwnGpio, GpioDirInInv, GpioOutDefault,   GpioIntEdge|GpioIntSci,    GpioPlatformReset,  GpioTermNone,  GpioPadConfigUnlock  }},  // PWRBTN_GPIO_N
+  {GPIO_VER2_LP_GPP_H19,   {GpioPadModeGpio, GpioHostOwnAcpi, GpioDirInInv, GpioOutDefault,   GpioIntBothEdge|GpioIntSci,    GpioHostDeepReset,  GpioTermNone,  GpioPadConfigUnlock  }},  // PWRBTN_GPIO_N
 
   // Unused pins set to high impedance
   {GPIO_VER2_LP_GPP_F11,   {GpioPadModeGpio, GpioHostOwnGpio, GpioDirNone,  GpioOutDefault,   GpioIntDefault,            GpioResetDefault,   GpioTermNone}},  // HiZ

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -286,9 +286,6 @@ BoardInit (
   case PreSiliconInit:
     EnableLegacyRegions ();
     switch (GetPlatformId ()) {
-      case PLATFORM_ID_ADL_N_DDR5_CRB:
-        ConfigureGpio (CDATA_NO_TAG, sizeof (mGpioTablePostMemAdlNDdr5Crb) / sizeof (mGpioTablePostMemAdlNDdr5Crb[0]), (UINT8*)mGpioTablePostMemAdlNDdr5Crb);
-        break;
       case PLATFORM_ID_ADL_N_LPDDR5_RVP:
         ConfigureGpio (CDATA_NO_TAG, sizeof (mGpioTablePostMemAdlNLpddr5Rvp) / sizeof (mGpioTablePostMemAdlNLpddr5Rvp[0]), (UINT8*)mGpioTablePostMemAdlNLpddr5Rvp);
         break;

--- a/Platform/CommonBoardPkg/Tools/GpioDataConvert.py
+++ b/Platform/CommonBoardPkg/Tools/GpioDataConvert.py
@@ -792,6 +792,7 @@ def convert_from_inp_to_out (gpio_tmp_fmt, inp_fmt, cfg_file, out_fmt, parts):
         if pad_name != '':
             if out_fmt == 'yaml':
                 if gpio_tmp_fmt == 'new':
+                #Ex: !expand { GPIO_TMPL : [ GPP_A,  00,  0x0350A383,  0x00002019 ] }
                     idx = len(pad_name)
                     while idx > 0:
                         if not pad_name[idx-1].isdigit():


### PR DESCRIPTION
- Process Gpio Cfg data from the dlt file instead of the hard-coded
  GPIO table.
- The table in the PostMem hdr file is only for reference.

Signed-off-by: Sindhura Grandhi <sindhura.grandhi@intel.com>