### PR TITLE
fix: [ADL] TCC was never getting enabled via the board config option.

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -161,6 +161,7 @@
   #               New HOB format refer these file headers: SmmS3CommunicationInfoGuid.h, SpiFlashInfoGuid.h
   #               SmmRegisterInfoGuid.h and NvVariableInfoGuid.h
   gPlatformCommonLibTokenSpaceGuid.PcdBuildSmmHobs                     |        0x03| UINT8 | 0x20000705
+  gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled                  | FALSE  | BOOLEAN | 0x20000221
 
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   # For patchable PCDs, try to set the default as none-zero
@@ -323,4 +324,3 @@
   gPlatformCommonLibTokenSpaceGuid.PcdMultiUsbBootDeviceEnabled   | FALSE  | BOOLEAN | 0x20000219
   # Control if X2APIC should be used or not
   gPlatformCommonLibTokenSpaceGuid.PcdCpuX2ApicEnabled            | FALSE  | BOOLEAN | 0x20000220
-  gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled                  | FALSE  | BOOLEAN | 0x20000221

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -262,6 +262,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdBootPerformanceMask       | $(BOOT_PERFORMANCE_MASK)
   gPlatformModuleTokenSpaceGuid.PcdSblResiliencyEnabled         | $(ENABLE_SBL_RESILIENCY)
   gPlatformModuleTokenSpaceGuid.PcdIdenticalTopSwapsBuilt       | $(BUILD_IDENTICAL_TS)
+  gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled          | $(ENABLE_TCC)
 
 [PcdsPatchableInModule]
   gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel   | 0x8000004F
@@ -325,7 +326,6 @@
   gPlatformModuleTokenSpaceGuid.PcdSplashEnabled          | $(ENABLE_SPLASH)
   gPlatformModuleTokenSpaceGuid.PcdFramebufferInitEnabled | $(ENABLE_FRAMEBUFFER_INIT)
   gPlatformModuleTokenSpaceGuid.PcdVtdEnabled             | $(ENABLE_VTD)
-  gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled          | $(ENABLE_TCC)
   gPlatformModuleTokenSpaceGuid.PcdPsdBiosEnabled         | $(HAVE_PSD_TABLE)
   gPayloadTokenSpaceGuid.PcdGrubBootCfgEnabled            | $(ENABLE_GRUB_CONFIG)
   gPlatformModuleTokenSpaceGuid.PcdSmbiosEnabled          | $(ENABLE_SMBIOS)

--- a/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -58,7 +58,7 @@ GetCpuStepping(
   return ((CPU_STEPPING) (Eax.Uint32 & CPUID_FULL_STEPPING));
 }
 
-#if FeaturePcdGet (PcdTccEnabled)
+#if FixedPcdGet8 (PcdTccEnabled)
 /**
   Update FSP-M UPD config data for TCC mode and tuning
 
@@ -644,7 +644,7 @@ UpdateFspConfig (
 
   // Tcc enabling
   if (IsPchS() || IsPchN()) {
-#if FeaturePcdGet (PcdTccEnabled)
+#if FixedPcdGet8 (PcdTccEnabled)
     Fspmcfg->WdtDisableAndLock = 0x0;
     TccModePreMemConfig (FspmUpd);
 #endif

--- a/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.inf
+++ b/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.inf
@@ -44,4 +44,6 @@
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
   gPlatformModuleTokenSpaceGuid.PcdVtdEnabled
   gPlatformModuleTokenSpaceGuid.PcdFastBootEnabled
+
+[FixedPcd]
   gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled

--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -319,7 +319,7 @@ GetMaxCpuPciePortNum (
   }
 }
 
-#if FeaturePcdGet (PcdTccEnabled)
+#if FixedPcdGet8 (PcdTccEnabled)
 /**
   Update FSP-S UPD config data for TCC mode and tuning
 
@@ -624,7 +624,7 @@ UpdateFspConfig (
     DEBUG ((DEBUG_INFO, "Failed to find Silicon Cfg Data\n"));
   } else {
     FspsUpd->FspsConfig.AcSplitLock               = SiCfgData->AcSplitLock;   // AC check on split locks
-#if FeaturePcdGet (PcdTccEnabled)
+#if FixedPcdGet8 (PcdTccEnabled)
     FspsUpd->FspsConfig.PsfTccEnable              = SiCfgData->PsfTccEnable;  // Enable will decrease psf transaction latency by disabling psf power mgmt features
 #endif
     FspsUpd->FspsConfig.PchDmiAspmCtrl            = SiCfgData->PchDmiAspmCtrl;// ASPM configuration on the PCH side of the DMI/OPI Link
@@ -1228,7 +1228,7 @@ UpdateFspConfig (
   }
 
   if (IsPchS () || IsPchN()) {
-#if FeaturePcdGet (PcdTccEnabled)
+#if FixedPcdGet8 (PcdTccEnabled)
     Status = TccModePostMemConfig (FspsUpd);
 #endif
   }

--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.inf
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.inf
@@ -42,10 +42,10 @@
 
 [Pcd]
   gPlatformModuleTokenSpaceGuid.PcdFramebufferInitEnabled
-  gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled
   gPlatformModuleTokenSpaceGuid.PcdEnablePciePm
   gPlatformModuleTokenSpaceGuid.PcdFastBootEnabled
   gPlatformModuleTokenSpaceGuid.PcdSblResiliencyEnabled
 
 [FixedPcd]
+  gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled
   gPlatformAlderLakeTokenSpaceGuid.PcdAdlLpSupport


### PR DESCRIPTION
PcdTccEnabled was declared as a FeaturePcd which evaluates to a code symbol and can't be used in a #if. From the preprocessor perspective it is always undefined. Changed this pcd to a FixedPcd instead.

Signed-off-by: Bejean Mosher <bejean.mosher@intel.com>