### PR TITLE
OSLoader: Append mender command line only if not exist

### DIFF
--- a/PayloadPkg/Library/SblParameterLib/SblParameterLib.c
+++ b/PayloadPkg/Library/SblParameterLib/SblParameterLib.c
@@ -284,9 +284,13 @@ AddSblCommandLine (
   //
   if ((BootOption->BootFlags & BOOT_FLAGS_MENDER) != 0) {
     if ((BootOption->BootFlags & LOAD_IMAGE_FROM_BACKUP) == 0) {
-      AsciiStrCatS (CommandLine, MaxCmdSize, " root=PARTLABEL=primary");
+      if (AsciiStrStr (CommandLine, " root=PARTLABEL=primary") == NULL) {
+        AsciiStrCatS (CommandLine, MaxCmdSize, " root=PARTLABEL=primary");
+      }
     } else {
-      AsciiStrCatS (CommandLine, MaxCmdSize, " root=PARTLABEL=secondary");
+      if (AsciiStrStr (CommandLine, " root=PARTLABEL=secondary") == NULL) {
+        AsciiStrCatS (CommandLine, MaxCmdSize, " root=PARTLABEL=secondary");
+      }
     }
   }
 


### PR DESCRIPTION
This patch fixes the issue that OS Loader appends an unwanted mender setting (i.e., root=PARTLABEL=primary/secondary) to Linux kernel command line when the mender setting already exists.

With the patch, the mender setting is appended to kernel command line only if BOOT_FLAGS_MENDER AND no existing mender setting.

Signed-off-by: Stanley Chang <stanley.chang@intel.com>