### PR TITLE
feat: [RPL-P] Add support for enabling FSP FuSa features.

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -171,7 +171,7 @@
 
   # The number of 0.6s ticks to wait before assuming boot failure and forcing a reboot
   gPlatformModuleTokenSpaceGuid.PcdTcoTimeout             |  35        | UINT16  | 0x200000F6
-
+  gPlatformModuleTokenSpaceGuid.PcdFusaSupport            | FALSE      | BOOLEAN | 0x20000223
 
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   #
@@ -217,6 +217,7 @@
   gPlatformModuleTokenSpaceGuid.PcdPciResourceIoBase      | 0x00000000 | UINT32 | 0x200001A1
   gPlatformModuleTokenSpaceGuid.PcdPciResourceMem32Base   | 0x00000000 | UINT32 | 0x200001A2
   gPlatformModuleTokenSpaceGuid.PcdPciResourceMem64Base   | 0x0000000000000000  | UINT64     | 0x200001A3
+
 
 
 [PcdsFeatureFlag]

--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_Power.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_Power.yaml
@@ -253,14 +253,6 @@
                      Enable or Disable initialization of machine check registers; 0- Disable; <b>1- Enable</b>.
       length       : 0x01
       value        : 0x01
-  - IsFusaSupported :
-      name         : Check if FUSA is supported
-      type         : Combo
-      option       : $EN_DIS
-      help         : >
-                     Check if FUSA is supported; 0- Disable; <b>1- Enable</b>.
-      length       : 0x01
-      value        : 0x01
   - ApIdleManner :
       name         : AP Idle Manner of waiting for SIPI
       type         : Combo

--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -459,6 +459,92 @@
                      Describes whether Embedded Controller is availabile or not
       length       : 0x01
       value        : 0x1
-  - SiliconRsvd  :
-      length       : 0x02
-      value        : 0x00
+  - FusaConfigEnable :
+      name         : Enable FuSa support
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     Enable or Disable global FuSa support; 0- Disable; <b>1- Enable</b>.
+      length       : 0x01
+      value        : 0x01
+  - DisplayFusaConfigEnable :
+      name         : Fusa Display Configuration
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     Fusa (Functional Safety) Enable Fusa Feature on Display, 0- Disable, 1- Enable
+      length       : 0x01
+      value        : 0x01
+  - GraphicFusaConfigEnable :
+      name         : Fusa Graphics Configuration
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     Fusa (Functional Safety) Enable Fusa Feature on Graphics, 0- Disable, 1- Enable
+      length       : 0x01
+      value        : 0x01
+  - OpioFusaConfigEnable :
+      name         : Fusa Opio Configuration
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     Fusa (Functional Safety) Enable Fusa Feature on Opio, 0- Disable, 1- Enable
+      length       : 0x01
+      value        : 0x01
+  - IopFusaConfigEnable :
+      name         : Fusa Iop Configuration
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     Fusa (Functional Safety) Enable Fusa Feature on Iop, 0- Disable, 1- Enable
+      length       : 0x01
+      value        : 0x01
+  - PsfFusaConfigEnable :
+      name         : Fusa Psf Configuration
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     Fusa (Functional Safety) Enable Fusa Feature on Psf, 0- Disable, 1- Enable
+      length       : 0x01
+      value        : 0x1
+  - FusaRunStartupArrayBist :
+      name         : Fusa Run Start Up Array BIST
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     Enabling this will execute startup array test during boot, 0: Disable, 1: Enable
+      length       : 0x01
+      value        : 0x1
+  - FusaRunStartupScanBist :
+      name         : Fusa Run Start Up Scan BIST
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     Enabling this will execute startup scan test during boot, 0: Disable, 1: Enable
+      length       : 0x01
+      value        : 0x1
+  - FusaRunPeriodicScanBist :
+      name         : Fusa Run Periodic Scan BIST
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     Enabling this will execute periodic scan test during boot, 0: Disable, 1: Enable
+      length       : 0x01
+      value        : 0x1
+  - Module0Lockstep :
+      name         : Fusa Module 0 Lockstep Configuration
+      type         : Combo
+      option       : 0: Disable lockstep, 1: Enable lockstep for Core 0 with Core 1; Core 2 with Core 3, 2: Enable lockstep for Core 0 with Core 1, 3: Enable lockstep for Core 2 with Core 3
+      help         : >
+                     Enable/Disable Lockstep for Atom module 0, which has 4 cores;
+      length       : 0x01
+      value        : 0x1
+  - Module1Lockstep :
+      name         : Fusa Module 1 Lockstep Configuration
+      type         : Combo
+      option       : 0: Disable lockstep, 1: Enable lockstep for Core 0 with Core 1; Core 2 with Core 3, 2: Enable lockstep for Core 0 with Core 1, 3: Enable lockstep for Core 2 with Core 3
+      help         : >
+                     Enable/Disable Lockstep for Atom module 1, which has 4 cores;
+      length       : 0x01
+      value        : 0x1
+

