### PR TITLE
Add SBL Boot Performance Data to FPDT

### DIFF
--- a/BootloaderCorePkg/Include/Library/AcpiInitLib.h
+++ b/BootloaderCorePkg/Include/Library/AcpiInitLib.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -11,14 +11,42 @@
 #include <Uefi/UefiBaseType.h>
 #include <IndustryStandard/Acpi.h>
 
+typedef struct {
+  EFI_ACPI_5_0_FPDT_PERFORMANCE_RECORD_HEADER     Header;
+  UINT32                                          Reserved;
+  ///
+  /// 64-bit processor-relative physical address of the SBL Performance Table.
+  ///
+  UINT64                                          SblPerfTablePointer;
+} SBL_PERFORMANCE_TABLE_POINTER_RECORD;
+
+typedef struct {
+  EFI_ACPI_5_0_FPDT_PERFORMANCE_RECORD_HEADER     Header;
+  UINT32                                          Reserved;
+  ///
+  /// Time taken for Stage 1 execution in nanoseconds
+  ///
+  UINT64                                          Stage1Time;
+  ///
+  /// Time taken for Stage 2 execution in nanoseconds
+  ///
+  UINT64                                          Stage2Time;
+  ///
+  /// Time taken for OsLoader execution in nanoseconds
+  ///
+  UINT64                                          OsLoaderTime;
+
+} SBL_PERFORMANCE_RECORD;
+
 #pragma pack(1)
 ///
 /// Firmware Performance Data Table.
 ///
 typedef struct {
-  EFI_ACPI_DESCRIPTION_HEADER                             Header;            ///< Common ACPI description table header.
-  EFI_ACPI_5_0_FPDT_BOOT_PERFORMANCE_TABLE_POINTER_RECORD BootPointerRecord; ///< Basic Boot Performance Table Pointer record.
-  EFI_ACPI_5_0_FPDT_S3_PERFORMANCE_TABLE_POINTER_RECORD   S3PointerRecord;   ///< S3 Performance Table Pointer record.
+  EFI_ACPI_DESCRIPTION_HEADER                             Header;                 ///< Common ACPI description table header.
+  EFI_ACPI_5_0_FPDT_BOOT_PERFORMANCE_TABLE_POINTER_RECORD BootPointerRecord;      ///< Basic Boot Performance Table Pointer record.
+  EFI_ACPI_5_0_FPDT_S3_PERFORMANCE_TABLE_POINTER_RECORD   S3PointerRecord;        ///< S3 Performance Table Pointer record.
+  SBL_PERFORMANCE_TABLE_POINTER_RECORD                    SblPerfPointerRecord;   ///< SBL Performance Table Pointer record.
 } FIRMWARE_PERFORMANCE_TABLE;
 
 ///
@@ -42,6 +70,18 @@ typedef struct {
   EFI_ACPI_5_0_FPDT_PERFORMANCE_TABLE_HEADER  Header;    ///< Common ACPI table header.
   EFI_ACPI_5_0_FPDT_S3_RESUME_RECORD          S3Resume;  ///< Basic S3 Resume performance record.
 } S3_PERFORMANCE_TABLE;
+
+///
+/// SBL Performance Data Table.
+/// This structure contains SBL performance records like Stage1 done time,
+/// Stage2 done time, OsLoader done time
+#define SBL_PERFORMANCE_TABLE_SIGNATURE       SIGNATURE_32('S', 'B', 'L', 'T')
+#define SBL_PERFORMACE_TABLE_TYPE             0x3000
+#define SBL_PERFORMACE_TABLE_REVISION         0x01
+typedef struct {
+  EFI_ACPI_5_0_FPDT_PERFORMANCE_TABLE_HEADER  Header;         ///< Common ACPI table header.
+  SBL_PERFORMANCE_RECORD                      SblPerfRecord;  ///< SBL performance record.
+} SBL_PERFORMANCE_TABLE;
 
 #pragma pack()
 
