### PR TITLE
[TESTS] revert the premem gpio change for S17 board

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/GpioTableTestPreMem.h
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/GpioTableTestPreMem.h
@@ -41,32 +41,4 @@ GLOBAL_REMOVE_IF_UNREFERENCED GPIO_INIT_CONFIG mGpioTableEarlyPreMemTestSDdr5UDi
   {GPIO_VER4_S_GPP_E7,   {GpioPadModeGpio, GpioHostOwnGpio, GpioDirOut,     GpioOutHigh,     GpioIntDefault,          GpioPlatformReset,  GpioTermNone}},  // GPIO_TBT_RST_N
 };
 
-GLOBAL_REMOVE_IF_UNREFERENCED GPIO_INIT_CONFIG mGpioTableEarlyPreMemTestSDdr5SODimm1DRvp[] =
-{
-  {GPIO_VER4_S_GPP_F4,   {GpioPadModeGpio, GpioHostOwnAcpi, GpioDirOut,     GpioOutHigh,     GpioIntDefault,          GpioPlatformReset,  GpioTermNone }}, //CPU PEG Slot1 Power enable
-  {GPIO_VER4_S_GPP_E2,   {GpioPadModeGpio, GpioHostOwnAcpi, GpioDirOut,     GpioOutHigh,      GpioIntDefault,          GpioPlatformReset,  GpioTermNone }}, //CPU PEG Slot1 Reset
-
-  {GPIO_VER4_S_GPP_H16,  {GpioPadModeGpio, GpioHostOwnAcpi, GpioDirOut,     GpioOutHigh,     GpioIntDefault,          GpioPlatformReset,  GpioTermNone }}, //CPU M.2 SSD Slot Power enable
-
-  {GPIO_VER4_S_GPP_E1,   {GpioPadModeGpio, GpioHostOwnAcpi, GpioDirOut,     GpioOutHigh,     GpioIntDefault,          GpioPlatformReset,  GpioTermNone }}, //PCIE SLOT 1 - X4 CONNECTOR Power enable
-  {GPIO_VER4_S_GPP_F11,  {GpioPadModeGpio, GpioHostOwnAcpi, GpioDirOut,     GpioOutHigh,      GpioIntDefault,          GpioPlatformReset,  GpioTermNone }}, //PCIE SLOT 1 - X4 CONNECTOR Reset
-
-  {GPIO_VER4_S_GPP_H11,  {GpioPadModeGpio, GpioHostOwnAcpi, GpioDirOut,     GpioOutHigh,     GpioIntDefault,          GpioPlatformReset,  GpioTermNone }}, //PCIE SLOT 2 - X4 CONNECTOR Power enable
-  {GPIO_VER4_S_GPP_F12,  {GpioPadModeGpio, GpioHostOwnAcpi, GpioDirOut,     GpioOutHigh,      GpioIntDefault,          GpioPlatformReset,  GpioTermNone }}, //PCIE SLOT 2 - X4 CONNECTOR Reset
-
-  {GPIO_VER4_S_GPP_B21,  {GpioPadModeGpio, GpioHostOwnAcpi, GpioDirOut,     GpioOutHigh,     GpioIntDefault,          GpioPlatformReset,  GpioTermNone }}, //PCIE SLOT 3 - X2 CONNECTOR Power enable
-  {GPIO_VER4_S_GPP_F13,  {GpioPadModeGpio, GpioHostOwnAcpi, GpioDirOut,     GpioOutHigh,      GpioIntDefault,          GpioPlatformReset,  GpioTermNone }}, //PCIE SLOT 3 - X2 CONNECTOR Reset
-
-  {GPIO_VER4_S_GPP_K11,  {GpioPadModeGpio, GpioHostOwnAcpi, GpioDirOut,     GpioOutHigh,     GpioIntDefault,          GpioPlatformReset,  GpioTermNone }}, //PCH M.2 SSD Slot 1 Power enable
-  //{GPIO_VER4_S_GPP_C10,   {GpioPadModeGpio, GpioHostOwnAcpi, GpioDirOut,     GpioOutLow,      GpioIntDefault,          GpioPlatformReset,  GpioTermNone}},//PCH M.2 SSD Slot 1 Reset
-
-  {GPIO_VER4_S_GPP_B22,  {GpioPadModeGpio, GpioHostOwnAcpi, GpioDirOut,     GpioOutHigh,     GpioIntDefault,          GpioPlatformReset,  GpioTermNone }}, //PCH M.2 SSD Slot 2 Power enable,not used on S08
-  //{GPIO_VER4_S_GPP_F16,   {GpioPadModeGpio, GpioHostOwnAcpi, GpioDirOut,     GpioOutLow,      GpioIntDefault,          GpioPlatformReset,  GpioTermNone}},//PCH M.2 SSD Slot 2 Reset
-
-  {GPIO_VER4_S_GPP_K2,   {GpioPadModeGpio, GpioHostOwnAcpi, GpioDirOut,     GpioOutHigh,     GpioIntDefault,          GpioPlatformReset,  GpioTermNone }}, //PCH M.2 SSD Slot 3 Power enable
-  //{GPIO_VER4_S_GPP_B6,   {GpioPadModeGpio, GpioHostOwnAcpi, GpioDirOut,     GpioOutLow,      GpioIntDefault,          GpioPlatformReset,  GpioTermNone}},//PCH M.2 SSD Slot 3 Reset
-  {GPIO_VER4_S_GPP_F5,    {GpioPadModeGpio, GpioHostOwnGpio, GpioDirOut,     GpioOutHigh,     GpioIntDefault,          GpioResetDefault,   GpioTermNone}}, //POR Thunderbolt RTD3 enable,and CIO_PWR_EN
-  {0x0}
-};
-
 #endif

