### PR TITLE
[ADL/RPL] Update PlatformMemorySize default value

### DIFF
--- a/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adln_Crb_Ddr5.dlt
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adln_Crb_Ddr5.dlt
@@ -97,9 +97,6 @@ MEMORY_CFG_DATA.PrmrrSize                  | 0x200000
 # This setting is used for debug purposes
 #MEMORY_CFG_DATA.PlatformDebugConsent       | 0x7
 
-# Increase the size to 64MB in order to get rid of an error during Tcc init flow in FSP
-MEMORY_CFG_DATA.PlatformMemorySize | 0x4000000
-
 GRAPHICS_CFG_DATA.InternalGfx              | 0x2
 
 GEN_CFG_DATA.VbtImageId                    | 1

--- a/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adln_Rvp_Lpddr5.dlt
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adln_Rvp_Lpddr5.dlt
@@ -70,9 +70,6 @@ MEMORY_CFG_DATA.PchHdaAudioLinkHdaEnable   | 0x1
 MEMORY_CFG_DATA.PchHdaDspEnable            | 0x1
 MEMORY_CFG_DATA.WdtDisableAndLock | 0
 
-# Increase the size to 64MB in order to get rid of an error during Tcc init flow in FSP
-MEMORY_CFG_DATA.PlatformMemorySize | 0x4000000
-
 GRAPHICS_CFG_DATA.InternalGfx              | 0x2
 
 GEN_CFG_DATA.VbtImageId                    | 1

--- a/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr4.dlt
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr4.dlt
@@ -2,7 +2,7 @@
 #
 #  Platform Configuration Delta File.
 #
-#  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 #
@@ -51,9 +51,6 @@ MEMORY_CFG_DATA.PchHdaAudioLinkHdaEnable   | 0x1
 MEMORY_CFG_DATA.PchHdaAudioLinkDmicEnable  | {0x1, 0x1}
 MEMORY_CFG_DATA.PchHdaDspEnable            | 0x1
 MEMORY_CFG_DATA.DmiMaxLinkSpeed            | 0x0
-
-# Increase the size to 64MB in order to get rid of an error during Tcc init flow in FSP
-MEMORY_CFG_DATA.PlatformMemorySize | 0x4000000
 
 PLDSEL_CFG_DATA.PldSelGpio.Enable      | 1
 PLDSEL_CFG_DATA.PldSelGpio.PadGroup    | 5

--- a/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr5.dlt
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr5.dlt
@@ -2,7 +2,7 @@
 #
 #  Platform Configuration Delta File.
 #
-#  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2021 - 2023, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 #
@@ -51,9 +51,6 @@ MEMORY_CFG_DATA.TcssDma1En | 0x1
 MEMORY_CFG_DATA.PchHdaAudioLinkHdaEnable   | 0x1
 MEMORY_CFG_DATA.PchHdaAudioLinkDmicEnable  | {0x1, 0x1}
 MEMORY_CFG_DATA.PchHdaDspEnable            | 0x1
-
-# Increase the size to 64MB in order to get rid of an error during Tcc init flow in FSP
-MEMORY_CFG_DATA.PlatformMemorySize | 0x4000000
 
 PLDSEL_CFG_DATA.PldSelGpio.Enable      | 1
 PLDSEL_CFG_DATA.PldSelGpio.PadGroup    | 5

--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_Memory.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_Memory.yaml
@@ -2,7 +2,7 @@
 #
 #  Slim Bootloader CFGDATA Option File.
 #
-#  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -257,12 +257,12 @@
       length       : 0x01
       value        : 0x01
   - PlatformMemorySize :
-      name         : Platform Reserved Memory Size
+      name         : Minimum Platform Memory Size
       type         : EditNum, HEX, (0x00,0xFFFFFFFFFFFFFFFF)
       help         : >
                      The minimum platform memory size required to pass control to post-memory init
       length       : 0x08
-      value        : 0x400000
+      value        : 0x4000000
   - CpuRatio     :
       name         : CPU ratio value
       type         : EditNum, HEX, (0x00, 0x3F)


### PR DESCRIPTION
SBL config data PlatformMemorySize is used to set FSP UPD PlatformMemorySize which is used by FSP to check available memory range size for FSP reserved memory.
A too small size might cause FSP to use a small available memory range used for other purpose. So change the default value of PlatformMemorySize to 64MB.
Since default value change, remove unnecessary override.