### PR TITLE
[ExtLib] fix the failure of loading files in Ext4 partition

### DIFF
--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.c
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext2Fs.c
@@ -294,6 +294,12 @@ BlockMap (
 
     while (Etable->Eheader.EhDepth > 0) {
       ExtIndex = NULL;
+
+      /* if only one entry exists, the first entry should be used */
+      if (Etable->Eheader.EhEntries == 1) {
+        ExtIndex = &(Etable->Enodes.Eindex[0]);
+      }
+
       for (Index=1; Index < Etable->Eheader.EhEntries; Index++) {
         ExtIndex = &(Etable->Enodes.Eindex[Index]);
         if (((UINT32) FileBlock) < ExtIndex->EiBlk) {


### PR DESCRIPTION
This patch fixes an issue that SBL fails to load a file in Ext4 partition, when
1. the ext4 partition uses Extent
2. the inode's first extent block is an internal node
3. the node has only one entry (i.e., eh_entries = 1)
Under the above conditions, the data block may point to the child of first ei_block when accessing the data within the range of child node.

Test method:
1. Install Ubuntu 20.04.5 LTS/(min install) in an eMMC disk

    Note: this issue is only reproducible when loading a file satisfying all conditions mentioned above (i.e., eh_entries = 1).
    So far, the /boot/initrd.img after installing Ubuntu in an eMMC (where part table: 500MB(FAT), 20GB (EXT4), 4GB (Swap)) satisfies the conditions. However, for some reasons, when using USB SATA disk, it will not generate a /boot/initr.rd meeting the conditions.

2. Boot to OSLoader
3. "fs init 2:0 0 1" the eMMC disk (assume the HW:SW-part is 0 1)
4. "fs load boot/initrd.img"

Expected result:
1. With this patch: successfully load the file.
2. Without this patch: ASSERT [OsLoader] ..
     
Verified: EHL CRB

Signed-off-by: Stanley Chang <stanley.chang@intel.com>