### PR TITLE
[ADLN/ASL] Fastboot improvement

### DIFF
--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
@@ -128,8 +128,8 @@ class Board(BaseBoard):
             self.VERIFIED_BOOT_HASH_MASK    = 0
 
         if self.RELEASE_MODE and self.ENABLE_FAST_BOOT:
-            self.STAGE1A_SIZE         = 0x00015000
-            self.STAGE1B_SIZE         = 0x000C0000
+            self.STAGE1A_SIZE         = 0x00016000
+            self.STAGE1B_SIZE         = 0x000E0000
             self.STAGE2_SIZE          = 0x000C0000
             self.STAGE2_FD_SIZE       = 0x000F0000
             self.PAYLOAD_SIZE         = 0x00024000

--- a/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/EcSupport.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/EcSupport.c
@@ -348,7 +348,10 @@ GetBoardId (
   //
   *PlatformId = 0xFF;
 
+#if !defined(PLATFORM_ADLN) && !defined(PLATFORM_ASL)
   GetBoardIdFromEC(&BoardID);
+#endif
+
   if (BoardID == 0xFF){
     //EC is not detected (timeout)
     GetBoardIdFromSmbus(PlatformId);


### PR DESCRIPTION
Saved timeout from reading EC. Reduced up to 300ms. Adjusted Stage 1A & 1B region size for ADLN Fastboot feature.