### PR TITLE
fix: [ADLN] program memory range above max address uncacheable

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.h
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.h
@@ -58,6 +58,7 @@
 #include <Library/SocInitLib.h>
 #include <Library/SmbusLib.h>
 #include <Library/CrashLogLib.h>
+#include <Register/Intel/ArchitecturalMsr.h>
 
 /**
   Initialize Variable.


### PR DESCRIPTION
Windows memory test failed with write back cacheable setting for memory address above maximum usable address.
The fix programs one MTRR register for memory range above max usable address to override default MTRR register setting after temp ram exit.