### PR TITLE
[ADLS] Update FSP/UCODE/platform version for MR5 release

### DIFF
--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlS.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlS.py
@@ -25,7 +25,7 @@ class Board(BaseBoard):
 
         self.VERINFO_IMAGE_ID     = 'SBL_ADL'
         self.VERINFO_PROJ_MAJOR_VER = 1
-        self.VERINFO_PROJ_MINOR_VER = 3
+        self.VERINFO_PROJ_MINOR_VER = 5
         self.VERINFO_SVN            = 1
         self.VERINFO_BUILD_DATE     = time.strftime("%m/%d/%Y")
 

--- a/Silicon/AlderlakePkg/Microcode/Microcode.inf
+++ b/Silicon/AlderlakePkg/Microcode/Microcode.inf
@@ -14,15 +14,15 @@
   VERSION_STRING       = 1.0
 
 [Sources]
-  m_07_90672_00000025.mcb
+  m_07_90672_0000002e.mcb
   m_80_906a3_0000042a.mcb
   m_01_b06e0_00000010.mcb
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
-  COMMIT = 66fd9a992c369db6d59cb664396ba4b316804dd0
+  COMMIT = 13add70d7e228a750f2e30f16ccfddc19a18bf08
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/AlderLake/m_07_90672_00000025.pdb  : Silicon/AlderlakePkg/Microcode/m_07_90672_00000025.mcb
+  Microcode/AlderLake/m_07_90672_0000002e.pdb  : Silicon/AlderlakePkg/Microcode/m_07_90672_0000002e.mcb
   Microcode/AlderLake/m_80_906a3_0000042a.pdb  : Silicon/AlderlakePkg/Microcode/m_80_906a3_0000042a.mcb
   Microcode/AlderLake/m_01_b06e0_00000010.pdb  : Silicon/AlderlakePkg/Microcode/m_01_b06e0_00000010.mcb


### PR DESCRIPTION
- update FSP version to IoT ADL-S MR5 (0C.00.A4.13)
- update microcode version to 2E
- update platform version to 1.5