### PR TITLE
Cover IBB corruption in SBL resiliency implementation

### DIFF
--- a/BootloaderCommonPkg/Include/FirmwareUpdateStatus.h
+++ b/BootloaderCommonPkg/Include/FirmwareUpdateStatus.h
@@ -1,0 +1,72 @@
+/** @file
+The header file for firmware update status definitions.
+
+Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _FIRMWARE_UPDATE_STATUS_H_
+#define _FIRMWARE_UPDATE_STATUS_H_
+
+#define FW_UPDATE_SM_INIT             0xFF
+#define FW_UPDATE_SM_CAP_PROCESSING   0x7F
+#define FW_UPDATE_SM_PART_A           0x7E
+#define FW_UPDATE_SM_PART_B           0x7D
+#define FW_UPDATE_SM_PART_AB          0x7C
+#define FW_UPDATE_SM_RECOVERY         0x7B
+#define FW_UPDATE_SM_DONE             0x77 // Lower 3 bits are ignored
+
+#define FW_UPDATE_IMAGE_UPDATE_NONE         0xFF
+#define FW_UPDATE_IMAGE_UPDATE_PENDING      0xFE
+#define FW_UPDATE_IMAGE_UPDATE_PROCESSING   0xFC
+#define FW_UPDATE_IMAGE_UPDATE_DONE         0xF8
+
+#define CSME_NEED_RESET_INIT     0xFF
+#define CSME_NEED_RESET_PENDING  0xFE
+#define CSME_NEED_RESET_DONE     0xFC
+#define CSME_NEED_RESET_INVALID  0xF8
+
+#define FW_UPDATE_COMP_BIOS_REGION SIGNATURE_32('B', 'I', 'O', 'S')
+#define FW_UPDATE_COMP_CSME_REGION SIGNATURE_32('C', 'S', 'M', 'E')
+#define FW_UPDATE_COMP_CSME_DRIVER SIGNATURE_32('C', 'S', 'M', 'D')
+#define FW_UPDATE_COMP_CMD_REQUEST SIGNATURE_32('C', 'M', 'D', 'I')
+#define FW_UPDATE_COMP_ACM0_REGION SIGNATURE_32('A', 'C', 'M', '0')
+#define FW_UPDATE_COMP_UCOD_REGION SIGNATURE_32('U', 'C', 'O', 'D')
+
+#define FW_UPDATE_STATUS_SIGNATURE    SIGNATURE_32 ('F', 'W', 'U', 'S')
+#define FW_RECOVERY_STATUS_SIGNATURE  SIGNATURE_32 ('F', 'W', 'R', 'S')
+#define FW_UPDATE_STATUS_VERSION      0x1
+#define FW_UPDATE_SIG_LENGTH          256
+
+#pragma pack(push, 1)
+//
+// Firmware Update status structure
+// This structure maintains the firmware update status
+// in the non volatile reserved region of Slim Bootloader
+// ESRT ACPI table will be populated based on this structure
+//
+typedef struct {
+  UINT32                Signature;
+  UINT16                Version;
+  UINT16                Length;
+  UINT8                 CapsuleSig[FW_UPDATE_SIG_LENGTH];
+  UINT8                 StateMachine;
+  UINT8                 RetryCount;
+  UINT8                 CsmeNeedReset;
+  UINT8                 Reserved[5];
+} FW_UPDATE_STATUS;
+
+typedef struct {
+  EFI_GUID              FirmwareId;
+  UINT64                HardwareInstance;
+  UINT32                LastAttemptVersion;
+  UINT32                LastAttemptStatus;
+  UINT8                 UpdatePending;
+  UINT8                 Reserved[3];
+} FW_UPDATE_COMP_STATUS;
+
+#pragma pack(pop)
+
+#endif
+

--- a/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
+++ b/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
@@ -104,6 +104,39 @@ typedef enum {
   BackupPartition
 } BOOT_PARTITION;
 
+//
+// States for FWU state machine
+//
+#define FW_UPDATE_SM_INIT             0xFF
+#define FW_UPDATE_SM_CAP_PROCESSING   0x7F
+#define FW_UPDATE_SM_PART_A           0x7E
+#define FW_UPDATE_SM_PART_B           0x7D
+#define FW_UPDATE_SM_PART_AB          0x7C
+#define FW_UPDATE_SM_RECOVERY         0x7B
+#define FW_UPDATE_SM_DONE             0x77 // Lower 3 bits are ignored
+
+#define FW_UPDATE_SIG_LENGTH    256
+
+#pragma pack(push, 1)
+//
+// Firmware Update status structure
+// This structure maintains the firmware update status
+// in the non volatile reserved region of Slim Bootloader
+// ESRT ACPI table will be populated based on this structure
+//
+typedef struct {
+  UINT32                Signature;
+  UINT16                Version;
+  UINT16                Length;
+  UINT8                 CapsuleSig[FW_UPDATE_SIG_LENGTH];
+  UINT8                 StateMachine;
+  UINT8                 RetryCount;
+  UINT8                 CsmeNeedReset;
+  UINT8                 Reserved[5];
+} FW_UPDATE_STATUS;
+
+#pragma pack(pop)
+
 /**
   Returns the current stage of Bootloader execution.
 

--- a/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
+++ b/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
@@ -104,39 +104,6 @@ typedef enum {
   BackupPartition
 } BOOT_PARTITION;
 
-//
-// States for FWU state machine
-//
-#define FW_UPDATE_SM_INIT             0xFF
-#define FW_UPDATE_SM_CAP_PROCESSING   0x7F
-#define FW_UPDATE_SM_PART_A           0x7E
-#define FW_UPDATE_SM_PART_B           0x7D
-#define FW_UPDATE_SM_PART_AB          0x7C
-#define FW_UPDATE_SM_RECOVERY         0x7B
-#define FW_UPDATE_SM_DONE             0x77 // Lower 3 bits are ignored
-
-#define FW_UPDATE_SIG_LENGTH    256
-
-#pragma pack(push, 1)
-//
-// Firmware Update status structure
-// This structure maintains the firmware update status
-// in the non volatile reserved region of Slim Bootloader
-// ESRT ACPI table will be populated based on this structure
-//
-typedef struct {
-  UINT32                Signature;
-  UINT16                Version;
-  UINT16                Length;
-  UINT8                 CapsuleSig[FW_UPDATE_SIG_LENGTH];
-  UINT8                 StateMachine;
-  UINT8                 RetryCount;
-  UINT8                 CsmeNeedReset;
-  UINT8                 Reserved[5];
-} FW_UPDATE_STATUS;
-
-#pragma pack(pop)
-
 /**
   Returns the current stage of Bootloader execution.
 

--- a/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
+++ b/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
@@ -22,14 +22,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define MAX_UPDATE_REGIONS      4
 
-#define FW_UPDATE_SM_INIT             0xFF
-#define FW_UPDATE_SM_CAP_PROCESSING   0x7F
-#define FW_UPDATE_SM_PART_A           0x7E
-#define FW_UPDATE_SM_PART_B           0x7D
-#define FW_UPDATE_SM_PART_AB          0x7C
-#define FW_UPDATE_SM_RECOVERY         0x7B
-#define FW_UPDATE_SM_DONE             0x77 // Lower 3 bits are ignored
-
 #define FW_UPDATE_IMAGE_UPDATE_NONE         0xFF
 #define FW_UPDATE_IMAGE_UPDATE_PENDING      0xFE
 #define FW_UPDATE_IMAGE_UPDATE_PROCESSING   0xFC
@@ -37,8 +29,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define FW_UPDATE_PARTITION_A   0
 #define FW_UPDATE_PARTITION_B   1
-
-#define FW_UPDATE_SIG_LENGTH    256
 
 #define MAX_FILE_LEN            16
 #define MAX_FW_COMPONENTS       6
@@ -100,23 +90,6 @@ typedef struct {
   EFI_SYSTEM_RESOURCE_TABLE     EsrtTablePtr;
   EFI_SYSTEM_RESOURCE_ENTRY     EsrtTableEntry[MAX_FW_COMPONENTS];
 } EFI_FWST_ACPI_DESCRIPTION_TABLE;
-
-//
-// Firmware Update status structure
-// This structure maintains the firmware update status
-// in the non volatile reserved region of Slim Bootloader
-// ESRT ACPI table will be populated based on this structure
-//
-typedef struct {
-  UINT32                Signature;
-  UINT16                Version;
-  UINT16                Length;
-  UINT8                 CapsuleSig[FW_UPDATE_SIG_LENGTH];
-  UINT8                 StateMachine;
-  UINT8                 RetryCount;
-  UINT8                 CsmeNeedReset;
-  UINT8                 Reserved[5];
-} FW_UPDATE_STATUS;
 
 typedef struct {
   EFI_GUID              FirmwareId;

--- a/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
+++ b/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
@@ -16,16 +16,12 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Guid/BootLoaderVersionGuid.h>
 #include <Service/SpiFlashService.h>
 #include <Library/BootloaderCommonLib.h>
+#include <FirmwareUpdateStatus.h>
 
 #define CMOS_ADDREG             0x70
 #define CMOS_DATAREG            0x71
 
 #define MAX_UPDATE_REGIONS      4
-
-#define FW_UPDATE_IMAGE_UPDATE_NONE         0xFF
-#define FW_UPDATE_IMAGE_UPDATE_PENDING      0xFE
-#define FW_UPDATE_IMAGE_UPDATE_PROCESSING   0xFC
-#define FW_UPDATE_IMAGE_UPDATE_DONE         0xF8
 
 #define FW_UPDATE_PARTITION_A   0
 #define FW_UPDATE_PARTITION_B   1
@@ -34,29 +30,12 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define MAX_FW_COMPONENTS       6
 #define MAX_FW_FAILED_RETRY     3
 
-#define CSME_NEED_RESET_INIT     0xFF
-#define CSME_NEED_RESET_PENDING  0xFE
-#define CSME_NEED_RESET_DONE     0xFC
-#define CSME_NEED_RESET_INVALID  0xF8
-
 #define CAPSULE_FLAGS_CFG_DATA  BIT0
-
-#define FW_UPDATE_COMP_BIOS_REGION SIGNATURE_32('B', 'I', 'O', 'S')
-#define FW_UPDATE_COMP_CSME_REGION SIGNATURE_32('C', 'S', 'M', 'E')
-#define FW_UPDATE_COMP_CSME_DRIVER SIGNATURE_32('C', 'S', 'M', 'D')
-#define FW_UPDATE_COMP_CMD_REQUEST SIGNATURE_32('C', 'M', 'D', 'I')
-#define FW_UPDATE_COMP_ACM0_REGION SIGNATURE_32('A', 'C', 'M', '0')
-#define FW_UPDATE_COMP_UCOD_REGION SIGNATURE_32('U', 'C', 'O', 'D')
 
 #define FW_UPDATE_COMP_CSME_REGION_ORDER      1
 #define FW_UPDATE_COMP_CSME_DRIVER_ORDER      2
 #define FW_UPDATE_COMP_BIOS_REGION_ORDER      3
 #define FW_UPDATE_COMP_DEFAULT_ORDER          4
-
-
-#define FW_UPDATE_STATUS_SIGNATURE    SIGNATURE_32 ('F', 'W', 'U', 'S')
-#define FW_RECOVERY_STATUS_SIGNATURE  SIGNATURE_32 ('F', 'W', 'R', 'S')
-#define FW_UPDATE_STATUS_VERSION      0x1
 
 ///
 /// "FWST"  Firmware Update status data Table
@@ -90,15 +69,6 @@ typedef struct {
   EFI_SYSTEM_RESOURCE_TABLE     EsrtTablePtr;
   EFI_SYSTEM_RESOURCE_ENTRY     EsrtTableEntry[MAX_FW_COMPONENTS];
 } EFI_FWST_ACPI_DESCRIPTION_TABLE;
-
-typedef struct {
-  EFI_GUID              FirmwareId;
-  UINT64                HardwareInstance;
-  UINT32                LastAttemptVersion;
-  UINT32                LastAttemptStatus;
-  UINT8                 UpdatePending;
-  UINT8                 Reserved[3];
-} FW_UPDATE_COMP_STATUS;
 
 typedef union _FIRMWARE_UPDATE_POLICY {
   UINT32 Data;

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -390,10 +390,11 @@
 
   BootloaderCorePkg/Stage1B/Stage1B.inf {
     <LibraryClasses>
-      FspApiLib    | BootloaderCorePkg/Library/FspApiLib/FspmApiLib.inf
-      BaseMemoryLib| MdePkg/Library/BaseMemoryLibRepStr/BaseMemoryLibRepStr.inf
-      SocInitLib   | $(SOC_INIT_STAGE1B_LIB_INF_FILE)
-      BoardInitLib | $(BRD_INIT_STAGE1B_LIB_INF_FILE)
+      FspApiLib             | BootloaderCorePkg/Library/FspApiLib/FspmApiLib.inf
+      BaseMemoryLib         | MdePkg/Library/BaseMemoryLibRepStr/BaseMemoryLibRepStr.inf
+      FirmwareResiliencyLib | BootloaderCorePkg/Library/FirmwareResiliencyLib/FirmwareResiliencyLib.inf
+      SocInitLib            | $(SOC_INIT_STAGE1B_LIB_INF_FILE)
+      BoardInitLib          | $(BRD_INIT_STAGE1B_LIB_INF_FILE)
   }
 
   BootloaderCorePkg/Stage2/Stage2.inf {

--- a/BootloaderCorePkg/Include/Library/FirmwareResiliencyLib.h
+++ b/BootloaderCorePkg/Include/Library/FirmwareResiliencyLib.h
@@ -1,0 +1,45 @@
+/** @file
+The header file for firmware resiliency definitions.
+
+Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _FIRMWARE_RESILIENCY_LIB_H_
+#define _FIRMWARE_RESILIENCY_LIB_H_
+
+/**
+  Retrieve FW update state from the reserved region
+
+  @param[in,out] StateMachine The current FW update state
+**/
+VOID
+EFIAPI
+GetStateMachine (
+  IN OUT UINT8* StateMachine
+  );
+
+/**
+  Check if ACM detected corruption in IBB
+
+  @param[in] StateMachine The current FW update state
+**/
+VOID
+EFIAPI
+CheckForAcmFailures (
+  IN UINT8 StateMachine
+  );
+
+/**
+  Check if TCO timer detected corruption in OBB or a dead loop/crash in IBB/OBB
+
+    @param[in] BootFailureThreshold The number of boots to attempt before recovery
+**/
+VOID
+EFIAPI
+CheckForTcoTimerFailures (
+  IN UINT8 BootFailureThreshold
+  );
+
+#endif

