### PR TITLE
MultibootLib: Fix unable to load multiboot image with modules

### DIFF
--- a/BootloaderCommonPkg/Library/MultibootLib/Multiboot.c
+++ b/BootloaderCommonPkg/Library/MultibootLib/Multiboot.c
@@ -256,7 +256,7 @@ LoadMultibootModString (
   UINT8                      *NewCmdBuffer;
   UINT32                     NewSize;
 
-  if ((MultiBoot == NULL) || (File == NULL) || (ModuleIndex >= MultiBoot->MbModuleNumber)) {
+  if ((MultiBoot == NULL) || (File == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
 


### PR DESCRIPTION
LoadMultibootModString() checks the module index against MultiBoot-> MbModuleNumber, which value has not been assigned when called, causing failure when loading multiboot image with modules. Remove the check to fix it.

Fixes c9d70e74dcfe ("fix: multiboot mod string in zero-terminated ASCII format #1913")