### PR TITLE
fix: [RPL-S] Fix for TSN build error caused by FSP UPD updates.

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -741,7 +741,12 @@ UpdateFspConfig (
 
     // TSN feature support
     if (IsPchS () || IsPchN () ) {
+#if PLATFORM_RPLS
+      FspsConfig->PchTsnEnable[0] = SiCfgData->PchTsnEnable;
+      FspsConfig->PchTsnEnable[1] = SiCfgData->PchTsnEnable;
+#else
       FspsConfig->PchTsnEnable = SiCfgData->PchTsnEnable;
+#endif
       if(SiCfgData->PchTsnEnable == 1) {
         FspsConfig->PchTsnMultiVcEnable = SiCfgData->PchTsnMultiVcEnable;
 


### PR DESCRIPTION
RPL-S FSP UPD was updated so PchTsnEnable is now a 2-byte array with a separate byte for each port. This is now different from the ADL platforms and needs to be included selectively at build time.

Signed-off-by: Bejean Mosher <bejean.mosher@intel.com>