### PR TITLE
[ADL/RPL] Update default boot options

### DIFF
--- a/BootloaderCommonPkg/Library/ShellLib/CmdBoot.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdBoot.c
@@ -170,7 +170,7 @@ GetBootDeviceInfo (
   }
 
   do {
-    ShellPrint (L"Enter BootFlags (MISC 0x1, CRASH_OS 0x2, PREOS 0x4, EXTRA 0x8, MENDER 0x10)\n");
+    ShellPrint (L"Enter BootFlags (NORMAL 0x0, MISC 0x1, CRASH_OS 0x2, PREOS 0x4, EXTRA 0x8, MENDER 0x10)\n");
     ShellPrint (L"(default 0x%X) ", CurrOption->BootFlags);
     Status = ShellReadUintn (Shell, Buffer, BufferSize, &IsHex);
     if (EFI_ERROR (Status)) {

--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_BootOption.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_BootOption.yaml
@@ -10,11 +10,11 @@
 
 - $ACTION      :
     page         : OS
-- !expand { BOOT_OPTION_TMPL : [ 0 ,   0       ,  16 ,    5   ,   0   ,    0xFF  ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 1 ,   0x1F    ,  16 ,    5   ,   0   ,    0     ,     1 ,     1 , '/boot/sbl_rtcm' ] }
-- !expand { BOOT_OPTION_TMPL : [ 2 ,   0       ,  16 ,    6   ,   1   ,    0     ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 3 ,   0x1F    ,  16 ,    6   ,   1   ,    0     ,     1 ,     1 , '/boot/sbl_rtcm' ] }
-- !expand { BOOT_OPTION_TMPL : [ 4 ,   0       ,  16 ,    6   ,   0   ,    0     ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 5 ,   0x1F    ,  16 ,    6   ,   0   ,    0     ,     1 ,     1 , '/boot/sbl_rtcm' ] }
-- !expand { BOOT_OPTION_TMPL : [ 6 ,   0       ,  16 ,    0   ,   0   ,    0xFF  ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 7 ,   0x1F    ,  16 ,    0   ,   0   ,    0     ,     1 ,     1 , '/boot/sbl_rtcm' ] }
+- !expand { BOOT_OPTION_TMPL : [ 0 ,   0       ,  0 ,    5   ,   0   ,    0xFF  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 1 ,   0x1F    ,  0 ,    5   ,   0   ,    0     ,     1 ,     1 , '/boot/sbl_rtcm' ] }
+- !expand { BOOT_OPTION_TMPL : [ 2 ,   0       ,  0 ,    6   ,   1   ,    0     ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 3 ,   0x1F    ,  0 ,    6   ,   1   ,    0     ,     1 ,     1 , '/boot/sbl_rtcm' ] }
+- !expand { BOOT_OPTION_TMPL : [ 4 ,   0       ,  0 ,    6   ,   0   ,    0     ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 5 ,   0x1F    ,  0 ,    6   ,   0   ,    0     ,     1 ,     1 , '/boot/sbl_rtcm' ] }
+- !expand { BOOT_OPTION_TMPL : [ 6 ,   0       ,  0 ,    0   ,   0   ,    0xFF  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 7 ,   0x1F    ,  0 ,    0   ,   0   ,    0     ,     1 ,     1 , '/boot/sbl_rtcm' ] }


### PR DESCRIPTION
Change boot flag to 0 to enable booting Yocto and Ubuntu

TEST:Boot to yocto on ADL

Signed-off-by: Kalp Parikh <kalp.parikh@intel.com>