@@ -88,6 +128,24 @@ EFI_STATUS
 EFIAPI
 UpdateFpdtS3Table (
   IN  UINT32                   AcpiTableBase
+  );
+
+/**
+  Find an ACPI table using the given signature.
+
+  @param[in] Rsdt            ACPI table RSDT pointer.
+  @param[in] Signature       ACPI table signature to find.
+  @param[in] EntryIndex      Address to receive the entry index if found.
+
+  @retval  ACPI table pointer if found.  And EntryIndex is updated.
+           NULL if not found.
+
+**/
+EFI_ACPI_DESCRIPTION_HEADER *
+FindAcpiTableBySignature (
+  IN   EFI_ACPI_DESCRIPTION_HEADER  *Rsdt,
+  IN   UINT32                        Signature,
+  IN   UINT32                       *EntryIndex   OPTIONAL
   );
 
 #endif

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -13,6 +13,7 @@
 #include <Library/SocInitLib.h>
 #include <Library/BoardInitLib.h>
 #include <Library/DebugDataLib.h>
+#include <Library/TimeStampLib.h>
 #include <Library/AcpiInitLib.h>
 #include <Service/PlatformService.h>
 #include <IndustryStandard/Acpi.h>
@@ -117,7 +118,85 @@ UpdateAcpiGnvs (
 }
 
 /**
-  Update ACPI tables using the new table provided.
+  This function updates SBL performance table in FPDT
+
+  @param[in]  SblPerfTable  Pointer to the SBL performance table
+
+  @retval  EFI_SUCCESS if operation is successful, EFI_NOT_FOUND if
+           performance HOB is not found
+
+**/
+EFI_STATUS
+UpdateAcpiSblt (
+  IN SBL_PERFORMANCE_TABLE            *SblPerfTable
+  )
+{
+  EFI_STATUS                        Status;
+  UINT32                            PerfIdx;
+  UINT64                            PerfTsc;
+  UINT32                            Time;
+  UINT64                            ResetVectorTime;
+  UINT16                            Id;
+  BL_PERF_DATA                      *PerfData;
+
+  PerfData = GetPerfDataPtr();
+  if (PerfData == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  // Grab relevant performance metrics
+  for (PerfIdx = 0; PerfIdx < MAX_TS_NUM; PerfIdx++) {
+    Id   = (RShiftU64 (PerfData->TimeStamp[PerfIdx], 48)) & 0xFFFF;
+    switch (Id) {
+    case 0x1000:  // Reset vector time
+    PerfTsc = PerfData->TimeStamp[PerfIdx] & 0x0000FFFFFFFFFFFFULL;
+    Time = (UINT32)DivU64x32 (PerfTsc, PerfData->FreqKhz);
+    ResetVectorTime = Time;
+    break;
+    case 0x3000:  // Stage 1 done (Stage 2 entry)
+      PerfTsc = PerfData->TimeStamp[PerfIdx] & 0x0000FFFFFFFFFFFFULL;
+      Time = (UINT32)DivU64x32 (PerfTsc, PerfData->FreqKhz);
+      SblPerfTable->SblPerfRecord.Stage1Time= Time;
+    break;
+    case 0x31F0:  // Stage 2 done (End of stage 2)
+      PerfTsc = PerfData->TimeStamp[PerfIdx] & 0x0000FFFFFFFFFFFFULL;
+      Time = (UINT32)DivU64x32 (PerfTsc, PerfData->FreqKhz);
+      SblPerfTable->SblPerfRecord.Stage2Time = Time;
+    break;
+    default:
+    break;
+    }
+
+    // 0x31F0 is the last measure point we can get from BL_PERF_DATA
+    // Get the current measure point by reading the timestamp
+    // to get an accurate timing measurement for OsLoader. Then,
+    // calculate deltas, convert timings to nanoseconds, and break
+    if (Id == 0x31F0) {
+      PerfTsc = ReadTimeStamp();
+      Time = (UINT32)DivU64x32 (PerfTsc, PerfData->FreqKhz);
+      SblPerfTable->SblPerfRecord.OsLoaderTime = Time;
+
+      SblPerfTable->SblPerfRecord.OsLoaderTime -= SblPerfTable->SblPerfRecord.Stage2Time;
+      SblPerfTable->SblPerfRecord.Stage2Time -= SblPerfTable->SblPerfRecord.Stage1Time;
+      SblPerfTable->SblPerfRecord.Stage1Time -= ResetVectorTime;
+
+      SblPerfTable->SblPerfRecord.Stage1Time = MultU64x32(SblPerfTable->SblPerfRecord.Stage1Time, 1000000);
+      SblPerfTable->SblPerfRecord.Stage2Time = MultU64x32(SblPerfTable->SblPerfRecord.Stage2Time, 1000000);
+      SblPerfTable->SblPerfRecord.OsLoaderTime = MultU64x32(SblPerfTable->SblPerfRecord.OsLoaderTime, 1000000);
+      break;
+    }
+  }
+
+  Status = EFI_SUCCESS;
+  DEBUG((DEBUG_INFO, "Updated SBL Performance Table: S1 = %ldns, S2 = %ldns, OSL = %ldns\n",
+        SblPerfTable->SblPerfRecord.Stage1Time, SblPerfTable->SblPerfRecord.Stage2Time,
+        SblPerfTable->SblPerfRecord.OsLoaderTime));
+
+  return Status;
+}
+
+/**
+  Find an ACPI table using the given signature.
 
   @param[in] Rsdt            ACPI table RSDT pointer.
   @param[in] Signature       ACPI table signature to find.
@@ -188,6 +267,8 @@ AcpiTableUpdate (
   EFI_STATUS                        Status;
   S3_DATA                          *S3Data;
   UINT32                            AcpiMax;
+  SBL_PERFORMANCE_TABLE            *SblPerfTable;
+  FIRMWARE_PERFORMANCE_TABLE        *Fpdt;
 
   if ((AcpiTable == NULL) || (Length < sizeof (EFI_ACPI_DESCRIPTION_HEADER))) {
     return EFI_INVALID_PARAMETER;
@@ -207,6 +288,22 @@ AcpiTableUpdate (
   Size   = 0;
   while (Size < Length) {
     AcpiHdr = (EFI_ACPI_DESCRIPTION_HEADER *)(AcpiTable + Size);
+
+    // Update SBL Performance Table if signature matches
+    if (AcpiHdr->Signature == EFI_ACPI_5_0_FIRMWARE_PERFORMANCE_DATA_TABLE_SIGNATURE) {
+      // FPDT points to SBL Performance Table
+      Fpdt = (FIRMWARE_PERFORMANCE_TABLE *)AcpiHdr;
+      SblPerfTable = (SBL_PERFORMANCE_TABLE *)(UINTN)Fpdt->SblPerfPointerRecord.SblPerfTablePointer;
+      if (SblPerfTable == NULL) {
+        DEBUG((DEBUG_INFO, "SBL Performance table not found!\n"));
+        Status = EFI_NOT_FOUND;
+        break;
+      } else {
+        DEBUG ((DEBUG_INFO, "SBLT found @ 0x%X, updating..\n", SblPerfTable));
+        Status = UpdateAcpiSblt(SblPerfTable);
+        break;
+      }
+    }
 
     //
     // Verify Checksum

--- a/PayloadPkg/OsLoader/BootParameters.c
+++ b/PayloadPkg/OsLoader/BootParameters.c
@@ -324,6 +324,7 @@ UpdateOsParameters (
   }
   DEBUG ((DEBUG_INFO, "\nDump normal boot image info:\n"));
   DisplayInfo (LoadedImage);
+  AddMeasurePoint(0x40E0);
 
   return Status;
 }

--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -646,17 +646,10 @@ BeforeOSJump (
   CHAR8 *Message
   )
 {
-  PLATFORM_SERVICE          *PlatformService;
-  LOADER_PLATFORM_INFO      *LoaderPlatformInfo;
-  DEBUG_LOG_BUFFER_HEADER   *LogBufHdr;
-  UINT8                      PlatformDebugEnabled;
-
-  PlatformService = (PLATFORM_SERVICE *) GetServiceBySignature (PLATFORM_SERVICE_SIGNATURE);
-  if ((PlatformService != NULL) && (PlatformService->NotifyPhase != NULL)) {
-    PlatformService->NotifyPhase (ReadyToBoot);
-    PlatformService->NotifyPhase (EndOfFirmware);
-  }
-  AddMeasurePoint (0x40F0);
+  PLATFORM_SERVICE                              *PlatformService;
+  LOADER_PLATFORM_INFO                          *LoaderPlatformInfo;
+  DEBUG_LOG_BUFFER_HEADER                       *LogBufHdr;
+  UINT8                                          PlatformDebugEnabled;
 
   LoaderPlatformInfo = (LOADER_PLATFORM_INFO *)GetLoaderPlatformInfoPtr();
   if (LoaderPlatformInfo == NULL) {
@@ -667,6 +660,13 @@ BeforeOSJump (
     if(TpmIndicateReadyToBoot (PlatformDebugEnabled) != EFI_SUCCESS) {
       DEBUG ((DEBUG_ERROR, "FAILED to complete TPM ReadyToBoot actions. \n"));
     }
+    AddMeasurePoint (0x40F0);
+  }
+
+  PlatformService = (PLATFORM_SERVICE *) GetServiceBySignature (PLATFORM_SERVICE_SIGNATURE);
+  if ((PlatformService != NULL) && (PlatformService->NotifyPhase != NULL)) {
+    PlatformService->NotifyPhase (ReadyToBoot);
+    PlatformService->NotifyPhase (EndOfFirmware);
   }
   AddMeasurePoint (0x4100);
 

--- a/PayloadPkg/OsLoader/PerformanceData.c
+++ b/PayloadPkg/OsLoader/PerformanceData.c
@@ -47,9 +47,9 @@ LinuxPerfIdToStr (
   case 0x40E0:
     return "Kernel setup";
   case 0x40F0:
-    return "FSP ReadyToBoot/EndOfFirmware notify";
-  case 0x4100:
     return "TPM IndicateReadyToBoot";
+  case 0x4100:
+    return "FSP ReadyToBoot/EndOfFirmware notify";
   default:
     return NULL;
   }

--- a/Platform/CommonBoardPkg/AcpiTables/Fpdt/Fpdt.aslc
+++ b/Platform/CommonBoardPkg/AcpiTables/Fpdt/Fpdt.aslc
@@ -1,7 +1,7 @@
 /**@file
   This file contains a structure definition for the ACPI FPDT Table.
 
-  Copyright (c) 2019 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -56,6 +56,18 @@ FIRMWARE_PERFORMANCE_TABLE  FPDT = {
       },
       0,  // Reserved
       0   // S3PerformanceTablePointer will be updated at runtime.
+    },
+    //
+    // SBL Performance Table Pointer Record.
+    //
+    {
+      {
+        SBL_PERFORMACE_TABLE_TYPE,     // Type
+        sizeof (SBL_PERFORMANCE_RECORD), // Length
+        SBL_PERFORMACE_TABLE_REVISION  // Revision
+      },
+      0,  // Reserved
+      0   // SblPerfTablePointer will be updated at runtime.
     }
 };
 


### PR DESCRIPTION
Adds the SBL boot performance data (Stage1 time, Stage 2 time, OsLoader time)
to the FPDT with type 0x3000 (Reserved for platform firmware Vendor usage)