### PR TITLE
feat: [CFL] add ResetSystemLib

### DIFF
--- a/Platform/CoffeelakeBoardPkg/BoardConfig.py
+++ b/Platform/CoffeelakeBoardPkg/BoardConfig.py
@@ -185,6 +185,7 @@ class Board(BaseBoard):
         common_libs = [
             'LoaderLib|Platform/CommonBoardPkg/Library/LoaderLib/LoaderLib.inf',
             'PlatformHookLib|Silicon/$(SILICON_PKG_NAME)/Library/PlatformHookLib/PlatformHookLib.inf',
+            'ResetSystemLib|Platform/$(BOARD_PKG_NAME)/Library/ResetSystemLib/ResetSystemLib.inf',
             'PchSpiLib|Silicon/CommonSocPkg/Library/PchSpiLib/PchSpiLib.inf',
             'SpiFlashLib|Silicon/CommonSocPkg/Library/SpiFlashLib/SpiFlashLib.inf',
             'PchSbiAccessLib|Silicon/CommonSocPkg/Library/PchSbiAccessLib/PchSbiAccessLib.inf',

--- a/Platform/CoffeelakeBoardPkg/Library/ResetSystemLib/ResetSystemLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/ResetSystemLib/ResetSystemLib.c
@@ -1,0 +1,164 @@
+/** @file
+  Reset System Library
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/IoLib.h>
+#include <Library/ResetSystemLib.h>
+#include <Library/PcdLib.h>
+#include <FspEas/FspApi.h>
+#include <Register/PchRegsPmc.h>
+#include <PchReservedResources.h>
+#include <PlatformBase.h>
+
+//
+// Reset Control Register
+//
+#define R_RST_CNT                     0xCF9 ///< Reset Control
+#define V_RST_CNT_FULLRESET           0x0E
+#define V_RST_CNT_HARDRESET           0x06
+
+#define R_PMC_PWRM_ETR3                                     0x1048
+#define B_PMC_PWRM_ETR3_CF9GR                               BIT20           ///< CF9h Global Reset
+
+/**
+  Calling this function causes a system-wide reset. This sets
+  all circuitry within the system to its initial state. This type of reset
+  is asynchronous to system operation and operates without regard to
+  cycle boundaries.
+
+  System reset should not return, if it returns, it means the system does
+  not support cold reset.
+**/
+VOID
+ResetCold (
+  VOID
+  )
+{
+  IoWrite8 ((UINTN) R_RST_CNT, V_RST_CNT_FULLRESET);
+}
+
+/**
+  Calling this function causes a system-wide initialization. The processors
+  are set to their initial state, and pending cycles are not corrupted.
+
+  System reset should not return, if it returns, it means the system does
+  not support warm reset.
+**/
+VOID
+ResetWarm (
+  VOID
+  )
+{
+  AsmWbinvd ();
+  IoWrite8 ((UINTN) R_RST_CNT, V_RST_CNT_HARDRESET);
+}
+
+/**
+  Calling this function causes the system to enter a power state equivalent
+  to the ACPI G2/S5 or G3 states.
+
+  System shutdown should not return, if it returns, it means the system does
+  not support shut down reset.
+**/
+VOID
+ResetShutdown (
+  VOID
+  )
+{
+  UINT32         Data32;
+
+  ///
+  /// Firstly, GPE0_EN should be disabled to avoid any GPI waking up the system from S5
+  ///
+  IoWrite32 (ACPI_BASE_ADDRESS + R_ACPI_IO_GPE0_EN_127_96, 0);
+
+  ///
+  /// Secondly, PwrSts register must be cleared
+  ///
+  /// Write a "1" to bit[8] of power button status register at
+  /// (PM_BASE + PM1_STS_OFFSET) to clear this bit
+  ///
+  IoWrite16 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_STS, B_ACPI_IO_PM1_STS_PRBTN);
+
+  ///
+  /// Finally, transform system into S5 sleep state
+  ///
+  Data32 = IoRead32 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_CNT);
+
+  Data32 = (UINT32) ((Data32 &~(B_ACPI_IO_PM1_CNT_SLP_TYP + B_ACPI_IO_PM1_CNT_SLP_EN)) | V_ACPI_IO_PM1_CNT_S5);
+
+  IoWrite32 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_CNT, Data32);
+
+  Data32 = Data32 | B_ACPI_IO_PM1_CNT_SLP_EN;
+
+  IoWrite32 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_CNT, Data32);
+
+  return;
+}
+
+/**
+  Calling this function causes a PCH Global reset in addition to system-wide
+  initialization.
+
+  System reset should not return, if it returns, it means the system does
+  not support warm reset.
+**/
+VOID
+ResetPchGlobal (
+  VOID
+  )
+{
+  MmioOr32 (PCH_PWRM_BASE_ADDRESS + R_PMC_PWRM_ETR3, (UINT32) B_PMC_PWRM_ETR3_CF9GR);
+  IoWrite8 ((UINTN) R_RST_CNT, V_RST_CNT_FULLRESET);
+}
+
+/**
+  Resets the entire platform.
+
+  @param[in] ResetType          The type of reset to perform.
+
+**/
+VOID
+EFIAPI
+ResetSystem (
+  IN EFI_RESET_TYPE   ResetType
+  )
+{
+  EFI_STATUS    FspResetRequest = 0;
+
+  switch (ResetType) {
+  case EfiResetWarm:
+    ResetWarm ();
+    break;
+
+  case EfiResetCold:
+    ResetCold ();
+    break;
+
+  case EfiResetShutdown:
+    ResetShutdown ();
+    break;
+
+  case EfiResetPlatformSpecific:
+    FspResetRequest = (EFI_STATUS)PcdGet32(PcdFspResetStatus);
+    if (FspResetRequest == FSP_STATUS_RESET_REQUIRED_3) {
+      ResetPchGlobal ();
+    }
+
+  default:
+    break;
+  }
+
+  //
+  // Coming here, either we are waiting while system reset is in progress
+  // or reset failed and we are in dead loop
+  //
+  CpuDeadLoop();
+}

