### PR TITLE
[ADLPS] resolve ACPI error from yocto dmesg

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
@@ -267,6 +267,7 @@ PlatformUpdateAcpiTable (
   GLOBAL_NVS_AREA             *GlobalNvs;
   UINT32                       Base;
   UINT16                       Size;
+  SILICON_CFG_DATA            *SiCfgData;
   VOID                        *FspHobList;
   PLATFORM_DATA               *PlatformData;
   FEATURES_CFG_DATA           *FeaturesCfgData;
@@ -280,6 +281,12 @@ PlatformUpdateAcpiTable (
   Ptr  = (UINT8 *)Table;
   End  = (UINT8 *)Table + Table->Length;
 
+  if (Table->Signature == EFI_ACPI_5_0_EMBEDDED_CONTROLLER_BOOT_RESOURCES_TABLE_SIGNATURE) {
+    SiCfgData = (SILICON_CFG_DATA *)FindConfigDataByTag (CDATA_SILICON_TAG);
+    if ((SiCfgData == NULL) || (SiCfgData->EcAvailable == 0)) {
+      return EFI_UNSUPPORTED;
+    }
+  }
   if (Table->Signature == EFI_ACPI_5_0_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE) {
     for (; Ptr < End; Ptr++) {
       if (*(Ptr-1) != AML_NAME_OP)

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -450,16 +450,19 @@ BoardInit (
       ProgramSecuritySetting ();
     }
 
-    //
-    // Enable decoding of I/O locations 62h and 66h to LPC
-    //
-    LpcBase = MM_PCI_ADDRESS (0, PCI_DEVICE_NUMBER_PCH_LPC, 0, 0);
-    MmioOr16 (LpcBase + R_LPC_CFG_IOE, B_LPC_CFG_IOE_ME1);
+    SiCfgData = (SILICON_CFG_DATA *)FindConfigDataByTag (CDATA_SILICON_TAG);
+    if ( (SiCfgData != NULL) && (SiCfgData->EcAvailable == 1)) {
+      //
+      // Enable decoding of I/O locations 62h and 66h to LPC
+      //
+      LpcBase = MM_PCI_ADDRESS (0, PCI_DEVICE_NUMBER_PCH_LPC, 0, 0);
+      MmioOr16 (LpcBase + R_LPC_CFG_IOE, B_LPC_CFG_IOE_ME1);
 
-    //
-    // Enable EC's ACPI mode to control power to motherboard during Sleep (S3)
-    //
-    IoWrite16 (EC_C_PORT, EC_C_ACPI_ENABLE);
+      //
+      // Enable EC's ACPI mode to control power to motherboard during Sleep (S3)
+      //
+      IoWrite16 (EC_C_PORT, EC_C_ACPI_ENABLE);
+    }
     break;
   case ReadyToBoot:
     if ((GetBootMode() != BOOT_ON_FLASH_UPDATE) && (GetPayloadId() == 0)) {


### PR DESCRIPTION
Check EC UPD flag prior to publish ECDT table and send EC cmd. On Ecless board, EC ACPI object will not be invoked.

Signed-off-by: Kevin Tsai <kevin.tsai@intel.com>