### PR TITLE
[ADL/RPL]: Fix a typo

### DIFF
--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -503,7 +503,7 @@
   - IehMode :
       name         : IEH Mode
       type         : Combo
-      option       : 0:Bypass. 1:Enable
+      option       : 0:Bypass, 1:Enable
       help         : >
                      Integrated Error Handler Mode
       length       : 0x01


### PR DESCRIPTION
Config data uses comma ',' instead of dot '.' as the option separator. Fix a typo in IehMode option which would cause ConfigEditor.py error.