### PR TITLE
[ADLN] Set FIVR transition value

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -867,6 +867,10 @@ UpdateFspConfig (
       FspsConfig->PchLanEnable = 0x0;
       ZeroMem (FspsConfig->PchIshI2cEnable, sizeof (FspsConfig->PchIshI2cEnable));
       ZeroMem (FspsConfig->PchIshGpEnable, sizeof (FspsConfig->PchIshGpEnable));
+      // Apply FIVR workaround
+      if(IsPchN()) {
+        FspsConfig->PchFivrVccinAuxOffToHighCurModeVolTranTime = 0;
+      }
       DEBUG ((DEBUG_INFO, "Stage 2 S0ix config applied.\n"));
     }
   }


### PR DESCRIPTION
For S0ix usecase, set Fivr transition time to zero to resolve a hardware issue.

Signed-off-by: "Grandhi, Sindhura" <sindhura.grandhi@intel.com>