### PR TITLE
fix: [Common] Dereference null return TempSmbiosStrTbl

### DIFF
--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -154,7 +154,10 @@ InitializeSmbiosInfo (
   PlatformId    = GetPlatformId ();
   TempSmbiosStrTbl  = (SMBIOS_TYPE_STRINGS *) AllocateTemporaryMemory (0);
   VerInfoTbl    = GetVerInfoPtr ();
-
+  if (TempSmbiosStrTbl == NULL) {
+    DEBUG ((DEBUG_ERROR, "TempSmbiosStrTbl allocation failed\n"));
+    return EFI_OUT_OF_RESOURCES;
+  }
   //
   // SMBIOS_TYPE_BIOS_INFORMATION
   //

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -567,6 +567,9 @@ InitializeSmbiosInfo (
   Index         = 0;
   PlatformId    = GetPlatformId ();
   TempSmbiosStrTbl  = (SMBIOS_TYPE_STRINGS *) AllocateTemporaryMemory (0);
+  if (TempSmbiosStrTbl == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
   VerInfoTbl    = GetVerInfoPtr ();
 
   //

--- a/Platform/CometlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CometlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -743,6 +743,9 @@ InitializeSmbiosInfo (
   Index         = 0;
   PlatformId    = GetPlatformId ();
   TempSmbiosStrTbl  = (SMBIOS_TYPE_STRINGS *) AllocateTemporaryMemory (0);
+  if (TempSmbiosStrTbl == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
   VerInfoTbl    = GetVerInfoPtr ();
 
   //

--- a/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -736,6 +736,9 @@ InitializeSmbiosInfo (
   Index         = 0;
   PlatformId    = GetPlatformId ();
   TempSmbiosStrTbl  = (SMBIOS_TYPE_STRINGS *) AllocateTemporaryMemory (0);
+  if (TempSmbiosStrTbl == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
   VerInfoTbl    = GetVerInfoPtr ();
 
   //

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -484,8 +484,10 @@ InitializeSmbiosInfo (
 
   Index         = 0;
   TempSmbiosStrTbl  = (SMBIOS_TYPE_STRINGS *) AllocateTemporaryMemory (0);
+  if (TempSmbiosStrTbl == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
   VerInfoTbl    = GetVerInfoPtr ();
-
   //
   // SMBIOS_TYPE_BIOS_INFORMATION
   //

--- a/Platform/IdavilleBoardPkg/Library/Stage2BoardInitLib/SmbiosInit.c
+++ b/Platform/IdavilleBoardPkg/Library/Stage2BoardInitLib/SmbiosInit.c
@@ -67,6 +67,9 @@ InitializeSmbiosInfo (
   if (FeaturePcdGet (PcdSmbiosEnabled)) {
     Index            = 0;
     TempSmbiosStrTbl = (SMBIOS_TYPE_STRINGS *) AllocateTemporaryMemory (0);
+    if (TempSmbiosStrTbl == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
     VerInfoTbl       = GetVerInfoPtr ();
 
     //

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -313,6 +313,9 @@ InitializeSmbiosInfo (
 
   Index             = 0;
   TempSmbiosStrTbl  = (SMBIOS_TYPE_STRINGS *) AllocateTemporaryMemory (0);
+  if (TempSmbiosStrTbl == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
   VerInfoTbl    = GetVerInfoPtr ();
 
   //

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -540,6 +540,9 @@ InitializeSmbiosInfo (
 
   Index         = 0;
   TempSmbiosStrTbl  = (SMBIOS_TYPE_STRINGS *) AllocateTemporaryMemory (0);
+  if (TempSmbiosStrTbl == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
   VerInfoTbl    = GetVerInfoPtr ();
 
   //


### PR DESCRIPTION
If the function actually returns a null value,
a null pointer dereference will occur.
In InitializeSmbiosInfo: Return value of function which returns null is dereferenced without checking (CWE-476)