### PR TITLE
fix: [Common] Support FSP 2.3 FSP_NON_VOLATILE_STORAGE_HOB2

### DIFF
--- a/BootloaderCorePkg/Library/FspSupportLib/FspSupportLib.c
+++ b/BootloaderCorePkg/Library/FspSupportLib/FspSupportLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017-2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -30,7 +30,13 @@ GetFspNvsDataBuffer (
   UINT32           *Length
   )
 {
-  return GetGuidHobData (HobListPtr, Length, &gFspNonVolatileStorageHobGuid);
+  VOID             *GuidHobData;
+
+  GuidHobData = GetGuidHobData (HobListPtr, Length, &gFspNonVolatileStorageHob2Guid);
+  if (GuidHobData == NULL){
+    GuidHobData = GetGuidHobData (HobListPtr, Length, &gFspNonVolatileStorageHobGuid);
+  }
+  return GuidHobData;
 }
 
 /**

--- a/BootloaderCorePkg/Library/FspSupportLib/FspSupportLib.inf
+++ b/BootloaderCorePkg/Library/FspSupportLib/FspSupportLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017-2023, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -36,5 +36,6 @@
 
 [Guids]
   gFspNonVolatileStorageHobGuid
+  gFspNonVolatileStorageHob2Guid
 
 [Pcd]


### PR DESCRIPTION
Implementation should search gFspNonVolatileStorageHob2Guid firstly and only search gFspNonVolatileStorageHobGuid when former one is not found.

Signed-off-by: Kobe <kok.tong.ong@intel.com>