### PR TITLE
fix: [RPL/ADL] Enable OpioRecenter by default.

### DIFF
--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -491,7 +491,7 @@
       help         : >
                      Opio Recentering Disabling for Pcie Latency Improvement
       length       : 0x01
-      value        : 0x0
+      value        : 0x1
   - L2QosEnumerationEn :
       name         : L2 QOS Enumeration
       type         : Combo


### PR DESCRIPTION
OpioRecenter was enabled in default FSP UPD, but after adding this in SBL CfgData, the default was mistakenly set to disabled. This was breaking S0ix on RPL-P and likely other platforms. Restoring the CfgData value to enabled.