### PR TITLE
fix: [EHL] send EOP message

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -330,3 +330,4 @@
   gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled                  | FALSE  | BOOLEAN | 0x20000221
   # This PCD will enable the SBL component corruption command
   gPlatformCommonLibTokenSpaceGuid.PcdCmdCorruptShellAppEnabled   | FALSE  | BOOLEAN | 0x20000222
+  gPlatformCommonLibTokenSpaceGuid.PcdFspNoEop                    | FALSE  | BOOLEAN | 0x20000223

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -345,6 +345,7 @@
   gPayloadTokenSpaceGuid.PcdPayloadModuleEnabled          | $(ENABLE_PAYLOD_MODULE)
   gPlatformModuleTokenSpaceGuid.PcdEnableDts              | $(ENABLE_DTS)
   gPlatformModuleTokenSpaceGuid.PcdEnablePciePm           | $(ENABLE_PCIE_PM)
+  gPlatformCommonLibTokenSpaceGuid.PcdFspNoEop            | $(HAVE_NO_FSP_EOP)
 
 !ifdef $(S3_DEBUG)
   gPlatformModuleTokenSpaceGuid.PcdS3DebugEnabled         | $(S3_DEBUG)

--- a/Platform/ElkhartlakeBoardPkg/BoardConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/BoardConfig.py
@@ -1,7 +1,7 @@
 ## @file
 # This file is used to provide board specific image information.
 #
-#  Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
@@ -56,6 +56,9 @@ class Board(BaseBoard):
         # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)
         self.ENABLE_SMM_REBASE    = 2
         self.ENABLE_FRAMEBUFFER_INIT = 1
+
+        # EHL FSP Ready To Boot does not call EOP
+        self.HAVE_NO_FSP_EOP      = 1
 
         self.SIIPFW_SIZE = 0x1000
 

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -80,6 +80,7 @@
 #include <Register/RegsSpi.h>
 #include <Library/GpioLib.h>
 #include <Library/PlatformHookLib.h>
+#include <Library/ResetSystemLib.h>
 
 BOOLEAN mTccDsoTuning      = FALSE;
 UINT8   mTccRtd3Support    = 0;
