### PR TITLE
feat: Update # of X2Apic Processor Local APIC

### DIFF
--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
@@ -395,7 +395,7 @@ UpdateMadt (
   while (MadtPtr < MadtEnd) {
     EntryHeader = (EFI_ACPI_MADT_ENTRY_COMMON_HEADER *)MadtPtr;
     Length = EntryHeader->Length;
-    if (EntryHeader->Type != EFI_ACPI_5_0_PROCESSOR_LOCAL_APIC) {
+    if ((EntryHeader->Type != EFI_ACPI_5_0_PROCESSOR_LOCAL_APIC) && (EntryHeader->Type != EFI_ACPI_5_0_PROCESSOR_LOCAL_X2APIC)) {
       CopyMem ((VOID *)Current, (VOID *)MadtPtr, Length);
       Current += Length;
     }


### PR DESCRIPTION
Since # of PROCESSOR_LOCAL_APICs are
Madt Local Apic # is 1.
Madt X2 Local Apic # is 9.

Need to update # of structure type of X2Apic.