### PR TITLE
[ADLN] Sync different settings

### DIFF
--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_PepConstraints.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_PepConstraints.yaml
@@ -2,7 +2,7 @@
 #
 #  Slim Bootloader CFGDATA Option File.
 #
-#  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -76,6 +76,14 @@
                        Enable- Enable Cpu , Disable- Disable Cpu
         length       : 0x01
         value        : 0x1
+    - PepEmmc       :
+        name         : Enable/disable Low Power constraints eMMC
+        type         : Combo
+        option       : $EN_DIS
+        help         : >
+                       Enable- Enable eMMC , Disable- Disable eMMC
+        length       : 0x01
+        value        : 0x0
     - PepI2c2      :
         name         : Enable/disable Low Power constraints I2C2
         type         : Combo
@@ -277,5 +285,5 @@
         length       : 0x01
         value        : 0x0
     - Dummy        :
-        length       : 0x0
+        length       : 0x1
         value        : 0x0

--- a/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -509,10 +509,10 @@ UpdateFspConfig (
     Fspmcfg->DciModphyPg                  = 0;
     Fspmcfg->DciUsb3TypecUfpDbg           = 2;
     Fspmcfg->DebugInterfaceLockEnable     = TRUE;
-    Fspmcfg->DciDbcMode                   = DciDbcNoChange; // 4
+    Fspmcfg->DciDbcMode                   = DciDbcNoChange;
     Fspmcfg->DciEn                        = MemCfgData->DciEn;
-    Fspmcfg->CpuTraceHubMode              = MemCfgData->CpuTraceHubMode; // 2
-    Fspmcfg->PchTraceHubMode              = MemCfgData->PchTraceHubMode; // 2
+    Fspmcfg->CpuTraceHubMode              = MemCfgData->CpuTraceHubMode;
+    Fspmcfg->PchTraceHubMode              = MemCfgData->PchTraceHubMode;
     Fspmcfg->CpuTraceHubMemReg0Size       = MemCfgData->CpuTraceHubMemReg0Size;
     Fspmcfg->CpuTraceHubMemReg1Size       = MemCfgData->CpuTraceHubMemReg1Size;
     Fspmcfg->PchTraceHubMemReg0Size       = MemCfgData->PchTraceHubMemReg0Size;
@@ -638,7 +638,7 @@ UpdateFspConfig (
         Fspmcfg->Lp5CccConfig = 0xff;
         Fspmcfg->SkipCpuReplacementCheck = 0x0;
         Fspmcfg->FirstDimmBitMask = 0x0;
-        //Fspmcfg->FirstDimmBitMaskEcc = 0x0;
+        Fspmcfg->FirstDimmBitMaskEcc = 0x0;
         Fspmcfg->Lp5BankMode = 0x0;
         break;
       case PLATFORM_ID_ADL_N_LPDDR5_RVP:

--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -1158,7 +1158,7 @@ UpdateFspConfig (
         FspsConfig->CnviBtAudioOffload = 0x1;
         FspsConfig->IomTypeCPortPadCfg[0] = 0x90e0016;
         FspsConfig->IomTypeCPortPadCfg[1] = 0x90e0017;
-        FspsConfig->VmdEnable = 1;
+        FspsConfig->VmdEnable = 0;
         FspsConfig->Irms[0] = 0x0;
         FspsConfig->Irms[1] = 0x0;
         FspsConfig->ThcMode[0] = 1;
@@ -1166,9 +1166,10 @@ UpdateFspConfig (
         FspsConfig->PortResetMessageEnable[1] = 0x0;
         FspsConfig->PortResetMessageEnable[2] = 0x0;
         FspsConfig->PortResetMessageEnable[4] = 0x0;
-        FspsConfig->AmtEnabled = 0x1;
+        FspsConfig->AmtEnabled = 0x0;
         FspsConfig->LidStatus = 0x5b;
         FspsConfig->TcssAuxOri = 0x1;
+        FspsConfig->Device4Enable = 0x0; //this controls the thermal device (B0,D4,F0)
 #ifdef PLATFORM_ADLN
         FspsConfig->PchFivrVccstIccMaxControl = 0x1;
 #endif

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -1287,7 +1287,8 @@ PlatformUpdateAcpiGnvs (
   SaNvs->PcieLtrMaxNoSnoopLatency[2] = 0x8C8;
   SaNvs->PcieLtrMaxNoSnoopLatency[3] = 0x8C8;
   SaNvs->SlotSelection = 1;
-  SaNvs->CpuPcieRtd3 = 1;
+  SaNvs->CpuPcieRtd3   = 1;
+  SaNvs->VmdEnable     = FspsConfig ->VmdEnable;
 
   PlatformNvs->PpmFlags           = CpuNvs->PpmFlags;
   SocUpdateAcpiGnvs ((VOID *)GnvsIn);

--- a/Silicon/AlderlakePkg/Library/PchInfoLib/PchInfoLibAdl.c
+++ b/Silicon/AlderlakePkg/Library/PchInfoLib/PchInfoLibAdl.c
@@ -1,7 +1,7 @@
 /** @file
   Pch information library for ADL.
 
-  Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -608,6 +608,9 @@ PchGetSeriesStr (
     case PCH_S:
       return "ADL PCH-S";
 
+    case PCH_N:
+      return "ADL PCH-N";
+
     default:
       return NULL;
   }
@@ -659,6 +662,7 @@ GetPchMaxTypeCPortNum (
   switch (PchSeries ()) {
     case PCH_P:
     case PCH_M:
+    case PCH_N:
       return 4;
     default:
       return 0;
@@ -950,7 +954,12 @@ IsPchEmmcSupported (
   VOID
   )
 {
-  return FALSE;
+  switch (PchSeries ()) {
+    case PCH_N:
+      return TRUE;
+    default:
+      return FALSE;
+  }
 }
 
 /**


### PR DESCRIPTION
- Match the Pep constraints cfg with that of default.
- Sync few FSP cfg settings.
- Minor clean up.

Signed-off-by: Sindhura Grandhi <sindhura.grandhi@intel.com>