### PR TITLE
fix: [ADL-N] Removed COM port config from debug interface

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -237,7 +237,7 @@ UpdateFspConfig (
 
   DebugPort = GetDebugPort ();
   if (DebugPort < GetPchMaxSerialIoUartControllersNum ()) {
-    Fspmcfg->PcdDebugInterfaceFlags = BIT4 | BIT5 | BIT1;
+    Fspmcfg->PcdDebugInterfaceFlags = BIT4 | BIT5;
     Fspmcfg->SerialIoUartDebugControllerNumber = DebugPort;
     Fspmcfg->SerialIoUartDebugMode = 4;
   } else {


### PR DESCRIPTION
When SioInit code configures the COM ports in stage 2, it might have settings conflict with debug interface. Remove it from FSP debug interface to resolve conflict and boot issue.

Signed-off-by: Kevin Tsai <kevin.tsai@intel.com>