### PR TITLE
Move TCO Timer Status Check/Start Right Before FSP-M

### DIFF
--- a/BootloaderCorePkg/Library/FirmwareResiliencyLib/FirmwareResiliencyLib.c
+++ b/BootloaderCorePkg/Library/FirmwareResiliencyLib/FirmwareResiliencyLib.c
@@ -103,8 +103,8 @@ CheckForTcoTimerFailures (
     DEBUG ((DEBUG_INFO, "Boot failure occurred! Failed boot count: %d\n", FailedBootCount));
     if (FailedBootCount >= BootFailureThreshold) {
       if (IsRecoveryTriggered ()) {
-        StopTcoTimer ();
-        CpuHalt("Unable to recover partition, both partitions are failing!\n");
+        DEBUG ((DEBUG_ERROR, "Unable to recover partition, both partitions are failing!\n"));
+        ResetSystem (EfiResetShutdown);
       }
       ClearFailedBootCount ();
       SetRecoveryTrigger ();
@@ -112,7 +112,8 @@ CheckForTcoTimerFailures (
       DEBUG ((DEBUG_INFO, "Boot failure threshold reached! Switching to partition: %d\n", NewPartition));
       Status = SetBootPartition (NewPartition);
       if (EFI_ERROR (Status)) {
-        CpuHalt("Unable to recover partition, failed to switch boot partition!\n");
+        DEBUG ((DEBUG_ERROR, "Unable to recover partition, failed to switch boot partition!\n"));
+        ResetSystem (EfiResetShutdown);
       }
       ResetSystem (EfiResetCold);
     }

--- a/BootloaderCorePkg/Library/FirmwareResiliencyLib/FirmwareResiliencyLib.c
+++ b/BootloaderCorePkg/Library/FirmwareResiliencyLib/FirmwareResiliencyLib.c
@@ -49,6 +49,12 @@ CheckForAcmFailures (
   )
 {
   UINT8 StateMachine;
+
+  // If already marked in recovery path, no need to check for recovery path.
+  if (IsRecoveryTriggered ()) {
+    return;
+  }
+
   StateMachine = GetFwuStateMachine ();
   switch (StateMachine) {
     case FW_UPDATE_SM_PART_A:
@@ -90,7 +96,7 @@ CheckForTcoTimerFailures (
   UINT32              FailedBootCount;
 
   // If unable to boot all the way up to PLD, recovery is necessary.
-  if (WasPreviousTcoTimeout ()) {
+  if (WasBootCausedByTcoTimeout ()) {
     ClearTcoStatus ();
     IncrementFailedBootCount ();
     FailedBootCount = GetFailedBootCount ();

--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -372,11 +372,6 @@ SecStartup2 (
   BoardInit (PostTempRamInit);
   AddMeasurePoint (0x1040);
 
-  if (PcdGetBool (PcdSblResiliencyEnabled)) {
-    SetTcoTimeout (PcdGet16 (PcdTcoTimeout));
-    StartTcoTimer ();
-  }
-
   // Set DebugPrintErrorLevel to default PCD.
   SetDebugPrintErrorLevel (PcdGet32 (PcdDebugPrintErrorLevel));
 

--- a/BootloaderCorePkg/Stage1A/Stage1A.h
+++ b/BootloaderCorePkg/Stage1A/Stage1A.h
@@ -30,7 +30,6 @@
 #include <Library/ContainerLib.h>
 #include <Library/StageLib.h>
 #include <Library/DebugPrintErrorLevelLib.h>
-#include <Library/TcoTimerLib.h>
 #include <Library/TopSwapLib.h>
 #include <Register/Intel/ArchitecturalMsr.h>
 #include <Guid/FspHeaderFile.h>

--- a/BootloaderCorePkg/Stage1A/Stage1A.inf
+++ b/BootloaderCorePkg/Stage1A/Stage1A.inf
@@ -55,7 +55,6 @@
   DebugAgentLib
   ExtraBaseLib
   StageLib
-  TcoTimerLib
   TopSwapLib
 
 [Guids]
@@ -89,9 +88,7 @@
   gPlatformModuleTokenSpaceGuid.PcdHashStoreSize
   gPlatformCommonLibTokenSpaceGuid.PcdPcdLibId
   gPlatformCommonLibTokenSpaceGuid.PcdCompSignHashAlg
-  gPlatformModuleTokenSpaceGuid.PcdSblResiliencyEnabled
   gPlatformModuleTokenSpaceGuid.PcdIdenticalTopSwapsBuilt
-  gPlatformModuleTokenSpaceGuid.PcdTcoTimeout
 
 [Depex]
   TRUE

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -384,7 +384,7 @@ SecStartup2 (
   // Perform pre-config board init
   BoardInit (PreConfigInit);
 
-  // Check if recovery is needed, if not in recovery path already
+  // Check for failures in ACM or TCO timer on last boot
   if (PcdGetBool (PcdSblResiliencyEnabled)) {
     CheckForAcmFailures ();
     CheckForTcoTimerFailures (PcdGet8 (PcdBootFailureThreshold));
@@ -414,6 +414,11 @@ SecStartup2 (
 
   // Perform pre-memory board init
   BoardInit (PreMemoryInit);
+
+  // Start TCO timer here as ACM active timer is stopped within FSP-M
+  if (PcdGetBool (PcdSblResiliencyEnabled)) {
+    StartTcoTimer (PcdGet16 (PcdTcoTimeout));
+  }
 
   // Initialize memory
   HobList = NULL;

--- a/BootloaderCorePkg/Stage1B/Stage1B.inf
+++ b/BootloaderCorePkg/Stage1B/Stage1B.inf
@@ -106,6 +106,7 @@
   gPlatformModuleTokenSpaceGuid.PcdEnableSetup
   gPlatformModuleTokenSpaceGuid.PcdSblResiliencyEnabled
   gPlatformModuleTokenSpaceGuid.PcdBootFailureThreshold
+  gPlatformModuleTokenSpaceGuid.PcdTcoTimeout
 
 [Depex]
   TRUE

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -158,11 +158,13 @@ NormalBootPath (
   // Load payload
   Dst = (UINT32 *)(UINTN)PreparePayload (Stage2Param);
   if (Dst == NULL) {
-    // Unable to recover non-FWU payload, no need to reboot
+    // Unable to recover non-FWU payload, so avoid triggering of recovery flow
     if (PcdGetBool (PcdSblResiliencyEnabled) && GetBootMode () != BOOT_ON_FLASH_UPDATE) {
-      StopTcoTimer ();
+      DEBUG ((DEBUG_ERROR, "Unable to recover partition, failed to switch boot partition!\n"));
+      ResetSystem (EfiResetShutdown);
+    } else {
+      CpuHalt ("Failed to load payload !");
     }
-    CpuHalt ("Failed to load payload !");
   }
 
   BoardInit (PostPayloadLoading);

--- a/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -169,9 +169,6 @@ PlatformDeviceTableInitialize (
 
     SetDeviceTable (PltDeviceTable);
   }
-
-  // clear SmBus in use status as TCO timer reload causes it to be marked in use here
-  SmBusClearInUseStatus ();
 }
 
 /**

--- a/Silicon/CommonSocPkg/Include/Library/TcoTimerLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/TcoTimerLib.h
@@ -27,7 +27,7 @@ StopTcoTimer (
   );
 
 /**
-  Initialize TCO base address, set TCO timeout, and stop the TCO timer
+  Initialize TCO base address and stop the TCO timer
 
   @param[in] Timeout    Number of 0.6s ticks to wait
 **/
@@ -38,34 +38,25 @@ InitTcoTimer (
   );
 
 /**
-  Set the TCO timeout
+  Start a countdown from a value on the TCO timer
 
   @param[in] Timeout    Number of 0.6s ticks to wait
 **/
 VOID
 EFIAPI
-SetTcoTimeout (
+StartTcoTimer (
   IN UINT16 Timeout
   );
 
 /**
-  Reload the TCO timer with its timeout
-**/
-VOID
-EFIAPI
-StartTcoTimer (
-  VOID
-  );
+  Check if current boot was caused by TCO timeout
 
-/**
-  Check if TCO status indicates failure on previous boot
-
-  @return TRUE if twice the timeout exceeded on previous boot
-  @return FALSE if twice the timeout not exceeded on previous boot
+  @return TRUE if current boot was caused by TCO timeout
+  @return FALSE if current boot was not caused by TCO timeout
 **/
 BOOLEAN
 EFIAPI
-WasPreviousTcoTimeout (
+WasBootCausedByTcoTimeout (
   VOID
   );
 

--- a/Silicon/CommonSocPkg/Library/TcoTimerLib/TcoTimerLib.c
+++ b/Silicon/CommonSocPkg/Library/TcoTimerLib/TcoTimerLib.c
@@ -47,7 +47,7 @@ StopTcoTimer (
 }
 
 /**
-  Initialize TCO base address, set TCO timeout, and stop the TCO timer
+  Initialize TCO base address and stop the TCO timer
 
   @param[in] Timeout    Number of 0.6s ticks to wait
 **/
@@ -62,28 +62,19 @@ InitTcoTimer (
 }
 
 /**
-  Set the TCO timeout
+  Start a countdown from a value on the TCO timer
 
   @param[in] Timeout    Number of 0.6s ticks to wait
 **/
 VOID
 EFIAPI
-SetTcoTimeout (
+StartTcoTimer (
   IN UINT16 Timeout
   )
 {
+  // Set the TCO timeout
   IoOr16 (TCO_BASE_ADDRESS + R_TCO_IO_TMR, Timeout);
-}
 
-/**
-  Reload the TCO timer with its timeout
-**/
-VOID
-EFIAPI
-StartTcoTimer (
-  VOID
-  )
-{
   // Reload the TCO timer with the timeout
   IoOr16 (TCO_BASE_ADDRESS + R_TCO_IO_RLD, B_TCO_IO_RLD);
 
@@ -92,14 +83,14 @@ StartTcoTimer (
 }
 
 /**
-  Check if TCO status indicates failure on previous boot
+  Check if current boot was caused by TCO timeout
 
-  @return TRUE if twice the timeout exceeded on previous boot
-  @return FALSE if twice the timeout not exceeded on previous boot
+  @return TRUE if current boot was caused by TCO timeout
+  @return FALSE if current boot was not caused by TCO timeout
 **/
 BOOLEAN
 EFIAPI
-WasPreviousTcoTimeout (
+WasBootCausedByTcoTimeout (
   VOID
   )
 {


### PR DESCRIPTION
It was discovered that, when BiosRedAssistance = Enabled, CSME actually uses the ACM active timer to time all of SG1A through the beginning of SG1B (up to end of FSP-M), flipping the TS and rebooting if a certain timeout is reached. This change closes the resiliency gap in SG1B while ensuring that there is as little overlap as possible between the TCO timer and the ACM active timer.