### PR TITLE
fix: Revert PcdDebugPrintErrorLevel change made mistakenly in #1760.

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -267,7 +267,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled          | $(ENABLE_TCC)
 
 [PcdsPatchableInModule]
-  gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel   | 0x8040004F
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel   | 0x8000004F
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress  | $(PCI_EXPRESS_BASE)
   gPlatformModuleTokenSpaceGuid.PcdAcpiTablesRsdp    | 0xFF000000
   gPlatformModuleTokenSpaceGuid.PcdAcpiTablesAddress | 0xFF000000


### PR DESCRIPTION
PR #1760 mistakenly included a debug change to increase the default debug print level. Reverting that one change.

Signed-off-by: Bejean Mosher <bejean.mosher@intel.com>