### PR TITLE
[ADL] Fix for THC1 PEP constraints appearing even when device is disa…

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/LowPowerSupport.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/LowPowerSupport.c
@@ -198,7 +198,8 @@ UINT64 GetLowPowerS0IdleConstraint(VOID)
     //
     if (FspsConfig->ThcPort0Assignment  != 1) {
       PepConfigData->PepThc0 = 0;
-    } else if (FspsConfig->ThcPort1Assignment  != 2) {
+    } 
+    if (FspsConfig->ThcPort1Assignment  != 1) {
       PepConfigData->PepThc1 = 0;
     }
 


### PR DESCRIPTION
…bled.

FSP-S UPD format for THC port assignment was updated, but PEP logic was using the old format, and causing the PEP constraint to always be enabled. This issue didn't seem to be causing a problem, but resulted in noncompliant low power idle constraints.