### PR TITLE
fix:[MTL-P] Sync FSP Upd value with BIOS

### DIFF
--- a/Platform/MeteorlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/MeteorlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -434,7 +434,6 @@ UpdateFspConfig (
   Fspmcfg->PchHdaEnable                                         = 0x1;
   Fspmcfg->DmiMaxLinkSpeed                                      = 0x1;
   Fspmcfg->DmiAspm                                              = 0x4;
-  Fspmcfg->Gen3LtcoEnable                                       = 0x1;
   Fspmcfg->CsVrefLow                                            = 0x45;
   Fspmcfg->CsVrefHigh                                           = 0x1d;
   Fspmcfg->CaVrefLow                                            = 0x45;
@@ -445,22 +444,6 @@ UpdateFspConfig (
   Fspmcfg->PchDmiRtlepceb                                       = 0x0;
   Fspmcfg->SkipCpuReplacementCheck                              = 0x1;
   Fspmcfg->CridEnable                                           = 0x0;
-  Fspmcfg->DqsMapCpu2DramMc0Ch0[1] = 0x1;
-  Fspmcfg->DqsMapCpu2DramMc0Ch1[1] = 0x1;
-  Fspmcfg->DqsMapCpu2DramMc0Ch2[1] = 0x1;
-  Fspmcfg->DqsMapCpu2DramMc0Ch3[1] = 0x1;
-  Fspmcfg->DqsMapCpu2DramMc1Ch0[1] = 0x1;
-  Fspmcfg->DqsMapCpu2DramMc1Ch1[1] = 0x1;
-  Fspmcfg->DqsMapCpu2DramMc1Ch2[1] = 0x1;
-  Fspmcfg->DqsMapCpu2DramMc1Ch3[1] = 0x1;
-  Fspmcfg->DmiGen3DsPortRxPreset[0] = 0x1;
-  Fspmcfg->DmiGen3DsPortRxPreset[1] = 0x1;
-  Fspmcfg->DmiGen3DsPortRxPreset[2] = 0x1;
-  Fspmcfg->DmiGen3DsPortRxPreset[3] = 0x1;
-  Fspmcfg->DmiGen3DsPortRxPreset[4] = 0x1;
-  Fspmcfg->DmiGen3DsPortRxPreset[5] = 0x1;
-  Fspmcfg->DmiGen3DsPortRxPreset[6] = 0x1;
-  Fspmcfg->DmiGen3DsPortRxPreset[7] = 0x2;
 
   if (FeaturesCfgData != NULL) {
     if (FeaturesCfgData->Features.S0ix == 1) {
@@ -479,4 +462,3 @@ UpdateFspConfig (
     }
   }
 }
-

--- a/Platform/MeteorlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/MeteorlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -558,8 +558,9 @@ UpdateFspConfig (
       FspsConfig->PcieGen3EqPh3PostCursor0List[Index]      = 0xc;
       FspsConfig->PcieGen3EqPh3PostCursor2List[Index]      = 0xa;
       FspsConfig->PcieGen3EqPh3PreCursor9List[Index]       = 0x0;
-      FspsConfig->PcieGen3EqPh3Preset4List[Index]          = 0x0;
-      FspsConfig->PcieGen3EqPh3Preset5List[Index]          = 0x8;
+      FspsConfig->PcieGen3EqPh3Preset4List[Index]          = 0x8;
+      FspsConfig->PcieGen3EqPh3Preset5List[Index]          = 0x0;
+      FspsConfig->PcieGen4EqPh1DpTxPreset[Index]           = 0x7;
       FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[Index]    = 0x3;
       FspsConfig->PcieGen4EqPh3PostCursor0List[Index]      = 0xc;
       FspsConfig->PcieGen4EqPh3PostCursor2List[Index]      = 0xa;
@@ -577,7 +578,7 @@ UpdateFspConfig (
       FspsConfig->PcieRpNonSnoopLatencyOverrideMode[Index] = 0x2;
       FspsConfig->PcieRpPhysicalSlotNumber[Index]          = (UINT8)Index;
     }
-    FspsConfig->PcieGen3EqPh3Preset5List[11]               = 0x9;
+    FspsConfig->PcieGen3EqPh3Preset4List[11]               = 0x9;
     FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[11]         = 0x5;
 
     for (Index = 0; Index < 8; Index++) {
@@ -589,8 +590,8 @@ UpdateFspConfig (
   for (Index = 0; Index < 8; Index++) {
     FspsConfig->PcieRpSnoopLatencyOverrideMode[Index]      = 0x2;
     FspsConfig->PcieRpNonSnoopLatencyOverrideMode[Index]   = 0x2;
-    FspsConfig->TurboRatioLimitNumCore[Index]              = Index + 1;
-    FspsConfig->AtomTurboRatioLimitNumCore[Index]          = Index + 1;
+    FspsConfig->TurboRatioLimitNumCore[Index]              = 0x0;
+    FspsConfig->AtomTurboRatioLimitNumCore[Index]          = 0x0;
   }
 
   if(GetPayloadId () == 0) {
@@ -779,8 +780,8 @@ UpdateFspConfig (
   FspsConfig->MaxRatio                        = 0x4;
   FspsConfig->X2ApicEnable                    = 0x0;
   FspsConfig->PchUnlockGpioPads               = 0x1;
-  FspsConfig->PchPmDisableEnergyReport        = 0x1;
-  FspsConfig->XdciEnable                      = 0x1;
+  FspsConfig->PchPmDisableEnergyReport        = 0x0;
+  FspsConfig->XdciEnable                      = 0x0;
   FspsConfig->IshUartRxPinMuxing[1]           = 0x146806;
   FspsConfig->IshUartTxPinMuxing[1]           = 0x146807;
   FspsConfig->IshI2cSdaPinMuxing[2]           = 0x143012;
@@ -826,7 +827,7 @@ UpdateFspConfig (
   FspsConfig->PcieRpLtrOverrideSpecComplaint[10] = 0x0;
   FspsConfig->PcieRpLtrOverrideSpecComplaint[11] = 0x0;
   FspsConfig->TcssAuxOri = 0x1;
-  FspsConfig->EnableTcssCovTypeA[1] = 0x82;
+  FspsConfig->EnableTcssCovTypeA[1] = 0x0;
   FspsConfig->SerialIoSpiCsPinMux[0] = 0x14a48a;
   FspsConfig->SerialIoSpiClkPinMux[0] = 0x14a48b;
   FspsConfig->SerialIoSpiMisoPinMux[0] = 0x14a48c;


### PR DESCRIPTION
Sync up FSP UPD value to BIOS v3323_48

This UPD sync fixed DXE assert error when booting Ubuntu on pendrive