### PR TITLE
Stop TCO timer if OS/UEFI payload not found

### DIFF
--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -158,6 +158,10 @@ NormalBootPath (
   // Load payload
   Dst = (UINT32 *)(UINTN)PreparePayload (Stage2Param);
   if (Dst == NULL) {
+    // Unable to recover non-FWU payload, no need to reboot
+    if (PcdGetBool (PcdSblResiliencyEnabled) && GetBootMode () != BOOT_ON_FLASH_UPDATE) {
+      StopTcoTimer ();
+    }
     CpuHalt ("Failed to load payload !");
   }
 


### PR DESCRIPTION
If OS/UEFI payload is not found, stop the TCO timer before halting the CPU as there is no backup of
OS/UEFI payload

Signed-off-by: Sean McGinn <sean.mcginn@intel.com>