### PR TITLE
feat: Add BoardInit hook for system reset.

### DIFF
--- a/BootloaderCommonPkg/Include/Service/PlatformService.h
+++ b/BootloaderCommonPkg/Include/Service/PlatformService.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -14,6 +14,7 @@
 #define PLATFORM_SERVICE_VERSION    1
 
 typedef enum {
+  ResetSystemInit    = 0x00,
   PreTempRamInit     = 0x10,
   PostTempRamInit    = 0x20,
   PreConfigInit      = 0x30,

--- a/BootloaderCorePkg/Library/FspApiLib/FspMisc.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspMisc.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -8,6 +8,7 @@
 #include <FspApiLibInternal.h>
 #include <Library/ResetSystemLib.h>
 #include <Library/LitePeCoffLib.h>
+#include <Library/BoardInitLib.h>
 
 /**
   This function will handle FSP reset request.
@@ -23,6 +24,8 @@ FspResetHandler (
 {
   if ((Status >= FSP_STATUS_RESET_REQUIRED_COLD) && (Status <= FSP_STATUS_RESET_REQUIRED_8)) {
     DEBUG ((DEBUG_INIT, "FSP Requested Reboot ...\n\n"));
+    // Pass FSP reset type to BoardInit hook for special reset type handling
+    BoardInit(ResetSystemInit | (Status & 0xF));
     if (Status == FSP_STATUS_RESET_REQUIRED_WARM) {
       ResetSystem(EfiResetWarm);
     } else {

--- a/BootloaderCorePkg/Library/FspApiLib/FspmApiLib.inf
+++ b/BootloaderCorePkg/Library/FspApiLib/FspmApiLib.inf
@@ -1,7 +1,7 @@
 ## @file
 #  FSP API interfaces
 #
-#  Copyright (c) 2016 - 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2016 - 2023, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -44,6 +44,7 @@
   BaseMemoryLib
   ResetSystemLib
   ThunkLib
+  BoardInitLib
 
 [Pcd]
   gPlatformModuleTokenSpaceGuid.PcdFSPMBase

--- a/BootloaderCorePkg/Library/FspApiLib/FspsApiLib.inf
+++ b/BootloaderCorePkg/Library/FspApiLib/FspsApiLib.inf
@@ -38,6 +38,7 @@
   BaseMemoryLib
   ResetSystemLib
   ThunkLib
+  BoardInitLib
 
 [Pcd]
   gPlatformModuleTokenSpaceGuid.PcdFSPSBase

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -296,6 +296,12 @@ BoardInit (
 
   SiCfgData = NULL;
 
+  if (InitPhase == (ResetSystemInit | (FSP_STATUS_RESET_REQUIRED_3 & 0xF))) {
+    // Enable PMC Global reset on FSP_STATUS_RESET_REQUIRED_3
+    MmioOr32 (PCH_PWRM_BASE_ADDRESS + R_PMC_PWRM_ETR3, (UINT32) (B_PMC_PWRM_ETR3_CF9GR));
+    return;
+  }
+
   switch (InitPhase) {
   case PreSiliconInit:
     EnableLegacyRegions ();


### PR DESCRIPTION
Add ResetSystemInit Board Init Phase for executing platform hooks before system reset. This is needed to escalate PCH global reset requests from FSP.

Signed-off-by: Bejean Mosher <bejean.mosher@intel.com>