### PR TITLE
fix: multiboot mod string in zero-terminated ASCII format #1913

### DIFF
--- a/BootloaderCommonPkg/Include/Library/IasImageLib.h
+++ b/BootloaderCommonPkg/Include/Library/IasImageLib.h
@@ -129,6 +129,21 @@ IasGetFiles (
   OUT  IMAGE_DATA  *Img
   );
 
+/**
+  Free the allocated memory in an image data
+
+  This function free a memory allocated in IMAGE_DATA according to Allocation Type.
+
+  @param[in]  ImageData       An image data pointer which has allocated memory address,
+                              its size, and allocation type.
+
+**/
+VOID
+EFIAPI
+FreeImageData (
+  IN  IMAGE_DATA    *ImageData
+  );
+
 // Image type subfields (cf. boot subsustem HLD, appendix A for details).
 #define IAS_IMAGE_TYPE(it)      (((it) & 0xffff0000) >> 16)
 #define IAS_IMAGE_IS_SIGNED(it)  ((it) &      0x100)

--- a/BootloaderCommonPkg/Include/Library/MultibootLib.h
+++ b/BootloaderCommonPkg/Include/Library/MultibootLib.h
@@ -1,4 +1,7 @@
 /** @file
+  Copyright (c) 2018 - 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Paten
+
   Copyright (c) 2005, 2006 The NetBSD Foundation, Inc.
   All rights reserved.
 
@@ -358,6 +361,24 @@ UpdateMultiboot2MemInfo (
   IN UINT64                   RsvdMemBase,
   IN UINT64                   RsvdMemSize,
   IN UINT32                   RsvdMemExtra
+  );
+
+/**
+  Load Multiboot module string
+
+  @param[in,out] MultiBoot   Point to loaded Multiboot image structure
+  @param[in] ModuleIndex     Module index to load
+  @param[in] File            Source image file
+
+  @retval  EFI_SUCCESS       Load Multiboot module image successfully
+  @retval  Others            There is error when setup image
+**/
+EFI_STATUS
+EFIAPI
+LoadMultibootModString (
+  IN OUT MULTIBOOT_IMAGE     *MultiBoot,
+  IN     UINT16              ModuleIndex,
+  IN     IMAGE_DATA          *File
   );
 
 #endif

--- a/PayloadPkg/OsLoader/LoadImage.c
+++ b/PayloadPkg/OsLoader/LoadImage.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -637,6 +637,7 @@ GetLoadedImageByType (
 
 **/
 VOID
+EFIAPI
 FreeImageData (
   IN  IMAGE_DATA    *ImageData
   )

--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -269,10 +269,9 @@ UpdateLoadedImage (
         //
         // IMAGE_DATA memory will be freed later if fails
         //
-        CopyMem (&MultiBoot->MbModuleData[ModuleIndex].CmdFile, &File[Index], sizeof (IMAGE_DATA));
+        Status = LoadMultibootModString(MultiBoot, ModuleIndex, &File[Index]);
         CopyMem (&MultiBoot->MbModuleData[ModuleIndex].ImgFile, &File[Index + 1], sizeof (IMAGE_DATA));
 
-        MultiBoot->MbModule[ModuleIndex].String = (UINT8 *) MultiBoot->MbModuleData[ModuleIndex].CmdFile.Addr;
         MultiBoot->MbModule[ModuleIndex].Start  = (UINT32)(UINTN)MultiBoot->MbModuleData[ModuleIndex].ImgFile.Addr;
         MultiBoot->MbModule[ModuleIndex].End    = (UINT32)(UINTN)MultiBoot->MbModuleData[ModuleIndex].ImgFile.Addr
           + MultiBoot->MbModuleData[ModuleIndex].ImgFile.Size;

--- a/PayloadPkg/OsLoader/OsLoader.h
+++ b/PayloadPkg/OsLoader/OsLoader.h
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -252,20 +252,6 @@ UnloadBootImages (
 VOID
 UnloadLoadedImage (
   IN  LOADED_IMAGE  *LoadedImage
-  );
-
-/**
-  Free the allocated memory in an image data
-
-  This function free a memory allocated in IMAGE_DATA according to Allocation Type.
-
-  @param[in]  ImageData       An image data pointer which has allocated memory address,
-                              its size, and allocation type.
-
-**/
-VOID
-FreeImageData (
-  IN  IMAGE_DATA    *ImageData
   );
 
 /**


### PR DESCRIPTION
Required by multiboot spec (*1), a mod string is a zero-terminated ASCII string. The patch introduces LoadMultibootModString to load mod string from a IMAGE_DATA (allocating a new buffer when requiring to append zero-terminated char).

The patch does not reuse GetFromConfigFile because GetFromConfigFile was designed to be compatible with legacy format (e.g., EOF signature) and truncates new line chars (which is not required by multiboot mod).

For performance, the patch does not run "isascii" check.

Minor changes:
  - Fix typo error (InitMultibootMmap)
  - Declare FreeImageData in Library/IasImageLib.h
  - Dump mod string for debug build

Reference:
1. https://www.gnu.org/software/grub/manual/multiboot/multiboot.html

Verify: EHL CRB
Acked-by: Jiaqing Zhao <jiaqing.zhao@intel.com>
Signed-off-by: Stanley Chang <stanley.chang@intel.com>