--- a/Platform/CoffeelakeBoardPkg/Library/ResetSystemLib/ResetSystemLib.inf
+++ b/Platform/CoffeelakeBoardPkg/Library/ResetSystemLib/ResetSystemLib.inf
@@ -1,0 +1,42 @@
+## @file
+#   Library instance for ResetSystem library class for PCAT systems
+#
+#  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = ResetSystemLib
+  FILE_GUID                      = EC4F3E59-F879-418b-9E4C-7D6F434714A0
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = ResetSystemLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 IPF
+#
+
+[Sources]
+  ResetSystemLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+  BootloaderCorePkg/BootloaderCorePkg.dec
+  Silicon/CoffeelakePkg/CoffeelakePkg.dec
+  IntelFsp2Pkg/IntelFsp2Pkg.dec
+
+[LibraryClasses]
+  DebugLib
+  IoLib
+  BaseLib
+
+[Guids]
+  gPlatformModuleTokenSpaceGuid
+
+[Pcd]
+  gPlatformModuleTokenSpaceGuid.PcdFspResetStatus

--- a/Silicon/CoffeelakePkg/Include/Register/PchRegsPmc.h
+++ b/Silicon/CoffeelakePkg/Include/Register/PchRegsPmc.h
@@ -26,6 +26,7 @@
 
 #define R_ACPI_IO_PM1_CNT                        0x04
 #define B_ACPI_IO_PM1_CNT_SLP_TYP                (BIT12 | BIT11 | BIT10)
+#define B_ACPI_IO_PM1_CNT_SLP_EN                 BIT13
 
 #define R_ACPI_IO_PM1_TMR                        0x08
 #define B_ACPI_IO_PM1_TMR_VAL                    0xFFFFFF


### PR DESCRIPTION
A recent commit (b9057d) changed the FspResetHandler by seperating FSP_STATUS_RESET_REQUIRED_COLD from the other undefined cases with EfiResetPlatformSpecific reset. The common ResetSystemLib (BootloaderCommonPkg/Library/ResetSystemLib) does not handle EfiResetPlatformSpecific.

On CFL, FSP may register a EfiResetPlatformSpecific reset if some platform configuration changed, including but not limited to the case:
  - CSME update resulting in HECI FW EOP requsting for a reset Therefore, EfiResetPlatformSpecific must be handled.

The patch also adds support of EfiResetShutdown.