### PR TITLE
fix: [ADL/RPL] SBL image larger than 16MB hangs after TempRamInit.

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
@@ -172,6 +172,10 @@ BoardInit (
       MskLen = (AsmReadMsr64(MSR_CACHE_VARIABLE_MTRR_BASE + 1) | (SIZE_4GB - 1)) + 1;
       MsrIdx = MSR_CACHE_VARIABLE_MTRR_BASE + 1 * 2;
       ImgLen = PcdGet32(PcdFlashSize);
+      // PCH only decodes max 16MB of SPI flash from the top down to MMIO.
+      if (ImgLen > SIZE_16MB) {
+        ImgLen = SIZE_16MB;
+      }
       AdjLen = GetPowerOfTwo32(ImgLen);
       if (ImgLen > AdjLen) {
         AdjLen <<= 1;


### PR DESCRIPTION
The PCH decodes MMIO accesses to the top of 4GB to SPI flash for a maximum window size of 16MB. For SBL images larger than 16MB, this PostTempRamInit hook was causing the MTRR to overlap with NEM stack set up by FSP-T, causing a hang.