### PR TITLE
[TGL] Init EC CPU fan control

### DIFF
--- a/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/EcSupport.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/EcSupport.c
@@ -27,7 +27,11 @@
 #define EC_TIME_OUT      0x20000
 
 #define EC_C_FAB_ID         0x0D    // Get the board fab ID in the lower 3 bits
+#define EC_C_UPDATE_PWM     0x1A    // Update the FAN Speed
 #define EC_C_LOW_POWER_EXIT 0x2D    // Exit Low Power Mode
+#define EC_C_FAIL_SAFE_FAN_CTRL    0x39    // Set Fail safe FAN speed for given Cpu temp
+#define EC_C_WRITE_MEM      0x81    // Write the EC memory
+
 
 #define EC_S_IBF         0x02    // Input buffer is full/empty
 #define EC_S_OBF         0x01    // Output buffer is full/empty
@@ -71,9 +75,8 @@ ReceiveEcStatus (
 }
 
 /**
-  Sends command to EC.
+  Wait EC to be ready
 
-  @param[in] Command           Command byte to send
   @param[in] Timeout           Timeout in microseonds
 
   @retval    EFI_SUCCESS       Command success
@@ -81,8 +84,7 @@ ReceiveEcStatus (
   @retval    EFI_TIMEOUT       Command timeout
 **/
 EFI_STATUS
