### PR TITLE
TPM: Continue boot platform when TPM is not present

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -429,7 +429,11 @@ TpmInitialize (
     }
 
     if (EFI_ERROR (Status)) {
-      CpuHalt ("Tpm Initialization failed !!\n");
+      DEBUG ((DEBUG_ERROR, "Tpm Initialization failed  %r !! \n", Status));
+
+      Features  = GetFeatureCfg ();
+      Features &= (UINT32)(~FEATURE_MEASURED_BOOT);
+      SetFeatureCfg (Features);
     } else {
       if (BootMode != BOOT_ON_S3_RESUME) {
         // Create and add BootGuard Event logs in TCG Event log


### PR DESCRIPTION
Plaform is halted when TPM is not detected.TPM support is enabled with BTG 0 and boot halted when PTT is not enabled in straps.

TPM should be able to boot when TPM is not present and this patch fixes this issue.

Signed-off-by: Subash Lakkimsetti <subash.lakkimsetti@intel.com>