### PR TITLE
fix: correct the default key for signing BOOT container

### DIFF
--- a/BootloaderCorePkg/Tools/GenContainer.py
+++ b/BootloaderCorePkg/Tools/GenContainer.py
@@ -592,7 +592,10 @@ class CONTAINER ():
             auth_type_str = self.get_auth_type_str (self.header.auth_type)
             match = re.match('RSA(\d+)_', auth_type_str)
             if match:
-                key_file = 'KEY_ID_CONTAINER_RSA%s' % match.group(1)
+                if self.header.signature.decode() == 'BOOT':
+                    key_file = 'KEY_ID_OS1_PRIVATE_RSA%s' % match.group(1)
+                else:
+                    key_file = 'KEY_ID_CONTAINER_RSA%s' % match.group(1)
             else:
                 key_file = ''
             alignment = self.header.alignment

--- a/BootloaderCorePkg/Tools/SingleSign.py
+++ b/BootloaderCorePkg/Tools/SingleSign.py
@@ -49,6 +49,9 @@ SIGNING_KEY = {
     "KEY_ID_OS2_PUBLIC_RSA2048"      :    "OS2_TestKey_Pub_RSA2048.pem",
     "KEY_ID_OS2_PUBLIC_RSA3072"      :    "OS2_TestKey_Pub_RSA3072.pem",
 
+    # KEY_ID_OS1_PRIVATE is used for signing container header with BOOT signature
+    "KEY_ID_OS1_PRIVATE_RSA2048"     :    "OS1_TestKey_Priv_RSA2048.pem",
+    "KEY_ID_OS1_PRIVATE_RSA3072"     :    "OS1_TestKey_Priv_RSA3072.pem",
     }
 
 MESSAGE_SBL_KEY_DIR = (


### PR DESCRIPTION
When GenContainer.py extracts a container image, a layout file is created that specifies the format of header and components. For container header with BOOT name, the signing key is expected to be KEY_ID_OS1_PRIVATE. Correct it for not misleading.

Signed-off-by: Vincent Chen <vincent.chen@intel.com>