### PR TITLE
Check that uCode slot sizes line up during uCode update

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -87,8 +87,9 @@
   gPlatformModuleTokenSpaceGuid.PcdMrcDataSize            | 0x00000000 | UINT32 | 0x2000008B
   gPlatformModuleTokenSpaceGuid.PcdUcodeBase              | 0x00000000 | UINT32 | 0x2000008C
   gPlatformModuleTokenSpaceGuid.PcdUcodeSize              | 0x00000000 | UINT32 | 0x2000008D
-  gPlatformModuleTokenSpaceGuid.PcdVariableRegionBase     | 0x00000000 | UINT32 | 0x2000008E
-  gPlatformModuleTokenSpaceGuid.PcdVariableRegionSize     | 0x00000000 | UINT32 | 0x2000008F
+  gPlatformModuleTokenSpaceGuid.PcdUcodeSlotSize          | 0x00000000 | UINT32 | 0x2000008E
+  gPlatformModuleTokenSpaceGuid.PcdVariableRegionBase     | 0x00000000 | UINT32 | 0x2000008F
+  gPlatformModuleTokenSpaceGuid.PcdVariableRegionSize     | 0x00000000 | UINT32 | 0x20000090
 
   gPlatformModuleTokenSpaceGuid.PcdMemoryMapEntryNumber   | 0x00000000 | UINT32 | 0x200000A2
   gPlatformModuleTokenSpaceGuid.PcdOsBootOptionNumber     | 0x00000008 | UINT32 | 0x200000A3

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -206,6 +206,7 @@
   gPlatformModuleTokenSpaceGuid.PcdMrcDataSize            | $(MRCDATA_SIZE)
   gPlatformModuleTokenSpaceGuid.PcdUcodeBase              | $(UCODE_BASE)
   gPlatformModuleTokenSpaceGuid.PcdUcodeSize              | $(UCODE_SIZE)
+  gPlatformModuleTokenSpaceGuid.PcdUcodeSlotSize          | $(UCODE_SLOT_SIZE)
   gPlatformModuleTokenSpaceGuid.PcdVariableRegionBase     | $(VARIABLE_BASE)
   gPlatformModuleTokenSpaceGuid.PcdVariableRegionSize     | $(VARIABLE_SIZE)
 

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
@@ -81,6 +81,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdFrameBufferMaxConsoleHeight
   gPlatformModuleTokenSpaceGuid.PcdSblResiliencyEnabled
   gPlatformModuleTokenSpaceGuid.PcdBootFailureThreshold
+  gPlatformModuleTokenSpaceGuid.PcdUcodeSlotSize
 
 [Depex]
   TRUE

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.c
@@ -1188,12 +1188,19 @@ VerifyUcodeStruct (
   ImageBase = (UINTN)ImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER);
   ImageOffset = 0;
 
-  // Ensure patches in update image start at slot boundaries
   ImageByte = (UINT8*)(ImageBase + ImageOffset);
   while (*ImageByte != PAD_BYTE && ImageOffset < ImageHdr->UpdateImageSize) {
     UCodeHdr = (CPU_MICROCODE_HEADER *)ImageByte;
+
+    // Ensure patches in update image start at slot boundaries
     if (UCodeHdr->HeaderVersion != 1) {
-      DEBUG((DEBUG_ERROR, "Existing image slots do not line up with new image slots!!\n"));
+      DEBUG((DEBUG_ERROR, "Existing uCode slots do not line up with new uCode slots!!\n"));
+      return EFI_NO_MAPPING;
+    }
+
+    // Ensure total size from header does not exceed slot size
+    if (UCodeHdr->TotalSize > PcdGet32 (PcdUcodeSlotSize)) {
+      DEBUG((DEBUG_ERROR, "Total uCode size from header exceeds uCode slot size!!\n"));
       return EFI_NO_MAPPING;
     }
     ImageOffset += PcdGet32(PcdUcodeSlotSize);

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
@@ -99,6 +99,19 @@ VerifyFwVersion (
   );
 
 /**
+  Verify uCode internal structure
+
+  @param[in] ImageHdr     Pointer to the fw mgmt capsule image header
+
+  @retval  EFI_SUCCESS    The operation completed successfully.
+  @retval  others         There is error happening.
+**/
+EFI_STATUS
+VerifyUcodeStruct (
+  IN  EFI_FW_MGMT_CAP_IMAGE_HEADER  *ImageHdr
+  );
+
+/**
   Verify the firmware internal structure.
 
   @param[in] ImageHdr     Pointer to the fw mgmt capsule image header

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
@@ -12,6 +12,24 @@
 #include <Uefi/UefiBaseType.h>
 #include <Library/ResetSystemLib.h>
 
+///
+/// Structure to describe microcode header
+///
+typedef struct {
+  UINT32 HeaderVersion;  ///< Version number of the update header.
+  UINT32 UpdateRevision; ///< Unique version number for the update.
+  UINT32 Date;           ///< Date of the update creation.
+  UINT32 ProcessorId;    ///< Signature of the processor that requires this update.
+  UINT32 Checksum;       ///< Checksum of update data and header.
+  UINT32 LoaderRevision; ///< Version number of the microcode loader program.
+  UINT32 ProcessorFlags; ///< Lower 4 bits denoting platform type information.
+  UINT32 DataSize;       ///< Size of encoded data in bytes.
+  UINT32 TotalSize;      ///< Total size of microcode update in bytes.
+  UINT8  Reserved[12];   ///< Reserved bits.
+} CPU_MICROCODE_HEADER;
+
+#define PAD_BYTE  0xFF
+
 /**
   Update a region block.
 
@@ -78,6 +96,19 @@ EFI_STATUS
 VerifyFwVersion (
   IN  EFI_FW_MGMT_CAP_IMAGE_HEADER  *ImageHdr,
   IN  FIRMWARE_UPDATE_POLICY  FwPolicy
+  );
+
+/**
+  Verify the firmware internal structure.
+
+  @param[in] ImageHdr     Pointer to the fw mgmt capsule image header
+
+  @retval  EFI_SUCCESS    The operation completed successfully.
+  @retval  others         There is error happening.
+**/
+EFI_STATUS
+VerifyFwStruct (
+  IN  EFI_FW_MGMT_CAP_IMAGE_HEADER  *ImageHdr
   );
 
 /**


### PR DESCRIPTION
Currently, users are able to update the uCode component with a new binary that uses a different slot size than the existing binary. If these slot sizes do not line up, there is potential to trigger recovery (if enabled) or brick the system. This change disallows updates where these slot sizes do not line up.

Signed-off-by: Sean McGinn <sean.mcginn@intel.com>