### PR TITLE
feat: [ADL/RPL] FuSa updates based on latest FSP and specification.

### DIFF
--- a/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr4.dlt
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr4.dlt
@@ -62,6 +62,8 @@ GEN_CFG_DATA.VbtImageId                  | 1
 SILICON_CFG_DATA.CpuPcieRpAspm           | {0x2, 0x2, 0x2, 0x0}
 SILICON_CFG_DATA.EnableTimedGpio0        | 0x1
 SILICON_CFG_DATA.EnableTimedGpio1        | 0x1
+SILICON_CFG_DATA.D3HotEnable             | 0x0
+SILICON_CFG_DATA.VccSt                   | 0x0
 
 POWER_CFG_DATA.PsysPmax                  | 0
 POWER_CFG_DATA.TdcEnable                 | {0x1, 0x1, 0x0, 0x0, 0x0}

--- a/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr4_Sodimm.dlt
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr4_Sodimm.dlt
@@ -55,6 +55,8 @@ GEN_CFG_DATA.VbtImageId                  | 1
 SILICON_CFG_DATA.CpuPcieRpAspm           | {0x2, 0x2, 0x2, 0x0}
 SILICON_CFG_DATA.EnableTimedGpio0        | 0x1
 SILICON_CFG_DATA.EnableTimedGpio1        | 0x1
+SILICON_CFG_DATA.D3HotEnable             | 0x0
+SILICON_CFG_DATA.VccSt                   | 0x0
 
 POWER_CFG_DATA.TdcEnable | {0x1, 0x1, 0x0, 0x0, 0x0}
 

--- a/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr5.dlt
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr5.dlt
@@ -67,6 +67,8 @@ GEN_CFG_DATA.VbtImageId                  | 1
 SILICON_CFG_DATA.CpuPcieRpAspm           | {0x2, 0x2, 0x2, 0x0}
 SILICON_CFG_DATA.EnableTimedGpio0        | 0x1
 SILICON_CFG_DATA.EnableTimedGpio1        | 0x1
+SILICON_CFG_DATA.D3HotEnable             | 0x0
+SILICON_CFG_DATA.VccSt                   | 0x0
 
 MEMORY_CFG_DATA.BootFrequency            | 0x2
 

--- a/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr5_Sodimm.dlt
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgDataInt_Adls_Crb_Ddr5_Sodimm.dlt
@@ -60,6 +60,8 @@ GEN_CFG_DATA.VbtImageId                  | 1
 SILICON_CFG_DATA.CpuPcieRpAspm           | {0x2, 0x2, 0x2, 0x0}
 SILICON_CFG_DATA.EnableTimedGpio0        | 0x1
 SILICON_CFG_DATA.EnableTimedGpio1        | 0x1
+SILICON_CFG_DATA.D3HotEnable             | 0x0
+SILICON_CFG_DATA.VccSt                   | 0x0
 
 MEMORY_CFG_DATA.BootFrequency            | 0x2
 

--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_FuSa.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_FuSa.yaml
@@ -102,11 +102,11 @@ $ACTION      :
       length       : 0x01
       value        : 0x0
   - McParity :
-      name         : FuSa MC Parity
+      name         : FuSa MC/CMF Parity
       type         : Combo
       option       : $EN_DIS
       help         : >
-                     MC Parity and error reporting configuration
+                     MC and CMF Parity and error reporting configuration
       length       : 0x01
       value        : 0x0
   - IbeccParity :
@@ -115,14 +115,6 @@ $ACTION      :
       option       : $EN_DIS
       help         : >
                      IBECC Parity and error reporting configuration
-      length       : 0x01
-      value        : 0x0
-  - CmfParity :
-      name         : FuSa CMF Parity
-      type         : Combo
-      option       : $EN_DIS
-      help         : >
-                     CMF Parity and error reporting configuration
       length       : 0x01
       value        : 0x0
   - DiagGspiCtrlr :

--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_Fusa_Feature.dlt
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_Fusa_Feature.dlt
@@ -28,7 +28,6 @@ FUSA_CFG_DATA.IopFusaConfigEnable | 1
 FUSA_CFG_DATA.PsfFusaConfigEnable | 1
 FUSA_CFG_DATA.McParity | 1
 FUSA_CFG_DATA.IbeccParity | 1
