### PR TITLE
Align the Ia32 Stage1B/Stage2 stack to 16 bytes

### DIFF
--- a/MdePkg/Library/BaseLib/Ia32/InternalSwitchStack.nasm
+++ b/MdePkg/Library/BaseLib/Ia32/InternalSwitchStack.nasm
@@ -32,7 +32,7 @@ ASM_PFX(InternalSwitchStack):
   mov   ebp, esp
 
   mov   esp, [ebp + 20]    ; switch stack
-  sub   esp, 8
+  sub   esp, 16            ; keep the stack 16-byte aligned
   mov   eax, [ebp + 16]
   mov   [esp + 4], eax
   mov   eax, [ebp + 12]


### PR DESCRIPTION
Much like the corresponding Stage1A patch, this patch aligns the Ia32 Stage1B and Stage2 stacks to 16 bytes, like what is already the case for X64, so that we follow Version 1.0 of the System V Intel386 ABI supplement, and satisfy any expectations our compiler may have regarding stack alignment.

A nice side effect of this change is that it allows building an Ia32 Slimbootloader with -msse which can run on real hardware, which requires 16-byte stack alignment.  Slimbootloader currently already enables SSE in XCR0 early on in Stage1A, and it has SSE versions of various helper functions written in assembly, in other words, it already makes use of SSE, but allowing the compiler to emit SSE instructions requires 16-byte stack alignment, because access to unaligned on-stack SSE variables will throw #GP on real hardware.  (QEMU doesn't seem to enforce the requirement for natural alignment of SSE memory arguments.)

Suggested-by: Peter Edwards <peadar@arista.com>
Signed-off-by: Lennert Buytenhek <buytenh@arista.com>