@@ -711,6 +712,7 @@ BoardInit (
   VOID                        *FspHobList;
   UINT32                      TsegBase;
   UINT32                      TsegSize;
+  UINT32                      NeedReboot;
 
   if (mPchSciSupported == 0xFF){
     mPchSciSupported = PchIsSciSupported();
@@ -812,6 +814,13 @@ BoardInit (
     }
     break;
   case ReadyToBoot:
+    if (FeaturePcdGet (PcdFspNoEop)) {
+      MeEndOfPostEvent (&NeedReboot);
+      if (NeedReboot) {
+        DEBUG ((DEBUG_INIT, "Me Requested Reboot ...\n\n"));
+        ResetSystem (EfiResetPlatformSpecific);
+      }
+    }
     if ((GetBootMode() != BOOT_ON_FLASH_UPDATE) && (GetPayloadId() == 0)) {
       ProgramSecuritySetting ();
     }

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -1,7 +1,7 @@
 ## @file
 #
 #
-# Copyright (c) 2008-2022, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2008-2023, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -62,6 +62,7 @@
   MeExtMeasurementLib
   TccLib
   WatchDogTimerLib
+  ResetSystemLib
 
 [Guids]
   gOsConfigDataGuid
@@ -103,3 +104,4 @@
   gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled
   gPlatformModuleTokenSpaceGuid.PcdAcpiTableTemplatePtr
   gPlatformModuleTokenSpaceGuid.PcdFspsUpdPtr
+  gPlatformCommonLibTokenSpaceGuid.PcdFspNoEop

--- a/Silicon/ElkhartlakePkg/Include/Library/HeciInitLib.h
+++ b/Silicon/ElkhartlakePkg/Include/Library/HeciInitLib.h
@@ -1,7 +1,7 @@
 /** @file
   Heci init library.
 
-  Copyright (c) 2007 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2007 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -432,4 +432,21 @@ EFIAPI
 HeciRevokeOemKey (
    VOID
    );
+
+/**
+  Send ME the BIOS end of Post message.
+
+  @param[out] RequestedActions    Action request returned by EOP ACK
+                                    0x00 (HECI_EOP_STATUS_SUCCESS) - Continue to boot
+                                    0x01 (HECI_EOP_PERFORM_GLOBAL_RESET) - Global reset
+
+  @retval EFI_SUCCESS             Platform reached End of Post successfully
+  @retval EFI_DEVICE_ERROR        An error has occured by EoP message
+**/
+EFI_STATUS
+EFIAPI
+MeEndOfPostEvent (
+  OUT UINT32                          *RequestedActions
+  );
+
 #endif

--- a/Silicon/ElkhartlakePkg/Library/HeciInitLib/HeciCore.h
+++ b/Silicon/ElkhartlakePkg/Library/HeciInitLib/HeciCore.h
@@ -1,7 +1,6 @@
-/** @file
-  Definitions for HECI driver
+/** @file Definitions for HECI driver
 
-  Copyright (c) 2006 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2006 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 #ifndef _HECI_CORE_H
@@ -324,4 +323,34 @@ PseHeciSendAndReceive (
   IN      UINT8                   HostAddress,
   IN      UINT8                   MeAddress
   );
+
+/**
+  Send End of Post Request Message through HECI.
+
+  @param[out] RequestedActions    Action request returned by EOP ACK
+                                    0x00 (HECI_EOP_STATUS_SUCCESS) - Continue to boot
+                                    0x01 (HECI_EOP_PERFORM_GLOBAL_RESET) - Global reset
+
+  @retval EFI_UNSUPPORTED         Current ME mode doesn't support this function
+  @retval EFI_SUCCESS             Command succeeded
+  @retval EFI_DEVICE_ERROR        HECI Device error, command aborts abnormally
+  @retval EFI_TIMEOUT             HECI does not return the buffer before timeout
+**/
+EFI_STATUS
+HeciSendEndOfPostMessage (
+  OUT UINT32                      *RequestedActions
+  );
+
+/**
+  This message is sent by the BIOS if EOP-ACK not received to force ME to disable
+  HECI interfaces.
+
+  @retval EFI_UNSUPPORTED         Current ME mode doesn't support this function
+  @retval EFI_SUCCESS             HECI interfaces disabled by ME
+**/
+EFI_STATUS
+HeciDisableHeciBusMsg (
+  VOID
+  );
+
 #endif // _HECI_CORE_H

--- a/Silicon/ElkhartlakePkg/Library/HeciInitLib/MkhiMsgs.h
+++ b/Silicon/ElkhartlakePkg/Library/HeciInitLib/MkhiMsgs.h
@@ -1,7 +1,7 @@
 /** @file
   MKHI Messages
 
-  Copyright (c) 2010 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2010 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 #ifndef _MKHI_MSGS_H
@@ -83,6 +83,10 @@ typedef union {
 
 #define ARB_SVN_COMMIT_ALL                      0xFF ///< Value 0xFF refers to committing all pending ARBSVN values.
 
+///
+/// HECI BUS command
+///
+#define HECI_BUS_DISABLE_OPCODE           0x0C
 
 //
 // Typedef for Result field of MHKI Header
@@ -673,6 +677,24 @@ typedef union {
  END_OF_POST_ACK Response;
 } END_OF_POST_BUFFER;
 
+typedef union {
+  UINT8 Data;
+  struct {
+    UINT8 Command    : 7;
+    UINT8 IsResponse : 1;
+  } Fields;
+} HBM_COMMAND;
+
+typedef struct {
+  HBM_COMMAND Command;
+  UINT8       Reserved[3];
+} HECI_BUS_DISABLE_CMD;
+
+typedef struct {
+  HBM_COMMAND Command;
+  UINT8       Status;
+  UINT8       Reserved[2];
+} HECI_BUS_DISABLE_CMD_ACK;
 
 typedef struct {
   MKHI_MESSAGE_HEADER MkhiHeader;


### PR DESCRIPTION
EHL FSP does not send EOP (End Of Post) message at the Ready to Boot. The patch adds support for SBL to send the EOP during Ready to Boot.