--- a/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -625,10 +625,8 @@ DEBUG_CODE_END();
       ConfigureGpio (CDATA_NO_TAG, sizeof (mGpioTablePreMemAdlPDdr5Rvp) / sizeof (mGpioTablePreMemAdlPDdr5Rvp[0]), (UINT8*)mGpioTablePreMemAdlPDdr5Rvp);
       break;
     case PLATFORM_ID_TEST_S_DDR5_UDIMM_RVP:
-      ConfigureGpio (CDATA_NO_TAG, sizeof (mGpioTableEarlyPreMemTestSDdr5UDimm1DRvp) / sizeof (mGpioTableEarlyPreMemTestSDdr5UDimm1DRvp[0]), (UINT8*)mGpioTableEarlyPreMemTestSDdr5UDimm1DRvp);
-      break;
     case PLATFORM_ID_TEST_S_DDR5_SODIMM_RVP:
-      ConfigureGpio (CDATA_NO_TAG, sizeof (mGpioTableEarlyPreMemTestSDdr5SODimm1DRvp) / sizeof (mGpioTableEarlyPreMemTestSDdr5SODimm1DRvp[0]), (UINT8*)mGpioTableEarlyPreMemTestSDdr5SODimm1DRvp);
+      ConfigureGpio (CDATA_NO_TAG, sizeof (mGpioTableEarlyPreMemTestSDdr5UDimm1DRvp) / sizeof (mGpioTableEarlyPreMemTestSDdr5UDimm1DRvp[0]), (UINT8*)mGpioTableEarlyPreMemTestSDdr5UDimm1DRvp);
       break;
     case PLATFORM_ID_ADL_PS_DDR5_RVP:
       ConfigureGpio (CDATA_NO_TAG, sizeof (mGpioTablePreMemAdlPsDdr5Rvp) / sizeof (mGpioTablePreMemAdlPsDdr5Rvp[0]), (UINT8*)mGpioTablePreMemAdlPsDdr5Rvp);


### PR DESCRIPTION
Premem GPIO table for S17 board caused boot hang,
so revert the change back.

Signed-off-by: Guo Dong <guo.dong@intel.com>