### PR TITLE
[ExtLib] fix invalid memory access to support large EXT fs

### DIFF
--- a/PayloadPkg/OsLoader/LoadImage.c
+++ b/PayloadPkg/OsLoader/LoadImage.c
@@ -398,6 +398,8 @@ LoadLinuxFile (
 
   FileBuffer = AllocatePages (EFI_SIZE_TO_PAGES(FileSize));
   if (FileBuffer == NULL) {
+    DEBUG ((DEBUG_INFO, "Unable to allocate memory to load file '%s' (size: %d) \n", FileName, FileSize));
+    DEBUG ((DEBUG_INFO, "Please increase PLD_HEAP_SIZE\n"));
     Status = EFI_OUT_OF_RESOURCES;
     goto Done;
   }

--- a/Platform/ElkhartlakeBoardPkg/BoardConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/BoardConfig.py
@@ -180,7 +180,7 @@ class Board(BaseBoard):
         self.SPI_IAS1_SIZE        = 0x0
         self.SPI_IAS2_SIZE        = 0x0
 
-        self.PLD_HEAP_SIZE        = 0x08000000
+        self.PLD_HEAP_SIZE        = 0x0C000000
         self.PLD_STACK_SIZE       = 0x00020000
         self.PLD_RSVD_MEM_SIZE    = 0x00500000
         self.LOADER_RSVD_MEM_SIZE = 0x500000


### PR DESCRIPTION
This patch fixes an invalid memory access issue caused by fs->Ext2FsGDSize is smaller than the size of EXT2GD.

The EXT2GD is a 64-byte structure, but fs->Ext2FsGDSize is not always 32.
Before this patch, Ext2fsOpen() allocates a smaller memory than expected, i.e., Ext2FsGrpDes = AllocatePool (Ext2FsGDSize * Ext2FsNumCylinder). When ReadGDBlock() loads data (E2FS_CGLOAD) into fs->Ext2FsGrpDes, it possibly accesses mem out of the allocated Ext2FsGrpDes space.

This patch loads each element into fs->Ext2FsGrpDes.

This patch also
1. show informative messages when OS Loader fails to load Linux files.
2. increase EHL's PLD_HEAP_SIZE (since the size of initrd in Ubuntu LiveCD
       is over 130MB)

Test method:
1. create a huge EXT FS (says, at least 36GB)
2. In the fs, place the following file/dir:
        a: non-empty file
        b: dir
        b/c: non-empty file
3. boot with SBL OS Loader and enter Shell.
4. execute "fs init <...skip...>" to init the fs
5. execute "fs ls"
6. execute "fs ls b/c"
7. execute "fs load a"
8. execute "fs load b/c"

Verify:
1. 10MB/10GB/100GB/200GB EXT2/EXT3/EXT4 FS
2. EHL CRB

Signed-off-by: Stanley Chang <stanley.chang@intel.com>