-FUSA_CFG_DATA.CmfParity | 1
 
 # IBECC
 MEMORY_CFG_DATA.Ibecc | 1
@@ -41,7 +40,6 @@ SILICON_CFG_DATA.CrashLogReporting | 1
 
 # PROCHOT
 POWER_CFG_DATA.BiProcHot | 0
-POWER_CFG_DATA.DisableProcHotOut | 1
 POWER_CFG_DATA.ProcHotResponse | 1
 POWER_CFG_DATA.ProcHotLock | 1
 
@@ -72,6 +70,16 @@ SILICON_CFG_DATA.CpuPcieRpAspm                | {0, 0, 0, 0}
 SILICON_CFG_DATA.CpuPcieRpL1Substates         | {0, 0, 0, 0}
 SILICON_CFG_DATA.CpuPcieRpPtmEnabled          | {1, 1, 1, 1}
 SILICON_CFG_DATA.CpuPcieClockGating           | 0
+SILICON_CFG_DATA.CpuPciePowerGating           | 0
 SILICON_CFG_DATA.CpuPcieRpMultiVcEnabled      | {1, 1, 1, 1}
 SILICON_CFG_DATA.L2QosEnumerationEn           | 1
 SILICON_CFG_DATA.RenderStandby                | 0
+
+# MISC settings that affect FuSa
+SILICON_CFG_DATA.D3ColdEnable                 | 0
+SILICON_CFG_DATA.D3HotEnable                  | 0
+SILICON_CFG_DATA.IehMode                      | 1
+SILICON_CFG_DATA.TcCstateLimit                | 0
+SILICON_CFG_DATA.VccSt                        | 0
+
+MEMORY_CFG_DATA.PlatformDebugConsent          | 1

--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -109,6 +109,14 @@
                      Describes whether the PCI Express Clock Gating for each root port is enabled by platform modules. 0- Disable; 1- Enable.
       length       : 0x01
       value        : 0x1
+  - CpuPciePowerGating :
+      name         : CPU PCIe RootPort Power Gating
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     Describes whether the PCI Express Power Gating for each root port is enabled by platform modules. 0- Disable; 1- Enable.
+      length       : 0x01
+      value        : 0x1
   - CpuPcieRpAspm :
       name         : PCIE RP Aspm
       type         : EditNum, HEX, (0x00,0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
@@ -492,3 +500,43 @@
                      Enable L2 Qos Enumerate
       length       : 0x01
       value        : 0x0
+  - IehMode :
+      name         : IEH Mode
+      type         : Combo
+      option       : 0:Bypass. 1:Enable
+      help         : >
+                     Integrated Error Handler Mode
+      length       : 0x01
+      value        : 0x0
+  - D3HotEnable :
+      name         : Enable D3 Hot in TCSS
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     This policy will enable/disable D3 hot support in IOM
+      length       : 0x01
+      value        : 0x1
+  - D3ColdEnable :
+      name         : Enable D3 Cold in TCSS
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     This policy will enable/disable D3 cold support in IOM
+      length       : 0x01
+      value        : 0x1
+  - TcCstateLimit :
+      name         : TC State in TCSS
+      type         : Combo
+      option       : 0:Disable, 1:1, 2:2, 4:4, 5:5, 6:6, 7:7, 10:10
+      help         : >
+                     TC C-State Limit in IOM
+      length       : 0x01
+      value        : 10
+  - VccSt        :
+      name         : VCCST request for IOM
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     This policy will enable/disable VCCST and also decides if message would be replayed in S4/S5
+      length       : 0x01
+      value        : 0x01

--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -798,7 +798,17 @@ UpdateFspConfig (
         DEBUG ((DEBUG_ERROR, "TSN MAC subregion not found! %r\n", Status));
       }
     }
