### PR TITLE
[EHL] UPDs for Zephyr support

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -1905,6 +1905,13 @@
                      Set PSE TSN 1 Phy Interface Type 0: Not Connected, 1: RGMII, 2: SGMII, 3:SGMII+
       length       : 2b
       value        : 0x01
+  - PchPseEcliteEnabled:
+      name         : Enable PSE ECLITE option
+      type         : EditNum, HEX, (0x0,0xFF)
+      help         : >
+                     Set if to enable PSE Eclite feature. 0: Disable; 1: Enable.
+      length       : 1b
+      value        : 0x1
   - PchPseAicEnabled:
       name         : Enable PSE AIC SPI1 option
       type         : EditNum, HEX, (0x0,0xFF)
@@ -1926,5 +1933,5 @@
       option       : $EN_DIS
       help         : >
                      Reserved for SA Post-Mem Test
-      length       : 13b
+      length       : 12b
       value        : 0x0

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -988,10 +988,10 @@ FspUpdatePsePolicy (
   Fspscfg->PchPseLogOutputChannel = SiCfgData->PchPseLogOutputChannel;
   Fspscfg->PchPseLogOutputSize    = SiCfgData->PchPseLogOutputSize;
   Fspscfg->PchPseLogOutputOffset  = SiCfgData->PchPseLogOutputOffset;
-  Fspscfg->PchPseEcliteEnabled    = 1;
   Fspscfg->PchPseOobEnabled       = 0;
   Fspscfg->PchPseWoLEnabled       = 1;
   Fspscfg->PchPseAicEnabled       = (UINT8)SiCfgData->PchPseAicEnabled;
+  Fspscfg->PchPseEcliteEnabled    = (UINT8)SiCfgData->PchPseEcliteEnabled;
   Fspscfg->CpuTempSensorReadEnable= 1;
   //Fspscfg->PseJtagEnabled       = 0;
   //Fspscfg->PseJtagPinMux        = 0;
@@ -1039,6 +1039,7 @@ FspUpdatePsePolicy (
     Fspscfg->PchPseSpiEnable[Index]            = SiCfgData->PchPseSpiEnable[Index];
     Fspscfg->PchPseSpiSbInterruptEnable[Index] = SiCfgData->PchPseSpiSbInterruptEnable[Index];
     Fspscfg->PchPseSpiCs0Enable[Index]         = SiCfgData->PchPseSpiCs0Enable[Index];
+    Fspscfg->PchPseSpiCs1Enable[Index]          = SiCfgData->PchPseSpiCs1Enable[Index];
   }
   Fspscfg->PchPseSpiMosiPinMux[1]              = GPIO_VER3_MUXING_PSE_SPI1_MOSI_GPP_D3;
   Fspscfg->PchPseSpiMisoPinMux[1]              = GPIO_VER3_MUXING_PSE_SPI1_MISO_GPP_D2;


### PR DESCRIPTION
1. Expose PchPseEcliteEnabled
2. PchPseSpiCs1Enable is unconfigurable, fix it.

Signed-off-by: Randy Lin <randy.lin@intel.com>