### PR TITLE
Fix OsLoader handling of non-container images and remove PcdContainerBootEnabled

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -315,7 +315,6 @@
   gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled     | FALSE      | BOOLEAN | 0x20000210
   gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootEnabled     | FALSE      | BOOLEAN | 0x20000211
   gPlatformCommonLibTokenSpaceGuid.PcdSourceDebugEnabled      | FALSE      | BOOLEAN | 0x20000212
-  gPlatformCommonLibTokenSpaceGuid.PcdContainerBootEnabled    | FALSE      | BOOLEAN | 0x20000213
   gPlatformCommonLibTokenSpaceGuid.PcdEmmcHs400SupportEnabled | TRUE       | BOOLEAN | 0x20000214
   # This PCD will force to initialize SerialPort regardless of its initialized state
   gPlatformCommonLibTokenSpaceGuid.PcdForceToInitSerialPort   | FALSE      | BOOLEAN | 0x20000216

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -332,7 +332,6 @@
   gPayloadTokenSpaceGuid.PcdGrubBootCfgEnabled            | $(ENABLE_GRUB_CONFIG)
   gPlatformModuleTokenSpaceGuid.PcdSmbiosEnabled          | $(ENABLE_SMBIOS)
   gPlatformModuleTokenSpaceGuid.PcdLinuxPayloadEnabled    | $(ENABLE_LINUX_PAYLOAD)
-  gPlatformCommonLibTokenSpaceGuid.PcdContainerBootEnabled| $(ENABLE_CONTAINER_BOOT)
   gPayloadTokenSpaceGuid.PcdCsmeUpdateEnabled             | $(ENABLE_CSME_UPDATE)
   gPlatformModuleTokenSpaceGuid.PcdLegacyEfSegmentEnabled | $(ENABLE_LEGACY_EF_SEG)
   gPlatformCommonLibTokenSpaceGuid.PcdEmmcHs400SupportEnabled | $(ENABLE_EMMC_HS400)

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -168,7 +168,6 @@ class BaseBoard(object):
         self.ENABLE_GRUB_CONFIG    = 0
         self.ENABLE_SMBIOS         = 0
         self.ENABLE_LINUX_PAYLOAD  = 0
-        self.ENABLE_CONTAINER_BOOT = 1
         self.ENABLE_CSME_UPDATE    = 0
         self.ENABLE_EMMC_HS400     = 1
         self.ENABLE_DMA_PROTECTION = 0

--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -978,7 +978,7 @@ ParseBootImages (
   EFI_STATUS           Status;
   UINT8                Type;
 
-  Status = EFI_SUCCESS;
+  Status = EFI_UNSUPPORTED;
   for (Type = 0; Type < LoadImageTypeMax; Type++) {
     if (Type == LoadImageTypeMisc) {
       continue;
@@ -996,6 +996,8 @@ ParseBootImages (
       }
     } else if ((LoadedImage->Flags & LOADED_IMAGE_COMPONENT) != 0) {
       Status = ParseComponentImage (OsBootOption, LoadedImage);
+    } else if ((LoadedImage->Flags & LOADED_IMAGE_LINUX) != 0) {
+      Status = EFI_SUCCESS;
     }
 
     if (EFI_ERROR (Status)) {

--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -991,9 +991,7 @@ ParseBootImages (
 
     DEBUG ((DEBUG_INFO, "ParseBootImage ImageType-%d\n", Type));
     if ((LoadedImage->Flags & LOADED_IMAGE_CONTAINER) != 0) {
-      if (FeaturePcdGet (PcdContainerBootEnabled)) {
-        Status = ParseContainerImage (OsBootOption, LoadedImage);
-      }
+      Status = ParseContainerImage (OsBootOption, LoadedImage);
     } else if ((LoadedImage->Flags & LOADED_IMAGE_COMPONENT) != 0) {
       Status = ParseComponentImage (OsBootOption, LoadedImage);
     } else if ((LoadedImage->Flags & LOADED_IMAGE_LINUX) != 0) {

--- a/PayloadPkg/OsLoader/OsLoader.inf
+++ b/PayloadPkg/OsLoader/OsLoader.inf
@@ -112,7 +112,6 @@
   gPlatformCommonLibTokenSpaceGuid.PcdFrameBufferMaxConsoleWidth
   gPlatformCommonLibTokenSpaceGuid.PcdFrameBufferMaxConsoleHeight
   gPayloadTokenSpaceGuid.PcdGrubBootCfgEnabled
-  gPlatformCommonLibTokenSpaceGuid.PcdContainerBootEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashMask
   gPayloadTokenSpaceGuid.PcdRtcmRsvdSize
 


### PR DESCRIPTION
OsLoader should not attempt to boot images that are not packaged as containers.

Earlier, OsLoader would attempt to load and boot a non-container image and fail in
SetupBootImages() as the LoadedImage struct would not be populated correctly.

Now, ParseBootImage() will report a non-container file as unsupported and OsLoader
will move on to the next entry in the boot options.