-    FspsConfig->OpioRecenter = SiCfgData->OpioRecenter;
+    FspsConfig->IehMode               = SiCfgData->IehMode;
+    FspsConfig->OpioRecenter          = SiCfgData->OpioRecenter;
+    FspsConfig->D3HotEnable           = SiCfgData->D3HotEnable;
+    FspsConfig->D3ColdEnable          = SiCfgData->D3ColdEnable;
+    FspsConfig->TcCstateLimit         = SiCfgData->TcCstateLimit;
+    FspsConfig->VccSt                 = SiCfgData->VccSt;
+    // Cpu Pcie
+    FspsConfig->CpuPciePowerGating[0] = SiCfgData->CpuPciePowerGating;
+    FspsConfig->CpuPciePowerGating[1] = SiCfgData->CpuPciePowerGating;
+    FspsConfig->CpuPciePowerGating[2] = SiCfgData->CpuPciePowerGating;
+    FspsConfig->CpuPciePowerGating[3] = SiCfgData->CpuPciePowerGating;
 #if !defined(PLATFORM_ADLN) && !defined(PLATFORM_ASL)
     FspsConfig->L2QosEnumerationEn = SiCfgData->L2QosEnumerationEn;
 #endif
@@ -822,10 +832,6 @@ UpdateFspConfig (
   FspsConfig->VmdEnable = 0;
 
   // Cpu Pcie
-  FspsConfig->CpuPciePowerGating[0] = 0x1;
-  FspsConfig->CpuPciePowerGating[1] = 0x1;
-  FspsConfig->CpuPciePowerGating[2] = 0x1;
-  FspsConfig->CpuPciePowerGating[3] = 0x1;
   FspsConfig->CpuPcieRpFunctionSwap = 0x0;
   for (Index = 0; Index < 3; Index++) {
     FspsConfig->CpuPcieRpMaxPayload[Index] = 0x1;
@@ -859,7 +865,6 @@ UpdateFspConfig (
   FspsConfig->PchEspiLgmrEnable = 0x0;
   FspsConfig->ForcMebxSyncUp = 0x0;
   FspsConfig->PmcModPhySusPgEnable = 0x0;
-  FspsConfig->D3HotEnable = 0x0;
   FspsConfig->IomTypeCPortPadCfg[2] = 0x6040000;
   FspsConfig->IomTypeCPortPadCfg[3] = 0x6040011;
   FspsConfig->DmiTS0TW = 0x3;
@@ -1039,14 +1044,14 @@ UpdateFspConfig (
     FspsConfig->CstateLatencyControl1TimeUnit = PowerCfgData->CstateLatencyControl1TimeUnit;
     FspsConfig->CstateLatencyControl2TimeUnit = PowerCfgData->CstateLatencyControl2TimeUnit;
     FspsConfig->CstateLatencyControl3TimeUnit = PowerCfgData->CstateLatencyControl3TimeUnit;
-     FspsConfig->CstateLatencyControl4TimeUnit = PowerCfgData->CstateLatencyControl4TimeUnit;
-     FspsConfig->CstateLatencyControl5TimeUnit = PowerCfgData->CstateLatencyControl5TimeUnit;
-     FspsConfig->PkgCStateLimit                = PowerCfgData->PkgCStateLimit;
-     FspsConfig->CstateLatencyControl1Irtl     = PowerCfgData->CstateLatencyControl1Irtl;
-     FspsConfig->CstateLatencyControl2Irtl     = PowerCfgData->CstateLatencyControl2Irtl;
-     FspsConfig->CstateLatencyControl3Irtl     = PowerCfgData->CstateLatencyControl3Irtl;
-     FspsConfig->CstateLatencyControl4Irtl     = PowerCfgData->CstateLatencyControl4Irtl;
-     FspsConfig->CstateLatencyControl5Irtl     = PowerCfgData->CstateLatencyControl5Irtl;
+    FspsConfig->CstateLatencyControl4TimeUnit = PowerCfgData->CstateLatencyControl4TimeUnit;
+    FspsConfig->CstateLatencyControl5TimeUnit = PowerCfgData->CstateLatencyControl5TimeUnit;
+    FspsConfig->PkgCStateLimit                = PowerCfgData->PkgCStateLimit;
+    FspsConfig->CstateLatencyControl1Irtl     = PowerCfgData->CstateLatencyControl1Irtl;
+    FspsConfig->CstateLatencyControl2Irtl     = PowerCfgData->CstateLatencyControl2Irtl;
+    FspsConfig->CstateLatencyControl3Irtl     = PowerCfgData->CstateLatencyControl3Irtl;
+    FspsConfig->CstateLatencyControl4Irtl     = PowerCfgData->CstateLatencyControl4Irtl;
+    FspsConfig->CstateLatencyControl5Irtl     = PowerCfgData->CstateLatencyControl5Irtl;
 
     // Cpu power related settings
     for (Index = 0; Index < TURBO_RATIO_LIMIT_ARRAY_SIZE; Index++) {
@@ -1113,10 +1118,8 @@ UpdateFspConfig (
     FspsConfig->CnviClkreqPinMux = 0x294ce605;
     FspsConfig->PmcUsb2PhySusPgEnable = 0x1;
     FspsConfig->PmcModPhySusPgEnable = 0x1;
-    FspsConfig->D3HotEnable = 0x1;
     FspsConfig->IomTypeCPortPadCfg[2] = 0x0;
     FspsConfig->IomTypeCPortPadCfg[3] = 0x0;
-    FspsConfig->D3ColdEnable = 0x1;
     FspsConfig->UsbTcPortEn = 0xF;
     FspsConfig->ITbtPcieTunnelingForUsb4 = 0x1;
     FspsConfig->ITbtPcieRootPortEn[0] = 0x1;
@@ -1135,7 +1138,6 @@ UpdateFspConfig (
     FspsConfig->CstCfgCtrIoMwaitRedirection = 0;
     FspsConfig->PmcLpmS0ixSubStateEnableMask = 0x9;
     FspsConfig->VbtSize           = 0x2200;
-    FspsConfig->VccSt             = 0x1;
     FspsConfig->CpuPcieRpGen3Uptp[2] = 0x5;
     FspsConfig->CpuPcieRpGen4Uptp[2] = 0x8;
     FspsConfig->CpuPcieRpGen4Dptp[2] = 0x9;

--- a/Silicon/AlderlakePkg/AlderlakePkg.dec
+++ b/Silicon/AlderlakePkg/AlderlakePkg.dec
@@ -25,5 +25,5 @@
   gPlatformAlderLakeTokenSpaceGuid.PcdAdlLpSupport    | FALSE      | BOOLEAN | 0x30000100
   gPlatformAlderLakeTokenSpaceGuid.PcdAdlNSupport     | FALSE      | BOOLEAN | 0x30000101
 
-[PcdsPatchableInModule]
-  gPlatformAlderLakeTokenSpaceGuid.PcdCrashLogDataPtr | 0x00000000 | UINT32  | 0x30000200
+[PcdsDynamic]
+  gPlatformAlderLakeTokenSpaceGuid.PcdFusaDiagnosticBoot | 0 | BOOLEAN | 0x30000200

--- a/Silicon/AlderlakePkg/Include/Library/PchGspiLib.h
+++ b/Silicon/AlderlakePkg/Include/Library/PchGspiLib.h
@@ -1,0 +1,46 @@
+/** @file
+  Pch access library for GSPI controller.
+
+  This library is provided as an example for FuSa proof of concept
+  communication, so only SPI write is implemented.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __PCH_GSPI_LIB_H__
+#define __PCH_GSPI_LIB_H__
+
+#include <Base.h>
+
+/**
+  Initialize GSPI controller instance for polled PIO operation.
+
+ */
+EFI_STATUS
+EFIAPI
+PchGspiInit(
+  UINT8 Controller
+  );
+
+/**
+  Write Buffer to SPI controller indicated. Configure HW
+  chip select setting first.
+
+  @param Controller
+  @param ChipSelect
+  @param Data
+  @param DataSize
+  @return EFI_STATUS
+ */
+EFI_STATUS
+EFIAPI
+PchGspiWrite(
+  UINT8 Controller,
+  UINT8 ChipSelect,
+  UINT8 *Data,
+  UINTN DataSize
+  );
+
+#endif //__PCH_GSPI_LIB_H__


### PR DESCRIPTION
- MC and CMF Parity combined into one FSP UPD.

- Added SBL Config items for IehMode, TCSS D3Hot and D3Cold, CPU PCIe Power gating, VccSt, TCSS Cstate limit. These are all needed for the FuSa specific dlt file. ADL-S dlt files updated so D3Hot and VccSt defaults are unchanged, since these defaults were previously set by PCH sku.

- FuSa diagnostic mode PCD to track Diagnostic mode across stages. Crash Log Data PCD will not be used and has been removed.

- GSPI example driver header file added.