### PR TITLE
fix: [Common] Fix Coverity issues

### DIFF
--- a/MdePkg/Include/Library/DebugLib.h
+++ b/MdePkg/Include/Library/DebugLib.h
@@ -371,7 +371,7 @@ DebugPrintLevelEnabled (
   @param  Expression  Boolean expression.
 
 **/
-#ifdef __KLOCWORK__
+#if defined(__KLOCWORK__) || defined(__COVERITY__)
   #define ASSERT(Expression)    _ASSERT (Expression)
 #else
   #if !defined(MDEPKG_NDEBUG)
@@ -606,7 +606,7 @@ DebugPrintLevelEnabled (
   @param  TestSignature  The 32-bit signature value to match.
 
 **/
-#ifdef __KLOCWORK__
+#if defined(__KLOCWORK__) || defined(__COVERITY__)
   #define CR(Record, TYPE, Field, TestSignature)  BASE_CR(Record, TYPE, Field)
 #else
   #if !defined(MDEPKG_NDEBUG)


### PR DESCRIPTION
Fixed CWE 476 NULL Pointer Dereference
Prevent DebugAssert from Coverity scan

Missing from PR#1927 fix: [Common] Fix Coverity issues