### PR TITLE
[ADL] Remove duplicated S3 code

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -428,17 +428,8 @@ BoardInit (
     HeciRegisterHeciService ();
     ClearSmi ();
     if (GetPayloadId () == UEFI_PAYLOAD_ID_SIGNATURE) {
-      if (GetBootMode() == BOOT_ON_S3_RESUME) {
-        RestoreS3RegInfo (FindS3Info (S3_SAVE_REG_COMM_ID));
-        //
-        // If payload registered a software SMI handler for bootloader to restore
-        // SMRR base and mask in S3 resume path, trigger sw smi
-        //
-        BlSwSmiInfo = FindS3Info (BL_SW_SMI_COMM_ID);
-        if (BlSwSmiInfo != NULL) {
-          TriggerPayloadSwSmi (BlSwSmiInfo->BlSwSmiHandlerInput);
-        }
-      } else {
+      if (GetBootMode() != BOOT_ON_S3_RESUME) {
+        ClearS3SaveRegion ();
         //
         // Set SMMBASE_INFO dummy strucutre in TSEG before others
         //


### PR DESCRIPTION
Restore SMM registers was done in the PostPciEnumeration.
so remove the duplicated code in EndOfStages
and call ClearS3SaveRegion() in normal path to avoid
appending multiple restore records.

Signed-off-by: Guo Dong <guo.dong@intel.com>