### PR TITLE
Fix TPM2 Event Logging

### DIFF
--- a/BootloaderCommonPkg/Library/TpmLib/TpmLib.c
+++ b/BootloaderCommonPkg/Library/TpmLib/TpmLib.c
@@ -927,11 +927,12 @@ ExtendStageHash (
   IN  COMPONENT_CALLBACK_INFO   *CbInfo
   )
 {
-  UINT8                DigestHash[HASH_DIGEST_MAX];
-  HASH_ALG_TYPE        MbHashType;
-  TPMI_ALG_HASH        MbTmpAlgHash;
-  UINT8               *HashPtr;
-  RETURN_STATUS        Status;
+  UINT8                       DigestHash[HASH_DIGEST_MAX];
+  HASH_ALG_TYPE               MbHashType;
+  TPMI_ALG_HASH               MbTmpAlgHash;
+  UINT8                       *HashPtr;
+  RETURN_STATUS               Status;
+  EFI_PLATFORM_FIRMWARE_BLOB  Blob;
 
   //Convert Measured boot Hash Mask to HASH_ALG_TYPE (CryptoLib)
   MbHashType   = GetCryptoHashAlg(PcdGet32(PcdMeasuredBootHashMask));
@@ -964,9 +965,13 @@ ExtendStageHash (
         TpmExtendPcrAndLogEvent (8, MbTmpAlgHash, HashPtr,
                               EV_COMPACT_HASH, sizeof("LinuxLoaderPkg: OS Image"), (UINT8 *)"LinuxLoaderPkg: OS Image");
       } else {
+        // Record base and length in event log
+        Blob.BlobBase = (UINT64)CbInfo->CompBuf;
+        Blob.BlobLength = CbInfo->CompLen;
+
         // TPM Extend for Stage components and payloads
         TpmExtendPcrAndLogEvent (0, MbTmpAlgHash, HashPtr,
-                              EV_POST_CODE, POST_CODE_STR_LEN, (UINT8 *)EV_POSTCODE_INFO_POST_CODE);
+                              EV_EFI_PLATFORM_FIRMWARE_BLOB, sizeof(Blob), (UINT8 *)&Blob);
       }
     } else {
       DEBUG((DEBUG_INFO, "Stage2 TPM PCR(0) extend failed!! \n"));

--- a/BootloaderCommonPkg/Library/TpmLib/TpmLib.c
+++ b/BootloaderCommonPkg/Library/TpmLib/TpmLib.c
@@ -966,7 +966,7 @@ ExtendStageHash (
                               EV_COMPACT_HASH, sizeof("LinuxLoaderPkg: OS Image"), (UINT8 *)"LinuxLoaderPkg: OS Image");
       } else {
         // Record base and length in event log
-        Blob.BlobBase = (UINT64)CbInfo->CompBuf;
+        Blob.BlobBase = (UINT64)(UINTN)CbInfo->CompBuf;
         Blob.BlobLength = CbInfo->CompLen;
 
         // TPM Extend for Stage components and payloads

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -711,7 +711,7 @@ ContinueFunc (
         // Extend External Config Data hash
         if (Stage1bParam->ConfigDataHashValid == 1) {
           CfgDataBlob = LdrGlobal->CfgDataPtr;
-          CfgDataFwBlob.BlobBase = (UINT64)CfgDataBlob;
+          CfgDataFwBlob.BlobBase = (UINT64)(UINTN)CfgDataBlob;
           CfgDataFwBlob.BlobLength = CfgDataBlob->UsedLength;
           TpmExtendPcrAndLogEvent (0,
                     MbTmpAlgHash,
@@ -724,7 +724,7 @@ ContinueFunc (
         // Extend Key hash manifest digest
         if (Stage1bParam->KeyHashManifestHashValid == 1) {
           KeyHashBlob = LdrGlobal->HashStorePtr;
-          KeyHashFwBlob.BlobBase = (UINT64)KeyHashBlob;
+          KeyHashFwBlob.BlobBase = (UINT64)(UINTN)KeyHashBlob;
           KeyHashFwBlob.BlobLength = KeyHashBlob->UsedLength;
           TpmExtendPcrAndLogEvent (0,
                     MbTmpAlgHash,


### PR DESCRIPTION
These changes ensure that:

- Each TPM2 event type matches the structure of the data associated with it
- Aligns TPM2 events between BIOS and SBL