### PR TITLE
[ADL] Skip SioInit when S0ix is enabled.

### DIFF
--- a/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adlps_Crb_Ddr5.dlt
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adlps_Crb_Ddr5.dlt
@@ -16,6 +16,11 @@ PLATFORMID_CFG_DATA.PlatformId           | 0x000D
 PLAT_NAME_CFG_DATA.PlatformName          | 'AdlPsCrb'
 GEN_CFG_DATA.PayloadId                   | ''
 
+FEATURES_CFG_DATA.Features.S0ix          | 0x0
+
+# DTT feature
+FEATURES_CFG_DATA.Features.DTT           | 0x0
+
 #
 #Delta configuration for DDR
 #

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -390,11 +390,16 @@ BoardInit (
       InitializeSmbiosInfo ();
     }
 
-    if ((SiCfgData != NULL) && (SiCfgData->EcAvailable == 0)){
-      //Init SIO if EC is not available
-      DEBUG ((DEBUG_INFO, "SioInit\n"));
-      SioInit();
+    if ((SiCfgData != NULL) && (SiCfgData->EcAvailable == 0)) {
+      if ((FeatureCfgData != NULL) && (FeatureCfgData->S0ix == 1)) {
+        DEBUG ((DEBUG_INFO, "S0ix enabled. Skipping SioInit\n"));
+      } else {
+        //Init SIO if EC is not available and S0ix is disabled.
+        DEBUG ((DEBUG_INFO, "SioInit\n"));
+        SioInit();
+      }
     }
+
     ZeroMem (&GetFipsModeData,sizeof(GetFipsModeData));
     HeciGetFipsMode(&GetFipsModeData);
     DEBUG ((DEBUG_INFO, "HeciGetFipsMode = 0x%x\n", GetFipsModeData.FipsMode));


### PR DESCRIPTION
On ECless platforms, Sio is initialized during boot flow. However, when S0ix is enabled, Sio need not be initialized.

Signed-off-by: Kalp Parikh <kalp.parikh@intel.com>