### PR TITLE
feat: [EHL] add ResetSystemLib

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/BoardConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/BoardConfig.py
@@ -236,6 +236,7 @@ class Board(BaseBoard):
             'PchInfoLib|Silicon/$(SILICON_PKG_NAME)/Library/PchInfoLib/PchInfoLib.inf',
             'PchSbiAccessLib|Silicon/CommonSocPkg/Library/PchSbiAccessLib/PchSbiAccessLib.inf',
             'PlatformHookLib|Silicon/$(SILICON_PKG_NAME)/Library/PlatformHookLib/PlatformHookLib.inf',
+            'ResetSystemLib|Platform/$(BOARD_PKG_NAME)/Library/ResetSystemLib/ResetSystemLib.inf',
             'TccLib|Silicon/CommonSocPkg/Library/TccLib/TccLib.inf',
             'GpioLib|Silicon/CommonSocPkg/Library/GpioLib/GpioLib.inf',
             'GpioSiLib|Silicon/$(SILICON_PKG_NAME)/Library/GpioSiLib/GpioSiLib.inf',

--- a/Platform/ElkhartlakeBoardPkg/Library/ResetSystemLib/ResetSystemLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/ResetSystemLib/ResetSystemLib.c
@@ -1,0 +1,111 @@
+/** @file
+  Reset System Library
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/IoLib.h>
+#include <Library/ResetSystemLib.h>
+#include <Library/PcdLib.h>
+#include <PchAccess.h>
+#include <FspEas/FspApi.h>
+
+//
+// Reset Control Register
+//
+#define R_RST_CNT                     0xCF9 ///< Reset Control
+#define V_RST_CNT_FULLRESET           0x0E
+#define V_RST_CNT_HARDRESET           0x06
+
+
+/**
+  Calling this function causes a system-wide reset. This sets
+  all circuitry within the system to its initial state. This type of reset
+  is asynchronous to system operation and operates without regard to
+  cycle boundaries.
+
+  System reset should not return, if it returns, it means the system does
+  not support cold reset.
+**/
+VOID
+ResetCold (
+  VOID
+  )
+{
+  IoWrite8 ((UINTN) R_RST_CNT, V_RST_CNT_FULLRESET);
+}
+
+/**
+  Calling this function causes a system-wide initialization. The processors
+  are set to their initial state, and pending cycles are not corrupted.
+
+  System reset should not return, if it returns, it means the system does
+  not support warm reset.
+**/
+VOID
+ResetWarm (
+  VOID
+  )
+{
+  IoWrite8 ((UINTN) R_RST_CNT, V_RST_CNT_HARDRESET);
+}
+
+/**
+  Calling this function causes a PCH Global reset in addition to system-wide
+  initialization.
+
+  System reset should not return, if it returns, it means the system does
+  not support warm reset.
+**/
+VOID
+ResetPchGlobal (
+  VOID
+  )
+{
+  IoWrite8 ((UINTN) R_RST_CNT, V_RST_CNT_FULLRESET);
+}
+
+/**
+  Resets the entire platform.
+
+  @param[in] ResetType          The type of reset to perform.
+
+**/
+VOID
+EFIAPI
+ResetSystem (
+  IN EFI_RESET_TYPE   ResetType
+  )
+{
+  EFI_STATUS    FspResetRequest = 0;
+
+  switch (ResetType) {
+  case EfiResetWarm:
+    ResetWarm ();
+    break;
+
+  case EfiResetCold:
+    ResetCold ();
+    break;
+
+  case EfiResetPlatformSpecific:
+    FspResetRequest = (EFI_STATUS)PcdGet32(PcdFspResetStatus);
+    if (FspResetRequest == FSP_STATUS_RESET_REQUIRED_3) {
+      ResetPchGlobal ();
+    }
+
+  default:
+    break;
+  }
+
+  //
+  // Coming here, either we are waiting while system reset is in progress
+  // or reset failed and we are in dead loop
+  //
+  CpuDeadLoop();
+}

--- a/Platform/ElkhartlakeBoardPkg/Library/ResetSystemLib/ResetSystemLib.inf
+++ b/Platform/ElkhartlakeBoardPkg/Library/ResetSystemLib/ResetSystemLib.inf
@@ -1,0 +1,42 @@
+## @file
+#   Library instance for ResetSystem library class for PCAT systems
+#
+#  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = ResetSystemLib
+  FILE_GUID                      = EC4F3E59-F879-418b-9E4C-7D6F434714A0
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = ResetSystemLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 IPF
+#
+
+[Sources]
+  ResetSystemLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+  BootloaderCorePkg/BootloaderCorePkg.dec
+  Silicon/AlderlakePkg/AlderlakePkg.dec
+  IntelFsp2Pkg/IntelFsp2Pkg.dec
+
+[LibraryClasses]
+  DebugLib
+  IoLib
+  BaseLib
+
+[Guids]
+  gPlatformModuleTokenSpaceGuid
+
+[Pcd]
+  gPlatformModuleTokenSpaceGuid.PcdFspResetStatus


### PR DESCRIPTION
A recent commit (b9057d) changed the FspResetHandler by seperating FSP_STATUS_RESET_REQUIRED_COLD from the other undefined case with EfiResetPlatformSpecific reset. The common ResetSystemLib (BootloaderCommonPkg/Library/ResetSystemLib) does not handle EfiResetPlatformSpecific.

On EHL, FSP may register a EfiResetPlatformSpecific reset if some platform configuration changed, including but not limited to the cases:
   - disable PSE on PSE CPU sku
   - update ChipsetInit FW Therefore, EfiResetPlatformSpecific must be handled.

Therefore, EfiResetPlatformSpecific must be handled.

Verify: EHL CRB

Signed-off-by: Stanley Chang <stanley.chang@intel.com>