### PR TITLE
[ADLPS] Resolve CATERR issue from Windows shutdown

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -1218,9 +1218,11 @@ UpdateFspConfig (
         FspsConfig->AmtEnabled = 0x1;
         FspsConfig->FwProgress = 0x1;
         FspsConfig->Irms[1] = 0x0;
+        FspsConfig->Usb4CmMode = 0x0;
         break;
       case PLATFORM_ID_ADL_PS_DDR5_CRB:
         FspsConfig->AmtEnabled = 0x1;
+        FspsConfig->Usb4CmMode = 0x0;
         break;
       default:
         break;


### PR DESCRIPTION
Change USB4 CM Mode to 0. This value is consumed by FSP and UEFI BIOS but not by SBL. Different setting causes issue with TBT device in Windows which might result in CATERR.

Tested to boot Windows and Yocto.

Signed-off-by: Kevin Tsai <kevin.tsai@intel.com>