### PR TITLE
[ADLS] Tcc related fixes

### DIFF
--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
@@ -99,7 +99,7 @@ SortSysCpu (
     return;
   }
 
-  // Sort the CPU by APIC ID
+  // Sort the CPU by APIC ID (ascending order)
   PerformQuickSort (SysCpuInfo->CpuInfo, SysCpuInfo->CpuCount, sizeof (CPU_INFO), CompareCpuApicId, &Temp);
 
   if (FixedPcdGet32 (PcdCpuSortMethod) == 2) {

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlS.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlS.py
@@ -164,6 +164,7 @@ class Board(BaseBoard):
             self.TCC_CRL_SIZE    = 0x00008000
             self.TCC_STREAM_SIZE = 0x00005000
             self.SIIPFW_SIZE    += self.TCC_CCFG_SIZE + self.TCC_CRL_SIZE + self.TCC_STREAM_SIZE
+            self.CPU_SORT_METHOD = 1  #sort CPU threads in ascending order
 
         self.ENABLE_TSN = 0
         if self.ENABLE_TSN:

--- a/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr4.dlt
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr4.dlt
@@ -52,6 +52,9 @@ MEMORY_CFG_DATA.PchHdaAudioLinkDmicEnable  | {0x1, 0x1}
 MEMORY_CFG_DATA.PchHdaDspEnable            | 0x1
 MEMORY_CFG_DATA.DmiMaxLinkSpeed            | 0x0
 
+# Increase the size to 64MB in order to get rid of an error during Tcc init flow in FSP
+MEMORY_CFG_DATA.PlatformMemorySize | 0x4000000
+
 PLDSEL_CFG_DATA.PldSelGpio.Enable      | 1
 PLDSEL_CFG_DATA.PldSelGpio.PadGroup    | 5
 PLDSEL_CFG_DATA.PldSelGpio.PinNumber   | 3

--- a/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr5.dlt
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr5.dlt
@@ -52,6 +52,9 @@ MEMORY_CFG_DATA.PchHdaAudioLinkHdaEnable   | 0x1
 MEMORY_CFG_DATA.PchHdaAudioLinkDmicEnable  | {0x1, 0x1}
 MEMORY_CFG_DATA.PchHdaDspEnable            | 0x1
 
+# Increase the size to 64MB in order to get rid of an error during Tcc init flow in FSP
+MEMORY_CFG_DATA.PlatformMemorySize | 0x4000000
+
 PLDSEL_CFG_DATA.PldSelGpio.Enable      | 1
 PLDSEL_CFG_DATA.PldSelGpio.PadGroup    | 5
 PLDSEL_CFG_DATA.PldSelGpio.PinNumber   | 3


### PR DESCRIPTION
- Increase PlatformMemorySize to get rid of FSP error caused
during Tcc SRAM init.
- Sort the CPUs in ascending order for Tcc validation purpose.

Signed-off-by: Sindhura Grandhi <sindhura.grandhi@intel.com>