### PR TITLE
feat: [FSP2.4] Added FSP variable serivices, Multi Phase Mem and SI.

### DIFF
--- a/BootloaderCommonPkg/Include/Library/VariableLib.h
+++ b/BootloaderCommonPkg/Include/Library/VariableLib.h
@@ -1,7 +1,7 @@
 /** @file
   Lite variable service library
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -123,5 +123,23 @@ VariableConstructor (
   IN  UINT32    Base,
   IN  UINT32    Size
   );
+
+/**
+ Get details on Variable Storage space
+
+ @param     MaxStorageSize        Total Storage region size
+ @param     RemainingStorageSize  Remaining Space available (includes reclaimable space)
+ @param     MaxVariableSize       Max size of a variable that can be stored
+ @retval    EFI_SUCCESS           Output values were returned successfully
+ @retval    EFI_INVALID_PARAMETER Output pointers passed in are invalid
+ @retval    EFI_VOLUME_CORRUPTED  Variable store is corrupted
+ */
+EFI_STATUS
+EFIAPI
+QueryVariableInfo(
+  OUT UINTN     *MaxStorageSize,
+  OUT UINTN     *RemainingStorageSize,
+  OUT UINTN     *MaxVariableSize
+);
 
 #endif

--- a/BootloaderCommonPkg/Include/Library/VariableLib.h
+++ b/BootloaderCommonPkg/Include/Library/VariableLib.h
@@ -1,7 +1,7 @@
 /** @file
   Lite variable service library
 
-  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/BootloaderCommonPkg/Library/LiteVariableLib/LiteVariableLib.c
+++ b/BootloaderCommonPkg/Library/LiteVariableLib/LiteVariableLib.c
@@ -1029,6 +1029,7 @@ VariableConstructor (
   @param     MaxStorageSize        Total Storage region size
   @param     RemainingStorageSize  Remaining Space available (includes reclaimable space)
   @param     MaxVariableSize       Max size of a variable that can be stored
+
   @retval    EFI_SUCCESS           Output values were returned successfully
   @retval    EFI_INVALID_PARAMETER Output pointers passed in are invalid
   @retval    EFI_VOLUME_CORRUPTED  Variable store is corrupted
@@ -1059,10 +1060,10 @@ QueryVariableInfo(
   // Loop through Variable entries looking for deleted vars and last entry
   for (VarHdrPtr = (VARIABLE_HEADER *)&VarStoreHdrPtr[1];
     IS_HEADER_VALID(VarHdrPtr->State);
-    VarHdrPtr = (VARIABLE_HEADER *) ((UINT8 *)&VarHdrPtr[1] + VarHdrPtr->DataSize))
-  {
-    if (IS_DELETED(VarHdrPtr->State))
+    VarHdrPtr = (VARIABLE_HEADER *) ((UINT8 *)&VarHdrPtr[1] + VarHdrPtr->DataSize)) {
+    if (IS_DELETED(VarHdrPtr->State)) {
       DeletedSpace += VarHdrPtr->DataSize + sizeof(VARIABLE_HEADER);
+    }
   }
   DEBUG((DEBUG_VERBOSE, "VarHdrPtr: 0x%X, VarEndPtr: 0x%X\n", VarHdrPtr, VarEndPtr));
   *RemainingStorageSize = (UINTN)(VarEndPtr - (UINT8*)VarHdrPtr) + DeletedSpace;

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -1,7 +1,7 @@
 ## @file
 # Provides driver and definitions to build bootloader.
 #
-# Copyright (c) 2016 - 2022, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2023, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -58,6 +58,7 @@
   DecompressLib|BootloaderCommonPkg/Library/DecompressLib/DecompressLib.inf
   RleCompressLib|BootloaderCommonPkg/Library/RleCompressLib/RleCompressLib.inf
   FspSupportLib|BootloaderCorePkg/Library/FspSupportLib/FspSupportLib.inf
+  FspVariableServicesLib|BootloaderCorePkg/Library/FspVariableServicesLib/FspVariableServicesLib.inf
   BootloaderLib|BootloaderCorePkg/Library/BootloaderLib/BootloaderLib.inf
   BootloaderCoreLib|BootloaderCorePkg/Library/BootloaderCoreLib/BootloaderCoreLib.inf
   PciEnumerationLib|BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.inf

--- a/BootloaderCorePkg/Include/Library/FspApiLib.h
+++ b/BootloaderCorePkg/Include/Library/FspApiLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -9,6 +9,8 @@
 #define _FSP_API_LIB_H_
 
 #include <FspEas/FspApi.h>
+
+typedef EFI_STATUS (EFIAPI *FSP_MULTI_PHASE_FUNCTION)(FSP_MULTI_PHASE_PARAMS *MultiPhaseInitParamPtr);
 
 /**
   This FSP API is called after TempRamInit and initializes the memory.
@@ -37,6 +39,39 @@ EFIAPI
 CallFspMemoryInit (
   UINT32                     FspmBase,
   VOID                       **HobList
+  );
+
+/**
+  This FSP API provides multi-phase memory and silicon initialization, which brings
+  greater modularity to the existing FspMemoryInit() and FspSiliconInit() API. Increased
+  modularity is achieved by adding an extra API to FSP-M and FSP-S. This allows the
+  bootloader to add board specific initialization steps throughout the MemoryInit and
+  SiliconInit flows as needed. The FspMemoryInit() API is always called before
+  FspMultiPhaseMemInit(); it is the first phase of memory initialization. Similarly, the
+  FspSiliconInit() API is always called before FspMultiPhaseSiInit(); it is the first phase of
+  silicon initialization. After the first phase, subsequent phases are invoked by calling the
+  FspMultiPhaseMem/SiInit() API.
+  The FspMultiPhaseMemInit() API may only be called after the FspMemoryInit() API and
+  before the FspSiliconInit() API; or in the case that FSP-T is being used, before the
+  TempRamExit() API. The FspMultiPhaseSiInit() API may only be called after the
+  FspSiliconInit() API and before NotifyPhase() API; or in the case that FSP-I is being used,
+  before the FspSmmInit() API. The multi-phase APIs may not be called at any other time.
+
+  @param[in] FspmBase                 The base address of FSPM.
+  @param[in] MultiPhaseInitParamPtr   Pointer to provide multi-phase init parameters.
+
+  @retval EFI_SUCCESS                 FSP execution environment was initialized successfully.
+  @retval EFI_INVALID_PARAMETER       Input parameters are invalid.
+  @retval EFI_UNSUPPORTED             The FSP calling conditions were not met.
+  @retval EFI_DEVICE_ERROR            FSP initialization failed.
+  @retval EFI_OUT_OF_RESOURCES        Stack range requested by FSP is not met.
+  @retval FSP_STATUS_RESET_REQUIREDx  A reset is reuired. These status codes will not be returned during S3.
+  @retval FSP_STATUS_VARIABLE_REQUEST An FSP variable access is required.
+**/
+EFI_STATUS
+EFIAPI
+CallFspMultiPhaseMemoryInit (
+  FSP_MULTI_PHASE_PARAMS     *MultiPhaseInitParamPtr
   );
 
 /**
@@ -84,6 +119,33 @@ CallFspSiliconInit (
   );
 
 /**
+  This FSP API provides multi-phase memory and silicon initialization, which brings
+  greater modularity to the existing FspMemoryInit() and FspSiliconInit() API. Increased
+  modularity is achieved by adding an extra API to FSP-M and FSP-S. This allows the
+  bootloader to add board specific initialization steps throughout the MemoryInit and
+  SiliconInit flows as needed. The FspMemoryInit() API is always called before
+  FspMultiPhaseMemInit(); it is the first phase of memory initialization. Similarly, the
+  FspSiliconInit() API is always called before FspMultiPhaseSiInit(); it is the first phase of
+  silicon initialization. After the first phase, subsequent phases are invoked by calling the
+  FspMultiPhaseMem/SiInit() API.
+
+  @param[in] MultiPhaseInitParamPtr   Pointer to provide multi-phase init parameters.
+
+  @retval EFI_SUCCESS                 FSP execution environment was initialized successfully.
+  @retval EFI_INVALID_PARAMETER       Input parameters are invalid.
+  @retval EFI_UNSUPPORTED             The FSP calling conditions were not met.
+  @retval EFI_DEVICE_ERROR            FSP initialization failed.
+  @retval EFI_OUT_OF_RESOURCES        Stack range requested by FSP is not met.
+  @retval FSP_STATUS_RESET_REQUIREDx  A reset is reuired. These status codes will not be returned during S3.
+  @retval FSP_STATUS_VARIABLE_REQUEST An FSP variable access is required.
+**/
+EFI_STATUS
+EFIAPI
+CallFspMultiPhaseSiliconInit (
+  FSP_MULTI_PHASE_PARAMS     *MultiPhaseInitParamPtr
+  );
+
+/**
   This FSP API is used to notify the FSP about the different phases in the boot process.
   This allows the FSP to take appropriate actions as needed during different initialization
   phases. The phases will be platform dependent and will be documented with the FSP
@@ -126,6 +188,37 @@ RebaseFspComponent (
   UINT32   Delta
   );
 
+/**
+  This function handles variable services requests from FspMemoryInit and FspSiliconInit.
+  This should be called immediately after returning from the respective FSP entrypoint.
+
+  @param[in] Status             The status return by the FSP entry point.
+
+  @retval Status
+ */
+EFI_STATUS
+FspVariableHandler(
+  EFI_STATUS                FspStatus,
+  FSP_MULTI_PHASE_FUNCTION  MultiPhaseFunction
+  );
+
+/**
+ * This calls the FspMultiPhaseMemInit entry point to find out if more phases of
+ * memory init remain, and executes them if so.
+ *
+ * @return EFI_STATUS
+ */
+EFI_STATUS
+FspMultiPhaseMemInitHandler(VOID);
+
+/**
+ * This calls the FspMultiPhaseSiliconInit entry point to find out
+ * if more phases of Silicon init remain, and executes them if so.
+ *
+ * @return EFI_STATUS
+ */
+EFI_STATUS
+FspMultiPhaseSiliconInitHandler(VOID);
 
 /**
   This function will handle FSP reset request.
@@ -148,7 +241,7 @@ FspResetHandler (
   @param[in] Param2       The second parameter to pass to 32bit code.
   @param[in] ExeInMem     If thunk needs to be executed from memory copy.
 
-  @return EFI_STATUS.
+  @return EFI_STATUS
 **/
 EFI_STATUS
 EFIAPI

