### PR TITLE
FWU: reboot the system before CMDI command if CSME is updated

### DIFF
--- a/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
+++ b/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
@@ -111,7 +111,8 @@ typedef struct {
   UINT8                 CapsuleSig[FW_UPDATE_SIG_LENGTH];
   UINT8                 StateMachine;
   UINT8                 RetryCount;
-  UINT8                 Reserved[6];
+  UINT8                 CsmeNeedReset;
+  UINT8                 Reserved[5];
 } FW_UPDATE_STATUS;
 
 typedef struct {


### PR DESCRIPTION
This patch is to refine the reboot timing when CSME is updated.
During fwupdate process, a reboot is not required to immediately
follow CSME update. Besides, if CSME payload contains OEM KM
signed with key2 for key1 revocation, the system might result in
the undefined situation where OEM KM is with key2 while SBL KM
is with key1. So move the reboot before CMDI payload is processed.

Signed-off-by: Vincent Chen <vincent.chen@intel.com>