### PR TITLE
fix: [ICX-D] Fix Coverity issues

### DIFF
--- a/Platform/IdavilleBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/IdavilleBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -1045,6 +1045,7 @@ PlatformUpdateAcpiGnvs (
   TYPE_CHOPTYPE_ENUM        ChopType;
   PLATFORM_DATA             *PlatformData;
 
+  NumOfBitShift = 0;
   Gnvs          = (GLOBAL_NVS_AREA *)GnvsIn;
   PchNvs        = &Gnvs->PchNvs;
   AcpiParameter = &Gnvs->BiosAcpiParam;

--- a/Platform/IdavilleBoardPkg/Library/TmeVarLib/TmeVarLib.c
+++ b/Platform/IdavilleBoardPkg/Library/TmeVarLib/TmeVarLib.c
@@ -59,6 +59,7 @@ GetTmeVar (
   UINTN                   TmeKeyVarSize;
 
   DEBUG ((DEBUG_INFO, "GetTmeVar Enter\n"));
+  TmeKeyVarSize = 0;
 
   if (!IsTmeEnabled ()) {
     DEBUG ((DEBUG_INFO, "TME is Disabled. TME Variable will not be read.\n"));

--- a/Silicon/IdavillePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/IdavillePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -1,7 +1,7 @@
 /** @file
   This file contains the implementation of FirmwareUpdateLib library.
 
-  Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -75,6 +75,7 @@ InitCsmeUpdInputData (
     if ((CsmeUpdDriverInput->HeciReadMessage == NULL) ||
         (CsmeUpdDriverInput->HeciSendMessage == NULL) ||
         (CsmeUpdDriverInput->HeciReset == NULL)) {
+      FreePool(CsmeUpdDriverInput);
       return NULL;
     }
   }

--- a/Silicon/IdavillePkg/Library/PsdLib/PsdLib.c
+++ b/Silicon/IdavillePkg/Library/PsdLib/PsdLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -425,6 +425,7 @@ GetSgxCapabilities (
         break;
       case 0x4000000000: //512G
         SgxCaps.Bits.PRMRR =0x10;
+        break;
       default:
         SgxCaps.Bits.PRMRR =0x00;
         break;

--- a/Silicon/IdavillePkg/Library/VTdLib/VTdLib.c
+++ b/Silicon/IdavillePkg/Library/VTdLib/VTdLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020-2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -808,7 +808,6 @@ UpdateDmarHeader (
 {
   UINTN                       VtdBar;
   UINT8                       Bus;
-  UINT8                       Idx;
   UINT64                      VtdExtCap;
   EFI_CPUID_REGISTER          CpuidRegister;
 
@@ -823,13 +822,9 @@ UpdateDmarHeader (
   //
   // Check INTR REMAP capability (on Stack0)
   //
-  for (Idx = 0; Idx < RootBridgeInfoHob->Count; Idx++){
-    if (Idx == IIO_STACK0) {
-      Bus = RootBridgeInfoHob->Entry[Idx].BusBase;
-      break;
-    }
-  }
-  if (Bus == (UINT8) -1) {
+  if (IIO_STACK0 < RootBridgeInfoHob->Count) {
+    Bus = RootBridgeInfoHob->Entry[IIO_STACK0].BusBase;
+  } else {
     return EFI_INVALID_PARAMETER;
   }
 


### PR DESCRIPTION
Fixed missing break in switch (CID 1444785)
Fixed Uninitialized scalar variable (CID 1444786)
Fixed missing break in switch (CID 1444787)
Fixed Uninitialized scalar variable (CID 1444788)
Fixed Uninitialized scalar variable (CID 1444789)
Fixed Uninitialized scalar variable (CID 1444790)
Fixed Logically dead code (CID 1444791)
Fixed missing break in switch (CID 1444794)