### PR TITLE
fix: Check for possible NULL dereference introduced in #1695.

### DIFF
--- a/BootloaderCorePkg/Stage2/Stage2Hob.c
+++ b/BootloaderCorePkg/Stage2/Stage2Hob.c
@@ -989,7 +989,9 @@ BuildExtraInfoHob (
 
     TpmLibGetActivePcrBanks (&SecureBootInfoHob->TpmPcrActivePcrBanks);
 
-    SecureBootInfoHob->FirmwareDebuggerInitialized  = ((LoaderPlatformInfo->HwState >> 2) || (LoaderPlatformInfo->HwState >> 3));
+    if (LoaderPlatformInfo != NULL) {
+      SecureBootInfoHob->FirmwareDebuggerInitialized  = ((LoaderPlatformInfo->HwState >> 2) || (LoaderPlatformInfo->HwState >> 3));
+    }
 
     // SBL supports only TPM 2.0
     if (SecureBootInfoHob->MeasuredBootEnabled) {


### PR DESCRIPTION
PR #1695 possible NULL deregerence was triggering static analyzer failure. Added a NULL check before dereferencing.

Signed-off-by: Bejean Mosher <bejean.mosher@intel.com>