### PR TITLE
[ADL] Remove BIOS region protection overrides

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -800,10 +800,6 @@ UpdateFspConfig (
 
   // PCH Flash protection
   FspsConfig->PchPwrOptEnable             = 0x1;
-  FspsConfig->PchWriteProtectionEnable[0] = 0x0;
-  FspsConfig->PchWriteProtectionEnable[1] = 0x0;
-  FspsConfig->PchProtectedRangeLimit[0]   = 0x1fff;
-  FspsConfig->PchProtectedRangeBase[0]    = 0x1070;
 
   // MISC
   FspsConfig->PchFivrExtV1p05RailVoltage = 0x1a4;


### PR DESCRIPTION
BIOS region has been protected at an earlier place in this file based on the boot mode. Removing these hard-coded values as these override the previous behavior. Tested with UEFI payload and see no boot issues.