### PR TITLE
[ADLPS] Remove PlatformNvs parameters

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
@@ -1052,7 +1052,6 @@ PlatformUpdateAcpiGnvs (
     PlatformNvs->PcieSlot2RpNumber = 5;
     break;
   case PLATFORM_ID_ADL_P_DDR5_RVP:
-  case PLATFORM_ID_ADL_PS_DDR5_RVP:
     PlatformNvs->PcieSlot1WakeGpio = 0;
     PlatformNvs->PcieSlot1PowerEnableGpio = GPIO_VER2_LP_GPP_A22;
     PlatformNvs->PcieSlot1PowerEnableGpioPolarity = 0;


### PR DESCRIPTION
Current PlatformNvs parameters are causing the power management
(S3, S4 and S5) in Windows OS. Removing the Nvs parameters will fixed
the issues.

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>