### PR TITLE
FWU: refine the reboot timing for different payload combinations

### DIFF
--- a/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
+++ b/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
@@ -42,6 +42,11 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define MAX_FW_COMPONENTS       6
 #define MAX_FW_FAILED_RETRY     3
 
+#define CSME_NEED_RESET_INIT     0xFF
+#define CSME_NEED_RESET_PENDING  0xFE
+#define CSME_NEED_RESET_DONE     0xFC
+#define CSME_NEED_RESET_INVALID  0xF8
+
 #define CAPSULE_FLAGS_CFG_DATA  BIT0
 
 #define FW_UPDATE_COMP_BIOS_REGION SIGNATURE_32('B', 'I', 'O', 'S')
@@ -111,7 +116,8 @@ typedef struct {
   UINT8                 CapsuleSig[FW_UPDATE_SIG_LENGTH];
   UINT8                 StateMachine;
   UINT8                 RetryCount;
-  UINT8                 Reserved[6];
+  UINT8                 CsmeNeedReset;
+  UINT8                 Reserved[5];
 } FW_UPDATE_STATUS;
 
 typedef struct {

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
@@ -236,6 +236,36 @@ CheckAcmSvn (
   );
 
 /**
+  Read the value of FW_UPDATE_STATUS.CsmeNeedReset
+
+  The CsmeNeedReset flag is used to ensure CSME update
+  has taken effect before processing CMDI payload.
+  This is specific to prevent {OEMKEYREVOCATION} command
+  failure for the case that CSME payload contains OEM KM
+  with key revocation extension.
+
+  @retval  Value  Value of FW_UPDATE_STATUS.CsmeNeedReset
+**/
+UINT8
+ReadCsmeNeedResetFlag (
+  VOID
+  );
+
+/**
+  Write the value to FW_UPDATE_STATUS.CsmeNeedReset
+
+  @param[in] Value  Value to be written to FW_UPDATE_STATUS.CsmeNeedReset
+
+  @retval  EFI_SUCCESS            Write operation is successful
+  @retval  EFI_INVALID_PARAMETER  Invalid parameter
+  @retval  EFI_DEVICE_ERROR       Write operation failed
+**/
+EFI_STATUS
+WriteCsmeNeedResetFlag (
+  IN  UINT8  Value
+  );
+
+/**
   Reboot platform.
 
   @param[in]  ResetType   Cold, Warm or Shutdown


### PR DESCRIPTION
- If BIOS update is followed by any payload,
  reboot to ensure the update is completed.
- Before processing CMDI payload, ensure CSME update has
  taken effect to prevent {OEMKEYREVOCATION} command failure.

Signed-off-by: Vincent Chen <vincent.chen@intel.com>