### PR TITLE
[ExtLib] fix the list of symbolic links

### DIFF
--- a/BootloaderCommonPkg/Library/Ext23Lib/Ext2FsLs.c
+++ b/BootloaderCommonPkg/Library/Ext23Lib/Ext2FsLs.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2019 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
   Copyright (c) 1997 Manuel Bouyer.
@@ -136,7 +136,7 @@ Ext2fsLs (
   Fp = (FILE *)File->FileSystemSpecificData;
 
   if ((Fp->DiskInode.Ext2DInodeMode & EXT2_IFMT) == EXT2_IFREG) {
-    CONSOLE_PRINT_UNICODE ((L"  %-16a %u\n", File->FileNamePtr, Fp->DiskInode.Ext2DInodeSize));
+    CONSOLE_PRINT_UNICODE ((L"  %-16a %u\n", File->FileNameBuf, Fp->DiskInode.Ext2DInodeSize));
     return EFI_SUCCESS;
   } else if ((Fp->DiskInode.Ext2DInodeMode & EXT2_IFMT) != EXT2_IFDIR) {
     return EFI_NOT_FOUND;
@@ -224,6 +224,8 @@ Ext2fsLs (
         }
         Status = RETURN_SUCCESS;
         CONSOLE_PRINT_UNICODE ((L"  %-16a %u\n", New->EntryName, FileSize));
+      } else if (New->EntryType == 7) {
+        CONSOLE_PRINT_UNICODE ((L"  %a (symbolic link)\n", New->EntryName));
       }
       PNames = New->EntryNext;
     } while (PNames != NULL);

--- a/BootloaderCommonPkg/Library/Ext23Lib/LibsaFsStand.h
+++ b/BootloaderCommonPkg/Library/Ext23Lib/LibsaFsStand.h
@@ -1,4 +1,7 @@
 /** @file
+ Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+ SPDX-License-Identifier: BSD-2-Clause-Patent
+
  Copyright (c) 1999 Christopher G. Demetriou.  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -99,7 +102,7 @@ typedef struct {
 #if !defined(LIBSA_NO_RAW_ACCESS)
   OFFSET      FileOffset;                     // current file offset (F_RAW)
 #endif
-  CHAR8       *FileNamePtr;
+  CHAR8       FileNameBuf[EXT2FS_MAXNAMLEN];  // buffer to store file name (not always the actual name, e.g., symbolic link)
 } OPEN_FILE;
 
 #if ! defined(LIBSA_SINGLE_DEVICE)


### PR DESCRIPTION
This patch fixes 2 issues related to symbolic links:

1. when "fs ls" a directory, symbolic links are not shown. 
It is because Ext2fsLs() only shows regular files and directories.

2. when "fs ls <symbolic_link>" the output is incorrect.
It is because File->FileNamePtr points to a local variable, "NameBuf" in Ext2fsOpen(), if the file is a symbolic link

This patch replaces File->FileNamePtr with FileNameBuf. It slightly increases Ext2fsLs/Ext2fsOpen/SearchDirectory time, because of the use of strcpy and strcat.

Test method:

1. create a regular file, "a", in directory "x"
2. create a symbolic link file, "b", pointing to "a".
3. under the shell of OSLoader, 
- "fs ls x" - expected result: a, b (symbolic link) 
- "fs ls x/a" - expected result: a and its file size is shown
- "fs ls x/b" - expected result: b -> a, and the file size of a is shown

Verify: TGL-UP3 RVP

Signed-off-by: Stanley Chang <stanley.chang@intel.com>