### PR TITLE
fix: [RPL-P] CRB hang in UEFI payload when PCIe switch present.

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -458,9 +458,13 @@ BoardInit (
     if (FeaturePcdGet (PcdEnablePciePm)) {
       PciePmConfig ();
     }
-    Status = SetFrameBufferWriteCombining (0, MAX_UINT32);
-    if (EFI_ERROR(Status)) {
-      DEBUG ((DEBUG_INFO, "Failed to set GFX framebuffer as WC\n"));
+    // UEFI Payload will change cache type to UC based on PCI root bridge
+    // info HOB MMIO range. In some cases this causes a CPU exception.
+    if (GetPayloadId () != UEFI_PAYLOAD_ID_SIGNATURE) {
+      Status = SetFrameBufferWriteCombining (0, MAX_UINT32);
+      if (EFI_ERROR(Status)) {
+        DEBUG ((DEBUG_INFO, "Failed to set GFX framebuffer as WC\n"));
+      }
     }
     InterruptRoutingInit ();
     break;


### PR DESCRIPTION
This change only sets the GFX framebuffer cache type to Write-combining when not booting the UEFI payload. The UEFI payload PCI hostbridge driver will override the WC setting anways for the whole PCI root bridge memory range, so it wasn't gaining the write-combining performance bonus, and was causing a CPU exception in this particular case for RPL-P.