### PR TITLE
[ADL/RPL] Add MMC option for OS loader

### DIFF
--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_BootOption.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_BootOption.yaml
@@ -2,7 +2,7 @@
 #
 #  Slim Bootloader CFGDATA Option File.
 #
-#  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -10,11 +10,17 @@
 
 - $ACTION      :
     page         : OS
+# usb
 - !expand { BOOT_OPTION_TMPL : [ 0 ,   0       ,  0 ,    5   ,   0   ,    0xFF  ,     1 ,     1 , '/boot/sbl_os' ] }
 - !expand { BOOT_OPTION_TMPL : [ 1 ,   0x1F    ,  0 ,    5   ,   0   ,    0     ,     1 ,     1 , '/boot/sbl_rtcm' ] }
+# nvme
 - !expand { BOOT_OPTION_TMPL : [ 2 ,   0       ,  0 ,    6   ,   1   ,    0     ,     1 ,     1 , '/boot/sbl_os' ] }
 - !expand { BOOT_OPTION_TMPL : [ 3 ,   0x1F    ,  0 ,    6   ,   1   ,    0     ,     1 ,     1 , '/boot/sbl_rtcm' ] }
 - !expand { BOOT_OPTION_TMPL : [ 4 ,   0       ,  0 ,    6   ,   0   ,    0     ,     1 ,     1 , '/boot/sbl_os' ] }
 - !expand { BOOT_OPTION_TMPL : [ 5 ,   0x1F    ,  0 ,    6   ,   0   ,    0     ,     1 ,     1 , '/boot/sbl_rtcm' ] }
+# sata
 - !expand { BOOT_OPTION_TMPL : [ 6 ,   0       ,  0 ,    0   ,   0   ,    0xFF  ,     1 ,     1 , '/boot/sbl_os' ] }
 - !expand { BOOT_OPTION_TMPL : [ 7 ,   0x1F    ,  0 ,    0   ,   0   ,    0     ,     1 ,     1 , '/boot/sbl_rtcm' ] }
+# emmc
+- !expand { BOOT_OPTION_TMPL : [ 8,    0       ,  0 ,    2   ,   0   ,    0     ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 9,    0x1F    ,  0 ,    2   ,   0   ,    0     ,     1 ,     1 , '/boot/sbl_rtcm' ] }


### PR DESCRIPTION
ADL boards come with emmc as an in-built boot media. Add EMMC option in the default list in order for the OS to boot up when using OS loader payload.