### PR TITLE
[ADL-N/P/PS] Workaround for S4 resume when S0ix disabled.

### DIFF
--- a/Platform/AlderlakeBoardPkg/AcpiTables/Dsdt/Pep.asl
+++ b/Platform/AlderlakeBoardPkg/AcpiTables/Dsdt/Pep.asl
@@ -603,7 +603,7 @@ Scope(\_SB)
 
     Method(_STA, 0x0, NotSerialized)
     {
-      If(LOr(LGreaterEqual(OSYS,2015), LAnd(LGreaterEqual(OSYS,2012),LEqual(S0ID, 1))))
+      If(LEqual(S0ID, 1))
       {
         PSOP () // Update _DSD
         Return(0xf)


### PR DESCRIPTION
Remove OS version check in PEPD _STA method. This is a change to the intelpep.sys ASL device (PEPD) for low power idle support. Previously, _STA would always return present/enabled for Win10 even if S0ix config flag was disabled. Changed version always returns status based on S0ix flag. Without this workaround, S4 resume was failing on ADL-N/P/PS.

Signed-off-by: Bejean Mosher <bejean.mosher@intel.com>