### PR TITLE
ICXD: Fix Stage1A UART setup functions for UART1

### DIFF
--- a/Platform/IdavilleBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
+++ b/Platform/IdavilleBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
@@ -32,8 +32,8 @@ FSPT_UPD TempRamInitParams = {
 CONST GPIO_INIT_CONFIG mUartGpioTable[] = {
   {GPIO_CDF_GPP_B20, {GpioPadModeNative1, GpioHostOwnDefault, GpioDirDefault, GpioOutDefault, GpioIntDefault, GpioResetDefault, GpioTermDefault}},//UART0_RXD
   {GPIO_CDF_GPP_B21, {GpioPadModeNative1, GpioHostOwnDefault, GpioDirDefault, GpioOutDefault, GpioIntDefault, GpioResetDefault, GpioTermDefault}},//UART0_TXD
-  {GPIO_CDF_GPP_B22, {GpioPadModeNative1, GpioHostOwnDefault, GpioDirDefault, GpioOutDefault, GpioIntDefault, GpioResetDefault, GpioTermDefault}},//UART1_RXD
-  {GPIO_CDF_GPP_B23, {GpioPadModeNative1, GpioHostOwnDefault, GpioDirDefault, GpioOutDefault, GpioIntDefault, GpioResetDefault, GpioTermDefault}},//UART1_TXD
+  {GPIO_CDF_GPP_B22, {GpioPadModeNative2, GpioHostOwnDefault, GpioDirDefault, GpioOutDefault, GpioIntDefault, GpioResetDefault, GpioTermDefault}},//UART1_RXD
+  {GPIO_CDF_GPP_B23, {GpioPadModeNative2, GpioHostOwnDefault, GpioDirDefault, GpioOutDefault, GpioIntDefault, GpioResetDefault, GpioTermDefault}},//UART1_TXD
   {GPIO_CDF_GPP_D0,  {GpioPadModeNative1, GpioHostOwnDefault, GpioDirDefault, GpioOutDefault, GpioIntDefault, GpioResetDefault, GpioTermDefault}},//IE_UART_RXD
   {GPIO_CDF_GPP_D1,  {GpioPadModeNative1, GpioHostOwnDefault, GpioDirDefault, GpioOutDefault, GpioIntDefault, GpioResetDefault, GpioTermDefault}},//IE_UART_TXD
 };


### PR DESCRIPTION
The UART1_[RT]XD modes for the UART1 pins are function #2, not #1.

The UART2_[RT]XD pins are L12/L13, and the UART modes are function #2.

Signed-off-by: Lennert Buytenhek <buytenh@arista.com>