### PR TITLE
feat: [CFL] add ACPI DMAR table

### DIFF
--- a/Platform/CoffeelakeBoardPkg/AcpiTables/AcpiTables.inf
+++ b/Platform/CoffeelakeBoardPkg/AcpiTables/AcpiTables.inf
@@ -5,7 +5,7 @@
 #  All .asi files tagged with "ToolCode="DUMMY"" in following file list are device description and are included
 #  by top level ASL file which will be dealed with by asl.exe application.
 #
-# Copyright (c)  1999  - 2019, Intel Corporation. All rights reserved
+# Copyright (c)  1999 - 2023, Intel Corporation. All rights reserved
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -52,6 +52,8 @@
   CpuSsdt/ApIst.asl
   CpuSsdt/ApPsd.asl
   CpuSsdt/ApTst.asl
+  Dmar/Dmar.aslc
+  Dmar/Dmar.h
   CpuSsdt/CpuSsdt.asl
   Psd/Psd.aslc
   Platform/CommonBoardPkg/AcpiTables/Dsdt/AslInc.h

--- a/Platform/CoffeelakeBoardPkg/AcpiTables/Dmar/Dmar.aslc
+++ b/Platform/CoffeelakeBoardPkg/AcpiTables/Dmar/Dmar.aslc
@@ -1,0 +1,250 @@
+/** @file
+  This file describes the contents of the ACPI DMA address Remapping
+
+  Copyright (c) 2019 - 2023 Intel Corporation. All rights reserved. <BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "Dmar.h"
+#include <Register/PchRegsP2sb.h>
+
+EFI_ACPI_DMAR_TABLE DmarTable = {
+  //
+  // EFI_ACPI_DMAR_HEADER
+  //
+  {
+    //
+    // EFI_ACPI_DESCRIPTION_HEADER
+    //
+    {
+      EFI_ACPI_VTD_DMAR_TABLE_SIGNATURE,
+      sizeof (EFI_ACPI_DMAR_TABLE),
+      EFI_ACPI_DMAR_TABLE_REVISION,
+
+      //
+      // Checksum will be updated at runtime
+      //
+      0x00,
+
+      //
+      // It is expected that these values will be programmed at runtime
+      //
+      { 'I', 'N', 'T', 'E', 'L', ' ' },
+      EFI_ACPI_DMAR_OEM_TABLE_ID,
+      0x1,
+      EFI_ACPI_DMAR_OEM_CREATOR_ID,
+      1
+    },
+
+    //
+    // DMAR table specific entries below:
+    //
+
+    //
+    // 39-bit addressing Host Address Width
+    //
+    38,
+
+    //
+    // Flags
+    //
+    0,
+
+    //
+    // Reserved fields
+    //
+    { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
+  },
+
+  //
+  // First DRHD structure, VT-d Engine #1
+  //
+  {
+    //
+    // EFI_ACPI_DMAR_DRHD_HEADER
+    //
+    {
+      {0,                                         // Type = 0 (DRHD)
+      sizeof (EFI_ACPI_DRHD_ENGINE1_STRUCT)},     // Length of structure
+      0,                                          // Flag - Do not include all
+      0,                                          // Reserved fields
+      0,                                          // Segment
+      0                                           // Base address of DMA-remapping hardware - Updated at boot time
+    },
+    //
+    // Device Scopes
+    //
+    {
+      {
+        {1,                                     // Type
+        sizeof (EFI_ACPI_DEV_SCOPE_STRUCTURE),  // Length
+        0,                                      // Segment number
+        0,                                      // Reserved
+        0},                                     // Start bus number
+        {2, 0}                                  // PCI path
+      }
+    }
+  },
+
+  //
+  //Third DRHD structure VT-d Engine# 3
+  //
+  {
+    //
+    // EFI_ACPI_DMAR_DRHD_HEADER
+    //
+    {
+      {0,                                        // Type = 0 (DRHD)
+      sizeof (EFI_ACPI_DRHD_ENGINE3_STRUCT)},    // Length of strucure.
+      1,                                         // Flag - Include all
+      0,                                         // Reserved
+      0,                                         // Segment Number
+      0                                          // Base address of DMA-remapping hardware.
+    },
+    {
+      //
+      // Device Scopes
+      //
+      {
+        {3,                                          // Type=IO APIC
+        sizeof (EFI_ACPI_DEV_SCOPE_STRUCTURE),       // Length
+        0,                                           // Reserved
+        2,                                           // Enumeration ID
+        V_P2SB_CFG_IBDF_BUS},                        // Start bus number
+        {V_P2SB_CFG_IBDF_DEV, V_P2SB_CFG_IBDF_FUNC}  // PCI path
+      },
+      //
+      // Device Scopes
+      //
+      {
+        {4,                                          // Type=HPET
+        sizeof (EFI_ACPI_DEV_SCOPE_STRUCTURE),       // Length
+        0,                                           // Reserved
+        0,                                           // Enumeration ID
+        V_P2SB_CFG_HBDF_BUS},                        // Start bus number
+        {V_P2SB_CFG_HBDF_DEV, V_P2SB_CFG_HBDF_FUNC}  // PCI path
+      }
+    }
+  },
+  //RMRR structure for USB devices.
+  {
+    //
+    // EFI_ACPI_DMAR_RMRR_HEADER
+    //
+    {
+      {
+        0x1,                                     // Type 1 - RMRR structure
+        sizeof(EFI_ACPI_RMRR_USB_STRUC)          // Length
+      },
+      { 0x00, 0x00 },                            // Reserved
+      0x0000,                                    // Segment Num
+      0x00000000000E0000,                        // RMRR Base address - Updated in runtime.
+      0x00000000000EFFFF                         // RMRR Limit address - Updated in runtime.
+    },
+    //
+    // Device Scopes
+    //
+    {
+      {
+        {1,                                    // Type
+        sizeof (EFI_ACPI_DEV_SCOPE_STRUCTURE), // Length
+        0,                                     // Reserved
+        0,                                     // Enum ID
+        0},                                    // Start bus number
+        {20, 0}                                // PCI path
+      },
+      {
+        {1,                                    // Type
+        sizeof (EFI_ACPI_DEV_SCOPE_STRUCTURE), // Length
+        0,                                     // Reserved
+        0,                                     // Enum ID
+        0},                                    // Start bus number
+        {20, 1}                                // PCI path
+      }
+    }
+  },
+
+  //RMRR structure for IGD device.
+  {
+    //
+    // EFI_ACPI_DMAR_RMRR_HEADER
+    //
+    {
+      {1,                                       // Type 1 - RMRR structure
+      sizeof (EFI_ACPI_RMRR_IGD_STRUC)},        // Length
+      {0x0000},                                 // Reserved
+      0x0000,                                   // Segment Num
+      0x0000000000000000,                       // RMRR Base address - Updated in runtime.
+      0x0000000000000000                        // RMRR Limit address - Updated in runtime.
+    },
+    //
+    // Device Scopes
+    //
+    {
+      {
+        {1,                                   // Type
+        sizeof (EFI_ACPI_DEV_SCOPE_STRUCTURE), // Length
+        0,                                    // Reserved
+        0,                                    // Enum ID
+        0},                                   // Start bus number
+        {2, 0}                                // PCI path
+      }
+    }
+  },
+
+  // RMRR structure for WiAMT DMA access.
+  // Keep this device in end of RMRR queue.
+  {
+    //
+    // EFI_ACPI_DMAR_RMRR_HEADER
+    //
+    {
+      {1,                                       // Type 1 - RMRR structure
+      sizeof (EFI_ACPI_RMRR_CSME_STRUC)},       // Length
+      {0x0000},                                 // Reserved
+      0x0000,                                   // Segment Num
+      0x0000000000000000,                       // RMRR Base address - Updated in runtime.
+      0x0000000000000000                        // RMRR Limit address - Updated in runtime.
+    },
+    //
+    // Device Scopes
+    //
+    {
+      {
+        {1,                                   // Type
+        sizeof (EFI_ACPI_DEV_SCOPE_STRUCTURE), // Length
+        0,                                    // Reserved
+        0,                                    // Enum ID
+        0},                                   // Start bus number
+        {22, 7}                               // PCI path
+      }
+    }
+  }
+};
+
+//
+// Dummy function required for build tools
+//
+#if defined (__GNUC__)
+VOID*
+ReferenceAcpiTable (
+  VOID
+  )
+
+{
+  //
+  // Reference the table being generated to prevent the optimizer from removing the
+  // data structure from the exeutable
+  //
+  return (VOID*)&DmarTable;
+}
+#else
+int
+main (
+  VOID
+  )
+{
+  return 0;
+}
+#endif

--- a/Platform/CoffeelakeBoardPkg/AcpiTables/Dmar/Dmar.h
+++ b/Platform/CoffeelakeBoardPkg/AcpiTables/Dmar/Dmar.h
@@ -1,0 +1,23 @@
+/** @file
+  This file describes the contents of the ACPI DMA address Remapping
+  Some additional ACPI values are defined in Acpi1_0.h and Acpi2_0.h.
+
+  Copyright (c) 2023 Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _DMAR_H_
+#define _DMAR_H_
+
+///
+/// Include standard ACPI table definitions
+///
+#include <IndustryStandard/Acpi30.h>
+#include <Library/DmaRemappingTable.h>
+
+#pragma pack(1)
+
+#define EFI_ACPI_DMAR_OEM_TABLE_ID    0x746F6F626D696C53  ///< "Slimboot"
+#define EFI_ACPI_DMAR_OEM_CREATOR_ID  0x4C544E49  ///< "INTL"
+#pragma pack()
+
+#endif

--- a/Platform/CoffeelakeBoardPkg/BoardConfig.py
+++ b/Platform/CoffeelakeBoardPkg/BoardConfig.py
@@ -1,7 +1,7 @@
 ## @file
 # This file is used to provide board specific image information.
 #
-#  Copyright (c) 2017-2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -56,6 +56,7 @@ class Board(BaseBoard):
         self.ENABLE_SPLASH        = 1
         self.ENABLE_FRAMEBUFFER_INIT  = 1
         self.HAVE_PSD_TABLE       = 1
+        self.ENABLE_VTD           = 1
         self.ENABLE_GRUB_CONFIG   = 1
         self.ENABLE_CSME_UPDATE   = 0
         self.ENABLE_DMA_PROTECTION    = 0
@@ -200,6 +201,7 @@ class Board(BaseBoard):
             'HeciLib|Silicon/CommonSocPkg/Library/HeciLib/HeciLib.inf',
             'MeChipsetLib|Silicon/CommonSocPkg/Library/MeChipsetLib/MeChipsetLib.inf',
             'ShellExtensionLib|Platform/$(BOARD_PKG_NAME)/Library/ShellExtensionLib/ShellExtensionLib.inf',
+            'VtdLib|Silicon/$(SILICON_PKG_NAME)/Library/VTdLib/VTdLib.inf',
             'VtdPmrLib|Silicon/CommonSocPkg/Library/VtdPmrLib/VtdPmrLib.inf',
             'TcoTimerLib|Silicon/CommonSocPkg/Library/TcoTimerLib/TcoTimerLib.inf',
             'TopSwapLib|Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.inf',

--- a/Platform/CoffeelakeBoardPkg/CfgData/CfgData_Memory.yaml
+++ b/Platform/CoffeelakeBoardPkg/CfgData/CfgData_Memory.yaml
@@ -2,7 +2,7 @@
 #
 #  Slim Bootloader CFGDATA Option File.
 #
-#  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -146,7 +146,23 @@
                      To 'opt-in' for debug, please select 'Enabled' with the desired debug probe type. Enabling this BIOS option may alter the default value of other debug-related BIOS options. Note- DCI OOB (aka BSSB) uses CCA probe; [DCI OOB+DbC] and [USB2 DbC] have the same setting
       length       : 0x01
       value        : 0x00
-  - MemRsvd      :
-      length       : 0x01
+  - VtdDisable   :
+      name         : Disable VT-d
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     0=Enable/FALSE(VT-d enabled), 1=Disable/TRUE (VT-d disabled)
+      length       : 0x1
+      value        : 0x0
+  - X2ApicOptOut :
+      name         : State of X2APIC_OPT_OUT bit in the DMAR table
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     0=Disable/Clear, 1=Enable/Set
+      length       : 0x1
+      value        : 0x0
+  - Dummy      :
+      length       : 0x03
       value        : 0x00
 

--- a/Platform/CoffeelakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/CoffeelakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -2,7 +2,7 @@
 #
 #  Slim Bootloader CFGDATA Option File.
 #
-#  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -72,7 +72,15 @@
         help         : >
                        Enable/Disable this pin for payload selection.
         length       : 1bW
-  - SiliconRsvd  :
-      length       : 0x03
+  - InterruptRemappingSupport :
+      name         : InterruptRemappingSupport
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     InterruptRemappingSupport
+      length       : 0x01
+      value        : 0x1
+  - Dummy  :
+      length       : 0x02
       value        : 0x00
 

--- a/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -54,3 +54,4 @@
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
   gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootEnabled
   gPlatformModuleTokenSpaceGuid.PcdSmmRebaseMode
+  gPlatformModuleTokenSpaceGuid.PcdVtdEnabled

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017-2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -55,6 +55,7 @@
   S3SaveRestoreLib
   BoardSupportLib
   VtdPmrLib
+  VtdLib
 
 [Guids]
   gSmmInformationGuid
@@ -90,3 +91,4 @@
   gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferAlignment
   gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferSize
   gPlatformModuleTokenSpaceGuid.PcdPciResourceMem64Base
+  gPlatformModuleTokenSpaceGuid.PcdVtdEnabled

--- a/Silicon/CoffeelakePkg/Include/Library/DmaRemappingTable.h
+++ b/Silicon/CoffeelakePkg/Include/Library/DmaRemappingTable.h
@@ -1,0 +1,71 @@
+/** @file
+  This code defines ACPI DMA Remapping table related definitions.
+  See the System Agent BIOS specification for definition of the table.
+
+  Copyright (c) 2019 - 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _DMA_REMAPPING_TABLE_H_
+#define _DMA_REMAPPING_TABLE_H_
+
+#include <Base.h>
+#include <IndustryStandard/DmaRemappingReportingTable.h>
+#include <IndustryStandard/Acpi.h>
+
+#pragma pack(1)
+///
+/// DMAR table signature
+///
+#define EFI_ACPI_VTD_DMAR_TABLE_SIGNATURE   0x52414D44  ///< "DMAR"
+#define EFI_ACPI_DMAR_TABLE_REVISION        1
+#define EFI_ACPI_DRHD_ENGINE_HEADER_LENGTH  0x10
+#define EFI_ACPI_RMRR_HEADER_LENGTH         0x18
+#define MAX_PCI_DEPTH                       5
+
+typedef struct {
+  EFI_ACPI_DMAR_DEVICE_SCOPE_STRUCTURE_HEADER DeviceScopeStructureHeader;
+  EFI_ACPI_DMAR_PCI_PATH                      PciPath;     // device, function
+} EFI_ACPI_DEV_SCOPE_STRUCTURE;
+
+typedef struct {
+  EFI_ACPI_DMAR_DRHD_HEADER     DrhdHeader;
+  EFI_ACPI_DEV_SCOPE_STRUCTURE  DeviceScope[1];
+} EFI_ACPI_DRHD_ENGINE1_STRUCT;
+
+typedef struct {
+  EFI_ACPI_DMAR_DRHD_HEADER     DrhdHeader;
+  EFI_ACPI_DEV_SCOPE_STRUCTURE  DeviceScope[2];
+} EFI_ACPI_DRHD_ENGINE3_STRUCT;
+
+typedef struct {
+  EFI_ACPI_DMAR_RMRR_HEADER     RmrrHeader;
+  EFI_ACPI_DEV_SCOPE_STRUCTURE  DeviceScope[2];
+} EFI_ACPI_RMRR_USB_STRUC;
+
+typedef struct {
+  EFI_ACPI_DMAR_RMRR_HEADER     RmrrHeader;
+  EFI_ACPI_DEV_SCOPE_STRUCTURE  DeviceScope[1];    // IGD
+} EFI_ACPI_RMRR_IGD_STRUC;
+
+typedef struct {
+  EFI_ACPI_DMAR_RMRR_HEADER     RmrrHeader;
+  EFI_ACPI_DEV_SCOPE_STRUCTURE  DeviceScope[1];    // CSME
+} EFI_ACPI_RMRR_CSME_STRUC;
+
+typedef struct {
+  EFI_ACPI_DMAR_ANDD_HEADER     AnddHeader;
+  UINT8                         AcpiObjectName[20];
+} EFI_ACPI_ANDD_STRUC;
+
+typedef struct {
+  EFI_ACPI_DMAR_HEADER          DmarHeader;
+  EFI_ACPI_DRHD_ENGINE1_STRUCT  DrhdEngine1;
+  EFI_ACPI_DRHD_ENGINE3_STRUCT  DrhdEngine3;
+  EFI_ACPI_RMRR_USB_STRUC       RmrrUsb;
+  EFI_ACPI_RMRR_IGD_STRUC       RmrrIgd;
+  EFI_ACPI_RMRR_CSME_STRUC      RmrrCsme;
+} EFI_ACPI_DMAR_TABLE;
+
+#pragma pack()
+
+#endif

--- a/Silicon/CoffeelakePkg/Include/Library/VTdLib.h
+++ b/Silicon/CoffeelakePkg/Include/Library/VTdLib.h
@@ -1,0 +1,48 @@
+/** @file
+  This code provides a initialization of intel VT-d (Virtualization Technology for Directed I/O).
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _VT_D_LIB_H_
+#define _VT_D_LIB_H_
+
+#define SA_VTD_ENGINE_NUMBER  3
+
+#include <IndustryStandard/Acpi.h>
+
+typedef UINT32  EFI_ACPI_TABLE_VERSION;
+#define EFI_ACPI_TABLE_VERSION_1_0B (1 << 1)
+#define EFI_ACPI_TABLE_VERSION_2_0  (1 << 2)
+#define EFI_ACPI_TABLE_VERSION_3_0  (1 << 3)
+
+
+#define  DMAR_TABLE_FLAGS_INT_REMAPPING_SUPPORT       BIT0
+#define  DMAR_TABLE_FLAGS_X2APIC_OPT_OUT              BIT1
+
+/**
+  Update the DMAR table
+
+  @param[in, out] Table              The pointer to ACPI DMAR table
+  @param[in] DmarTableFlags          The flags related with DMAR table
+**/
+VOID
+EFIAPI
+UpdateDmarAcpi (
+  EFI_ACPI_DESCRIPTION_HEADER *Table,
+  UINTN                       DmarTableFlags
+  );
+
+/**
+  Read VTD Engine Base Address from VTD BAR Offsets.
+
+  @param[in]  VtdEngineNumber        - Engine number for which VTD Base Adderess is required.
+
+  @retval   VTD Engine Base Address
+**/
+UINT32
+EFIAPI
+ReadVtdBaseAddress (
+  IN UINT8        VtdEngineNumber
+  );
+#endif

