### PR TITLE
fix: [MTL] Fix header missing build failure

### DIFF
--- a/Silicon/MeteorlakePkg/Library/BootGuardLibCBnT/BootGuardLibCBnT.inf
+++ b/Silicon/MeteorlakePkg/Library/BootGuardLibCBnT/BootGuardLibCBnT.inf
@@ -30,6 +30,7 @@
   BootloaderCorePkg/BootloaderCorePkg.dec
   BootloaderCommonPkg/BootloaderCommonPkg.dec
   Silicon/MeteorlakePkg/MeteorlakePkg.dec
+  Silicon/CommonSocPkg/CommonSocPkg.dec
 
 [Sources]
   BootGuardLibrary.c


### PR DESCRIPTION
Fix SBL build failure:
Update BootGuardCBnt.inf to include Silicon common dec file