### PR TITLE
feat: Fix ACPI FPDT SBL boot performance

### DIFF
--- a/BootloaderCorePkg/Include/Library/AcpiInitLib.h
+++ b/BootloaderCorePkg/Include/Library/AcpiInitLib.h
@@ -131,21 +131,16 @@ UpdateFpdtS3Table (
   );
 
 /**
-  Find an ACPI table using the given signature.
+  This function updates SBL performance table in FPDT
 
-  @param[in] Rsdt            ACPI table RSDT pointer.
-  @param[in] Signature       ACPI table signature to find.
-  @param[in] EntryIndex      Address to receive the entry index if found.
-
-  @retval  ACPI table pointer if found.  And EntryIndex is updated.
-           NULL if not found.
+  @retval  EFI_SUCCESS if operation is successful, EFI_NOT_FOUND if
+           performance HOB is not found
 
 **/
-EFI_ACPI_DESCRIPTION_HEADER *
-FindAcpiTableBySignature (
-  IN   EFI_ACPI_DESCRIPTION_HEADER  *Rsdt,
-  IN   UINT32                        Signature,
-  IN   UINT32                       *EntryIndex   OPTIONAL
+EFI_STATUS
+EFIAPI
+UpdateFpdtSblTable (
+  VOID
   );
 
 #endif

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -293,6 +293,7 @@ NormalBootPath (
   PrintStackHeapInfo ();
   DEBUG_CODE_END ();
 
+  UpdateFpdtSblTable ();
   // FWU payload is the only payload in SBL scope, so stop TCO
   // timer if another payload is set to be launched
   if (PcdGetBool (PcdSblResiliencyEnabled) && GetBootMode () != BOOT_ON_FLASH_UPDATE) {

--- a/BootloaderCorePkg/Stage2/Stage2Support.c
+++ b/BootloaderCorePkg/Stage2/Stage2Support.c
@@ -32,9 +32,6 @@ BoardNotifyPhase (
   FSP_INIT_PHASE                                   FspPhase;
   UINT8                                            FspPhaseMask;
   EFI_STATUS                                       Status;
-  EFI_ACPI_5_0_ROOT_SYSTEM_DESCRIPTION_POINTER    *Rsdp;
-  EFI_ACPI_DESCRIPTION_HEADER                     *Fpdt;
-  PLATFORM_SERVICE                                *PlatformService;
 
   // This is board notification from payload
   FspPhaseMask = 0;
@@ -75,25 +72,9 @@ BoardNotifyPhase (
     }
   }
 
-  // Populate FPDT with SBL performance data (SBLT) in EndOfFirmware phase
-  if (Phase == EndOfFirmware) {
-    Status = EFI_NOT_FOUND;
-    PlatformService = (PLATFORM_SERVICE *) GetServiceBySignature (PLATFORM_SERVICE_SIGNATURE);
-    // Add perf data to FPDT - SBL Performance Table
-    Rsdp = (EFI_ACPI_5_0_ROOT_SYSTEM_DESCRIPTION_POINTER *)(UINTN)PcdGet32 (PcdAcpiTablesRsdp);
-    if (Rsdp != NULL) {
-      Fpdt = FindAcpiTableBySignature((EFI_ACPI_DESCRIPTION_HEADER *)(UINTN)Rsdp->RsdtAddress, SIGNATURE_32('F', 'P', 'D', 'T'), NULL);
-      if (Fpdt != NULL) {
-        if (PlatformService != NULL){
-          Status = PlatformService->AcpiTableUpdate((UINT8 *)Fpdt, Fpdt->Length);
-          DEBUG ((DEBUG_INFO, "Update FPDT @ 0x%X, Status =%r\n", Fpdt, Status));
-        } else {
-          DEBUG ((DEBUG_INFO, "Could not find PlatformService!\n"));
-        }
-      } else {
-        DEBUG ((DEBUG_INFO, "Failed to update SBL Performance Table\n"));
-      }
-    }
+  // Update Osloader boot time in FPDT
+  if ((Phase == EndOfFirmware) && (GetBootMode () != BOOT_ON_S3_RESUME)) {
+    UpdateFpdtSblTable ();
   }
 }
 


### PR DESCRIPTION
In current code, BoardNotifyPhase() would update FPDT SBL performance table in S3 path. It could cause S3 issue since PcdAcpiTablesRsdp is not updated.
Move the FPDT related code to AcpiFpdt.c
Update FPDT SBL performance table in stage2 so that this table could be updated for all payloads.