### PR TITLE
feat: [ADL/RPL] Add support for FSP CrashLog data HOB.

### DIFF
--- a/Silicon/AlderlakePkg/AlderlakePkg.dec
+++ b/Silicon/AlderlakePkg/AlderlakePkg.dec
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -18,10 +18,8 @@
   gFspVariableNvDataHobGuid        = { 0xa034147d, 0x690c, 0x4154, {0x8d, 0xe6, 0xc0, 0x44, 0x64, 0x1d, 0xe9, 0x42}}
   gSchemaListGuid                  = { 0x3047c2ac, 0x5e8e, 0x4c55, {0xa1, 0xcb, 0xea, 0xad, 0x0a, 0x88, 0x86, 0x1b}}
   gPlatformAlderLakeTokenSpaceGuid = { 0xfec38282, 0xab42, 0x4aba, {0x8c, 0x25, 0xa4, 0x4e, 0x46, 0x23, 0xf7, 0x6e}}
+  gCpuCrashLogDataBufferHobGuid    = { 0x09f119d5, 0xa5ad, 0x4b30, {0x90, 0x9e, 0xfa, 0x94, 0xdc, 0xa3, 0xc9, 0xb5}}
 
 [PcdsFixedAtBuild]
   gPlatformAlderLakeTokenSpaceGuid.PcdAdlLpSupport    | FALSE      | BOOLEAN | 0x30000100
   gPlatformAlderLakeTokenSpaceGuid.PcdAdlNSupport     | FALSE      | BOOLEAN | 0x30000101
-
-[PcdsDynamic]
-  gPlatformAlderLakeTokenSpaceGuid.PcdCrashLogDataPtr | 0x0        | UINT32  | 0x30000102


### PR DESCRIPTION
When FSP implements Silicon support for dumping CrashLog data in FSP hoblist it will use this GUID. The PCD CrashLog Data pointer will no longer be used.