### PR TITLE
Add description for performance data

### DIFF
--- a/BootloaderCommonPkg/Include/Library/LoaderPerformanceLib.h
+++ b/BootloaderCommonPkg/Include/Library/LoaderPerformanceLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2016 - 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -48,5 +48,38 @@ PrintMeasurePoint (
   IN PERF_ID_TO_STR  PerfIdToStrTbl
   );
 
+/**
+  Provide description string corresponding to Id.
+
+  If there is a description in default description table corresponding to Id,
+  default description will be returned.
+  If there is no description in default description table,
+    look for description in overrided description table once if it is provided
+  Otherwise,just return empty string
+
+  @param[in]  Id                MeasurePoint Id
+  @param[in]  PerfIdToStrTbl    A pointer to description table
+
+  @retval Description string
+**/
+CHAR8 *
+EFIAPI
+PerfIdToStr (
+  IN UINT32            Id,
+  IN PERF_ID_TO_STR    PerfIdToStrTbl
+  );
+
+/**
+  Provide description string for csme perf data corresponding to Id.
+
+  @param[in]  Id  MeasurePoint Id
+
+  @retval Default description string
+**/
+CHAR8 *
+EFIAPI
+CsmePerfIdToStr (
+  IN UINT32          Id
+  );
 
 #endif

--- a/BootloaderCommonPkg/Library/ShellLib/ShellLib.inf
+++ b/BootloaderCommonPkg/Library/ShellLib/ShellLib.inf
@@ -80,6 +80,7 @@
   MtrrLib
   RngLib
   MemoryAllocationLib
+  LoaderPerformanceLib
 
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress


### PR DESCRIPTION
When running "perf" command from OsLoader shell, it would print the performance data but it is difficult to know what they are mean. The patch adds the description to performance data.

Signed-off-by: Guo Dong <guo.dong@intel.com>