### PR TITLE
fix: Build stage2 stack and heap from suitable available memory.

### DIFF
--- a/BootloaderCorePkg/Include/Library/FspSupportLib.h
+++ b/BootloaderCorePkg/Include/Library/FspSupportLib.h
@@ -39,7 +39,7 @@ GetFspNvsDataBuffer (
   @retval              Reserved region start address.  0 if this region does not exist.
  */
 UINT64
-GetFspAvailableSystemMem(
+GetFspHighestAvailableSystemMem(
   CONST VOID     *HobListPtr,
   UINT64         *Length
   );

--- a/BootloaderCorePkg/Include/Library/FspSupportLib.h
+++ b/BootloaderCorePkg/Include/Library/FspSupportLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -26,6 +26,22 @@ EFIAPI
 GetFspNvsDataBuffer (
   CONST VOID             *HobListPtr,
   UINT32                 *Length
+  );
+
+/**
+  Find an FSP resource descriptor large enough to accomodate
+  requested length.
+
+  @param  HobListPtr   A HOB list pointer.
+  @param  Length       A pointer to the requested length. If suitable
+                       descriptor is found, length will be updated with
+                       resource length.
+  @retval              Reserved region start address.  0 if this region does not exist.
+ */
+UINT64
+GetFspAvailableSystemMem(
+  CONST VOID     *HobListPtr,
+  UINT64         *Length
   );
 
 /**

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -439,7 +439,7 @@ SecStartup2 (
                         PcdGet32 (PcdLoaderAcpiNvsSize) +
                         PcdGet32 (PcdLoaderAcpiReclaimSize) +
                         PcdGet32 (PcdPayloadReservedMemSize);
-  FspAvailableMemBase = (UINT32)GetFspAvailableSystemMem (
+  FspAvailableMemBase = (UINT32)GetFspHighestAvailableSystemMem (
                           HobList,
                           &FspAvailableMemSize);
   ASSERT (FspAvailableMemBase > 0);


### PR DESCRIPTION
Previously, Stage1B was building the Stage 2 stack and heap immediately below the FSP Reserved Memory resource descriptor region, assuming that this was a large available memory region. This assumption breaks when FSP resource descriptors move around, leading to unpredictable behavior.

This modification forces stage 1b to select a region for stack/heap from the FSP available memory descriptors that has adequete space for stack, heap, ACPI resources, and Payload reserved mem.