### PR TITLE
Remove unnecessary check in partition library

### DIFF
--- a/BootloaderCommonPkg/Include/Library/PartitionLib.h
+++ b/BootloaderCommonPkg/Include/Library/PartitionLib.h
@@ -2,7 +2,7 @@
   Routines supporting partition discovery and
   logical device reading
 
-Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -16,8 +16,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define  PART_MAX_BLOCK_SIZE      8192
 #define  PART_MAX_BLOCK_DEVICE    64
-
-#define  GPT_MAX_NUM_PARTITIONS   128
 
 typedef enum {
   EnumPartTypeUnknown = 0,

--- a/BootloaderCommonPkg/Library/PartitionLib/PartitionLib.c
+++ b/BootloaderCommonPkg/Library/PartitionLib/PartitionLib.c
@@ -1,7 +1,7 @@
 /** @file
   Routines supporting partition discovery
 
-Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2006 - 2022, Intel Corporation. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -417,12 +417,6 @@ FindGptPartitions (
   }
 
   GptPartCnt = Gpt->NumberOfPartitionEntries;
-
-  if (GptPartCnt > GPT_MAX_NUM_PARTITIONS) {
-    Status = EFI_UNSUPPORTED;
-    goto Done;
-  }
-
   Status = EFI_NOT_FOUND;
   for (Index = 0; Index < GptPartCnt; Index++) {
     if (CompareGuid (&GptEntries[Index].PartitionTypeGUID, &gEfiPartTypeUnusedGuid)) {


### PR DESCRIPTION
In the Ubuntu ISO image, it has 0xF8 partition entries. The partition library could not work as expected since it expects the partition entries are no more than 128.

Potentially it could have more partition entries, so just remove the check.

Signed-off-by: Guo Dong <guo.dong@intel.com>