### PR TITLE
[EHL] Enable SIO UART in COM mode

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -1,7 +1,7 @@
 ## @file
 #
 #
-# Copyright (c) 2008-2020, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2008-2022, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -102,3 +102,4 @@
   gPlatformModuleTokenSpaceGuid.PcdSmbiosEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled
   gPlatformModuleTokenSpaceGuid.PcdAcpiTableTemplatePtr
+  gPlatformModuleTokenSpaceGuid.PcdFspsUpdPtr


### PR DESCRIPTION
The patch fixes SIO UART in COM mode by providing Acpi Gns correct values.

Test method: grep 16550A /proc/tty/driver/serial
  If a SIO UART run in COM mode, its MMIO should be in
  FE020000 ~ FE035FFF (EHL serial IO in ACPI mode).

Verfiied: EHL CRB

Signed-off-by: Stanley Chang <stanley.chang@intel.com>