### PR TITLE
feat: Fix device enumerate in NVMe library

### DIFF
--- a/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpress.c
+++ b/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpress.c
@@ -177,9 +177,6 @@ Exit:
     FreePool (NamespaceData);
   }
 
-  if (Device != NULL) {
-    FreePool (Device);
-  }
   return Status;
 }
 


### PR DESCRIPTION
There is a NVMe regression caused by https://github.com/slimbootloader/slimbootloader/pull/1958. The NVMe device enumerated should not be freed since it will be used in other APIs.