### PR TITLE
fix: [ADL/RPL] Move NVME boot option update to PCI Enumeration hook.

### DIFF
--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -714,10 +714,18 @@ PciSearchDevice (
   OUT PCI_IO_DEVICE                         **PciDevice
   )
 {
-  PCI_IO_DEVICE *PciIoDevice;
+  PCI_IO_DEVICE                     *PciIoDevice;
+  PLATFORM_PCI_ENUM_HOOK_PROC       PlatformPciEnumHookProc;
 
   PciIoDevice = NULL;
 
+  //
+  // Nofify EfiPciBeforeResourceCollection
+  //
+  PlatformPciEnumHookProc = (PLATFORM_PCI_ENUM_HOOK_PROC)(UINTN)PcdGet32 (PcdPciEnumHookProc);
+  if (PlatformPciEnumHookProc != NULL) {
+    PlatformPciEnumHookProc (Bus, Device, Func, EfiPciBeforeResourceCollection);
+  }
 #if DEBUG_PCI_ENUM
   DEBUG ((
            DEBUG_INFO,

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -118,6 +118,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled
   gPlatformModuleTokenSpaceGuid.PcdEnablePciePm
   gPlatformCommonLibTokenSpaceGuid.PcdBootPerformanceMask
+  gPlatformModuleTokenSpaceGuid.PcdPciEnumHookProc
 
 [FixedPcd]
   gPlatformAlderLakeTokenSpaceGuid.PcdAdlLpSupport


### PR DESCRIPTION
Re-scanning PCI devices to find NVME controllers was adding an additional ~20ms to the end of Stage 2. Moving this to the existing PCI scan that is part of PCI enumeration saves this time. However, this EfiPciBeforeResourceCollection phase was not actually getting called and needed to be added.