### PR TITLE
fix: address HelloWorld payload build failure

### DIFF
--- a/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
+++ b/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.c
@@ -1,7 +1,7 @@
 /** @file
   This file provides payload common library interfaces.
 
-  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -14,7 +14,6 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/PayloadLib.h>
 #include <Library/BootloaderCommonLib.h>
-#include <Library/BootloaderCoreLib.h>
 #include <Library/LoaderPerformanceLib.h>
 #include <Library/PayloadMemoryAllocationLib.h>
 #include <Library/SerialPortLib.h>
@@ -273,7 +272,7 @@ SecStartup (
 
   // ACPI table
   SystemTableInfo = GetSystemTableInfo ();
-  if (SystemTableInfo != NULL && ACPI_ENABLED()) {
+  if ((SystemTableInfo != NULL) && (SystemTableInfo->AcpiTableBase != 0)) {
     ParseAcpiTableInfo ((UINT32)SystemTableInfo->AcpiTableBase);
   }
 

--- a/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.inf
+++ b/PayloadPkg/Library/PayloadEntryLib/PayloadEntryLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -26,7 +26,6 @@
   MdePkg/MdePkg.dec
   BootloaderCommonPkg/BootloaderCommonPkg.dec
   PayloadPkg/PayloadPkg.dec
-  BootloaderCorePkg/BootloaderCorePkg.dec
 
 [LibraryClasses]
   BaseLib
@@ -41,7 +40,6 @@
   DebugLogBufferLib
   DebugPrintErrorLevelLib
   PagingLib
-  BootloaderCoreLib
 
 [Guids]
   gLoaderLibraryDataGuid
@@ -61,4 +59,3 @@
   gPlatformCommonLibTokenSpaceGuid.PcdDmaProtectionEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferSize
   gPlatformCommonLibTokenSpaceGuid.PcdDmaBufferAlignment
-  gPlatformModuleTokenSpaceGuid.PcdAcpiEnabled


### PR DESCRIPTION
HelloWorld consumes BootloaderCoreLib but the entry for this LibraryClass was missing in the PayloadPkg DSC file.