### PR TITLE
GPIO shell command enhancement for ADL platform

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/ShellExtensionLib/ShellExtensionLib.inf
+++ b/Platform/AlderlakeBoardPkg/Library/ShellExtensionLib/ShellExtensionLib.inf
@@ -43,6 +43,8 @@
 [LibraryClasses]
   BaseMemoryLib
   GpioLib
+  PchInfoLib
+  GpioSiLib
 
 [Pcd]
 


### PR DESCRIPTION
Updated the GPIO shell command to take GPIO group and pin number as inputs.

Signed-off-by: M Karuppasamy <karuppasamy.m@intel.com>
Signed-off-by: Sachin Kamat <sachin.kamat@intel.com>
Signed-off-by: Akshatha Thekkade <akshatha.thekkade@intel.com>