### PR TITLE
[ADLP] Update VBT data in Igd Op Region

### DIFF
--- a/Silicon/AlderlakePkg/Library/IgdOpRegionLib/IgdOpRegionLib.c
+++ b/Silicon/AlderlakePkg/Library/IgdOpRegionLib/IgdOpRegionLib.c
@@ -294,7 +294,7 @@ UpdateVbt (
   case PLATFORM_ID_ADL_P_LP5_RVP:
   case PLATFORM_ID_RPL_P_DDR5_CRB:
     DEBUG((DEBUG_INFO, "UpdateVbt: BoardIdAdlP DDR5 or Lp4/5Rvp .....\n"));
-    GopVbtSpecificUpdate = (GOP_VBT_SPECIFIC_UPDATE)(UINTN)&AdlGopVbtSpecificUpdateNull;
+    GopVbtSpecificUpdate = (GOP_VBT_SPECIFIC_UPDATE)(UINTN)&AdlPDdr5GopVbtSpecificUpdate;
     break;
   case PLATFORM_ID_ADL_N_DDR5_CRB:
     DEBUG((DEBUG_INFO, "UpdateVbt: BoardIdAdlNDdr5 .....\n"));


### PR DESCRIPTION
This patch fixed the issue that no display seen
once the Windows system resumed from S4.
This issue happened in particular when the Iris
Xe Graphics driver is in place.

Signed-off-by: Vincent Chen <vincent.chen@intel.com>