### PR TITLE
[QEMU] Allow building with the debug FSP

### DIFF
--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -1,7 +1,7 @@
 ## @file
 # This file is used to provide board specific image information.
 #
-#  Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -105,7 +105,7 @@ class Board(BaseBoard):
         if self.NO_OPT_MODE:
             self.STAGE1A_SIZE    += 0x1000
         self.STAGE1B_SIZE         = 0x00030000
-        self.STAGE2_SIZE          = 0x00018000
+        self.STAGE2_SIZE          = 0x0001A000
 
         self.TEST_SIZE            = 0x00001000
         self.SIIPFW_SIZE          = 0x00010000

--- a/Silicon/QemuSocPkg/FspBin/Patches/0001-Build-QEMU-FSP-2.0-binaries.patch
+++ b/Silicon/QemuSocPkg/FspBin/Patches/0001-Build-QEMU-FSP-2.0-binaries.patch
@@ -996,7 +996,7 @@ new file mode 100644
 index 0000000000..9420bba30d
 --- /dev/null
 +++ b/QemuFspPkg/FspmInit/FspmInit.c
-@@ -0,0 +1,802 @@
+@@ -0,0 +1,800 @@
 +/** @file
 +  FSP-M component implementation.
 +
@@ -1595,7 +1595,6 @@ index 0000000000..9420bba30d
 +  UINT32                          TsegBase;
 +  UINT8                           EsmramcVal;
 +  UINT8                           Q35TsegMbytes;
-+  UINT8                           RegMask8;
 +  UINT32                          TopOfLowRam;
 +  UINT32                          TopOfLowRamMb;
 +  UINT16                          HostBridgeDevId;
@@ -1657,7 +1656,6 @@ index 0000000000..9420bba30d
 +  // bits are hard-coded as 1 by QEMU.
 +  //
 +  EsmramcVal = PciRead8 (DRAMC_REGISTER_Q35 (MCH_ESMRAMC));
-+  RegMask8 = MCH_ESMRAMC_SM_CACHE | MCH_ESMRAMC_SM_L1 | MCH_ESMRAMC_SM_L2;
 +
 +  TopOfLowRam = LowMemLen;
 +  ASSERT ((TopOfLowRam & (SIZE_1MB - 1)) == 0);


### PR DESCRIPTION
Fix two errors that prevent building QEMU SBL with the debug FSP on Linux:
- 0001-Build-QEMU-FSP-2.0-binaries.patch adds a variable "RegMask8" to FspmInitEntryPoint() that is written but not read; GCC treats this as an error;
- the resulting STAGE2 binary is larger than the 0x18000 bytes allocated for it.

Signed-off-by: Bruno Achauer <bruno.achauer@intel.com>