### PR TITLE
feat: [EHL] enable BoardNotifyPhase during FWU

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -245,6 +245,7 @@
   gPlatformModuleTokenSpaceGuid.PcdLegacyEfSegmentEnabled | TRUE       | BOOLEAN | 0x20000214
   gPlatformModuleTokenSpaceGuid.PcdEnableDts              | FALSE      | BOOLEAN | 0x20000215
   gPlatformModuleTokenSpaceGuid.PcdEnablePciePm           | FALSE      | BOOLEAN | 0x20000222
+  gPlatformModuleTokenSpaceGuid.PcdEnableFwuNotify        | FALSE      | BOOLEAN | 0x20000225
 
 [PcdsDynamic]
   gPlatformModuleTokenSpaceGuid.PcdFspResetStatus         | 0          | UINT32 | 0x20000224

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -346,6 +346,7 @@
   gPlatformModuleTokenSpaceGuid.PcdEnableDts              | $(ENABLE_DTS)
   gPlatformModuleTokenSpaceGuid.PcdEnablePciePm           | $(ENABLE_PCIE_PM)
   gPlatformCommonLibTokenSpaceGuid.PcdFspNoEop            | $(HAVE_NO_FSP_EOP)
+  gPlatformModuleTokenSpaceGuid.PcdEnableFwuNotify        | $(ENABLE_FWU_NOTIFY)
 
 !ifdef $(S3_DEBUG)
   gPlatformModuleTokenSpaceGuid.PcdS3DebugEnabled         | $(S3_DEBUG)

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -557,7 +557,7 @@ SecStartup (
     AddMeasurePoint (0x30B0);
 
     if (!EFI_ERROR (Status)) {
-      if (BootMode != BOOT_ON_FLASH_UPDATE) {
+      if (FeaturePcdGet(PcdEnableFwuNotify) || (BootMode != BOOT_ON_FLASH_UPDATE)) {
         BoardNotifyPhase (PostPciEnumeration);
         AddMeasurePoint (0x30C0);
       }

--- a/BootloaderCorePkg/Stage2/Stage2.inf
+++ b/BootloaderCorePkg/Stage2/Stage2.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2016 - 2022, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2016 - 2023, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -152,6 +152,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdBuildSmmHobs
   gPlatformCommonLibTokenSpaceGuid.PcdBootPerformanceMask
   gPlatformModuleTokenSpaceGuid.PcdSblResiliencyEnabled
+  gPlatformModuleTokenSpaceGuid.PcdEnableFwuNotify
 
 [Depex]
   TRUE

--- a/Platform/ElkhartlakeBoardPkg/BoardConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/BoardConfig.py
@@ -56,6 +56,8 @@ class Board(BaseBoard):
         # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)
         self.ENABLE_SMM_REBASE    = 2
         self.ENABLE_FRAMEBUFFER_INIT = 1
+        # allow FSP notify during FWU
+        self.ENABLE_FWU_NOTIFY = 1
 
         # EHL FSP Ready To Boot does not call EOP
         self.HAVE_NO_FSP_EOP      = 1

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1888,6 +1888,7 @@ UpdateFspConfig (
 
   if (GetBootMode () == BOOT_ON_FLASH_UPDATE) {
     Fspscfg->PchLockDownBiosInterface = FALSE;
+    Fspscfg->PchLockDownBiosLock      = FALSE;
     Fspscfg->RtcBiosInterfaceLock     = FALSE;
     Fspscfg->PchSbAccessUnlock        = TRUE;
     Fspscfg->SkipMpInit               = TRUE;


### PR DESCRIPTION
The FSP may request for a reboot when some features are enable/disable. The SiliconInit FW update is one case for the "FSP requested boot". Without the patch, SBL has no way to get the notification from CallFspNotifyPhase.

The patch introduces a feature, PcdEnableFwuNotify, to allow SBL to keep BoardNotifyPhase during firmware update.

On EHL, the feature can be enabled by "disable BIOS Lock".

Verify: EHL-CRB