### PR TITLE
Allow to load capsules signed with RSA3072 from raw partition

### DIFF
--- a/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
+++ b/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
@@ -191,16 +191,6 @@ GetCapsuleFromRawPartition (
     return EFI_NOT_FOUND;
   }
 
-  if (FwUpdHeader->PubKeySize != RSA2048_MOD_SIZE + RSA_E_SIZE + sizeof (UINT32)) {
-    DEBUG ((DEBUG_INFO, "Invalid Capsule image found, Public Key size mismatch\n"));
-    return EFI_NOT_FOUND;
-  }
-
-  if (FwUpdHeader->SignatureSize != RSA2048_NUMBYTES) {
-    DEBUG ((DEBUG_INFO, "Invalid Capsule image found, Signature size mismatch\n"));
-    return EFI_NOT_FOUND;
-  }
-
   //
   // Make sure to round the image size to be block aligned in bytes.
   //


### PR DESCRIPTION
When loading capsule from raw partition, some check prevent capsules signed by a RSA3072 from being recognized as a valid capsule. Remove obsolete checks which expect RSA2048, signature type is already checked at a later stage from AuthenticateCapsule.