### PR TITLE
feat: Enforce newlines at the end of all text files in PatchCheck.py.

### DIFF
--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -408,7 +408,7 @@ class GitDiffCheck:
             elif line.startswith('\r\n'):
                 pass
             elif line.startswith(r'\ No newline '):
-                pass
+                self.error('No newline at end of file %s' % (self.filename))
             elif not line.startswith(' '):
                 self.format_error("unexpected patch line")
             self.line_num += 1


### PR DESCRIPTION
PatchCheck.py currently checks for files without terminating newlines but takes no action. This change will report this as a code format error.

Signed-off-by: Bejean Mosher <bejean.mosher@intel.com>