### PR TITLE
fix: [RPL-P] eDP output not working on DDR5 RVP board.

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -589,6 +589,9 @@ UpdateFspConfig (
         Fspmcfg->Lp5CccConfig = 0xff;
         break;
       case PLATFORM_ID_ADL_P_DDR5_RVP:
+#if PLATFORM_RPLP
+        Fspmcfg->DdiPortAConfig = 0x1;
+#endif
         Fspmcfg->DdiPortBHpd = 0x1;
         Fspmcfg->PrmrrSize = 0x200000;
         Fspmcfg->PcieClkReqGpioMux[9] = 0x796e9000;

--- a/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -589,9 +589,7 @@ UpdateFspConfig (
         Fspmcfg->Lp5CccConfig = 0xff;
         break;
       case PLATFORM_ID_ADL_P_DDR5_RVP:
-#if PLATFORM_RPLP
         Fspmcfg->DdiPortAConfig = 0x1;
-#endif
         Fspmcfg->DdiPortBHpd = 0x1;
         Fspmcfg->PrmrrSize = 0x200000;
         Fspmcfg->PcieClkReqGpioMux[9] = 0x796e9000;


### PR DESCRIPTION
Needed to set DdiPortAConfig to eDP for DDR5 RVP.

Signed-off-by: Bejean Mosher <bejean.mosher@intel.com>