### PR TITLE
fix: [ADL/RPL-S/P/PS] I2C3 IRQ reported in ACPI is incorrect.

### DIFF
--- a/Platform/AlderlakeBoardPkg/AcpiTables/Dsdt/PciTree.asl
+++ b/Platform/AlderlakeBoardPkg/AcpiTables/Dsdt/PciTree.asl
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2021 - 2022, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2021 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -124,7 +124,7 @@ Scope(\_SB) {
     Package(){0x0015FFFF, 0, 0, 27 },
     Package(){0x0015FFFF, 1, 0, 40 },
     Package(){0x0015FFFF, 2, 0, 29 },
-    Package(){0x0015FFFF, 3, 0, 43 },
+    Package(){0x0015FFFF, 3, 0, 30 },
 #endif
 // D20
     Package(){0x0014FFFF, 0, 0, 16 },


### PR DESCRIPTION
The DevIntConfigPtr table sets the IRQ for I2C3 to 30 for ADP-S/P while ACPI DSDT _PRT is reporting IRQ 43. ACPI IRQ corrected to 30. This was resulting in decreased performance in benchmarks.