### PR TITLE
feat: [EHL] support gfx(i915) S3 resume for Linux kernel 5.15.71+

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1238,8 +1238,9 @@ UpdateFspConfig (
     Fspscfg->CdClock                    = SiCfgData->CdClock;
     Fspscfg->PeiGraphicsPeimInit        = SiCfgData->PeiGraphicsPeimInit;
 
-
-    Fspscfg->GraphicsConfigPtr          = (UINT32)GetVbtAddress ();
+    if ((GetBootMode() != BOOT_ON_S3_RESUME)) {
+      Fspscfg->GraphicsConfigPtr          = (UINT32)GetVbtAddress ();
+    }
 
     CopyMem(SaDisplayConfigTable, (VOID *)(UINTN)mEhlCrbRowDisplayDdiConfig, sizeof(mEhlCrbRowDisplayDdiConfig));
     Fspscfg->DdiPortAConfig             = SaDisplayConfigTable[0];


### PR DESCRIPTION
During S3 resume, bootloader must not set VBT pointer. Otherwise the i915 driver in newer kernel will fail to load GuC.

Test method:
  1. S3 suspend, says 5 seconds: rtcwake -m mem -s 5
  2. check the display and dmesg

Verify: EHL CRB + Linux kernel 5.15.49 and 5.15.71

Signed-off-by: Stanley Chang <stanley.chang@intel.com>