### PR TITLE
[ADLP] Update FSP/UCODE/platform version for MR4 release

### DIFF
--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlP.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlP.py
@@ -23,7 +23,7 @@ class Board(AlderlakeBoardConfig.Board):
         self.VERINFO_IMAGE_ID     = 'SB_ADLP'
         self.BOARD_NAME           = 'adlp'
         self.VERINFO_PROJ_MAJOR_VER = 1
-        self.VERINFO_PROJ_MINOR_VER = 3
+        self.VERINFO_PROJ_MINOR_VER = 4
         self._EXTRA_INC_PATH      = ['Silicon/AlderlakePkg/Adlp/Include']
         self._FSP_PATH_NAME       = 'Silicon/AlderlakePkg/Adlp/FspBin'
         self.MICROCODE_INF_FILE   = 'Silicon/AlderlakePkg/Microcode/Microcode.inf'

--- a/Platform/AlderlakeBoardPkg/Script/StitchIfwiConfig_adlp.py
+++ b/Platform/AlderlakeBoardPkg/Script/StitchIfwiConfig_adlp.py
@@ -141,6 +141,7 @@ def get_xml_change_list (platform, plt_params_list):
         ('./FlashLayout/BiosRegion/InputFile',                                      '$SourceDir\BiosRegion.bin'),
         ('./FlashLayout/Ifwi_IntelMePmcRegion/MeRegionFile',                        '$SourceDir\MeRegionFile.bin'),
         ('./FlashLayout/Ifwi_IntelMePmcRegion/PmcBinary',                           '$SourceDir\PmcBinary.bin'),
+        ('./FlashLayout/Ifwi_IntelMePmcRegion/ChipInitBinary',                      '$SourceDir\ChipInitBinary.bin'),
         ('./FlashLayout/EcRegion/InputFile',                                        '$SourceDir\EcRegion.bin'),
         ('./FlashLayout/EcRegion/Enabled',                                          'Enabled'),
         ('./FlashLayout/EcRegion/EcRegionPointer',                                  '$SourceDir\EcRegionPointer.bin'),
@@ -149,6 +150,7 @@ def get_xml_change_list (platform, plt_params_list):
         ('./FlashLayout/SubPartitions/PchcSubPartitionData/InputFile',              '$SourceDir\PchcSubPartitionData.bin'),
         ('./FlashSettings/FlashConfiguration/SpiDualIoReadEnable',                   'Yes'),
         ('./FlashSettings/FlashConfiguration/SpiDualOutReadEnable',                  'Yes'),
+        # TopSwapOverride value will be updated by patch_xml_file() in StitchIfwi.py
         ('./FlashSettings/BiosConfiguration/TopSwapOverride',                        '512KB'),
         ('./PlatformProtection/PlatformIntegrity/OemPublicKeyHash',                  'F8 F0 E3 69 15 81 76 99 0A 54 9E D4 C3 6D 1A 86 39 D8 87 3D EF F7 ED 2D E3 4C B4 1B CC B3 04 76 CE 0A A0 63 BC 5B 7A AC FF D9 50 9E 96 40 C6 99'),
         ('./PlatformProtection/PlatformIntegrity/OemExtInputFile',                   '$SourceDir\OemExtInputFile.bin'),
@@ -178,11 +180,9 @@ def get_xml_change_list (platform, plt_params_list):
         ('./Debug/DirectConnectInterfaceConfiguration/DciDbcEnable',                 'No'),
         ('./Debug/DirectConnectInterfaceConfiguration/Usb1DciOobEnable',             'No'),
         ('./Debug/DirectConnectInterfaceConfiguration/Usb2DciOobEnable',             'No'),
-        ('./FlexIO/Type-CSubsystemConfiguration/IomBinaryFile',                      '$SourceDir\Iom_L0R0.bin'),
-        ('./FlexIO/Type-CSubsystemConfiguration/PhyBinaryFile',                      '$SourceDir\TypeC_NorthPHYRegion_L1.bin'),
-        ('./FlexIO/Type-CSubsystemConfiguration/TbtBinaryFile',                      '$SourceDir\TBT.bin'),
         ('./FlexIO/Type-CSubsystemConfiguration/IomBinaryFile',                      '$SourceDir\Iom.bin'),
         ('./FlexIO/Type-CSubsystemConfiguration/PhyBinaryFile',                      '$SourceDir\TypeC_NorthPHYRegion.bin'),
+        ('./FlexIO/Type-CSubsystemConfiguration/TbtBinaryFile',                      '$SourceDir\TBT.bin'),
         ('./IntelUniquePlatformId/EntitlementsConfiguration/IcpsSwSkuing',           'Yes'),
         ('./FlexIO/Type-CSubsystemConfiguration/XdciSplitDieConfig',                 'xDCI Split Die Disabled'),
     ])

--- a/Silicon/AlderlakePkg/Microcode/Microcode.inf
+++ b/Silicon/AlderlakePkg/Microcode/Microcode.inf
@@ -15,8 +15,7 @@
 
 [Sources]
   m_07_90672_00000025.mcb
-  m_80_906a3_00000423.mcb
-  m_80_906a3_00000424.mcb
+  m_80_906a3_0000042a.mcb
   m_01_b06e0_00000010.mcb
 
 [UserExtensions.SBL."CloneRepo"]
@@ -25,6 +24,5 @@
 
 [UserExtensions.SBL."CopyList"]
   Microcode/AlderLake/m_07_90672_00000025.pdb  : Silicon/AlderlakePkg/Microcode/m_07_90672_00000025.mcb
-  Microcode/AlderLake/m_80_906a3_00000423.pdb  : Silicon/AlderlakePkg/Microcode/m_80_906a3_00000423.mcb
-  Microcode/AlderLake/m_80_906a3_00000424.pdb  : Silicon/AlderlakePkg/Microcode/m_80_906a3_00000424.mcb
+  Microcode/AlderLake/m_80_906a3_0000042a.pdb  : Silicon/AlderlakePkg/Microcode/m_80_906a3_0000042a.mcb
   Microcode/AlderLake/m_01_b06e0_00000010.pdb  : Silicon/AlderlakePkg/Microcode/m_01_b06e0_00000010.mcb


### PR DESCRIPTION
- update FSP version to IoT ADL-P MR4 (0C.01.A4.12)
- update microcode version to 42A
- update platform version to 1.4
- Add ChipInitBinary.bin update in stitch process