### PR TITLE
[ADLS] Update FSP/VBT/UCODE/platform version since MR2 is released

### DIFF
--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlS.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlS.py
@@ -25,7 +25,7 @@ class Board(BaseBoard):
 
         self.VERINFO_IMAGE_ID     = 'SBL_ADL'
         self.VERINFO_PROJ_MAJOR_VER = 1
-        self.VERINFO_PROJ_MINOR_VER = 1
+        self.VERINFO_PROJ_MINOR_VER = 2
         self.VERINFO_SVN            = 1
         self.VERINFO_BUILD_DATE     = time.strftime("%m/%d/%Y")
 

--- a/Silicon/AlderlakePkg/FspBin/FspBin.inf
+++ b/Silicon/AlderlakePkg/FspBin/FspBin.inf
@@ -11,7 +11,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = 81dd5055f4c75db7c7b3d69fbc00c218a329bfa4
+  COMMIT  = 5d78fcc69817771c5b60ebe96b4e126766a33712
 
 [UserExtensions.SBL."CopyList"]
 # For ADL-S

--- a/Silicon/AlderlakePkg/Microcode/Microcode.inf
+++ b/Silicon/AlderlakePkg/Microcode/Microcode.inf
@@ -14,13 +14,13 @@
   VERSION_STRING       = 1.0
 
 [Sources]
-  m_03_90672_0000001e.mcb
+  m_07_90672_00000023.mcb
   m_80_906a3_00000421.mcb
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
-  COMMIT = affdf8d09b6767b2bca01ea8343f45755c9d657b
+  COMMIT = 7c77c0df56bd4bb3f80b7a0a4dbfde136eab0c04
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/AlderLake/m_03_90672_0000001e.pdb  : Silicon/AlderlakePkg/Microcode/m_03_90672_0000001e.mcb
+  Microcode/AlderLake/m_07_90672_00000023.pdb  : Silicon/AlderlakePkg/Microcode/m_07_90672_00000023.mcb
   Microcode/AlderLake/m_80_906a3_00000421.pdb  : Silicon/AlderlakePkg/Microcode/m_80_906a3_00000421.mcb


### PR DESCRIPTION
- FSP version - 0C.00.69.74
- Vbt version - 1077
- Microcode version - m_07_90672_00000023
- Minor version updated to '2' for MR2.

Signed-off-by: Sindhura Grandhi <sindhura.grandhi@intel.com>