### PR TITLE
[ADL] Clear RTC EN SCI to avoid interrupt storming

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.h
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.h
@@ -99,6 +99,7 @@
 #include "GpioPinsVer2Lp.h"
 #include <Library/TimerLib.h>
 #include <Library/PrintLib.h>
+#include <Register/RtcRegs.h>
 
 #define NHLT_ACPI_TABLE_SIGNATURE  SIGNATURE_32 ('N', 'H', 'L', 'T')
 #define V_EPOC_XTAL_38_4_MHZ  0x249F000

--- a/Silicon/AlderlakePkg/Include/Register/PmcRegs.h
+++ b/Silicon/AlderlakePkg/Include/Register/PmcRegs.h
@@ -51,6 +51,7 @@
 #define V_ACPI_IO_PM1_CNT_S4                     (BIT12 | BIT11)
 #define V_ACPI_IO_PM1_CNT_S5                     (BIT12 | BIT11 | BIT10)
 #define B_ACPI_IO_PM1_CNT_SCI_EN                 BIT0                                   ///< SCI Enable
+#define B_ACPI_IO_PM1_STS_RTC_EN                 BIT26
 
 #define R_ACPI_IO_PM1_TMR                        0x08                                   ///< Power Management 1 Timer
 #define V_ACPI_IO_PM1_TMR_MAX_VAL                0x1000000       ///< The timer is 24 bit overflow

--- a/Silicon/AlderlakePkg/Include/Register/RtcRegs.h
+++ b/Silicon/AlderlakePkg/Include/Register/RtcRegs.h
@@ -43,5 +43,8 @@ Conventions:
 // RTC PCRs (PID:RTC)
 //
 #define R_RTC_PCR_BUC                         0x3414               ///< Backed Up Control
+#define R_RTC_IO_INDEX                        0x70
+#define R_RTC_IO_TARGET                       0x71
+#define R_RTC_IO_REGC                         0x0C
 
 #endif


### PR DESCRIPTION
Clear the RTC EN SCI flag to avoid interrupt storming
that cause system hang when using rtcwake method to perform
powre management test

Signed-off-by: Ong Kok Tong <kok.tong.ong@intel.com>