### PR TITLE
fix: update GPIO base table ID check

### DIFF
--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -119,7 +119,7 @@ GpioInit (
   GpioCfgBaseHdr = NULL;
 
   //Find the GPIO CFG Data based on Platform ID. GpioTableData is the start of the GPIO entries
-  if (GpioCfgCurrHdr->GpioBaseTableId < 16) {
+  if (GpioCfgCurrHdr->GpioBaseTableId < GPIO_MAX_BASE_TABLE_PLATFORM_ID) {
     DEBUG ((DEBUG_INFO, "Get base platform GPIO table from board ID %d\n", GpioCfgCurrHdr->GpioBaseTableId));
     GpioCfgBaseHdr = (GPIO_CFG_HDR *)FindConfigDataByPidTag (GpioCfgCurrHdr->GpioBaseTableId, CDATA_GPIO_TAG);
     if (GpioCfgBaseHdr == NULL) {

--- a/Silicon/CommonSocPkg/Include/Library/GpioLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/GpioLib.h
@@ -23,6 +23,11 @@
 //
 #define GPIO_PADCFG_DW_REG_NUMBER  4
 
+//
+// Max supported platform ID for GPIO base table
+//
+#define GPIO_MAX_BASE_TABLE_PLATFORM_ID  32
+
 /**
   This procedure will initialize multiple GPIO pins. Use GPIO_INIT_CONFIG structure.
   Structure contains fields that can be used to configure each pad.

--- a/Silicon/CommonSocPkg/Library/GpioLib/GpioInit.c
+++ b/Silicon/CommonSocPkg/Library/GpioLib/GpioInit.c
@@ -692,7 +692,7 @@ ConfigureGpio (
   // Find the GPIO CFG Data based on Platform ID
   // GpioTableData is the start of the GPIO entries
   //
-  if (GpioCfgCurrHdr->BaseTableId < 16) {
+  if (GpioCfgCurrHdr->BaseTableId < GPIO_MAX_BASE_TABLE_PLATFORM_ID) {
     GpioCfgBaseHdr = (ARRAY_CFG_HDR *)FindConfigDataByPidTag (GpioCfgCurrHdr->BaseTableId, Tag);
     if (GpioCfgBaseHdr == NULL) {
       DEBUG ((GPIO_DEBUG_ERROR, "Cannot find base GPIO table for platform ID %d\n", GpioCfgCurrHdr->BaseTableId));


### PR DESCRIPTION
A GPIO YAML can refer to any platform ID's GPIO table as the base GPIO table. Since SBL supports upto 32 platform IDs, the number for the check in the if condition should be 32.