### PR TITLE
[Common] Fix Osloader hang when HAVE_ACPI_TABLE=0

### DIFF
--- a/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
+++ b/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
@@ -14,6 +14,7 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/PayloadLib.h>
 #include <Library/BootloaderCommonLib.h>
+#include <Library/BootloaderCoreLib.h>
 #include <Library/LoaderPerformanceLib.h>
 #include <Library/PayloadMemoryAllocationLib.h>
 #include <Library/SerialPortLib.h>
@@ -272,7 +273,7 @@ SecStartup (
 
   // ACPI table
   SystemTableInfo = GetSystemTableInfo ();
-  if (SystemTableInfo != NULL) {
+  if (SystemTableInfo != NULL && ACPI_ENABLED()) {
     ParseAcpiTableInfo ((UINT32)SystemTableInfo->AcpiTableBase);
   }
 

--- a/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.inf
+++ b/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.inf
@@ -26,6 +26,7 @@
   MdePkg/MdePkg.dec
   BootloaderCommonPkg/BootloaderCommonPkg.dec
   PayloadPkg/PayloadPkg.dec
+  BootloaderCorePkg/BootloaderCorePkg.dec
 
 [LibraryClasses]
   BaseLib
@@ -40,6 +41,7 @@
   DebugLogBufferLib
   DebugPrintErrorLevelLib
   PagingLib
+  BootloaderCoreLib
 
 [Guids]
   gLoaderLibraryDataGuid
@@ -59,3 +61,4 @@
   gPlatformCommonLibTokenSpaceGuid.PcdDmaProtectionEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferSize
   gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferAlignment
+  gPlatformModuleTokenSpaceGuid.PcdAcpiEnabled


### PR DESCRIPTION
Verified on EHL

Signed-off-by: Randy Lin <randy.lin@intel.com>