--- a/Silicon/CoffeelakePkg/Include/PlatformData.h
+++ b/Silicon/CoffeelakePkg/Include/PlatformData.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -21,7 +21,13 @@ typedef struct {
 } STITCH_DATA;
 
 typedef struct {
+  UINT32  VtdEnable    : 1;
+  UINT32  Rsvd         : 31;
+} PLAT_FEATURES;
+
+typedef struct {
   BOOT_GUARD_INFO     BtGuardInfo;
+  PLAT_FEATURES       PlatformFeatures;
   VTD_INFO            VtdInfo;
 } PLATFORM_DATA;
 

--- a/Silicon/CoffeelakePkg/Include/Register/PchRegsP2sb.h
+++ b/Silicon/CoffeelakePkg/Include/Register/PchRegsP2sb.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -29,5 +29,16 @@
 #define R_P2SB_CFG_SBIEXTADDR                      0xDC
 
 #define R_P2SB_CFG_E0                              0xE0
+
+#define V_P2SB_CFG_IBDF_BUS                        0
+#define V_P2SB_CFG_IBDF_DEV                        30
+#define V_P2SB_CFG_IBDF_FUNC                       7
+#define V_P2SB_CFG_HBDF_BUS                        0
+#define V_P2SB_CFG_HBDF_DEV                        30
+#define V_P2SB_CFG_HBDF_FUNC                       6
+
+#define R_IO_APIC_INDEX_OFFSET                     0x00
+#define R_IO_APIC_DATA_OFFSET                      0x10
+
 
 #endif

