### PR TITLE
Create OS loader shell tool for SBL component corruption

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -328,5 +328,5 @@
   # Control if X2APIC should be used or not
   gPlatformCommonLibTokenSpaceGuid.PcdCpuX2ApicEnabled            | FALSE  | BOOLEAN | 0x20000220
   gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled                  | FALSE  | BOOLEAN | 0x20000221
-  # This PCD will enable a debug Shell with security-related tools.
-  gPlatformCommonLibTokenSpaceGuid.PcdSecurityShellEnabled        | FALSE  | BOOLEAN | 0x20000222
+  # This PCD will enable the SBL component corruption command
+  gPlatformCommonLibTokenSpaceGuid.PcdCmdCorruptShellAppEnabled   | FALSE  | BOOLEAN | 0x20000222

--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -327,3 +327,6 @@
   gPlatformCommonLibTokenSpaceGuid.PcdMultiUsbBootDeviceEnabled   | FALSE  | BOOLEAN | 0x20000219
   # Control if X2APIC should be used or not
   gPlatformCommonLibTokenSpaceGuid.PcdCpuX2ApicEnabled            | FALSE  | BOOLEAN | 0x20000220
+  gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled                  | FALSE  | BOOLEAN | 0x20000221
+  # This PCD will enable a debug Shell with security-related tools.
+  gPlatformCommonLibTokenSpaceGuid.PcdSecurityShellEnabled        | FALSE  | BOOLEAN | 0x20000222

