### PR TITLE
Resolve Klocwork alarm

### DIFF
--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -1537,6 +1537,11 @@ InitFirmwareRecovery (
 
   AllocateSize = sizeof (FIRMWARE_UPDATE_PARTITION) + sizeof (FIRMWARE_UPDATE_REGION);
   UpdatePartition = (FIRMWARE_UPDATE_PARTITION *) AllocateZeroPool (AllocateSize);
+
+  if (UpdatePartition == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   UpdatePartition->RegionCount = 2;
 
   if (GetCurrentBootPartition () == PrimaryPartition) {


### PR DESCRIPTION
Adds a null check before dereference of a pointer
in the FW recovery flow

Signed-off-by: Sean McGinn <sean.mcginn@intel.com>