### PR TITLE
Halt boot retries when SG02 is failing on both partitions

### DIFF
--- a/BootloaderCorePkg/Library/FirmwareResiliencyLib/FirmwareResiliencyLib.c
+++ b/BootloaderCorePkg/Library/FirmwareResiliencyLib/FirmwareResiliencyLib.c
@@ -103,8 +103,7 @@ CheckForTcoTimerFailures (
     DEBUG ((DEBUG_INFO, "Boot failure occurred! Failed boot count: %d\n", FailedBootCount));
     if (FailedBootCount >= BootFailureThreshold) {
       if (IsRecoveryTriggered ()) {
-        DEBUG ((DEBUG_ERROR, "Unable to recover partition, both partitions are failing!\n"));
-        ResetSystem (EfiResetShutdown);
+        CpuHalt ("Unable to recover partition, both partitions are failing!\n");
       }
       ClearFailedBootCount ();
       SetRecoveryTrigger ();
@@ -112,8 +111,7 @@ CheckForTcoTimerFailures (
       DEBUG ((DEBUG_INFO, "Boot failure threshold reached! Switching to partition: %d\n", NewPartition));
       Status = SetBootPartition (NewPartition);
       if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_ERROR, "Unable to recover partition, failed to switch boot partition!\n"));
-        ResetSystem (EfiResetShutdown);
+        CpuHalt ("Unable to recover partition, failed to switch boot partition!\n");
       }
       ResetSystem (EfiResetCold);
     }

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -160,11 +160,9 @@ NormalBootPath (
   if (Dst == NULL) {
     // Unable to recover non-FWU payload, so avoid triggering of recovery flow
     if (PcdGetBool (PcdSblResiliencyEnabled) && GetBootMode () != BOOT_ON_FLASH_UPDATE) {
-      DEBUG ((DEBUG_ERROR, "Unable to recover partition, failed to switch boot partition!\n"));
-      ResetSystem (EfiResetShutdown);
-    } else {
-      CpuHalt ("Failed to load payload !");
+      StopTcoTimer ();
     }
+    CpuHalt ("Failed to load payload !");
   }
 
   BoardInit (PostPayloadLoading);


### PR DESCRIPTION
When SG02 is failing on both partitions, a shutdown is supposed to occur after trying to boot from each partition 3 times. However, it was noticed that this was not occurring as the shutdown function was left empty. This caused dead loops and further ACM active timer expirations.

This change resolves this issue by moving the TCO timer check and start until after the ACM active timer has been stopped. This change also converts the shutdown to a CPU halt for further clarity.

Signed-off-by: Sean McGinn <sean.mcginn@intel.com>