### PR TITLE
feat: [ADL/TGL] support gfx(i915) S3 resume for Linux kernel 5.15.71+

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -592,7 +592,7 @@ UpdateFspConfig (
     DEBUG (((BiosProtected) ? DEBUG_INFO : DEBUG_WARN, "BIOS SPI region will %a protected\n", (BiosProtected) ? "be" : "NOT BE"));
   }
 
-  if (PcdGetBool (PcdFramebufferInitEnabled)) {
+  if (PcdGetBool (PcdFramebufferInitEnabled) && (GetBootMode() != BOOT_ON_S3_RESUME)) {
     DEBUG ((DEBUG_INFO, "Frame Buffer Enabled\n"));
     FspsConfig->GraphicsConfigPtr = (UINT32)GetVbtAddress ();
     VbtPtr = (VBIOS_VBT_STRUCTURE*)(UINTN)(FspsConfig->GraphicsConfigPtr);

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1411,7 +1411,7 @@ UpdateFspConfig (
       DEBUG ((DEBUG_ERROR, "UpdateFspConfig Error: Could not allocate Memory for HdaVerbTable\n"));
     }
   }
-  if (PcdGetBool (PcdFramebufferInitEnabled)) {
+  if (PcdGetBool (PcdFramebufferInitEnabled) && (GetBootMode() != BOOT_ON_S3_RESUME)) {
     FspsConfig->GraphicsConfigPtr = (UINT32) GetVbtAddress();
     FspsConfig->PeiGraphicsPeimInit = 1;
   } else {


### PR DESCRIPTION
During S3 resume, bootloader must not set VBT pointer. Otherwise the i915 driver in newer kernel will fail to load GuC.

Test method:
  1. S3 suspend, says 5 seconds: rtcwake -m mem -s 5
  2. check the display and dmesg

Verify: ADLS and TGLU RVP + Linux kernel 5.15.71

Signed-off-by: Vincent Chen <vincent.chen@intel.com>