### PR TITLE
[ADL-P] Revert USB4 CM mode to FW CM only.

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -1118,7 +1118,7 @@ UpdateFspConfig (
 
     switch (GetPlatformId ()) {
       case PLATFORM_ID_ADL_P_DDR5_RVP:
-        FspsConfig->Usb4CmMode = 0x1;
+        FspsConfig->Usb4CmMode = 0x0;
         break;
       case PLATFORM_ID_ADL_N_DDR5_CRB:
         FspsConfig->PchLanEnable = 0x0;


### PR DESCRIPTION
Previous setting of SW-first CM mode was causing a hang during S3/S4 entry. Likely this setting requires additional ACPI/driver support which is missing.

Signed-off-by: Bejean Mosher <bejean.mosher@intel.com>