### PR TITLE
[EHL] Update FSP/UCODE/platform version since MR5 is released

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/BoardConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/BoardConfig.py
@@ -26,7 +26,7 @@ class Board(BaseBoard):
         # VERINFO_PROJ_MAJOR_VER: 1 PV Quality release
         # VERINFO_PROJ_MINOR_VER: 0: PV  1: MR1  2: MR2 etc.
         self.VERINFO_PROJ_MAJOR_VER = 1
-        self.VERINFO_PROJ_MINOR_VER = 4
+        self.VERINFO_PROJ_MINOR_VER = 5
         self.VERINFO_SVN          = 1
         self.VERINFO_BUILD_DATE   = time.strftime("%m/%d/%Y")
         self.LOWEST_SUPPORTED_FW_VER = ((self.VERINFO_PROJ_MAJOR_VER << 8) + self.VERINFO_PROJ_MINOR_VER)

--- a/Silicon/ElkhartlakePkg/FspBin/FspBin.inf
+++ b/Silicon/ElkhartlakePkg/FspBin/FspBin.inf
@@ -11,7 +11,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = 751a02a2d3236bfebc3928928ec361c3956476e9
+  COMMIT  = 3905c552478520f825ea9962044150726c9aaa79
 
 [UserExtensions.SBL."CopyList"]
   ElkhartLakeFspBinPkg/FspBin/FSPRel.bin               : Silicon/ElkhartlakePkg/FspBin/FspDbg.bin
@@ -24,3 +24,4 @@
   ElkhartLakeFspBinPkg/Include/MemInfoHob.h            : Silicon/ElkhartlakePkg/Include/MemInfoHob.h
   ElkhartLakeFspBinPkg/VbtBin/Vbt.bin                  : Platform/ElkhartlakeBoardPkg/VbtBin/Vbt.dat
   ElkhartLakeFspBinPkg/VbtBin/Vbt.bsf                  : Platform/ElkhartlakeBoardPkg/VbtBin/Vbt.bsf
+  FSP_License.pdf                                      : Silicon/ElkhartlakePkg/FspBin/FSP_License.pdf

--- a/Silicon/ElkhartlakePkg/Microcode/Microcode.inf
+++ b/Silicon/ElkhartlakePkg/Microcode/Microcode.inf
@@ -14,11 +14,11 @@
   VERSION_STRING       = 1.0
 
 [Sources]
-  m0190661_00000016.mcb
+  m0190661_00000017.mcb
 
 [UserExtensions.SBL."CloneRepo"]
-  REPO  = https://github.com/tianocore/edk2-non-osi.git
-  COMMIT= 6996a45d7f4014fd4aa0f1eb4cbe97d8a3c5957a
+  REPO  = https://github.com/slimbootloader/firmwareblob.git
+  COMMIT= 98918f6881ce7f3a551712260d6d04f5f117d219
 
 [UserExtensions.SBL."CopyList"]
-  Silicon/Intel/ElkhartlakeSiliconBinPkg/Microcode/m0190661_00000016.mcb  : Silicon/ElkhartlakePkg/Microcode/m0190661_00000016.mcb
+  Microcode/ElkhartLake/m_01_90661_00000017.pdb  : Silicon/ElkhartlakePkg/Microcode/m0190661_00000017.mcb


### PR DESCRIPTION
- update FSP version to MR5 FSP (09.04.30.51)
- update microcode version to 17
- update platform version to 1.5

Signed-off-by: Vincent Chen <vincent.chen@intel.com>