### PR TITLE
Fix compiler warnings in x64 build

### DIFF
--- a/BootloaderCommonPkg/Library/IppCryptoLib/hmac.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/hmac.c
@@ -16,6 +16,7 @@
 #define  DEBUG_IPP    0
 
 EFI_STATUS
+EFIAPI
 HmacSha256 (const Ipp8u* pMsg, Ipp32u msgLen, const Ipp8u* pKey, Ipp32u keyLen, Ipp8u* pMD, Ipp32u mdLen)
 {
   IppStatus Result;

--- a/BootloaderCommonPkg/Library/ShellLib/CmdPci.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdPci.c
@@ -24,7 +24,7 @@ VOID
 EFIAPI
 MmRead (
   IN UINTN   Addr,
-  IN UINTN   Width,
+  IN UINT32  Width,
   IN UINT32  Count,
   IN BOOLEAN IsIoAddr
 );


### PR DESCRIPTION
Fixes following compiler warnings

```
BootloaderCommonPkg/Library/ShellLib/CmdPci.c:25:1: warning: type of ‘MmRead’ does not match original declaration [-Wlto-type-mismatch]
   25 | MmRead (
      | ^
BootloaderCommonPkg/Library/ShellLib/CmdMm.c:107:1: note: type mismatch in parameter 2
  107 | MmRead (
      | ^
BootloaderCommonPkg/Library/ShellLib/CmdMm.c:107:1: note: type ‘UINT32’ should match type ‘UINTN’
BootloaderCommonPkg/Library/ShellLib/CmdMm.c:107:1: note: ‘MmRead’ was previously declared here

BootloaderCommonPkg/Include/Library/CryptoLib.h:241:1: warning: type of ‘HmacSha256’ does not match original declaration [-Wlto-type-mismatch]
  241 | HmacSha256 (
      | ^
BootloaderCommonPkg/Library/IppCryptoLib/hmac.c:19:1: note: ‘HmacSha256’ was previously declared here
   19 | HmacSha256 (const Ipp8u* pMsg, Ipp32u msgLen, const Ipp8u* pKey, Ipp32u keyLen, Ipp8u* pMD, Ipp32u mdLen)
      | ^
```