### PR TITLE
fix: [ADLN] Revert FIPS mode debug info

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -401,9 +401,11 @@ BoardInit (
 
     // FIPS is disabled by default. enable it only when it is required.
     if (FeatureCfgData != NULL && (FeatureCfgData->MeFipsMode != 0)){
-      HeciSetFipsMode(FeatureCfgData->MeFipsMode);
-      DEBUG ((DEBUG_INFO, "Enabled FIPS mode.\n"));
       DEBUG ((DEBUG_INFO, "Set HeciSetFipsMode to 0x%x\n", FeatureCfgData->MeFipsMode));
+      Status = HeciSetFipsMode(FeatureCfgData->MeFipsMode);
+      if (!EFI_ERROR(Status)) {
+        DEBUG ((DEBUG_INFO, "Enabled FIPS mode.\n"));
+      }
     }
 
     break;

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -403,6 +403,7 @@ BoardInit (
     if (FeatureCfgData != NULL && (FeatureCfgData->MeFipsMode != 0)){
       HeciSetFipsMode(FeatureCfgData->MeFipsMode);
       DEBUG ((DEBUG_INFO, "Enabled FIPS mode.\n"));
+      DEBUG ((DEBUG_INFO, "Set HeciSetFipsMode to 0x%x\n", FeatureCfgData->MeFipsMode));
     }
 
     break;


### PR DESCRIPTION
Revert FIPS mode debug info for automation test.

Signed-off-by: Kevin Tsai <kevin.tsai@intel.com>