### PR TITLE
OsLoader - Container Type Cleanup

### DIFF
--- a/BootloaderCommonPkg/Include/Library/ContainerLib.h
+++ b/BootloaderCommonPkg/Include/Library/ContainerLib.h
@@ -42,7 +42,7 @@ typedef UINT8 AUTH_TYPE;
 
 // Container Image types
 #define CONTAINER_TYPE_NORMAL               0x0     // Used for boot images in FV, regular ELF, PE32, etc. formats
-#define CONTAINER_TYPE_CLASSIC              0x3     // Used for booting Linux with bzImage, cmdline, initrd, etc.
+#define CONTAINER_TYPE_CLASSIC_LINUX        0x3     // Used for booting Linux with bzImage, cmdline, initrd, etc.
 #define CONTAINER_TYPE_MULTIBOOT            0x4     // Multiboot compliant ELF images
 
 // Max images per container

--- a/BootloaderCommonPkg/Include/Library/IasImageLib.h
+++ b/BootloaderCommonPkg/Include/Library/IasImageLib.h
@@ -1,7 +1,7 @@
 /** @file
   This file defines IAS File structures.
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -66,6 +66,7 @@ typedef struct {        /* a file (sub-image) inside a boot image */
   VOID                 *Addr;
   UINT32                Size;
   IMAGE_ALLOCATE_TYPE   AllocType;
+  UINT32                Name;   // Name specified for the component when building the container
 } IMAGE_DATA;
 
 //

--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -261,6 +261,9 @@ ParseContainerImage (
       }
     }
 
+    // Save the name of the component
+    File[Index].Name = (UINT32) ComponentName;
+
     Index++;
   } while ((Status == EFI_SUCCESS) && (Index < ARRAY_SIZE (File)));
 

--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -117,7 +117,7 @@ UpdateLoadedImage (
     }
 
     return EFI_SUCCESS;
-  } else if (ImageType == CONTAINER_TYPE_CLASSIC) {
+  } else if (ImageType == CONTAINER_TYPE_CLASSIC_LINUX) {
     // Files: cmdline, bzImage, initrd, other optional files (acpi, firmware1, firmware2, ...)
     // The file order for the first three files mentioned above is fixed. The rest are optional and can be in any order.
     // Container can contain additional ACPI binary blobs


### PR DESCRIPTION
This PR attempts to streamline the container types supported by OsLoader.

1. Normal: Used for PE, FV, bzImage, ELF images
2. Classic Linux: Used for a traditional Linux booting setup (cmdline, kernel, initrd, etc.). This type was renamed to CLASSIC_LINUX from CLASSIC to avoid any confusion.
3. Multiboot: Multiboot-compliant MB/MB-2 images

All 3 container types support ACPI table updates

This PR also adds one feature for the Linux container. Earlier, any additional files (blobs) loaded with the kernel were just loaded into memory. However, the OS did not know where these resided. To fix this, we add a placeholder in the kernel cmdline which will be updated with the actual address of the blob. The placeholder will be "SBL.XXXX=0x0000000000000000" where XXXX is the component name.

The open-source documentation will be updated to reflect these changes.