### PR TITLE
fix: [ADL-PS] Fix for TSN build error caused by FSP UPD updates.

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -737,7 +737,7 @@ UpdateFspConfig (
     }
 
     // TSN feature support
-#if PLATFORM_RPLS || PLATFORM_RPLP || PLATFORM_RPLPCRB || PLATFORM_ADLP
+#if PLATFORM_RPLS || PLATFORM_RPLP || PLATFORM_RPLPCRB || PLATFORM_ADLP || PLATFORM_ADLPS
     FspsConfig->PchTsnEnable[0] = SiCfgData->PchTsnEnable;
     FspsConfig->PchTsnEnable[1] = SiCfgData->PchTsnEnable;
 #else


### PR DESCRIPTION
FSP M-UPD was updated so PchTsnEnable is now a 2-byte array with a separate byte for each port.

Tested on adlps-crb.