### PR TITLE
[RPL/ADL] L2 CAT not getting enabled when TCC enabled.

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -468,7 +468,7 @@ TccModePostMemConfig (
 
     if (IsPchS ()) {
       FspsUpd->FspsConfig.TccMode = 1;
-#ifdef PLATFORM_ADLS
+#if FixedPcdGet8(PcdAdlNSupport) == 0
       FspsUpd->FspsConfig.L2QosEnumerationEn = 1;
 #endif
     }

--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.inf
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.inf
@@ -49,3 +49,4 @@
 [FixedPcd]
   gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled
   gPlatformAlderLakeTokenSpaceGuid.PcdAdlLpSupport
+  gPlatformAlderLakeTokenSpaceGuid.PcdAdlNSupport


### PR DESCRIPTION
FspsUpdUpdateLIb was not enabling FspsUpd->FspsConfig.L2QosEnumerationEn based on PLATFORM_ADLS, which is no longer used. L2QosEnumerationEn is present in ADL-P,S,PS, and RPL-S,P FSP UPD, just not ADL-N, so need to prevent compiling this code for that platform only.

Signed-off-by: Bejean Mosher <bejean.mosher@intel.com>