### PR TITLE
fix: [ADL] align 64KB flash protected ranges

### DIFF
--- a/Platform/AlderlakeBoardPkg/BoardConfig.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfig.py
@@ -154,7 +154,7 @@ class Board(BaseBoard):
         self.TOP_SWAP_SIZE        = 0x00080000
         self.REDUNDANT_SIZE       = self.UCODE_SIZE + self.STAGE2_SIZE + self.STAGE1B_SIZE + \
                                     self.FWUPDATE_SIZE + self.CFGDATA_SIZE + self.KEYHASH_SIZE
-
+        self.REDUNDANT_SIZE       = ((self.REDUNDANT_SIZE + 0xFFFF) & ~0xFFFF)
         self.SIIPFW_SIZE = 0x1000
 
         self.ENABLE_TCC = 0
@@ -392,8 +392,8 @@ class Board(BaseBoard):
                 ('VARIABLE.bin' ,  ''        , self.VARIABLE_SIZE, STITCH_OPS.MODE_FILE_NOP, STITCH_OPS.MODE_POS_TAIL),
                 ('MRCDATA.bin'  ,  ''        , self.MRCDATA_SIZE,  STITCH_OPS.MODE_FILE_NOP, STITCH_OPS.MODE_POS_TAIL),
                 ('EPAYLOAD.bin',   ''        , self.EPAYLOAD_SIZE, STITCH_OPS.MODE_FILE_PAD, STITCH_OPS.MODE_POS_TAIL),
-                ('UEFIVARIABLE.bin', ''      , self.UEFI_VARIABLE_SIZE,  STITCH_OPS.MODE_FILE_NOP, STITCH_OPS.MODE_POS_TAIL),
                 ('PAYLOAD.bin'  ,  'Lz4'    , self.PAYLOAD_SIZE,  STITCH_OPS.MODE_FILE_PAD, STITCH_OPS.MODE_POS_TAIL),
+                ('UEFIVARIABLE.bin', ''      , self.UEFI_VARIABLE_SIZE,  STITCH_OPS.MODE_FILE_NOP, STITCH_OPS.MODE_POS_TAIL),
                 ]
             ),
             ('REDUNDANT_A.bin', [


### PR DESCRIPTION
When UEFI Payload exists, SBL splits BIOS region into two flash protected ranges, PR0 and PR1, by excluding UVAR (UEFI Var) component.

Because ADL SPI controller supports 64KB maximum Erase Block Size, current flash layout will result into 2 faults without the patch:
  Fault 1: the size of PR0 and PR1 are not 64KB aligned,
  Fault 2: the base address of PR1 is not 64KB aligned.

The patch updates REDUNDANT_SIZE to make sure it is 64KB aligned and moves UVAR as the 1st region in non-redundant region. Because (1)	TOP_SWAP_SIZE, (2) SLIMBOOTLOADER_SIZE and (3) UEFI_VARIABLE_SIZE (when payload exists) are already 64KB aligned, it will be 64KB aligned after moving UVAR to the 1st region of non-redudant region.

Verified: ADL-P RVP