--- a/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -689,4 +689,12 @@ UpdateFspConfig (
       }
     }
   }
+#if FixedPcdGetBool(PcdFusaSupport)
+  if ((SiCfgData != NULL) && (SiCfgData->FusaConfigEnable)) {
+    DEBUG((DEBUG_INFO, "FuSa enabled. Overriding CpuCrashLog and IBECC settings to Enabled - All requests protected.\n"));
+    Fspmcfg->CpuCrashLogEnable = 1;
+    Fspmcfg->Ibecc = 1;
+    Fspmcfg->IbeccOperationMode = 2;
+  }
+#endif
 }

--- a/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.inf
+++ b/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.inf
@@ -47,3 +47,4 @@
 
 [FixedPcd]
   gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled
+  gPlatformModuleTokenSpaceGuid.PcdFusaSupport

--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -1238,6 +1238,28 @@ UpdateFspConfig (
   if (FeaturePcdGet (PcdEnablePciePm)) {
     StoreRpConfig (FspsConfig);
   }
+
+#if FixedPcdGetBool(PcdFusaSupport)
+    if (SiCfgData != NULL) {
+      FspsConfig->FusaConfigEnable = SiCfgData->FusaConfigEnable;
+      FspsConfig->DisplayFusaConfigEnable = SiCfgData->DisplayFusaConfigEnable;
+      FspsConfig->GraphicFusaConfigEnable = SiCfgData->GraphicFusaConfigEnable;
+      FspsConfig->OpioFusaConfigEnable = SiCfgData->OpioFusaConfigEnable;
+      FspsConfig->IopFusaConfigEnable = SiCfgData->IopFusaConfigEnable;
+      FspsConfig->PsfFusaConfigEnable = SiCfgData->PsfFusaConfigEnable;
+      FspsConfig->FusaRunStartupArrayBist = SiCfgData->FusaRunStartupArrayBist;
+      FspsConfig->FusaRunStartupScanBist = SiCfgData->FusaRunStartupScanBist;
+      FspsConfig->FusaRunPeriodicScanBist = SiCfgData->FusaRunPeriodicScanBist;
+      FspsConfig->Module0Lockstep = SiCfgData->Module0Lockstep;
+      FspsConfig->Module1Lockstep = SiCfgData->Module1Lockstep;
+      if (SiCfgData->FusaConfigEnable)
+      {
+        DEBUG((DEBUG_INFO, "FuSa enabled. Disabling Bidir Prochot and enabling L2 CAT.\n"));
+        FspsConfig->BiProcHot = 0;
+        FspsConfig->L2QosEnumerationEn = 1;
+      }
+    }
+#endif
 }
 
 

--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.inf
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.inf
@@ -50,3 +50,4 @@
   gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled
   gPlatformAlderLakeTokenSpaceGuid.PcdAdlLpSupport
   gPlatformAlderLakeTokenSpaceGuid.PcdAdlNSupport
+  gPlatformModuleTokenSpaceGuid.PcdFusaSupport


### PR DESCRIPTION
FSP UPD FuSa toggles will be set based on new config data fields where applicable or to predefined values when called for by the FuSa spec. This requires setting PcdFusaSupport at build time in case platform FSP doesn't support FuSa.

Signed-off-by: Bejean Mosher <bejean.mosher@intel.com>