### PR TITLE
[EHL] Add MemTestOnWarmBoot UPD to Config Editor

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Memory.yaml
+++ b/Platform/ElkhartlakeBoardPkg/CfgData/CfgData_Memory.yaml
@@ -905,6 +905,14 @@
                      Enables/Disable Memory Test
       length       : 0x01
       value        : 0x00
+  - MemTestOnWarmBoot       :
+      name         : MRC Boot Mode
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     Enables/Disable Memory Test
+      length       : 0x01
+      value        : 0x00
   - ECT          :
       name         : Early Command Training
       type         : Combo
@@ -1413,5 +1421,5 @@
       length       : 0x2
       value        : 0x0
   - Dummy        :
-      length       : 0x2
+      length       : 0x1
       value        : 0x0

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -490,6 +490,7 @@ UpdateFspConfig (
     Fspmcfg->BdatTestType               = MemCfgData->BdatTestType;
     Fspmcfg->RMC                        = MemCfgData->RMC;
     Fspmcfg->MEMTST                     = MemCfgData->MEMTST;
+    Fspmcfg->MemTestOnWarmBoot          = MemCfgData->MemTestOnWarmBoot;
     //FspmUpd->FspmRestrictedConfig.PerBankRefresh = 0x1;
 
     Fspmcfg->ECT                        = MemCfgData->ECT;
@@ -665,6 +666,8 @@ UpdateFspConfig (
       DEBUG ((DEBUG_INFO, "PchTraceHubMemReg0Size = %x\n", Fspmcfg->PchTraceHubMemReg0Size));
       DEBUG ((DEBUG_INFO, "PchTraceHubMemReg1Size = %x\n", Fspmcfg->PchTraceHubMemReg1Size));
       DEBUG ((DEBUG_INFO, "FiaLaneReversalEnable = %x\n", Fspmcfg->FiaLaneReversalEnable));
+      DEBUG ((DEBUG_INFO, "Memory Test = 0x%x\n", Fspmcfg->MEMTST));
+      DEBUG ((DEBUG_INFO, "MemTestOnWarmBoot = 0x%x\n", Fspmcfg->MemTestOnWarmBoot));
   }
 
   // IGD config data


### PR DESCRIPTION
MemTestOnWarmBoot UPD added into Config Editor. This UPD is enabled to ensure Base Memory Test is running in SBL.

Signed-off-by: Syahirah Sabryna <nur.syahirah.sabryna.mohmad@intel.com>