### PR TITLE
feat: Fix ADLS build failure

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -754,7 +754,7 @@ UpdateFspConfig (
     }
 
     // TSN feature support
-#if PLATFORM_RPLS || PLATFORM_RPLP || PLATFORM_RPLPCRB || PLATFORM_ADLP || PLATFORM_ADLPS
+#if PLATFORM_RPLS || PLATFORM_RPLP || PLATFORM_RPLPCRB || PLATFORM_ADLP || PLATFORM_ADLPS || PLATFORM_ADLS
     FspsConfig->PchTsnEnable[0] = SiCfgData->PchTsnEnable;
     FspsConfig->PchTsnEnable[1] = SiCfgData->PchTsnEnable;
 #else


### PR DESCRIPTION
New ADL FSP changed TSN UPD from PchTsnEnable to PchTsnEnable[2]. So need update the code to fix the build failure.