### PR TITLE
[ADL] enable TCO timer by default

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -725,9 +725,7 @@ UpdateFspConfig (
     FspsConfig->EnableTimedGpio1 = SiCfgData->EnableTimedGpio1;
     FspsConfig->PchPmSlpAMinAssert = SiCfgData->PchPmSlpAMinAssert;
 
-    if (PcdGetBool (PcdSblResiliencyEnabled)) {
-      FspsConfig->EnableTcoTimer = 0x1;
-    }
+    FspsConfig->EnableTcoTimer = 0x1;
 
     // UFS
     if (IsPchLp ()) {


### PR DESCRIPTION
TCO timer could be enabled regardless resiliency feature. So just remove the resiliency conditional.

Signed-off-by: Guo Dong <guo.dong@intel.com>