### PR TITLE
feat: [ADL/RPL] Update CrashLog support implementation for latest FSP.

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -615,7 +615,6 @@ DEBUG_CODE_END();
     break;
   case PostMemoryInit:
     UpdateMemoryInfo ();
-    GetCrashLogData();
     break;
   case PreTempRamExit:
     break;

--- a/Silicon/AlderlakePkg/AlderlakePkg.dec
+++ b/Silicon/AlderlakePkg/AlderlakePkg.dec
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -18,10 +18,8 @@
   gFspVariableNvDataHobGuid        = { 0xa034147d, 0x690c, 0x4154, {0x8d, 0xe6, 0xc0, 0x44, 0x64, 0x1d, 0xe9, 0x42}}
   gSchemaListGuid                  = { 0x3047c2ac, 0x5e8e, 0x4c55, {0xa1, 0xcb, 0xea, 0xad, 0x0a, 0x88, 0x86, 0x1b}}
   gPlatformAlderLakeTokenSpaceGuid = { 0xfec38282, 0xab42, 0x4aba, {0x8c, 0x25, 0xa4, 0x4e, 0x46, 0x23, 0xf7, 0x6e}}
+  gCpuCrashLogDataBufferHobGuid    = { 0x09f119d5, 0xa5ad, 0x4b30, {0x90, 0x9e, 0xfa, 0x94, 0xdc, 0xa3, 0xc9, 0xb5}}
 
 [PcdsFixedAtBuild]
   gPlatformAlderLakeTokenSpaceGuid.PcdAdlLpSupport    | FALSE      | BOOLEAN | 0x30000100
   gPlatformAlderLakeTokenSpaceGuid.PcdAdlNSupport     | FALSE      | BOOLEAN | 0x30000101
-
-[PcdsDynamic]
-  gPlatformAlderLakeTokenSpaceGuid.PcdCrashLogDataPtr | 0x0        | UINT32  | 0x30000102

--- a/Silicon/CommonSocPkg/Include/Library/CrashLogLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/CrashLogLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2022 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -24,16 +24,6 @@ typedef struct {
   CRASHLOG_HOB  Trace;
   CRASHLOG_HOB  Telemetry;
 } CPU_CRASHLOG_HOB;
-
-/**
-  Collect Crashlog Data for creating BERT table later in boot.
-
-**/
-VOID
-EFIAPI
-GetCrashLogData (
-  VOID
-);
 
 /**
   Update BERT Table with Crash Log data

--- a/Silicon/CommonSocPkg/Library/CrashLogLibNull/CrashLogLibNull.c
+++ b/Silicon/CommonSocPkg/Library/CrashLogLibNull/CrashLogLibNull.c
@@ -1,7 +1,7 @@
 /** @file
   This file contains the CrashLog feature support library template.
 
-  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2022 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -9,19 +9,6 @@
 #include <Uefi.h>
 #include <IndustryStandard/Acpi.h>
 #include <Library/CrashLogLib.h>
-
-/**
-  Collect CPU CrashLog data from Telemetry SRAM and store in ACPI BERT Table .
-
-**/
-VOID
-EFIAPI
-GetCrashLogData (
-  VOID
-)
-{
-  return;
-}
 
 /**
   Update BERT Table with Crash Log Telemetry SRAM data


### PR DESCRIPTION
New CrashLog support design is for FSP to collect CrashLog info and report in HOB. Bootloader responsibility is just to populate ACPI BERT with FSP collected CrashLog Data now. That way bootloader has no Silicon code.