### PR TITLE
[TGL][EHL] Fix CSME FW update hang on debug fsp build

### DIFF
--- a/Silicon/ElkhartlakePkg/Library/HeciInitLib/HeciHpet.c
+++ b/Silicon/ElkhartlakePkg/Library/HeciInitLib/HeciHpet.c
@@ -11,8 +11,6 @@
 #include <Register/HeciRegs.h>
 #include "HeciCore.h"
 
-GLOBAL_REMOVE_IF_UNREFERENCED UINT32 mHpetBaseAddr = 0;
-
 /**
   Used for calculating timeouts
 
@@ -30,16 +28,11 @@ StartTimer (
 {
   UINT32 HpetTimer;
 
-  HpetTimer = 0;
-
   ///
   /// Get the High Precision Event Timer base address
   ///
-  if (mHpetBaseAddr == 0) {
-    mHpetBaseAddr = HPET_BASE_ADDRESS;
-  } else {
-    HpetTimer = mHpetBaseAddr;
-  }
+
+  HpetTimer = HPET_BASE_ADDRESS;
 
   ///
   /// Start the timer so it is up and running
@@ -77,16 +70,10 @@ IsHeciTimeout (
   UINT32 Current;
   UINT32 HpetTimer;
 
-  HpetTimer = 0;
-
   ///
   /// Get the High Precision Event Timer base address
   ///
-  if (mHpetBaseAddr == 0) {
-    mHpetBaseAddr = HPET_BASE_ADDRESS;
-  } else {
-    HpetTimer = mHpetBaseAddr;
-  }
+  HpetTimer = HPET_BASE_ADDRESS;
 
   ///
   /// Read HPET and assign the value as the current time.

--- a/Silicon/TigerlakePchPkg/Library/HeciInitLib/HeciHpet.c
+++ b/Silicon/TigerlakePchPkg/Library/HeciInitLib/HeciHpet.c
@@ -13,8 +13,6 @@
 #include <PchAccess.h>
 #include "HeciCore.h"
 
-GLOBAL_REMOVE_IF_UNREFERENCED UINT32 mHpetBaseAddr = 0;
-
 /**
   Used for calculating timeouts
 
@@ -32,16 +30,11 @@ StartTimer (
 {
   UINT32 HpetTimer;
 
-  HpetTimer = 0;
-
   ///
   /// Get the High Precision Event Timer base address
   ///
-  if (mHpetBaseAddr == 0) {
-    mHpetBaseAddr = HPET_BASE_ADDRESS;
-  } else {
-    HpetTimer = mHpetBaseAddr;
-  }
+  HpetTimer = HPET_BASE_ADDRESS;
+
 
   ///
   /// Start the timer so it is up and running
@@ -79,16 +72,10 @@ IsHeciTimeout (
   UINT32 Current;
   UINT32 HpetTimer;
 
-  HpetTimer = 0;
-
   ///
   /// Get the High Precision Event Timer base address
   ///
-  if (mHpetBaseAddr == 0) {
-    mHpetBaseAddr = HPET_BASE_ADDRESS;
-  } else {
-    HpetTimer = mHpetBaseAddr;
-  }
+  HpetTimer = HPET_BASE_ADDRESS;
 
   ///
   /// Read HPET and assign the value as the current time.


### PR DESCRIPTION
The HPET timer address is wrong at first time invoke.
Assign to fixed value directly.

Verified on EHL TGLU.

Signed-off-by: Randy Lin <randy.lin@intel.com>