### PR TITLE
[EHL] Update FSP and platform version since MR6 is released

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/BoardConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/BoardConfig.py
@@ -26,7 +26,7 @@ class Board(BaseBoard):
         # VERINFO_PROJ_MAJOR_VER: 1 PV Quality release
         # VERINFO_PROJ_MINOR_VER: 0: PV  1: MR1  2: MR2 etc.
         self.VERINFO_PROJ_MAJOR_VER = 1
-        self.VERINFO_PROJ_MINOR_VER = 5
+        self.VERINFO_PROJ_MINOR_VER = 6
         self.VERINFO_SVN          = 1
         self.VERINFO_BUILD_DATE   = time.strftime("%m/%d/%Y")
         self.LOWEST_SUPPORTED_FW_VER = ((self.VERINFO_PROJ_MAJOR_VER << 8) + self.VERINFO_PROJ_MINOR_VER)

--- a/Silicon/ElkhartlakePkg/FspBin/FspBin.inf
+++ b/Silicon/ElkhartlakePkg/FspBin/FspBin.inf
@@ -11,7 +11,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = 3905c552478520f825ea9962044150726c9aaa79
+  COMMIT  = 3ae8ca82ee519ca4f5f60a59ca7d4f8cec7b402d
 
 [UserExtensions.SBL."CopyList"]
   ElkhartLakeFspBinPkg/FspBin/FSPRel.bin               : Silicon/ElkhartlakePkg/FspBin/FspDbg.bin


### PR DESCRIPTION
- update FSP version to MR6 (09.04.51.31)
- update platform version to 1.6

Verify on EHL CRB.