### PR TITLE
fix: [ADL/RPL] Force CPU Root Port MultiVC to disabled for S0ix.

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -865,6 +865,7 @@ UpdateFspConfig (
       FspsConfig->EnableTimedGpio0 = 0;
       FspsConfig->EnableTimedGpio1 = 0;
       FspsConfig->PchLanEnable = 0x0;
+      ZeroMem (FspsConfig->CpuPcieRpMultiVcEnabled, sizeof (FspsConfig->CpuPcieRpMultiVcEnabled));
       ZeroMem (FspsConfig->PchIshI2cEnable, sizeof (FspsConfig->PchIshI2cEnable));
       ZeroMem (FspsConfig->PchIshGpEnable, sizeof (FspsConfig->PchIshGpEnable));
       DEBUG ((DEBUG_INFO, "Stage 2 S0ix config applied.\n"));


### PR DESCRIPTION
This is a silicon requirement for S0ix support.

Signed-off-by: Bejean Mosher <bejean.mosher@intel.com>