### PR TITLE
fix: [ADL/RPL] Fix up flash map memory map entry when flash size > 16MB.

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -120,6 +120,8 @@
   gPlatformModuleTokenSpaceGuid.PcdEnablePciePm
   gPlatformCommonLibTokenSpaceGuid.PcdBootPerformanceMask
   gPlatformModuleTokenSpaceGuid.PcdPciEnumHookProc
+  gPlatformModuleTokenSpaceGuid.PcdFlashBaseAddress
+  gPlatformModuleTokenSpaceGuid.PcdFlashSize
 
 [FixedPcd]
   gPlatformAlderLakeTokenSpaceGuid.PcdAdlLpSupport


### PR DESCRIPTION
When PcdFlashSize is > 16MB, the corresponding memory map entry will be incorrect since on ADL/RPL only the top 16MB of flash is mapped into memory by the PCH.