### PR TITLE
[ADLN] Update and cleanup

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -212,7 +212,7 @@ SI_PCH_DEVICE_INTERRUPT_CONFIG mPchNDevIntConfig[] = {
 //  {31, 0, PchNoInt, 0}, // LPC/eSPI Interface, doesn't use interrupts
 //  {31, 1, PchNoInt, 0}, // P2SB, doesn't use interrupts
 //  {31, 2, PchNoInt, 0}, // PMC , doesn't use interrupts
-  {31, 3, SiPchIntA, 16}, // cAVS(Audio, Voice, Speach), INTA is default, programmed in PciCfgSpace 3Dh
+  {31, 3, SiPchIntD, 19}, // cAVS(Audio, Voice, Speach), INTD is default, programmed in PciCfgSpace 3Dh
   {31, 4, SiPchIntA, 16}, // SMBus Controller, no default value, programmed in PciCfgSpace 3Dh
 //  {31, 5, PchNoInt, 0}, // SPI , doesn't use interrupts
   {31, 7, SiPchIntA, 16}, // TraceHub, INTA is default, RO register

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
@@ -1163,7 +1163,7 @@ PlatformUpdateAcpiGnvs (
     PlatformNvs->PcieSlot1PowerEnableGpio = GPIO_VER2_LP_GPP_A8;
     PlatformNvs->PcieSlot1RstGpio = GPIO_VER2_LP_GPP_F10;
     PlatformNvs->PcieSlot1RpNumber = 9;
-    PlatformNvs->PcieSlot2WakeGpio = GPIO_VER4_S_GPP_F1;
+    PlatformNvs->PcieSlot2WakeGpio = 0;
     PlatformNvs->PcieSlot2RpNumber = 0;
     PlatformNvs->PcieSlot2PowerEnableGpio = 0;
     PlatformNvs->PcieSlot2PowerEnableGpioPolarity = 0;
@@ -1201,11 +1201,6 @@ PlatformUpdateAcpiGnvs (
     PlatformNvs->PegSlot2RstGpioPolarity = 0;
     PlatformNvs->PegSlot2WakeGpioPin = 0;
     PlatformNvs->PegSlot2RootPort = 0;
-    //PlatformNvs->PegSlot3PwrEnableGpioNo = 0;
-    //PlatformNvs->PegSlot3PwrEnableGpioPolarity = 0;
-    //PlatformNvs->PegSlot3RstGpioNo = 0;
-    //PlatformNvs->PegSlot3RstGpioPolarity = 0;
-    //PlatformNvs->PegSlot3WakeGpioPin = 0;
     PlatformNvs->FoxLanWakeGpio = GPIO_VER2_LP_GPD2;
     PlatformNvs->FoxLanDisableNGpio = GPIO_VER2_LP_GPP_E5;
     PlatformNvs->FoxLanDisableNGpioPolarity = 1;
@@ -1233,7 +1228,7 @@ PlatformUpdateAcpiGnvs (
   PlatformNvs->SensorStandby = 0x0;
   PlatformNvs->Rtd3Config0 = 0x0;
   PlatformNvs->Rtd3Config1 = 0x0;
-  PlatformNvs->StorageRtd3Support = 0x1;
+  PlatformNvs->StorageRtd3Support = 0x2;
 
   PlatformNvs->Rp08D3ColdDisable = 0x0;
   PlatformNvs->Rp08D3ColdSupport = 0x0;

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/LowPowerSupport.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/LowPowerSupport.c
@@ -148,6 +148,8 @@ UINT64 GetLowPowerS0IdleConstraint(VOID)
       return 0x000000AE60CBE677;
     } else if (IsPchP ()) {
       return 0x000000AE60E98677;
+    } else if (IsPchN ()) {
+      return 0x000000AE60698EF7;
     }
   } else {
 

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/SioChip.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/SioChip.c
@@ -617,14 +617,14 @@ SioInit (
   // Program and Enable Default Super IO Configuration Port Addresses and range
   //
 
-  DEBUG((DEBUG_INFO, "AdlPsSioInit - Entry\n"));
+  DEBUG((DEBUG_INFO, "SioInit - Entry\n"));
   // Enable LPC IO decode for LPC/eSPI Bridge communication
   // Enable 4e/4f Decode over eSPI CS1#.
-  DEBUG((DEBUG_INFO, "AdlPsSioInit - Enable 4E 4F\n"));
+  DEBUG((DEBUG_INFO, "SioInit - Enable 4E 4F\n"));
   LpcBaseAddr = LpcPciCfgBase();
   LpcIoDecodeRanges = PciSegmentRead16(LpcBaseAddr + R_LPC_CFG_IOE);
   LpcIoDecodeRanges |= (B_LPC_CFG_IOE_ME2 | B_LPC_CFG_IOE_CAE | B_LPC_CFG_IOE_CBE);
-  DEBUG((DEBUG_INFO, "AdlPsSioInit - LpcIoDecodeRanges: %x\n", LpcIoDecodeRanges));
+  DEBUG((DEBUG_INFO, "SioInit - LpcIoDecodeRanges: %x\n", LpcIoDecodeRanges));
   PciSegmentWrite16((UINTN)(LpcBaseAddr + R_LPC_CFG_IOE), (UINT16)LpcIoDecodeRanges);
 
   //Enter Config Mode
@@ -639,13 +639,13 @@ SioInit (
       IoWrite8(SIO_CONFIG_PORT, 0x21);
       if ((IoRead8(SIO_DATA_PORT) & 0xFF) != 0x59)
       {
-          DEBUG((DEBUG_INFO, "AdlPsSioInit - Return CHIPID2:Not ITE8659\n"));
+          DEBUG((DEBUG_INFO, "SioInit - Return CHIPID2:Not ITE8659\n"));
           return;
       }
   }
   else
   {
-      DEBUG((DEBUG_INFO, "AdlPsSioInit - Return CHIPID1:Not ITE8659\n"));
+      DEBUG((DEBUG_INFO, "SioInit - Return CHIPID1:Not ITE8659\n"));
       return;
   }
 


### PR DESCRIPTION
- Fix the  interrupt config table.
- Update some NVS data.
- Cleanup debug prints so it is generic.
- Sync Pep constraints default value.

Signed-off-by: Sindhura Grandhi <sindhura.grandhi@intel.com>