### PR TITLE
feat: [EHL] add EfiResetShutdown in ResetSystemLib

### DIFF
--- a/BootloaderCommonPkg/Library/ShellLib/CmdReset.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdReset.c
@@ -83,7 +83,11 @@ ShellCommandResetFunc (
     FuncResetSystem = PlatformService->ResetSystem;
   }
 
-  ShellPrint (L"Resetting...\n");
+  if (ResetType == EfiResetShutdown) {
+    ShellPrint (L"Start shutdowning...\n");
+  } else {
+    ShellPrint (L"Resetting...\n");
+  }
 
   FuncResetSystem (ResetType);
   return EFI_SUCCESS;

--- a/Platform/ElkhartlakeBoardPkg/Library/ResetSystemLib/ResetSystemLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/ResetSystemLib/ResetSystemLib.c
@@ -12,6 +12,7 @@
 #include <Library/IoLib.h>
 #include <Library/ResetSystemLib.h>
 #include <Library/PcdLib.h>
+#include <Register/PmcRegs.h>
 #include <PchAccess.h>
 #include <FspEas/FspApi.h>
 
@@ -56,6 +57,46 @@ ResetWarm (
 }
 
 /**
+  Calling this function causes the system to enter a power state equivalent
+  to the ACPI G2/S5 or G3 states.
+
+  System shutdown should not return, if it returns, it means the system does
+  not support shut down reset.
+**/
+VOID
+ResetShutdown (
+  VOID
+  )
+{
+  UINT32         Data32;
+  ///
+  /// Firstly, GPE0_EN should be disabled to avoid any GPI waking up the system from S5
+  ///
+  IoWrite32 (ACPI_BASE_ADDRESS + R_ACPI_IO_GPE0_EN_127_96, 0);
+
+  ///
+  /// Secondly, PwrSts register must be cleared
+  ///
+  /// Write a "1" to bit[8] of power button status register at
+  /// (PM_BASE + PM1_STS_OFFSET) to clear this bit
+  ///
+  IoWrite16 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_STS, B_ACPI_IO_PM1_STS_PWRBTN);
+
+  ///
+  /// Finally, transform system into S5 sleep state
+  ///
+  Data32 = IoRead32 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_CNT);
+
+  Data32 = (UINT32) ((Data32 &~(B_ACPI_IO_PM1_CNT_SLP_TYP + B_ACPI_IO_PM1_CNT_SLP_EN)) | V_ACPI_IO_PM1_CNT_S5);
+
+  IoWrite32 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_CNT, Data32);
+
+  Data32 = Data32 | B_ACPI_IO_PM1_CNT_SLP_EN;
+
+  IoWrite32 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_CNT, Data32);
+}
+
+/**
   Calling this function causes a PCH Global reset in addition to system-wide
   initialization.
 
@@ -91,6 +132,10 @@ ResetSystem (
 
   case EfiResetCold:
     ResetCold ();
+    break;
+
+  case EfiResetShutdown:
+    ResetShutdown ();
     break;
 
   case EfiResetPlatformSpecific:

--- a/Platform/ElkhartlakeBoardPkg/Library/ResetSystemLib/ResetSystemLib.inf
+++ b/Platform/ElkhartlakeBoardPkg/Library/ResetSystemLib/ResetSystemLib.inf
@@ -27,7 +27,7 @@
   MdePkg/MdePkg.dec
   BootloaderCommonPkg/BootloaderCommonPkg.dec
   BootloaderCorePkg/BootloaderCorePkg.dec
-  Silicon/AlderlakePkg/AlderlakePkg.dec
+  Silicon/ElkhartlakePkg/ElkhartlakePkg.dec
   IntelFsp2Pkg/IntelFsp2Pkg.dec
 
 [LibraryClasses]

--- a/Silicon/ElkhartlakePkg/Include/Register/PmcRegs.h
+++ b/Silicon/ElkhartlakePkg/Include/Register/PmcRegs.h
@@ -64,6 +64,7 @@
 #define B_ACPI_IO_PM1_EN_PWRBTN                  BIT8
 
 #define R_ACPI_IO_PM1_CNT                        0x04
+#define B_ACPI_IO_PM1_CNT_SLP_EN                 BIT13
 #define B_ACPI_IO_PM1_CNT_SLP_TYP                (BIT12 | BIT11 | BIT10)
 #define V_ACPI_IO_PM1_CNT_S0                     0
 #define V_ACPI_IO_PM1_CNT_S3                     (BIT12 | BIT10)


### PR DESCRIPTION
The patch handles EfiResetShutdown. With the patch, one can test "reset off" under OS Loader.

The patch also fixes a wrong reference error in ResetSystemLib.inf.
