### PR TITLE
feat: Added support to set ref_clock frequency for UFS device

### DIFF
--- a/BootloaderCommonPkg/Library/UfsBlockIoLib/UfsHci.h
+++ b/BootloaderCommonPkg/Library/UfsBlockIoLib/UfsHci.h
@@ -2,7 +2,7 @@
   UfsPassThruDxe driver is used to produce EFI_EXT_SCSI_PASS_THRU protocol interface
   for upper layer application to execute UFS-supported SCSI cmds.
 
-  Copyright (c) 2014, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -411,6 +411,13 @@ typedef enum {
   UfsUicDmeHibernateExit  = 0x18,
   UfsUicDmeTestMode       = 0x1A
 } UFS_UIC_OPCODE;
+
+typedef enum {
+  UfsCardRefClkFreq19p2Mhz,
+  UfsCardRefClkFreq26Mhz,
+  UfsCardRefClkFreq38p4Mhz,
+  UfsCardRefClkFreqObsolete
+} UFS_CARD_REF_CLK_FREQ_ATTRIBUTE;
 
 //
 // UTP Transfer Request Descriptor

--- a/BootloaderCommonPkg/Library/UfsBlockIoLib/UfsInternal.h
+++ b/BootloaderCommonPkg/Library/UfsBlockIoLib/UfsInternal.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2014, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -196,6 +196,21 @@ UfsExecScsiCmds (
   );
 
 /**
+  Switches the link Power Mode and Gear.
+
+  @param Private                    The pointer to the UFS_PEIM_HC_PRIVATE_DATA data structure.
+
+  @retval EFI_SUCCESS                Successfully switched the Power Mode and Gear
+  @retval others                     Failed to switch the Power Mode and Gear
+
+**/
+EFI_STATUS
+EFIAPI
+UfsPowerModeAndGearSwitch (
+  IN  UFS_PEIM_HC_PRIVATE_DATA       *Private
+  );
+
+/**
   Initialize the UFS host controller.
 
   @param[in] Private                 The pointer to the UFS_PEIM_HC_PRIVATE_DATA data structure.
@@ -265,6 +280,31 @@ UfsRwDeviceDesc (
   IN     UINT8                        Selector,
   IN OUT VOID                         *Descriptor,
   IN     UINT32                       *DescSize
+  );
+
+/**
+  Read or write specified attribute of a UFS device.
+
+  @param[in]      Private       The pointer to the UFS_PEIM_HC_PRIVATE_DATA data structure.
+  @param[in]      Read          The boolean variable to show r/w direction.
+  @param[in]      AttrId        The ID of Attribute.
+  @param[in]      Index         The Index of Attribute.
+  @param[in]      Selector      The Selector of Attribute.
+  @param[in, out] Attributes    The value of Attribute to be read or written.
+
+  @retval EFI_SUCCESS           The Attribute was read/written successfully.
+  @retval EFI_DEVICE_ERROR      A device error occurred while attempting to r/w the Attribute.
+  @retval EFI_TIMEOUT           A timeout occurred while waiting for the completion of r/w the Attribute.
+
+**/
+EFI_STATUS
+UfsRwAttributes (
+  IN     UFS_PEIM_HC_PRIVATE_DATA  *Private,
+  IN     BOOLEAN                     Read,
+  IN     UINT8                       AttrId,
+  IN     UINT8                       Index,
+  IN     UINT8                       Selector,
+  IN OUT UINT32                      *Attributes
   );
 
 /**


### PR DESCRIPTION
This Patch add the support to set UFS clock frequency.
- Added the function to read or write specified attribute of a UFS device
- Shifted function which switch the link power mode and gear after ref_clock setting because if an unsuported clock frequency being set, it won't be able to overwrite the corrupted UFS attributes.