--- a/BootloaderCorePkg/Include/Library/FirmwareResiliencyLib.h
+++ b/BootloaderCorePkg/Include/Library/FirmwareResiliencyLib.h
@@ -16,7 +16,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 VOID
 EFIAPI
-GetStateMachine (
+GetFwuStateMachine (
   IN OUT UINT8* StateMachine
   );
 

--- a/BootloaderCorePkg/Library/FirmwareResiliencyLib/FirmwareResiliencyLib.c
+++ b/BootloaderCorePkg/Library/FirmwareResiliencyLib/FirmwareResiliencyLib.c
@@ -1,0 +1,114 @@
+/** @file
+
+Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/TcoTimerLib.h>
+#include <Library/BootloaderCommonLib.h>
+#include <Library/ResetSystemLib.h>
+#include <Library/DebugLib.h>
+#include <Library/FirmwareResiliencyLib.h>
+#include <Library/TopSwapLib.h>
+#include <Library/PcdLib.h>
+#include <Library/WatchDogTimerLib.h>
+#include <FirmwareUpdateStatus.h>
+
+/**
+  Retrieve FW update state from the reserved region
+
+  @param[in,out] StateMachine The current FW update state
+**/
+VOID
+EFIAPI
+GetStateMachine (
+  IN OUT UINT8* StateMachine
+  )
+{
+  FW_UPDATE_STATUS    *FwUpdStatus;
+  EFI_STATUS          Status;
+  UINT32              RsvdBase;
+  UINT32              RsvdSize;
+
+  if (StateMachine != NULL) {
+    Status = GetComponentInfoByPartition (FLASH_MAP_SIG_BLRESERVED, FALSE, &RsvdBase, &RsvdSize);
+    if (EFI_ERROR (Status)) {
+      *StateMachine = FW_UPDATE_SM_INIT;
+    } else {
+      FwUpdStatus = (FW_UPDATE_STATUS *)(UINTN)RsvdBase;
+      *StateMachine = FwUpdStatus->StateMachine;
+    }
+  }
+}
+
+/**
+  Check if ACM detected corruption in IBB
+
+  @param[in] StateMachine The current FW update state
+**/
+VOID
+EFIAPI
+CheckForAcmFailures (
+  IN UINT8 StateMachine
+  )
+{
+  switch (StateMachine) {
+    case FW_UPDATE_SM_PART_A:
+      if (GetCurrentBootPartition () == PrimaryPartition) {
+        DEBUG((DEBUG_INFO, "Partition to be updated is same as current boot partition (primary)\n"));
+        SetRecoveryTrigger ();
+      }
+      break;
+
+    case FW_UPDATE_SM_PART_B:
+    case FW_UPDATE_SM_PART_AB:
+      if (GetCurrentBootPartition () == BackupPartition) {
+        DEBUG((DEBUG_INFO, "Partition to be updated is same as current boot partition (backup)\n"));
+        SetRecoveryTrigger ();
+      }
+      break;
+
+    default:
+      if (GetCurrentBootPartition () == BackupPartition) {
+        DEBUG((DEBUG_INFO, "Booting from backup partition outside of update\n"));
+        SetRecoveryTrigger ();
+      }
+      break;
+  }
+}
+
+/**
+  Check if TCO timer detected corruption in OBB or a dead loop/crash in IBB/OBB
+
+    @param[in] BootFailureThreshold The number of boots to attempt before recovery
+**/
+VOID
+EFIAPI
+CheckForTcoTimerFailures (
+  IN UINT8 BootFailureThreshold
+  )
+{
+  EFI_STATUS          Status;
+  BOOT_PARTITION      NewPartition;
+  UINT32              FailedBootCount;
+
+  // If unable to boot all the way up to PLD, recovery is necessary.
+  if (WasPreviousTcoTimeout ()) {
+    ClearTcoStatus ();
+    IncrementFailedBootCount ();
+    FailedBootCount = GetFailedBootCount ();
+    DEBUG ((DEBUG_INFO, "Boot failure occurred! Failed boot count: %d\n", FailedBootCount));
+    if (FailedBootCount >= BootFailureThreshold) {
+      ClearFailedBootCount ();
+      SetRecoveryTrigger ();
+      NewPartition = GetCurrentBootPartition () == PrimaryPartition ? BackupPartition : PrimaryPartition;
+      DEBUG ((DEBUG_INFO, "Boot failure threshold reached! Switching to partition: %d\n", NewPartition));
+      Status = SetBootPartition (NewPartition);
+      if (EFI_ERROR (Status)) {
+        CpuHalt("Unable to recover corrupted partition!\n");
+      }
+      ResetSystem (EfiResetCold);
+    }
+  }
+}

--- a/BootloaderCorePkg/Library/FirmwareResiliencyLib/FirmwareResiliencyLib.c
+++ b/BootloaderCorePkg/Library/FirmwareResiliencyLib/FirmwareResiliencyLib.c
@@ -22,7 +22,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 VOID
 EFIAPI
-GetStateMachine (
+GetFwuStateMachine (
   IN OUT UINT8* StateMachine
   )
 {

--- a/BootloaderCorePkg/Library/FirmwareResiliencyLib/FirmwareResiliencyLib.inf
+++ b/BootloaderCorePkg/Library/FirmwareResiliencyLib/FirmwareResiliencyLib.inf
@@ -1,0 +1,39 @@
+## @file
+#
+#  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = FirmwareResiliencyLib
+  FILE_GUID                      = d804006e-f9bf-4fa6-a200-fb1db2ceb7a4
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = FirmwareResiliencyLib
+
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  FirmwareResiliencyLib.c
+
+[Packages]
+  Silicon/CommonSocPkg/CommonSocPkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+  MdePkg/MdePkg.dec
+  BootloaderCorePkg/BootloaderCorePkg.dec
+
+[LibraryClasses]
+  TcoTimerLib
+  BootloaderCommonLib
+  ResetSystemLib
+  DebugLib
+  TopSwapLib
+  PcdLib
+  WatchDogTimerLib

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -306,36 +306,94 @@ CreateConfigDatabase (
 }
 
 /**
-  Count boot failures and react appropriately.
+  Retrieve FW update state from the reserved region
+
+  @param[in,out] StateMachine The current FW update state
 **/
 VOID
-EFIAPI
-HandleBootFailures (
+GetStateMachine (
+  IN OUT UINT8* StateMachine
+  )
+{
+  FW_UPDATE_STATUS    *FwUpdStatus;
+  EFI_STATUS          Status;
+  UINT32              RsvdBase;
+  UINT32              RsvdSize;
+
+  if (StateMachine != NULL) {
+    Status = GetComponentInfoByPartition (FLASH_MAP_SIG_BLRESERVED, FALSE, &RsvdBase, &RsvdSize);
+    if (EFI_ERROR (Status)) {
+      *StateMachine = FW_UPDATE_SM_INIT;
+    } else {
+      FwUpdStatus = (FW_UPDATE_STATUS *)(UINTN)RsvdBase;
+      *StateMachine = FwUpdStatus->StateMachine;
+    }
+  }
+}
+
+/**
+  Check if ACM detected corruption in IBB
+
+  @param[in] StateMachine The current FW update state
+**/
+VOID
+CheckForAcmFailures (
+  IN UINT8 StateMachine
+  )
+{
+  switch (StateMachine) {
+    case FW_UPDATE_SM_PART_A:
+      if (GetCurrentBootPartition () == PrimaryPartition) {
+        DEBUG((DEBUG_INFO, "Partition to be updated is same as current boot partition (primary)\n"));
+        SetRecoveryTrigger ();
+      }
+      break;
+
+    case FW_UPDATE_SM_PART_B:
+    case FW_UPDATE_SM_PART_AB:
+      if (GetCurrentBootPartition () == BackupPartition) {
+        DEBUG((DEBUG_INFO, "Partition to be updated is same as current boot partition (backup)\n"));
+        SetRecoveryTrigger ();
+      }
+      break;
+
+    default:
+      if (GetCurrentBootPartition () == BackupPartition) {
+        DEBUG((DEBUG_INFO, "Booting from backup partition outside of update\n"));
+        SetRecoveryTrigger ();
+      }
+      break;
+  }
+}
+
+/**
+  Check if TCO timer detected corruption in OBB, a dead loop in IBB, or a dead loop in OBB
+**/
+VOID
+CheckForTcoTimerFailures (
   VOID
   )
 {
-  EFI_STATUS      Status;
-  BOOT_PARTITION  CurrentPartition;
-  BOOT_PARTITION  NewPartition;
-  UINT32          FailedBootCount;
+  EFI_STATUS          Status;
+  BOOT_PARTITION      NewPartition;
+  UINT32              FailedBootCount;
 
+  // If unable to boot all the way up to PLD, recovery is necessary.
   if (WasPreviousTcoTimeout ()) {
     ClearTcoStatus ();
     IncrementFailedBootCount ();
     FailedBootCount = GetFailedBootCount ();
     DEBUG ((DEBUG_INFO, "Boot failure occurred! Failed boot count: %d\n", FailedBootCount));
     if (FailedBootCount >= PcdGet8 (PcdBootFailureThreshold)) {
-      CurrentPartition = GetCurrentBootPartition ();
-      if ((CurrentPartition == PrimaryPartition) ||
-          (CurrentPartition == BackupPartition && GetBootMode () == BOOT_ON_FLASH_UPDATE)) {
-        NewPartition = (CurrentPartition == PrimaryPartition) ? BackupPartition : PrimaryPartition;
-        DEBUG ((DEBUG_INFO, "Boot failure threshold reached! Switching to partition: %d\n", NewPartition));
-        Status = SetBootPartition (NewPartition);
-        if (EFI_ERROR (Status)) {
-          CpuHalt("Unable to recover corrupted partition!\n");
-        }
-        ResetSystem (EfiResetWarm);
+      ClearFailedBootCount ();
+      SetRecoveryTrigger ();
+      NewPartition = GetCurrentBootPartition () == PrimaryPartition ? BackupPartition : PrimaryPartition;
+      DEBUG ((DEBUG_INFO, "Boot failure threshold reached! Switching to partition: %d\n", NewPartition));
+      Status = SetBootPartition (NewPartition);
+      if (EFI_ERROR (Status)) {
+        CpuHalt("Unable to recover corrupted partition!\n");
       }
+      ResetSystem (EfiResetCold);
     }
   }
 }
@@ -391,6 +449,7 @@ SecStartup2 (
   VOID                    **FieldPtr;
   UINT32                    Tolum;
   UINT64                    Touum;
+  UINT8                     StateMachine;
 
   LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
   ASSERT (LdrGlobal != NULL);
@@ -419,6 +478,14 @@ SecStartup2 (
   // Perform pre-config board init
   BoardInit (PreConfigInit);
 
+  // Check if recovery is needed, if not in recovery path already
+  GetStateMachine (&StateMachine);
+  DEBUG ((DEBUG_INFO, "Current FW update state machine: %d\n", StateMachine));
+  if (PcdGetBool (PcdSblResiliencyEnabled) && StateMachine != FW_UPDATE_SM_RECOVERY && !IsRecoveryTriggered ()) {
+    CheckForTcoTimerFailures ();
+    CheckForAcmFailures (StateMachine);
+  }
+
   Status = AppendHashStore (LdrGlobal, &Stage1bParam);
   DEBUG ((DEBUG_INFO,  "Append public key hash into store: %r\n", Status));
 
@@ -432,10 +499,6 @@ SecStartup2 (
   }
 
   BoardInit (PostConfigInit);
-
-  if (PcdGetBool (PcdSblResiliencyEnabled)) {
-    HandleBootFailures ();
-  }
 
   //Get Platform ID and Boot Mode
   DEBUG ((DEBUG_INIT, "BOOT: BP%d \nMODE: %d\nBoardID: 0x%02X\n",

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -356,7 +356,7 @@ SecStartup2 (
   VOID                    **FieldPtr;
   UINT32                    Tolum;
   UINT64                    Touum;
-  UINT8                     StateMachine;
+  UINT8                     FwuStateMachine;
 
   LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
   ASSERT (LdrGlobal != NULL);
@@ -387,11 +387,11 @@ SecStartup2 (
 
   // Check if recovery is needed, if not in recovery path already
   if (PcdGetBool (PcdSblResiliencyEnabled)) {
-    GetStateMachine (&StateMachine);
-    DEBUG ((DEBUG_INFO, "Current FW update state machine: %d\n", StateMachine));
-    if (StateMachine != FW_UPDATE_SM_RECOVERY && !IsRecoveryTriggered ()) {
+    GetFwuStateMachine (&FwuStateMachine);
+    DEBUG ((DEBUG_INFO, "Current FW update state machine: %d\n", FwuStateMachine));
+    if (FwuStateMachine != FW_UPDATE_SM_RECOVERY && !IsRecoveryTriggered ()) {
       CheckForTcoTimerFailures (PcdGet8 (PcdBootFailureThreshold));
-      CheckForAcmFailures (StateMachine);
+      CheckForAcmFailures (FwuStateMachine);
     }
   }
 

--- a/BootloaderCorePkg/Stage1B/Stage1B.h
+++ b/BootloaderCorePkg/Stage1B/Stage1B.h
@@ -42,6 +42,8 @@
 #include <Guid/PcdDataBaseSignatureGuid.h>
 #include <Guid/LoaderPlatformDataGuid.h>
 #include <Library/TopSwapLib.h>
+#include <Library/FirmwareResiliencyLib.h>
+#include <FirmwareUpdateStatus.h>
 #include <VerInfo.h>
 
 /**

--- a/BootloaderCorePkg/Stage1B/Stage1B.inf
+++ b/BootloaderCorePkg/Stage1B/Stage1B.inf
@@ -59,6 +59,7 @@
   TcoTimerLib
   TopSwapLib
   WatchDogTimerLib
+  FirmwareResiliencyLib
 
 [Guids]
   gPlatformModuleTokenSpaceGuid

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -249,14 +249,6 @@ NormalBootPath (
 
   BoardInit (EndOfStages);
 
-  // Stop timer so boot retries stop
-  if (PcdGetBool (PcdSblResiliencyEnabled)) {
-    StopTcoTimer ();
-    if (GetBootMode () != BOOT_ON_FLASH_UPDATE) {
-      ClearFailedBootCount ();
-    }
-  }
-
   PayloadId = GetPayloadId ();
   if (PayloadId == 0) {
     // For built-in payload including OsLoader and FirmwareUpdate, it will handle
@@ -296,6 +288,12 @@ NormalBootPath (
   DEBUG_CODE_BEGIN ();
   PrintStackHeapInfo ();
   DEBUG_CODE_END ();
+
+  // Stop timer so boot retries stop
+  if (PcdGetBool (PcdSblResiliencyEnabled)) {
+    StopTcoTimer ();
+    ClearFailedBootCount ();
+  }
 
   DEBUG ((DEBUG_INFO, "Payload entry: 0x%08X\n", PldEntry));
   if (PldEntry != NULL) {
@@ -347,14 +345,6 @@ S3ResumePath (
   // Call the board notification
   BoardInit (EndOfStages);
 
-  // Stop timer so boot retries stop
-  if (PcdGetBool (PcdSblResiliencyEnabled)) {
-    StopTcoTimer ();
-    if (GetBootMode () != BOOT_ON_FLASH_UPDATE) {
-      ClearFailedBootCount ();
-    }
-  }
-
   // Call board and FSP Notify ReadyToBoot
   BoardNotifyPhase (ReadyToBoot);
   AddMeasurePoint (0x31D0);
@@ -370,8 +360,15 @@ S3ResumePath (
   // Update FPDT table
   UpdateFpdtS3Table (S3Data->AcpiBase);
 
-  // Find Wake Vector and Jump to OS
   AddMeasurePoint (0x31F0);
+
+  // Stop timer so boot retries stop
+  if (PcdGetBool (PcdSblResiliencyEnabled)) {
+    StopTcoTimer ();
+    ClearFailedBootCount ();
+  }
+
+  // Find Wake Vector and Jump to OS
   FindAcpiWakeVectorAndJump (S3Data->AcpiBase);
 }
 

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -1516,7 +1516,7 @@ InitFirmwareRecovery (
     return Status;
   }
 
-  ClearFailedBootCount ();
+  ClearRecoveryTrigger ();
 
   Status = GetRegionInfo (&TopSwapRegionSize, &RedundantRegionSize, NULL);
   if (EFI_ERROR (Status)) {
@@ -1716,7 +1716,7 @@ PayloadMain (
   // Prepare Console Print
   //
   InitConsole ();
-  ConsolePrint ("Starting Firmware Update\n");
+  ConsolePrint ("Starting Firmware Update/Recovery\n");
 
   //
   // Initialize boot media to look for the capsule image
@@ -1774,13 +1774,14 @@ PayloadMain (
   //
   GetStateMachineFlag (&StateMachine);
   if (PcdGetBool (PcdSblResiliencyEnabled) &&
-     (StateMachine == FW_UPDATE_SM_RECOVERY || GetFailedBootCount () >= PcdGet8 (PcdBootFailureThreshold))) {
-    DEBUG((DEBUG_ERROR, "Triggered FW recovery!\n"));
+     (StateMachine == FW_UPDATE_SM_RECOVERY || IsRecoveryTriggered ())) {
+    DEBUG((DEBUG_INFO, "Triggered FW recovery!\n"));
     Status = InitFirmwareRecovery ();
     if (EFI_ERROR (Status)) {
       DEBUG((DEBUG_ERROR, "Firmware recovery failed with Status = %r\n", Status));
     }
   } else {
+    DEBUG((DEBUG_INFO, "Triggered FW update!\n"));
     Status = InitFirmwareUpdate ();
     if (EFI_ERROR (Status)) {
       if (Status != EFI_ALREADY_STARTED) {

--- a/Silicon/AlderlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/AlderlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -27,6 +27,7 @@
 #include <Service/HeciService.h>
 #include <CsmeUpdateDriver.h>
 #include <PlatformBase.h>
+#include <Library/WatchDogTimerLib.h>
 
 #define FWU_BOOT_MODE_OFFSET   0x40
 #define FWU_BOOT_MODE_VALUE    0x5A
@@ -158,6 +159,11 @@ SetBootPartition (
 
   DEBUG ((DEBUG_INFO, "Read it to ensure data is written. Data32=0x%x\n", Data32));
 #endif
+  // Need to signal for TS back to other partition in SG1B, since TS
+  // is blocked from being performed in FWU payload
+  if (GetCurrentBootPartition () != Partition) {
+    SetTopSwapTrigger ();
+  }
   return EFI_SUCCESS;
 }
 
@@ -385,7 +391,7 @@ ClearFwUpdateTrigger (
   VOID
   )
 {
-  IoAnd32(ACPI_BASE_ADDRESS + R_ACPI_IO_OC_WDT_CTL, 0xFF00FFFF);
+  ClearUpdateTrigger ();
 }
 
 /**

--- a/Silicon/AlderlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.inf
+++ b/Silicon/AlderlakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.inf
@@ -39,6 +39,7 @@
   #HeciLib
   LitePeCoffLib
   HeciMeExtLib
+  WatchDogTimerLib
 
 [Guids]
   gEfiPartTypeSystemPartGuid

--- a/Silicon/CommonSocPkg/Include/Library/WatchDogTimerLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/WatchDogTimerLib.h
@@ -159,4 +159,76 @@ ClearFailedBootCount (
   VOID
   );
 
+/**
+  Check if FW update triggered.
+**/
+BOOLEAN
+EFIAPI
+IsUpdateTriggered (
+  VOID
+  );
+
+/**
+  Clear FW update trigger.
+**/
+VOID
+EFIAPI
+ClearUpdateTrigger (
+  VOID
+  );
+
+/**
+  Check if top swap triggered.
+**/
+BOOLEAN
+EFIAPI
+IsTopSwapTriggered (
+  VOID
+  );
+
+/**
+  Clear top swap trigger.
+**/
+VOID
+EFIAPI
+ClearTopSwapTrigger (
+  VOID
+  );
+
+/**
+  Set top swap trigger.
+**/
+VOID
+EFIAPI
+SetTopSwapTrigger (
+  VOID
+  );
+
+/**
+  Check if FW recovery triggered.
+**/
+BOOLEAN
+EFIAPI
+IsRecoveryTriggered (
+  VOID
+  );
+
+/**
+  Clear FW recovery trigger.
+**/
+VOID
+EFIAPI
+ClearRecoveryTrigger (
+  VOID
+  );
+
+/**
+  Set FW recovery trigger.
+**/
+VOID
+EFIAPI
+SetRecoveryTrigger (
+  VOID
+  );
+
 #endif

--- a/Silicon/CommonSocPkg/Library/WatchDogTimerLib/WatchDogTimerLib.c
+++ b/Silicon/CommonSocPkg/Library/WatchDogTimerLib/WatchDogTimerLib.c
@@ -17,6 +17,9 @@
 #define B_ACPI_IO_OC_WDT_CTL_RLD                          BIT31
 #define B_ACPI_IO_OC_WDT_CTL_ICCSURV_STS                  BIT25
 #define B_ACPI_IO_OC_WDT_CTL_NO_ICCSURV_STS               BIT24
+#define B_ACPI_IO_OC_WDT_CTL_TOP_SWAP_TRIGGER             BIT21
+#define B_ACPI_IO_OC_WDT_CTL_RECOVERY_TRIGGER             BIT20
+#define B_ACPI_IO_OC_WDT_CTL_UPDATE_TRIGGER               BIT16
 #define B_ACPI_IO_OC_WDT_CTL_FORCE_ALL                    BIT15
 #define B_ACPI_IO_OC_WDT_CTL_EN                           BIT14
 #define B_ACPI_IO_OC_WDT_CTL_ICCSURV                      BIT13
@@ -310,4 +313,100 @@ ClearFailedBootCount (
   )
 {
   WdtClearScratchpad (B_ACPI_IO_OC_WDT_CTL_SCRATCHPAD_BOOT_CNT_MASK);
+}
+
+/**
+  Check if FW update triggered.
+**/
+BOOLEAN
+EFIAPI
+IsUpdateTriggered (
+  VOID
+  )
+{
+  return WdtGetScratchpad (B_ACPI_IO_OC_WDT_CTL_UPDATE_TRIGGER) != 0;
+}
+
+/**
+  Clear FW update trigger.
+**/
+VOID
+EFIAPI
+ClearUpdateTrigger (
+  VOID
+  )
+{
+  WdtClearScratchpad (B_ACPI_IO_OC_WDT_CTL_UPDATE_TRIGGER);
+}
+
+/**
+  Check if top swap triggered.
+**/
+BOOLEAN
+EFIAPI
+IsTopSwapTriggered (
+  VOID
+  )
+{
+  return WdtGetScratchpad (B_ACPI_IO_OC_WDT_CTL_TOP_SWAP_TRIGGER) != 0;
+}
+
+/**
+  Clear top swap trigger.
+**/
+VOID
+EFIAPI
+ClearTopSwapTrigger (
+  VOID
+  )
+{
+  WdtClearScratchpad (B_ACPI_IO_OC_WDT_CTL_TOP_SWAP_TRIGGER);
+}
+
+/**
+  Set top swap trigger.
+**/
+VOID
+EFIAPI
+SetTopSwapTrigger (
+  VOID
+  )
+{
+  WdtSetScratchpad (B_ACPI_IO_OC_WDT_CTL_TOP_SWAP_TRIGGER);
+}
+
+/**
+  Check if FW recovery triggered.
+**/
+BOOLEAN
+EFIAPI
+IsRecoveryTriggered (
+  VOID
+  )
+{
+  return WdtGetScratchpad (B_ACPI_IO_OC_WDT_CTL_RECOVERY_TRIGGER) != 0;
+}
+
+/**
+  Clear FW recovery trigger.
+**/
+VOID
+EFIAPI
+ClearRecoveryTrigger (
+  VOID
+  )
+{
+  WdtClearScratchpad (B_ACPI_IO_OC_WDT_CTL_RECOVERY_TRIGGER);
+}
+
+/**
+  Set FW recovery trigger.
+**/
+VOID
+EFIAPI
+SetRecoveryTrigger (
+  VOID
+  )
+{
+  WdtSetScratchpad (B_ACPI_IO_OC_WDT_CTL_RECOVERY_TRIGGER);
 }


### PR DESCRIPTION
If TS bit flipped and it does not match FWU state,
assume ACM detected corruption in SG1A or SG1B and
recover broken BP

Add WDT trigger for recovery

Add ADL-specific WDT trigger for TS

Signed-off-by: Sean McGinn <sean.mcginn@intel.com>