### PR TITLE
[LiteVariable] Added Data NULL conditional check in InternalGetVariable()

### DIFF
--- a/BootloaderCommonPkg/Library/LiteVariableLib/LiteVariableLib.c
+++ b/BootloaderCommonPkg/Library/LiteVariableLib/LiteVariableLib.c
@@ -412,7 +412,7 @@ InternalGetVariable (
   DataSizeIn = *DataSize;
   VariableDataLen = FindVarHdrPtr->DataSize - VariableNameLen;
   *DataSize = VariableDataLen;
-  if (DataSizeIn <  VariableDataLen) {
+  if ((Data != NULL) && (DataSizeIn <  VariableDataLen)) {
     return EFI_BUFFER_TOO_SMALL;
   }
 


### PR DESCRIPTION

Argument DataLen of function InternalGetVariable() inside Reclaim() function is not initialized. This uninitialized value is assigned to another variable and compared, resulting in EFI_BUFFER_TOO_SMALL error when Data is NULL. Hence added Data NULL conditional check with DataLen to overcome EFI_BUFFER_TOO_SMALL error when Data is NULL.

Signed-off-by: M Karuppasamy <karuppasamy.m@intel.com>
Signed-off-by: Sachin Kamat <sachin.kamat@intel.com>