--- a/BootloaderCommonPkg/Library/ShellLib/CmdCorruptComp.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdCorruptComp.c
@@ -50,8 +50,9 @@ ShowUsage (
   )
 {
   ShellPrint (L"Usage: corruptcomp <boot partition> <component>\n");
+  ShellPrint (L"Example: corruptcomp 1 SG1A\n");
   ShellPrint (L"Example: corruptcomp 0 SG1B\n");
-  ShellPrint (L"Example: corruptcomp 1 ACM0\n");
+  ShellPrint (L"Example: corruptcomp 0 SG02\n");
 }
 
 /**

--- a/BootloaderCommonPkg/Library/ShellLib/CmdCorruptComponent.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdCorruptComponent.c
@@ -1,0 +1,201 @@
+/** @file
+  Shell command corrupt an SBL component (for test purposes).
+
+  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/ShellLib.h>
+#include <Library/BootloaderCommonLib.h>
+#include <Library/RngLib.h>
+#include <Service/SpiFlashService.h>
+#include <Library/MemoryAllocationLib.h>
+
+/**
+  Perform random corruption in SBL region.
+
+  @param[in]  Shell        shell instance
+  @param[in]  Argc         number of command line arguments
+  @param[in]  Argv         command line arguments
+
+  @retval EFI_SUCCESS
+
+**/
+EFI_STATUS
+EFIAPI
+ShellCommandCorruptComponentFunc (
+  IN SHELL  *Shell,
+  IN UINTN   Argc,
+  IN CHAR16 *Argv[]
+  );
+
+CONST SHELL_COMMAND ShellCommandCorruptComponent = {
+  L"corruptcomponent",
+  L"Perform random corruption in SBL component",
+  &ShellCommandCorruptComponentFunc
+};
+
+VOID
+ShowUsage (
+  VOID
+  )
+{
+  ShellPrint (L"Usage: corruptcomponent <boot partition> <component>\n");
+}
+
+/**
+  Perform random corruption in SBL component.
+
+  @param[in]  Shell        Shell instance
+  @param[in]  Argc         Number of command line arguments
+  @param[in]  Argv         Command line arguments
+
+  @retval EFI_SUCCESS
+
+**/
+EFI_STATUS
+EFIAPI
+ShellCommandCorruptComponentFunc (
+  IN SHELL  *Shell,
+  IN UINTN   Argc,
+  IN CHAR16 *Argv[]
+  )
+{
+  EFI_STATUS          Status;
+  BOOLEAN             IsBackup;
+  CHAR16              *CompStr;
+  UINT32              CompSig;
+  SPI_FLASH_SERVICE   *SpiService;
+  UINT32              BiosStart;
+  UINT8               *Buf;
+  UINT32              CompOffset;
+  UINT32              CompSize;
+  UINT32              RandOffset;
+  UINT32              ChunkAddr;
+  UINT32              ChunkAddrAligned;
+  UINT8*              CurrVal;
+  UINT16              RandVal;
+  UINT8               NewVal;
+
+  Status = EFI_SUCCESS;
+
+  if (Argc == 3) {
+    switch (StrDecimalToUintn (Argv[1])) {
+      case 0:
+        IsBackup = FALSE;
+        break;
+      case 1:
+        IsBackup = TRUE;
+        break;
+      default:
+        ShellPrint (L"Error, invalid boot partition\n");
+        ShowUsage ();
+        return EFI_INVALID_PARAMETER;
+    }
+    CompStr = Argv[2];
+    if (StrLen(CompStr) != 4) {
+      ShellPrint (L"Error, invalid component\n");
+      ShowUsage ();
+      return EFI_INVALID_PARAMETER;
+    }
+    CompSig = SIGNATURE_32 (CompStr[0], CompStr[1], CompStr[2], CompStr[3]);
+  } else if (Argc < 3) {
+    ShellPrint (L"Error, too few arguments\n");
+    ShowUsage ();
+    return EFI_INVALID_PARAMETER;
+  } else if (Argc > 3) {
+    ShellPrint (L"Error, too many arguments\n");
+    ShowUsage ();
+    return EFI_INVALID_PARAMETER;
+  }
+
+  SpiService = (SPI_FLASH_SERVICE *) GetServiceBySignature (SPI_FLASH_SERVICE_SIGNATURE);
+  if (SpiService == NULL) {
+    ShellPrint (L"Error occured getting SPI flash service");
+    return EFI_UNSUPPORTED;
+  }
+
+  Status = SpiService->SpiInit ();
+  if (EFI_ERROR(Status)) {
+    ShellPrint (L"Error occured initializing SPI flash service %r\n", Status);
+    return Status;
+  }
+
+  Status = SpiService->SpiGetRegion (FlashRegionBios, NULL, &BiosStart);
+  if (EFI_ERROR(Status)) {
+    ShellPrint (L"Error occured getting BIOS SPI flash address %r\n", Status);
+    return Status;
+  }
+
+  Buf = AllocatePages (EFI_SIZE_TO_PAGES (SIZE_4KB));
+  if (Buf == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Status = GetComponentInfoByPartition (CompSig, IsBackup, &CompOffset, &CompSize);
+  if (EFI_ERROR (Status)) {
+    ShellPrint (L"Error, component info unable to be retrieved\n");
+    return Status;
+  }
+
+  // Choose a random offset in the component to corrupt
+  if (!GetRandomNumber32 (&RandOffset)) {
+    ShellPrint (L"Error, random offset unable to be generated\n");
+    return EFI_UNSUPPORTED;
+  }
+
+  RandOffset %= CompSize;
+  ChunkAddr = BiosStart + CompOffset + RandOffset;
+  ChunkAddrAligned = ALIGN_DOWN (ChunkAddr, SIZE_4KB);
+
+  // Read the whole 4KB chunk containing the offset from SPI flash
+  Status = SpiService->SpiRead (FlashRegionBios,
+                                ChunkAddrAligned,
+                                SIZE_4KB,
+                                Buf);
+  if (EFI_ERROR(Status)) {
+    ShellPrint (L"Error occured in SPI flash read %r\n", Status);
+    return Status;
+  }
+
+  // Erase the whole 4KB chunk containing the offset from SPI flash
+  Status = SpiService->SpiErase (FlashRegionBios, ChunkAddrAligned, SIZE_4KB);
+  if (EFI_ERROR(Status)) {
+    ShellPrint (L"Error occured in SPI flash erase %r\n", Status);
+    return Status;
+  }
+
+  CurrVal = Buf + ChunkAddr - ChunkAddrAligned;
+
+  // Make sure the random value to be put at the offset
+  // is not the same as the existing value at the offset
+  do {
+    if (!GetRandomNumber16 (&RandVal)) {
+      ShellPrint (L"Error, random value unable to be generated\n");
+      return EFI_UNSUPPORTED;
+    }
+    NewVal = (UINT8)RandVal;
+  } while (*CurrVal == NewVal);
+
+  // Write the random value at the offset in memory
+  *CurrVal = NewVal;
+
+  // Write the new 4KB chunk containing the offset
+  Status = SpiService->SpiWrite (FlashRegionBios,
+                                 ChunkAddrAligned,
+                                 SIZE_4KB,
+                                 Buf);
+  if (EFI_ERROR(Status)) {
+    ShellPrint (L"Error occured in SPI flash write %r\n", Status);
+    return Status;
+  }
+
+  if (Buf != NULL) {
+    FreePages (Buf, EFI_SIZE_TO_PAGES (SIZE_4KB));
+  }
+
+  ShellPrint (L"Successfully wrote 0x%x to 0x%x\n", NewVal, ChunkAddr);
+
+  return EFI_SUCCESS;
+}

--- a/BootloaderCommonPkg/Library/ShellLib/ShellCmds.c
+++ b/BootloaderCommonPkg/Library/ShellLib/ShellCmds.c
@@ -35,7 +35,6 @@ LoadShellCommands (
   ShellCommandRegister (Shell, &ShellCommandMtrr);
   ShellCommandRegister (Shell, &ShellCommandUcode);
   ShellCommandRegister (Shell, &ShellCommandCls);
-  ShellCommandRegister (Shell, &ShellCommandCorruptComponent);
 
   if (!FeaturePcdGet (PcdMiniShellEnabled)) {
     // More Shell commands
@@ -56,6 +55,11 @@ LoadShellCommands (
     for (Iter = ShellExtensionCmds; *Iter != NULL; Iter++) {
       ShellCommandRegister (Shell, *Iter);
     }
+  }
+
+  if (FeaturePcdGet (PcdSecurityShellEnabled)) {
+    // Security-related Shell commands
+    ShellCommandRegister (Shell, &ShellCommandCorruptComp);
   }
 
   return EFI_SUCCESS;

--- a/BootloaderCommonPkg/Library/ShellLib/ShellCmds.c
+++ b/BootloaderCommonPkg/Library/ShellLib/ShellCmds.c
@@ -57,8 +57,8 @@ LoadShellCommands (
     }
   }
 
-  if (FeaturePcdGet (PcdSecurityShellEnabled)) {
-    // Security-related Shell commands
+  if (FeaturePcdGet (PcdCmdCorruptShellAppEnabled)) {
+    // SBL component corruption command
     ShellCommandRegister (Shell, &ShellCommandCorruptComp);
   }
 

--- a/BootloaderCommonPkg/Library/ShellLib/ShellCmds.c
+++ b/BootloaderCommonPkg/Library/ShellLib/ShellCmds.c
@@ -35,6 +35,7 @@ LoadShellCommands (
   ShellCommandRegister (Shell, &ShellCommandMtrr);
   ShellCommandRegister (Shell, &ShellCommandUcode);
   ShellCommandRegister (Shell, &ShellCommandCls);
+  ShellCommandRegister (Shell, &ShellCommandCorruptComponent);
 
   if (!FeaturePcdGet (PcdMiniShellEnabled)) {
     // More Shell commands

--- a/BootloaderCommonPkg/Library/ShellLib/ShellCmds.h
+++ b/BootloaderCommonPkg/Library/ShellLib/ShellCmds.h
@@ -29,7 +29,7 @@ extern CONST SHELL_COMMAND ShellCommandUcode;
 extern CONST SHELL_COMMAND ShellCommandCls;
 extern CONST SHELL_COMMAND ShellCommandFs;
 extern CONST SHELL_COMMAND ShellCommandUsbDev;
-extern CONST SHELL_COMMAND ShellCommandCorruptComponent;
+extern CONST SHELL_COMMAND ShellCommandCorruptComp;
 
 /**
   Load shell commands.

--- a/BootloaderCommonPkg/Library/ShellLib/ShellCmds.h
+++ b/BootloaderCommonPkg/Library/ShellLib/ShellCmds.h
@@ -29,6 +29,7 @@ extern CONST SHELL_COMMAND ShellCommandUcode;
 extern CONST SHELL_COMMAND ShellCommandCls;
 extern CONST SHELL_COMMAND ShellCommandFs;
 extern CONST SHELL_COMMAND ShellCommandUsbDev;
+extern CONST SHELL_COMMAND ShellCommandCorruptComponent;
 
 /**
   Load shell commands.

--- a/BootloaderCommonPkg/Library/ShellLib/ShellLib.inf
+++ b/BootloaderCommonPkg/Library/ShellLib/ShellLib.inf
@@ -45,6 +45,7 @@
   CmdCls.c
   CmdFs.c
   CmdUsbDev.c
+  CmdCorruptComponent.c
   ShellCmds.c
   Parsing.c
   History.c
@@ -53,6 +54,7 @@
 [Packages]
   MdePkg/MdePkg.dec
   BootloaderCommonPkg/BootloaderCommonPkg.dec
+  Silicon/CommonSocPkg/CommonSocPkg.dec
 
 [LibraryClasses]
   BaseLib
@@ -76,6 +78,8 @@
   PartitionLib
   ShellExtensionLib
   MtrrLib
+  RngLib
+  MemoryAllocationLib
 
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress

--- a/BootloaderCommonPkg/Library/ShellLib/ShellLib.inf
+++ b/BootloaderCommonPkg/Library/ShellLib/ShellLib.inf
@@ -45,7 +45,7 @@
   CmdCls.c
   CmdFs.c
   CmdUsbDev.c
-  CmdCorruptComponent.c
+  CmdCorruptComp.c
   ShellCmds.c
   Parsing.c
   History.c
@@ -86,6 +86,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdMiniShellEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdConsoleInDeviceMask
   gPlatformCommonLibTokenSpaceGuid.PcdBootPerformanceMask
+  gPlatformCommonLibTokenSpaceGuid.PcdSecurityShellEnabled
 
 [Guids]
   gLoaderPerformanceInfoGuid

--- a/BootloaderCommonPkg/Library/ShellLib/ShellLib.inf
+++ b/BootloaderCommonPkg/Library/ShellLib/ShellLib.inf
@@ -86,7 +86,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdMiniShellEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdConsoleInDeviceMask
   gPlatformCommonLibTokenSpaceGuid.PcdBootPerformanceMask
-  gPlatformCommonLibTokenSpaceGuid.PcdSecurityShellEnabled
+  gPlatformCommonLibTokenSpaceGuid.PcdCmdCorruptShellAppEnabled
 
 [Guids]
   gLoaderPerformanceInfoGuid

--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -1096,7 +1096,6 @@ UpdateFspConfig (
     FspsConfig->SaPcieItbtRpSnoopLatencyOverrideValue[2] = 0xc8;
     FspsConfig->TdcTimeWindow[0] = 0x3e8;
     FspsConfig->TdcTimeWindow[1] = 0x3e8;
-    FspsConfig->PchLockDownBiosLock = 0x1;
     FspsConfig->IehMode = 0x0;
     FspsConfig->PortResetMessageEnable[0] = 0x1;
     FspsConfig->PortResetMessageEnable[1] = 0x1;


### PR DESCRIPTION
Create a runtime tool that corrupts SBL components so that the SBL resiliency feature can more easily be tested and demonstrated

Signed-off-by: Sean McGinn <sean.mcginn@intel.com>