### PR TITLE
[ADLP] Update FSP/UCODE/platform version for MR2 release

### DIFF
--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlP.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlP.py
@@ -23,7 +23,7 @@ class Board(AlderlakeBoardConfig.Board):
         self.VERINFO_IMAGE_ID     = 'SB_ADLP'
         self.BOARD_NAME           = 'adlp'
         self.VERINFO_PROJ_MAJOR_VER = 1
-        self.VERINFO_PROJ_MINOR_VER = 1
+        self.VERINFO_PROJ_MINOR_VER = 2
         self._EXTRA_INC_PATH      = ['Silicon/AlderlakePkg/Adlp/Include']
         self._FSP_PATH_NAME       = 'Silicon/AlderlakePkg/Adlp/FspBin'
         self.MICROCODE_INF_FILE   = 'Silicon/AlderlakePkg/Microcode/Microcode.inf'

--- a/Silicon/AlderlakePkg/FspBin/FspBin.inf
+++ b/Silicon/AlderlakePkg/FspBin/FspBin.inf
@@ -11,7 +11,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = 5d78fcc69817771c5b60ebe96b4e126766a33712
+  COMMIT  = 034f316eae95cd0c7b21e92051beb4fe1aae18cb
 
 [UserExtensions.SBL."CopyList"]
 # For ADL-S
@@ -33,6 +33,7 @@
   AlderLakeFspBinPkg/IoT/AlderLakeP/Include/FsptUpd.h         : Silicon/AlderlakePkg/Adlp/Include/FsptUpd.h
   AlderLakeFspBinPkg/IoT/AlderLakeP/Include/FspmUpd.h         : Silicon/AlderlakePkg/Adlp/Include/FspmUpd.h
   AlderLakeFspBinPkg/IoT/AlderLakeP/Include/FspsUpd.h         : Silicon/AlderlakePkg/Adlp/Include/FspsUpd.h
-  AlderLakeFspBinPkg/IoT/AlderLakeP/Include/FspInfoHob.h      : Silicon/AlderlakePkg/Adlp/Include/MemInfoHob.h
+  AlderLakeFspBinPkg/IoT/AlderLakeP/Include/FspInfoHob.h      : Silicon/AlderlakePkg/Adlp/Include/FspInfoHob.h
   AlderLakeFspBinPkg/IoT/AlderLakeP/VBT/VbtAdlP.bin           : Platform/AlderlakeBoardPkg/VbtBin/VbtAdlP.dat
   AlderLakeFspBinPkg/IoT/AlderLakeP/VBT/VbtAdlP.json          : Platform/AlderlakeBoardPkg/VbtBin/VbtAdlP.json
+  FSP_License.pdf                                             : Silicon/AlderlakePkg/Adlp/FspBin/FSP_License.pdf

--- a/Silicon/AlderlakePkg/Microcode/Microcode.inf
+++ b/Silicon/AlderlakePkg/Microcode/Microcode.inf
@@ -15,12 +15,12 @@
 
 [Sources]
   m_07_90672_00000023.mcb
-  m_80_906a3_00000421.mcb
+  m_80_906a3_00000423.mcb
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
-  COMMIT = 7c77c0df56bd4bb3f80b7a0a4dbfde136eab0c04
+  COMMIT = 8fa255471f211673f7a3a20f89dedbb19a78e165
 
 [UserExtensions.SBL."CopyList"]
   Microcode/AlderLake/m_07_90672_00000023.pdb  : Silicon/AlderlakePkg/Microcode/m_07_90672_00000023.mcb
-  Microcode/AlderLake/m_80_906a3_00000421.pdb  : Silicon/AlderlakePkg/Microcode/m_80_906a3_00000421.mcb
+  Microcode/AlderLake/m_80_906a3_00000423.pdb  : Silicon/AlderlakePkg/Microcode/m_80_906a3_00000423.mcb


### PR DESCRIPTION
- update FSP version to IoT ADL-P MR2 (0C.01.73.10)
- update Microcode version to 423
- update platform version to 1.2

Signed-off-by: Vincent Chen <vincent.chen@intel.com>