### PR TITLE
[TGL] Update FSP/UCODE/platform version for MR7 release

### DIFF
--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -1,7 +1,7 @@
 ## @file
 # This file is used to provide board specific image information.
 #
-#  Copyright (c) 2018 - 2022, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2018 - 2023, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -25,7 +25,7 @@ class Board(BaseBoard):
 
         self.VERINFO_IMAGE_ID       = 'SBL_TGL'
         self.VERINFO_PROJ_MAJOR_VER = 1
-        self.VERINFO_PROJ_MINOR_VER = 6
+        self.VERINFO_PROJ_MINOR_VER = 7
         self.VERINFO_SVN            = 1
         self.VERINFO_BUILD_DATE     = time.strftime("%m/%d/%Y")
 

--- a/Silicon/TigerlakePkg/FspBin/FspBin.inf
+++ b/Silicon/TigerlakePkg/FspBin/FspBin.inf
@@ -1,7 +1,7 @@
 ## @file
 #  File to describe FSP repo information
 #
-#  Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -11,7 +11,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = 6f5ae9679e662353bc5570a1bc89e137e262155f
+  COMMIT  = 9ff157011c695a99488576b2ae98d58609579179
 
 [UserExtensions.SBL."CopyList"]
   TigerLakeFspBinPkg/TGL_IOT/Fsp.fd                    : Silicon/TigerlakePkg/FspBin/FspDbg.bin
@@ -24,4 +24,4 @@
   TigerLakeFspBinPkg/TGL_IOT/Include/MemInfoHob.h      : Silicon/TigerlakePkg/Include/MemInfoHob.h
   TigerLakeFspBinPkg/TGL_IOT/SampleCode/Vbt/Vbt.bin    : Platform/TigerlakeBoardPkg/VbtBin/Vbt.dat
   TigerLakeFspBinPkg/TGL_IOT/SampleCode/Vbt/Vbt.json   : Platform/TigerlakeBoardPkg/VbtBin/Vbt.json
-  FSP_License.pdf                                      : Platform/TigerlakeBoardPkg/FspBin/FSP_License.pdf
+  FSP_License.pdf                                      : Silicon/TigerlakePkg/FspBin/FSP_License.pdf

--- a/Silicon/TigerlakePkg/Microcode/Microcode.inf
+++ b/Silicon/TigerlakePkg/Microcode/Microcode.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2019 - 2022, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2019 - 2023, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 #
@@ -14,14 +14,14 @@
   VERSION_STRING       = 1.0
 
 [Sources]
-  m_80_806c1_000000a4.mcb
-  m_c2_806d1_0000003c.mcb
+  m_80_806c1_000000a6.mcb
+  m_c2_806d1_00000042.mcb
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
-  COMMIT = b587cd64ac87bde380b113a32867ff5dc2ef3fb7
+  COMMIT = bcc108df84e73b02e1f1bd2444fdd3d3b4a71aeb
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/TigerLake/m_80_806c1_000000a4.pdb  : Silicon/TigerlakePkg/Microcode/m_80_806c1_000000a4.mcb
-  Microcode/TigerLake/m_c2_806d1_0000003c.pdb  : Silicon/TigerlakePkg/Microcode/m_c2_806d1_0000003c.mcb
+  Microcode/TigerLake/m_80_806c1_000000a6.pdb  : Silicon/TigerlakePkg/Microcode/m_80_806c1_000000a6.mcb
+  Microcode/TigerLake/m_c2_806d1_00000042.pdb  : Silicon/TigerlakePkg/Microcode/m_c2_806d1_00000042.mcb
 


### PR DESCRIPTION
- update FSP version to IoT FSP 5505_01_MR7 (0A.00.7D.72)
- update TGLU microcode version to A6
- update TGLH microcode version to 42
- update TGL platform version to 1.7

Signed-off-by: Vincent <vincent.chen@intel.com>