### PR TITLE
Consider Simultaneous SG02 Corruptions in BP0 and BP1 for Resiliency

### DIFF
--- a/BootloaderCorePkg/Include/Library/FirmwareResiliencyLib.h
+++ b/BootloaderCorePkg/Include/Library/FirmwareResiliencyLib.h
@@ -12,23 +12,21 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 /**
   Retrieve FW update state from the reserved region
 
-  @param[in,out] StateMachine The current FW update state
+  @retval StateMachine The current FWU state machine
 **/
-VOID
+UINT8
 EFIAPI
 GetFwuStateMachine (
-  IN OUT UINT8* StateMachine
+  VOID
   );
 
 /**
   Check if ACM detected corruption in IBB
-
-  @param[in] StateMachine The current FW update state
 **/
 VOID
 EFIAPI
 CheckForAcmFailures (
-  IN UINT8 StateMachine
+  VOID
   );
 
 /**

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -356,7 +356,6 @@ SecStartup2 (
   VOID                    **FieldPtr;
   UINT32                    Tolum;
   UINT64                    Touum;
-  UINT8                     FwuStateMachine;
 
   LdrGlobal = (LOADER_GLOBAL_DATA *)GetLoaderGlobalDataPointer ();
   ASSERT (LdrGlobal != NULL);
@@ -387,12 +386,8 @@ SecStartup2 (
 
   // Check if recovery is needed, if not in recovery path already
   if (PcdGetBool (PcdSblResiliencyEnabled)) {
-    GetFwuStateMachine (&FwuStateMachine);
-    DEBUG ((DEBUG_INFO, "Current FW update state machine: %d\n", FwuStateMachine));
-    if (FwuStateMachine != FW_UPDATE_SM_RECOVERY && !IsRecoveryTriggered ()) {
-      CheckForTcoTimerFailures (PcdGet8 (PcdBootFailureThreshold));
-      CheckForAcmFailures (FwuStateMachine);
-    }
+    CheckForAcmFailures ();
+    CheckForTcoTimerFailures (PcdGet8 (PcdBootFailureThreshold));
   }
 
   Status = AppendHashStore (LdrGlobal, &Stage1bParam);

--- a/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -203,7 +203,6 @@ FwuTopSwapSetting (
     pFwUpdStatus = (FW_UPDATE_STATUS *)(UINTN)RsvdBase;
   }
 
-  DEBUG ((DEBUG_INFO, "Current FW update state machine: %d\n", pFwUpdStatus->StateMachine));
   // If in a recovery path, stay on current partition.
   if (PcdGetBool (PcdSblResiliencyEnabled) &&
      (IsRecoveryTriggered () ||


### PR DESCRIPTION
Before this change, whenever SG02 is corrupted
in both BP0 and BP1, SBL will continuously loop
trying to recover BP0 via BP1 and vice versa

This change makes it so that, if a failure is
detected on a recovery flow, the CPU halts

Signed-off-by: Sean McGinn <sean.mcginn@intel.com>