--- a/Silicon/CoffeelakePkg/Include/Register/SaRegs.h
+++ b/Silicon/CoffeelakePkg/Include/Register/SaRegs.h
@@ -15,7 +15,7 @@
   - Registers / bits of new devices introduced in a SA generation will be just named
     as "_SA_" without [generation_name] inserted.
 
-  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -80,5 +80,14 @@ typedef struct {
 //  This register contains the Top of low memory address.
 #define R_SA_TOLUD       (0xbc)
 #define B_SA_TOLUD_MASK  (0xfff00000)
+
+#define R_SA_MC_CAPID0_A_OFFSET (0xE4)
+
+#define R_SA_GGC             (0x50)
+#define N_SA_GGC_GMS_OFFSET  (0x8)
+#define B_SA_GGC_GMS_MASK    (0xff00)
+#define N_SA_GGC_GGMS_OFFSET (0x6)
+#define B_SA_GGC_GGMS_MASK   (0xc0)
+#define V_SA_GGC_GGMS_8MB    3
 
 #endif

--- a/Silicon/CoffeelakePkg/Include/Register/VtdRegs.h
+++ b/Silicon/CoffeelakePkg/Include/Register/VtdRegs.h
@@ -1,0 +1,22 @@
+/** @file
+  Register names for VTD block
+  <b>Conventions</b>:
+  - Prefixes:
+    - Definitions beginning with "R_" are registers
+    - Definitions beginning with "B_" are bits within registers
+    - Definitions beginning with "V_" are meaningful values of bits within the registers
+    - Definitions beginning with "S_" are register sizes
+    - Definitions beginning with "N_" are the bit position
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _VTD_REGS_H_
+#define _VTD_REGS_H_
+
+///
+/// Vt-d Engine base address.
+///
+#define R_MCHBAR_VTD1_OFFSET                 0x5400  ///< HW UNIT1 for IGD
+#define R_MCHBAR_VTD3_OFFSET                 0x5410  ///< HW UNIT3 for all other - PEG, USB, SATA etc
+
+#endif

--- a/Silicon/CoffeelakePkg/Include/SaNvsAreaDef.h
+++ b/Silicon/CoffeelakePkg/Include/SaNvsAreaDef.h
@@ -1,6 +1,6 @@
 /**@file
 
-  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -128,9 +128,9 @@ typedef struct {
   UINT32   Pcie1WakeGpioNo;                         ///< Offset 255     PCIe1 RTD3 Device Wake GPIO Number
   UINT32   Pcie2WakeGpioNo;                         ///< Offset 259     PCIe2 RTD3 Device Wake GPIO Number
   UINT8    VtdDisable;                              ///< Offset 263     VT-d Enable/Disable
-  UINT32   VtdBaseAddress1;                         ///< Offset 264     VT-d Base Address 1
-  UINT32   VtdBaseAddress2;                         ///< Offset 268     VT-d Base Address 2
-  UINT32   VtdBaseAddress3;                         ///< Offset 272     VT-d Base Address 3
+  UINT32   VtdBaseAddress[3];                       ///< Offset 264     VT-d Base Address 1
+                                                    ///< Offset 268     VT-d Base Address 2
+                                                    ///< Offset 272     VT-d Base Address 3
   UINT16   VtdEngine1Vid;                           ///< Offset 276     VT-d Engine#1 Vendor ID
   UINT16   VtdEngine2Vid;                           ///< Offset 278     VT-d Engine#2 Vendor ID
   UINT8    Pcie3SecBusNum;                          ///< Offset 280     PCIe3 Secondary Bus Number (PCIe3 Endpoint Bus Number)

--- a/Silicon/CoffeelakePkg/Library/Stage2SocInitLib/Stage2SocInitLib.c
+++ b/Silicon/CoffeelakePkg/Library/Stage2SocInitLib/Stage2SocInitLib.c
@@ -1,7 +1,7 @@
 /** @file
   The platform hook library.
 
-  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -14,6 +14,9 @@
 #include <Library/PciLib.h>
 #include <Library/PcdLib.h>
 #include <GlobalNvsAreaDef.h>
+#include <Register/SaRegs.h>
+#include <Library/VTdLib.h>
+#include <PlatformData.h>
 
 UINT32
 EFIAPI
@@ -30,6 +33,43 @@ SocUpdateAcpiGnvs (
   IN VOID  *GnvsIn
 )
 {
+  ///
+  /// Vtd Initialization
+  ///
+  UINTN                           McD0BaseAddress;
+  UINTN                           McD2BaseAddress;
+  GLOBAL_NVS_AREA                 *Gnvs;
+  UINT8                           Index;
+  PLATFORM_DATA                   *PlatformData;
+
+  if (FeaturePcdGet (PcdVtdEnabled)) {
+    PlatformData = (PLATFORM_DATA *)GetPlatformDataPtr ();
+    if (PlatformData != NULL) {
+      if (PlatformData->PlatformFeatures.VtdEnable == 0) {
+        return;
+      }
+    }
+
+    Gnvs = (GLOBAL_NVS_AREA *)GnvsIn;
+    DEBUG ((DEBUG_INFO, "Initialize VT-d\n"));
+    McD0BaseAddress  = PCI_LIB_ADDRESS (SA_MC_BUS, 0, 0, 0);
+    McD2BaseAddress  = PCI_LIB_ADDRESS (SA_IGD_BUS, SA_IGD_DEV, SA_IGD_FUN_0, 0);
+
+    Gnvs->SaNvs.VtdDisable = !FeaturePcdGet (PcdVtdEnabled);
+    for (Index = 0; Index < SA_VTD_ENGINE_NUMBER; Index++) {
+      Gnvs->SaNvs.VtdBaseAddress[Index] = ReadVtdBaseAddress (Index);
+    }
+    Gnvs->SaNvs.VtdEngine1Vid = PciRead16(McD2BaseAddress + PCI_VENDOR_ID_OFFSET);
+
+    ///
+    /// Check if SA supports VTD
+    ///
+    if ((Gnvs->SaNvs.VtdDisable) || (PciRead32 (McD0BaseAddress + R_SA_MC_CAPID0_A_OFFSET) & BIT23)) {
+      DEBUG ((DEBUG_INFO, "VTd disabled or no capability!\n"));
+    } else {
+      DEBUG ((DEBUG_INFO, "VTd enabled\n"));
+    }
+  }
 }
 
 VOID

--- a/Silicon/CoffeelakePkg/Library/Stage2SocInitLib/Stage2SocInitLib.inf
+++ b/Silicon/CoffeelakePkg/Library/Stage2SocInitLib/Stage2SocInitLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -25,6 +25,8 @@
 [Packages]
   MdePkg/MdePkg.dec
   BootloaderCorePkg/BootloaderCorePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+  Silicon/CommonSocPkg/CommonSocPkg.dec
   Silicon/CoffeelakePkg/CoffeelakePkg.dec
 
 [LibraryClasses]
@@ -33,4 +35,5 @@
   IoLib
 
 [Pcd]
+  gPlatformModuleTokenSpaceGuid.PcdVtdEnabled
 

--- a/Silicon/CoffeelakePkg/Library/VTdLib/VTdLib.c
+++ b/Silicon/CoffeelakePkg/Library/VTdLib/VTdLib.c
@@ -1,0 +1,538 @@
+/** @file
+  This code provides a initialization of Intel VT-d (Virtualization Technology for Directed I/O).
+
+  Copyright (c) 2019 - 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Base.h>
+#include <Uefi/UefiBaseType.h>
+#include <Library/IoLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/VTdLib.h>
+#include <Register/SaRegs.h>
+#include <Register/PchRegsP2sb.h>
+#include <Library/DmaRemappingTable.h>
+#include <Library/PciLib.h>
+#include <Library/ConfigDataLib.h>
+#include <Register/VtdRegs.h>
+
+/**
+  For device that specified by Device Num and Function Num,
+  mDevEnMap is used to check device presence.
+  0x80 means use Device ID to detemine presence
+  0x8F means force to update
+
+  The structure is used to check if device scope is valid when update DMAR table
+**/
+UINT16  mDevEnMap[][2] = {{0x0200, 0x80}, {0x1400, 0x80}, {0x1401, 0x80}, {0x1607, 0x8F}};
+UINTN   mDevEnMapSize = sizeof (mDevEnMap) / (sizeof (UINT16) * 2);
+
+UINTN   mDmarTableFlags = 0;
+
+/**
+  Get the corresponding device Enable/Disable bit according DevNum and FunNum
+
+  @param[in] DevNum  - Device Number
+  @param[in] FunNum  - Function Number
+
+  @retval If the device is found, return disable/Enable bit in FD/Deven reigster
+  @retval If not found return 0xFF
+**/
+UINT16
+GetFunDisableBit (
+  UINT8 DevNum,
+  UINT8 FunNum
+  )
+{
+  UINTN Index;
+
+  for (Index = 0; Index < mDevEnMapSize; Index++) {
+    if (mDevEnMap[Index][0] == ((DevNum << 0x08) | FunNum)) {
+      return mDevEnMap[Index][1];
+    }
+  }
+
+  return 0xFF;
+}
+
+/**
+  Update the DRHD structure
+
+  @param[in, out] DrhdEnginePtr       - A pointer to DRHD structure
+**/
+VOID
+UpdateDrhd (
+  IN OUT VOID *DrhdEnginePtr
+  )
+{
+  UINT16                        Length;
+  UINT16                        DisableBit;
+  BOOLEAN                       NeedRemove;
+  EFI_ACPI_DRHD_ENGINE1_STRUCT  *DrhdEngine;
+  UINT32                        VidDid;
+
+  //
+  // Convert DrhdEnginePtr to EFI_ACPI_DRHD_ENGINE1_STRUCT Pointer
+  //
+  DrhdEngine      = (EFI_ACPI_DRHD_ENGINE1_STRUCT *) DrhdEnginePtr;
+  Length          = DrhdEngine->DrhdHeader.Header.Length;
+  DisableBit = GetFunDisableBit (
+                 DrhdEngine->DeviceScope[0].PciPath.Device,
+                 DrhdEngine->DeviceScope[0].PciPath.Function
+                 );
+  NeedRemove = FALSE;
+
+  VidDid = PciRead32 (PCI_LIB_ADDRESS (0, DrhdEngine->DeviceScope[0].PciPath.Device, DrhdEngine->DeviceScope[0].PciPath.Function, 0x00));
+  if ((DisableBit == 0xFF) ||
+      (DrhdEngine->DrhdHeader.RegisterBaseAddress == 0) ||
+      ((DisableBit == 0x80) && (VidDid == 0xFFFFFFFF))
+      ) {
+    NeedRemove = TRUE;
+  }
+  if (NeedRemove) {
+    Length -= sizeof (EFI_ACPI_DEV_SCOPE_STRUCTURE);
+  }
+  ///
+  /// If no devicescope is left, we set the structure length as 0x00
+  ///
+  if ((Length > EFI_ACPI_DRHD_ENGINE_HEADER_LENGTH) || (DrhdEngine->DrhdHeader.Flags == 0x01)) {
+    DrhdEngine->DrhdHeader.Header.Length = Length;
+  } else {
+    DrhdEngine->DrhdHeader.Header.Length = 0;
+  }
+}
+
+/**
+  Get IOAPIC ID from LPC
+
+  @retval APIC ID
+**/
+UINT8
+GetIoApicId (
+  VOID
+  )
+{
+  UINT32                IoApicAddress;
+  UINT32                IoApicId;
+
+  IoApicAddress = 0XFEC00000;
+
+  ///
+  /// Get current IO APIC ID
+  ///
+  MmioWrite8 ((UINTN) (IoApicAddress + R_IO_APIC_INDEX_OFFSET), 0);
+  IoApicId = MmioRead32 ((UINTN) (IoApicAddress + R_IO_APIC_DATA_OFFSET)) >> 24;
+
+  return (UINT8) IoApicId;
+}
+
+/**
+  Update the second DRHD structure
+
+  @param[in, out] DrhdEnginePtr       - A pointer to DRHD structure
+**/
+VOID
+UpdateDrhd2 (
+  IN OUT VOID *DrhdEnginePtr
+  )
+{
+  UINT16                        Length;
+  UINTN                         DeviceScopeNum;
+  UINTN                         ValidDeviceScopeNum;
+  UINT16                        Index;
+  UINT8                         Bus;
+  UINT8                         Path[2];
+  BOOLEAN                       NeedRemove;
+  EFI_ACPI_DRHD_ENGINE3_STRUCT  *DrhdEngine;
+
+  ///
+  /// Convert DrhdEnginePtr to EFI_ACPI_DRHD_ENGINE3_STRUCT Pointer
+  ///
+  DrhdEngine      = (EFI_ACPI_DRHD_ENGINE3_STRUCT *) DrhdEnginePtr;
+
+  Length          = DrhdEngine->DrhdHeader.Header.Length;
+  DeviceScopeNum  = (DrhdEngine->DrhdHeader.Header.Length - EFI_ACPI_DRHD_ENGINE_HEADER_LENGTH) / sizeof (EFI_ACPI_DEV_SCOPE_STRUCTURE);
+  Bus             = 0;
+  ValidDeviceScopeNum = 0;
+  Path[0]         = 0;
+  Path[1]         = 0;
+
+  for (Index = 0; Index < DeviceScopeNum; Index++) {
+    NeedRemove = FALSE;
+    /**
+      For HPET and APIC, update device scope if Interrupt remapping is supported. remove device scope
+      if interrupt remapping is not supported.
+      - Index = 0 - IOAPIC
+      - Index = 1 - HPET
+    **/
+    if ((mDmarTableFlags & DMAR_TABLE_FLAGS_INT_REMAPPING_SUPPORT) != 0) {
+      if (Index == 0) {
+        ///
+        /// Update source id for IoApic's device scope entry
+        ///
+        Bus = V_P2SB_CFG_IBDF_BUS;
+        Path[0] = V_P2SB_CFG_IBDF_DEV;
+        Path[1] = V_P2SB_CFG_IBDF_FUNC;
+        DrhdEngine->DeviceScope[Index].DeviceScopeStructureHeader.StartBusNumber = Bus;
+        DrhdEngine->DeviceScope[Index].PciPath.Device = Path[0];
+        DrhdEngine->DeviceScope[Index].PciPath.Function = Path[1];
+        //
+        // Update APIC ID
+        //
+        DrhdEngine->DeviceScope[Index].DeviceScopeStructureHeader.EnumerationId = GetIoApicId ();
+      }
+      if (Index == 1) {
+        ///
+        /// Update source id for HPET's device scope entry
+        ///
+        Bus     = V_P2SB_CFG_HBDF_BUS;
+        Path[0] = V_P2SB_CFG_HBDF_DEV;
+        Path[1] = V_P2SB_CFG_HBDF_FUNC;
+        DrhdEngine->DeviceScope[Index].DeviceScopeStructureHeader.StartBusNumber = Bus;
+        DrhdEngine->DeviceScope[Index].PciPath.Device = Path[0];
+        DrhdEngine->DeviceScope[Index].PciPath.Function = Path[1];
+      }
+    } else {
+      if ((Index == 0) || (Index == 1)) {
+        NeedRemove = TRUE;
+      }
+    }
+
+    CopyMem (
+      &DrhdEngine->DeviceScope[ValidDeviceScopeNum],
+      &DrhdEngine->DeviceScope[Index],
+      sizeof (EFI_ACPI_DEV_SCOPE_STRUCTURE)
+      );
+    if (NeedRemove) {
+      Length -= sizeof (EFI_ACPI_DEV_SCOPE_STRUCTURE);
+    } else {
+      ValidDeviceScopeNum++;
+    }
+  }
+  ///
+  /// If no devicescope is left, we set the structure length as 0x00
+  ///
+  if ((Length > EFI_ACPI_DRHD_ENGINE_HEADER_LENGTH) || (DrhdEngine->DrhdHeader.Flags == 0x01)) {
+    DrhdEngine->DrhdHeader.Header.Length = Length;
+  } else {
+    DrhdEngine->DrhdHeader.Header.Length = 0;
+  }
+}
+
+/**
+  Update the RMRR structure
+
+  @param[in, out] RmrrPtr             - A pointer to RMRR structure
+**/
+VOID
+UpdateRmrr (
+  IN OUT VOID *RmrrPtr
+  )
+{
+  UINT16                  Length;
+  UINT16                  DisableBit;
+  UINTN                   DeviceScopeNum;
+  UINTN                   ValidDeviceScopeNum;
+  UINTN                   Index;
+  BOOLEAN                 NeedRemove;
+  EFI_ACPI_RMRR_USB_STRUC *Rmrr;
+
+  ///
+  /// To make sure all devicescope can be checked,
+  /// we convert the RmrrPtr to EFI_ACPI_RMRR_USB_STRUC pointer
+  ///
+  Rmrr                = (EFI_ACPI_RMRR_USB_STRUC *) RmrrPtr;
+
+  Length              = Rmrr->RmrrHeader.Header.Length;
+  ValidDeviceScopeNum = 0;
+  DeviceScopeNum      = (Rmrr->RmrrHeader.Header.Length - EFI_ACPI_RMRR_HEADER_LENGTH) / sizeof (EFI_ACPI_DEV_SCOPE_STRUCTURE);
+  for (Index = 0; Index < DeviceScopeNum; Index++) {
+    DisableBit = GetFunDisableBit (
+                   Rmrr->DeviceScope[Index].PciPath.Device,
+                   Rmrr->DeviceScope[Index].PciPath.Function
+                   );
+    NeedRemove = FALSE;
+    if ((DisableBit == 0xFF) ||
+        ((DisableBit == 0x80) &&
+         (PciRead32 (PCI_LIB_ADDRESS (0, Rmrr->DeviceScope[Index].PciPath.Device, Rmrr->DeviceScope[Index].PciPath.Function, 0x00)) == 0xFFFFFFFF))
+        ) {
+      NeedRemove = TRUE;
+    } else if (DisableBit == 0x8F) {
+      DEBUG ((DEBUG_INFO, "Rmrr->RmrrHeader.ReservedMemoryRegionBaseAddress %x\n", Rmrr->RmrrHeader.ReservedMemoryRegionBaseAddress));
+      NeedRemove = FALSE;
+    }
+
+    CopyMem (
+      &Rmrr->DeviceScope[ValidDeviceScopeNum],
+      &Rmrr->DeviceScope[Index],
+      sizeof (EFI_ACPI_DEV_SCOPE_STRUCTURE)
+      );
+
+    if (Rmrr->RmrrHeader.ReservedMemoryRegionLimitAddress == 0x0) {
+      NeedRemove = TRUE;
+    }
+
+    if (NeedRemove) {
+      Length -= sizeof (EFI_ACPI_DEV_SCOPE_STRUCTURE);
+    } else {
+      ValidDeviceScopeNum++;
+    }
+  }
+  ///
+  /// If No deviceScope is left, set length as 0x00
+  ///
+  if (Length > EFI_ACPI_RMRR_HEADER_LENGTH) {
+    Rmrr->RmrrHeader.Header.Length = Length;
+  } else {
+    Rmrr->RmrrHeader.Header.Length = 0;
+  }
+}
+
+/**
+  Read VTD Engine Base Address from VTD BAR Offsets.
+
+  @param[in]  VtdEngineNumber        - Engine number for which VTD Base Adderess is required.
+
+  @retval   VTD Engine Base Address
+**/
+UINT32
+EFIAPI
+ReadVtdBaseAddress (
+  IN UINT8        VtdEngineNumber
+  )
+{
+  UINT64              McD0BaseAddress;
+  UINTN               MchBar;
+
+  McD0BaseAddress = PCI_LIB_ADDRESS (SA_MC_BUS, 0, 0, 0);
+  MchBar          = PciRead32 ((UINTN)McD0BaseAddress + R_SA_MCHBAR) & (~BIT0);
+
+  switch (VtdEngineNumber) {
+    case 0:
+      return (MmioRead32 (MchBar + R_MCHBAR_VTD1_OFFSET) & (~BIT0));
+      break;
+    case 2:
+      return (MmioRead32 (MchBar + R_MCHBAR_VTD3_OFFSET) & (~BIT0));
+      break;
+    default:
+      return 0x0;
+      break;
+  }
+}
+
+/**
+  Update the DMAR table
+
+  @param[in, out] TableHeader         - The table to be set
+  @param[in, out] Version             - Version to publish
+**/
+VOID
+DmarTableUpdate (
+  IN OUT   EFI_ACPI_DESCRIPTION_HEADER       *TableHeader,
+  IN OUT   EFI_ACPI_TABLE_VERSION            *Version
+  )
+{
+  EFI_ACPI_DMAR_TABLE *DmarTable;
+  EFI_ACPI_DMAR_TABLE TempDmarTable;
+  UINTN               Offset;
+  UINTN               StructureLen;
+  UINT64              McD0BaseAddress;
+  UINT16              IgdMode;
+  UINT16              GttMode;
+  UINT32              IgdMemSize;
+  UINT32              GttMemSize;
+
+  IgdMemSize  = 0;
+  GttMemSize  = 0;
+  DmarTable   = (EFI_ACPI_DMAR_TABLE *) TableHeader;
+  ///
+  /// Set INTR_REMAP bit (BIT 0) if interrupt remapping is supported
+  ///
+  if ((mDmarTableFlags & DMAR_TABLE_FLAGS_INT_REMAPPING_SUPPORT) != 0) {
+    DmarTable->DmarHeader.Flags |= BIT0;
+  }
+
+  if ((mDmarTableFlags & DMAR_TABLE_FLAGS_X2APIC_OPT_OUT) != 0) {
+    DmarTable->DmarHeader.Flags |= BIT1;
+  } else {
+    DmarTable->DmarHeader.Flags &= 0xFD;
+  }
+
+
+  ///
+  /// Get OemId
+  ///
+  CopyMem (DmarTable->DmarHeader.Header.OemId, "INTEL ", sizeof (DmarTable->DmarHeader.Header.OemId));
+  DmarTable->DmarHeader.Header.OemTableId      = 0x20202020324B4445;
+  DmarTable->DmarHeader.Header.OemRevision     = 0x00000002;
+  DmarTable->DmarHeader.Header.CreatorId       = 0x20202020;
+  DmarTable->DmarHeader.Header.CreatorRevision = 0x01000013;
+
+  ///
+  /// Calculate IGD memsize
+  ///
+  McD0BaseAddress = PCI_LIB_ADDRESS (SA_MC_BUS, 0, 0, 0);
+  IgdMode         = ((PciRead16 ((UINTN)McD0BaseAddress + R_SA_GGC) & B_SA_GGC_GMS_MASK) >> N_SA_GGC_GMS_OFFSET) & 0xFF;
+
+  DEBUG ((DEBUG_INFO, "McD0BaseAddress 0x%08X, IgdMode 0x%04X\n", McD0BaseAddress, IgdMode));
+
+  if (IgdMode < 0xF0) {
+    IgdMemSize = IgdMode * 32 * (1024) * (1024);
+  } else {
+    IgdMemSize = 4 * (IgdMode - 0xF0 + 1) * (1024) * (1024);
+  }
+  ///
+  /// Calculate GTT mem size
+  ///
+  GttMemSize = 0;
+  GttMode = (PciRead16 ((UINTN)McD0BaseAddress + R_SA_GGC) & B_SA_GGC_GGMS_MASK) >> N_SA_GGC_GGMS_OFFSET;
+  if (GttMode <= V_SA_GGC_GGMS_8MB) {
+    GttMemSize = (1 << GttMode) * (1024) * (1024);
+  }
+
+  DmarTable->RmrrIgd.RmrrHeader.ReservedMemoryRegionBaseAddress   = (PciRead32 ((UINTN)McD0BaseAddress + R_SA_TOLUD) & ~(0x01)) - IgdMemSize - GttMemSize;
+  DmarTable->RmrrIgd.RmrrHeader.ReservedMemoryRegionLimitAddress  = DmarTable->RmrrIgd.RmrrHeader.ReservedMemoryRegionBaseAddress + IgdMemSize + GttMemSize - 1;
+
+  DEBUG ((DEBUG_INFO, "RMRR Base  address IGD %016lX\n", DmarTable->RmrrIgd.RmrrHeader.ReservedMemoryRegionBaseAddress));
+  DEBUG ((DEBUG_INFO, "RMRR Limit address IGD %016lX\n", DmarTable->RmrrIgd.RmrrHeader.ReservedMemoryRegionLimitAddress));
+
+  DmarTable->RmrrUsb.RmrrHeader.ReservedMemoryRegionBaseAddress   = 0;
+  DmarTable->RmrrUsb.RmrrHeader.ReservedMemoryRegionLimitAddress  = 0;
+
+  ///
+  /// Convert to 4KB alignment.
+  ///
+  if (DmarTable->RmrrUsb.RmrrHeader.ReservedMemoryRegionLimitAddress != 0x0) {
+    DmarTable->RmrrUsb.RmrrHeader.ReservedMemoryRegionBaseAddress  &= (EFI_PHYSICAL_ADDRESS) ~0xFFF;
+    DmarTable->RmrrUsb.RmrrHeader.ReservedMemoryRegionLimitAddress &= (EFI_PHYSICAL_ADDRESS) ~0xFFF;
+    DmarTable->RmrrUsb.RmrrHeader.ReservedMemoryRegionLimitAddress += 0x1000-1;
+  }
+
+  DEBUG ((DEBUG_INFO, "RMRR Base  address USB %016lX\n", DmarTable->RmrrUsb.RmrrHeader.ReservedMemoryRegionBaseAddress));
+  DEBUG ((DEBUG_INFO, "RMRR Limit address USB %016lX\n", DmarTable->RmrrUsb.RmrrHeader.ReservedMemoryRegionLimitAddress));
+
+  if (DmarTable->RmrrUsb.RmrrHeader.ReservedMemoryRegionBaseAddress == 0) {
+    DEBUG ((DEBUG_INFO, "WARNING:  RmrrUsb.RmrrHeader.ReservedMemoryRegionBaseAddress is 0.\n"));
+  }
+
+  DmarTable->RmrrCsme.RmrrHeader.ReservedMemoryRegionBaseAddress   = 0;
+  DmarTable->RmrrCsme.RmrrHeader.ReservedMemoryRegionLimitAddress  = 0;
+
+  ///
+  /// Update DRHD structures of DmarTable
+  ///
+  DmarTable->DrhdEngine1.DrhdHeader.RegisterBaseAddress = ReadVtdBaseAddress(0);
+  DmarTable->DrhdEngine3.DrhdHeader.RegisterBaseAddress = ReadVtdBaseAddress(2);
+
+  DEBUG ((DEBUG_INFO, "VTD base address 1 = %x\n", DmarTable->DrhdEngine1.DrhdHeader.RegisterBaseAddress));
+  DEBUG ((DEBUG_INFO, "VTD base address 3 = %x\n", DmarTable->DrhdEngine3.DrhdHeader.RegisterBaseAddress));
+  ///
+  /// copy DmarTable to TempDmarTable to be processed
+  ///
+  CopyMem (&TempDmarTable, DmarTable, sizeof (EFI_ACPI_DMAR_TABLE));
+
+  ///
+  /// Update DRHD structures of temp DMAR table
+  ///
+  UpdateDrhd (&TempDmarTable.DrhdEngine1);
+  UpdateDrhd2 (&TempDmarTable.DrhdEngine3);
+
+  ///
+  /// Update RMRR structures of temp DMAR table
+  ///
+  UpdateRmrr ((VOID *) &TempDmarTable.RmrrUsb);
+  UpdateRmrr ((VOID *) &TempDmarTable.RmrrIgd);
+  UpdateRmrr ((VOID *) &TempDmarTable.RmrrCsme);
+
+  ///
+  /// Remove unused device scope or entire DRHD structures
+  ///
+  Offset = (UINTN) (&TempDmarTable.DrhdEngine1);
+  if (TempDmarTable.DrhdEngine1.DrhdHeader.Header.Length != 0) {
+    Offset += TempDmarTable.DrhdEngine1.DrhdHeader.Header.Length;
+  }
+
+  if (TempDmarTable.DrhdEngine3.DrhdHeader.Header.Length != 0) {
+    StructureLen = TempDmarTable.DrhdEngine3.DrhdHeader.Header.Length;
+    CopyMem ((VOID *) Offset, (VOID *) &TempDmarTable.DrhdEngine3, TempDmarTable.DrhdEngine3.DrhdHeader.Header.Length);
+    Offset += StructureLen;
+  }
+  ///
+  /// Remove unused device scope or entire RMRR structures
+  ///
+  if (TempDmarTable.RmrrUsb.RmrrHeader.Header.Length != 0) {
+    StructureLen = TempDmarTable.RmrrUsb.RmrrHeader.Header.Length;
+    CopyMem ((VOID *) Offset, (VOID *) &TempDmarTable.RmrrUsb, TempDmarTable.RmrrUsb.RmrrHeader.Header.Length);
+    Offset += StructureLen;
+  }
+
+  if (TempDmarTable.RmrrIgd.RmrrHeader.Header.Length != 0) {
+    StructureLen = TempDmarTable.RmrrIgd.RmrrHeader.Header.Length;
+    CopyMem ((VOID *) Offset, (VOID *) &TempDmarTable.RmrrIgd, TempDmarTable.RmrrIgd.RmrrHeader.Header.Length);
+    Offset += StructureLen;
+  }
+
+  if (TempDmarTable.RmrrCsme.RmrrHeader.Header.Length != 0) {
+    StructureLen = TempDmarTable.RmrrCsme.RmrrHeader.Header.Length;
+    CopyMem ((VOID *) Offset, (VOID *) &TempDmarTable.RmrrCsme, TempDmarTable.RmrrCsme.RmrrHeader.Header.Length);
+    Offset += StructureLen;
+  }
+
+  Offset = Offset - (UINTN) &TempDmarTable;
+  ///
+  /// Re-calculate DMAR table check sum
+  ///
+  TempDmarTable.DmarHeader.Header.Checksum = (UINT8) (TempDmarTable.DmarHeader.Header.Checksum + TempDmarTable.DmarHeader.Header.Length - Offset);
+  ///
+  /// Set DMAR table length
+  ///
+  TempDmarTable.DmarHeader.Header.Length = (UINT32) Offset;
+  ///
+  /// Replace DMAR table with rebuilt table TempDmarTable
+  ///
+  CopyMem ((VOID *) DmarTable, (VOID *) &TempDmarTable, TempDmarTable.DmarHeader.Header.Length);
+}
+
+/**
+  Update the DMAR table
+
+  @param[in, out] Table              The pointer to ACPI DMAR table
+  @param[in] DmarTableFlags          The flags related with DMAR table
+**/
+VOID
+EFIAPI
+UpdateDmarAcpi (
+  EFI_ACPI_DESCRIPTION_HEADER *Table,
+  UINTN                       DmarTableFlags
+  )
+{
+  EFI_ACPI_TABLE_VERSION          Version;
+  STATIC BOOLEAN                  Triggered = FALSE;
+
+  if (Triggered) {
+    return;
+  }
+
+  Triggered     = TRUE;
+
+  DEBUG ((DEBUG_INFO, "Update Dmar ACPI Table\n"));
+
+  ///
+  /// Fix DMAR Table always created, skip install when disabled
+  ///
+  if ((FeaturePcdGet (PcdVtdEnabled) == FALSE) || (PciRead32 (PCI_LIB_ADDRESS (SA_MC_BUS, 0, 0, R_SA_MC_CAPID0_A_OFFSET)) & BIT23)) {
+    DEBUG ((DEBUG_INFO, "Vtd Disabled, skip DMAR Table install\n"));
+    return;
+  }
+
+  mDmarTableFlags  = DmarTableFlags;
+
+  ///
+  /// By default, a table belongs in all ACPI table versions published.
+  ///
+  Version = EFI_ACPI_TABLE_VERSION_1_0B | EFI_ACPI_TABLE_VERSION_2_0 | EFI_ACPI_TABLE_VERSION_3_0;
+
+  DmarTableUpdate (Table, &Version);
+}

--- a/Silicon/CoffeelakePkg/Library/VTdLib/VTdLib.inf
+++ b/Silicon/CoffeelakePkg/Library/VTdLib/VTdLib.inf
@@ -1,0 +1,49 @@
+#/*++
+#
+#  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+#  Module Name:
+#
+#    VTdLib.inf
+#
+#  Abstract:
+#
+#    Component description file for VTd Library
+#
+#--*/
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = VtdLib
+  FILE_GUID                      = 846a0248-df29-4d79-a590-65699d08dde4
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = VtdLib
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 IPF EBC ARM
+#
+
+[Sources]
+  VTdLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  IntelFsp2Pkg/IntelFsp2Pkg.dec
+  BootloaderCorePkg/BootloaderCorePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+  Silicon/CoffeelakePkg/CoffeelakePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  IoLib
+  PcdLib
+  DebugLib
+  HobLib
+  MemoryAllocationLib
+
+[Pcd]
+  gPlatformModuleTokenSpaceGuid.PcdAcpiGnvsAddress
+  gPlatformModuleTokenSpaceGuid.PcdVtdEnabled


### PR DESCRIPTION
This patch adds ACPI DMAR table for CFL.
Some VT-d init code are ported from EDK2.

Test method:
  1. dump acpi tables: acpidump -b
  2. check the dmar table: iasl -d dmar.dat

Verify: CFL-s RVP

Signed-off-by: Stanley Chang <stanley.chang@intel.com>