### PR TITLE
fix: verify fwupdate capsule only when Verified Boot is enabled

### DIFF
--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
@@ -1,5 +1,5 @@
 ## @file
-#  Copyright (c) 2008 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2008 - 2023, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -82,6 +82,7 @@
   gPlatformModuleTokenSpaceGuid.PcdSblResiliencyEnabled
   gPlatformModuleTokenSpaceGuid.PcdBootFailureThreshold
   gPlatformModuleTokenSpaceGuid.PcdUcodeSlotSize
+  gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled
 
 [Depex]
   TRUE


### PR DESCRIPTION
Firmware update got failed when verified boot was turned off. While fwupdate capsule is always generated with signing key,
it should be verified only when verified boot is enabled. Otherwise, raise a warning to inform that the capsule is not authenticated.