### PR TITLE
Stop TCO timer in beginning of FWU PLD

### DIFF
--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -289,8 +289,9 @@ NormalBootPath (
   PrintStackHeapInfo ();
   DEBUG_CODE_END ();
 
-  // Stop timer so boot retries stop
-  if (PcdGetBool (PcdSblResiliencyEnabled)) {
+  // FWU payload is the only payload in SBL scope, so stop TCO
+  // timer if another payload is set to be launched
+  if (PcdGetBool (PcdSblResiliencyEnabled) && GetBootMode () != BOOT_ON_FLASH_UPDATE) {
     StopTcoTimer ();
     ClearFailedBootCount ();
   }
@@ -362,8 +363,9 @@ S3ResumePath (
 
   AddMeasurePoint (0x31F0);
 
-  // Stop timer so boot retries stop
-  if (PcdGetBool (PcdSblResiliencyEnabled)) {
+  // FWU payload is the only payload in SBL scope, so stop TCO
+  // timer if another payload is set to be launched
+  if (PcdGetBool (PcdSblResiliencyEnabled) && GetBootMode () != BOOT_ON_FLASH_UPDATE) {
     StopTcoTimer ();
     ClearFailedBootCount ();
   }

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -363,9 +363,8 @@ S3ResumePath (
 
   AddMeasurePoint (0x31F0);
 
-  // FWU payload is the only payload in SBL scope, so stop TCO
-  // timer if another payload is set to be launched
-  if (PcdGetBool (PcdSblResiliencyEnabled) && GetBootMode () != BOOT_ON_FLASH_UPDATE) {
+  // No payload is executed in S3 resume, so stop TCO timer in all cases
+  if (PcdGetBool (PcdSblResiliencyEnabled)) {
     StopTcoTimer ();
     ClearFailedBootCount ();
   }

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -31,6 +31,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Guid/OsBootOptionGuid.h>
 #include <Library/BootGuardLib.h>
 #include <Library/WatchDogTimerLib.h>
+#include <Library/TcoTimerLib.h>
 #include "FirmwareUpdateHelper.h"
 
 UINT32   mSblImageBiosRgnOffset;
@@ -1768,6 +1769,14 @@ PayloadMain (
   // Set PCD for Firmware Update status structure offset within BIOS region
   //
   (VOID) PcdSet32S (PcdFwUpdStatusBase, mSblImageBiosRgnOffset + (FlashMap->RomSize - (~RsvdBase + 1)));
+
+  //
+  // Stop TCO timer here as SPI read/write timings are highly variable
+  //
+  if (PcdGetBool (PcdSblResiliencyEnabled)) {
+    StopTcoTimer ();
+    ClearFailedBootCount ();
+  }
 
   //
   // Perform firmware recovery/update

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
@@ -55,6 +55,7 @@
   TimerLib
   BootGuardLib
   WatchDogTimerLib
+  TcoTimerLib
 
 [Guids]
   gLoaderMemoryMapInfoGuid


### PR DESCRIPTION
Stop TCO timer in beginning of FWU PLD
to ensure it is started without error