### PR TITLE
[EHL] support multi VBT

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/BoardConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/BoardConfig.py
@@ -185,6 +185,14 @@ class Board(BaseBoard):
         self.PLD_RSVD_MEM_SIZE    = 0x00500000
         self.LOADER_RSVD_MEM_SIZE = 0x500000
 
+        # If mulitple VBT table support is required, list them as:
+        #   {VbtImageId1 : VbtFileName1, VbtImageId2 : VbtFileName2, ...}
+        # VbtImageId is ID to identify a VBT image. It is a UINT32 number to match
+        #   the ImageId field in the VBT container.
+        # VbtFileName is the VBT file name. It needs to be located under platform
+        #   VbtBin folder.
+        self._MULTI_VBT_FILE      = {1:'Vbt.dat'}
+
         # _CFGDATA_INT_FILE - Internal cfg data is generally used for internal boards like MRBs, RVPs etc.
         # _CFGDATA_EXT_FILE - External cfg data is for the customer boards to populate new data on top of the internal defaults.
         # Cfg data dlt files for internal boards could also put into external cfg data if want to update cfg data for these platforms

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1237,7 +1237,9 @@ UpdateFspConfig (
     Fspscfg->PavpEnable                 = SiCfgData->PavpEnable;
     Fspscfg->CdClock                    = SiCfgData->CdClock;
     Fspscfg->PeiGraphicsPeimInit        = SiCfgData->PeiGraphicsPeimInit;
-    Fspscfg->GraphicsConfigPtr          = PcdGet32(PcdGraphicsVbtAddress);
+
+
+    Fspscfg->GraphicsConfigPtr          = (UINT32)GetVbtAddress ();
 
     CopyMem(SaDisplayConfigTable, (VOID *)(UINTN)mEhlCrbRowDisplayDdiConfig, sizeof(mEhlCrbRowDisplayDdiConfig));
     Fspscfg->DdiPortAConfig             = SaDisplayConfigTable[0];


### PR DESCRIPTION
Currently, Slim Bootloader support for multiple VBT files doesn't work on EHL. Support for multiple VBT files, which works on other platform, does not work correctly for EHL. However, this change can fix it locally by adding the support from another platform into the EHL support once integrated into the public SBL

Signed-off-by: Devathurai Linggeis Daran <linggeis.daran.devathurai@intel.com>


