### PR TITLE
[UPX i12] Update Platform ID and display configuration

### DIFF
--- a/Platform/AlderlakeBoardPkg/Include/PlatformBoardId.h
+++ b/Platform/AlderlakeBoardPkg/Include/PlatformBoardId.h
@@ -38,6 +38,7 @@ Defines Platform BoardIds
 #define BoardIdAdlPLp5Rvp                             0x13
 #define PLATFORM_ID_ADL_P_LP5_RVP                     0x13
 
+#define BoardIdAdlpUpXtremei12                        0x04
 #define PLATFORM_ID_ADL_P_UPXI12                      0x04
 
 // AlderLake-S & ADP-S Boards

--- a/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -705,6 +705,7 @@ UpdateFspConfig (
         case PLATFORM_ID_ADL_P_LP4_RVP:
         case PLATFORM_ID_ADL_P_LP5_RVP:
         case PLATFORM_ID_ADL_P_DDR5_RVP:
+        case PLATFORM_ID_ADL_P_UPXI12:
           Fspmcfg->PchIshEnable       = 1;
       }
     }

--- a/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/EcSupport.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/EcSupport.c
@@ -393,6 +393,9 @@ GetBoardId (
     case BoardIdTestSDdr5SODimmRvp:
       *PlatformId = PLATFORM_ID_TEST_S_DDR5_SODIMM_RVP;
       break;
+    case BoardIdAdlpUpXtremei12:
+      *PlatformId = PLATFORM_ID_ADL_P_UPXI12;
+      break;
     default:
       DEBUG((DEBUG_INFO, "Unsupported board Id %x .....\n", *PlatformId));
       break;


### PR DESCRIPTION
Update Platform ID and display configuration.

Bootable with Ubuntu 22.04.1. Display supported via HDMI.

To stitch the SlimBootloader.bin with IFWI uses StitchLoader.py script with '-p' as given below:

python Platform/AlderlakeBoardPkg/Script/StitchLoader.py -i <BIOS_IMAGE_NAME> -s Outputs/adlp/SlimBootloader.bin -o sbl_upx12_ifwi.bin -p 0xAA000104