### PR TITLE
[UPX i12] Disable EC from ACPI table

### DIFF
--- a/Platform/AlderlakeBoardPkg/CfgData/CfgDataExt_Upx12.dlt
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgDataExt_Upx12.dlt
@@ -99,6 +99,7 @@ SILICON_CFG_DATA.CpuPcieRpAspm        | {0x2, 0x2, 0x2, 0x0}
 SILICON_CFG_DATA.CpuPcieRpL1Substates | {0x2, 0x2, 0x2, 0x2}
 SILICON_CFG_DATA.PtmEnabled           | { 0x1, 0x1, 0x1, 0x1}
 SILICON_CFG_DATA.PchUfsEnable         |  0x0
+SILICON_CFG_DATA.EcAvailable          | 0x0
 
 GPIO_CFG_DATA.GpioPinConfig0_GPP_B00 | 0x0350A383
 GPIO_CFG_DATA.GpioPinConfig1_GPP_B00 | 0x00002001


### PR DESCRIPTION
Reset EC available flag to 0 in dlt file.
Resolved ACPI Errors from dmesg log that point to EC Hardware.
Tested to boot up Ubuntu and Windows.