### PR TITLE
[ADLS] Update FSP/UCODE/platform version for MR3 release

### DIFF
--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlS.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlS.py
@@ -25,7 +25,7 @@ class Board(BaseBoard):
 
         self.VERINFO_IMAGE_ID     = 'SBL_ADL'
         self.VERINFO_PROJ_MAJOR_VER = 1
-        self.VERINFO_PROJ_MINOR_VER = 2
+        self.VERINFO_PROJ_MINOR_VER = 3
         self.VERINFO_SVN            = 1
         self.VERINFO_BUILD_DATE     = time.strftime("%m/%d/%Y")
 

--- a/Silicon/AlderlakePkg/FspBin/FspBin.inf
+++ b/Silicon/AlderlakePkg/FspBin/FspBin.inf
@@ -11,7 +11,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = 034f316eae95cd0c7b21e92051beb4fe1aae18cb
+  COMMIT  = 0cee967cc4a648368c7135013239e13c2ce35ce1
 
 [UserExtensions.SBL."CopyList"]
 # For ADL-S
@@ -22,9 +22,10 @@
   AlderLakeFspBinPkg/IoT/AlderLakeS/Include/FsptUpd.h         : Silicon/AlderlakePkg/Adls/Include/FsptUpd.h
   AlderLakeFspBinPkg/IoT/AlderLakeS/Include/FspmUpd.h         : Silicon/AlderlakePkg/Adls/Include/FspmUpd.h
   AlderLakeFspBinPkg/IoT/AlderLakeS/Include/FspsUpd.h         : Silicon/AlderlakePkg/Adls/Include/FspsUpd.h
-  AlderLakeFspBinPkg/IoT/AlderLakeS/Include/FspInfoHob.h      : Silicon/AlderlakePkg/Adls/Include/MemInfoHob.h
+  AlderLakeFspBinPkg/IoT/AlderLakeS/Include/FspInfoHob.h      : Silicon/AlderlakePkg/Adls/Include/FspInfoHob.h
   AlderLakeFspBinPkg/IoT/AlderLakeS/VBT/Vbt.bin               : Platform/AlderlakeBoardPkg/VbtBin/Vbt.dat
   AlderLakeFspBinPkg/IoT/AlderLakeS/VBT/Vbt.json              : Platform/AlderlakeBoardPkg/VbtBin/Vbt.json
+  FSP_License.pdf                                             : Silicon/AlderlakePkg/Adls/FspBin/FSP_License.pdf
 # For ADL-P
   AlderLakeFspBinPkg/IoT/AlderLakeP/Fsp.fd                    : Silicon/AlderlakePkg/Adlp/FspBin/FspDbg.bin
   AlderLakeFspBinPkg/IoT/AlderLakeP/Fsp.fd                    : Silicon/AlderlakePkg/Adlp/FspBin/FspRel.bin

--- a/Silicon/AlderlakePkg/Microcode/Microcode.inf
+++ b/Silicon/AlderlakePkg/Microcode/Microcode.inf
@@ -14,13 +14,13 @@
   VERSION_STRING       = 1.0
 
 [Sources]
-  m_07_90672_00000023.mcb
+  m_07_90672_00000025.mcb
   m_80_906a3_00000423.mcb
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
-  COMMIT = 8fa255471f211673f7a3a20f89dedbb19a78e165
+  COMMIT = 9c03abf21e598e81107242c2bfd8b5b7b7542dfb
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/AlderLake/m_07_90672_00000023.pdb  : Silicon/AlderlakePkg/Microcode/m_07_90672_00000023.mcb
+  Microcode/AlderLake/m_07_90672_00000025.pdb  : Silicon/AlderlakePkg/Microcode/m_07_90672_00000025.mcb
   Microcode/AlderLake/m_80_906a3_00000423.pdb  : Silicon/AlderlakePkg/Microcode/m_80_906a3_00000423.mcb


### PR DESCRIPTION
- update FSP version to IoT ADL-S MR3 (0C.00.73.10)
- update Microcode version to 25
- update platform version to 1.3

Signed-off-by: Vincent Chen <vincent.chen@intel.com>