### PR TITLE
OsLoader: Add Multiboot-2 support

### DIFF
--- a/BootloaderCommonPkg/Include/Library/MultibootLib.h
+++ b/BootloaderCommonPkg/Include/Library/MultibootLib.h
@@ -234,11 +234,18 @@ typedef struct {
   BOOTPARAMS_IMAGE_DATA   BootParamsData;
 } TRUSTY_IMAGE_DATA;
 
+typedef struct multiboot2_start_tag MULTIBOOT2_START_TAG;  /* opaque type */
+
+typedef struct {
+  MULTIBOOT2_START_TAG   *StartTag;
+} MULTIBOOT2_INFO;
+
 #define MAX_MULTIBOOT_MODULE_NUMBER  16
 typedef struct {
   IMAGE_DATA              BootFile;
   IMAGE_DATA              CmdFile;
   MULTIBOOT_INFO          MbInfo;
+  MULTIBOOT2_INFO         Mb2Info;
   IA32_BOOT_STATE         BootState;
   UINT16                  CmdBufferSize;
   UINT16                  MbModuleNumber;
@@ -294,6 +301,63 @@ VOID
 EFIAPI
 JumpToMultibootOs (
   IN IA32_BOOT_STATE *State  // esp + 4
+  );
+
+/* ======================================================================== */
+/**
+  Check if it is Multiboot-2 image
+
+  @param[in]  ImageAddr    Memory address of an image
+
+  @retval TRUE             Image is Multiboot 2.0 compliant image
+  @retval FALSE            Not multiboot image
+**/
+BOOLEAN
+EFIAPI
+IsMultiboot2 (
+  IN  VOID                   *ImageAddr
+  );
+
+/**
+  Setup Multiboot-2 image and its boot info.
+
+  @param[in,out] MultiBoot   Point to loaded Multiboot-2 image structure
+
+  @retval  RETURN_SUCCESS    Setup Multiboot-2 image successfully
+  @retval  Others            There is error when setup image
+**/
+EFI_STATUS
+EFIAPI
+SetupMultiboot2Image (
+  IN OUT MULTIBOOT_IMAGE     *MultiBoot
+  );
+
+/**
+  Setup the Multiboot-2 info for boot usage.
+
+  @param[in,out]   MultiBoot  Point to loaded Multiboot-2 image structure
+**/
+VOID
+EFIAPI
+SetupMultiboot2Info (
+  IN OUT MULTIBOOT_IMAGE     *MultiBoot
+  );
+
+/**
+  Update the memory info inside the Multiboot-2 info.
+
+  @param[in,out]   MultiBoot     Point to loaded Multiboot-2 image structure
+  @param[in]       RsvdMemBase   Reserved memory base address
+  @param[in]       RsvdMemSize   Reserved memory size
+  @param[in]       RsvdMemExtra  Extra space to add to the reserved memory region.
+**/
+VOID
+EFIAPI
+UpdateMultiboot2MemInfo (
+  IN OUT MULTIBOOT_IMAGE     *MultiBoot,
+  IN UINT64                   RsvdMemBase,
+  IN UINT64                   RsvdMemSize,
+  IN UINT32                   RsvdMemExtra
   );
 
 #endif

--- a/BootloaderCommonPkg/Library/MultibootLib/Multiboot.c
+++ b/BootloaderCommonPkg/Library/MultibootLib/Multiboot.c
@@ -1,7 +1,7 @@
 /** @file
   This file Multiboot specification (implementation).
 
-  Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -16,9 +16,12 @@
 #include <Library/BootloaderCommonLib.h>
 #include <Guid/MemoryMapInfoGuid.h>
 #include <Guid/GraphicsInfoHob.h>
+#include "MultibootLibInternal.h"
 
 #define SUPPORTED_FEATURES  (MULTIBOOT_HEADER_MODS_ALIGNED | MULTIBOOT_HEADER_WANT_MEMORY | MULTIBOOT_HEADER_HAS_VBE)
 UINT8 mLoaderName[]        = "Slim BootLoader\0";
+
+VOID DumpMbHeader (CONST MULTIBOOT_HEADER *Mh);
 
 
 /**
@@ -81,6 +84,7 @@ IsMultiboot (
 
   MbHeader = GetMultibootHeader (ImageAddr);
   if (MbHeader != NULL) {
+    DumpMbHeader (MbHeader);
     return TRUE;
   }
   return FALSE;
@@ -238,7 +242,7 @@ SetupMultibootInfo (
 **/
 EFI_STATUS
 EFIAPI
-AlignMulitibootModules (
+AlignMultibootModules (
   IN OUT MULTIBOOT_IMAGE     *MultiBoot
   )
 {
@@ -310,7 +314,7 @@ SetupMultibootImage (
 
   if ((MbHeader->Flags & MULTIBOOT_HEADER_MODS_ALIGNED) != 0) {
     // Other modules should be page (4KB) aligned
-    Status = AlignMulitibootModules (MultiBoot);
+    Status = AlignMultibootModules (MultiBoot);
     if (EFI_ERROR (Status)) {
       return Status;
     }
@@ -340,6 +344,34 @@ SetupMultibootImage (
   return EFI_SUCCESS;
 }
 
+
+/**
+  Print out the Multiboot header.
+
+  @param[in]  Mh  The Multiboot header to be printed.
+**/
+VOID
+DumpMbHeader (CONST MULTIBOOT_HEADER *Mh)
+{
+  DEBUG ((DEBUG_INFO, "\nDump MB header @%p:\n", Mh));
+
+  DEBUG ((DEBUG_INFO, "- Magic:             %8x\n", Mh->Magic));
+  DEBUG ((DEBUG_INFO, "- Flags:             %8x\n", Mh->Flags));
+  DEBUG ((DEBUG_INFO, "- Checksum:          %8x\n", Mh->Checksum));
+
+  /* Valid if mh_flags sets MULTIBOOT_HEADER_HAS_ADDR. */
+  DEBUG ((DEBUG_INFO, "- HeaderAddr:        %8x\n", Mh->HeaderAddr));
+  DEBUG ((DEBUG_INFO, "- LoadAddr:          %8x\n", Mh->LoadAddr));
+  DEBUG ((DEBUG_INFO, "- LoadEndAddr:       %8x\n", Mh->LoadEndAddr));
+  DEBUG ((DEBUG_INFO, "- BssEndAddr:        %8x\n", Mh->BssEndAddr));
+  DEBUG ((DEBUG_INFO, "- EntryAddr:         %8x\n", Mh->EntryAddr));
+
+  /* Valid if mh_flags sets MULTIBOOT_HEADER_HAS_VBE. */
+  DEBUG ((DEBUG_INFO, "- ModeType:          %8x\n", Mh->ModeType));
+  DEBUG ((DEBUG_INFO, "- Width:             %8x\n", Mh->Width));
+  DEBUG ((DEBUG_INFO, "- Height:            %8x\n", Mh->Height));
+  DEBUG ((DEBUG_INFO, "- Depth:             %8x\n", Mh->Depth));
+}
 
 /**
   Print out the Multiboot information block.

--- a/BootloaderCommonPkg/Library/MultibootLib/Multiboot2.c
+++ b/BootloaderCommonPkg/Library/MultibootLib/Multiboot2.c
@@ -1,0 +1,686 @@
+/** @file
+  This file Multiboot-2 specification (implementation).
+
+  Copyright (c) 2014 - 2022, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiPei.h>
+#include <Library/MultibootLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HobLib.h>
+#include <Library/BootloaderCommonLib.h>
+#include <Guid/MemoryMapInfoGuid.h>
+#include <Guid/GraphicsInfoHob.h>
+#include "MultibootLibInternal.h"
+#include "multiboot2.h"
+
+VOID DumpMb2Header (CONST struct multiboot2_header *Mh);
+
+
+/**
+  Get multiboot header address
+
+  Get multiboot header following Multboot spec 2.0.
+
+  @param[in]  ImageAddr    Memory address of an image
+
+  @retval MultibootHeader  Pointer to Multiboot header if found.
+  @retval NULL             No valid Multiboot header found or requesting
+                           features not support.
+**/
+CONST struct multiboot2_header *
+EFIAPI
+GetMultiboot2Header (
+  IN  VOID                   *ImageAddr
+  )
+{
+  UINT32                     AlignedAddress;
+  struct multiboot2_header  *MbHeader;
+  UINT32                     Offset;
+
+  // Multiboot header must be 64-bit aligned.
+  AlignedAddress = ALIGN_UP((UINT32)(UINTN)ImageAddr, MULTIBOOT2_HEADER_ALIGN);
+
+  // Multiboot header must completely within the first 32K bytes of the image.
+  for (Offset = 0; Offset < MULTIBOOT2_SEARCH - sizeof (struct multiboot2_header); Offset += MULTIBOOT2_HEADER_ALIGN) {
+    MbHeader = (struct multiboot2_header *)(UINTN)(AlignedAddress + Offset);
+    if ((MbHeader->magic == MULTIBOOT2_HEADER_MAGIC) &&
+        (MbHeader->architecture == MULTIBOOT2_ARCHITECTURE_I386) &&
+        (MbHeader->magic + MbHeader->architecture + MbHeader->header_length + MbHeader->checksum == 0)) {
+      return (CONST struct multiboot2_header *) MbHeader;
+    }
+  }
+
+  return NULL;
+}
+
+/**
+  Check if it is Multiboot image
+
+  @param[in]  ImageAddr    Memory address of an image
+
+  @retval TRUE             Image is Multiboot 0.6.98 compliant image
+  @retval FALSE            Not multiboot image
+**/
+BOOLEAN
+EFIAPI
+IsMultiboot2 (
+  IN  VOID                   *ImageAddr
+  )
+{
+  CONST struct multiboot2_header *MbHeader;
+
+  MbHeader = GetMultiboot2Header (ImageAddr);
+  if (MbHeader != NULL) {
+    DumpMb2Header (MbHeader);
+    return TRUE;
+  }
+  return FALSE;
+}
+
+
+/**
+  Get memory map information.
+
+  @retval   Memory Map Info pointer
+**/
+STATIC
+MEMORY_MAP_INFO *
+EFIAPI
+GetMemoryMapInfo (
+  VOID
+  )
+{
+  EFI_HOB_GUID_TYPE          *GuidHob;
+
+  GuidHob = GetNextGuidHob (&gLoaderMemoryMapInfoGuid, GetHobList());
+  if (GuidHob == NULL) {
+    ASSERT (GuidHob);
+    return NULL;
+  }
+
+  return (MEMORY_MAP_INFO *)GET_GUID_HOB_DATA (GuidHob);
+}
+
+
+/**
+  Init Multiboot-2 memory map.
+
+  @param[out]  MbMmap         Multiboot memmap buffer
+  @param[in]   MemoryMapInfo  Memmap buffer from boot loader
+**/
+VOID
+InitMultiboot2Mmap (
+  OUT     struct multiboot2_mmap_entry *MbMmap,
+  IN      MEMORY_MAP_INFO              *MemoryMapInfo
+  )
+{
+  UINT32                     Index;
+  MEMORY_MAP_ENTRY           *MmapEntry;
+
+  MmapEntry = &MemoryMapInfo->Entry[0];
+  for (Index = 0; Index < MemoryMapInfo->Count; Index++) {
+    MbMmap[Index].addr = MmapEntry[Index].Base;
+    MbMmap[Index].len  = MmapEntry[Index].Size;
+    MbMmap[Index].type = MmapEntry[Index].Type;
+    MbMmap[Index].zero = 0;
+  }
+}
+
+
+/**
+  Setup the Multiboot info for boot usage.
+
+  @param[in,out]   MultiBoot  Point to loaded Multiboot image structure
+**/
+VOID
+EFIAPI
+SetupMultiboot2Info (
+  IN OUT MULTIBOOT_IMAGE     *MultiBoot
+  )
+{
+  MULTIBOOT2_INFO *Mb2Info = &MultiBoot->Mb2Info;
+
+  unsigned mb2_info_size_max = 0x1000;
+  void *mb2_info = AllocatePool (mb2_info_size_max);
+  if (mb2_info == NULL) {
+    DEBUG ((DEBUG_INFO, "Multiboot-2 info buffer allocation Error\n"));
+    ASSERT (mb2_info);
+  }
+
+  struct multiboot2_start_tag *mbi_start = (struct multiboot2_start_tag *)mb2_info;
+  Mb2Info->StartTag = mbi_start;
+  unsigned info_idx = sizeof(*mbi_start);
+
+  /*
+  ** Add tags:
+  */
+#define DECLARE_TAG(STRUCT, TAG, BASE, P) \
+  STRUCT *TAG = (STRUCT *) ((char *)(BASE) + (P))
+#define APPEND_TAG(P, TAG, TYPE, SIZE) do { \
+  (TAG)->type = (TYPE); \
+  (TAG)->size = (SIZE); \
+  (P) += ALIGN_UP((TAG)->size, MULTIBOOT2_TAG_ALIGN); \
+} while (0)
+
+  // command line tag (1)
+  if (MultiBoot->CmdFile.Size != 0)
+  {
+    DECLARE_TAG (struct multiboot2_tag_string, tag, mb2_info, info_idx);
+
+    unsigned len = MultiBoot->CmdFile.Size;
+    CopyMem(tag->string, MultiBoot->CmdFile.Addr, len);
+    tag->string[len] = '\0';
+
+    APPEND_TAG (info_idx, tag, MULTIBOOT2_TAG_TYPE_CMDLINE, sizeof(struct multiboot2_tag_string) + len + 1);
+  }
+
+  // bootloader name tag (2)
+  {
+    DECLARE_TAG (struct multiboot2_tag_string, tag, mb2_info, info_idx);
+
+    UINT32 len = (UINT32) AsciiStrSize((CHAR8 *) mLoaderName);
+    CopyMem(tag->string, mLoaderName, len);
+
+    APPEND_TAG (info_idx, tag, MULTIBOOT2_TAG_TYPE_BOOT_LOADER_NAME, sizeof(struct multiboot2_tag_string) + len);
+  }
+
+  // module tags (3)
+  for (unsigned idx = 0; idx < MultiBoot->MbModuleNumber; idx += 1)
+  {
+    DECLARE_TAG (struct multiboot2_tag_module, module_tag, mb2_info, info_idx);
+
+    const MULTIBOOT_MODULE *mod = &MultiBoot->MbModule[idx];
+    UINT32 len = (UINT32) AsciiStrSize((CHAR8 *) mod->String);
+
+    module_tag->mod_start   = mod->Start;
+    module_tag->mod_end     = mod->End;
+    CopyMem(module_tag->cmdline, mod->String, len);
+
+    APPEND_TAG (info_idx, module_tag, MULTIBOOT2_TAG_TYPE_MODULE, sizeof(struct multiboot2_tag_module) + len);
+  }
+
+  // basic memory info tag (4)
+  {
+    DECLARE_TAG (struct multiboot2_tag_basic_meminfo, tag, mb2_info, info_idx);
+
+    // The amount of lower and upper memory size (in KB) will be updated
+    // later since current memmap is not the final memmap.
+    tag->mem_upper = 0;
+    tag->mem_lower = 0;
+
+    APPEND_TAG (info_idx, tag, MULTIBOOT2_TAG_TYPE_BASIC_MEMINFO, sizeof(struct multiboot2_tag_basic_meminfo));
+  }
+
+  // normal memory map tag (6)
+  {
+    DECLARE_TAG (struct multiboot2_tag_mmap, mmap_tag, mb2_info, info_idx);
+
+    MEMORY_MAP_INFO *mmap_info = GetMemoryMapInfo();
+    unsigned mb_mmap_count = mmap_info->Count;
+
+    mmap_tag->entry_size = sizeof(struct multiboot2_mmap_entry);
+    mmap_tag->entry_version = 0;
+    InitMultiboot2Mmap (&mmap_tag->entries[0], mmap_info);
+
+    APPEND_TAG (info_idx, mmap_tag, MULTIBOOT2_TAG_TYPE_MMAP,
+                sizeof(struct multiboot2_tag_mmap) + sizeof(struct multiboot2_mmap_entry) * mb_mmap_count);
+  }
+
+  // framebuffer tag (8)
+  EFI_HOB_GUID_TYPE *GuidHob = GetFirstGuidHob (&gEfiGraphicsInfoHobGuid);
+  if (GuidHob != NULL)
+  {
+    DECLARE_TAG (struct multiboot2_tag_framebuffer, tag, mb2_info, info_idx);
+
+    EFI_PEI_GRAPHICS_INFO_HOB  *GfxInfoHob = (EFI_PEI_GRAPHICS_INFO_HOB *)GET_GUID_HOB_DATA (GuidHob);
+    tag->common.framebuffer_addr   = (UINT64)(UINTN)GfxInfoHob->FrameBufferBase;
+    tag->common.framebuffer_pitch  = GfxInfoHob->GraphicsMode.PixelsPerScanLine * 4;
+    tag->common.framebuffer_width  = GfxInfoHob->GraphicsMode.HorizontalResolution;
+    tag->common.framebuffer_height = GfxInfoHob->GraphicsMode.VerticalResolution;
+    tag->common.framebuffer_bpp    = 32;
+    tag->common.framebuffer_type   = 1;
+    tag->u.type1.framebuffer_red_field_position   = 0x10;
+    tag->u.type1.framebuffer_red_mask_size        = 8;
+    tag->u.type1.framebuffer_green_field_position = 0x08;
+    tag->u.type1.framebuffer_green_mask_size      = 8;
+    tag->u.type1.framebuffer_blue_field_position  = 0x00;
+    tag->u.type1.framebuffer_blue_mask_size       = 8;
+
+    APPEND_TAG (info_idx, &tag->common, MULTIBOOT2_TAG_TYPE_FRAMEBUFFER, sizeof(struct multiboot2_tag_framebuffer));
+  }
+
+  // end tag (0)
+  {
+    DECLARE_TAG (struct multiboot2_tag, end_tag, mb2_info, info_idx);
+    APPEND_TAG (info_idx, end_tag, MULTIBOOT2_TAG_TYPE_END, sizeof(struct multiboot2_tag));
+  }
+
+#undef DECLARE_TAG
+#undef APPEND_TAG
+
+  ASSERT (info_idx <= mb2_info_size_max);
+
+  mbi_start->size = info_idx;
+  mbi_start->reserved = 0x00;
+
+  /*
+  ** Arrange for passing this data to the image.
+  */
+  MultiBoot->BootState.Eax = MULTIBOOT2_BOOTLOADER_MAGIC;
+  MultiBoot->BootState.Ebx = (UINT32)(UINTN)mbi_start;
+}
+
+
+/**
+  Update the memory info inside the Multiboot-2 info.
+
+  @param[in,out]   MultiBoot     Point to loaded Multiboot-2 image structure
+  @param[in]       RsvdMemBase   Reserved memory base address
+  @param[in]       RsvdMemSize   Reserved memory size
+  @param[in]       RsvdMemExtra  Extra space to add to the reserved memory region.
+**/
+VOID
+EFIAPI
+UpdateMultiboot2MemInfo (
+  IN OUT MULTIBOOT_IMAGE     *MultiBoot,
+  IN UINT64                   RsvdMemBase,
+  IN UINT64                   RsvdMemSize,
+  IN UINT32                   RsvdMemExtra
+  )
+{
+  struct multiboot2_start_tag         *Mi = MultiBoot->Mb2Info.StartTag;
+  struct multiboot2_tag_basic_meminfo *minfo_tag = NULL;
+  struct multiboot2_tag_mmap          *mmap_tag = NULL;
+
+  //
+  //  Find the BASIC_MEMINFO and MMAP info tags; punt if not found (we created them).
+  //
+  for (unsigned off = sizeof(*Mi); off < Mi->size; ) {
+    struct multiboot2_tag *tag = (void *) ((char *) Mi + off);
+
+    if (tag->type == MULTIBOOT2_TAG_TYPE_BASIC_MEMINFO)
+      minfo_tag = (struct multiboot2_tag_basic_meminfo *) tag;
+    if (tag->type == MULTIBOOT2_TAG_TYPE_MMAP)
+      mmap_tag = (struct multiboot2_tag_mmap *) tag;
+    if (tag->type == MULTIBOOT2_TAG_TYPE_END)
+      break;
+
+    off += ALIGN_UP (MAX (tag->size, sizeof(*tag)), MULTIBOOT2_TAG_ALIGN);
+  }
+  if (minfo_tag == NULL || mmap_tag == NULL)
+    ASSERT (minfo_tag && mmap_tag);
+
+  //
+  //  Iterate over the memory map entries and look for:
+  //  - the given reserved region => extend it by the reqested extra size (from the beginning);
+  //  - the region that is immediately below the reserved space => shrink it by the extra space;
+  //  - usable memory regions starting at address 0x0 or 1M => record size in the basic mem info tag.
+  //
+  unsigned n_entries = (mmap_tag->size - sizeof(*mmap_tag)) / mmap_tag->entry_size;
+  for (unsigned idx = 0; idx < n_entries; idx += 1) {
+    struct multiboot2_mmap_entry *entry = &mmap_tag->entries[idx];
+
+    DEBUG ((DEBUG_INFO, "\n\t%12llx %12llx %4d",
+        mmap_tag->entries[idx].addr,
+        mmap_tag->entries[idx].len,
+        mmap_tag->entries[idx].type));
+
+    if (entry->addr == RsvdMemBase && entry->len == RsvdMemSize) {
+      entry->addr -= RsvdMemExtra;
+      entry->len  += RsvdMemExtra;
+    } else if (entry->addr + entry->len == RsvdMemBase) {
+      entry->len  -= RsvdMemExtra;
+    }
+
+    if (entry->type == MEM_MAP_TYPE_RAM) {
+      if (entry->addr == 0)
+        minfo_tag->mem_lower = (UINT32) (RShiftU64 (entry->len, 10));
+      else if (entry->addr == MB_ (1))
+        minfo_tag->mem_upper = (UINT32) (RShiftU64 (entry->len, 10));
+    }
+  }
+}
+
+
+/**
+  Parse Multiboot-2 image header tags and extract data required for setting up the image.
+
+  @param[in] Mh   The Multiboot header to be parsed.
+
+  @retval  RETURN_SUCCESS    All required information was found.
+  @retval  Others            Some required information is not present.
+**/
+EFI_STATUS
+EFIAPI
+ParseMultiboot2Header (
+  IN CONST struct multiboot2_header *Mh,
+  OUT BOOLEAN  *AlignModules,
+  OUT UINT8    **HeaderAddr,
+  OUT UINT8    **LoadAddr,
+  OUT UINT8    **LoadEnd,
+  OUT UINT8    **BssEnd,
+  OUT UINT32   *EntryPoint
+  )
+{
+  *AlignModules = FALSE;
+
+  UINT32 tags_needed = (1U << MULTIBOOT2_HEADER_TAG_ADDRESS)
+                     | (1U << MULTIBOOT2_HEADER_TAG_ENTRY_ADDRESS);
+
+  for (unsigned off = sizeof(*Mh); off < Mh->header_length ; )
+  {
+    const struct multiboot2_header_tag *htag = (void *) ((char *) Mh + off);
+
+    switch (htag->type)
+    {
+    case MULTIBOOT2_HEADER_TAG_ADDRESS:               // 2
+    {
+      const struct multiboot2_header_tag_address *tag = (void *) ((char *) Mh + off);
+      *HeaderAddr = (UINT8 *)(UINTN) tag->header_addr;
+      *LoadAddr   = (UINT8 *)(UINTN) tag->load_addr;
+      *LoadEnd    = (UINT8 *)(UINTN) tag->load_end_addr;
+      *BssEnd     = (UINT8 *)(UINTN) tag->bss_end_addr;
+    }
+    break;
+    case MULTIBOOT2_HEADER_TAG_ENTRY_ADDRESS:         // 3
+    {
+      const struct multiboot2_header_tag_entry_address *tag = (void *) ((char *) Mh + off);
+      *EntryPoint = tag->entry_addr;
+    }
+    break;
+    case MULTIBOOT2_HEADER_TAG_MODULE_ALIGN:          // 6
+      *AlignModules = TRUE;
+      break;
+
+    case MULTIBOOT2_HEADER_TAG_END:                   // 0
+    case MULTIBOOT2_HEADER_TAG_FRAMEBUFFER:           // 5
+      // noted, ignore the tag.
+      break;
+
+//  case MULTIBOOT2_HEADER_TAG_INFORMATION_REQUEST:   // 1
+//  case MULTIBOOT2_HEADER_TAG_CONSOLE_FLAGS:         // 4
+//  case MULTIBOOT2_HEADER_TAG_EFI_BS:                // 7
+//  case MULTIBOOT2_HEADER_TAG_ENTRY_ADDRESS_EFI32:   // 8
+//  case MULTIBOOT2_HEADER_TAG_ENTRY_ADDRESS_EFI64:   // 9
+//  case MULTIBOOT2_HEADER_TAG_RELOCATABLE:           // 10
+    default:
+      // unsupported or unknown tag, failure!
+      return RETURN_UNSUPPORTED;
+    }
+
+    off += ALIGN_UP (MAX (htag->size, sizeof(*htag)), MULTIBOOT2_TAG_ALIGN);
+    if (htag->type == MULTIBOOT2_TAG_TYPE_END)
+      break;
+    tags_needed &= ~(1U << htag->type);
+  }
+
+  return (tags_needed ? RETURN_UNSUPPORTED : RETURN_SUCCESS);
+}
+
+/**
+  Setup Multiboot image and its boot info.
+
+  @param[in,out] MultiBoot   Point to loaded Multiboot image structure
+
+  @retval  RETURN_SUCCESS    Setup Multiboot image successfully
+  @retval  Others            There is error when setup image
+**/
+EFI_STATUS
+EFIAPI
+SetupMultiboot2Image (
+  IN OUT MULTIBOOT_IMAGE     *MultiBoot
+  )
+{
+  EFI_STATUS                 Status;
+  BOOLEAN                    AlignModules;
+  UINT8                      *HeaderAddr;
+  UINT8                      *LoadAddr;
+  UINT8                      *LoadEnd;
+  UINT8                      *BssEnd;
+  UINT32                     EntryPoint;
+  CONST struct multiboot2_header     *MbHeader;
+  UINT32                      ImgOffset;
+  UINT32                      ImgLength;
+  UINT8                      *CopyStart;
+
+  if (MultiBoot == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  MbHeader = GetMultiboot2Header (MultiBoot->BootFile.Addr);
+  if (MbHeader == NULL) {
+    return RETURN_LOAD_ERROR;
+  }
+
+  Status = ParseMultiboot2Header (MbHeader, &AlignModules, &HeaderAddr, &LoadAddr, &LoadEnd, &BssEnd, &EntryPoint);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if (AlignModules) {
+    // Other modules should be page (4KB) aligned
+    Status = AlignMultibootModules (MultiBoot);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  }
+
+  ImgOffset  = (UINT32)((UINT8 *)MbHeader - (UINT8 *)MultiBoot->BootFile.Addr - (HeaderAddr - LoadAddr));
+  ImgLength  = (UINT32)((LoadEnd == NULL) ? MultiBoot->BootFile.Size - ImgOffset : LoadEnd - LoadAddr);
+  if ((ImgOffset >= MultiBoot->BootFile.Size) || (ImgOffset + ImgLength > MultiBoot->BootFile.Size)) {
+    return RETURN_LOAD_ERROR;
+  }
+
+  DEBUG ((DEBUG_INFO, "Mb: LoadAddr=0x%p, LoadEnd=0x%p , BssEnd=0x%p, Size=0x%x\n", LoadAddr, LoadEnd, BssEnd, ImgLength));
+  CopyStart = (UINT8 *)MultiBoot->BootFile.Addr + ImgOffset;
+  CopyMem (LoadAddr, CopyStart, ImgLength);
+  if ((BssEnd != NULL) && (LoadEnd != NULL)) {
+    if (BssEnd > LoadEnd) {
+      ZeroMem ((VOID *) LoadEnd, BssEnd - LoadEnd);
+    }
+  }
+
+  SetupMultiboot2Info (MultiBoot);
+  MultiBoot->BootState.EntryPoint = EntryPoint;
+  return EFI_SUCCESS;
+}
+
+
+/**
+  Print out the Multiboot header.
+
+  @param[in]  Mh  The Multiboot header to be printed.
+**/
+VOID
+DumpMb2Header (CONST struct multiboot2_header *Mh)
+{
+  DEBUG ((DEBUG_INFO, "\nDump MB2 header @%p:\n", Mh));
+
+  DEBUG ((DEBUG_INFO, "- magic:             %8x\n", Mh->magic));
+  DEBUG ((DEBUG_INFO, "- architecture:      %8x\n", Mh->architecture));
+  DEBUG ((DEBUG_INFO, "- header_length:     %8x\n", Mh->header_length));
+  DEBUG ((DEBUG_INFO, "- checksum:          %8x\n", Mh->checksum));
+
+  for (unsigned off = sizeof(*Mh); off < Mh->header_length ; )
+  {
+    const struct multiboot2_header_tag *htag = (void *) ((char *) Mh + off);
+
+    DEBUG ((DEBUG_INFO, "- tag @%02x [T=%2d F=%04x S=%2d]: ", off, htag->type, htag->flags, htag->size));
+    switch (htag->type)
+    {
+    case MULTIBOOT2_HEADER_TAG_END:                   // 0
+      DEBUG ((DEBUG_INFO, "<END>"));
+      break;
+    case MULTIBOOT2_HEADER_TAG_ADDRESS:               // 2
+    {
+      const struct multiboot2_header_tag_address *tag = (void *) ((char *) Mh + off);
+      DEBUG ((DEBUG_INFO, "header @%#x, load to %#x-%#x, bss-end @%#x",
+              tag->header_addr,
+              tag->load_addr,
+              tag->load_end_addr,
+              tag->bss_end_addr));
+    }
+    break;
+    case MULTIBOOT2_HEADER_TAG_ENTRY_ADDRESS:         // 3
+    {
+      const struct multiboot2_header_tag_entry_address *tag = (void *) ((char *) Mh + off);
+      DEBUG ((DEBUG_INFO, "entry point: %#x", tag->entry_addr));
+    }
+    break;
+    case MULTIBOOT2_HEADER_TAG_MODULE_ALIGN:          // 6
+      DEBUG ((DEBUG_INFO, "align modules."));
+      break;
+    case MULTIBOOT2_HEADER_TAG_FRAMEBUFFER:           // 5
+    {
+      const struct multiboot2_header_tag_framebuffer *t5 = (void *) ((char *) Mh + off);
+      DEBUG ((DEBUG_INFO, "(frame buffer) preferred graphics mode: width=%d, height=%d, depth=%d",
+              t5->width, t5->height, t5->depth));
+    }
+    break;
+
+//  case MULTIBOOT2_HEADER_TAG_INFORMATION_REQUEST:   // 1
+//  case MULTIBOOT2_HEADER_TAG_CONSOLE_FLAGS:         // 4
+//  case MULTIBOOT2_HEADER_TAG_EFI_BS:                // 7
+//  case MULTIBOOT2_HEADER_TAG_ENTRY_ADDRESS_EFI32:   // 8
+//  case MULTIBOOT2_HEADER_TAG_ENTRY_ADDRESS_EFI64:   // 9
+//  case MULTIBOOT2_HEADER_TAG_RELOCATABLE:           // 10
+
+    default:
+      DEBUG ((DEBUG_INFO, "??"));
+      break;
+    }
+    DEBUG ((DEBUG_INFO, "\n"));
+
+    off += ALIGN_UP (MAX (htag->size, sizeof(*htag)), MULTIBOOT2_TAG_ALIGN);
+    if (htag->type == MULTIBOOT2_TAG_TYPE_END)
+      break;
+  }
+}
+
+/**
+  Print out the Multiboot-2 information block.
+
+  @param[in]  Mi  The Multiboot-2 information block to be printed.
+**/
+VOID
+DumpMb2Info (
+  IN  CONST struct multiboot2_start_tag *Mi
+  )
+{
+  DEBUG ((DEBUG_INFO, "\nDump MB2 info @%p (size=%d, reserved=%x):\n", Mi, Mi->size, Mi->reserved));
+  if (Mi == NULL) {
+    return;
+  }
+
+  for (unsigned off = sizeof(*Mi); off < Mi->size; )
+  {
+      const struct multiboot2_tag *tag = (void *) ((char *) Mi + off);
+
+    DEBUG ((DEBUG_INFO, "- tag @%03x [T=%2d S=%2d]: ", off, tag->type, tag->size));
+    switch (tag->type)
+    {
+    case MULTIBOOT2_TAG_TYPE_END:               // 0
+      DEBUG ((DEBUG_INFO, "<END>"));
+      break;
+    case MULTIBOOT2_TAG_TYPE_CMDLINE:           // 1
+    {
+        struct multiboot2_tag_string *string_tag = (void *) ((char *) Mi + off);
+      DEBUG ((DEBUG_INFO, "command line: '%a'",
+              string_tag->string));
+    }
+    break;
+    case MULTIBOOT2_TAG_TYPE_BOOT_LOADER_NAME:  // 2
+    {
+        struct multiboot2_tag_string *string_tag = (void *) ((char *) Mi + off);
+      DEBUG ((DEBUG_INFO, "boot loader name: '%a'",
+              string_tag->string));
+    }
+    break;
+    case MULTIBOOT2_TAG_TYPE_MODULE:            // 3
+    {
+        struct multiboot2_tag_module *module_tag = (void *) ((char *) Mi + off);
+      DEBUG ((DEBUG_INFO, "module: start %#x, end %#x, cmd line '%a'",
+              module_tag->mod_start, module_tag->mod_end, module_tag->cmdline));
+    }
+    break;
+    case MULTIBOOT2_TAG_TYPE_BASIC_MEMINFO:     // 4
+    {
+        struct multiboot2_tag_basic_meminfo *meminfo_tag = (void *) ((char *) Mi + off);
+      DEBUG ((DEBUG_INFO, "basic memory info: %dK lower, %dK upper memory",
+              meminfo_tag->mem_lower, meminfo_tag->mem_upper));
+    }
+    break;
+    case MULTIBOOT2_TAG_TYPE_MMAP:              // 6
+    {
+        struct multiboot2_tag_mmap *mmap_tag = (void *) ((char *) Mi + off);
+      unsigned n_entries = (mmap_tag->size - sizeof(*mmap_tag)) / mmap_tag->entry_size;
+      DEBUG ((DEBUG_INFO, "memory map: %d entries (version=%d, size=%d):",
+              n_entries, mmap_tag->entry_version, mmap_tag->entry_size));
+      DEBUG ((DEBUG_INFO, "\n\t     address       length type\n\t------------ ------------ ----"));
+      for (unsigned idx = 0; idx < n_entries; idx += 1)
+      {
+        DEBUG ((DEBUG_INFO, "\n\t%12llx %12llx %4d",
+                mmap_tag->entries[idx].addr,
+                mmap_tag->entries[idx].len,
+                mmap_tag->entries[idx].type));
+      }
+    }
+    break;
+    case MULTIBOOT2_TAG_TYPE_FRAMEBUFFER:       // 8
+    {
+        struct multiboot2_tag_framebuffer *fb_tag = (void *) ((char *) Mi + off);
+      DEBUG ((DEBUG_INFO, "frame buffer @%llx: pitch %#x, width %d, height %d, bpp %d\n\ttype %d",
+              fb_tag->common.framebuffer_addr,
+              fb_tag->common.framebuffer_pitch,
+              fb_tag->common.framebuffer_width,
+              fb_tag->common.framebuffer_height,
+              fb_tag->common.framebuffer_bpp,
+              fb_tag->common.framebuffer_type));
+      if (fb_tag->common.framebuffer_type == MULTIBOOT2_FRAMEBUFFER_TYPE_INDEXED)
+        DEBUG ((DEBUG_INFO, " (indexed, %d colors): ...",
+                fb_tag->u.type0.framebuffer_palette_num_colors));
+      else if (fb_tag->common.framebuffer_type == MULTIBOOT2_FRAMEBUFFER_TYPE_RGB)
+        DEBUG ((DEBUG_INFO, " (RGB): R=(%d,%d) G=(%d,%d) B=(%d,%d)",
+                fb_tag->u.type1.framebuffer_red_field_position,   fb_tag->u.type1.framebuffer_red_mask_size,
+                fb_tag->u.type1.framebuffer_green_field_position, fb_tag->u.type1.framebuffer_green_mask_size,
+                fb_tag->u.type1.framebuffer_blue_field_position,  fb_tag->u.type1.framebuffer_blue_mask_size));
+      else if (fb_tag->common.framebuffer_type == MULTIBOOT2_FRAMEBUFFER_TYPE_EGA_TEXT)
+        DEBUG ((DEBUG_INFO, ": EGA TEXT"));
+      else
+        DEBUG ((DEBUG_INFO, " ???"));
+    }
+    break;
+
+//  case MULTIBOOT2_TAG_TYPE_BOOTDEV:           // 5
+//  case MULTIBOOT2_TAG_TYPE_VBE:               // 7
+//  case MULTIBOOT2_TAG_TYPE_ELF_SECTIONS:      // 9
+//  case MULTIBOOT2_TAG_TYPE_APM:               // 10
+//  case MULTIBOOT2_TAG_TYPE_EFI32:             // 11
+//  case MULTIBOOT2_TAG_TYPE_EFI64:             // 12
+//  case MULTIBOOT2_TAG_TYPE_SMBIOS:            // 13
+//  case MULTIBOOT2_TAG_TYPE_ACPI_OLD:          // 14
+//  case MULTIBOOT2_TAG_TYPE_ACPI_NEW:          // 15
+//  case MULTIBOOT2_TAG_TYPE_NETWORK:           // 16
+//  case MULTIBOOT2_TAG_TYPE_EFI_MMAP:          // 17
+//  case MULTIBOOT2_TAG_TYPE_EFI_BS:            // 18
+//  case MULTIBOOT2_TAG_TYPE_EFI32_IH:          // 19
+//  case MULTIBOOT2_TAG_TYPE_EFI64_IH:          // 20
+//  case MULTIBOOT2_TAG_TYPE_LOAD_BASE_ADDR:    // 21
+
+    default:
+      DEBUG ((DEBUG_INFO, "??"));
+      break;
+    }
+    DEBUG ((DEBUG_INFO, "\n"));
+
+    off += ALIGN_UP (MAX (tag->size, sizeof(*tag)), MULTIBOOT2_TAG_ALIGN);
+    if (tag->type == MULTIBOOT2_TAG_TYPE_END)
+      break;
+  }
+}

--- a/BootloaderCommonPkg/Library/MultibootLib/MultibootLib.inf
+++ b/BootloaderCommonPkg/Library/MultibootLib/MultibootLib.inf
@@ -25,6 +25,7 @@
 
 [Sources]
   Multiboot.c
+  Multiboot2.c
 
 [Sources.IA32]
   Ia32/MultibootJump.nasm

--- a/BootloaderCommonPkg/Library/MultibootLib/MultibootLibInternal.h
+++ b/BootloaderCommonPkg/Library/MultibootLib/MultibootLibInternal.h
@@ -1,0 +1,27 @@
+/** @file
+
+  Copyright (c) 2012, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _MULTIBOOT_LIB_INTERNAL_H_
+#define _MULTIBOOT_LIB_INTERNAL_H_
+
+extern UINT8 mLoaderName[];
+
+/**
+  Align multiboot modules if required by spec.
+
+  @param[in,out] MultiBoot   Point to loaded Multiboot image structure
+
+  @retval  RETURN_SUCCESS     Align modules successfully
+  @retval  Others             There is error when align image
+**/
+EFI_STATUS
+EFIAPI
+AlignMultibootModules (
+  IN OUT MULTIBOOT_IMAGE     *MultiBoot
+  );
+
+#endif  //_MULTIBOOT_LIB_INTERNAL_H

--- a/BootloaderCommonPkg/Library/MultibootLib/multiboot2.h
+++ b/BootloaderCommonPkg/Library/MultibootLib/multiboot2.h
@@ -1,0 +1,424 @@
+/*  multiboot2.h - Multiboot 2 header file.  */
+/*  Copyright (C) 1999,2003,2007,2008,2009,2010  Free Software Foundation, Inc.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ *  deal in the Software without restriction, including without limitation the
+ *  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ *  sell copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL ANY
+ *  DEVELOPER OR DISTRIBUTOR BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+ *  IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*  [FROM: https://github.com/NetBSD/src/blob/trunk/sys/arch/i386/include/multiboot2.h ]*/
+
+#ifndef __MULTIBOOT2_H__
+#define __MULTIBOOT2_H__
+
+/* How many bytes from the start of the file we search for the header.  */
+#define MULTIBOOT2_SEARCH           32768
+#define MULTIBOOT2_HEADER_ALIGN         8
+
+/* The magic field should contain this.  */
+#define MULTIBOOT2_HEADER_MAGIC         0xe85250d6
+
+/* This should be in %eax.  */
+#define MULTIBOOT2_BOOTLOADER_MAGIC     0x36d76289
+
+/* Alignment of multiboot modules.  */
+#define MULTIBOOT2_MOD_ALIGN            0x00001000
+
+/* Alignment of the multiboot info structure.  */
+#define MULTIBOOT2_INFO_ALIGN           0x00000008
+
+/* Flags set in the 'flags' member of the multiboot header.  */
+
+#define MULTIBOOT2_TAG_ALIGN                  8
+#define MULTIBOOT2_TAG_TYPE_END               0
+#define MULTIBOOT2_TAG_TYPE_CMDLINE           1
+#define MULTIBOOT2_TAG_TYPE_BOOT_LOADER_NAME  2
+#define MULTIBOOT2_TAG_TYPE_MODULE            3
+#define MULTIBOOT2_TAG_TYPE_BASIC_MEMINFO     4
+#define MULTIBOOT2_TAG_TYPE_BOOTDEV           5
+#define MULTIBOOT2_TAG_TYPE_MMAP              6
+#define MULTIBOOT2_TAG_TYPE_VBE               7
+#define MULTIBOOT2_TAG_TYPE_FRAMEBUFFER       8
+#define MULTIBOOT2_TAG_TYPE_ELF_SECTIONS      9
+#define MULTIBOOT2_TAG_TYPE_APM               10
+#define MULTIBOOT2_TAG_TYPE_EFI32             11
+#define MULTIBOOT2_TAG_TYPE_EFI64             12
+#define MULTIBOOT2_TAG_TYPE_SMBIOS            13
+#define MULTIBOOT2_TAG_TYPE_ACPI_OLD          14
+#define MULTIBOOT2_TAG_TYPE_ACPI_NEW          15
+#define MULTIBOOT2_TAG_TYPE_NETWORK           16
+#define MULTIBOOT2_TAG_TYPE_EFI_MMAP          17
+#define MULTIBOOT2_TAG_TYPE_EFI_BS            18
+#define MULTIBOOT2_TAG_TYPE_EFI32_IH          19
+#define MULTIBOOT2_TAG_TYPE_EFI64_IH          20
+#define MULTIBOOT2_TAG_TYPE_LOAD_BASE_ADDR    21
+
+#define MULTIBOOT2_HEADER_TAG_END  0
+#define MULTIBOOT2_HEADER_TAG_INFORMATION_REQUEST  1
+#define MULTIBOOT2_HEADER_TAG_ADDRESS  2
+#define MULTIBOOT2_HEADER_TAG_ENTRY_ADDRESS  3
+#define MULTIBOOT2_HEADER_TAG_CONSOLE_FLAGS  4
+#define MULTIBOOT2_HEADER_TAG_FRAMEBUFFER  5
+#define MULTIBOOT2_HEADER_TAG_MODULE_ALIGN  6
+#define MULTIBOOT2_HEADER_TAG_EFI_BS        7
+#define MULTIBOOT2_HEADER_TAG_ENTRY_ADDRESS_EFI32  8
+#define MULTIBOOT2_HEADER_TAG_ENTRY_ADDRESS_EFI64  9
+#define MULTIBOOT2_HEADER_TAG_RELOCATABLE  10
+
+#define MULTIBOOT2_ARCHITECTURE_I386  0
+#define MULTIBOOT2_ARCHITECTURE_MIPS32  4
+#define MULTIBOOT2_HEADER_TAG_OPTIONAL 1
+
+#define MULTIBOOT2_LOAD_PREFERENCE_NONE 0
+#define MULTIBOOT2_LOAD_PREFERENCE_LOW 1
+#define MULTIBOOT2_LOAD_PREFERENCE_HIGH 2
+
+#define MULTIBOOT2_CONSOLE_FLAGS_CONSOLE_REQUIRED 1
+#define MULTIBOOT2_CONSOLE_FLAGS_EGA_TEXT_SUPPORTED 2
+
+#ifndef ASM_FILE
+
+typedef UINT8   multiboot_uint8_t;
+typedef UINT16  multiboot_uint16_t;
+typedef UINT32  multiboot_uint32_t;
+typedef UINT64  multiboot_uint64_t;
+
+struct multiboot2_header
+{
+  /* Must be MULTIBOOT2_MAGIC - see above.  */
+  multiboot_uint32_t magic;
+
+  /* ISA */
+  multiboot_uint32_t architecture;
+
+  /* Total header length.  */
+  multiboot_uint32_t header_length;
+
+  /* The above fields plus this one must equal 0 mod 2^32. */
+  multiboot_uint32_t checksum;
+};
+
+struct multiboot2_header_tag
+{
+  multiboot_uint16_t type;
+  multiboot_uint16_t flags;
+  multiboot_uint32_t size;
+};
+
+struct multiboot2_header_tag_information_request
+{
+  multiboot_uint16_t type;
+  multiboot_uint16_t flags;
+  multiboot_uint32_t size;
+  multiboot_uint32_t requests[0];
+};
+
+struct multiboot2_start_tag {
+  multiboot_uint32_t size;
+  multiboot_uint32_t reserved;
+};
+
+struct multiboot2_header_tag_address
+{
+  multiboot_uint16_t type;
+  multiboot_uint16_t flags;
+  multiboot_uint32_t size;
+  multiboot_uint32_t header_addr;
+  multiboot_uint32_t load_addr;
+  multiboot_uint32_t load_end_addr;
+  multiboot_uint32_t bss_end_addr;
+};
+
+struct multiboot2_header_tag_entry_address
+{
+  multiboot_uint16_t type;
+  multiboot_uint16_t flags;
+  multiboot_uint32_t size;
+  multiboot_uint32_t entry_addr;
+};
+
+struct multiboot2_header_tag_console_flags
+{
+  multiboot_uint16_t type;
+  multiboot_uint16_t flags;
+  multiboot_uint32_t size;
+  multiboot_uint32_t console_flags;
+};
+
+struct multiboot2_header_tag_framebuffer
+{
+  multiboot_uint16_t type;
+  multiboot_uint16_t flags;
+  multiboot_uint32_t size;
+  multiboot_uint32_t width;
+  multiboot_uint32_t height;
+  multiboot_uint32_t depth;
+};
+
+struct multiboot2_header_tag_module_align
+{
+  multiboot_uint16_t type;
+  multiboot_uint16_t flags;
+  multiboot_uint32_t size;
+};
+
+struct multiboot2_header_tag_relocatable
+{
+  multiboot_uint16_t type;
+  multiboot_uint16_t flags;
+  multiboot_uint32_t size;
+  multiboot_uint32_t min_addr;
+  multiboot_uint32_t max_addr;
+  multiboot_uint32_t align;
+  multiboot_uint32_t preference;
+};
+
+struct multiboot2_color
+{
+  multiboot_uint8_t red;
+  multiboot_uint8_t green;
+  multiboot_uint8_t blue;
+};
+
+struct multiboot2_mmap_entry
+{
+  multiboot_uint64_t addr;
+  multiboot_uint64_t len;
+#define MULTIBOOT2_MEMORY_AVAILABLE     1
+#define MULTIBOOT2_MEMORY_RESERVED      2
+#define MULTIBOOT2_MEMORY_ACPI_RECLAIMABLE       3
+#define MULTIBOOT2_MEMORY_NVS                    4
+#define MULTIBOOT2_MEMORY_BADRAM                 5
+  multiboot_uint32_t type;
+  multiboot_uint32_t zero;
+};
+typedef struct multiboot2_mmap_entry multiboot2_memory_map_t;
+
+struct multiboot2_tag
+{
+  multiboot_uint32_t type;
+  multiboot_uint32_t size;
+};
+
+struct multiboot2_tag_string
+{
+  multiboot_uint32_t type;
+  multiboot_uint32_t size;
+  char string[0];
+};
+
+struct multiboot2_tag_module
+{
+  multiboot_uint32_t type;
+  multiboot_uint32_t size;
+  multiboot_uint32_t mod_start;
+  multiboot_uint32_t mod_end;
+  char cmdline[0];
+};
+
+struct multiboot2_tag_basic_meminfo
+{
+  multiboot_uint32_t type;
+  multiboot_uint32_t size;
+  multiboot_uint32_t mem_lower;
+  multiboot_uint32_t mem_upper;
+};
+
+struct multiboot2_tag_bootdev
+{
+  multiboot_uint32_t type;
+  multiboot_uint32_t size;
+  multiboot_uint32_t biosdev;
+  multiboot_uint32_t slice;
+  multiboot_uint32_t part;
+};
+
+struct multiboot2_tag_mmap
+{
+  multiboot_uint32_t type;
+  multiboot_uint32_t size;
+  multiboot_uint32_t entry_size;
+  multiboot_uint32_t entry_version;
+  struct multiboot2_mmap_entry entries[0];
+};
+
+struct multiboot2_vbe_info_block
+{
+  multiboot_uint8_t external_specification[512];
+};
+
+struct multiboot2_vbe_mode_info_block
+{
+  multiboot_uint8_t external_specification[256];
+};
+
+struct multiboot2_tag_vbe
+{
+  multiboot_uint32_t type;
+  multiboot_uint32_t size;
+
+  multiboot_uint16_t vbe_mode;
+  multiboot_uint16_t vbe_interface_seg;
+  multiboot_uint16_t vbe_interface_off;
+  multiboot_uint16_t vbe_interface_len;
+
+  struct multiboot2_vbe_info_block vbe_control_info;
+  struct multiboot2_vbe_mode_info_block vbe_mode_info;
+};
+
+struct multiboot2_tag_framebuffer_common
+{
+  multiboot_uint32_t type;
+  multiboot_uint32_t size;
+
+  multiboot_uint64_t framebuffer_addr;
+  multiboot_uint32_t framebuffer_pitch;
+  multiboot_uint32_t framebuffer_width;
+  multiboot_uint32_t framebuffer_height;
+  multiboot_uint8_t framebuffer_bpp;
+#define MULTIBOOT2_FRAMEBUFFER_TYPE_INDEXED 0
+#define MULTIBOOT2_FRAMEBUFFER_TYPE_RGB     1
+#define MULTIBOOT2_FRAMEBUFFER_TYPE_EGA_TEXT    2
+  multiboot_uint8_t framebuffer_type;
+  multiboot_uint16_t reserved;
+};
+
+struct multiboot2_tag_framebuffer
+{
+  struct multiboot2_tag_framebuffer_common common;
+
+  union
+  {
+    struct
+    {
+      multiboot_uint16_t framebuffer_palette_num_colors;
+      struct multiboot2_color framebuffer_palette[0];
+    } type0;
+    struct
+    {
+      multiboot_uint8_t framebuffer_red_field_position;
+      multiboot_uint8_t framebuffer_red_mask_size;
+      multiboot_uint8_t framebuffer_green_field_position;
+      multiboot_uint8_t framebuffer_green_mask_size;
+      multiboot_uint8_t framebuffer_blue_field_position;
+      multiboot_uint8_t framebuffer_blue_mask_size;
+    } type1;
+  } u;
+};
+
+struct multiboot2_tag_elf_sections
+{
+  multiboot_uint32_t type;
+  multiboot_uint32_t size;
+  multiboot_uint32_t num;
+  multiboot_uint32_t entsize;
+  multiboot_uint32_t shndx;
+  char sections[0];
+};
+
+struct multiboot2_tag_apm
+{
+  multiboot_uint32_t type;
+  multiboot_uint32_t size;
+  multiboot_uint16_t version;
+  multiboot_uint16_t cseg;
+  multiboot_uint32_t offset;
+  multiboot_uint16_t cseg_16;
+  multiboot_uint16_t dseg;
+  multiboot_uint16_t flags;
+  multiboot_uint16_t cseg_len;
+  multiboot_uint16_t cseg_16_len;
+  multiboot_uint16_t dseg_len;
+};
+
+struct multiboot2_tag_efi32
+{
+  multiboot_uint32_t type;
+  multiboot_uint32_t size;
+  multiboot_uint32_t pointer;
+};
+
+struct multiboot2_tag_efi64
+{
+  multiboot_uint32_t type;
+  multiboot_uint32_t size;
+  multiboot_uint64_t pointer;
+};
+
+struct multiboot2_tag_smbios
+{
+  multiboot_uint32_t type;
+  multiboot_uint32_t size;
+  multiboot_uint8_t major;
+  multiboot_uint8_t minor;
+  multiboot_uint8_t reserved[6];
+  multiboot_uint8_t tables[0];
+};
+
+struct multiboot2_tag_old_acpi
+{
+  multiboot_uint32_t type;
+  multiboot_uint32_t size;
+  multiboot_uint8_t rsdp[0];
+};
+
+struct multiboot2_tag_new_acpi
+{
+  multiboot_uint32_t type;
+  multiboot_uint32_t size;
+  multiboot_uint8_t rsdp[0];
+};
+
+struct multiboot2_tag_network
+{
+  multiboot_uint32_t type;
+  multiboot_uint32_t size;
+  multiboot_uint8_t dhcpack[0];
+};
+
+struct multiboot2_tag_efi_mmap
+{
+  multiboot_uint32_t type;
+  multiboot_uint32_t size;
+  multiboot_uint32_t descr_size;
+  multiboot_uint32_t descr_vers;
+  multiboot_uint8_t efi_mmap[0];
+};
+
+struct multiboot2_tag_efi32_ih
+{
+  multiboot_uint32_t type;
+  multiboot_uint32_t size;
+  multiboot_uint32_t pointer;
+};
+
+struct multiboot2_tag_efi64_ih
+{
+  multiboot_uint32_t type;
+  multiboot_uint32_t size;
+  multiboot_uint64_t pointer;
+};
+
+struct multiboot2_tag_load_base_addr
+{
+  multiboot_uint32_t type;
+  multiboot_uint32_t size;
+  multiboot_uint32_t load_base_addr;
+};
+
+#endif /* ! ASM_FILE */
+
+#endif /* ! __MULTIBOOT2_H__ */

--- a/PayloadPkg/OsLoader/LoadImage.c
+++ b/PayloadPkg/OsLoader/LoadImage.c
@@ -674,6 +674,7 @@ UnloadLoadedImage (
   MULTIBOOT_MODULE_DATA      *MbModuleData;
   TRUSTY_IMAGE_DATA          *TrustyImageData;
   MULTIBOOT_INFO             *MbInfo;
+  MULTIBOOT2_INFO            *Mb2Info;
   UINT32                      Index;
   UINT32                      Count;
 
@@ -733,6 +734,20 @@ UnloadLoadedImage (
     if ((MbInfo->MmapAddr != NULL) && (MbInfo->Flags & MULTIBOOT_INFO_HAS_MMAP)) {
       FreePool (MbInfo->MmapAddr);
       MbInfo->MmapAddr = NULL;
+    }
+  }
+
+  //
+  // Free MultiBoot-2 Image Data
+  //
+  if (LoadedImage->Flags & LOADED_IMAGE_MULTIBOOT2) {
+    MultiBootImage = &LoadedImage->Image.MultiBoot;
+
+    // Free info tags which are allocated in SetupMultiboot2Info ()
+    Mb2Info = &MultiBootImage->Mb2Info;
+    if (Mb2Info->StartTag != NULL) {
+      FreePool (Mb2Info->StartTag);
+      Mb2Info->StartTag = NULL;
     }
   }
 

--- a/PayloadPkg/OsLoader/OsLoader.h
+++ b/PayloadPkg/OsLoader/OsLoader.h
@@ -86,6 +86,7 @@
 #define LOADED_IMAGE_COMPONENT   BIT6
 #define LOADED_IMAGE_RUN_EXTRA   BIT7
 #define LOADED_IMAGE_ELF         BIT8
+#define LOADED_IMAGE_MULTIBOOT2  BIT9
 
 #define MAX_EXTRA_FILE_NUMBER    16
 
@@ -168,6 +169,17 @@ Print out the Multiboot information block.
 VOID
 DumpMbInfo (
   IN  CONST MULTIBOOT_INFO *Mi
+  );
+
+/**
+Print out the Multiboot-2 information block.
+
+@param[in]  Mi  The Multiboot-2 information block to be printed.
+
+**/
+VOID
+DumpMb2Info (
+  IN  CONST MULTIBOOT2_START_TAG *Mi
   );
 
 /**

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlS.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlS.py
@@ -152,6 +152,9 @@ class Board(BaseBoard):
         self.SBLRSVD_SIZE         = 0x00001000
         self.FWUPDATE_SIZE        = 0x00020000 if self.ENABLE_FWU else 0
 
+        self.OS_LOADER_FD_SIZE    = 0x00057000
+        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
+
         self.TOP_SWAP_SIZE        = 0x00080000
         self.REDUNDANT_SIZE       = self.UCODE_SIZE + self.STAGE2_SIZE + self.STAGE1B_SIZE + \
                                     self.FWUPDATE_SIZE + self.CFGDATA_SIZE + self.KEYHASH_SIZE

--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -116,7 +116,7 @@ class Board(BaseBoard):
         if self.ENABLE_SOURCE_DEBUG:
             self.STAGE1B_SIZE += 0x2000
         self.STAGE2_SIZE          = 0x00032000
-        self.PAYLOAD_SIZE         = 0x00020000
+        self.PAYLOAD_SIZE         = 0x00021000
 
         if len(self._PAYLOAD_NAME.split(';')) > 1:
             # EPAYLOAD is specified


### PR DESCRIPTION
- Add (partial) multiboot-2 support as specified in https://www.gnu.org/software/grub/manual/multiboot2/multiboot.html
- header file imported (and adjusted to SBL OsLoader) from https://github.com/NetBSD/src/blob/trunk/sys/arch/i386/include/multiboot2.h

Signed-off-by: Bruno Achauer <bruno.achauer@intel.com>