### PR TITLE
feat: [EHL] support ChipsetInit binary

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/BoardConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/BoardConfig.py
@@ -62,6 +62,10 @@ class Board(BaseBoard):
 
         self.SIIPFW_SIZE = 0x1000
 
+        # ChipsetInit binary
+        self.CHIPSET_SIZE = 0x4000
+        self.SIIPFW_SIZE += self.CHIPSET_SIZE
+
         self.ENABLE_TCC         = 0
         # TSN manual configuration- If enabled, user will be able to have more refined control over TSN configuration via
         # PseTsnIpConfig, TsnConfig and TsnMacAddr binaries
@@ -306,7 +310,13 @@ class Board(BaseBoard):
         CompFilePseTsnIpConfig='PseTsnIpConfig.bin' if os.path.exists(os.path.join(bins, 'PseTsnIpConfig.bin')) else ''
         CompFileTsnConfig='TsnConfig.bin' if os.path.exists(os.path.join(bins, 'TsnConfig.bin')) else ''
         CompFileTsnMacAddr='TsnMacAddr.bin' if os.path.exists(os.path.join(bins, 'TsnMacAddr.bin')) else ''
+        CompFileChipInitFw='ChipInitBinary.bin' if os.path.exists(os.path.join(bins, 'ChipInitBinary.bin')) else ''
         CompFileCrlFw='crl.bin' if os.path.exists(os.path.join(bins, 'crl.bin')) else ''
+
+        # chipset init fw
+        container_list.append (
+            ('CHIP', CompFileChipInitFw,     '',   container_list_auth_type,   'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE,    0,   self.CHIPSET_SIZE,  0),
+        )
 
         if self.ENABLE_TCC:
             container_list.append (

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1157,6 +1157,8 @@ UpdateFspConfig (
   UINT32      PseTsnIpConfigSize;
   UINT32      *TsnConfigBase;
   UINT32      TsnConfigSize;
+  UINT32      *ChipsetInitBinPtr;
+  UINT32      ChipsetInitBinSize;
   BOOLEAN     BiosProtected;
   BOOLEAN     IasProtected;
   EFI_STATUS  Status;
@@ -1574,6 +1576,17 @@ UpdateFspConfig (
     Fspscfg->SerialIoUartTxPinMuxPolicy[0]               = GPIO_VER3_MUXING_SERIALIO_UART0_TXD_GPP_F2;
     Fspscfg->SerialIoUartRtsPinMuxPolicy[0]              = GPIO_VER3_MUXING_SERIALIO_UART0_RTS_GPP_F0;
     Fspscfg->SerialIoUartCtsPinMuxPolicy[0]              = GPIO_VER3_MUXING_SERIALIO_UART0_CTS_GPP_F3;
+
+    // ChipsetInit
+    ChipsetInitBinPtr   = NULL;
+    ChipsetInitBinSize  = 0;
+    Status = LoadComponent (SIGNATURE_32 ('I', 'P', 'F', 'W'), SIGNATURE_32 ('C', 'H', 'I', 'P'),
+                            (VOID **)&ChipsetInitBinPtr, &ChipsetInitBinSize);
+    if (!EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_INFO, "Load ChipsetInitBin @0x%p, size = 0x%x\n", ChipsetInitBinPtr, ChipsetInitBinSize));
+      Fspscfg->ChipsetInitBinPtr = (UINT32)(UINTN)ChipsetInitBinPtr;
+      Fspscfg->ChipsetInitBinLen = ChipsetInitBinSize;
+    }
 
     // Check for TSN related sub-regions
     TsnMacAddrBase      = NULL;

--- a/Platform/ElkhartlakeBoardPkg/Script/StitchIfwiConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/Script/StitchIfwiConfig.py
@@ -79,6 +79,11 @@ def get_component_replace_list():
       ('IFWI/BIOS/TS1/ACM0',      'Input/acm.bin',           'dummy',  '',                              ''),
     ]
 
+    # ChipsetInit binary
+    if os.path.exists('IPFW/ChipInitBinary.bin'):
+        replace_list.append (
+            ('IFWI/BIOS/NRD/IPFW/CHIP', 'IPFW/ChipInitBinary.bin',   'dummy',  'KEY_ID_CONTAINER_COMP_RSA3072', 0 ),
+        )
     # need to set ENABLE_PRE_OS_CHECKER = 1 in BoardConfig.py
     if os.path.exists('IPFW/PreOsChecker.bin'):
         replace_list.append (


### PR DESCRIPTION
The patch allows SBL to add ChipsetInit binary by,
  - build time: Platform/ElkhartlakeBoardPkg/Binaries/ChipInitBinary.bin or
  - stitch time: IPFW/ChipInitBinary.bin

The binary is stored in IFWI/BIOS/NRD/IPFW/CHIP.

The ChipsetInit binary is optional to be stored in BIOS region, because the logic for FSP and CSE to use/update ChipsetInit is:
  - Platform boots with default ChipsetInit in CSE data region.
  - if FSP ChipsetInitBin does not exit -> END
  - if FSP ChipsetInitBin is incorrect -> END
  - if FSP and CSE ChipsetInit code are the same -> END
  - Otherwise, update the ChipsetInit in CSE

Test process:
         1. Cherry pick the patch under <mr6_source>
         2. Place mr6 ChipInitBinary.bin (V11) in
              <mr6_source>/Platform/ElkhartlakeBoardPkg/Binaries/
         3. Build & Stitch <mr6> sbl IFWI, says final BiosRegion.bin is
              <mr6_ifwi>/Temp/mr6_BiosRegion.bin
         4. Prepare the CSMD image - CsmeUpdateDriver.efi
         5. Prepare a csme.bin with
              mr6 PMC (154.01.10.1028) + mr6 CSE (15.40.30.2879)
         6. Generate a SBL FWU capsule, e.g.,
              SBL_KEY_DIR=../SblKeys python \
                BootloaderCorePkg/Tools/GenCapsuleFirmware.py
                -p BIOS mr6_BiosRegion.bin -p CSME csme.bin
                -p CSMD  CsmeUpdateDriver.efi
                -k ../SblKeys/FirmwareUpdateTestKey_Priv_RSA3072.pem -o FwuImage.bin
         7. Proceed FWU with FwuImage.bin (based on EHL MR5)

Verified: EHL CRB

Signed-off-by: Stanley Chang <stanley.chang@intel.com>