-SendEcCommandTimeout (
-  IN UINT8                  Command,
+WaitEcReady (
   IN UINT32                 Timeout
   )
 {
@@ -126,7 +128,32 @@ SendEcCommandTimeout (
     return EFI_TIMEOUT;
   }
 
-  //Printing EC Command Sent
+  return EFI_SUCCESS;
+}
+
+/**
+  Sends command to EC.
+
+  @param[in] Command           Command byte to send
+  @param[in] Timeout           Timeout in microseonds
+
+  @retval    EFI_SUCCESS       Command success
+  @retval    EFI_DEVICE_ERROR  Command error
+  @retval    EFI_TIMEOUT       Command timeout
+**/
+EFI_STATUS
+SendEcCommandTimeout (
+  IN UINT8                  Command,
+  IN UINT32                 Timeout
+  )
+{
+  EFI_STATUS Status;
+
+  Status = WaitEcReady (Timeout);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
   DEBUG ((DEBUG_INFO, "Sending EC Command: %02X\n", Command));
 
   //
@@ -134,9 +161,44 @@ SendEcCommandTimeout (
   //
   IoWrite8 (EC_C_PORT, Command);
 
-  DEBUG ((DEBUG_INFO, "SendEcDataTimeout sent %x \n", Command));
+  DEBUG ((DEBUG_INFO, "SendEcCommandTimeout sent %x\n", Command));
 
-  return EFI_SUCCESS;
+  return Status;
+}
+
+/**
+  Sends data to EC.
+
+  @param[in] Data              Data byte to send
+  @param[in] Timeout           Timeout in microseonds
+
+  @retval    EFI_SUCCESS       Command success
+  @retval    EFI_DEVICE_ERROR  Command error
+  @retval    EFI_TIMEOUT       Command timeout
+**/
+EFI_STATUS
+SendEcDataTimeout (
+  IN UINT8                  Data,
+  IN UINT32                 Timeout
+  )
+{
+  EFI_STATUS Status;
+
+  Status = WaitEcReady (Timeout);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  DEBUG ((DEBUG_INFO, "Sending EC Data: %02X\n", Data));
+
+  //
+  // Send the EC data
+  //
+  IoWrite8 (EC_D_PORT, Data);
+
+  DEBUG ((DEBUG_INFO, "SendEcDataTimeout sent %x\n", Data));
+
+  return Status;
 }
 
 /**
@@ -169,7 +231,7 @@ ReceiveEcDataTimeout (
     ReceiveEcStatus (&EcStatus);
     Index++;
   }
-  DEBUG ((DEBUG_INFO, "ReceiveEcDataTimeout Read %x \n",EcStatus));
+  DEBUG ((DEBUG_INFO, "ReceiveEcDataTimeout Read %x\n",EcStatus));
 
   if (Index >= Timeout) {
     return EFI_TIMEOUT;
@@ -186,28 +248,20 @@ ReceiveEcDataTimeout (
 }
 
 /**
-  Get the board ID from EC.
+  Wake up EC
 
-  @param[out] BoardId       Buffer to return the board ID
-
+  @retval    EFI_SUCCESS       Command success
+  @retval    EFI_DEVICE_ERROR  Command error
+  @retval    EFI_TIMEOUT       Command timeout
 **/
-VOID
-GetBoardId (
-  OUT UINT8                  *BoardId
+EFI_STATUS
+WakeupEc (
+  VOID
 )
 {
-  BOARD_ID_INFO BoardInfo;
   EFI_STATUS Status;
   UINTN   LpcBaseAddr;
   UINT16  Data16;
-  UINT8   EcData;
-
-  //
-  // Set board ID to unknown initially
-  // in case there is any issue encountered
-  // below.
-  //
-  *BoardId = 0xFF;
 
   LpcBaseAddr = PCI_LIB_ADDRESS (
                       DEFAULT_PCI_BUS_NUMBER_PCH,
@@ -220,11 +274,42 @@ GetBoardId (
   MmioWrite16 (PCH_PCR_ADDRESS (PID_DMI, R_PCH_DMI_PCR_LPCIOE), Data16);
   PciCf8Write16 (LpcBaseAddr + R_LPC_CFG_IOE, Data16);
 
-  BoardInfo.Raw = 0;
   Status = SendEcCommandTimeout (EC_C_LOW_POWER_EXIT, EC_TIME_OUT);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  return Status;
+}
+
+/**
+  Get the board ID from EC.
+
+  @param[out] BoardId       Buffer to return the board ID
+
+**/
+VOID
+GetBoardId (
+  OUT UINT8                  *BoardId
+)
+{
+  BOARD_ID_INFO BoardInfo;
+  EFI_STATUS Status;
+  UINT8   EcData;
+
+  //
+  // Set board ID to unknown initially
+  // in case there is any issue encountered
+  // below.
+  //
+  *BoardId = 0xFF;
+
+  BoardInfo.Raw = 0;
+  Status = WakeupEc ();
   if (EFI_ERROR (Status)) {
     return;
   }
+
   Status = SendEcCommandTimeout (EC_C_FAB_ID, EC_TIME_OUT);
   if (EFI_ERROR (Status)) {
     return;
@@ -244,4 +329,62 @@ GetBoardId (
   BoardInfo.Raw |= (UINT16) EcData;
 
   *BoardId = (UINT8) BoardInfo.TglRvpFields.BoardId;
+}
+
+/**
+  Initialize Cpu Fan Control
+
+**/
+VOID
+InitEcCpuFanControl (
+  VOID
+)
+{
+  EFI_STATUS Status;
+
+  Status = WakeupEc ();
+  if (EFI_ERROR (Status)) {
+    return;
+  }
+
+  // Set FailSafe Critical Temp & Fan Speed setting
+  DEBUG ((DEBUG_INFO, "EC: Set FailSafe Critical Temp & Fan\n"));
+  Status = SendEcCommandTimeout (EC_C_FAIL_SAFE_FAN_CTRL, EC_TIME_OUT);
+  if (EFI_ERROR (Status)) {
+    return;
+  }
+
+  Status = SendEcDataTimeout (85, EC_TIME_OUT);
+  if (EFI_ERROR (Status)) {
+    return;
+  }
+
+  Status = SendEcDataTimeout (65, EC_TIME_OUT);
+  if (EFI_ERROR (Status)) {
+    return;
+  }
+
+  // Set fan speed: Pwm value at offset 0x44
+  DEBUG ((DEBUG_INFO, "EC: Set fan pwm\n"));
+  Status = SendEcCommandTimeout (EC_C_WRITE_MEM, EC_TIME_OUT);
+  if (EFI_ERROR (Status)) {
+    return;
+  }
+
+  Status = SendEcDataTimeout (0x44, EC_TIME_OUT);
+  if (EFI_ERROR (Status)) {
+    return;
+  }
+
+  Status = SendEcDataTimeout (0x64, EC_TIME_OUT);
+  if (EFI_ERROR (Status)) {
+    return;
+  }
+
+  // Update PWM
+  Status = SendEcCommandTimeout (EC_C_UPDATE_PWM, EC_TIME_OUT);
+  DEBUG ((DEBUG_INFO, "EC: Update Pwm\n"));
+  if (EFI_ERROR (Status)) {
+    return;
+  }
 }

--- a/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -58,6 +58,12 @@ GetBoardId (
   OUT UINT8 *BoardId
 );
 
+VOID
+InitEcCpuFanControl (
+  VOID
+);
+
+
 /**
   Update FSP-M UPD config data for TCC mode and tuning
 
@@ -845,6 +851,7 @@ DEBUG_CODE_END();
     PlatformNameInit ();
     SetBootMode (IsFirmwareUpdate() ? BOOT_ON_FLASH_UPDATE : GetPlatformPowerState());
     PlatformFeaturesInit ();
+    InitEcCpuFanControl ();
     break;
   case PreMemoryInit:
     //


### PR DESCRIPTION
Without initializing CPU fan control, EC will stop CPU fan after default
timeout. This patch initializes CPU fan control and fail safe control.

Some scenarios are related to the case: (1) bootloader shell;
(2) unexpected hang; (3) OS with no ACPI support; and (4) OS fails to
load ACPI driver

Test method:
1. monitor CPU fan under SBL / UEFI Payload shell: expect non-stop
2. check CPU fan status after Linux starts: expect ACPI controls it

Verified: TGL RVP

Signed-off-by: Stanley Chang <stanley.chang@intel.com>