### PR TITLE
fix: [RPL-P] Combined ADL-P and RPL-P RVP board IDs so either can boot.

### DIFF
--- a/Platform/AlderlakeBoardPkg/Include/PlatformBoardId.h
+++ b/Platform/AlderlakeBoardPkg/Include/PlatformBoardId.h
@@ -59,10 +59,7 @@ Defines Platform BoardIds
 #define PLATFORM_ID_TEST_S_DDR5_SODIMM_RVP            0x11
 
 #define BoardIdRplPDdr5Rvp                            0x17
-#define PLATFORM_ID_RPL_P_DDR5_RVP                    0x06
-
 #define BoardIdRplPLp5Rvp                             0x05
-#define PLATFORM_ID_RPL_P_LP5_RVP                     0x05
 
 #define PLATFORM_ID_RPL_P_DDR5_CRB                    0x08
 

--- a/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -589,7 +589,6 @@ UpdateFspConfig (
         Fspmcfg->Lp5CccConfig = 0xff;
         break;
       case PLATFORM_ID_ADL_P_DDR5_RVP:
-      case PLATFORM_ID_RPL_P_DDR5_RVP:
         Fspmcfg->DdiPortBHpd = 0x1;
         Fspmcfg->PrmrrSize = 0x200000;
         Fspmcfg->PcieClkReqGpioMux[9] = 0x796e9000;
@@ -597,16 +596,6 @@ UpdateFspConfig (
         Fspmcfg->Ddr4OneDpc = 0x3;
         Fspmcfg->DmiHweq = 0x2;
         Fspmcfg->FirstDimmBitMaskEcc = 0x0;
-        break;
-      case PLATFORM_ID_RPL_P_LP5_RVP:
-        Fspmcfg->DdiPortBConfig = 0x1;
-        Fspmcfg->PrmrrSize = 0x400000;
-        Fspmcfg->PcieClkReqGpioMux[9] = 0x796e9000;
-        Fspmcfg->TcssXdciEn = 0x1;
-        Fspmcfg->Ddr4OneDpc = 0x3;
-        Fspmcfg->Lp5CccConfig = 0xff;
-        Fspmcfg->FirstDimmBitMaskEcc = 0x0;
-        Fspmcfg->DmiHweq = 0x2;
         break;
       case PLATFORM_ID_ADL_PS_DDR5_RVP:
         Fspmcfg->DdiPortBHpd = 0x1;
@@ -690,8 +679,6 @@ UpdateFspConfig (
         case PLATFORM_ID_ADL_P_LP4_RVP:
         case PLATFORM_ID_ADL_P_LP5_RVP:
         case PLATFORM_ID_ADL_P_DDR5_RVP:
-        case PLATFORM_ID_RPL_P_DDR5_RVP:
-        case PLATFORM_ID_RPL_P_LP5_RVP:
           Fspmcfg->PchIshEnable       = 1;
       }
     }

--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -1126,7 +1126,6 @@ UpdateFspConfig (
 
     switch (GetPlatformId ()) {
       case PLATFORM_ID_ADL_P_DDR5_RVP:
-      case PLATFORM_ID_RPL_P_DDR5_RVP:
         FspsConfig->Usb4CmMode = 0x0;
         break;
       case PLATFORM_ID_ADL_N_DDR5_CRB:

--- a/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/EcSupport.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/EcSupport.c
@@ -374,9 +374,11 @@ GetBoardId (
       *PlatformId = PLATFORM_ID_ADL_P_LP4_RVP;
       break;
     case BoardIdAdlPLp5Rvp:
+    case BoardIdRplPLp5Rvp:
       *PlatformId = PLATFORM_ID_ADL_P_LP5_RVP;
       break;
     case BoardIdAdlPDdr5Rvp:
+    case BoardIdRplPDdr5Rvp:
       *PlatformId = PLATFORM_ID_ADL_P_DDR5_RVP;
       break;
     case BoardIdAdlPSDdr5Rvp:
@@ -390,12 +392,6 @@ GetBoardId (
       break;
     case BoardIdTestSDdr5SODimmRvp:
       *PlatformId = PLATFORM_ID_TEST_S_DDR5_SODIMM_RVP;
-      break;
-    case BoardIdRplPDdr5Rvp:
-      *PlatformId = PLATFORM_ID_RPL_P_DDR5_RVP;
-      break;
-    case BoardIdRplPLp5Rvp:
-      *PlatformId = PLATFORM_ID_RPL_P_LP5_RVP;
       break;
     default:
       DEBUG((DEBUG_INFO, "Unsupported board Id %x .....\n", *PlatformId));

--- a/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -596,7 +596,6 @@ DEBUG_CODE_END();
       ConfigureGpio (CDATA_NO_TAG, sizeof (mGpioTablePreMemAdlPLp5Rvp) / sizeof (mGpioTablePreMemAdlPLp5Rvp[0]), (UINT8*)mGpioTablePreMemAdlPLp5Rvp);
       break;
     case PLATFORM_ID_ADL_P_DDR5_RVP:
-    case PLATFORM_ID_RPL_P_DDR5_RVP:
       ConfigureGpio (CDATA_NO_TAG, sizeof (mGpioTablePreMemAdlPDdr5Rvp) / sizeof (mGpioTablePreMemAdlPDdr5Rvp[0]), (UINT8*)mGpioTablePreMemAdlPDdr5Rvp);
       break;
     case PLATFORM_ID_TEST_S_DDR5_UDIMM_RVP:

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
@@ -869,7 +869,6 @@ PlatformUpdateAcpiGnvs (
   PchNvs->CnviBtAudioOffload = FspsConfig->CnviBtAudioOffload;
   switch (GetPlatformId ()) {
     case PLATFORM_ID_ADL_P_DDR5_RVP:
-    case PLATFORM_ID_RPL_P_DDR5_RVP:
     PchNvs->CnviBtAudioOffload = 0x1;
   }
   PchNvs->PsOnEnable         = FspsConfig->PsOnEnable;
@@ -1066,7 +1065,6 @@ PlatformUpdateAcpiGnvs (
     PlatformNvs->PcieSlot2RpNumber = 5;
     break;
   case PLATFORM_ID_ADL_P_DDR5_RVP:
-  case PLATFORM_ID_RPL_P_DDR5_RVP:
     PlatformNvs->PcieSlot1WakeGpio = 0;
     PlatformNvs->PcieSlot1PowerEnableGpio = GPIO_VER2_LP_GPP_A22;
     PlatformNvs->PcieSlot1PowerEnableGpioPolarity = 0;

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -321,7 +321,6 @@ BoardInit (
         switch (GetPlatformId ()) {
           case PLATFORM_ID_ADL_P_LP5_RVP:
           case PLATFORM_ID_ADL_P_DDR5_RVP:
-          case PLATFORM_ID_RPL_P_DDR5_RVP:
             DEBUG ((DEBUG_WARN, "TSN GPIO: No ADL-P GPIO table available currently...\n"));
             break;
           case PLATFORM_ID_ADL_S_ADP_S_CRB:

--- a/Silicon/AlderlakePkg/Library/IgdOpRegionLib/IgdOpRegionLib.c
+++ b/Silicon/AlderlakePkg/Library/IgdOpRegionLib/IgdOpRegionLib.c
@@ -290,10 +290,8 @@ UpdateVbt (
     GopVbtSpecificUpdate = (GOP_VBT_SPECIFIC_UPDATE)(UINTN)&AdlPDdr5GopVbtSpecificUpdate;
     break;
   case PLATFORM_ID_ADL_P_DDR5_RVP:
-  case PLATFORM_ID_RPL_P_DDR5_RVP:
   case PLATFORM_ID_ADL_P_LP4_RVP:
   case PLATFORM_ID_ADL_P_LP5_RVP:
-  case PLATFORM_ID_RPL_P_LP5_RVP:
   case PLATFORM_ID_RPL_P_DDR5_CRB:
     DEBUG((DEBUG_INFO, "UpdateVbt: BoardIdAdlP DDR5 or Lp4/5Rvp .....\n"));
     GopVbtSpecificUpdate = (GOP_VBT_SPECIFIC_UPDATE)(UINTN)&AdlGopVbtSpecificUpdateNull;


### PR DESCRIPTION
RPL-P and ADL-P RVPs are essentially identical except for BoardID FRU. Both need to work with SBL with RPL-P Silicon. To avoid duplicating config data, this change will treat both as the same board.

Signed-off-by: Bejean Mosher <bejean.mosher@intel.com>