### PR TITLE
fix: [ADL/RPL] Set FSPS for End of Post notify.

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -894,6 +894,9 @@ UpdateFspConfig (
   FspsConfig->CpuPcieRpGen5Uptp[1] = 0x5;
   FspsConfig->CpuPcieRpGen5Uptp[2] = 0x5;
 
+  // EndOfPost Upd
+  FspsUpd->FspsConfig.EndOfPostMessage = 1;
+
   if (FeaturesCfgData != NULL) {
     if (FeaturesCfgData->Features.S0ix == 1) {
       FspsConfig->XdciEnable = 0;


### PR DESCRIPTION
End of post is not notified at end of firmware
fromFSP for osloader boot.