--- a/BootloaderCorePkg/Include/Library/FspApiLib.h
+++ b/BootloaderCorePkg/Include/Library/FspApiLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -197,6 +197,7 @@ RebaseFspComponent (
   @retval Status
  */
 EFI_STATUS
+EFIAPI
 FspVariableHandler(
   EFI_STATUS                FspStatus,
   FSP_MULTI_PHASE_FUNCTION  MultiPhaseFunction
@@ -209,6 +210,7 @@ FspVariableHandler(
  * @return EFI_STATUS
  */
 EFI_STATUS
+EFIAPI
 FspMultiPhaseMemInitHandler(VOID);
 
 /**
@@ -218,6 +220,7 @@ FspMultiPhaseMemInitHandler(VOID);
  * @return EFI_STATUS
  */
 EFI_STATUS
+EFIAPI
 FspMultiPhaseSiliconInitHandler(VOID);
 
 /**

--- a/BootloaderCorePkg/Include/Library/FspApiLib.h
+++ b/BootloaderCorePkg/Include/Library/FspApiLib.h
@@ -57,7 +57,6 @@ CallFspMemoryInit (
   FspSiliconInit() API and before NotifyPhase() API; or in the case that FSP-I is being used,
   before the FspSmmInit() API. The multi-phase APIs may not be called at any other time.
 
-  @param[in] FspmBase                 The base address of FSPM.
   @param[in] MultiPhaseInitParamPtr   Pointer to provide multi-phase init parameters.
 
   @retval EFI_SUCCESS                 FSP execution environment was initialized successfully.
@@ -198,7 +197,7 @@ RebaseFspComponent (
  */
 EFI_STATUS
 EFIAPI
-FspVariableHandler(
+FspVariableHandler (
   EFI_STATUS                FspStatus,
   FSP_MULTI_PHASE_FUNCTION  MultiPhaseFunction
   );
@@ -211,7 +210,7 @@ FspVariableHandler(
  */
 EFI_STATUS
 EFIAPI
-FspMultiPhaseMemInitHandler(VOID);
+FspMultiPhaseMemInitHandler (VOID);
 
 /**
  * This calls the FspMultiPhaseSiliconInit entry point to find out
@@ -221,7 +220,7 @@ FspMultiPhaseMemInitHandler(VOID);
  */
 EFI_STATUS
 EFIAPI
-FspMultiPhaseSiliconInitHandler(VOID);
+FspMultiPhaseSiliconInitHandler (VOID);
 
 /**
   This function will handle FSP reset request.

--- a/BootloaderCorePkg/Include/Library/FspVariableServicesLib.h
+++ b/BootloaderCorePkg/Include/Library/FspVariableServicesLib.h
@@ -18,6 +18,7 @@
   @return EFI_STATUS
  */
 EFI_STATUS
+EFIAPI
 FspGetVariable(
   IN  CHAR16      *VariableName,
   IN  EFI_GUID    *VariableGuid,
@@ -37,6 +38,7 @@ FspGetVariable(
   @return EFI_STATUS
  */
 EFI_STATUS
+EFIAPI
 FspGetNextVariableName(
   IN OUT  UINT64   *VariableNameSize,
   OUT     CHAR16   *VariableName,
@@ -54,6 +56,7 @@ FspGetNextVariableName(
   @return EFI_STATUS
  */
 EFI_STATUS
+EFIAPI
 FspSetVariable(
   IN  CHAR16      *VariableName,
   IN  EFI_GUID    *VariableGuid,
@@ -72,6 +75,7 @@ FspSetVariable(
   @return EFI_STATUS
  */
 EFI_STATUS
+EFIAPI
 FspQueryVariableInfo(
   IN  UINT32      *Attributes,
   OUT UINT64      *MaximumVariableStorageSize,

--- a/BootloaderCorePkg/Include/Library/FspVariableServicesLib.h
+++ b/BootloaderCorePkg/Include/Library/FspVariableServicesLib.h
@@ -1,0 +1,81 @@
+/** @file
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#ifndef __FSP_VARIABLE_SERVICES_LIB_H__
+#define __FSP_VARIABLE_SERVICES_LIB_H__
+
+/**
+  FSP wrapper for SBL's Get Variable implementation.
+
+  @param VariableName
+  @param VariableGuid
+  @param Attributes
+  @param DataSize
+  @param Data
+  @return EFI_STATUS
+ */
+EFI_STATUS
+FspGetVariable(
+  IN  CHAR16      *VariableName,
+  IN  EFI_GUID    *VariableGuid,
+  OUT UINT32      *Attributes,
+  IN OUT UINT64   *DataSize,
+  IN  VOID        *Data
+);
+
+/**
+  FSP wrapper for SBL's Get Next Variable implementation.
+  This must always be called successively without any other
+  LiteVariable GetNextVariablName calls in between.
+
+  @param VariableNameSize
+  @param VariableName
+  @param VariableGuid
+  @return EFI_STATUS
+ */
+EFI_STATUS
+FspGetNextVariableName(
+  IN OUT  UINT64   *VariableNameSize,
+  OUT     CHAR16   *VariableName,
+  OUT     EFI_GUID *VariableGuid
+);
+
+/**
+  FSP wrapper for SBL's Set Variable implementation.
+
+  @param VariableName
+  @param VariableGuid
+  @param Attributes
+  @param DataSize
+  @param Data
+  @return EFI_STATUS
+ */
+EFI_STATUS
+FspSetVariable(
+  IN  CHAR16      *VariableName,
+  IN  EFI_GUID    *VariableGuid,
+  IN  UINT32      *Attributes,
+  IN  UINT64      *DataSize,
+  IN  VOID        *Data
+);
+
+/**
+  SBL implementation of FSP QueryVariableInfo API
+
+  @param Attributes
+  @param MaximumVariableStorageSize
+  @param RemainingVariableStorageSize
+  @param MaximumVariableSize
+  @return EFI_STATUS
+ */
+EFI_STATUS
+FspQueryVariableInfo(
+  IN  UINT32      *Attributes,
+  OUT UINT64      *MaximumVariableStorageSize,
+  OUT UINT64      *RemainingVariableStorageSize,
+  OUT UINT64      *MaximumVariableSize
+);
+#endif //__FSP_VARIABLE_SERVICES_LIB_H__

--- a/BootloaderCorePkg/Library/FspApiLib/FspMemoryInit.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspMemoryInit.c
@@ -173,7 +173,6 @@ FspMultiPhaseMemInitHandler(VOID)
   FspSiliconInit() API and before NotifyPhase() API; or in the case that FSP-I is being used,
   before the FspSmmInit() API. The multi-phase APIs may not be called at any other time.
 
-  @param[in] FspmBase                 The base address of FSPM.
   @param[in] MultiPhaseInitParamPtr   Pointer to provide multi-phase init parameters.
 
   @retval EFI_SUCCESS                 FSP execution environment was initialized successfully.
@@ -202,8 +201,9 @@ CallFspMultiPhaseMemoryInit (
   ASSERT (FspHeader->Signature == FSP_INFO_HEADER_SIGNATURE);
   ASSERT (FspHeader->ImageBase == FspmBase);
 
-  if (FspHeader->HeaderRevision < FSP24_HEADER_REVISION)
+  if (FspHeader->HeaderRevision < FSP24_HEADER_REVISION) {
     return EFI_UNSUPPORTED;
+  }
 
   ASSERT (FspHeader->FspMultiPhaseMemInitEntryOffset != 0);
   FspMultiPhaseMemoryInit = (FSP_MULTI_PHASE_MEM_INIT)(UINTN)(FspHeader->ImageBase + \

--- a/BootloaderCorePkg/Library/FspApiLib/FspMemoryInit.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspMemoryInit.c
@@ -1,11 +1,12 @@
 /** @file
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
 #include <FspApiLibInternal.h>
+#include <Library/FspApiLib.h>
 #include <Library/BoardInitLib.h>
 #include <Library/BootloaderCoreLib.h>
 
@@ -39,10 +40,11 @@ CallFspMemoryInit (
   )
 {
   UINT8                       FspmUpd[FixedPcdGet32 (PcdFSPMUpdSize)];
-  UINT8                      *DefaultMemoryInitUpd;
-  FSP_INFO_HEADER            *FspHeader;
+  UINT8                       *DefaultMemoryInitUpd;
+  FSP_INFO_HEADER             *FspHeader;
   FSP_MEMORY_INIT             FspMemoryInit;
-  FSPM_UPD_COMMON            *FspmUpdCommon;
+  FSPM_UPD_COMMON             *FspmUpdCommon;
+  FSPM_UPD_COMMON_FSP24       *FspmUpdCommon24;
   EFI_STATUS                  Status;
   UINTN                       NewStack;
 
@@ -56,10 +58,35 @@ CallFspMemoryInit (
   CopyMem (&FspmUpd, DefaultMemoryInitUpd, FspHeader->CfgRegionSize);
 
   /* Update architectural UPD fields */
-  FspmUpdCommon = (FSPM_UPD_COMMON *)FspmUpd;
-  FspmUpdCommon->FspmArchUpd.BootLoaderTolumSize = 0;
-  FspmUpdCommon->FspmArchUpd.BootMode            = (UINT32)GetBootMode();
-  FspmUpdCommon->FspmArchUpd.NvsBufferPtr        = (UINT32)(UINTN)FindNvsData();
+  if (FspHeader->SpecVersion < 0x24)
+  {
+    FspmUpdCommon = (FSPM_UPD_COMMON *)FspmUpd;
+    FspmUpdCommon->FspmArchUpd.BootLoaderTolumSize  = 0;
+    FspmUpdCommon->FspmArchUpd.BootMode             = (UINT32)GetBootMode();
+    FspmUpdCommon->FspmArchUpd.NvsBufferPtr         = (UINT32)(UINTN)FindNvsData();
+
+    NewStack = PcdGet32 (PcdFSPMStackTop);
+    if (NewStack == 0xFFFFFFFF) {
+      NewStack = (UINT32)FspmUpdCommon->FspmArchUpd.StackBase + (UINT32)FspmUpdCommon->FspmArchUpd.StackSize;
+    }
+  }
+  else
+  {
+    FspmUpdCommon24 = (FSPM_UPD_COMMON_FSP24 *)FspmUpd;
+    FspmUpdCommon24->FspmArchUpd.BootLoaderTolumSize  = 0;
+    FspmUpdCommon24->FspmArchUpd.BootMode             = (UINT32)GetBootMode();
+
+    // This must be set to NULL if ImageAttribute indicates FSP Variable support
+    if ((FspHeader->ImageAttribute & IMAGE_ATTRIBUTE_VAR_SERVICES_SUPPORT) == IMAGE_ATTRIBUTE_VAR_SERVICES_SUPPORT)
+      FspmUpdCommon24->FspmArchUpd.NvsBufferPtr       = (UINTN)NULL;
+    else
+      FspmUpdCommon24->FspmArchUpd.NvsBufferPtr       = (UINTN)FindNvsData();
+
+    NewStack = PcdGet32 (PcdFSPMStackTop);
+    if (NewStack == 0xFFFFFFFF) {
+      NewStack = (UINT32)FspmUpdCommon24->FspmArchUpd.StackBase + (UINT32)FspmUpdCommon24->FspmArchUpd.StackSize;
+    }
+  }
 
   UpdateFspConfig (FspmUpd);
 
@@ -69,10 +96,6 @@ CallFspMemoryInit (
 
   DEBUG ((DEBUG_INFO, "Call FspMemoryInit ... "));
 
-  NewStack = PcdGet32 (PcdFSPMStackTop);
-  if (NewStack == 0xFFFFFFFF) {
-    NewStack = FspmUpdCommon->FspmArchUpd.StackBase + FspmUpdCommon->FspmArchUpd.StackSize;
-  }
   if (IS_X64) {
     if (NewStack != 0) {
       Status = FspmSwitchStack ((VOID *)(UINTN)FspMemoryInit, (VOID *)FspmUpd, (VOID *)HobList, (VOID *)NewStack);
@@ -86,6 +109,112 @@ CallFspMemoryInit (
     } else {
       Status = FspMemoryInit (&FspmUpd, HobList);
     }
+  }
+  DEBUG ((DEBUG_INFO, "%r\n", Status));
+
+  return Status;
+}
+
+/**
+ * This calls the FspMultiPhaseMemInit entry point to find out if more phases of
+ * memory init remain, and executes them if so.
+ *
+ * @return EFI_STATUS
+ */
+EFI_STATUS
+FspMultiPhaseMemInitHandler(VOID)
+{
+  EFI_STATUS                                  Status;
+  FSP_MULTI_PHASE_PARAMS                      MultiPhaseInitParams;
+  FSP_MULTI_PHASE_GET_NUMBER_OF_PHASES_PARAMS GetNumPhasesParams;
+
+  MultiPhaseInitParams.MultiPhaseAction   = EnumMultiPhaseGetNumberOfPhases;
+  MultiPhaseInitParams.PhaseIndex         = 0;
+  MultiPhaseInitParams.MultiPhaseParamPtr = (VOID*)&GetNumPhasesParams;
+  GetNumPhasesParams.PhasesExecuted       = 0;
+  // If FSP binary doesn't support 2.4 spec, multi phase mem init will return EFI_UNSUPPORTED
+  Status = CallFspMultiPhaseMemoryInit(&MultiPhaseInitParams);
+  if (EFI_ERROR(Status))
+    return Status;
+
+  MultiPhaseInitParams.MultiPhaseAction   = EnumMultiPhaseExecutePhase;
+  MultiPhaseInitParams.MultiPhaseParamPtr = NULL;
+
+  // Loop through all phases. Break on error status or FSP_STATUS_* not
+  // handled by variable services handler
+  for (MultiPhaseInitParams.PhaseIndex = 1;
+    GetNumPhasesParams.PhasesExecuted < GetNumPhasesParams.NumberOfPhases &&
+      !EFI_ERROR(Status) &&
+      !(Status & ENCODE_RESET_REQUEST(0));
+    GetNumPhasesParams.PhasesExecuted++, MultiPhaseInitParams.PhaseIndex++)
+  {
+    Status = CallFspMultiPhaseMemoryInit(&MultiPhaseInitParams);
+    ASSERT_EFI_ERROR(Status);
+    Status = FspVariableHandler(Status,CallFspMultiPhaseMemoryInit);
+    ASSERT_EFI_ERROR(Status);
+  }
+  return Status;
+}
+
+/**
+  This FSP API provides multi-phase memory and silicon initialization, which brings
+  greater modularity to the existing FspMemoryInit() and FspSiliconInit() API. Increased
+  modularity is achieved by adding an extra API to FSP-M and FSP-S. This allows the
+  bootloader to add board specific initialization steps throughout the MemoryInit and
+  SiliconInit flows as needed. The FspMemoryInit() API is always called before
+  FspMultiPhaseMemInit(); it is the first phase of memory initialization. Similarly, the
+  FspSiliconInit() API is always called before FspMultiPhaseSiInit(); it is the first phase of
+  silicon initialization. After the first phase, subsequent phases are invoked by calling the
+  FspMultiPhaseMem/SiInit() API.
+  The FspMultiPhaseMemInit() API may only be called after the FspMemoryInit() API and
+  before the FspSiliconInit() API; or in the case that FSP-T is being used, before the
+  TempRamExit() API. The FspMultiPhaseSiInit() API may only be called after the
+  FspSiliconInit() API and before NotifyPhase() API; or in the case that FSP-I is being used,
+  before the FspSmmInit() API. The multi-phase APIs may not be called at any other time.
+
+  @param[in] FspmBase                 The base address of FSPM.
+  @param[in] MultiPhaseInitParamPtr   Pointer to provide multi-phase init parameters.
+
+  @retval EFI_SUCCESS                 FSP execution environment was initialized successfully.
+  @retval EFI_INVALID_PARAMETER       Input parameters are invalid.
+  @retval EFI_UNSUPPORTED             The FSP calling conditions were not met.
+  @retval EFI_DEVICE_ERROR            FSP initialization failed.
+  @retval EFI_OUT_OF_RESOURCES        Stack range requested by FSP is not met.
+  @retval FSP_STATUS_RESET_REQUIREDx  A reset is reuired. These status codes will not be returned during S3.
+  @retval FSP_STATUS_VARIABLE_REQUEST An FSP variable access is required.
+**/
+EFI_STATUS
+EFIAPI
+CallFspMultiPhaseMemoryInit (
+  FSP_MULTI_PHASE_PARAMS     *MultiPhaseInitParamPtr
+  )
+{
+  FSP_INFO_HEADER             *FspHeader;
+  FSP_MULTI_PHASE_MEM_INIT    FspMultiPhaseMemoryInit;
+  EFI_STATUS                  Status;
+  UINT32                      FspmBase;
+
+  FspmBase = PCD_GET32_WITH_ADJUST (PcdFSPMBase);
+
+  FspHeader = (FSP_INFO_HEADER *)(UINTN)(FspmBase + FSP_INFO_HEADER_OFF);
+
+  ASSERT (FspHeader->Signature == FSP_INFO_HEADER_SIGNATURE);
+  ASSERT (FspHeader->ImageBase == FspmBase);
+
+  if (FspHeader->HeaderRevision < FSP24_HEADER_REVISION)
+    return EFI_UNSUPPORTED;
+
+  ASSERT (FspHeader->FspMultiPhaseMemInitEntryOffset != 0);
+  FspMultiPhaseMemoryInit = (FSP_MULTI_PHASE_MEM_INIT)(UINTN)(FspHeader->ImageBase + \
+                                           FspHeader->FspMultiPhaseMemInitEntryOffset);
+
+  DEBUG ((DEBUG_INFO, "Call FspMultiPhaseMemoryInit ... "));
+
+  if (IS_X64) {
+    Status = Execute32BitCode ((UINTN)FspMultiPhaseMemoryInit, (UINTN)MultiPhaseInitParamPtr, (UINTN)NULL, FALSE);
+    Status = (UINTN)LShiftU64 (Status & ((UINTN)MAX_INT32 + 1), 32) | (Status & MAX_INT32);
+  } else {
+    Status = FspMultiPhaseMemoryInit (MultiPhaseInitParamPtr);
   }
   DEBUG ((DEBUG_INFO, "%r\n", Status));
 

--- a/BootloaderCorePkg/Library/FspApiLib/FspMemoryInit.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspMemoryInit.c
@@ -122,6 +122,7 @@ CallFspMemoryInit (
  * @return EFI_STATUS
  */
 EFI_STATUS
+EFIAPI
 FspMultiPhaseMemInitHandler(VOID)
 {
   EFI_STATUS                                  Status;

--- a/BootloaderCorePkg/Library/FspApiLib/FspSiliconInit.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspSiliconInit.c
@@ -148,8 +148,9 @@ CallFspMultiPhaseSiliconInit (
   ASSERT (FspHeader->ImageBase == FspsBase);
 
   // Multi Phase silicon init support added in FSP 2.2
-  if (FspHeader->HeaderRevision < FSP22_HEADER_REVISION || FspHeader->FspMultiPhaseSiInitEntryOffset == 0)
+  if (FspHeader->HeaderRevision < FSP22_HEADER_REVISION || FspHeader->FspMultiPhaseSiInitEntryOffset == 0) {
     return EFI_UNSUPPORTED;
+  }
 
   FspMultiPhaseSiliconInit = (FSP_MULTI_PHASE_MEM_INIT)(UINTN)(FspHeader->ImageBase + \
                                            FspHeader->FspMultiPhaseSiInitEntryOffset);

--- a/BootloaderCorePkg/Library/FspApiLib/FspSiliconInit.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspSiliconInit.c
@@ -73,6 +73,7 @@ CallFspSiliconInit (
  * @return EFI_STATUS
  */
 EFI_STATUS
+EFIAPI
 FspMultiPhaseSiliconInitHandler(VOID)
 {
   EFI_STATUS                                  Status;

--- a/BootloaderCorePkg/Library/FspApiLib/FspSiliconInit.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspSiliconInit.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -8,6 +8,7 @@
 #include <FspApiLibInternal.h>
 #include <Library/BoardInitLib.h>
 #include <Library/BlMemoryAllocationLib.h>
+#include <Library/FspApiLib.h>
 
 
 /**
@@ -27,7 +28,7 @@ CallFspSiliconInit (
   VOID
   )
 {
-  VOID                      *FspsUpdptr;
+  VOID                       *FspsUpdptr;
   UINT8                      *DefaultSiliconInitUpd;
   FSP_INFO_HEADER            *FspHeader;
   FSP_SILICON_INIT            FspSiliconInit;
@@ -59,6 +60,106 @@ CallFspSiliconInit (
     Status = (UINTN)LShiftU64 (Status & ((UINTN)MAX_INT32 + 1), 32) | (Status & MAX_INT32);
   } else {
     Status = FspSiliconInit (FspsUpdptr);
+  }
+  DEBUG ((DEBUG_INFO, "%r\n", Status));
+
+  return Status;
+}
+
+/**
+ * This calls the FspMultiPhaseSiliconInit entry point to find out
+ * if more phases of Silicon init remain, and executes them if so.
+ *
+ * @return EFI_STATUS
+ */
+EFI_STATUS
+FspMultiPhaseSiliconInitHandler(VOID)
+{
+  EFI_STATUS                                  Status;
+  FSP_MULTI_PHASE_PARAMS                      MultiPhaseInitParams;
+  FSP_MULTI_PHASE_GET_NUMBER_OF_PHASES_PARAMS GetNumPhasesParams;
+
+  MultiPhaseInitParams.MultiPhaseAction   = EnumMultiPhaseGetNumberOfPhases;
+  MultiPhaseInitParams.PhaseIndex         = 0;
+  MultiPhaseInitParams.MultiPhaseParamPtr = (VOID*)&GetNumPhasesParams;
+  GetNumPhasesParams.PhasesExecuted       = 0;
+
+  Status = CallFspMultiPhaseSiliconInit(&MultiPhaseInitParams);
+  if (EFI_ERROR(Status))
+    return Status;
+
+  MultiPhaseInitParams.MultiPhaseAction   = EnumMultiPhaseExecutePhase;
+  MultiPhaseInitParams.MultiPhaseParamPtr = NULL;
+
+  // Loop through all phases. Break on error status or FSP_STATUS_* not
+  // handled by variable services handler
+  for (MultiPhaseInitParams.PhaseIndex = 1;
+    GetNumPhasesParams.PhasesExecuted < GetNumPhasesParams.NumberOfPhases &&
+      !EFI_ERROR(Status) &&
+      !(Status & ENCODE_RESET_REQUEST(0));
+    GetNumPhasesParams.PhasesExecuted++, MultiPhaseInitParams.PhaseIndex++)
+  {
+    Status = CallFspMultiPhaseSiliconInit(&MultiPhaseInitParams);
+    ASSERT_EFI_ERROR(Status);
+    Status = FspVariableHandler(Status,CallFspMultiPhaseSiliconInit);
+    ASSERT_EFI_ERROR(Status);
+  }
+  return Status;
+}
+
+/**
+  This FSP API provides multi-phase memory and silicon initialization, which brings
+  greater modularity to the existing FspMemoryInit() and FspSiliconInit() API. Increased
+  modularity is achieved by adding an extra API to FSP-M and FSP-S. This allows the
+  bootloader to add board specific initialization steps throughout the MemoryInit and
+  SiliconInit flows as needed. The FspMemoryInit() API is always called before
+  FspMultiPhaseMemInit(); it is the first phase of memory initialization. Similarly, the
+  FspSiliconInit() API is always called before FspMultiPhaseSiInit(); it is the first phase of
+  silicon initialization. After the first phase, subsequent phases are invoked by calling the
+  FspMultiPhaseMem/SiInit() API.
+
+  @param[in] MultiPhaseInitParamPtr   Pointer to provide multi-phase init parameters.
+
+  @retval EFI_SUCCESS                 FSP execution environment was initialized successfully.
+  @retval EFI_INVALID_PARAMETER       Input parameters are invalid.
+  @retval EFI_UNSUPPORTED             The FSP calling conditions were not met.
+  @retval EFI_DEVICE_ERROR            FSP initialization failed.
+  @retval EFI_OUT_OF_RESOURCES        Stack range requested by FSP is not met.
+  @retval FSP_STATUS_RESET_REQUIREDx  A reset is reuired. These status codes will not be returned during S3.
+  @retval FSP_STATUS_VARIABLE_REQUEST An FSP variable access is required.
+**/
+EFI_STATUS
+EFIAPI
+CallFspMultiPhaseSiliconInit (
+  FSP_MULTI_PHASE_PARAMS     *MultiPhaseInitParamPtr
+  )
+{
+  FSP_INFO_HEADER             *FspHeader;
+  FSP_MULTI_PHASE_MEM_INIT    FspMultiPhaseSiliconInit;
+  EFI_STATUS                  Status;
+  UINT32                      FspsBase;
+
+  FspsBase = PcdGet32 (PcdFSPSBase);
+
+  FspHeader = (FSP_INFO_HEADER *)(UINTN)(FspsBase + FSP_INFO_HEADER_OFF);
+
+  ASSERT (FspHeader->Signature == FSP_INFO_HEADER_SIGNATURE);
+  ASSERT (FspHeader->ImageBase == FspsBase);
+
+  // Multi Phase silicon init support added in FSP 2.2
+  if (FspHeader->HeaderRevision < FSP22_HEADER_REVISION || FspHeader->FspMultiPhaseSiInitEntryOffset == 0)
+    return EFI_UNSUPPORTED;
+
+  FspMultiPhaseSiliconInit = (FSP_MULTI_PHASE_MEM_INIT)(UINTN)(FspHeader->ImageBase + \
+                                           FspHeader->FspMultiPhaseSiInitEntryOffset);
+
+  DEBUG ((DEBUG_INFO, "Call FspMultiPhaseSiliconInit ... "));
+
+  if (IS_X64) {
+    Status = Execute32BitCode ((UINTN)FspMultiPhaseSiliconInit, (UINTN)MultiPhaseInitParamPtr, (UINTN)NULL, FALSE);
+    Status = (UINTN)LShiftU64 (Status & ((UINTN)MAX_INT32 + 1), 32) | (Status & MAX_INT32);
+  } else {
+    Status = FspMultiPhaseSiliconInit (MultiPhaseInitParamPtr);
   }
   DEBUG ((DEBUG_INFO, "%r\n", Status));
 

--- a/BootloaderCorePkg/Library/FspApiLib/FspVariableServices.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspVariableServices.c
@@ -1,0 +1,103 @@
+/** @file
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <Uefi.h>
+#include <FspApiLibInternal.h>
+#include <Library/BootloaderCoreLib.h>
+#include <Library/FspApiLib.h>
+#include <Library/FspVariableServicesLib.h>
+
+/**
+  This function handles variable services requests from FspMemoryInit or FspMultPhaseMemInit.
+  This should be called immediately after returning from the respective FSP entrypoint.
+
+  @param[in] Status             The status return by the FSP entry point.
+
+  @retval Status
+ */
+EFI_STATUS
+FspVariableHandler(
+  EFI_STATUS                FspStatus,
+  FSP_MULTI_PHASE_FUNCTION  MultiPhaseFunction
+  )
+{
+  EFI_STATUS                                    Status;
+  FSP_MULTI_PHASE_PARAMS                        MultiPhaseInitParams;
+  FSP_MULTI_PHASE_VARIABLE_REQUEST_INFO_PARAMS  *FspVarReqParams;
+
+  while (FspStatus == FSP_STATUS_VARIABLE_REQUEST)
+  {
+    DEBUG((DEBUG_VERBOSE, "FspVariableHandler: Got FSP_STATUS_VARIABLE_REQUEST\n"));
+    // Request details of variable request from Multi-phase API.
+    MultiPhaseInitParams.MultiPhaseAction = EnumMultiPhaseGetVariableRequestInfo;
+    Status = MultiPhaseFunction(&MultiPhaseInitParams);
+    ASSERT_EFI_ERROR(Status);
+    if (EFI_ERROR(Status)) break;
+
+    FspVarReqParams = (FSP_MULTI_PHASE_VARIABLE_REQUEST_INFO_PARAMS*)MultiPhaseInitParams.MultiPhaseParamPtr;
+    ASSERT (FspVarReqParams != NULL);
+    if (FspVarReqParams == NULL)
+    {
+      Status = EFI_UNSUPPORTED;
+      break;
+    }
+
+    DEBUG((DEBUG_VERBOSE, "FSP Variable Request %d\n", FspVarReqParams->VariableRequest));
+    if (NULL != FspVarReqParams->VariableName)
+      DEBUG((DEBUG_VERBOSE, "\tVariableName %s\n", FspVarReqParams->VariableName));
+    if (NULL != FspVarReqParams->VariableGuid)
+      DEBUG((DEBUG_VERBOSE, "\tVariableGuid %g\n", FspVarReqParams->VariableGuid));
+    if (NULL != FspVarReqParams->DataSize)
+      DEBUG((DEBUG_VERBOSE, "\tDataSize 0x%X\n", *(FspVarReqParams->DataSize)));
+    DEBUG((DEBUG_VERBOSE, "\tData ptr 0x%X\n", FspVarReqParams->Data));
+
+    switch (FspVarReqParams->VariableRequest)
+    {
+      case EnumFspVariableRequestGetVariable:
+        Status = FspGetVariable(
+          FspVarReqParams->VariableName,
+          FspVarReqParams->VariableGuid,
+          FspVarReqParams->Attributes,
+          FspVarReqParams->DataSize,
+          FspVarReqParams->Data
+        );
+        break;
+      case EnumFspVariableRequestGetNextVariableName:
+        Status = FspGetNextVariableName(
+          FspVarReqParams->VariableNameSize,
+          FspVarReqParams->VariableName,
+          FspVarReqParams->VariableGuid
+        );
+        break;
+      case EnumFspVariableRequestSetVariable:
+        Status = FspSetVariable(
+          FspVarReqParams->VariableName,
+          FspVarReqParams->VariableGuid,
+          FspVarReqParams->Attributes,
+          FspVarReqParams->DataSize,
+          FspVarReqParams->Data
+        );
+        break;
+      case EnumFspVariableRequestQueryVariableInfo:
+        Status = FspQueryVariableInfo(
+          FspVarReqParams->Attributes,
+          FspVarReqParams->MaximumVariableStorageSize,
+          FspVarReqParams->RemainingVariableStorageSize,
+          FspVarReqParams->MaximumVariableSize
+        );
+        break;
+      default:
+        break;
+    }
+    FspVarReqParams->Status = Status;
+
+    MultiPhaseInitParams.MultiPhaseAction = EnumMultiPhaseCompleteVariableRequest;
+    Status = FspStatus = MultiPhaseFunction(&MultiPhaseInitParams);
+    ASSERT_EFI_ERROR(FspStatus);
+    if (EFI_ERROR(FspStatus)) return FspStatus;
+  }
+  return Status;
+}

--- a/BootloaderCorePkg/Library/FspApiLib/FspVariableServices.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspVariableServices.c
@@ -31,31 +31,34 @@ FspVariableHandler(
 
   Status = EFI_SUCCESS;
 
-  while (FspStatus == FSP_STATUS_VARIABLE_REQUEST)
-  {
+  while (FspStatus == FSP_STATUS_VARIABLE_REQUEST) {
     DEBUG((DEBUG_VERBOSE, "FspVariableHandler: Got FSP_STATUS_VARIABLE_REQUEST\n"));
     // Request details of variable request from Multi-phase API.
     MultiPhaseInitParams.MultiPhaseAction = EnumMultiPhaseGetVariableRequestInfo;
     MultiPhaseInitParams.PhaseIndex = 0;
     Status = MultiPhaseFunction(&MultiPhaseInitParams);
     ASSERT_EFI_ERROR(Status);
-    if (EFI_ERROR(Status)) break;
+    if (EFI_ERROR(Status)) {
+      break;
+    }
 
     FspVarReqParams = (FSP_MULTI_PHASE_VARIABLE_REQUEST_INFO_PARAMS*)MultiPhaseInitParams.MultiPhaseParamPtr;
     ASSERT (FspVarReqParams != NULL);
-    if (FspVarReqParams == NULL)
-    {
+    if (FspVarReqParams == NULL) {
       Status = EFI_UNSUPPORTED;
       break;
     }
 
     DEBUG((DEBUG_VERBOSE, "FSP Variable Request %d\n", FspVarReqParams->VariableRequest));
-    if (NULL != FspVarReqParams->VariableName)
+    if (NULL != FspVarReqParams->VariableName) {
       DEBUG((DEBUG_VERBOSE, "\tVariableName %s\n", FspVarReqParams->VariableName));
-    if (NULL != FspVarReqParams->VariableGuid)
+    }
+    if (NULL != FspVarReqParams->VariableGuid) {
       DEBUG((DEBUG_VERBOSE, "\tVariableGuid %g\n", FspVarReqParams->VariableGuid));
-    if (NULL != FspVarReqParams->DataSize)
+    }
+    if (NULL != FspVarReqParams->DataSize) {
       DEBUG((DEBUG_VERBOSE, "\tDataSize 0x%X\n", *(FspVarReqParams->DataSize)));
+    }
     DEBUG((DEBUG_VERBOSE, "\tData ptr 0x%X\n", FspVarReqParams->Data));
 
     switch (FspVarReqParams->VariableRequest)

--- a/BootloaderCorePkg/Library/FspApiLib/FspVariableServices.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspVariableServices.c
@@ -19,6 +19,7 @@
   @retval Status
  */
 EFI_STATUS
+EFIAPI
 FspVariableHandler(
   EFI_STATUS                FspStatus,
   FSP_MULTI_PHASE_FUNCTION  MultiPhaseFunction
@@ -35,6 +36,7 @@ FspVariableHandler(
     DEBUG((DEBUG_VERBOSE, "FspVariableHandler: Got FSP_STATUS_VARIABLE_REQUEST\n"));
     // Request details of variable request from Multi-phase API.
     MultiPhaseInitParams.MultiPhaseAction = EnumMultiPhaseGetVariableRequestInfo;
+    MultiPhaseInitParams.PhaseIndex = 0;
     Status = MultiPhaseFunction(&MultiPhaseInitParams);
     ASSERT_EFI_ERROR(Status);
     if (EFI_ERROR(Status)) break;

--- a/BootloaderCorePkg/Library/FspApiLib/FspVariableServices.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspVariableServices.c
@@ -28,6 +28,8 @@ FspVariableHandler(
   FSP_MULTI_PHASE_PARAMS                        MultiPhaseInitParams;
   FSP_MULTI_PHASE_VARIABLE_REQUEST_INFO_PARAMS  *FspVarReqParams;
 
+  Status = EFI_SUCCESS;
+
   while (FspStatus == FSP_STATUS_VARIABLE_REQUEST)
   {
     DEBUG((DEBUG_VERBOSE, "FspVariableHandler: Got FSP_STATUS_VARIABLE_REQUEST\n"));

--- a/BootloaderCorePkg/Library/FspApiLib/FspmApiLib.inf
+++ b/BootloaderCorePkg/Library/FspApiLib/FspmApiLib.inf
@@ -31,6 +31,7 @@
   FspTempRamExit.c
   FspMemoryInit.c
   FspMisc.c
+  FspVariableServices.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -45,6 +46,8 @@
   ResetSystemLib
   ThunkLib
   PcdLib
+  FspVariableServicesLib
+  BootloaderLib
 
 [Pcd]
   gPlatformModuleTokenSpaceGuid.PcdFSPMBase

--- a/BootloaderCorePkg/Library/FspApiLib/FspsApiLib.inf
+++ b/BootloaderCorePkg/Library/FspApiLib/FspsApiLib.inf
@@ -25,6 +25,7 @@
   FspSiliconInit.c
   FspNotifyPhase.c
   FspMisc.c
+  FspVariableServices.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -39,6 +40,7 @@
   ResetSystemLib
   ThunkLib
   PcdLib
+  FspVariableServicesLib
 
 [Pcd]
   gPlatformModuleTokenSpaceGuid.PcdFSPSBase

--- a/BootloaderCorePkg/Library/FspVariableServicesLib/FspVariableServicesLib.c
+++ b/BootloaderCorePkg/Library/FspVariableServicesLib/FspVariableServicesLib.c
@@ -1,0 +1,427 @@
+/** @file
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <FspVariableServicesLibInternal.h>
+
+/**
+  Form the concatenated GUID + Varname string used by this LiteVariable wrapper.
+
+  @param VariableName    Input unicode Variable name provided by FSP
+  @param VariableGuid    Input Variable GUID provded by FSP
+  @param FspVarName      Output ASCII Variable Name used by LiteVariable
+  @return EFI_STATUS
+ */
+EFI_STATUS
+FormFspVarName(
+  IN CHAR16   *VariableName,
+  IN EFI_GUID *VariableGuid,
+  OUT CHAR8   **FspVarName
+)
+{
+  CHAR8           *AsciiVarName;
+  UINTN           AsciiVarNameLength;
+
+  if (VariableName == NULL || VariableGuid == NULL || FspVarName == NULL)
+    return EFI_INVALID_PARAMETER;
+
+  // Lite Variable doesn't support GUID natively, so we'll form
+  // the ASCII name from the ASCII GUID contcatenated with Unicode name.
+  AsciiVarNameLength = StrLen(VariableName);
+  // number of characters in an ascii guid, plus null terminator
+  AsciiVarNameLength += ASCII_GUID_LENGTH + 1;
+
+  AsciiVarName = AllocateTemporaryMemory(AsciiVarNameLength * sizeof(CHAR8));
+  ASSERT(AsciiVarName != NULL);
+  if (AsciiVarName == NULL)
+    return EFI_OUT_OF_RESOURCES;
+
+  AsciiSPrint(AsciiVarName, AsciiVarNameLength, "%g%s", VariableGuid, VariableName);
+  *FspVarName = AsciiVarName;
+  return EFI_SUCCESS;
+}
+
+/**
+  Split the ASCII name returned by LiteVariable calls into GUID and Unicode name expected by FSP.
+
+  @param FspVarName          ASCII combined variable name returned from LiteVariableLib
+  @param VariableNameSize    Max number of bytes VariableName can hold, including null-terminator
+  @param VariableName
+  @param VariableGuid
+  @return EFI_STATUS
+ */
+EFI_STATUS
+SplitFspVarName(
+  IN CHAR8      *FspVarName,
+  IN OUT UINTN  *VariableNameSize,
+  OUT CHAR16    *VariableName,
+  OUT EFI_GUID  *VariableGuid
+)
+{
+  EFI_STATUS  Status;
+  UINTN       FspVarNameLength;
+  CHAR8       AsciiGuid[MAXIMUM_VALUE_CHARACTERS];
+
+  if (FspVarName == NULL || *FspVarName == '\0' ||
+    VariableNameSize == NULL || VariableName == NULL || VariableGuid == NULL)
+    return EFI_INVALID_PARAMETER;
+
+  FspVarNameLength = AsciiStrLen(FspVarName);
+  // Make sure FspVarName contains at least one character after GUID
+  if (FspVarNameLength <= ASCII_GUID_LENGTH)
+    return EFI_INVALID_PARAMETER;
+
+  // Output buffer needs to hold FspVarName minus ASCII GUID size (including null)
+  if (*VariableNameSize < sizeof(CHAR16)*(FspVarNameLength - ASCII_GUID_LENGTH + 1))
+  {
+    *VariableNameSize = sizeof(CHAR16)*(FspVarNameLength - ASCII_GUID_LENGTH + 1);
+    return EFI_BUFFER_TOO_SMALL;
+  }
+
+  Status = AsciiStrnCpyS(AsciiGuid, MAXIMUM_VALUE_CHARACTERS, FspVarName,ASCII_GUID_LENGTH);
+  ASSERT_EFI_ERROR(Status);
+  if (EFI_ERROR(Status))
+    return Status;
+  DEBUG((DEBUG_VERBOSE, "Extracted ASCII GUID %a\n", AsciiGuid));
+
+  Status = AsciiStrToGuid(AsciiGuid, VariableGuid);
+  ASSERT_EFI_ERROR(Status);
+  if (EFI_ERROR(Status))
+    return Status;
+   DEBUG((DEBUG_VERBOSE, "Extracted GUID %g\n", VariableGuid));
+
+  Status = AsciiStrToUnicodeStrS(&FspVarName[ASCII_GUID_LENGTH],VariableName,*VariableNameSize);
+  ASSERT_EFI_ERROR(Status);
+  DEBUG((DEBUG_VERBOSE, "Extracted VarName %s\n", VariableName));
+  return Status;
+}
+
+/**
+  FSP wrapper for SBL's Get Variable implementation.
+
+  @param VariableName
+  @param VariableGuid
+  @param Attributes
+  @param DataSize
+  @param Data
+  @return EFI_STATUS
+ */
+EFI_STATUS
+FspGetVariable(
+  IN  CHAR16      *VariableName,
+  IN  EFI_GUID    *VariableGuid,
+  OUT UINT32      *Attributes,
+  IN OUT UINT64   *DataSize,
+  IN  VOID        *Data
+)
+{
+  EFI_STATUS                Status;
+  CHAR8                     *LiteVarName;
+  UINTN                     LiteVarSize = 0;
+  FSP_LITE_VARIABLE_HEADER  *VarHeader;
+
+  if (VariableName == NULL || DataSize == NULL) return EFI_INVALID_PARAMETER;
+
+  Status = FormFspVarName(VariableName, VariableGuid, &LiteVarName);
+  if (EFI_ERROR(Status))
+    return Status;
+
+  DEBUG((DEBUG_VERBOSE, "FspGetVariable: Passing %a to LiteVariableLib\n", LiteVarName));
+
+  // Get variable size
+  Status = GetVariable(LiteVarName, NULL, &LiteVarSize, NULL);
+  // We expect buffer too small. Anything else means there was a problem with name/guid.
+  if (Status != EFI_BUFFER_TOO_SMALL)
+  {
+    FreeTemporaryMemory(LiteVarName);
+    return Status;
+  }
+
+  // LiteVariable stored data is encapsulated with a header for storing unsupported data.
+  // We expect variable size to be passed in datasize plus FSP_LITE_VARIABLE_HEADER size
+  if (LiteVarSize > *DataSize + sizeof(FSP_LITE_VARIABLE_HEADER))
+  {
+    *DataSize = LiteVarSize - sizeof(FSP_LITE_VARIABLE_HEADER);
+    FreeTemporaryMemory(LiteVarName);
+    return EFI_BUFFER_TOO_SMALL;
+  }
+
+  // passed in data size is good. Allocate a pool and Get encapsulated variable.
+  VarHeader = AllocateTemporaryMemory(LiteVarSize);
+  ASSERT(VarHeader != NULL);
+  if (VarHeader == NULL)
+  {
+    FreeTemporaryMemory(LiteVarName);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Status = GetVariable(LiteVarName, NULL, &LiteVarSize, (VOID*)VarHeader);
+  // Done with Var Name now.
+  FreeTemporaryMemory(LiteVarName);
+  if (EFI_ERROR(Status))
+  {
+    FreeTemporaryMemory(VarHeader);
+    return Status;
+  }
+  // Sanity check returned data
+  ASSERT(VarHeader->Signature == FSP_LITE_VAR_SIGNATURE);
+  if (VarHeader->Signature != FSP_LITE_VAR_SIGNATURE)
+  {
+    FreeTemporaryMemory(VarHeader);
+    return EFI_NOT_FOUND;
+  }
+  if (Data != NULL)
+    CopyMem(Data, VarHeader->Data, LiteVarSize - sizeof(FSP_LITE_VARIABLE_HEADER));
+
+  if (Attributes != NULL)
+    *Attributes = VarHeader->Attributes;
+
+  FreeTemporaryMemory(VarHeader);
+  return EFI_SUCCESS;
+}
+
+/**
+  FSP wrapper for SBL's Get Next Variable implementation.
+  This must always be called successively without any other
+  LiteVariable GetNextVariablName calls in between.
+
+  @param VariableNameSize
+  @param VariableName
+  @param VariableGuid
+  @return EFI_STATUS
+ */
+EFI_STATUS
+FspGetNextVariableName(
+  IN OUT  UINT64   *VariableNameSize,
+  OUT     CHAR16   *VariableName,
+  OUT     EFI_GUID *VariableGuid
+)
+{
+  EFI_STATUS                Status;
+  static UINTN              VariableKey = 0;
+  UINTN                     OldKey, LiteVarNameSize, NameSize;
+  CHAR8                     *LiteVarName="";
+  FSP_LITE_VARIABLE_HEADER  *VarHeader=NULL;
+  UINTN                     VarSize;
+
+  DEBUG((DEBUG_VERBOSE, "FspGetNextVariableName Entry\n"));
+
+  if (VariableNameSize == NULL ||
+    ((VariableName == NULL || VariableGuid == NULL)
+      && *VariableNameSize != 0))
+    return EFI_INVALID_PARAMETER;
+
+  DEBUG((DEBUG_VERBOSE, "Parameter Check Pass\n"));
+
+  // Reset variable key when FSP indicates first call.
+  if (*VariableNameSize == sizeof(CHAR16) && *VariableName == L'\0')
+    VariableKey = 0;
+
+  NameSize = (UINTN)*VariableNameSize;
+  DEBUG((DEBUG_VERBOSE, "Loop Init Done\n"));
+  // Need to loop through LiteVariable GetNextVariableName and only return FSP created variables.
+  do
+  {
+    DEBUG((DEBUG_VERBOSE, "Key: %d\n", VariableKey));
+    LiteVarNameSize = 0;
+    OldKey = VariableKey;
+    Status = GetNextVariableName(&LiteVarNameSize, LiteVarName, &VariableKey);
+    DEBUG((DEBUG_VERBOSE, "GetNextVariableName Status %r, Size 0x%X, Name %a\n", Status, LiteVarNameSize, LiteVarName));
+    if (Status != EFI_BUFFER_TOO_SMALL) return Status;
+
+    LiteVarName = AllocateTemporaryMemory(LiteVarNameSize);
+    ASSERT(LiteVarName != NULL);
+    if (LiteVarName == NULL) return EFI_OUT_OF_RESOURCES;
+
+    Status = GetNextVariableName(&LiteVarNameSize, LiteVarName, &VariableKey);
+    DEBUG((DEBUG_VERBOSE, "GetNextVariableName Status %r, Size 0x%X, Name %a\n", Status, LiteVarNameSize, LiteVarName));
+    if (Status == EFI_SUCCESS)
+    {
+      VarSize = 0;
+      VarHeader = NULL;
+      Status = GetVariable(LiteVarName, NULL, &VarSize, (VOID*)VarHeader);
+      DEBUG((DEBUG_VERBOSE, "GetVariable Status %r, Size 0x%X, Name %a\n", Status, VarSize, LiteVarName));
+      ASSERT(Status == EFI_BUFFER_TOO_SMALL);
+      if (Status == EFI_BUFFER_TOO_SMALL && VarSize >= sizeof(VarHeader))
+      {
+        // Now we know the size. Allocate and get the variable.
+        VarHeader = AllocateTemporaryMemory(VarSize);
+        Status = GetVariable(LiteVarName, NULL, &VarSize, (VOID*)VarHeader);
+        DEBUG((DEBUG_VERBOSE, "GetVariable Status %r, Size 0x%X, Name %a\n", Status, VarSize, LiteVarName));
+        ASSERT_EFI_ERROR(Status);
+        // Did we successfully get an FSP variable?
+        if (!EFI_ERROR(Status) && (VarHeader->Signature == FSP_LITE_VAR_SIGNATURE))
+        {
+          // Don't need the actual variable anymore
+          FreeTemporaryMemory(VarHeader);
+          Status = SplitFspVarName(LiteVarName, &NameSize, VariableName, VariableGuid);
+          DEBUG((DEBUG_VERBOSE, "SplitFspVarName Status %r, Size 0x%X, LiteVarName %a, VarName %s, GUID %g\n", Status, NameSize, LiteVarName, VariableName, VariableGuid));
+          if (EFI_ERROR(Status))
+          {
+            // Edge case:
+            // if Caller VariableNameSize was too small, we need to reset key so caller can try again.
+            VariableKey = OldKey;
+            *VariableNameSize = sizeof(CHAR16)*(LiteVarNameSize - ASCII_GUID_LENGTH);
+          }
+          FreeTemporaryMemory(LiteVarName);
+          return Status;
+        }
+      }
+    }
+    if (LiteVarName != NULL) FreeTemporaryMemory(LiteVarName);
+    if (VarHeader != NULL) FreeTemporaryMemory(VarHeader);
+  } while (Status != EFI_NOT_FOUND);
+  return Status;
+}
+
+/**
+  FSP wrapper for SBL's Set Variable implementation.
+
+  @param VariableName
+  @param VariableGuid
+  @param Attributes
+  @param DataSize
+  @param Data
+  @return EFI_STATUS
+ */
+EFI_STATUS
+FspSetVariable(
+  IN  CHAR16      *VariableName,
+  IN  EFI_GUID    *VariableGuid,
+  IN  UINT32      *Attributes,
+  IN  UINT64      *DataSize,
+  IN  VOID        *Data
+)
+{
+  EFI_STATUS                Status;
+  CHAR8                     *LiteVarName;
+  UINTN                     LiteVarSize, OldVarSize;
+  FSP_LITE_VARIABLE_HEADER  *VarHeader, *OldVar;
+
+  if (VariableName == NULL || DataSize == NULL || Attributes == NULL ||
+    (Data == NULL && *DataSize != 0)) return EFI_INVALID_PARAMETER;
+  // We don't support authenticated variables or volatile variables,
+  // and FSP doesn't require them.
+  if ((*Attributes & EFI_VARIABLE_NON_VOLATILE) == 0 ||
+    *Attributes & (EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS |
+    EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS))
+    return EFI_INVALID_PARAMETER;
+
+  // Concatenate GUID + Unicode name
+  Status = FormFspVarName(VariableName, VariableGuid, &LiteVarName);
+  if (EFI_ERROR(Status))
+    return Status;
+
+  // Check if this is an attempt to delete the variable
+  if (*DataSize == 0 && ((*Attributes & EFI_VARIABLE_APPEND_WRITE) == 0))
+  {
+    Status = SetVariable(LiteVarName, 0, 0, NULL);
+    FreeTemporaryMemory(LiteVarName);
+    return Status;
+  }
+
+  // check Attribute compatibility
+  OldVarSize=0;
+  OldVar = NULL;
+  Status = GetVariable(LiteVarName, NULL, &OldVarSize, OldVar);
+  if (Status == EFI_BUFFER_TOO_SMALL)
+  {
+    OldVar = AllocateTemporaryMemory(OldVarSize);
+    ASSERT(OldVar != NULL);
+    if (OldVar == NULL)
+    {
+      FreeTemporaryMemory(LiteVarName);
+      return EFI_OUT_OF_RESOURCES;
+    }
+    Status = GetVariable(LiteVarName, NULL, &OldVarSize, OldVar);
+  }
+  if (!EFI_ERROR(Status))
+  {
+    if ((*Attributes & ~EFI_VARIABLE_APPEND_WRITE) != OldVar->Attributes)
+    {
+      FreeTemporaryMemory(LiteVarName);
+      FreeTemporaryMemory(OldVar);
+      return Status;
+    }
+  }
+
+  // handle Append Write case
+  if (OldVar != NULL && *Attributes & EFI_VARIABLE_APPEND_WRITE)
+  {
+    LiteVarSize = (UINTN)*DataSize + OldVarSize;
+  }
+  else
+  {
+    LiteVarSize = (UINTN)*DataSize + sizeof(FSP_LITE_VARIABLE_HEADER);
+  }
+
+  // Allocate a pool and create encapsulated variable.
+  VarHeader = AllocateTemporaryMemory(LiteVarSize);
+  ASSERT(VarHeader != NULL);
+  if (VarHeader == NULL)
+  {
+    FreeTemporaryMemory(LiteVarName);
+    if (OldVar != NULL) FreeTemporaryMemory(OldVar);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  VarHeader->Signature = FSP_LITE_VAR_SIGNATURE;
+  VarHeader->Attributes = *Attributes & ~EFI_VARIABLE_APPEND_WRITE;
+  if (OldVar != NULL && *Attributes & EFI_VARIABLE_APPEND_WRITE)
+  {
+    // Copy old variable data into new variable.
+    CopyMem(VarHeader->Data, OldVar->Data, OldVarSize-sizeof(FSP_LITE_VARIABLE_HEADER));
+    // Copy new data at the end
+    CopyMem(((UINT8*)VarHeader)+OldVarSize, Data, (UINTN)*DataSize);
+    FreeTemporaryMemory(OldVar);
+  }
+  else{
+    // Copy new data into new variable
+    CopyMem(VarHeader->Data, Data, (UINTN)*DataSize);
+  }
+
+  Status = SetVariable(LiteVarName, 0, LiteVarSize, (VOID*)VarHeader);
+  // Done with temp buffers now.
+  FreeTemporaryMemory(LiteVarName);
+  FreeTemporaryMemory(VarHeader);
+  return Status;
+}
+
+/**
+  SBL implementation of FSP QueryVariableInfo API
+
+  @param Attributes
+  @param MaximumVariableStorageSize
+  @param RemainingVariableStorageSize
+  @param MaximumVariableSize
+  @return EFI_STATUS
+ */
+EFI_STATUS
+FspQueryVariableInfo(
+  IN  UINT32      *Attributes,
+  OUT UINT64      *MaximumVariableStorageSize,
+  OUT UINT64      *RemainingVariableStorageSize,
+  OUT UINT64      *MaximumVariableSize
+)
+{
+  EFI_STATUS      Status;
+  UINTN           LiteMaxStoreSize, LiteRemainingSize, LiteMaxVarSize;
+  // don't support authenticated or volatile variables
+  if (*Attributes & (EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS | EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS) ||
+    (*Attributes & EFI_VARIABLE_NON_VOLATILE) == 0)
+    return EFI_UNSUPPORTED;
+
+  Status = QueryVariableInfo(
+    &LiteMaxStoreSize,
+    &LiteRemainingSize,
+    &LiteMaxVarSize);
+  if (!EFI_ERROR(Status))
+  {
+    *MaximumVariableStorageSize = (UINT64)LiteMaxStoreSize;
+    *RemainingVariableStorageSize = (UINT64)LiteRemainingSize - sizeof(FSP_LITE_VARIABLE_HEADER);
+    *MaximumVariableSize = (UINT64)LiteMaxVarSize - sizeof(FSP_LITE_VARIABLE_HEADER);
+  }
+  return Status;
+}

--- a/BootloaderCorePkg/Library/FspVariableServicesLib/FspVariableServicesLib.c
+++ b/BootloaderCorePkg/Library/FspVariableServicesLib/FspVariableServicesLib.c
@@ -15,17 +15,22 @@
   @return EFI_STATUS
  */
 EFI_STATUS
-FormFspVarName(
+EFIAPI
+FormFspVarName (
   IN CHAR16   *VariableName,
   IN EFI_GUID *VariableGuid,
   OUT CHAR8   **FspVarName
-)
+  )
 {
   CHAR8           *AsciiVarName;
   UINTN           AsciiVarNameLength;
 
-  if (VariableName == NULL || VariableGuid == NULL || FspVarName == NULL)
+  if (VariableName == NULL
+    || VariableGuid == NULL
+    || FspVarName == NULL)
+  {
     return EFI_INVALID_PARAMETER;
+  }
 
   // Lite Variable doesn't support GUID natively, so we'll form
   // the ASCII name from the ASCII GUID contcatenated with Unicode name.
@@ -35,8 +40,9 @@ FormFspVarName(
 
   AsciiVarName = AllocateTemporaryMemory(AsciiVarNameLength * sizeof(CHAR8));
   ASSERT(AsciiVarName != NULL);
-  if (AsciiVarName == NULL)
+  if (AsciiVarName == NULL) {
     return EFI_OUT_OF_RESOURCES;
+  }
 
   AsciiSPrint(AsciiVarName, AsciiVarNameLength, "%g%s", VariableGuid, VariableName);
   *FspVarName = AsciiVarName;
@@ -53,44 +59,52 @@ FormFspVarName(
   @return EFI_STATUS
  */
 EFI_STATUS
-SplitFspVarName(
+EFIAPI
+SplitFspVarName (
   IN CHAR8      *FspVarName,
   IN OUT UINTN  *VariableNameSize,
   OUT CHAR16    *VariableName,
   OUT EFI_GUID  *VariableGuid
-)
+  )
 {
   EFI_STATUS  Status;
   UINTN       FspVarNameLength;
   CHAR8       AsciiGuid[MAXIMUM_VALUE_CHARACTERS];
 
-  if (FspVarName == NULL || *FspVarName == '\0' ||
-    VariableNameSize == NULL || VariableName == NULL || VariableGuid == NULL)
+  if (FspVarName == NULL
+    || *FspVarName == '\0'
+    || VariableNameSize == NULL
+    || VariableName == NULL
+    || VariableGuid == NULL)
+  {
     return EFI_INVALID_PARAMETER;
+  }
 
   FspVarNameLength = AsciiStrLen(FspVarName);
   // Make sure FspVarName contains at least one character after GUID
-  if (FspVarNameLength <= ASCII_GUID_LENGTH)
+  if (FspVarNameLength <= ASCII_GUID_LENGTH) {
     return EFI_INVALID_PARAMETER;
+  }
 
   // Output buffer needs to hold FspVarName minus ASCII GUID size (including null)
-  if (*VariableNameSize < sizeof(CHAR16)*(FspVarNameLength - ASCII_GUID_LENGTH + 1))
-  {
+  if (*VariableNameSize < sizeof(CHAR16)*(FspVarNameLength - ASCII_GUID_LENGTH + 1)) {
     *VariableNameSize = sizeof(CHAR16)*(FspVarNameLength - ASCII_GUID_LENGTH + 1);
     return EFI_BUFFER_TOO_SMALL;
   }
 
   Status = AsciiStrnCpyS(AsciiGuid, MAXIMUM_VALUE_CHARACTERS, FspVarName,ASCII_GUID_LENGTH);
   ASSERT_EFI_ERROR(Status);
-  if (EFI_ERROR(Status))
+  if (EFI_ERROR(Status)) {
     return Status;
+  }
   DEBUG((DEBUG_VERBOSE, "Extracted ASCII GUID %a\n", AsciiGuid));
 
   Status = AsciiStrToGuid(AsciiGuid, VariableGuid);
   ASSERT_EFI_ERROR(Status);
-  if (EFI_ERROR(Status))
+  if (EFI_ERROR(Status)) {
     return Status;
-   DEBUG((DEBUG_VERBOSE, "Extracted GUID %g\n", VariableGuid));
+  }
+  DEBUG((DEBUG_VERBOSE, "Extracted GUID %g\n", VariableGuid));
 
   Status = AsciiStrToUnicodeStrS(&FspVarName[ASCII_GUID_LENGTH],VariableName,*VariableNameSize);
   ASSERT_EFI_ERROR(Status);
@@ -109,40 +123,44 @@ SplitFspVarName(
   @return EFI_STATUS
  */
 EFI_STATUS
-FspGetVariable(
+EFIAPI
+FspGetVariable (
   IN  CHAR16      *VariableName,
   IN  EFI_GUID    *VariableGuid,
   OUT UINT32      *Attributes,
   IN OUT UINT64   *DataSize,
   IN  VOID        *Data
-)
+  )
 {
   EFI_STATUS                Status;
   CHAR8                     *LiteVarName;
   UINTN                     LiteVarSize = 0;
   FSP_LITE_VARIABLE_HEADER  *VarHeader;
 
-  if (VariableName == NULL || DataSize == NULL) return EFI_INVALID_PARAMETER;
+  if (VariableName == NULL
+    || DataSize == NULL)
+  {
+    return EFI_INVALID_PARAMETER;
+  }
 
   Status = FormFspVarName(VariableName, VariableGuid, &LiteVarName);
-  if (EFI_ERROR(Status))
+  if (EFI_ERROR(Status)) {
     return Status;
+  }
 
   DEBUG((DEBUG_VERBOSE, "FspGetVariable: Passing %a to LiteVariableLib\n", LiteVarName));
 
   // Get variable size
   Status = GetVariable(LiteVarName, NULL, &LiteVarSize, NULL);
   // We expect buffer too small. Anything else means there was a problem with name/guid.
-  if (Status != EFI_BUFFER_TOO_SMALL)
-  {
+  if (Status != EFI_BUFFER_TOO_SMALL) {
     FreeTemporaryMemory(LiteVarName);
     return Status;
   }
 
   // LiteVariable stored data is encapsulated with a header for storing unsupported data.
   // We expect variable size to be passed in datasize plus FSP_LITE_VARIABLE_HEADER size
-  if (LiteVarSize > *DataSize + sizeof(FSP_LITE_VARIABLE_HEADER))
-  {
+  if (LiteVarSize > *DataSize + sizeof(FSP_LITE_VARIABLE_HEADER)) {
     *DataSize = LiteVarSize - sizeof(FSP_LITE_VARIABLE_HEADER);
     FreeTemporaryMemory(LiteVarName);
     return EFI_BUFFER_TOO_SMALL;
@@ -151,8 +169,7 @@ FspGetVariable(
   // passed in data size is good. Allocate a pool and Get encapsulated variable.
   VarHeader = AllocateTemporaryMemory(LiteVarSize);
   ASSERT(VarHeader != NULL);
-  if (VarHeader == NULL)
-  {
+  if (VarHeader == NULL) {
     FreeTemporaryMemory(LiteVarName);
     return EFI_OUT_OF_RESOURCES;
   }
@@ -193,58 +210,67 @@ FspGetVariable(
   @return EFI_STATUS
  */
 EFI_STATUS
-FspGetNextVariableName(
+EFIAPI
+FspGetNextVariableName (
   IN OUT  UINT64   *VariableNameSize,
   OUT     CHAR16   *VariableName,
   OUT     EFI_GUID *VariableGuid
-)
+  )
 {
   EFI_STATUS                Status;
   static UINTN              VariableKey = 0;
-  UINTN                     OldKey, LiteVarNameSize, NameSize;
+  UINTN                     OldKey;
+  UINTN                     LiteVarNameSize;
+  UINTN                     NameSize;
   CHAR8                     *LiteVarName="";
   FSP_LITE_VARIABLE_HEADER  *VarHeader=NULL;
   UINTN                     VarSize;
 
   DEBUG((DEBUG_VERBOSE, "FspGetNextVariableName Entry\n"));
 
-  if (VariableNameSize == NULL ||
-    ((VariableName == NULL || VariableGuid == NULL)
-      && *VariableNameSize != 0))
+  if (VariableNameSize == NULL
+    || ((VariableName == NULL
+        || VariableGuid == NULL)
+      && *VariableNameSize != 0)) {
     return EFI_INVALID_PARAMETER;
+  }
 
   DEBUG((DEBUG_VERBOSE, "Parameter Check Pass\n"));
 
   // Reset variable key when FSP indicates first call.
-  if (*VariableNameSize == sizeof(CHAR16) && *VariableName == L'\0')
+  if (*VariableNameSize == sizeof(CHAR16) && *VariableName == L'\0') {
     VariableKey = 0;
+  }
 
   NameSize = (UINTN)*VariableNameSize;
   DEBUG((DEBUG_VERBOSE, "Loop Init Done\n"));
   // Need to loop through LiteVariable GetNextVariableName and only return FSP created variables.
-  do
-  {
+  do {
     DEBUG((DEBUG_VERBOSE, "Key: %d\n", VariableKey));
     LiteVarNameSize = 0;
     OldKey = VariableKey;
     Status = GetNextVariableName(&LiteVarNameSize, LiteVarName, &VariableKey);
     DEBUG((DEBUG_VERBOSE, "GetNextVariableName Status %r, Size 0x%X, Name %a\n", Status, LiteVarNameSize, LiteVarName));
-    if (Status != EFI_BUFFER_TOO_SMALL) return Status;
+    if (Status != EFI_BUFFER_TOO_SMALL) {
+      return Status;
+    }
 
     LiteVarName = AllocateTemporaryMemory(LiteVarNameSize);
     ASSERT(LiteVarName != NULL);
-    if (LiteVarName == NULL) return EFI_OUT_OF_RESOURCES;
+    if (LiteVarName == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
 
     Status = GetNextVariableName(&LiteVarNameSize, LiteVarName, &VariableKey);
     DEBUG((DEBUG_VERBOSE, "GetNextVariableName Status %r, Size 0x%X, Name %a\n", Status, LiteVarNameSize, LiteVarName));
-    if (Status == EFI_SUCCESS)
-    {
+    if (Status == EFI_SUCCESS) {
       VarSize = 0;
       VarHeader = NULL;
       Status = GetVariable(LiteVarName, NULL, &VarSize, (VOID*)VarHeader);
       DEBUG((DEBUG_VERBOSE, "GetVariable Status %r, Size 0x%X, Name %a\n", Status, VarSize, LiteVarName));
       ASSERT(Status == EFI_BUFFER_TOO_SMALL);
-      if (Status == EFI_BUFFER_TOO_SMALL && VarSize >= sizeof(VarHeader))
+      if (Status == EFI_BUFFER_TOO_SMALL
+        && VarSize >= sizeof(VarHeader))
       {
         // Now we know the size. Allocate and get the variable.
         VarHeader = AllocateTemporaryMemory(VarSize);
@@ -252,14 +278,14 @@ FspGetNextVariableName(
         DEBUG((DEBUG_VERBOSE, "GetVariable Status %r, Size 0x%X, Name %a\n", Status, VarSize, LiteVarName));
         ASSERT_EFI_ERROR(Status);
         // Did we successfully get an FSP variable?
-        if (!EFI_ERROR(Status) && (VarHeader->Signature == FSP_LITE_VAR_SIGNATURE))
+        if (!EFI_ERROR(Status)
+          && (VarHeader->Signature == FSP_LITE_VAR_SIGNATURE))
         {
           // Don't need the actual variable anymore
           FreeTemporaryMemory(VarHeader);
           Status = SplitFspVarName(LiteVarName, &NameSize, VariableName, VariableGuid);
           DEBUG((DEBUG_VERBOSE, "SplitFspVarName Status %r, Size 0x%X, LiteVarName %a, VarName %s, GUID %g\n", Status, NameSize, LiteVarName, VariableName, VariableGuid));
-          if (EFI_ERROR(Status))
-          {
+          if (EFI_ERROR(Status)) {
             // Edge case:
             // if Caller VariableNameSize was too small, we need to reset key so caller can try again.
             VariableKey = OldKey;
@@ -270,8 +296,12 @@ FspGetNextVariableName(
         }
       }
     }
-    if (LiteVarName != NULL) FreeTemporaryMemory(LiteVarName);
-    if (VarHeader != NULL) FreeTemporaryMemory(VarHeader);
+    if (LiteVarName != NULL) {
+      FreeTemporaryMemory(LiteVarName);
+    }
+    if (VarHeader != NULL) {
+      FreeTemporaryMemory(VarHeader);
+    }
   } while (Status != EFI_NOT_FOUND);
   return Status;
 }
@@ -287,35 +317,45 @@ FspGetNextVariableName(
   @return EFI_STATUS
  */
 EFI_STATUS
-FspSetVariable(
+EFIAPI
+FspSetVariable (
   IN  CHAR16      *VariableName,
   IN  EFI_GUID    *VariableGuid,
   IN  UINT32      *Attributes,
   IN  UINT64      *DataSize,
   IN  VOID        *Data
-)
+  )
 {
   EFI_STATUS                Status;
   CHAR8                     *LiteVarName;
-  UINTN                     LiteVarSize, OldVarSize;
+  UINTN                     LiteVarSize;
+  UINTN                     OldVarSize;
   FSP_LITE_VARIABLE_HEADER  *VarHeader, *OldVar;
 
-  if (VariableName == NULL || DataSize == NULL || Attributes == NULL ||
-    (Data == NULL && *DataSize != 0)) return EFI_INVALID_PARAMETER;
+  if (VariableName == NULL
+    || DataSize == NULL
+    || Attributes == NULL
+    || (Data == NULL && *DataSize != 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
   // We don't support authenticated variables or volatile variables,
   // and FSP doesn't require them.
-  if ((*Attributes & EFI_VARIABLE_NON_VOLATILE) == 0 ||
-    *Attributes & (EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS |
-    EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS))
+  if ((*Attributes & EFI_VARIABLE_NON_VOLATILE) == 0
+    || *Attributes & (EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS
+      | EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS))
+  {
     return EFI_INVALID_PARAMETER;
+  }
 
   // Concatenate GUID + Unicode name
   Status = FormFspVarName(VariableName, VariableGuid, &LiteVarName);
-  if (EFI_ERROR(Status))
+  if (EFI_ERROR(Status)) {
     return Status;
+  }
 
   // Check if this is an attempt to delete the variable
-  if (*DataSize == 0 && ((*Attributes & EFI_VARIABLE_APPEND_WRITE) == 0))
+  if (*DataSize == 0
+    && ((*Attributes & EFI_VARIABLE_APPEND_WRITE) == 0))
   {
     Status = SetVariable(LiteVarName, 0, 0, NULL);
     FreeTemporaryMemory(LiteVarName);
@@ -326,21 +366,17 @@ FspSetVariable(
   OldVarSize=0;
   OldVar = NULL;
   Status = GetVariable(LiteVarName, NULL, &OldVarSize, OldVar);
-  if (Status == EFI_BUFFER_TOO_SMALL)
-  {
+  if (Status == EFI_BUFFER_TOO_SMALL) {
     OldVar = AllocateTemporaryMemory(OldVarSize);
     ASSERT(OldVar != NULL);
-    if (OldVar == NULL)
-    {
+    if (OldVar == NULL) {
       FreeTemporaryMemory(LiteVarName);
       return EFI_OUT_OF_RESOURCES;
     }
     Status = GetVariable(LiteVarName, NULL, &OldVarSize, OldVar);
   }
-  if (!EFI_ERROR(Status))
-  {
-    if ((*Attributes & ~EFI_VARIABLE_APPEND_WRITE) != OldVar->Attributes)
-    {
+  if (!EFI_ERROR(Status)) {
+    if ((*Attributes & ~EFI_VARIABLE_APPEND_WRITE) != OldVar->Attributes) {
       FreeTemporaryMemory(LiteVarName);
       FreeTemporaryMemory(OldVar);
       return Status;
@@ -348,36 +384,34 @@ FspSetVariable(
   }
 
   // handle Append Write case
-  if (OldVar != NULL && *Attributes & EFI_VARIABLE_APPEND_WRITE)
+  if (OldVar != NULL
+    && *Attributes & EFI_VARIABLE_APPEND_WRITE)
   {
     LiteVarSize = (UINTN)*DataSize + OldVarSize;
-  }
-  else
-  {
+  } else {
     LiteVarSize = (UINTN)*DataSize + sizeof(FSP_LITE_VARIABLE_HEADER);
   }
 
   // Allocate a pool and create encapsulated variable.
   VarHeader = AllocateTemporaryMemory(LiteVarSize);
   ASSERT(VarHeader != NULL);
-  if (VarHeader == NULL)
-  {
+  if (VarHeader == NULL) {
     FreeTemporaryMemory(LiteVarName);
-    if (OldVar != NULL) FreeTemporaryMemory(OldVar);
+    if (OldVar != NULL) {
+      FreeTemporaryMemory(OldVar);
+    }
     return EFI_OUT_OF_RESOURCES;
   }
 
   VarHeader->Signature = FSP_LITE_VAR_SIGNATURE;
   VarHeader->Attributes = *Attributes & ~EFI_VARIABLE_APPEND_WRITE;
-  if (OldVar != NULL && *Attributes & EFI_VARIABLE_APPEND_WRITE)
-  {
+  if (OldVar != NULL && *Attributes & EFI_VARIABLE_APPEND_WRITE) {
     // Copy old variable data into new variable.
     CopyMem(VarHeader->Data, OldVar->Data, OldVarSize-sizeof(FSP_LITE_VARIABLE_HEADER));
     // Copy new data at the end
     CopyMem(((UINT8*)VarHeader)+OldVarSize, Data, (UINTN)*DataSize);
     FreeTemporaryMemory(OldVar);
-  }
-  else{
+  } else {
     // Copy new data into new variable
     CopyMem(VarHeader->Data, Data, (UINTN)*DataSize);
   }
@@ -399,26 +433,30 @@ FspSetVariable(
   @return EFI_STATUS
  */
 EFI_STATUS
-FspQueryVariableInfo(
+EFIAPI
+FspQueryVariableInfo (
   IN  UINT32      *Attributes,
   OUT UINT64      *MaximumVariableStorageSize,
   OUT UINT64      *RemainingVariableStorageSize,
   OUT UINT64      *MaximumVariableSize
-)
+  )
 {
   EFI_STATUS      Status;
-  UINTN           LiteMaxStoreSize, LiteRemainingSize, LiteMaxVarSize;
+  UINTN           LiteMaxStoreSize;
+  UINTN           LiteRemainingSize;
+  UINTN           LiteMaxVarSize;
+
   // don't support authenticated or volatile variables
-  if (*Attributes & (EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS | EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS) ||
-    (*Attributes & EFI_VARIABLE_NON_VOLATILE) == 0)
+  if (*Attributes & (EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS | EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS)
+    || (*Attributes & EFI_VARIABLE_NON_VOLATILE) == 0) {
     return EFI_UNSUPPORTED;
+  }
 
   Status = QueryVariableInfo(
     &LiteMaxStoreSize,
     &LiteRemainingSize,
     &LiteMaxVarSize);
-  if (!EFI_ERROR(Status))
-  {
+  if (!EFI_ERROR(Status)) {
     *MaximumVariableStorageSize = (UINT64)LiteMaxStoreSize;
     *RemainingVariableStorageSize = (UINT64)LiteRemainingSize - sizeof(FSP_LITE_VARIABLE_HEADER);
     *MaximumVariableSize = (UINT64)LiteMaxVarSize - sizeof(FSP_LITE_VARIABLE_HEADER);

--- a/BootloaderCorePkg/Library/FspVariableServicesLib/FspVariableServicesLib.inf
+++ b/BootloaderCorePkg/Library/FspVariableServicesLib/FspVariableServicesLib.inf
@@ -1,0 +1,37 @@
+## @file
+#  FSP Variable Services Wrapper implementation
+#
+#  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = FspVariableServicesLib
+  FILE_GUID                      = a0f869dd-5d4e-47f8-ba43-c65b98bb3d19
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = FspVariableServicesLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 IPF EBC
+#
+[Sources]
+  FspVariableServicesLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCorePkg/BootloaderCorePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+  IntelFsp2Pkg/IntelFsp2Pkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  BaseMemoryLib
+  VariableLib
+  MemoryAllocationLib
+  PrintLib

--- a/BootloaderCorePkg/Library/FspVariableServicesLib/FspVariableServicesLibInternal.h
+++ b/BootloaderCorePkg/Library/FspVariableServicesLib/FspVariableServicesLibInternal.h
@@ -1,0 +1,30 @@
+/** @file
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#ifndef __FSP_VARIABLE_SERVICES_LIB_INTERNAL_H__
+#define __FSP_VARIABLE_SERVICES_LIB_INTERNAL_H__
+
+#include <Uefi.h>
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PrintLib.h>
+#include <Library/FspVariableServicesLib.h>
+#include <Library/VariableLib.h>
+#include <Library/BlMemoryAllocationLib.h>
+
+#define FSP_LITE_VAR_SIGNATURE            SIGNATURE_32('F', 'S', 'P', 'V')
+#define ASCII_GUID_LENGTH                 36    //ASCII GUIDs have 36 CHARs (32 + 4 hyphens)
+
+typedef struct {
+  UINT32    Signature;          //'FSPV'
+  UINT32    Attributes;         // EFI attributes field
+  UINT8     Data[0];
+} FSP_LITE_VARIABLE_HEADER;
+
+
+#endif //__FSP_VARIABLE_SERVICES_LIB_INTERNAL_H__

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -424,7 +424,7 @@ SecStartup2 (
   FspResetHandler (Status);
   ASSERT_EFI_ERROR (Status);
 
-  Status = FspVariableHandler(Status,CallFspMultiPhaseMemoryInit);
+  Status = FspVariableHandler(Status, CallFspMultiPhaseMemoryInit);
   ASSERT_EFI_ERROR(Status);
 
   Status = FspMultiPhaseMemInitHandler();

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2016 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -420,9 +420,22 @@ SecStartup2 (
   DEBUG ((DEBUG_INIT, "Memory Init\n"));
   AddMeasurePoint (0x2020);
   Status = CallFspMemoryInit (PCD_GET32_WITH_ADJUST (PcdFSPMBase), &HobList);
-  AddMeasurePoint (0x2030);
+
   FspResetHandler (Status);
   ASSERT_EFI_ERROR (Status);
+
+  Status = FspVariableHandler(Status,CallFspMultiPhaseMemoryInit);
+  ASSERT_EFI_ERROR(Status);
+
+  Status = FspMultiPhaseMemInitHandler();
+  if (Status == EFI_UNSUPPORTED)
+    DEBUG((DEBUG_INFO, "FspMultiPhaseMemInit() returned EFI_UNSUPPORTED. This is expected for FSP 2.3 and older.\n"));
+  else
+    ASSERT_EFI_ERROR(Status);
+
+  AddMeasurePoint (0x2030);
+
+  FspResetHandler (Status);
 
   if (PcdGetBool (PcdSblResiliencyEnabled)) {
     // React to TCO timer failures here as not to conflict with ACM active timer

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2016 - 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -465,9 +465,22 @@ SecStartup (
   DEBUG ((DEBUG_INIT, "Silicon Init\n"));
   AddMeasurePoint (0x3020);
   Status = CallFspSiliconInit ();
+
+  FspResetHandler(Status);
+  ASSERT_EFI_ERROR (Status);
+
+  Status = FspVariableHandler(Status, CallFspMultiPhaseSiliconInit);
+  ASSERT_EFI_ERROR(Status);
+
+  Status = FspMultiPhaseSiliconInitHandler();
+  if (Status == EFI_UNSUPPORTED)
+    DEBUG((DEBUG_INFO, "FspMultiPhaseSiliconInitHandler() returned EFI_UNSUPPORTED.\n"));
+  else
+    ASSERT_EFI_ERROR(Status);
+
   AddMeasurePoint (0x3030);
   FspResetHandler (Status);
-  ASSERT_EFI_ERROR (Status);
+
 
   if (FixedPcdGetBool (PcdSmbiosEnabled)) {
     InitSmbiosStringPtr ();

--- a/IntelFsp2Pkg/Include/FspEas/FspApi.h
+++ b/IntelFsp2Pkg/Include/FspEas/FspApi.h
@@ -443,8 +443,8 @@ typedef enum {
 
 typedef enum {
  EnumFspVariableRequestGetVariable          = 0x0,
- EnumFspVariableRequestSetVariable          = 0x1,
- EnumFspVariableRequestGetNextVariableName  = 0x2,
+ EnumFspVariableRequestGetNextVariableName  = 0x1,
+ EnumFspVariableRequestSetVariable          = 0x2,
  EnumFspVariableRequestQueryVariableInfo    = 0x3
 } FSP_VARIABLE_REQUEST_TYPE;
 

--- a/IntelFsp2Pkg/Include/FspEas/FspApi.h
+++ b/IntelFsp2Pkg/Include/FspEas/FspApi.h
@@ -2,7 +2,7 @@
   Intel FSP API definition from Intel Firmware Support Package External
   Architecture Specification v2.0 - v2.2
 
-  Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -11,19 +11,24 @@
 #define _FSP_API_H_
 
 #include <Pi/PiStatusCode.h>
+#include <Base.h>
 
 ///
 /// FSP Reset Status code
-/// These are defined in FSP EAS v2.0 section 11.2.2 - OEM Status Code
+/// These are defined in FSP EAS v2.4 section 13.3 - OEM Status Code
 /// @{
-#define FSP_STATUS_RESET_REQUIRED_COLD         0x40000001
-#define FSP_STATUS_RESET_REQUIRED_WARM         0x40000002
-#define FSP_STATUS_RESET_REQUIRED_3            0x40000003
-#define FSP_STATUS_RESET_REQUIRED_4            0x40000004
-#define FSP_STATUS_RESET_REQUIRED_5            0x40000005
-#define FSP_STATUS_RESET_REQUIRED_6            0x40000006
-#define FSP_STATUS_RESET_REQUIRED_7            0x40000007
-#define FSP_STATUS_RESET_REQUIRED_8            0x40000008
+
+#define ENCODE_RESET_REQUEST(ResetType)  \
+        ((EFI_STATUS)((MAX_BIT >> 1) | (ResetType)))
+#define FSP_STATUS_RESET_REQUIRED_COLD  ENCODE_RESET_REQUEST(1)
+#define FSP_STATUS_RESET_REQUIRED_WARM  ENCODE_RESET_REQUEST(2)
+#define FSP_STATUS_RESET_REQUIRED_3     ENCODE_RESET_REQUEST(3)
+#define FSP_STATUS_RESET_REQUIRED_4     ENCODE_RESET_REQUEST(4)
+#define FSP_STATUS_RESET_REQUIRED_5     ENCODE_RESET_REQUEST(5)
+#define FSP_STATUS_RESET_REQUIRED_6     ENCODE_RESET_REQUEST(6)
+#define FSP_STATUS_RESET_REQUIRED_7     ENCODE_RESET_REQUEST(7)
+#define FSP_STATUS_RESET_REQUIRED_8     ENCODE_RESET_REQUEST(8)
+#define FSP_STATUS_VARIABLE_REQUEST     ENCODE_RESET_REQUEST(10)
 /// @}
 
 ///
@@ -129,6 +134,27 @@ typedef struct {
 } FSPT_ARCH_UPD;
 
 ///
+/// FSPT_ARCH2_UPD Configuration.
+///
+typedef struct {
+  ///
+  /// Revision of the structure is 2 for this version of the specification.
+  ///
+  UINT8                Revision;
+  UINT8                Reserved[3];
+  ///
+  /// Length of the structure in bytes. The current value for this field is 32.
+  ///
+  UINT32               Length;
+  ///
+  /// FspDebugHandler Optional debug handler for the bootloader to receive debug messages
+  /// occurring during FSP execution.
+  ///
+  EFI_PHYSICAL_ADDRESS FspDebugHandler;
+  UINT8                Reserved1[16];
+} FSPT_ARCH2_UPD;
+
+///
 /// FSPM_ARCH_UPD Configuration.
 ///
 typedef struct {
@@ -169,6 +195,54 @@ typedef struct {
   UINT8                       Reserved1[4];
 } FSPM_ARCH_UPD;
 
+///
+/// FSPM_ARCH2_UPD Configuration.
+///
+typedef struct {
+  ///
+  /// Revision of the structure is 3 for this version of the specification.
+  ///
+  UINT8                Revision;
+  UINT8                Reserved[3];
+  ///
+  /// Length of the structure in bytes. The current value for this field is 64.
+  ///
+  UINT32               Length;
+  ///
+  /// Pointer to the non-volatile storage (NVS) data buffer.
+  /// If it is NULL it indicates the NVS data is not available.
+  ///
+  EFI_PHYSICAL_ADDRESS NvsBufferPtr;
+  ///
+  /// Pointer to the temporary stack base address to be
+  /// consumed inside FspMemoryInit() API.
+  ///
+  EFI_PHYSICAL_ADDRESS StackBase;
+  ///
+  /// Temporary stack size to be consumed inside
+  /// FspMemoryInit() API.
+  ///
+  UINT64               StackSize;
+  ///
+  /// Size of memory to be reserved by FSP below "top
+  /// of low usable memory" for bootloader usage.
+  ///
+  UINT32               BootLoaderTolumSize;
+  ///
+  /// Current boot mode.
+  ///
+  UINT32               BootMode;
+  ///
+  /// Optional event handler for the bootloader to be informed of events occurring during FSP execution.
+  /// This value is only valid if Revision is >= 2.
+  ///
+  EFI_PHYSICAL_ADDRESS FspEventHandler;
+  UINT8                Reserved1[16];
+} FSPM_ARCH2_UPD;
+
+///
+/// FSPS_ARCH_UPD Configuration.
+///
 typedef struct {
   ///
   /// Revision Revision of the structure is 1 for this version of the specification.
@@ -196,6 +270,27 @@ typedef struct {
 } FSPS_ARCH_UPD;
 
 ///
+/// FSPS_ARCH2_UPD Configuration.
+///
+typedef struct {
+  ///
+  /// Revision of the structure is 2 for this version of the specification.
+  ///
+  UINT8                Revision;
+  UINT8                Reserved[3];
+  ///
+  /// Length of the structure in bytes. The current value for this field is 32.
+  ///
+  UINT32               Length;
+  ///
+  /// FspEventHandler Optional event handler for the bootloader to be informed of events
+  /// occurring during FSP execution.
+  ///
+  EFI_PHYSICAL_ADDRESS FspEventHandler;
+  UINT8                Reserved1[16];
+} FSPS_ARCH2_UPD;
+
+///
 /// FSPT_UPD_COMMON Configuration.
 ///
 typedef struct {
@@ -221,6 +316,21 @@ typedef struct {
 } FSPT_UPD_COMMON_FSP22;
 
 ///
+/// FSPT_UPD_COMMON Configuration for FSP spec. 2.4 and above.
+///
+typedef struct {
+  ///
+  /// FSP_UPD_HEADER Configuration.
+  ///
+  FSP_UPD_HEADER    FspUpdHeader;
+
+  ///
+  /// FSPT_ARCH2_UPD Configuration.
+  ///
+  FSPT_ARCH2_UPD    FsptArchUpd;
+} FSPT_UPD_COMMON_FSP24;
+
+///
 /// FSPM_UPD_COMMON Configuration.
 ///
 typedef struct {
@@ -233,6 +343,20 @@ typedef struct {
   ///
   FSPM_ARCH_UPD               FspmArchUpd;
 } FSPM_UPD_COMMON;
+
+///
+/// FSPM_UPD_COMMON Configuration for FSP spec. 2.4 and above.
+///
+typedef struct {
+  ///
+  /// FSP_UPD_HEADER Configuration.
+  ///
+  FSP_UPD_HEADER    FspUpdHeader;
+  ///
+  /// FSPM_ARCH2_UPD Configuration.
+  ///
+  FSPM_ARCH2_UPD    FspmArchUpd;
+} FSPM_UPD_COMMON_FSP24;
 
 ///
 /// FSPS_UPD_COMMON Configuration.
@@ -258,6 +382,21 @@ typedef struct {
   ///
   FSPS_ARCH_UPD               FspsArchUpd;
 } FSPS_UPD_COMMON_FSP22;
+
+///
+/// FSPS_UPD_COMMON Configuration for FSP spec. 2.4 and above.
+///
+typedef struct {
+  ///
+  /// FSP_UPD_HEADER Configuration.
+  ///
+  FSP_UPD_HEADER    FspUpdHeader;
+
+  ///
+  /// FSPS_ARCH2_UPD Configuration.
+  ///
+  FSPS_ARCH2_UPD    FspsArchUpd;
+} FSPS_UPD_COMMON_FSP24;
 
 ///
 /// Enumeration of FSP_INIT_PHASE for NOTIFY_PHASE.
@@ -296,9 +435,34 @@ typedef struct {
 /// Action definition for FspMultiPhaseSiInit API
 ///
 typedef enum {
-  EnumMultiPhaseGetNumberOfPhases  = 0x0,
-  EnumMultiPhaseExecutePhase       = 0x1
+  EnumMultiPhaseGetNumberOfPhases       = 0x0,
+  EnumMultiPhaseExecutePhase            = 0x1,
+  EnumMultiPhaseGetVariableRequestInfo  = 0x2,
+  EnumMultiPhaseCompleteVariableRequest = 0x3
 } FSP_MULTI_PHASE_ACTION;
+
+typedef enum {
+ EnumFspVariableRequestGetVariable          = 0x0,
+ EnumFspVariableRequestSetVariable          = 0x1,
+ EnumFspVariableRequestGetNextVariableName  = 0x2,
+ EnumFspVariableRequestQueryVariableInfo    = 0x3
+} FSP_VARIABLE_REQUEST_TYPE;
+
+#pragma pack(16)
+typedef struct {
+  IN     FSP_VARIABLE_REQUEST_TYPE   VariableRequest;
+  IN OUT CHAR16                      *VariableName;
+  IN OUT UINT64                      *VariableNameSize;
+  IN OUT EFI_GUID                    *VariableGuid;
+  IN OUT UINT32                      *Attributes;
+  IN OUT UINT64                      *DataSize;
+  IN OUT VOID                        *Data;
+  OUT    UINT64                      *MaximumVariableStorageSize;
+  OUT    UINT64                      *RemainingVariableStorageSize;
+  OUT    UINT64                      *MaximumVariableSize;
+  OUT    EFI_STATUS                  Status;
+} FSP_MULTI_PHASE_VARIABLE_REQUEST_INFO_PARAMS;
+#pragma pack()
 
 ///
 /// Data structure returned by FSP when bootloader calling
@@ -323,7 +487,7 @@ typedef struct {
 typedef struct {
   IN     FSP_MULTI_PHASE_ACTION  MultiPhaseAction;
   IN     UINT32                  PhaseIndex;
-  IN OUT UINT32                  MultiPhaseParamPtr;
+  IN OUT VOID                    *MultiPhaseParamPtr;
 } FSP_MULTI_PHASE_PARAMS;
 
 #pragma pack()
@@ -481,5 +645,31 @@ EFI_STATUS
 (EFIAPI *FSP_MULTI_PHASE_SI_INIT) (
   IN FSP_MULTI_PHASE_PARAMS     *MultiPhaseSiInitParamPtr
 );
+
+/**
+  The FspMultiPhaseMemInit() API may only be called after the FspMemoryInit() API and before the
+  FspSiliconInit() API; or in the case that FSP-T is being used, before the TempRamExit() API.
+  This FSP API provides multi-phase memory initialization; which brings greater modularity
+  beyond the existing FspMemoryInit() API. Increased modularity is achieved by adding an
+  extra API to FSP-M. This allows the bootloader to add board specific initialization steps
+  throughout the MemoryInit flow as needed.
+
+  @param[in,out] FSP_MULTI_PHASE_PARAMS   For action - EnumMultiPhaseGetNumberOfPhases:
+                                            FSP_MULTI_PHASE_PARAMS->MultiPhaseParamPtr will contain
+                                            how many phases supported by FSP.
+                                          For action - EnumMultiPhaseExecutePhase:
+                                            FSP_MULTI_PHASE_PARAMS->MultiPhaseParamPtr shall be NULL.
+  @retval EFI_SUCCESS                     FSP execution environment was initialized successfully.
+  @retval EFI_INVALID_PARAMETER           Input parameters are invalid.
+  @retval EFI_UNSUPPORTED                 The FSP calling conditions were not met.
+  @retval EFI_DEVICE_ERROR                FSP initialization failed.
+  @retval FSP_STATUS_RESET_REQUIREDx      A reset is required. These status codes will not be returned during S3.
+  @retval FSP_STATUS_VARIABLE_REQUEST     A variable request has been made by FSP that needs boot loader handling.
+**/
+typedef
+EFI_STATUS
+(EFIAPI *FSP_MULTI_PHASE_MEM_INIT)(
+  IN FSP_MULTI_PHASE_PARAMS     *MultiPhaseSiInitParamPtr
+  );
 
 #endif

--- a/IntelFsp2Pkg/Include/Guid/FspHeaderFile.h
+++ b/IntelFsp2Pkg/Include/Guid/FspHeaderFile.h
@@ -2,15 +2,22 @@
   Intel FSP Header File definition from Intel Firmware Support Package External
   Architecture Specification v2.0 and above.
 
-  Copyright (c) 2014 - 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
+
+#include <Base.h>
 
 #ifndef __FSP_HEADER_FILE_H__
 #define __FSP_HEADER_FILE_H__
 
 #define FSP_HEADER_REVISION_3   3
+#define FSP20_HEADER_REVISION   3
+#define FSP21_HEADER_REVISION   4
+#define FSP22_HEADER_REVISION   5
+#define FSP23_HEADER_REVISION   6
+#define FSP24_HEADER_REVISION   7
 
 #define FSPE_HEADER_REVISION_1  1
 #define FSPP_HEADER_REVISION_1  1
@@ -23,6 +30,13 @@
 #define OFFSET_IN_FSP_INFO_HEADER(x)  (UINT32)&((FSP_INFO_HEADER *)(UINTN)0)->x
 
 #define FSP_INFO_HEADER_SIGNATURE  SIGNATURE_32 ('F', 'S', 'P', 'H')
+
+#define IMAGE_ATTRIBUTE_GRAPHICS_SUPPORT      BIT0
+#define IMAGE_ATTRIBUTE_DISPATCH_MODE_SUPPORT BIT1
+#define IMAGE_ATTRIBUTE_64BIT_MODE_SUPPORT    BIT2
+#define IMAGE_ATTRIBUTE_VAR_SERVICES_SUPPORT  BIT3
+#define FSP_IA32                              0
+#define FSP_X64                               1
 
 #pragma pack(1)
 
@@ -49,7 +63,7 @@ typedef struct {
   UINT8   SpecVersion;
   ///
   /// Byte 0x0B: Revision of the FSP Information Header.
-  ///            The Current value for this field is 0x6.
+  ///            The Current value for this field is 0x7.
   ///
   UINT8   HeaderRevision;
   ///
@@ -82,6 +96,10 @@ typedef struct {
   UINT32  ImageBase;
   ///
   /// Byte 0x20: Attribute for the FSP binary.
+  ///   Bit 0: Graphics Support - Set to 1 when FSP supports enabling Graphics Display.
+  ///   Bit 1: Dispatch Mode Support - Set to 1 when FSP supports the optional Dispatch Mode API defined in Section 7.2 and 9. This bit is only valid if FSP HeaderRevision is >= 4.
+  ///   Bit 2: 64-bit mode support - Set to 1 to indicate FSP supports 64-bit long mode interfaces. Set to 0 to indicate FSP supports 32-bit mode interfaces. This bit is only valid if FSP HeaderRevision is >= 7.
+  ///   Bits 15:3 - Reserved
   ///
   UINT16  ImageAttribute;
   ///
@@ -147,6 +165,10 @@ typedef struct {
   /// Byte 0x4E: Reserved4.
   ///
   UINT16  Reserved4;
+  ///
+  /// Byte 0x50: Multi Phase Mem Init offset.
+  ///
+  UINT32  FspMultiPhaseMemInitEntryOffset;
 } FSP_INFO_HEADER;
 
 ///

--- a/IntelFsp2Pkg/Tools/SplitFspBin.py
+++ b/IntelFsp2Pkg/Tools/SplitFspBin.py
@@ -1,6 +1,6 @@
 ## @ SplitFspBin.py
 #
-# Copyright (c) 2015 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2015 - 2023, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -125,7 +125,8 @@ class FSP_INFORMATION_HEADER(Structure):
         ('FspSiliconInitEntryOffset',      c_uint32),
         ('FspMultiPhaseSiInitEntryOffset', c_uint32),
         ('ExtendedImageRevision',          c_uint16),
-        ('Reserved4',                      c_uint16)
+        ('Reserved4',                      c_uint16),
+        ('FspMultiPhaseMemoryInitEntryOffset', c_uint32)
     ]
 
 class FSP_PATCH_TABLE(Structure):

--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -112,7 +112,7 @@ class Board(BaseBoard):
         self.FSP_IMAGE_ID         = '$APLFSP$'
 
         self.STAGE1A_SIZE         = 0x00008000
-        self.STAGE1B_SIZE         = 0x00037000
+        self.STAGE1B_SIZE         = 0x00038000
         if self.ENABLE_SOURCE_DEBUG:
             self.STAGE1B_SIZE += 0x2000
         self.STAGE2_SIZE          = 0x00033000

--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -112,10 +112,10 @@ class Board(BaseBoard):
         self.FSP_IMAGE_ID         = '$APLFSP$'
 
         self.STAGE1A_SIZE         = 0x00008000
-        self.STAGE1B_SIZE         = 0x00036000
+        self.STAGE1B_SIZE         = 0x00037000
         if self.ENABLE_SOURCE_DEBUG:
             self.STAGE1B_SIZE += 0x2000
-        self.STAGE2_SIZE          = 0x00032000
+        self.STAGE2_SIZE          = 0x00033000
         self.PAYLOAD_SIZE         = 0x00021000
 
         if len(self._PAYLOAD_NAME.split(';')) > 1:
@@ -136,7 +136,7 @@ class Board(BaseBoard):
         self.STAGE1B_XIP          = 0
         self.STAGE1B_LOAD_BASE    = 0xFEF10000
         self.STAGE1B_FD_BASE      = 0xFEF80000
-        self.STAGE1B_FD_SIZE      = 0x0006B000
+        self.STAGE1B_FD_SIZE      = 0x0006D000
         if self.ENABLE_SOURCE_DEBUG:
             self.STAGE1B_FD_SIZE += 0x00001000
         if self.RELEASE_MODE == 0:

--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -117,7 +117,7 @@ class Board(BaseBoard):
 
         if self.RELEASE_MODE:
             self.STAGE1A_SIZE         = 0x0000D000
-            self.STAGE1B_SIZE         = 0x000B0000
+            self.STAGE1B_SIZE         = 0x000B1000
             self.STAGE2_SIZE          = 0x00070000
             self.STAGE2_FD_SIZE       = 0x000E0000
             self.PAYLOAD_SIZE         = 0x00024000


### PR DESCRIPTION
FSP 2.4 adds a requirement for Bootloader to respond to FSP Variable requests in a way that is similar to UEFI variable services. This implementation adds support for this using FspVariableServicesLib which acts as a wrapper for the SBL LiteVariableLib.

Additionally, support for Multi-Phase mem and SI init is added. FSP 2.4 introduces the mandatory MultiPhaseMemInit call, and makes the MultiPhaseSiInit call mandatory where it was previously optional.