### PR TITLE
feat: Addition of GPIO V2 library support

### DIFF
--- a/Silicon/CommonSocPkg/Include/GpioV2Config.h
+++ b/Silicon/CommonSocPkg/Include/GpioV2Config.h
@@ -1,0 +1,101 @@
+/** @file
+  Header file for GpioConfig structure used by GPIOV2 library.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _GPIOV2_CONFIG_H_
+#define _GPIOV2_CONFIG_H_
+
+#include <Library/GpioV2Pad.h>
+
+#pragma pack(push, 1)
+
+/**
+  GPIO configuration structure used for pin programming.
+  Structure contains fields that can be used to configure pad.
+**/
+typedef struct {
+  /**
+  Pad Mode
+  Pad can be set as GPIO or one of its native functions.
+  When in native mode setting Direction (except Inversion), OutputState,
+  InterruptConfig, Host Software Pad Ownership and OutputStateLock are unnecessary.
+  Refer to definition of GPIOV2_PAD_MODE.
+  Refer to EDS for each native mode according to the pad.
+  **/
+  UINT32 PadMode       : 5;
+  /**
+  Host Software Pad Ownership
+  Set pad to ACPI mode or GPIO Driver Mode.
+  Refer to definition of GPIOV2_HOSTSW_OWN.
+  **/
+  UINT32 HostOwn     : 2;
+  /**
+  GPIO Direction
+  Can choose between In, In with inversion, Out, both In and Out, both In with inversion and out or disabling both.
+  Refer to definition of GPIOV2_DIRECTION for supported settings.
+  **/
+  UINT32 Direction      : 6;
+  /**
+  Output State
+  Set Pad output value.
+  Refer to definition of GPIOV2_PAD_STATE for supported settings.
+  This setting takes place when output is enabled.
+  **/
+  UINT32 OutputState         : 2;
+  /**
+  GPIO Interrupt Configuration
+  Set Pad to cause one of interrupts (IOxAPIC/SCI/SMI/NMI).
+  This setting is applicable only if GPIO is in GpioMode with input enabled.
+  Refer to definition of GPIOV2_INT_CONFIG for supported settings.
+  **/
+  UINT32 InterruptConfig     : 9;
+  /**
+  GPIO Reset Configuration.
+  This setting controls Pad Reset Configuration.
+  Refer to definition of GPIOV2_RESET_CONFIG for supported settings.
+  **/
+  UINT32 ResetConfig        : 8;
+  /**
+  GPIO Electrical Configuration
+  This setting controls pads termination.
+  Refer to definition of GPIOV2_TERMINATION_CONFIG for supported settings.
+  **/
+  UINT32 TerminationConfig   : 9;
+  /**
+  GPIO Lock Configuration
+  This setting controls pads lock.
+  Refer to definition of GPIOV2_PAD_LOCK for supported settings.
+  **/
+  UINT32 LockConfig         : 2;
+  /**
+  GPIO Lock Output State
+  This setting controls pads lock.
+  Refer to definition of GPIOV2_PAD_LOCK for supported settings.
+  **/
+  UINT32 LockTx         : 2;
+  /**
+  Additional GPIO configuration
+  Refer to definition of GPIOV2_OTHER_CONFIG for supported settings.
+  **/
+  UINT32 OtherSettings      : 12;
+
+  /**
+  Virtual GPIO eSPI Chip Select configuration
+  This setting selects between CS0 and CS1.
+  Refer to definition of VGPIO_CS_CONFIG for supported settings.
+  **/
+  UINT32 VgpioCs            : 2;
+
+  UINT32 RsvdBits           : 5;    ///< Reserved bits for future extension
+} GPIOV2_CONFIG;
+
+#pragma pack(pop)
+
+typedef struct {
+  GPIOV2_PAD           GpioPad;
+  GPIOV2_CONFIG        GpioConfig;
+} GPIOV2_INIT_CONFIG;
+
+#endif //_GPIOV2_CONFIG_H_

--- a/Silicon/CommonSocPkg/Include/Library/GpioTopologyLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/GpioTopologyLib.h
@@ -1,0 +1,130 @@
+
+/** @file
+  Header file for common part for GPIO V2 Controller
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef _GPIOV2_CONTROLLER_INIT_IBL_H_
+#define _GPIOV2_CONTROLLER_INIT_IBL_H_
+
+#include <Library/GpioV2ControllerInterface.h>
+#include <Library/P2SbController.h>
+
+#define GPIO_NAME_LENGTH_MAX          32
+#define MAX_GPIO_PINS                 100
+#define GPIOV2_NAME_LENGTH_MAX        32
+#define GPIOV2_CONTROLLER_HID_LENGTH  8
+
+/**
+  This procedure retrieves number of GPIO communities.
+
+  @retval  Number of GPIO communities
+**/
+UINT32
+GpioGetCommunitiesNum (
+  VOID
+  );
+
+/**
+  This procedure retrieves pointer to array of GPIO communities.
+
+  @retval  pointer to array of GPIO communities
+**/
+GPIOV2_COMMUNITY *
+GpioGetCommunities (
+  IN UINT32 CommunityIndex
+  );
+
+/**
+  This function returns whether given GPIO pad is a hard GPIO.
+  It checks whether given GPIO pad does not belong to the virtual GPIO community.
+
+  @param[in] GpioPad  Gpio pad
+  @retval             TRUE if given pad is hard GPIO, FALSE otherwise
+**/
+BOOLEAN
+IsHardGpio (
+  GPIOV2_PAD  GpioPad
+  );
+
+GPIOV2_GROUP
+SocGpioGetGroups (
+  IN UINT32 CommunityIndex,
+  IN UINT32 GroupIndex
+  );
+
+/**
+  This procedure retrieves register offset
+
+  @param[in] CommunityIndex      GPIO community group index
+  @retval P2sb side band register base address
+**/
+P2SB_SIDEBAND_REGISTER_ACCESS
+GetP2sbAddress (
+ IN UINT32  CommunityIndex
+);
+
+EFI_STATUS
+SocInstallCommunityAccess (
+ OUT P2SB_SIDEBAND_REGISTER_ACCESS   *CommunityAccess
+);
+
+/**
+  This procedure will confirm All pads in GpioPadsConfigTable belong to the same ChipsetId.
+
+  @param[in] GpioPad     Gpio pad
+
+  @retval Status
+**/
+EFI_STATUS
+GetGpioV2ServicesFromPad (
+  IN  GPIOV2_PAD                GpioPad
+  );
+
+/**
+  This procedure retrieves ChipID for the platform.
+
+  @retval  ChipId for the platform
+**/
+UINT32
+GpioGetChipId ( VOID );
+
+/**
+  return support status for P2SB PCR 20-bit addressing
+
+  @retval    TRUE
+  @retval    FALSE
+**/
+BOOLEAN
+IsP2sb20bPcrSupported (
+  VOID
+  );
+
+/**
+  Get P2SB instance for SOC
+
+  @param[in, out] None
+
+  @retval     P2SB_CONTROLLER           - P2SB_CONTROLLER Structure
+
+**/
+P2SB_CONTROLLER
+SocGetP2SbController (
+  VOID
+  );
+
+/**
+  Get P2SB instance for SOC
+
+  @param[in, out] None
+
+  @retval     P2SB_CONTROLLER           - P2SB_CONTROLLER Structure
+
+**/
+UINTN
+GetVgpioBaseAddress (
+  VOID
+  );
+#endif //_GPIOV2_CONTROLLER_INIT_IBL_H_

--- a/Silicon/CommonSocPkg/Include/Library/GpioV2ControllerInterface.h
+++ b/Silicon/CommonSocPkg/Include/Library/GpioV2ControllerInterface.h
@@ -1,0 +1,85 @@
+/** @file
+  Header file for GPIO V2 Controller Interace library.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef _GPIOV2_CONTROLLER_PRIVATE_H_
+#define _GPIOV2_CONTROLLER_PRIVATE_H_
+
+
+#include <Library/P2SbSidebandAccessLib.h>
+#include <Library/GpioV2Pad.h>
+typedef struct {
+  UINT8       GpeControllerDwxVal;
+  UINT8       GpioGpeDwxVal;
+} GPIOV2_GROUP_TO_GPE_MAPPING;
+
+typedef struct _GPIOV2_SERVICES_PRIVATE GPIOV2_SERVICES_PRIVATE;
+
+//
+// Stores information about the unlock request for each pad in the group.
+// Groups are assumed to be limited to 32 pads. Each bit in each UINT32 fields
+// corresponds to single pad in the group.
+//
+typedef struct {
+  UINT32  UnlockConfigBitMask;
+  UINT32  UnlockTxBitMask;
+} GPIOV2_UNLOCK_GROUP_DATA;
+
+typedef struct {
+  GPIOV2_PAD  GpioPad;
+  UINT32      GpioPadMode:5;
+  UINT32      Reserved:27;
+} GPIOV2_PAD_MODE_INFO;
+
+typedef union _GPIOV2_SIGNAL {
+  struct {
+    UINT32  PinIndex: 4;
+    UINT32  InterfaceIndex: 8;
+    UINT32  SignalType: 8;
+    UINT32  Interface: 8;
+    UINT32  InstanceIndex: 4;
+  }                               Fields;
+  UINT32                          Value;
+} GPIOV2_SIGNAL;
+
+typedef struct _GPIOV2_NATIVE_SIGNAL_DATA {
+  GPIOV2_SIGNAL                   Signal;
+  GPIOV2_IOSTANDBY_STATE          IosState;
+  GPIOV2_IOSTANDBY_TERM           IosTerm;
+  BOOLEAN                         VirtualWireMessageMappingAvailable;
+  UINT8                           VwIndex;
+  UINT8                           BitPosition;
+} GPIOV2_NATIVE_SIGNAL_DATA;
+
+typedef struct _GPIOV2_PAD_SIGNAL {
+  GPIOV2_SIGNAL                   Signal;
+  GPIOV2_PAD_MODE                 PadMode;
+} GPIOV2_PAD_SIGNAL;
+
+typedef struct _GPIOV2_PAD_DATA {
+  GPIOV2_PAD_SIGNAL               *PadSignals;
+  UINT32                          PadSignalsNum;
+} GPIOV2_PAD_DATA;
+
+typedef struct {
+  CONST CHAR8                     *Name;
+  GPIOV2_PAD_GROUP                GpioPadGroup;
+  GPIOV2_GROUP_TO_GPE_MAPPING     GroupToGpeMapping;
+  GPIOV2_GROUP_REGISTERS_OFFSETS  RegisterOffsets;
+  UINT32                          PadsNum;
+  GPIOV2_PAD                      *Pads;
+  GPIOV2_PAD_DATA                 *PadDataArray;
+} GPIOV2_GROUP;
+
+typedef struct GPIOV2_COMMUNITY_S {
+  GPIOV2_COMMUNITY_REGISTERS_OFFSETS  RegisterOffsets;
+  UINT32                              GroupsNum;
+  GPIOV2_GROUP                        *Groups;
+  UINT32                              Pid;
+  BOOLEAN                             IsComDsw;
+} GPIOV2_COMMUNITY;
+
+#endif // _GPIOV2_CONTROLLER_PRIVATE_H_

--- a/Silicon/CommonSocPkg/Include/Library/GpioV2Lib.h
+++ b/Silicon/CommonSocPkg/Include/Library/GpioV2Lib.h
@@ -1,0 +1,769 @@
+/** @file
+  Header file for platform GPIO V2 library.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _GPIOV2_LIB_H_
+#define _GPIOV2_LIB_H_
+
+#include <Base.h>
+#include <Uefi/UefiBaseType.h>
+#include <Library/IoLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Include/GpioV2Config.h>
+#include <Library/GpioV2ControllerInterface.h>
+#include <Library/BlMemoryAllocationLib.h>
+
+/**
+  This procedure verifies if requested GpioGroup definition is ment for platform that it is used on
+
+  @param[in]  GpioGroup           GPIO pad
+  @param[out] IsValid             Pointer to a buffer for validation information, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+IsGroupValid (
+  IN  GPIOV2_PAD_GROUP        GpioGroup,
+  OUT BOOLEAN                 *IsValid
+  );
+
+/**
+  This procedure verifies if requested GpioPad definition is ment for platform that it is used on
+
+  @param[in] GpioPad              GPIO pad
+  @param[out] IsValid             Pointer to a buffer for validation information, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+IsPadValid (
+  IN  GPIOV2_PAD              GpioPad,
+  OUT BOOLEAN                 *IsValid
+  );
+
+/**
+  This procedure retrieves name of requested Gpio Pad
+
+  @param[in] GpioPad              Gpio Pad. Please refer to GpioPinsYYY.h - where YYY name of the platform (eg. MTL, EBG, ...)
+  @param[in] NameBufferLength     Maximum number of characters to be stored in NameBuffer
+  @param[out] NameBuffer          Pointer to a buffer for Gpio Pad name
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+GetPadName (
+  IN  GPIOV2_PAD            GpioPad,
+  IN  UINT32                NameBufferLength,
+  OUT CHAR8                 *NameBuffer
+  );
+
+/**
+  This procedure retrieves register offset
+
+  @param[in]  Register            Register for which user want to retrieve offset. Please refer to GpioV2Pad.h
+  @param[in]  GpioPad             Gpio Pad. Please refer to GpioPinsYYY.h - where YYY name of the platform (eg. MTL, EBG, ...)
+  @param[out] RegisterOffset      Pointer to a buffer for register offset
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+GetRegisterOffset (
+  IN  GPIOV2_REGISTER     Register,
+  IN  GPIOV2_PAD          GpioPad,
+  OUT UINT32              *RegisterOffset
+  );
+
+/**
+  This procedure retrieves register offset
+
+  @param[in] CommunityIndex      GPIO community group index
+  @retval P2sb side band register base address
+**/
+P2SB_SIDEBAND_REGISTER_ACCESS
+GetP2sbAddress (
+ IN UINT32  CommunityIndex
+);
+
+/**
+  This procedure reads current ownership configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Ownership            Pointer to a buffer for ownership, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+GetOwnership (
+  IN  GPIOV2_PAD              GpioPad,
+  OUT GPIOV2_PAD_OWN          *Ownership
+  );
+
+/**
+  This procedure will set GPIO mode
+
+  @param[in] GpioPad              Gpio Pad. Please refer to GpioPinsYYY.h - where YYY name of the platform (eg. MTL, EBG, ...)
+  @param[in] PadModeValue         GPIO pad mode value
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetPadMode (
+  IN GPIOV2_PAD              GpioPad,
+  IN GPIOV2_PAD_MODE         PadMode
+  );
+
+/**
+  This procedure reads current GPIO Pad Mode
+
+  @param[in] GpioPad             GPIO Pad. Please refer to GpioPinsYYY.h - where YYY name of the platform (eg. MTL, EBG, ...)
+  @param[in] PadMode             Pointer to a buffer for GPIO Pad Mode
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetPadMode (
+  IN GPIOV2_PAD            GpioPad,
+  IN GPIOV2_PAD_MODE       *PadMode
+  );
+
+/**
+  This procedure sets host ownership configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Ownership            Host ownership, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+SetHostOwnership (
+  IN GPIOV2_PAD               GpioPad,
+  IN GPIOV2_HOSTSW_OWN        HostOnwership
+  );
+
+/**
+  This procedure reads current host ownership configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Ownership            Pointer to a buffer for ownership, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetHostOwnership (
+  IN  GPIOV2_PAD              GpioPad,
+  OUT GPIOV2_HOSTSW_OWN       *HostOwnership
+  );
+
+/**
+  This procedure sets Gpio Pad output state
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] OutputState         GpioV2StateLow - output state low, GpioV2StateHigh - output state high
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetTx (
+  IN GPIOV2_PAD             GpioPad,
+  IN GPIOV2_PAD_STATE       OutputState
+  );
+
+/**
+  This procedure reads current Gpio Pad output state
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] OutputState         Pointer to a buffer for output state
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetTx (
+  IN GPIOV2_PAD             GpioPad,
+  IN GPIOV2_PAD_STATE       *OutputState
+  );
+
+/**
+  This procedure reads current Gpio Pad input state
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] InputState          Pointer to a buffer for input state
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetRx (
+  IN GPIOV2_PAD           GpioPad,
+  IN GPIOV2_PAD_STATE     *InputState
+  );
+
+/**
+  This procedure reads if TX buffer for requested Gpio Pad is enabled or disabled
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] TxDisabled          Pointer to a buffer for enabled/disabled information
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetTxDisable (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  *TxDisabled
+  );
+
+/**
+  This procedure sets TX buffer for requested Gpio Pad as enabled or disabled
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] TxDisabled          True - TX buffer disabled, False - TX buffer enabled
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetTxDisable (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  TxDisabled
+  );
+
+/**
+  This procedure reads if RX buffer for requested Gpio Pad is enabled or disabled
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] RxDisabled          Pointer to a buffer for enabled/disabled information
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetRxDisable (
+  IN GPIOV2_PAD              GpioPad,
+  IN BOOLEAN                 *RxDisabled
+  );
+
+/**
+  This procedure sets Rx buffer for requested Gpio Pad as enabled or disabled
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] TxDisabled          True - TX buffer disabled, False - TX buffer enabled
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetRxDisable (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  RxDisabled
+  );
+
+/**
+  This procedure will set GPIO enable or disable input inversion on rquested pad
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] InputInversion      GpioV2InputInversionEnable or GpioV2InputInversionDisable, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetInputInversion (
+  IN GPIOV2_PAD                  GpioPad,
+  IN GPIOV2_PAD_INPUT_INVERSION  InputInversion
+  );
+
+/**
+  This procedure will Get GPIO enable or disable input inversion on rquested pad
+
+  @param[in]  GpioPad             GPIO pad
+  @param[Out] Inverted            Buffer for Boolean value
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetInputInversion (
+  IN GPIOV2_PAD                  GpioPad,
+  OUT BOOLEAN                    *Inverted
+  );
+
+/**
+  This procedure will set GPIO Lock (register PADCFGLOCK)
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] Lock                GpioV2Unlock - Unlock pad, GpioV2Lock - Lock pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+SetLock (
+  IN GPIOV2_PAD                GpioPad,
+  IN GPIOV2_PAD_LOCK           Lock
+  );
+
+/**
+  This procedure will get GPIO Lock (register PADCFGLOCK)
+
+  @param[in]  GpioPad             GPIO pad
+  @param[out] Lock                Buffer for GPIOV2_PAD_LOCK
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetLock (
+  IN  GPIOV2_PAD                   GpioPad,
+  OUT GPIOV2_PAD_LOCK              *Lock
+  );
+
+/**
+  This procedure will set GPIO Lock Tx (register PADCFGLOCKTX)
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] LockTx              GpioV2Unlock - Unlock output state of Gpio Pad, GpioV2Lock - Lock output state of Gpio Pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+SetLockTx (
+  IN GPIOV2_PAD                  GpioPad,
+  IN GPIOV2_PAD_LOCK             LockTx
+  );
+
+/**
+  This procedure will get GPIO Lock Tx (register PADCFGLOCKTX)
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] Lock                Buffer for GPIOV2_PAD_LOCK
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetLockTx (
+  IN GPIOV2_PAD                   GpioPad,
+  IN GPIOV2_PAD_LOCK              *Lock
+  );
+
+/**
+  This procedure sets NMI Enable for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] NmiEn                NMI Enable, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetNmiEn (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  NmiEn
+  );
+
+/**
+  This procedure sets SMI Enable configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] SmiEn                SMI Enable, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetSmiEn (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  SmiEn
+  );
+
+/**
+  This procedure sets GPI GPE Enable configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] GpiIe                GPI GPE Enable, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetGpiGpeEn (
+  IN GPIOV2_PAD              GpioPad,
+  IN BOOLEAN                 GpiGpeEn
+  );
+
+/**
+  This procedure reads current GPI GPE Enable configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] GpiIe                GPI GPE Enable, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetGpiGpeEn (
+  IN GPIOV2_PAD              GpioPad,
+  IN BOOLEAN                 *GpiGpeEn
+  );
+
+/**
+  This procedure sets Gpi Enable configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] GpiIe                GPI Enable, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetGpiIe (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  GpiIe
+  );
+
+
+/**
+  This procedure reads current Gpi Enable configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] GpiIe                Pointer to a buffer for GPI Enable
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetGpiIe (
+  IN GPIOV2_PAD              GpioPad,
+  IN BOOLEAN                 *GpiIe
+  );
+
+/**
+  This procedure reads current Gpi Status for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] GpiIe                Pointer to a buffer for GPI Enable
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetGpiIs (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  *GpiIs
+  );
+
+/**
+  This procedure sets GPIROUTNMI bit (17th bit in DW0) for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Enable               TRUE or FALSE, either enable or disable 17 bit in DW0
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetRouteNmi (
+  IN GPIOV2_PAD           GpioPad,
+  IN BOOLEAN              Enable
+  );
+
+/**
+  This procedure sets GPIROUTSMI bit (18th bit in DW0) for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Enable               TRUE or FALSE, either enable or disable 18 bit in DW0
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetRouteSmi (
+  IN GPIOV2_PAD           GpioPad,
+  IN BOOLEAN              Enable
+  );
+
+/**
+  This procedure sets GPIROUTIOXAPIC bit (20th bit in DW0) for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Enable               TRUE or FALSE, either enable or disable 20th bit in DW0
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetRouteIoxApic (
+  IN GPIOV2_PAD           GpioPad,
+  IN BOOLEAN              Enable
+  );
+
+/**
+  This procedure sets RxEv configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] RxEvCfg              RxEv configuration
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetRxEvCfg (
+  IN GPIOV2_PAD           GpioPad,
+  IN GPIOV2_RXEVCFG       RxEvCfg
+  );
+
+/**
+  This procedure sets GPIROUTSCI bit (19th bit in DW0) for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Enable               TRUE or FALSE, either enable or disable 19 bit in DW0
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetRouteSci (
+  IN GPIOV2_PAD           GpioPad,
+  IN BOOLEAN              Enable
+  );
+
+/**
+  This procedure sets Reset Configuration for requested Gpio Pad
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] ResetConfig         Reset Configuration - please refer to GpioV2Pad.h (GPIOV2_RESET_CONFIG)
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+SetResetConfig (
+  IN GPIOV2_PAD               GpioPad,
+  IN GPIOV2_RESET_CONFIG      ResetConfig
+  );
+
+/**
+  This procedure reads current Reset Configuration for requested Gpio Pad
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] ResetConfig         Pointer to a buffer for Reset Configuration
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetResetConfig (
+  IN GPIOV2_PAD               GpioPad,
+  IN GPIOV2_RESET_CONFIG      *ResetConfig
+  );
+
+/**
+  This function retreives Global Group Index from GPIOV2_PAD_GROUP.
+  Global Group Index is used in ASL code in ACPI interface.
+  Please refer to OneSiliconPkg\Fru\XXX\Include\AcpiTables\Dsdt\GpioGroupsXXX.asl file.
+
+  @param[in]  GpioGroup           Gpio Group
+  @param[out] GlobalGroupIndex    buffer for Global Group Index
+
+  @retval EFI_SUCCESS                    The function completed successfully
+  @retval EFI_INVALID_PARAMETER          Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+GetGlobalGroupIndex (
+  IN   GPIOV2_PAD_GROUP            GpioGroup,
+  OUT  UINT32                      *GlobalGroupIndex
+  );
+
+/**
+  Store unlock data.
+
+  @param[in] GpioPad        GPIO pad
+  @param[in] LockCfg        Pad config lock policy
+  @param[in] LockTx         Pad Tx lock policy
+**/
+VOID
+GpioV2StoreUnlockData (
+  IN GPIOV2_PAD        GpioPad,
+  IN GPIOV2_PAD_LOCK   LockCfg,
+  IN GPIOV2_PAD_LOCK   LockTx
+  );
+
+/**
+  This procedure will set GPIO mode for HDA SNDW functionality
+
+  @param[in] GpioPad              Gpio Pad
+  @param[in] PadConfig            Gpio Pad configuration - please refer to GPIOV2_CONFIG in GpioV2Config.h
+
+  @retval EFI_SUCCESS              The function completed successfully
+  @retval EFI_INVALID_PARAMETER    Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+ConfigurePad (
+  IN GPIOV2_PAD              GpioPad,
+  IN GPIOV2_CONFIG           *PadConfig
+  );
+
+/**
+  This procedure will confirm All pads in GpioPadsConfigTable belong to the same ChipsetId.
+
+  @param[in] GpioPad     Gpio pad
+
+  @retval Status
+**/
+EFI_STATUS
+GetGpioV2ServicesFromPad (
+  IN  GPIOV2_PAD                GpioPad
+  );
+
+/**
+  This procedure will configure all GPIO pads based on GpioPadsConfigTable
+
+  @param[in] GpioPadsConfigTable     Pointer to PadInitConfigTable
+  @param[in] GpioPadsConfigTableSize Size of PadInitConfigTable
+
+  @retval Status
+**/
+EFI_STATUS
+EFIAPI
+ConfigurePads (
+  IN GPIOV2_INIT_CONFIG       *GpioPadsConfigTable,
+  IN UINT32                   GpioPadsConfigTableSize
+  );
+
+/**
+  This procedure will initialize configuration for all GPIO based on GpioPadsConfigTable
+
+  @param[in] GpioPadsConfigTable     Pointer to PadInitConfigTable
+  @param[in] GpioPadsConfigTableSize Size of PadInitConfigTable
+
+  @retval Status
+**/
+EFI_STATUS
+GpioV2ConfigurePads (
+  IN GPIOV2_INIT_CONFIG       *GpioPadsConfigTable,
+  IN UINT32                   GpioPadsConfigTableSize
+  );
+
+/**
+  Print the output of the GPIO Config table that was read from CfgData.
+
+  @param GpioPinNum           Number of GPIO entries in the table.
+
+  @param GpioConfData         GPIO Config Data that was read from the Configuration region either from internal or external source.
+
+**/
+VOID
+PrintGpioV2ConfigTable (
+  IN UINT32              GpioPinNum,
+  IN VOID*               GpioConfData
+);
+
+/**
+  Configure the GPIO pins, available as part of platform specific GPIO CFG DATA.
+  If the pins are not part of GPIO CFG DATA, call GpioConfigurePads() directly
+  with the appropriate arguments.
+
+  @param    Tag         Tag ID of the Gpio Cfg data item
+  @param    Entries     Number of entries in Gpio Table
+  @param    DataBuffer  Pointer to the Gpio Table to be programmed
+
+  @retval EFI_SUCCESS                   The function completed successfully
+  @retval EFI_NOT_FOUND                 If Gpio Config Data cant be found
+**/
+EFI_STATUS
+EFIAPI
+ConfigureGpioV2 (
+  IN  UINT16  Tag,
+  IN GPIOV2_INIT_CONFIG                 *GpioTable,
+  IN UINT16                             GpioTableCount
+  );
+
+/**
+  This procedure sets termination configuration for requested Gpio Pad
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] TerminationConfig   Termination configuration, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+SetTerminationConfig (
+  IN GPIOV2_PAD                 GpioPad,
+  IN GPIOV2_TERMINATION_CONFIG  TerminationConfig
+  );
+
+#endif // _GPIOV2_LIB_H_

--- a/Silicon/CommonSocPkg/Include/Library/GpioV2Pad.h
+++ b/Silicon/CommonSocPkg/Include/Library/GpioV2Pad.h
@@ -1,0 +1,615 @@
+/** @file
+  General GPIO V2 Pad definition
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef _GPIOV2_PAD_H_
+#define _GPIOV2_PAD_H_
+
+typedef UINT32  GPIOV2_PAD;
+typedef UINT32  GPIOV2_NATIVE_PAD;
+typedef UINT32  GPIOV2_PAD_GROUP;
+
+
+#define GPIOV2_PAD_NONE 0
+#define GPIOV2_PAD_INVALID 0xFFFFFFFF
+#define GPIOV2_PAD_GROUP_NONE 0
+
+// If Bit 0 is 0 then Library ignores remaining value
+// If Bit 0 is 1 then Library programes remaining value.
+#define GPIO_ASSIGN_VALUE(Val) (Val << 1) | 0x01
+
+#define GPIO_STATE(Val)  (UINT32) ((Val >> 1) & 0x01)
+
+#define GPIOV2_PAD_MASK_FUNCTIONALITY          (0x3FF)
+#define GPIOV2_PAD_POS_FUNCTIONALITY           (22)
+#define GPIOV2_PAD_MASK_CHIPSETID              (0x1F)
+#define GPIOV2_PAD_POS_CHIPSETID               (17)
+#define GPIOV2_PAD_MASK_NATIVE_FUNCTION        (0xF)
+#define GPIOV2_PAD_POS_NATIVE_FUNCTION         (13)
+#define GPIOV2_PAD_MASK_COMMUNITY_INDEX        (0x7)
+#define GPIOV2_PAD_POS_COMMUNITY_INDEX         (10)
+#define GPIOV2_PAD_MASK_GROUP_INDEX            (0x7)
+#define GPIOV2_PAD_POS_GROUP_INDEX             (7)
+#define GPIOV2_PAD_MASK_PAD_INDEX              (0x7F)
+#define GPIOV2_PAD_POS_PAD_INDEX               (0)
+
+#define GPIOV2_PAD_ID(Functionality, ChipsetId, NativeFunction, CommunityIndex, GroupIndex, PadIndex) \
+        ( ((Functionality & GPIOV2_PAD_MASK_FUNCTIONALITY) << GPIOV2_PAD_POS_FUNCTIONALITY) |\
+          ((ChipsetId & GPIOV2_PAD_MASK_CHIPSETID) << GPIOV2_PAD_POS_CHIPSETID) |\
+          ((NativeFunction & GPIOV2_PAD_MASK_NATIVE_FUNCTION) << GPIOV2_PAD_POS_NATIVE_FUNCTION) |\
+          ((CommunityIndex & GPIOV2_PAD_MASK_COMMUNITY_INDEX) << GPIOV2_PAD_POS_COMMUNITY_INDEX) |\
+          ((GroupIndex & GPIOV2_PAD_MASK_GROUP_INDEX) << GPIOV2_PAD_POS_GROUP_INDEX) |\
+          ((PadIndex & GPIOV2_PAD_MASK_PAD_INDEX) << GPIOV2_PAD_POS_PAD_INDEX) \
+        )
+
+#define GPIOV2_PAD_SET_FUNCTIONALITY(PadDefinition, Functionality) \
+        ( (PadDefinition & ~(GPIOV2_PAD_MASK_FUNCTIONALITY << GPIOV2_PAD_POS_FUNCTIONALITY)) | \
+          ((Functionality & GPIOV2_PAD_MASK_FUNCTIONALITY) << GPIOV2_PAD_POS_FUNCTIONALITY) \
+        )
+
+#define GPIOV2_PAD_SET_CHIPSETID(PadDefinition, ChipsetId) \
+        ( (PadDefinition & ~(GPIOV2_PAD_MASK_CHIPSETID << GPIOV2_PAD_POS_CHIPSETID)) | \
+          ((ChipsetId & GPIOV2_PAD_MASK_CHIPSETID) << GPIOV2_PAD_POS_CHIPSETID) \
+        )
+
+#define GPIOV2_PAD_SET_NATIVE_FUNCTION(PadDefinition, NativeFunction) \
+        ( (PadDefinition & ~(GPIOV2_PAD_MASK_NATIVE_FUNCTION << GPIOV2_PAD_POS_NATIVE_FUNCTION)) | \
+          ((NativeFunction & GPIOV2_PAD_MASK_NATIVE_FUNCTION) << GPIOV2_PAD_POS_NATIVE_FUNCTION) \
+        )
+
+#define GPIOV2_PAD_SET_COMMUNITY_INDEX(PadDefinition, CommunityIndex) \
+        ( (PadDefinition & ~(GPIOV2_PAD_MASK_COMMUNITY_INDEX << GPIOV2_PAD_POS_COMMUNITY_INDEX)) | \
+          ((CommunityIndex & GPIOV2_PAD_MASK_COMMUNITY_INDEX) << GPIOV2_PAD_POS_COMMUNITY_INDEX) \
+        )
+
+#define GPIOV2_PAD_SET_GROUP_INDEX(PadDefinition, GroupIndex) \
+        ( (PadDefinition & ~(GPIOV2_PAD_MASK_GROUP_INDEX << GPIOV2_PAD_POS_GROUP_INDEX)) | \
+          ((GroupIndex & GPIOV2_PAD_MASK_GROUP_INDEX) << GPIOV2_PAD_POS_GROUP_INDEX) \
+        )
+
+#define GPIOV2_PAD_SET_PAD_INDEX(PadDefinition, PadIndex) \
+        ( (PadDefinition & ~(GPIOV2_PAD_MASK_PAD_INDEX << GPIOV2_PAD_POS_PAD_INDEX)) | \
+          ((PadIndex & GPIOV2_PAD_MASK_PAD_INDEX) << GPIOV2_PAD_POS_PAD_INDEX) \
+        )
+
+#define GPIOV2_PAD_GET_FUNCTIONALITY(PadDefinition) \
+        ( (PadDefinition >> GPIOV2_PAD_POS_FUNCTIONALITY) & GPIOV2_PAD_MASK_FUNCTIONALITY )
+
+#define GPIOV2_PAD_GET_CHIPSETID(PadDefinition) \
+        ( (PadDefinition >> GPIOV2_PAD_POS_CHIPSETID) & GPIOV2_PAD_MASK_CHIPSETID )
+
+#define GPIOV2_PAD_GET_NATIVE_FUNCTION(PadDefinition) \
+        ( (PadDefinition >> GPIOV2_PAD_POS_NATIVE_FUNCTION) & GPIOV2_PAD_MASK_NATIVE_FUNCTION )
+
+#define GPIOV2_PAD_GET_COMMUNITY_INDEX(PadDefinition) \
+        ( (PadDefinition >> GPIOV2_PAD_POS_COMMUNITY_INDEX) & GPIOV2_PAD_MASK_COMMUNITY_INDEX )
+
+#define GPIOV2_PAD_GET_GROUP_INDEX(PadDefinition) \
+        ( (PadDefinition >> GPIOV2_PAD_POS_GROUP_INDEX) & GPIOV2_PAD_MASK_GROUP_INDEX )
+
+#define GPIOV2_PAD_GET_PAD_INDEX(PadDefinition) \
+        ( (PadDefinition >> GPIOV2_PAD_POS_PAD_INDEX) & GPIOV2_PAD_MASK_PAD_INDEX )
+
+#define GPIOV2_PAD_GET_PAD_MODE(PadDefinition) \
+        ( ((GPIOV2_PAD_GET_NATIVE_FUNCTION(PadDefinition)) << 1 ) | 0x1 )
+
+typedef enum {
+  GpioV2PadModeHardwareDefault  = 0x0,
+  GpioV2PadModeGpio             = GPIO_ASSIGN_VALUE(0x0),
+  GpioV2PadModeNative1          = GPIO_ASSIGN_VALUE(0x1),
+  GpioV2PadModeNative2          = GPIO_ASSIGN_VALUE(0x2),
+  GpioV2PadModeNative3          = GPIO_ASSIGN_VALUE(0x3),
+  GpioV2PadModeNative4          = GPIO_ASSIGN_VALUE(0x4),
+  GpioV2PadModeNative5          = GPIO_ASSIGN_VALUE(0x5),
+  GpioV2PadModeNative6          = GPIO_ASSIGN_VALUE(0x6),
+  GpioV2PadModeNative7          = GPIO_ASSIGN_VALUE(0x7),
+  GpioV2PadModeNative8          = GPIO_ASSIGN_VALUE(0x8),
+  GpioV2PadModeNative9          = GPIO_ASSIGN_VALUE(0x9),
+  GpioV2PadModeNative10         = GPIO_ASSIGN_VALUE(0xA),
+  GpioV2PadModeNative11         = GPIO_ASSIGN_VALUE(0xB),
+  GpioV2PadModeNative12         = GPIO_ASSIGN_VALUE(0xC),
+  GpioV2PadModeNative13         = GPIO_ASSIGN_VALUE(0xD),
+  GpioV2PadModeNative14         = GPIO_ASSIGN_VALUE(0xE),
+  GpioV2PadModeNative15         = GPIO_ASSIGN_VALUE(0xF)
+} GPIOV2_PAD_MODE;
+
+#define GPIOV2_PAD_MODE_MASK       (0xF)
+#define GPIOV2_PAD_MODE_DW0_POS    (10)
+
+typedef enum {
+  GpioV2InputInversionHardwareDefault = 0x0,
+  GpioV2InputInversionDisable         = GPIO_ASSIGN_VALUE(0x0),
+  GpioV2InputInversionEnable          = GPIO_ASSIGN_VALUE(0x1)
+} GPIOV2_PAD_INPUT_INVERSION;
+
+#define GPIOV2_PAD_INPUT_INVERSION_MASK        (0x1)
+#define GPIOV2_PAD_INPUT_INVERSION_DW0_POS     (23)
+
+typedef enum {
+  GpioV2LockHardwareDefault   = 0x0,
+  GpioV2Unlock                = GPIO_ASSIGN_VALUE(0x0),  ///< Leave Pad configuration unlocked
+  GpioV2Lock                  = GPIO_ASSIGN_VALUE(0x1)   ///< Lock Pad configuration
+} GPIOV2_PAD_LOCK;
+
+#define GPIOV2_PAD_LOCK_MASK        (0x1)
+
+typedef enum {
+  GpioV2StateDefault     = 0x0,
+  GpioV2StateLow         = GPIO_ASSIGN_VALUE(0x0),
+  GpioV2StateHigh        = GPIO_ASSIGN_VALUE(0x1)
+} GPIOV2_PAD_STATE;
+
+#define GPIOV2_PAD_OUTPUT_STATE_MASK        (0x1)
+#define GPIOV2_PAD_OUTPUT_STATE_DW0_POS     (0)
+
+#define GPIOV2_PAD_INPUT_STATE_MASK         (0x1)
+#define GPIOV2_PAD_INPUT_STATE_DW0_POS      (1)
+
+#define GPIOV2_PAD_TX_DISABLE_MASK          (0x1)
+#define GPIOV2_PAD_TX_DISABLE_DW0_POS       (8)
+
+#define GPIOV2_PAD_RX_DISABLE_MASK          (0x1)
+#define GPIOV2_PAD_RX_DISABLE_DW0_POS       (9)
+
+typedef enum {
+  GpioV2ResetDefault     = 0x00,        ///< Leave value of pad reset unmodified
+  /**
+  Resume Reset (RSMRST)
+    GPP: PadRstCfg = 00b = "Powergood"
+    GPD: PadRstCfg = 11b = "Resume Reset"
+  Pad setting will reset on:
+  - DeepSx transition
+  - G3
+  Pad settings will not reset on:
+  - S3/S4/S5 transition
+  - Warm/Cold/Global reset
+  **/
+  GpioV2ResetResume      = GPIO_ASSIGN_VALUE(0x0),
+  /**
+  Host Deep Reset
+    PadRstCfg = 01b = "Deep GPIO Reset"
+  Pad settings will reset on:
+  - Warm/Cold/Global reset
+  - DeepSx transition
+  - G3
+  Pad settings will not reset on:
+  - S3/S4/S5 transition
+  **/
+  GpioV2ResetHostDeep    = GPIO_ASSIGN_VALUE(0x1),
+  /**
+  Platform Reset (PLTRST)
+    PadRstCfg = 10b = "GPIO Reset"
+  Pad settings will reset on:
+  - S3/S4/S5 transition
+  - Warm/Cold/Global reset
+  - DeepSx transition
+  - G3
+  **/
+  GpioV2ResetHost        = GPIO_ASSIGN_VALUE(0x2),
+  /**
+  Deep Sleep Well Reset (DSW_PWROK)
+    GPP: not applicable
+    GPD: PadRstCfg = 00b = "Powergood"
+  Pad settings will reset on:
+  - G3
+  Pad settings will not reset on:
+  - S3/S4/S5 transition
+  - Warm/Cold/Global reset
+  - DeepSx transition
+  **/
+  GpioV2DswReset          = GPIO_ASSIGN_VALUE(0x3),
+  /**
+  Global reset.
+    PadRstCfg = 11b = "Global reset"
+  Pad settings will reset on:
+  - Global reset
+  - G3
+  Pad settings will not reset on:
+  - S3/S4/S5 transition
+  - Warm/Cold reset
+  - DeepSx transition
+  **/
+  GpioV2ResetGlobal      = GPIO_ASSIGN_VALUE(0x4)
+} GPIOV2_RESET_CONFIG;
+
+
+#define GPIOV2_PAD_RESET_CONFIG_MASK        (0x3)
+#define GPIOV2_PAD_RESET_CONFIG_DW0_POS     (30)
+
+typedef enum {
+  GpioV2TermDefault          = 0x0,  ///< Leave termination setting unmodified
+  GpioV2TermNone             = 0x1,  ///< none
+  GpioV2TermWpd5K            = 0x5,  ///< 5kOhm weak pull-down
+  GpioV2TermWpd20K           = 0x9,  ///< 20kOhm weak pull-down
+  GpioV2TermWpu1K            = 0x13, ///< 1kOhm weak pull-up
+  GpioV2TermWpu2K            = 0x17, ///< 2kOhm weak pull-up
+  GpioV2TermWpu5K            = 0x15, ///< 5kOhm weak pull-up
+  GpioV2TermWpu20K           = 0x19, ///< 20kOhm weak pull-up
+  GpioV2TermWpu1K2K          = 0x1B, ///< 1kOhm & 2kOhm weak pull-up
+  /**
+  Native function controls pads termination
+  This setting is applicable only to some native modes.
+  Please check EDS to determine which native functionality
+  can control pads termination
+  **/
+  GpioV2TermNative           = 0x1F
+} GPIOV2_TERMINATION_CONFIG;
+
+#define GPIOV2_PAD_TERMINATION_CONFIG_MASK        (0xF)
+#define GPIOV2_PAD_TERMINATION_CONFIG_DW1_POS     (10)
+
+typedef enum {
+  GpioV2IosStateDefault         = 0x0,
+  GpioV2IosStateLatchLastValue  = GPIO_ASSIGN_VALUE(0x0),  ///< Latch last value driven on TX, TX Enable and RX Enable
+  GpioV2IosStateTx0Rx0RxDis     = GPIO_ASSIGN_VALUE(0x1),  ///< TX: 0, RX: 0 (internally), RX disabled
+  GpioV2IosStateTx0Rx1RxDis     = GPIO_ASSIGN_VALUE(0x2),  ///< TX: 0, RX: 1 (internally), RX disabled
+  GpioV2IosStateTx1Rx0RxDis     = GPIO_ASSIGN_VALUE(0x3),  ///< TX: 1, RX: 0 (internally), RX disabled
+  GpioV2IosStateTx1Rx1RxDis     = GPIO_ASSIGN_VALUE(0x4),  ///< TX: 1, RX: 1 (internally), RX disabled
+  GpioV2IosStateTx0RxEn         = GPIO_ASSIGN_VALUE(0x5),  ///< TX: 0, RX enabled
+  GpioV2IosStateTx1RxEn         = GPIO_ASSIGN_VALUE(0x6),  ///< TX: 1, RX enabled
+  GpioV2IosStateHizRx0          = GPIO_ASSIGN_VALUE(0x7),  ///< Hi-Z, RX: 0 (internally)
+  GpioV2IosStateHizRx1          = GPIO_ASSIGN_VALUE(0x8),  ///< Hi-Z, RX: 1 (internally)
+  GpioV2IosStateTxDisRxEn       = GPIO_ASSIGN_VALUE(0x9),  ///< TX Disabled and RX Enabled (i.e. wake or interrupt)
+  GpioV2IosStateMasked          = GPIO_ASSIGN_VALUE(0xF)   ///< IO Standby signal is masked for this pad. In this mode, a pad operates as if IOStandby has not been asserted.
+} GPIOV2_IOSTANDBY_STATE;
+
+#define GPIOV2_PAD_IOSTANDBY_STATE_MASK        (0xF)
+#define GPIOV2_PAD_IOSTANDBY_STATE_DW1_POS     (14)
+
+/**
+  GPIO Standby Term configuration
+  Standby Termination options for GPIO Pads
+**/
+typedef enum {
+  GpioV2IosTermDefault         = 0x00,
+  GpioV2IosTermSame            = GPIO_ASSIGN_VALUE(0x0), ///< Same as state specified in Term
+  GpioV2IosTermPuDisPdDis      = GPIO_ASSIGN_VALUE(0x1), ///< Disable Pullup and Pulldown
+  GpioV2IosTermPuDisPdEn       = GPIO_ASSIGN_VALUE(0x2), ///< Enable Pulldown
+  GpioV2IosTermPuEnPdDis       = GPIO_ASSIGN_VALUE(0x3)  ///< Enable Pullup
+} GPIOV2_IOSTANDBY_TERM;
+
+#define GPIOV2_PAD_IOSTANDBY_TERM_MASK        (0x3)
+#define GPIOV2_PAD_IOSTANDBY_TERM_DW1_POS     (8)
+
+#define GPIOV2_PAD_DEBOUNCE_ENABLE_MASK       (0x1)
+#define GPIOV2_PAD_DEBOUNCE_ENABLE_DW2_POS    (0)
+
+#define GPIOV2_PAD_DEBOUNCE_TIMER_MASK        (0xF)
+#define GPIOV2_PAD_DEBOUNCE_TIMER_DW2_POS     (1)
+
+#define GPIOV2_PAD_OWNERSHIP_HOST      (0x00)
+#define GPIOV2_PAD_OWNERSHIP_CSME      (0x01)
+#define GPIOV2_PAD_OWNERSHIP_ISH       (0x02)
+#define GPIOV2_PAD_OWNERSHIP_IE        (0x03)
+typedef enum {
+  GpioV2PadOwnHost = GPIO_ASSIGN_VALUE(GPIOV2_PAD_OWNERSHIP_HOST),
+  GpioV2PadOwnCsme = GPIO_ASSIGN_VALUE(GPIOV2_PAD_OWNERSHIP_CSME),
+  GpioV2PadOwnIsh  = GPIO_ASSIGN_VALUE(GPIOV2_PAD_OWNERSHIP_ISH),
+  GpioV2PadOwnIe   = GPIO_ASSIGN_VALUE(GPIOV2_PAD_OWNERSHIP_IE),
+} GPIOV2_PAD_OWN;
+
+#define GPIOV2_PAD_OWNERSHIP_MASK_REV1   (0x7)
+#define GPIOV2_PAD_OWNERSHIP_MASK        (0x3)
+#define GPIOV2_PAD_OWNERSHIP_POS         (0)
+
+/**
+  Pad Own Register Revision.
+  Supported settings:
+    0x0 : Multiple pad shares same PAD Ownership register and bit field is 2 bit wide for each Pad.
+    0x1 : Each pad has dedicated Pad Ownership register and bit field is 3 bit wide.
+**/
+typedef enum {
+  GpioV2PadOwnRegRev0       = 0x0,
+  GpioV2PadOwnRegRev1       = 0x1
+} GPIOV2_PAD_OWN_REG_REV;
+
+/**
+  Host Software Pad Ownership modes
+  This setting affects GPIO interrupt status registers. Depending on chosen ownership
+  some GPIO Interrupt status register get updated and other masked.
+  Please refer to EDS for HOSTSW_OWN register description.
+**/
+typedef enum {
+  GpioV2HostOwnDefault = 0x0,   ///< Leave ownership value unmodified
+  /**
+  Set HOST ownership to ACPI.
+  Use this setting if pad is not going to be used by GPIO OS driver.
+  If GPIO is configured to generate SCI/SMI/NMI then this setting must be
+  used for interrupts to work
+  **/
+  GpioV2HostOwnAcpi    = GPIO_ASSIGN_VALUE(0x0),
+  /**
+  Set HOST ownership to GPIO Driver mode.
+  Use this setting only if GPIO pad should be controlled by GPIO OS Driver.
+  GPIO OS Driver will be able to control the pad if appropriate entry in
+  ACPI exists (refer to ACPI specification for GpioIo and GpioInt descriptors)
+  **/
+  GpioV2HostOwnGpio    = GPIO_ASSIGN_VALUE(0x1)
+} GPIOV2_HOSTSW_OWN;
+
+#define GPIOV2_PAD_HOST_OWNERSHIP_MASK        (0x1)
+#define GPIOV2_PAD_HOST_OWNERSHIP_POS         (0x0)
+
+#define GPIOV2_PAD_GPI_IE_MASK                (0x1)
+#define GPIOV2_PAD_GPI_IE_POS                 (0x0)
+
+#define GPIOV2_PAD_GPI_IS_MASK                (0x1)
+#define GPIOV2_PAD_GPI_IS_POS                 (0x0)
+
+#define GPIOV2_PAD_GPI_GPE_EN_MASK            (0x1)
+#define GPIOV2_PAD_GPI_GPE_EN_POS             (0x0)
+
+#define GPIOV2_PAD_GPI_GPE_STS_MASK           (0x1)
+#define GPIOV2_PAD_GPI_GPE_STS_POS            (0x0)
+
+#define GPIOV2_PAD_NMI_EN_MASK                (0x1)
+#define GPIOV2_PAD_NMI_EN_POS                 (0x0)
+
+#define GPIOV2_PAD_NMI_STS_MASK               (0x1)
+#define GPIOV2_PAD_NMI_STS_POS                (0x0)
+
+#define GPIOV2_PAD_SMI_EN_MASK                (0x1)
+#define GPIOV2_PAD_SMI_EN_POS                 (0x0)
+
+#define GPIOV2_PAD_SMI_STS_MASK               (0x1)
+#define GPIOV2_PAD_SMI_STS_POS                (0x0)
+
+typedef enum {
+  GpioV2IntRxEvCfgDefault     = 0x00,
+  GpioV2IntRxEvCfgLevel       = GPIO_ASSIGN_VALUE(0x0),
+  GpioV2IntRxEvCfgEdge        = GPIO_ASSIGN_VALUE(0x1),
+  GpioV2IntRxEvCfgDisable     = GPIO_ASSIGN_VALUE(0x2),
+  GpioV2IntRxEvCfgLevelEdge   = GPIO_ASSIGN_VALUE(0x3),
+} GPIOV2_RXEVCFG;
+
+#define GPIOV2_PAD_RXEV_MASK                  (0x3)
+#define GPIOV2_PAD_RXEV_DW0_POS               (25)
+
+///
+/// GPIO Direction
+///
+typedef enum {
+  GpioV2DirDefault         = 0x0,                     ///< Leave pad direction setting unmodified
+  GpioV2DirInOut           = GPIO_ASSIGN_VALUE(0x1),  ///< Set pad for both output and input
+  GpioV2DirInInvOut        = GPIO_ASSIGN_VALUE(0x2),  ///< Set pad for both output and input with inversion
+  GpioV2DirIn              = GPIO_ASSIGN_VALUE(0x3),  ///< Set pad for input only
+  GpioV2DirInInv           = GPIO_ASSIGN_VALUE(0x4),  ///< Set pad for input with inversion
+  GpioV2DirOut             = GPIO_ASSIGN_VALUE(0x5),  ///< Set pad for output only
+  GpioV2DirNone            = GPIO_ASSIGN_VALUE(0x6)   ///< Disable both output and input
+} GPIOV2_DIRECTION;
+
+/**
+  GPIO interrupt configuration
+  This setting is applicable only if pad is in GPIO mode and has input enabled.
+  GPIO_INT_CONFIG allows to choose which interrupt is generated (IOxAPIC/SCI/SMI/NMI)
+  and how it is triggered (edge or level). Refer to PADCFG_DW0 register description in
+  EDS for details on this settings.
+  Field from GpioIntNmi to GpioIntApic can be OR'ed with GpioIntLevel to GpioIntBothEdge
+  to describe an interrupt e.g. GpioIntApic | GpioIntLevel
+  If GPIO is set to cause an SCI then also GPI_GPE_EN is enabled for this pad.
+  If GPIO is set to cause an NMI then also GPI_NMI_EN is enabled for this pad.
+  Not all GPIO are capable of generating an SMI or NMI interrupt.
+  When routing GPIO to cause an IOxAPIC interrupt care must be taken, as this
+  interrupt cannot be shared and its IRQn number is not configurable.
+  Refer to EDS for GPIO pads IRQ numbers (PADCFG_DW1.IntSel)
+  If GPIO is under GPIO OS driver control and appropriate ACPI GpioInt descriptor
+  exist then use only trigger type setting (from GpioIntLevel to GpioIntBothEdge).
+  This type of GPIO Driver interrupt doesn't have any additional routing setting
+  required to be set by SBL. Interrupt is handled by GPIO OS Driver.
+**/
+
+typedef enum {
+  GpioV2IntDefault            = 0x0,                     ///< Leave value of interrupt routing unmodified
+  GpioV2IntDis                = 0x1,                     ///< Disable IOxAPIC/SCI/SMI/NMI interrupt generation
+  GpioV2IntNmi                = GPIO_ASSIGN_VALUE(0x1),  ///< Enable NMI interrupt only
+  GpioV2IntSmi                = GPIO_ASSIGN_VALUE(0x2),  ///< Enable SMI interrupt only
+  GpioV2IntSci                = GPIO_ASSIGN_VALUE(0x4),  ///< Enable SCI interrupt only
+  GpioV2IntApic               = GPIO_ASSIGN_VALUE(0x8),  ///< Enable IOxAPIC interrupt only
+  GpioV2IntLevel              = GPIO_ASSIGN_VALUE(0x10), ///< Set interrupt as level triggered
+  GpioV2IntEdge               = GPIO_ASSIGN_VALUE(0x20), ///< Set interrupt as edge triggered (type of edge depends on input inversion)
+  GpioV2IntLvlEdgDis          = GPIO_ASSIGN_VALUE(0x40), ///< Disable interrupt trigger
+  GpioV2IntBothEdge           = GPIO_ASSIGN_VALUE(0x80), ///< Set interrupt as both edge triggered
+} GPIOV2_INT_CONFIG;
+
+#define GPIOV2_PAD_GPIROUTNMI_DW0_POS       (17)
+#define GPIOV2_PAD_GPIROUTNMI_DW0_MASK      (1)
+
+#define GPIOV2_PAD_GPIROUTSMI_DW0_POS       (18)
+#define GPIOV2_PAD_GPIROUTSMI_DW0_MASK      (1)
+
+#define GPIOV2_PAD_GPIROUTSCI_DW0_POS       (19)
+#define GPIOV2_PAD_GPIROUTSCI_DW0_MASK      (1)
+
+#define GPIOV2_PAD_GPIROUTIOXAPIC_DW0_POS   (20)
+#define GPIOV2_PAD_GPIROUTIOXAPIC_DW0_MASK  (1)
+
+/**
+  Other GPIO Configuration
+  GPIO_OTHER_CONFIG is used for less often settings and for future extensions
+  Supported settings:
+   - RX raw override to '1' - allows to override input value to '1'
+      This setting is applicable only if in input mode (both in GPIO and native usage).
+      The override takes place at the internal pad state directly from buffer and before the RXINV.
+**/
+typedef enum {
+  GpioV2RxRaw1Default           = 0x0,  ///< Use default input override value
+  GpioV2RxRaw1Dis               = 0x1,  ///< Don't override input
+  GpioV2RxRaw1En                = 0x3   ///< Override input to '1'
+} GPIOV2_OTHER_CONFIG;
+
+
+//
+// Structure for native pin data
+//
+typedef struct {
+  GPIOV2_PAD              Pad;
+  GPIOV2_PAD_MODE         Mode;
+  GPIOV2_IOSTANDBY_STATE  IosState;
+  GPIOV2_IOSTANDBY_TERM   IosTerm;
+} GPIOV2_PAD_NATIVE_FUNCTION;
+
+typedef enum {
+  // Ownership related registers
+  GpioV2PadOwnReg,
+  GpioV2PadHostSwOwnReg,
+
+  // Lock related registers
+  GpioV2PadCfgLockReg,
+  GpioV2PadCfgLockTxReg,
+
+  // Interrupts related registers
+  GpioV2GpiIsReg,
+  GpioV2GpiIeReg,
+  GpioV2GpiGpeStsReg,
+  GpioV2GpiGpeEnReg,
+  GpioV2SmiStsReg,
+  GpioV2SmiEnReg,
+  GpioV2NmiStsReg,
+  GpioV2NmiEnReg,
+
+  // Configuration registers
+  GpioV2Dw0Reg,
+  GpioV2Dw1Reg,
+  GpioV2Dw2Reg,
+
+  // Community registers
+  GpioV2MiscCfg,
+  GpioV2AcReg
+
+} GPIOV2_REGISTER;
+
+typedef struct {
+  UINT16  PadOwn;
+  UINT16  PadCfgLock;
+  UINT16  PadCfgLockTx;
+  UINT16  HostOwn;
+  UINT16  GpiIs;
+  UINT16  GpiIe;
+  UINT16  GpiGpeSts;
+  UINT16  GpiGpeEn;
+  UINT16  SmiSts;
+  UINT16  SmiEn;
+  UINT16  NmiSts;
+  UINT16  NmiEn;
+  UINT16  Dw0;
+} GPIOV2_GROUP_REGISTERS_OFFSETS;
+
+//
+// Access Control Registers
+//
+typedef struct {
+  UINT32  Rcp;
+  UINT16  Rrac;
+  UINT16  Rwac;
+} GPIOV2_ACCESS_CONTROL_REGISTERS_OFFSETS;
+
+typedef struct {
+  UINT32 Policy;
+  UINT32 Read;
+  UINT32 Write;
+} GPIOV2_ACCESS_CONTROL_SAI_DW_DATA;
+
+//
+// Community Registers Offsets
+//
+typedef struct {
+  UINT16  MiscCfg;
+  UINT16  AcSaiGrup0RcpDw0;
+} GPIOV2_COMMUNITY_REGISTERS_OFFSETS;
+
+//
+// DDPx pins
+//
+typedef enum {
+    GpioV2Ddp1 = 0x01,
+    GpioV2Ddp2 = 0x02,
+    GpioV2Ddp3 = 0x03,
+    GpioV2Ddp4 = 0x04,
+    GpioV2DdpA = 0x10,
+    GpioV2DdpB = 0x11,
+    GpioV2DdpC = 0x12,
+    GpioV2DdpD = 0x13,
+    GpioV2DdpF = 0x15,
+} GPIOV2_DDP;
+
+//
+// DDI Port TBT_LSX interface
+//
+typedef enum {
+    GpioV2TbtLsxDdi1,
+    GpioV2TbtLsxDdi2,
+    GpioV2TbtLsxDdi3,
+    GpioV2TbtLsxDdi4,
+    GpioV2TbtLsxDdi5,
+    GpioV2TbtLsxDdi6
+} GPIOV2_TBT_LSX;
+
+//
+// TBT_LSX_OE interface
+//
+typedef enum {
+    GpioV2TbtLsxOe0,
+    GpioV2TbtLsxOe1,
+    GpioV2TbtLsxOe2
+} GPIOV2_TBT_LSX_OE;
+
+/**
+  CNVi Bluetooth UART connection options
+**/
+typedef enum {
+    GpioV2CnviBtIfUart = 0,
+    GpioV2CnviBtIfUsb,
+} VGPIOV2_CNVI_BT_INTERFACE;
+
+/**
+  CNVi Bluetooth I2S connection options
+**/
+typedef enum {
+    GpioV2CnviBtI2sNotConnected,
+    GpioV2CnviBtI2sToSsp0,
+    GpioV2CnviBtI2sToSsp1,
+    GpioV2CnviBtI2sToSsp2,
+    GpioV2CnviBtI2sToExternalPads
+} VGPIOV2_CNVI_BT_I2S_CONNECTION_TYPE;
+
+/**
+  CNVi Bluetooth UART connection options
+**/
+typedef enum {
+    GpioV2CnviBtUartNotConnected,
+    GpioV2CnviBtUartToSerialIoUart0,
+    GpioV2CnviBtUartToIshUart0,
+    GpioV2CnviBtUartToExternalPads
+} VGPIOV2_CNVI_BT_UART_CONNECTION_TYPE;
+
+/**
+  CNVi MultiFunction UART connection options
+**/
+typedef enum {
+    GpioV2CnviMfUart1NotConnected,
+    GpioV2CnviMfUart1ToSerialIoUart2,
+    GpioV2CnviMfUart1ToIshUart0,
+    GpioV2CnviMfUart1ToExternalPads
+} VGPIOV2_CNVI_MF_UART1_CONNECTION_TYPE;
+
+/**
+  VCCIO level selection
+**/
+typedef enum {
+    GpioV2Vcc3v3,
+    GpioV2Vcc1v8,
+    GpioV2MaxVccioSel
+} GPIOV2_VCCIO_SEL;
+
+/**
+  VGPIO CS selection
+**/
+typedef enum {
+  GpioV2VgpioCs0,
+  GpioV2VgpioCs1
+} GPIOV2_VGPIO_CS;
+
+#endif // _GPIOV2_PAD_H_

--- a/Silicon/CommonSocPkg/Include/Library/GpioV2Virtual.h
+++ b/Silicon/CommonSocPkg/Include/Library/GpioV2Virtual.h
@@ -1,0 +1,593 @@
+/** @file
+  Routines for IBL GPIO virtual pads
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef GPIO_V2_VIRTUAL_H
+#define GPIO_V2_VIRTUAL_H
+
+#include "Library/GpioV2Lib.h"
+
+/**
+  This procedure reads current ownership configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Ownership            Pointer to a buffer for ownership, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetOwnership (
+  IN  GPIOV2_PAD              GpioPad,
+  OUT GPIOV2_PAD_OWN          *Ownership
+  );
+
+/**
+  This procedure retrieves register offset
+
+  @param[in]  Register            Register for which user want to retrieve offset. Please refer to GpioV2Pad.h
+  @param[in]  GpioPad             Gpio Pad. Please refer to GpioPinsYYY.h - where YYY name of the platform (eg. MTL, EBG, ...)
+  @param[out] RegisterOffset      Pointer to a buffer for register offset
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+VirtualGpioGetRegisterOffset (
+  IN  GPIOV2_REGISTER     Register,
+  IN  GPIOV2_PAD          GpioPad,
+  OUT UINT32              *RegisterOffset
+  );
+
+/**
+  This procedure reads current ownership configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Ownership            Pointer to a buffer for ownership, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetOwnership (
+  IN  GPIOV2_PAD              GpioPad,
+  OUT GPIOV2_PAD_OWN          *Ownership
+  );
+
+/**
+  This procedure sets host ownership configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Ownership            Host ownership, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetHostOwnership (
+  IN GPIOV2_PAD               GpioPad,
+  IN GPIOV2_HOSTSW_OWN        HostOnwership
+  );
+
+/**
+  This procedure sets Gpio Pad output state
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] OutputState         GpioV2StateLow - output state low, GpioV2StateHigh - output state high
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetTx (
+  IN GPIOV2_PAD             GpioPad,
+  IN GPIOV2_PAD_STATE       OutputState
+  );
+
+/**
+  This procedure sets TX buffer for requested Gpio Pad as enabled or disabled
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] TxDisabled          True - TX buffer disabled, False - TX buffer enabled
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetTxDisable (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  TxDisabled
+  );
+
+/**
+  This procedure sets Rx buffer for requested Gpio Pad as enabled or disabled
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] TxDisabled          True - TX buffer disabled, False - TX buffer enabled
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetRxDisable (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  RxDisabled
+  );
+
+/**
+  This procedure will set GPIO enable or disable input inversion on requested pad
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] InputInversion      GpioV2InputInversionEnable or GpioV2InputInversionDisable, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetInputInversion (
+  IN GPIOV2_PAD                  GpioPad,
+  IN GPIOV2_PAD_INPUT_INVERSION  InputInversion
+  );
+
+/**
+  This procedure sets NMI Enable for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] NmiEn                NMI Enable, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetNmiEn (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  NmiEn
+  );
+
+/**
+  This procedure sets SMI Enable configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] SmiEn                SMI Enable, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetSmiEn (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  SmiEn
+  );
+
+/**
+  This procedure sets GPI GPE Enable configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] GpiIe                GPI GPE Enable, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetGpiGpeEn (
+  IN GPIOV2_PAD              GpioPad,
+  IN BOOLEAN                 GpiGpeEn
+  );
+
+/**
+  This procedure sets Gpi Enable configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] GpiIe                GPI Enable, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetGpiIe (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  GpiIe
+  );
+
+/**
+  This procedure sets GPIROUTNMI bit (17th bit in DW0) for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Enable               TRUE or FALSE, either enable or disable 17 bit in DW0
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetRouteNmi (
+  IN GPIOV2_PAD           GpioPad,
+  IN BOOLEAN              Enable
+  );
+
+/**
+  This procedure will configure VGPIO INTERRUPT_OR_EVENT_TYPE field.
+
+  @param[in] GpioPad              Gpio Pad
+  @param[in] PadConfig            Gpio Pad configuration - please refer to GPIOV2_CONFIG in GpioV2Config.h
+
+  @retval EFI_SUCCESS              The function completed successfully
+  @retval EFI_INVALID_PARAMETER    Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetInterruptOrLevelType (
+  IN GPIOV2_PAD              GpioPad,
+  IN GPIOV2_CONFIG           *PadConfig
+  );
+
+/**
+  This procedure sets GPIROUTSMI bit (18th bit in DW0) for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Enable               TRUE or FALSE, either enable or disable 18 bit in DW0
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetRouteSmi (
+  IN GPIOV2_PAD           GpioPad,
+  IN BOOLEAN              Enable
+  );
+
+/**
+  This procedure sets GPIROUTSCI bit (19th bit in DW0) for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Enable               TRUE or FALSE, either enable or disable 19 bit in DW0
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetRouteSci (
+  IN GPIOV2_PAD           GpioPad,
+  IN BOOLEAN              Enable
+  );
+
+/**
+  This procedure sets GPIROUTIOXAPIC bit (20th bit in DW0) for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Enable               TRUE or FALSE, either enable or disable 20th bit in DW0
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetRouteIoxApic (
+  IN GPIOV2_PAD           GpioPad,
+  IN BOOLEAN              Enable
+  );
+
+/**
+  This procedure sets RxEv configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] RxEvCfg              RxEv configuration
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetRxEvCfg (
+  IN GPIOV2_PAD           GpioPad,
+  IN GPIOV2_RXEVCFG       RxEvCfg
+  );
+
+/**
+  This procedure sets Reset Configuration for requested Gpio Pad
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] ResetConfig         Reset Configuration - please refer to GpioV2Pad.h (GPIOV2_RESET_CONFIG)
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetResetConfig (
+  IN GPIOV2_PAD               GpioPad,
+  IN GPIOV2_RESET_CONFIG      ResetConfig
+  );
+
+/**
+  This procedure will set GPIO mode
+
+  @param[in] GpioPad              Gpio Pad. Please refer to GpioPinsYYY.h - where YYY name of the platform (eg. MTL, EBG, ...)
+  @param[in] PadModeValue         GPIO pad mode value
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetPadMode (
+  IN GPIOV2_PAD              GpioPad,
+  IN GPIOV2_PAD_MODE         PadMode
+  );
+
+/**
+  This procedure reads current GPIO Pad Mode
+
+  @param[in] GpioPad             GPIO Pad. Please refer to GpioPinsYYY.h - where YYY name of the platform (eg. MTL, EBG, ...)
+  @param[in] PadMode             Pointer to a buffer for GPIO Pad Mode
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetPadMode (
+  IN GPIOV2_PAD            GpioPad,
+  IN GPIOV2_PAD_MODE       *PadMode
+  );
+
+/**
+  This procedure will set GPIO mode
+
+  @param[in] GpioPad              Gpio Pad. Please refer to GpioPinsYYY.h - where YYY name of the platform (eg. MTL, EBG, ...)
+  @param[in] PadModeValue         GPIO pad mode value
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetPadMode (
+  IN GPIOV2_PAD              GpioPad,
+  IN GPIOV2_PAD_MODE         PadMode
+  );
+
+/**
+  This procedure reads current host ownership configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Ownership            Pointer to a buffer for ownership, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetHostOwnership (
+  IN  GPIOV2_PAD              GpioPad,
+  OUT GPIOV2_HOSTSW_OWN       *HostOwnership
+  );
+
+/**
+  This procedure reads current Gpio Pad output state
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] OutputState         Pointer to a buffer for output state
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetTx (
+  IN GPIOV2_PAD             GpioPad,
+  IN GPIOV2_PAD_STATE       *OutputState
+  );
+
+/**
+  This procedure reads current Gpio Pad input state
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] InputState          Pointer to a buffer for input state
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetRx (
+  IN GPIOV2_PAD           GpioPad,
+  IN GPIOV2_PAD_STATE     *InputState
+  );
+
+/**
+  This procedure reads if TX buffer for requested Gpio Pad is enabled or disabled
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] TxDisabled          Pointer to a buffer for enabled/disabled information
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetTxDisable (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  *TxDisabled
+  );
+
+/**
+  This procedure reads if RX buffer for requested Gpio Pad is enabled or disabled
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] RxDisabled          Pointer to a buffer for enabled/disabled information
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetRxDisable (
+  IN GPIOV2_PAD              GpioPad,
+  IN BOOLEAN                 *RxDisabled
+  );
+
+/**
+  This procedure will Get GPIO enable or disable input inversion on requested pad
+
+  IBL Virtaul GPIO does not support inversion, function return state as not inverted.
+
+  @param[in]  GpioPad             GPIO pad
+  @param[Out] Data                Enabled / Disabled
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetInputInversion (
+  IN  GPIOV2_PAD                 GpioPad,
+  OUT BOOLEAN                    *Inverted
+  );
+
+/**
+  This procedure will set GPIO Lock (register PADCFGLOCK)
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] Lock                GpioV2Unlock - Unlock pad, GpioV2Lock - Lock pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetLock (
+  IN GPIOV2_PAD                GpioPad,
+  IN GPIOV2_PAD_LOCK           Lock
+  );
+
+/**
+  This procedure will get GPIO Lock (register PADCFGLOCK)
+
+  @param[in]  GpioPad             GPIO pad
+  @param[out] Lock                GpioV2Unlock - Unlock pad, GpioV2Lock - Lock pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetLock (
+  IN  GPIOV2_PAD                GpioPad,
+  OUT GPIOV2_PAD_LOCK           *Lock
+  );
+
+/**
+  This procedure will set GPIO Lock Tx (register PADCFGLOCKTX)
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] LockTx              GpioV2Unlock - Unlock output state of Gpio Pad, GpioV2Lock - Lock output state of Gpio Pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetLockTx (
+  IN GPIOV2_PAD                  GpioPad,
+  IN GPIOV2_PAD_LOCK             LockTx
+  );
+
+/**
+  This procedure will get GPIO Lock TX
+
+  Virtual GPIO does not have Lock TX bit
+  Lock TX state is based on Lock pad state
+
+  @param[in]  GpioPad             GPIO pad
+  @param[out] LockTx              GpioV2Unlock - Unlock output state of Gpio Pad, GpioV2Lock - Lock output state of Gpio Pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetLockTx (
+  IN  GPIOV2_PAD                  GpioPad,
+  OUT GPIOV2_PAD_LOCK             *LockTx
+  );
+
+/**
+  This procedure reads current GPI GPE Enable configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] GpiIe                GPI GPE Enable, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetGpiGpeEn (
+  IN GPIOV2_PAD              GpioPad,
+  IN BOOLEAN                 *GpiGpeEn
+  );
+
+/**
+  This procedure reads current Gpi Enable configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] GpiIe                Pointer to a buffer for GPI Enable
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetGpiIe (
+  IN GPIOV2_PAD              GpioPad,
+  IN BOOLEAN                 *GpiIe
+  );
+
+/**
+  This procedure reads current Gpi Status for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] GpiIe                Pointer to a buffer for GPI Enable
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetGpiIs (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  *GpiIs
+  );
+
+/**
+  This procedure reads current Reset Configuration for requested Gpio Pad
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] ResetConfig         Pointer to a buffer for Reset Configuration
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetResetConfig (
+  IN GPIOV2_PAD               GpioPad,
+  IN GPIOV2_RESET_CONFIG      *ResetConfig
+  );
+
+/**
+  This procedure sets termination configuration for requested Gpio Pad
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] TerminationConfig   Termination configuration, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+VirtualGpioSetTerminationConfig (
+  IN GPIOV2_PAD                 GpioPad,
+  IN GPIOV2_TERMINATION_CONFIG  TerminationConfig
+  );
+
+/**
+  This procedure will configure VGPIO CS setting.
+
+  @param[in] GpioPad              Gpio Pad
+  @param[in] PadConfig            Gpio Pad configuration - please refer to GPIOV2_CONFIG in GpioV2Config.h
+
+  @retval EFI_SUCCESS              The function completed successfully
+  @retval EFI_INVALID_PARAMETER    Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetCs (
+  IN GPIOV2_PAD              GpioPad,
+  IN GPIOV2_CONFIG           *PadConfig
+  );
+
+#endif // _GPIO_V2_VIRTUAL_H_

--- a/Silicon/CommonSocPkg/Include/Library/P2SbController.h
+++ b/Silicon/CommonSocPkg/Include/Library/P2SbController.h
@@ -1,0 +1,37 @@
+/** @file
+  Header file for P2SB controller
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#ifndef _P2SB_CONTROLLER_H_
+#define _P2SB_CONTROLLER_H_
+
+/**
+  P2SB structure
+  Stores information required to access to registers
+  like base address, S:B:D:F etc.
+  and definitions specific to P2SB.
+**/
+typedef struct {
+  /**
+    P2SB controller PCI config space address
+    in PCI Segment Library representation.
+  **/
+  UINT64                      PciCfgBaseAddr;
+  /**
+    P2SB controller MMIO base address
+  **/
+  UINT64                      Mmio;
+  /**
+    Is 20 bits mode supported
+  **/
+  BOOLEAN                     P2sb20bPcrSupported;
+  /**
+    HPET MMIO base address
+  **/
+  UINT64                      HpetMmio;
+} P2SB_CONTROLLER;
+
+#endif // _P2SB_CONTROLLER_H_

--- a/Silicon/CommonSocPkg/Include/Library/P2SbSidebandAccessLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/P2SbSidebandAccessLib.h
@@ -1,0 +1,391 @@
+/** @file
+  Header for P2SbSidebandAccessLib
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _P2SB_SIDEBAND_ACCESS_LIB_H_
+#define _P2SB_SIDEBAND_ACCESS_LIB_H_
+
+#include "Library/RegisterAccess.h"
+#include <Library/PchSbiAccessLib.h>
+#include "Library/P2SbController.h"
+#include "Library/PcrDefine.h"
+#include <Uefi/UefiBaseType.h>
+//#include "PchSbiAccessV2Lib.h"
+
+#define P2SB_REGISTER_ACCESS_INIT  {P2SbSidebandRead8, P2SbSidebandWrite8, P2SbSidebandOr8, P2SbSidebandAnd8, P2SbSidebandAndThenOr8, \
+                                    P2SbSidebandRead16, P2SbSidebandWrite16, P2SbSidebandOr16, P2SbSidebandAnd16, P2SbSidebandAndThenOr16,\
+                                    P2SbSidebandRead32, P2SbSidebandWrite32, P2SbSidebandOr32, P2SbSidebandAnd32, P2SbSidebandAndThenOr32}
+
+typedef enum {
+  P2SbMemory = 0,
+  P2SbPciConfig,
+  P2SbPrivateConfig
+} P2SB_REGISTER_SPACE;
+
+typedef enum {
+  P2SbMmioAccess = 0,
+  P2SbMsgAccess
+} P2SB_SIDEBAND_ACCESS_METHOD;
+
+
+/**
+  REGISTER_ACCESS for P2SB device to support access to sideband registers.
+  Be sure to keep first member of this structure as REGISTER_ACCESS to allow
+  for correct casting between caller who sees this structure as REGISTER_ACCESS
+  and calle who will cast it to P2SB_SIDEBAND_REGISTER_ACCESS.
+**/
+typedef struct {
+  REGISTER_ACCESS              Access;
+  P2SB_SIDEBAND_ACCESS_METHOD  AccessMethod;
+  P2SB_PID                     P2SbPid;
+  UINT16                       Fid;
+  P2SB_REGISTER_SPACE          RegisterSpace;
+  BOOLEAN                      PostedWrites;
+  P2SB_CONTROLLER              P2SbCtrl;
+  UINT32                       Offset;
+} P2SB_SIDEBAND_REGISTER_ACCESS;
+
+/**
+  Reads an 8-bit register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+
+  @return The 8-bit register value specified by Offset
+**/
+UINT8
+P2SbSidebandRead8 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset
+  );
+
+/**
+  Writes an 8-bit register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+  @param[in] Value   Value to write to register
+
+  @return The 8-bit register value written to register
+**/
+UINT8
+P2SbSidebandWrite8 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT8            Value
+  );
+
+/**
+  Performs an 8-bit or on the register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+  @param[in] OrData  Data with which register should be OR-ed
+
+  @return The 8-bit register value written to register
+**/
+UINT8
+P2SbSidebandOr8 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT8            OrData
+  );
+
+/**
+  Performs an 8-bit and on the register
+
+  @param[in] This     Pointer to REGISTER_ACCESS
+  @param[in] Offset   Offset of the register in the register bank
+  @param[in] AndData  Data with which register should be AND-ed
+
+  @return The 8-bit register value written to register
+**/
+UINT8
+P2SbSidebandAnd8 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT8            AndData
+  );
+
+/**
+  Performs an 8-bit and then or on the register
+
+  @param[in] This     Pointer to REGISTER_ACCESS
+  @param[in] Offset   Offset of the register in the register bank
+  @param[in] AndData  Data with which register should be AND-ed
+  @param[in] OrData   Data with which register should be OR-ed
+
+  @return The 8-bit register value written to register
+**/
+UINT8
+P2SbSidebandAndThenOr8 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT8            AndData,
+  IN UINT8            OrData
+  );
+
+/**
+  Reads a 16-bit register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+
+  @return The 16-bit register value specified by Offset
+**/
+UINT16
+P2SbSidebandRead16 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset
+  );
+
+/**
+  Writes a 16-bit register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+  @param[in] Value   Value to write to register
+
+  @return The 16-bit register value written to register
+**/
+UINT16
+P2SbSidebandWrite16 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT16            Value
+  );
+
+/**
+  Performs a 16-bit or on the register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+  @param[in] OrData  Data with which register should be OR-ed
+
+  @return The 16-bit register value written to register
+**/
+UINT16
+P2SbSidebandOr16 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT16           OrData
+  );
+
+/**
+  Performs a 16-bit and on the register
+
+  @param[in] This     Pointer to REGISTER_ACCESS
+  @param[in] Offset   Offset of the register in the register bank
+  @param[in] AndData  Data with which register should be AND-ed
+
+  @return The 16-bit register value written to register
+**/
+UINT16
+P2SbSidebandAnd16 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT16           AndData
+  );
+
+/**
+  Performs a 16-bit and then or on the register
+
+  @param[in] This     Pointer to REGISTER_ACCESS
+  @param[in] Offset   Offset of the register in the register bank
+  @param[in] AndData  Data with which register should be AND-ed
+  @param[in] OrData   Data with which register should be OR-ed
+
+  @return The 16-bit register value written to register
+**/
+UINT16
+P2SbSidebandAndThenOr16 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT16           AndData,
+  IN UINT16           OrData
+  );
+
+/**
+  Reads a 32-bit register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+
+  @return The 32-bit register value specified by Offset
+**/
+UINT32
+P2SbSidebandRead32 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset
+  );
+
+/**
+  Writes a 32-bit register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+  @param[in] Value   Value to write to register
+
+  @return The 32-bit register value written to register
+**/
+UINT32
+P2SbSidebandWrite32 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT32            Value
+  );
+
+/**
+  Performs a 32-bit or on the register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+  @param[in] OrData  Data with which register should be OR-ed
+
+  @return The 32-bit register value written to register
+**/
+UINT32
+P2SbSidebandOr32 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT32           OrData
+  );
+
+/**
+  Performs a 32-bit and on the register
+
+  @param[in] This     Pointer to REGISTER_ACCESS
+  @param[in] Offset   Offset of the register in the register bank
+  @param[in] AndData  Data with which register should be AND-ed
+
+  @return The 32-bit register value written to register
+**/
+UINT32
+P2SbSidebandAnd32 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT32           AndData
+  );
+
+/**
+  Performs a 32-bit and then or on the register
+
+  @param[in] This     Pointer to REGISTER_ACCESS
+  @param[in] Offset   Offset of the register in the register bank
+  @param[in] AndData  Data with which register should be AND-ed
+  @param[in] OrData   Data with which register should be OR-ed
+
+  @return The 32-bit register value written to register
+**/
+UINT32
+P2SbSidebandAndThenOr32 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT32           AndData,
+  IN UINT32           OrData
+  );
+
+/**
+  Full function for executing P2SB SBI message
+  Take care of that there is no lock protection when using SBI programming in both POST time and SMI.
+  It will clash with POST time SBI programming when SMI happen.
+  Programmer MUST do the save and restore opration while using the PchSbiExecution inside SMI
+  to prevent from racing condition.
+  This function will reveal P2SB and hide P2SB if it's originally hidden. If more than one SBI access
+  needed, it's better to unhide the P2SB before calling and hide it back after done.
+
+  When the return value is "EFI_SUCCESS", the "Response" do not need to be checked as it would have been
+  SBI_SUCCESS. If the return value is "EFI_DEVICE_ERROR", then this would provide additional information
+  when needed.
+
+  @param[in] P2sbBase                   P2SB PCI config base
+  @param[in] Pid                        Port ID of the SBI message
+  @param[in] Offset                     Offset of the SBI message
+  @param[in] Opcode                     Opcode
+  @param[in] Posted                     Posted message
+  @param[in] Fbe                        First byte enable
+  @param[in] Bar                        Bar
+  @param[in] Fid                        Function ID
+  @param[in, out] Data32                Read/Write data
+  @param[out] Response                  Response
+
+  @retval EFI_SUCCESS                   Successfully completed.
+  @retval EFI_DEVICE_ERROR              Transaction fail
+  @retval EFI_INVALID_PARAMETER         Invalid parameter
+  @retval EFI_TIMEOUT                   Timeout while waiting for response
+**/
+EFI_STATUS
+P2SbSbiExecutionEx (
+  IN     UINT64           P2sbBase,
+  IN     P2SB_PID         Pid,
+  IN     UINT64           Offset,
+  IN     PCH_SBI_OPCODE  Opcode,
+  IN     BOOLEAN          Posted,
+  IN     UINT16           Fbe,
+  IN     UINT16           Bar,
+  IN     UINT16           Fid,
+  IN OUT UINT32           *Data32,
+  OUT    UINT8            *Response
+  );
+
+/**
+  Builds P2SB sideband access.
+
+  @param[in]  P2SbController      Pointer to P2SB controller implementing the sideband
+  @param[in]  P2SbPid             Port id
+  @param[in]  Fid                 Function id
+  @param[in]  RegisterSpace       Target register space
+  @param[in]  AccessMethod        Access method
+  @param[in]  PostedWrites        If TRUE writes sent through sideband msg will be posted
+  @param[out] P2SbSidebandAccess  On output an initialized sideband access descriptor
+
+  @retval TRUE   Access initialized successfuly
+  @retval FALSE  Failed to initialize access
+**/
+BOOLEAN
+BuildP2SbSidebandAccess (
+  IN P2SB_PID                        P2SbPid,
+  IN UINT16                          Fid,
+  IN P2SB_REGISTER_SPACE             RegisterSpace,
+  IN P2SB_SIDEBAND_ACCESS_METHOD     AccessMethod,
+  IN BOOLEAN                         PostedWrites,
+  OUT P2SB_SIDEBAND_REGISTER_ACCESS  *P2SbSidebandAccess
+  );
+
+/**
+  Builds P2SB sideband access using offset to config space.
+  This offset will be added to every register offset, when access callbacks are used.
+  Some IPs, like for example DMI, implement multiple register banks in the same register space.
+  For instance sideband register space can contain both PCR registers,
+  starting from the beginning of the register space,
+  and PCI config registers starting from the offset in the same register space.
+
+  @param[in]  P2SbController        Pointer to P2SB controller implementing the sideband
+  @param[in]  P2SbPid               Port id
+  @param[in]  Fid                   Function id
+  @param[in]  RegisterSpace         Target register space
+  @param[in]  AccessMethod          Access method
+  @param[in]  PostedWrites          If TRUE writes sent through sideband msg will be posted
+  @param[in]  Offset                Register space offset that will be added to register offset
+  @param[out] P2SbSidebandAccess    An initialized sideband access descriptor containing register space offset
+
+  @retval TRUE   Access initialized successfuly
+  @retval FALSE  Failed to initialize access
+**/
+BOOLEAN
+BuildP2SbSidebandAccessEx (
+  IN P2SB_CONTROLLER                    *P2SbController,
+  IN P2SB_PID                           P2SbPid,
+  IN UINT16                             Fid,
+  IN P2SB_REGISTER_SPACE                RegisterSpace,
+  IN P2SB_SIDEBAND_ACCESS_METHOD        AccessMethod,
+  IN BOOLEAN                            PostedWrites,
+  IN UINT32                             Offset,
+  OUT P2SB_SIDEBAND_REGISTER_ACCESS     *P2SbSidebandAccess
+  );
+
+#endif

--- a/Silicon/CommonSocPkg/Include/Library/PcrDefine.h
+++ b/Silicon/CommonSocPkg/Include/Library/PcrDefine.h
@@ -1,0 +1,59 @@
+/** @file
+  Private Control Register definitions
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#ifndef _PCR_DEFINE_H_
+#define _PCR_DEFINE_H_
+
+// #include <Library/PchReservedResources.h>
+
+/**
+  Definition for PCR address
+  The PCR address is used to the PCR MMIO programming
+
+  SBREG_BAR_20BITADDRESS is configured by SoC
+
+  SBREG_BAR_20BITADDRESS=1, the format has included 16b addressing.
+  +---------------------------------------------------------------------------------------------+
+  | Addr[63:28]    | Addr[27:24]           | Addr[23:16]     | Addr[15:2]           | Addr[1:0] |
+  +----------------+-----------------------+-----------------+----------------------------------+
+  | REG_BAR[63:28] | TargetRegister[19:16] | TargetPort[7:0] | TargetRegister[15:2]             |
+  +---------------------------------------------------------------------------------------------+
+
+  SBREG_BAR_20BITADDRESS=0
+  +---------------------------------------------------------------------------------------------+
+  | Addr[63:24]    | Addr[27:24]           | Addr[23:16]     | Addr[15:2]           | Addr[1:0] |
+  +----------------+-----------------------+-----------------+----------------------------------+
+  | REG_BAR[63:24] | REG_BAR[27:24]        | TargetPort[7:0] | TargetRegister[15:2]             |
+  +---------------------------------------------------------------------------------------------+
+**/
+/*#define PCH_PCR_ADDRESS(Pid, Offset)    (PCH_PCR_BASE_ADDRESS | (UINT32) (((Offset) & 0x0F0000) << 8) | ((UINT8)(Pid) << 16) | (UINT16) ((Offset) & 0xFFFF))*/
+
+/**
+  PCH PCR boot script accessing macro
+**/
+#define PCH_PCR_BOOT_SCRIPT_WRITE(Width, Pid, Offset, Count, Buffer) \
+          S3BootScriptSaveMemWrite (Width, PCH_PCR_ADDRESS (Pid, Offset), Count, Buffer); \
+
+#define PCH_PCR_BOOT_SCRIPT_READ_WRITE(Width, Pid, Offset, DataOr, DataAnd) \
+          S3BootScriptSaveMemReadWrite (Width, PCH_PCR_ADDRESS (Pid, Offset), DataOr, DataAnd); \
+
+#define PCH_PCR_BOOT_SCRIPT_READ(Width, Pid, Offset, BitMask, BitValue) \
+          S3BootScriptSaveMemPoll (Width, PCH_PCR_ADDRESS (Pid, Offset), BitMask, BitValue, 1, 1);
+
+typedef UINT8          P2SB_PID;
+
+typedef union {
+  UINT16 Pid16bit;
+  struct {
+    P2SB_PID LocalPid;
+    UINT8    SegmentId;
+  } PortId;
+} P2SB_PORT_16_ID;
+
+#define GET_P2SB_LOCAL_PID(id) ((id) & 0xFF)
+
+#endif // _PCR_DEFINE_H_

--- a/Silicon/CommonSocPkg/Include/Library/RegisterAccess.h
+++ b/Silicon/CommonSocPkg/Include/Library/RegisterAccess.h
@@ -1,0 +1,289 @@
+/** @file
+  Header file for register access.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _REGISTER_ACCESS_H_
+#define _REGISTER_ACCESS_H_
+
+typedef struct _REGISTER_ACCESS REGISTER_ACCESS;
+
+/**
+  Reads an 8-bit register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+
+  @return The 8-bit register value specified by Offset
+**/
+typedef
+UINT8
+(*REG_READ8) (
+  REGISTER_ACCESS  *This,
+  UINT32           Offset
+  );
+
+/**
+  Writes an 8-bit register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+  @param[in] Value   Value to write to register
+
+  @return The 8-bit register value written to register
+**/
+typedef
+UINT8
+(*REG_WRITE8) (
+  REGISTER_ACCESS  *This,
+  UINT32           Offset,
+  UINT8            Value
+  );
+
+/**
+  Performs an 8-bit or on the register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+  @param[in] OrData  Data with which register should be OR-ed
+
+  @return The 8-bit register value written to register
+**/
+typedef
+UINT8
+(*REG_OR8) (
+  REGISTER_ACCESS  *This,
+  UINT32           Offset,
+  UINT8            OrData
+  );
+
+/**
+  Performs an 8-bit and on the register
+
+  @param[in] This     Pointer to REGISTER_ACCESS
+  @param[in] Offset   Offset of the register in the register bank
+  @param[in] AndData  Data with which register should be AND-ed
+
+  @return The 8-bit register value written to register
+**/
+typedef
+UINT8
+(*REG_AND8) (
+  REGISTER_ACCESS  *This,
+  UINT32           Offset,
+  UINT8            AndData
+  );
+
+/**
+  Performs an 8-bit and then or on the register
+
+  @param[in] This     Pointer to REGISTER_ACCESS
+  @param[in] Offset   Offset of the register in the register bank
+  @param[in] AndData  Data with which register should be AND-ed
+  @param[in] OrData   Data with which register should be OR-ed
+
+  @return The 8-bit register value written to register
+**/
+typedef
+UINT8
+(*REG_AND_THEN_OR8) (
+  REGISTER_ACCESS  *This,
+  UINT32           Offset,
+  UINT8            AndData,
+  UINT8            OrData
+  );
+
+/**
+  Reads a 16-bit register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+
+  @return The 16-bit register value specified by Offset
+**/
+typedef
+UINT16
+(*REG_READ16) (
+  REGISTER_ACCESS  *This,
+  UINT32           Offset
+  );
+
+/**
+  Writes a 16-bit register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+  @param[in] Value   Value to write to register
+
+  @return The 16-bit register value written to register
+**/
+typedef
+UINT16
+(*REG_WRITE16) (
+  REGISTER_ACCESS  *This,
+  UINT32           Offset,
+  UINT16           Value
+  );
+
+/**
+  Performs a 16-bit or on the register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+  @param[in] OrData  Data with which register should be OR-ed
+
+  @return The 16-bit register value written to register
+**/
+typedef
+UINT16
+(*REG_OR16) (
+  REGISTER_ACCESS  *This,
+  UINT32           Offset,
+  UINT16           OrData
+  );
+
+/**
+  Performs a 16-bit and on the register
+
+  @param[in] This     Pointer to REGISTER_ACCESS
+  @param[in] Offset   Offset of the register in the register bank
+  @param[in] AndData  Data with which register should be AND-ed
+
+  @return The 16-bit register value written to register
+**/
+typedef
+UINT16
+(*REG_AND16) (
+  REGISTER_ACCESS  *This,
+  UINT32           Offset,
+  UINT16           AndData
+  );
+
+/**
+  Performs a 16-bit and then or on the register
+
+  @param[in] This     Pointer to REGISTER_ACCESS
+  @param[in] Offset   Offset of the register in the register bank
+  @param[in] AndData  Data with which register should be AND-ed
+  @param[in] OrData   Data with which register should be OR-ed
+
+  @return The 16-bit register value written to register
+**/
+typedef
+UINT16
+(*REG_AND_THEN_OR16) (
+  REGISTER_ACCESS  *This,
+  UINT32           Offset,
+  UINT16           AndData,
+  UINT16           OrData
+  );
+
+/**
+  Reads a 32-bit register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+
+  @return The 32-bit register value specified by Offset
+**/
+typedef
+UINT32
+(*REG_READ32) (
+  REGISTER_ACCESS  *This,
+  UINT32           Offset
+  );
+
+/**
+  Writes a 32-bit register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+  @param[in] Value   Value to write to register
+
+  @return The 32-bit register value written to register
+**/
+typedef
+UINT32
+(*REG_WRITE32) (
+  REGISTER_ACCESS  *This,
+  UINT32           Offset,
+  UINT32           Value
+  );
+
+/**
+  Performs a 32-bit or on the register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+  @param[in] OrData  Data with which register should be OR-ed
+
+  @return The 32-bit register value written to register
+**/
+typedef
+UINT32
+(*REG_OR32) (
+  REGISTER_ACCESS  *This,
+  UINT32           Offset,
+  UINT32           OrData
+  );
+
+/**
+  Performs a 32-bit and on the register
+
+  @param[in] This     Pointer to REGISTER_ACCESS
+  @param[in] Offset   Offset of the register in the register bank
+  @param[in] AndData  Data with which register should be AND-ed
+
+  @return The 32-bit register value written to register
+**/
+typedef
+UINT32
+(*REG_AND32) (
+  REGISTER_ACCESS  *This,
+  UINT32           Offset,
+  UINT32           AndData
+  );
+
+/**
+  Performs a 32-bit and then or on the register
+
+  @param[in] This     Pointer to REGISTER_ACCESS
+  @param[in] Offset   Offset of the register in the register bank
+  @param[in] AndData  Data with which register should be AND-ed
+  @param[in] OrData   Data with which register should be OR-ed
+
+  @return The 32-bit register value written to register
+**/
+typedef
+UINT32
+(*REG_AND_THEN_OR32) (
+  REGISTER_ACCESS  *This,
+  UINT32           Offset,
+  UINT32           AndData,
+  UINT32           OrData
+  );
+
+struct _REGISTER_ACCESS {
+  REG_READ8         Read8;
+  REG_WRITE8        Write8;
+  REG_OR8           Or8;
+  REG_AND8          And8;
+  REG_AND_THEN_OR8  AndThenOr8;
+
+  REG_READ16         Read16;
+  REG_WRITE16        Write16;
+  REG_OR16           Or16;
+  REG_AND16          And16;
+  REG_AND_THEN_OR16  AndThenOr16;
+
+  REG_READ32         Read32;
+  REG_WRITE32        Write32;
+  REG_OR32           Or32;
+  REG_AND32          And32;
+  REG_AND_THEN_OR32  AndThenOr32;
+};
+
+#endif

--- a/Silicon/CommonSocPkg/Include/Register/GpioV2VirtualRegs.h
+++ b/Silicon/CommonSocPkg/Include/Register/GpioV2VirtualRegs.h
@@ -1,0 +1,83 @@
+/** @file
+  Register names for IBL Virtual GPIO V2
+
+Conventions:
+
+  - Register definition format:
+    Prefix_[GenerationName]_RegisterSpace_RegisterName
+  - Prefix:
+    Definitions beginning with "B_" are bits within registers
+    Definitions beginning with "V_" are meaningful values within the bits
+    Definitions beginning with "N_" are the bit position
+  - [GenerationName]:
+    Register name without GenerationName applies to all generations.
+  - RegisterSpace:
+    PCR - Private configuration register of subsystem.
+  - RegisterName:
+    Full register name.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#ifndef IBL_GPIO_REGS_H
+#define IBL_GPIO_REGS_H
+
+//
+// Pad Configuration Register DW0
+//
+
+//Virtual GPIO Reset Config
+#define B_VGPIO_PCR_PAD_RESET_CONFIG    (BIT31 | BIT30)
+#define N_VGPIO_PCR_PAD_RESET_CONFIG    30
+
+//Virtual GPIO Ownership
+#define B_VGPIO_PCR_RX_PAD_OWNERSHIP    (BIT29 | BIT28)
+#define N_VGPIO_PCR_RX_PAD_OWNERSHIP    28
+
+//Virtual GPIO HostSW Ownership
+#define B_VGPIO_PCR_RX_PAD_HOSTSW_OWNERSHIP BIT27
+#define N_VGPIO_PCR_RX_PAD_HOSTSW_OWNERSHIP 27
+
+//Virtual GPIO interrupts routing
+#define B_VGPIO_PCR_INT_TYPE            (BIT26 | BIT25 | BIT24)
+#define N_VGPIO_PCR_INT_TYPE            24
+#define V_VGPIO_PCR_INT_TYPE_IRQ        0x0
+#define V_VGPIO_PCR_INT_TYPE_SCI        0x1
+#define V_VGPIO_PCR_INT_TYPE_SMI        0x2
+#define V_VGPIO_PCR_INT_TYPE_NMI        0x4
+#define V_VGPIO_PCR_INT_TYPE_DIS        0x7
+
+//RX Level/Edge Configuration for Virtual GPIO
+#define B_VGPIO_PCR_RX_LVL_EDG          (BIT23 | BIT22)
+#define N_VGPIO_PCR_RX_LVL_EDG          22
+#define V_VGPIO_PCR_RX_LVL_EDG_LVL      0x00
+#define V_VGPIO_PCR_RX_LVL_EDG_0        0x02
+
+//Interrupt number
+#define B_VGPIO_PCR_INTSEL              (BIT21 | BIT20 | BIT19 | BIT18 | BIT17 | BIT16 | BIT15 | BIT14)
+#define N_VGPIO_PCR_INTSEL              14
+
+// Virtual GPIO Chipselect
+#define B_VGPIO_PCR_OUT_CS              (BIT6 | BIT5)
+#define N_VGPIO_PCR_OUT_CS              5
+#define V_VGPIO_PCR_OUT_CS_0            0
+#define V_VGPIO_PCR_OUT_CS_1            1
+
+//GPIO RX Disable for Virtual GPIO
+#define B_VGPIO_PCR_RX_DISABLE          BIT4
+#define N_VGPIO_PCR_RX_DISABLE          4
+
+//GPIO TX Disable for Virtual GPIO
+#define B_VGPIO_PCR_TX_DISABLE          BIT3
+#define N_VGPIO_PCR_TX_DISABLE          3
+
+//GPIO RX State for Virtual GPIO
+#define B_VGPIO_PCR_RX_STATE            BIT1
+#define N_VGPIO_PCR_RX_STATE            1
+
+//GPIO TX State for Virtual GPIO
+#define B_VGPIO_PCR_TX_STATE            BIT0
+#define N_VGPIO_PCR_TX_STATE            0
+
+#endif // IBL_GPIO_REGS_H

--- a/Silicon/CommonSocPkg/Include/Register/P2sbRegs.h
+++ b/Silicon/CommonSocPkg/Include/Register/P2sbRegs.h
@@ -1,0 +1,402 @@
+/** @file
+  Register names for PCH P2SB device
+
+Conventions:
+
+  - Register definition format:
+    Prefix_SubsystemName_RegisterSpace_RegisterName
+  - Prefix:
+    Definitions beginning with "R_" are registers
+    Definitions beginning with "B_" are bits within registers
+    Definitions beginning with "V_" are meaningful values within the bits
+    Definitions beginning with "N_" are the bit position
+  - SubsystemName:
+    This field indicates the subsystem name of the component that the register belongs to
+    (e.g. PCIE, USB, SATA, GPIO, PMC etc.).
+  - RegisterSpace:
+    MEM - MMIO space register of subsystem.
+    IO  - IO space register of subsystem.
+    PCR - Private configuration register of subsystem.
+    CFG - PCI configuration space register of subsystem.
+  - RegisterName:
+    Full register name.
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#ifndef _P2SB_REGS_H_
+#define _P2SB_REGS_H_
+
+//
+// PCI to P2SB Bridge Registers
+//
+#define R_P2SB_CFG_SBREG_BAR                  0x00000010U      ///< Sideband Register Access BAR
+                                                               /* PCI header registers
+                                                                */
+#define B_P2SB_CFG_SBREG_BAR_RBA              ( BIT31 | BIT30 | BIT29 | BIT28 ) ///< Register Base Address
+                                                               /* Lower DWORD of the base address
+                                                                * for the sideband register access
+                                                                * BAR.
+                                                                */
+#define R_P2SB_CFG_SBREG_BARH                 0x00000014U      ///< Sideband Register BAR High DWORD
+                                                               /* PCI header registers
+                                                                */
+#define R_P2SB_CFG_HPTC                       0x00000060U      ///< High Performance Event Timer Configuration
+                                                               /* HPET configuration register
+                                                                */
+#define B_P2SB_CFG_HPTC_AS                    ( BIT1 | BIT0 )  ///< Address Select
+                                                               /* This 2-bit field selects 1 of 4
+                                                                * possible memory address ranges for
+                                                                * the High Performance Timer functionality.
+                                                                * The encodings are:
+                                                                * 00 : FED0_0000h - FED0_03FFFh
+                                                                * 01 : FED0_1000h - FED0_13FFFh
+                                                                * 10 : FED0_2000h - FED0_23FFFh
+                                                                * 11 : FED0_3000h - FED0_33FFFh
+                                                                */
+#define B_P2SB_CFG_HPTC_AE                    BIT7             ///< Address Enable
+                                                               /* When set, the P2SB will decode the
+                                                                * High Performance Timer memory address
+                                                                * range selected by bits 1:0 below.
+                                                                */
+#define N_HPET_ADDR_ASEL                      12
+#define R_P2SB_CFG_IOAC                       0x00000064U      ///< IOxAPIC Configuration
+                                                               /* IOAPIC configuration register
+                                                                */
+#define B_P2SB_CFG_IOAC_ASEL                  ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< APIC Range Select
+                                                               /* These bits define address bits 19:12
+                                                                * for the IOxAPIC range. The default
+                                                                * value of 00h enables compatibility
+                                                                * with prior products as an initial
+                                                                * value. This value must not be changed
+                                                                * unless the IOxAPIC Enable bit is
+                                                                * cleared.
+                                                                */
+#define B_P2SB_CFG_IOAC_AE                    BIT8             ///< Address Enable
+                                                               /* When set, the P2SB will decode the
+                                                                * IOxAPIC memory address range selected
+                                                                * by bits 7:0 below.
+                                                                */
+#define N_IO_APIC_ASEL                        12
+#define R_IO_APIC_MEM_INDEX_OFFSET            0x00000000U
+#define R_IO_APIC_MEM_DATA_OFFSET             0x00000010U
+#define R_P2SB_CFG_IBDF                       0x0000006cU      ///< IOxAPIC Bus:Device:Function
+                                                               /* This register specifies the bus:device:function
+                                                                * ID that the IOxAPIC will use in the following
+                                                                * :
+                                                                * tAs the Requester ID when initiating Interrupt
+                                                                * Messages to the CPU
+                                                                * tAs the Completer ID when responding to
+                                                                * the reads targeting the IOxAPICs Memory-Mapped
+                                                                * I/O registers
+                                                                * This field is default to Bus 0: Device 31:
+                                                                * Function 0 after reset. SBL shall program
+                                                                * this field accordingly if unique bus:device:function
+                                                                * number is required for the internal IOxAPIC.
+                                                                */
+#define V_P2SB_CFG_IBDF_BUS                   0
+#define V_P2SB_CFG_IBDF_DEV                   30
+#define V_P2SB_CFG_IBDF_FUNC                  7
+#define R_P2SB_CFG_HBDF                       0x00000070U      ///< HPET Bus:Device:Function
+                                                               /* This register specifies the bus:device:function
+                                                                * ID that the HPET device will use in the
+                                                                * following :
+                                                                * tAs the Requester ID when initiating Interrupt
+                                                                * Messages to the CPU
+                                                                * tAs the Completer ID when responding to
+                                                                * the reads targeting the corresponding HPETs
+                                                                * Memory-Mapped I/O registers
+                                                                * This field is default to Bus 0: Device 31:
+                                                                * Function 0 after reset. SBL shall program
+                                                                * this field accordingly if unique bus:device:function
+                                                                * number is required for the corresponding
+                                                                * HPET.
+                                                                */
+#define V_P2SB_CFG_HBDF_BUS                   0
+#define V_P2SB_CFG_HBDF_DEV                   30
+#define V_P2SB_CFG_HBDF_FUNC                  6
+#define R_P2SB_CFG_LFIORIEC                   0x00000074U      ///< LPC Fixed IO Route To IEC
+                                                               /* Select IEC (integrated EC) instead of LPC/eSPI
+                                                                * if register bit LFIORIEC[x]=1. If register
+                                                                * bit LFIORIEC[x]=0, LPC or eSPI is selected
+                                                                * based on hardstrap eSpiEnable
+                                                                */
+
+//
+// Definition for SBI
+//
+#define R_P2SB_CFG_SBIADDR_V2                    0x000000d0U      ///< SBI Address
+                                                               /* Provides mechanism to send message on IOSFSB;The
+                                                                * SAI check is only required on RS field but
+                                                                * due to tool limitation, the SAI check is
+                                                                * applied in RDL on whole register
+                                                                */
+#define B_P2SB_CFG_SBIADDR_OFFSET             0x0000ffffU      ///< Address Offset
+                                                               /* Register address offset.  The content
+                                                                * of this register field is sent in
+                                                                * the IOSF Sideband Message Register
+                                                                * Access address(15:0) field.
+                                                                */
+#define B_P2SB_CFG_SBIADDR_DESTID             ( BIT31 | BIT30 | BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Destination Port ID
+                                                               /* The content of this register field
+                                                                * is sent in the IOSF Sideband Message
+                                                                * Register Access dest field.
+                                                                * See the IOSF Sideband C-spec chapter
+                                                                * for Destination ID assignments.
+                                                                */
+#define N_P2SB_CFG_SBIADDR_DESTID             24
+#define R_P2SB_CFG_SBIDATA_V2                    0x000000d4U      ///< SBI Data
+                                                               /* Provides mechanism to send message on IOSFSB
+                                                                */
+#define R_P2SB_CFG_SBISTAT_V2                    0x000000d8U      ///< SBI Status
+                                                               /* Provides mechanism to send message on IOSFSB
+                                                                */
+#define B_P2SB_CFG_SBISTAT_INITRDY            BIT0             ///< Initiate/ Ready
+                                                               /* 0:  The IOSF sideband interface
+                                                                * is ready for a new transaction
+                                                                * 1:  The IOSF sideband interface
+                                                                * is busy with the previous transaction.
+                                                                * A write to set this register bit
+                                                                * to 1 will trigger an IOSF sideband
+                                                                * message on the private IOSF sideband
+                                                                * interface. The message will be formed
+                                                                * based on the values programmed in
+                                                                * the Sideband Message Interface Register
+                                                                * Access registers.
+                                                                * Software needs to ensure that the
+                                                                * interface is not busy (SBISTAT.INITRDY
+                                                                * is clear) before writing to this
+                                                                * register.
+                                                                */
+#define B_P2SB_CFG_SBISTAT_RESPONSE_V2           ( BIT2 | BIT1 )  ///< Response Status
+                                                               /* 00 - Successful
+                                                                * 01 - Unsuccessful / Not Supported
+                                                                * 10 - Powered Down
+                                                                * 11 - Multi-cast Mixed
+                                                                * This register reflects the response
+                                                                * status for the previously completed
+                                                                * transaction.  The value of this
+                                                                * register is only meaningful if SBISTAT.INITRDY
+                                                                * is zero.
+                                                                */
+#define N_P2SB_CFG_SBISTAT_RESPONSE           1
+#define B_P2SB_CFG_SBISTAT_POSTED             BIT7             ///< SBI Posted
+                                                               /* When set to 1, the message will
+                                                                * be send as a posted message instead
+                                                                * of non-posted.  This should only
+                                                                * be used if the receiver is known
+                                                                * to support posted operations for
+                                                                * the specified operation.
+                                                                */
+#define N_P2SB_CFG_SBISTAT_POSTED             7
+#define B_P2SB_CFG_SBISTAT_OPCODE_V2             ( BIT15 | BIT14 | BIT13 | BIT12 | BIT11 | BIT10 | BIT9 | BIT8 ) ///< SBI Opcode
+                                                               /* This is the Opcode sent in the IOSF
+                                                                * sideband message.
+                                                                */
+#define N_P2SB_CFG_SBISTAT_OPCODE             8
+#define R_P2SB_CFG_SBIRID_V2                     0x000000daU      ///< SBI Routing Identification
+                                                               /* Provides mechanism to send message on IOSFSB
+                                                                */
+#define B_P2SB_CFG_SBIRID_FID                 ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Function ID
+                                                               /* The contents of this field are sent
+                                                                * in the IOSF Sideband Register access
+                                                                * FID field.
+                                                                * This field should generally remain
+                                                                * at zero unless specifically required
+                                                                * by a particular application.
+                                                                */
+#define N_P2SB_CFG_SBIRID_FID                 0
+#define B_P2SB_CFG_SBIRID_BAR                 ( BIT10 | BIT9 | BIT8 ) ///< Base Address Register
+                                                               /* The contents of this field are sent
+                                                                * in the IOSF Sideband Register Access
+                                                                * BAR field.  This should be zero
+                                                                * performing a Memory Mapped operation
+                                                                * to a PCI compliant device.
+                                                                */
+#define N_P2SB_CFG_SBIRID_BAR                 8
+#define B_P2SB_CFG_SBIRID_FBE                 ( BIT15 | BIT14 | BIT13 | BIT12 ) ///< First Byte Enable
+                                                               /* The content of this field is sent
+                                                                * in the IOSF Sideband Register Access
+                                                                * FBE field.
+                                                                */
+#define N_P2SB_CFG_SBIRID_FBE                 12
+#define R_P2SB_CFG_SBIEXTADDR_V2                 0x000000dcU      ///< SBI Extended Address
+                                                               /* Provides mechanism to send message on IOSFSB
+                                                                */
+
+//
+// Others
+//
+#define R_P2SB_CFG_P2SBC                      0x000000e0U      ///< P2SB Control
+                                                               /* P2SB general configuration register
+                                                                */
+#define B_P2SB_CFG_P2SBC_RCSPE                BIT4             ///< RAVDM Completion Status Policy Enable
+                                                               /* When this bit is SET, P2SB performs
+                                                                * the following. 1) Return '000' (Succesful
+                                                                * Completion) for upstream Reg_rsp
+                                                                * RAVDM on IOSF-P. 2) Return '001'
+                                                                * (Unsupported Requst) for upstream
+                                                                * Reg_rsp. When clear P2SB always
+                                                                * returbn '000' (Succesful Completion)
+                                                                * for Upstream Reg_rsp RAVDM
+                                                                */
+#define B_P2SB_CFG_P2SBC_HIDE                 BIT8             ///< Hide Device
+                                                               /* When this bit is set, the P2SB will
+                                                                * return 1s on any PCI Configuration
+                                                                * Read on IOSF-P.  All other transactions
+                                                                * including PCI Configuration Writes
+                                                                * are unaffected by this.  This does
+                                                                * not affect reads performed on the
+                                                                * IOSF-SB interface.
+                                                                */
+#define B_P2SB_CFG_P2SBC_PGCBCGE              BIT16            ///< PGCB Clock Gating Enable
+                                                               /* When asserted the P2SB can de-assert
+                                                                * the clock request to disable the
+                                                                * PGCB clock dynamically when it reaches
+                                                                * the power down idle state.
+                                                                */
+#define B_P2SB_CFG_P2SBC_MASKLOCK             BIT17            ///< Endpoint Mask Lock
+                                                               /* Locks the value of the EPMASK[0-7]
+                                                                * registers.  Once this value is written
+                                                                * to a one it may only be cleared
+                                                                * by a reset.
+                                                                */
+#define B_P2SB_CFG_P2SBC_DPPEE                BIT24            ///< Data Phase Parity Error Enable
+                                                               /* IOSFP data phase parity error handling
+                                                                * enabling bit
+                                                                */
+#define B_P2SB_CFG_P2SBC_CPEE                 BIT25            ///< Command Parity Error Enable
+                                                               /* IOSFP command parity error handling
+                                                                * enabling bit
+                                                                */
+#define B_P2SB_CFG_P2SBC_DPEE                 BIT26            ///< Data Parity Error Enable
+                                                               /* IOSFP data parity error handling(EP
+                                                                * bit) enabling bit
+                                                                */
+#define R_P2SB_CFG_PCE                        0x000000e4U      ///< Power Control Enable
+                                                               /* Power Control Enable register
+                                                                */
+#define B_P2SB_CFG_PCE_PMCPG_EN               BIT0             ///< PMC Power Gating Enable
+                                                               /* When set to 1, the P2SB will engage
+                                                                * power gating if it is idle and the
+                                                                * pmc_p2sb_sw_pg_req_b signal is asserted.
+                                                                */
+#define B_P2SB_CFG_PCE_I3E                    BIT1             ///< I3 Enable
+                                                               /* No support for S0i3 power gating.
+                                                                */
+#define B_P2SB_CFG_PCE_D3HE                   BIT2             ///< D3-Hot Enable
+                                                               /* No support for D3 Hot power gating.
+                                                                */
+#define B_P2SB_CFG_PCE_HAE                    BIT5             ///< Hardware Autonomous Enable
+                                                               /* When set, the P2SB will automatically
+                                                                * engage power gating when it has
+                                                                * reached its idle condition.
+                                                                */
+#define R_P2SB_CFG_PDOMAIN                    0x000000e8U      ///< Primary Clock Domain Controls
+                                                               /* Primary CDC configuration register
+                                                                */
+#define B_P2SB_CFG_PDOMAIN_CGD                BIT0             ///< Primary Clock Gating Disable
+                                                               /* When set to 1, the local clock gating
+                                                                * for the IOSF-P clock domain within
+                                                                * the P2SB will be disabled.
+                                                                */
+#define B_P2SB_CFG_PDOMAIN_CKREQD             BIT1             ///< Primary CLKREQ DISABLE
+                                                               /* Primary CLKREQ DISABLE Register
+                                                                * bit
+                                                                */
+#define R_P2SB_CFG_SDOMAIN                    0x000000eaU      ///< Sideband Clock Domain Controls
+                                                               /* Sideband CDC configuration register
+                                                                */
+#define B_P2SB_CFG_SDOMAIN_CGD                BIT0             ///< Sideband Clock Gating Disable
+                                                               /* When set to 1, the local clock gating
+                                                                * for the IOSF-P clock domain within
+                                                                * the P2SB will be disabled.
+                                                                */
+#define B_P2SB_CFG_SDOMAIN_CKREQD             BIT1             ///< Sideband CLKREQ DISABLE
+                                                               /* Sideband CLKREQ DISABLE
+                                                                */
+#define R_P2SB_CFG_UREC                       0x000000f4U      ///< Unsupported Request Error Control
+                                                               /* This register is only reset by a loss of
+                                                                * core power
+                                                                */
+#define B_P2SB_CFG_UREC_ERE                   BIT0             ///< Error Reporting Enable
+                                                               /* When set, error logged in UES register
+                                                                * will trigger error reporting flow
+                                                                * in P2SB; Used only when ENABLE_AER
+                                                                * is set
+                                                                */
+#define R_P2SB_CFG_SBREGPOSTED0               0x00000200U      ///< Sideband Register Posted 0
+                                                               /* provides an mechanism to send MMIO writes
+                                                                * as posted writes on the IOSFSB space
+                                                                */
+#define R_P2SB_CFG_SBREGPOSTED1               0x00000204U      ///< Sideband Register Posted 1
+                                                               /* provides an mechanism to send MMIO writes
+                                                                * as posted writes on the IOSFSB space
+                                                                */
+#define R_P2SB_CFG_SBREGPOSTED2               0x00000208U      ///< Sideband Register Posted 2
+                                                               /* provides an mechanism to send MMIO writes
+                                                                * as posted writes on the IOSFSB space
+                                                                */
+#define R_P2SB_CFG_SBREGPOSTED3               0x0000020cU      ///< Sideband Register Posted 3
+                                                               /* provides an mechanism to send MMIO writes
+                                                                * as posted writes on the IOSFSB space
+                                                                */
+#define R_P2SB_CFG_SBREGPOSTED4               0x00000210U      ///< Sideband Register Posted 4
+                                                               /* provides an mechanism to send MMIO writes
+                                                                * as posted writes on the IOSFSB space
+                                                                */
+#define R_P2SB_CFG_SBREGPOSTED5               0x00000214U      ///< Sideband Register Posted 5
+                                                               /* provides an mechanism to send MMIO writes
+                                                                * as posted writes on the IOSFSB space
+                                                                */
+#define R_P2SB_CFG_SBREGPOSTED6               0x00000218U      ///< Sideband Register Posted 6
+                                                               /* provides an mechanism to send MMIO writes
+                                                                * as posted writes on the IOSFSB space
+                                                                */
+#define R_P2SB_CFG_SBREGPOSTED7               0x0000021cU      ///< Sideband Register Posted 7
+                                                               /* provides an mechanism to send MMIO writes
+                                                                * as posted writes on the IOSFSB space
+                                                                */
+#define R_P2SB_CFG_EPMASK0                    0x00000220U      ///< Endpoint Mask 0
+                                                               /* provide a mechanism for disabling particular
+                                                                * IOSF-SB endpoints from being allowed to
+                                                                * targeted by transactions from the P2SB
+                                                                */
+#define R_P2SB_CFG_EPMASK1                    0x00000224U      ///< Endpoint Mask 1
+                                                               /* provide a mechanism for disabling particular
+                                                                * IOSF-SB endpoints from being allowed to
+                                                                * targeted by transactions from the P2SB
+                                                                */
+#define R_P2SB_CFG_EPMASK2                    0x00000228U      ///< Endpoint Mask 2
+                                                               /* provide a mechanism for disabling particular
+                                                                * IOSF-SB endpoints from being allowed to
+                                                                * targeted by transactions from the P2SB
+                                                                */
+#define R_P2SB_CFG_EPMASK3                    0x0000022cU      ///< Endpoint Mask 3
+                                                               /* provide a mechanism for disabling particular
+                                                                * IOSF-SB endpoints from being allowed to
+                                                                * targeted by transactions from the P2SB
+                                                                */
+#define R_P2SB_CFG_EPMASK4                    0x00000230U      ///< Endpoint Mask 4
+                                                               /* provide a mechanism for disabling particular
+                                                                * IOSF-SB endpoints from being allowed to
+                                                                * targeted by transactions from the P2SB
+                                                                */
+#define R_P2SB_CFG_EPMASK5                    0x00000234U      ///< Endpoint Mask 5
+                                                               /* provide a mechanism for disabling particular
+                                                                * IOSF-SB endpoints from being allowed to
+                                                                * targeted by transactions from the P2SB
+                                                                */
+#define R_P2SB_CFG_EPMASK6                    0x00000238U      ///< Endpoint Mask 6
+                                                               /* provide a mechanism for disabling particular
+                                                                * IOSF-SB endpoints from being allowed to
+                                                                * targeted by transactions from the P2SB
+                                                                */
+#define R_P2SB_CFG_EPMASK7                    0x0000023cU      ///< Endpoint Mask 7
+                                                               /* provide a mechanism for disabling particular
+                                                                * IOSF-SB endpoints from being allowed to
+                                                                * targeted by transactions from the P2SB
+                                                                */
+
+#endif      // _P2SB_REGS_H_

--- a/Silicon/CommonSocPkg/Library/GpioV2Lib/GpioV2Init.c
+++ b/Silicon/CommonSocPkg/Library/GpioV2Lib/GpioV2Init.c
@@ -1,0 +1,2664 @@
+/** @file
+  This file contains routines for GPIO V2 Library
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi/UefiBaseType.h>
+#include <Library/GpioSiLib.h>
+#include <Library/PchSbiAccessLib.h>
+#include <Library/ConfigDataLib.h>
+#include <Library/PrintLib.h>
+#include <Library/GpioTopologyLib.h>
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/GpioV2Virtual.h>
+
+#define  GPIO_DEBUG_INFO     DEBUG_VERBOSE
+#define  GPIO_DEBUG_ERROR    DEBUG_VERBOSE
+
+/**
+  This procedure verifies if requested GpioGroup definition is ment for platform that it is used on
+
+  @param[in]  GpioGroup           GPIO pad
+  @param[out] IsValid             Pointer to a buffer for validation information, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+IsGroupValid (
+  IN  GPIOV2_PAD_GROUP        GpioGroup,
+  OUT BOOLEAN                 *IsValid
+  )
+{
+  UINT32  ChipsetId;
+  UINT32  CommunityIndex;
+  UINT32  GroupIndex;
+
+  ChipsetId = GPIOV2_PAD_GET_CHIPSETID (GpioGroup);
+  CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioGroup);
+  GroupIndex = GPIOV2_PAD_GET_GROUP_INDEX (GpioGroup);
+
+  *IsValid = FALSE;
+  if (ChipsetId != GpioGetChipId()) {
+    DEBUG((DEBUG_ERROR, "[GPIOV2][IsGroupValid] Error: wrong ChipsetId; com:%d,grp:%d id: 0x%x (exp: 0x%x)\n", CommunityIndex, GroupIndex, ChipsetId, GpioGetChipId()));
+    ASSERT(FALSE);
+    return EFI_SUCCESS;
+  }
+
+  if (CommunityIndex >= GpioGetCommunitiesNum()) {
+    DEBUG((DEBUG_ERROR, "[GPIOV2][IsGroupValid] Error: wrong community index; com:%d (max: %d)\n", CommunityIndex, GpioGetCommunitiesNum()));
+    ASSERT(FALSE);
+    return EFI_SUCCESS;
+  }
+
+  if (GroupIndex >= GpioGetCommunities(CommunityIndex)->GroupsNum) {
+    DEBUG((DEBUG_ERROR, "[GPIOV2][IsGroupValid] Error: wrong group index; g:%d (max: %d)\n", GroupIndex, GpioGetCommunities(CommunityIndex)->GroupsNum));
+    ASSERT(FALSE);
+    return EFI_SUCCESS;
+  }
+
+  *IsValid = TRUE;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure verifies if requested GpioPad definition is ment for platform that it is used on
+
+  @param[in] GpioPad              GPIO pad
+  @param[out] IsValid             Pointer to a buffer for validation information, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+IsPadValid (
+  IN  GPIOV2_PAD              GpioPad,
+  OUT BOOLEAN                 *IsValid
+  )
+{
+  UINT32  CommunityIndex;
+  UINT32  GroupIndex;
+  UINT32  PadIndex;
+
+  if ((IsValid == NULL)) {
+    ASSERT (FALSE);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  IsGroupValid ((GPIOV2_PAD_GROUP)GpioPad, IsValid);
+  if (*IsValid != TRUE) {
+    ASSERT(FALSE);
+    return EFI_SUCCESS;
+  }
+
+  CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+  GroupIndex = GPIOV2_PAD_GET_GROUP_INDEX (GpioPad);
+  PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+
+  if (PadIndex >= SocGpioGetGroups(CommunityIndex,GroupIndex).PadsNum) {
+    DEBUG((DEBUG_WARN, "[GPIOV2][IsPadValid] Error: Pad 0x%x, wrong pad index\n", GpioPad));
+    *IsValid = FALSE;
+    ASSERT(FALSE);
+    return EFI_SUCCESS;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure retrieves name of requested Gpio Pad
+
+  @param[in] GpioPad              Gpio Pad. Please refer to GpioPinsYYY.h - where YYY name of the platform (eg. MTL, EBG, ...)
+  @param[in] NameBufferLength     Maximum number of characters to be stored in NameBuffer
+  @param[out] NameBuffer          Pointer to a buffer for Gpio Pad name
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+GetPadName (
+  IN  GPIOV2_PAD            GpioPad,
+  IN  UINT32                NameBufferLength,
+  OUT CHAR8                 *NameBuffer
+  )
+{
+  UINT32 PadIndex;
+  UINT32 CommunityIndex;
+  UINT32 GroupIndex;
+
+  if ( (NameBuffer == NULL)) {
+    ASSERT (FALSE);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (GpioPad == GPIOV2_PAD_NONE) {
+    AsciiSPrint (NameBuffer, NameBufferLength, "No muxing");
+    return EFI_SUCCESS;
+  }
+
+  CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+  GroupIndex = GPIOV2_PAD_GET_GROUP_INDEX (GpioPad);
+  PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+
+  if (AsciiSPrint (NameBuffer, NameBufferLength, "%a_%02d",
+          SocGpioGetGroups(CommunityIndex,GroupIndex).Name,
+          PadIndex) == 0) {
+            ASSERT(FALSE);
+            return EFI_INVALID_PARAMETER;
+          }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure retrieves register offset
+
+  @param[in]  Register            Register for which user want to retrieve offset. Please refer to GpioV2Pad.h
+  @param[in]  GpioPad             Gpio Pad. Please refer to GpioPinsYYY.h - where YYY name of the platform (eg. MTL, EBG, ...)
+  @param[out] RegisterOffset      Pointer to a buffer for register offset
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+GetRegisterOffset (
+  IN  GPIOV2_REGISTER     Register,
+  IN  GPIOV2_PAD          GpioPad,
+  OUT UINT32              *RegisterOffset
+  )
+{
+  UINT32             CommunityIndex;
+  UINT32             GroupIndex;
+  UINT32             PadIndex;
+
+  ASSERT (RegisterOffset != NULL);
+  if (RegisterOffset == NULL)  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *RegisterOffset = 0;
+
+  CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+  GroupIndex = GPIOV2_PAD_GET_GROUP_INDEX (GpioPad);
+  PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+
+  switch (Register) {
+    case GpioV2PadOwnReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.PadOwn + (PadIndex / 8) * 0x04;
+      break;
+    case GpioV2PadCfgLockReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.PadCfgLock;
+      break;
+    case GpioV2PadCfgLockTxReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.PadCfgLockTx;
+      break;
+    case GpioV2PadHostSwOwnReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.HostOwn;
+      break;
+    case GpioV2GpiIsReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.GpiIs;
+      break;
+    case GpioV2GpiIeReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.GpiIe;
+      break;
+    case GpioV2GpiGpeStsReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.GpiGpeSts;
+      break;
+    case GpioV2GpiGpeEnReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.GpiGpeEn;
+      break;
+    case GpioV2SmiStsReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.SmiSts;
+      break;
+    case GpioV2SmiEnReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.SmiEn;
+      break;
+    case GpioV2NmiStsReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.NmiSts;
+      break;
+    case GpioV2NmiEnReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.NmiEn;
+      break;
+    case GpioV2Dw0Reg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.Dw0 + PadIndex * 0x8;
+      break;
+    case GpioV2Dw1Reg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.Dw0 + 0x04 + PadIndex * 0x8;
+      break;
+    case GpioV2MiscCfg:
+      *RegisterOffset = GpioGetCommunities(CommunityIndex)->RegisterOffsets.MiscCfg;
+      break;
+    default:
+      ASSERT(FALSE);
+      return EFI_INVALID_PARAMETER;
+  }
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure reads current ownership configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Ownership            Pointer to a buffer for ownership, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+GetOwnership (
+  IN  GPIOV2_PAD              GpioPad,
+  OUT GPIOV2_PAD_OWN          *Ownership
+  )
+{
+  if (IsHardGpio (GpioPad)) {
+    *Ownership = GpioV2PadOwnHost;
+    return EFI_SUCCESS;
+  } else {
+    return VirtualGpioGetOwnership (GpioPad, Ownership);
+  }
+}
+
+/**
+  This procedure will set GPIO mode
+
+  @param[in] GpioPad              Gpio Pad. Please refer to GpioPinsYYY.h - where YYY name of the platform (eg. MTL, EBG, ...)
+  @param[in] PadModeValue         GPIO pad mode value
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetPadMode (
+  IN GPIOV2_PAD              GpioPad,
+  IN GPIOV2_PAD_MODE         PadMode
+  )
+{
+  UINT32  AndValue;
+  UINT32  OrValue;
+  UINT32  CommunityIndex;
+  UINT32  RegisterOffset;
+  BOOLEAN PadValid;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+  GPIOV2_PAD_OWN  Ownership;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioSetPadMode (GpioPad, PadMode);
+  } else {
+    IsPadValid (GpioPad, &PadValid);
+    if (PadValid != TRUE) {
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    if (PadMode != GpioV2PadModeHardwareDefault) {
+      AndValue = (UINT32)~(GPIOV2_PAD_MODE_MASK << GPIOV2_PAD_MODE_DW0_POS);
+      OrValue  = ((PadMode >> 1) & GPIOV2_PAD_MODE_MASK) << GPIOV2_PAD_MODE_DW0_POS;
+      GetRegisterOffset (
+        GpioV2Dw0Reg,
+        GpioPad,
+        &RegisterOffset
+      );
+
+      P2sbPtr.Access.AndThenOr32 (
+        &(P2sbPtr.Access),
+        RegisterOffset,
+        AndValue,
+        OrValue
+      );
+    }
+  }
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure reads current GPIO Pad Mode
+
+  @param[in] GpioPad             GPIO Pad. Please refer to GpioPinsYYY.h - where YYY name of the platform (eg. MTL, EBG, ...)
+  @param[in] PadMode             Pointer to a buffer for GPIO Pad Mode
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetPadMode (
+  IN GPIOV2_PAD            GpioPad,
+  IN GPIOV2_PAD_MODE       *PadMode
+  )
+{
+  UINT32 CommunityIndex;
+  UINT32 RegisterOffset;
+  UINT32 RegisterValue;
+  P2SB_SIDEBAND_REGISTER_ACCESS   P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioGetPadMode (GpioPad, PadMode);
+  } else {
+    if (PadMode == NULL) {
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+    }
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+      GetRegisterOffset (
+        GpioV2Dw0Reg,
+        GpioPad,
+        &RegisterOffset
+      );
+
+    RegisterValue = P2sbPtr.Access.Read32 (
+      &(P2sbPtr.Access),
+      RegisterOffset
+    );
+
+    *PadMode = GPIO_ASSIGN_VALUE (((RegisterValue >> GPIOV2_PAD_MODE_DW0_POS) & GPIOV2_PAD_MODE_MASK));
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets host ownership configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Ownership            Host ownership, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+SetHostOwnership (
+  IN GPIOV2_PAD               GpioPad,
+  IN GPIOV2_HOSTSW_OWN        HostOnwership
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 AndValue;
+  UINT32 OrValue;
+  UINT32 CommunityIndex;
+  UINT32 PadIndex;
+  UINT32 RegisterOffset;
+  P2SB_SIDEBAND_REGISTER_ACCESS   P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioSetHostOwnership (GpioPad, HostOnwership);
+  } else {
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    if (HostOnwership != GpioV2HostOwnDefault) {
+      GetRegisterOffset (
+        GpioV2PadHostSwOwnReg,
+        GpioPad,
+        &RegisterOffset
+      );
+
+      AndValue = (UINT32)~(GPIOV2_PAD_HOST_OWNERSHIP_MASK << PadIndex);
+      OrValue  = ((HostOnwership >> 1) & GPIOV2_PAD_HOST_OWNERSHIP_MASK) << PadIndex;
+
+      P2sbPtr.Access.AndThenOr32 (
+        &(P2sbPtr.Access),
+        RegisterOffset,
+        AndValue,
+        OrValue
+      );
+    }
+  }
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure reads current host ownership configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Ownership            Pointer to a buffer for ownership, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetHostOwnership (
+  IN  GPIOV2_PAD              GpioPad,
+  OUT GPIOV2_HOSTSW_OWN       *HostOwnership
+  )
+{
+  GPIOV2_PAD_OWN Ownership;
+  UINT32 CommunityIndex;
+  UINT32 PadIndex;
+  UINT32 RegisterOffset;
+  UINT32 RegisterValue;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioGetHostOwnership (GpioPad, HostOwnership);
+  } else {
+    if (HostOwnership == NULL) {
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+    }
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    GetRegisterOffset (
+      GpioV2PadHostSwOwnReg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    RegisterValue = P2sbPtr.Access.Read32 (
+      &(P2sbPtr.Access),
+      RegisterOffset
+    );
+
+    // Please refer to enum GPIOV2_HOSTSW_OWN in GpioV2Pad.h file
+    *HostOwnership = (((RegisterValue >> PadIndex) & GPIOV2_PAD_HOST_OWNERSHIP_MASK) << 1) | 0x01;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets Gpio Pad output state
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] OutputState         GpioV2StateLow - output state low, GpioV2StateHigh - output state high
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetTx (
+  IN GPIOV2_PAD             GpioPad,
+  IN GPIOV2_PAD_STATE       OutputState
+  )
+{
+  GPIOV2_PAD_OWN Ownership;
+  UINT32 AndValue;
+  UINT32 OrValue;
+  UINT32 CommunityIndex;
+  UINT32 RegisterOffset;
+  P2SB_SIDEBAND_REGISTER_ACCESS  P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioSetTx (GpioPad, OutputState);
+  } else {
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    if (OutputState != GpioV2StateDefault) {
+      GetRegisterOffset (
+        GpioV2Dw0Reg,
+        GpioPad,
+        &RegisterOffset
+      );
+
+      AndValue = (UINT32)~(GPIOV2_PAD_OUTPUT_STATE_MASK << GPIOV2_PAD_OUTPUT_STATE_DW0_POS);
+      OrValue  = ((OutputState >> 1) & GPIOV2_PAD_OUTPUT_STATE_MASK) << GPIOV2_PAD_OUTPUT_STATE_DW0_POS;
+
+      P2sbPtr.Access.AndThenOr32 (
+        &(P2sbPtr.Access),
+        RegisterOffset,
+        AndValue,
+        OrValue
+      );
+    }
+  }
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure reads current Gpio Pad output state
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] OutputState         Pointer to a buffer for output state
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetTx (
+  IN GPIOV2_PAD             GpioPad,
+  IN GPIOV2_PAD_STATE       *OutputState
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 CommunityIndex;
+  UINT32 RegisterOffset;
+  UINT32 RegisterValue;
+  P2SB_SIDEBAND_REGISTER_ACCESS  P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioGetTx (GpioPad, OutputState);
+  } else {
+    if (OutputState == NULL) {
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+    }
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    GetRegisterOffset (
+      GpioV2Dw0Reg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    RegisterValue = P2sbPtr.Access.Read32 (
+      &(P2sbPtr.Access),
+      RegisterOffset
+    );
+
+    if ((RegisterValue >> GPIOV2_PAD_OUTPUT_STATE_DW0_POS) & (GPIOV2_PAD_OUTPUT_STATE_MASK)) {
+      *OutputState = GpioV2StateHigh;
+    } else {
+      *OutputState = GpioV2StateLow;
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure reads current Gpio Pad input state
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] InputState          Pointer to a buffer for input state
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetRx (
+  IN GPIOV2_PAD           GpioPad,
+  IN GPIOV2_PAD_STATE     *InputState
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 CommunityIndex;
+  UINT32 RegisterOffset;
+  UINT32 RegisterValue;
+  P2SB_SIDEBAND_REGISTER_ACCESS  P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioGetRx (GpioPad, InputState);
+  } else {
+    if (InputState == NULL) {
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+    }
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    GetRegisterOffset (
+      GpioV2Dw0Reg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    RegisterValue = P2sbPtr.Access.Read32 (
+      &(P2sbPtr.Access),
+      RegisterOffset
+    );
+
+    if ((RegisterValue >> GPIOV2_PAD_INPUT_STATE_DW0_POS) & (GPIOV2_PAD_INPUT_STATE_MASK)) {
+      *InputState = GpioV2StateHigh;
+    } else {
+      *InputState = GpioV2StateLow;
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure reads if TX buffer for requested Gpio Pad is enabled or disabled
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] TxDisabled          Pointer to a buffer for enabled/disabled information
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetTxDisable (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  *TxDisabled
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 CommunityIndex;
+  UINT32 RegisterOffset;
+  UINT32 RegisterValue;
+  P2SB_SIDEBAND_REGISTER_ACCESS  P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioGetTxDisable (GpioPad, TxDisabled);
+  } else {
+    if (TxDisabled == NULL) {
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+    }
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    GetRegisterOffset (
+      GpioV2Dw0Reg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    RegisterValue = P2sbPtr.Access.Read32 (
+      &(P2sbPtr.Access),
+      RegisterOffset
+    );
+
+    if ((RegisterValue >> GPIOV2_PAD_TX_DISABLE_DW0_POS) & (GPIOV2_PAD_TX_DISABLE_MASK)) {
+      *TxDisabled = TRUE;
+    } else {
+      *TxDisabled = FALSE;
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets TX buffer for requested Gpio Pad as enabled or disabled
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] TxDisabled          True - TX buffer disabled, False - TX buffer enabled
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetTxDisable (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  TxDisabled
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 AndValue;
+  UINT32 OrValue;
+  UINT32 CommunityIndex;
+  UINT32 RegisterOffset;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioSetTxDisable (GpioPad, TxDisabled);
+  } else {
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    GetRegisterOffset (
+      GpioV2Dw0Reg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    AndValue = (UINT32)~(GPIOV2_PAD_TX_DISABLE_MASK << GPIOV2_PAD_TX_DISABLE_DW0_POS);
+    OrValue  = (TxDisabled & GPIOV2_PAD_TX_DISABLE_MASK) << GPIOV2_PAD_TX_DISABLE_DW0_POS;
+
+    P2sbPtr.Access.AndThenOr32 (
+      &(P2sbPtr.Access),
+      RegisterOffset,
+      AndValue,
+      OrValue
+    );
+  }
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure reads if RX buffer for requested Gpio Pad is enabled or disabled
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] RxDisabled          Pointer to a buffer for enabled/disabled information
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetRxDisable (
+  IN GPIOV2_PAD              GpioPad,
+  IN BOOLEAN                 *RxDisabled
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 CommunityIndex;
+  UINT32 RegisterOffset;
+  UINT32 RegisterValue;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioGetRxDisable (GpioPad, RxDisabled);
+  } else {
+    if (RxDisabled == NULL) {
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    GetRegisterOffset (
+      GpioV2Dw0Reg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    RegisterValue = P2sbPtr.Access.Read32 (
+      &(P2sbPtr.Access),
+      RegisterOffset
+    );
+
+    if ((RegisterValue >> GPIOV2_PAD_RX_DISABLE_DW0_POS) & (GPIOV2_PAD_RX_DISABLE_MASK)) {
+      *RxDisabled = TRUE;
+    } else {
+      *RxDisabled = FALSE;
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets Rx buffer for requested Gpio Pad as enabled or disabled
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] TxDisabled          True - TX buffer disabled, False - TX buffer enabled
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetRxDisable (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  RxDisabled
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 AndValue;
+  UINT32 OrValue;
+  UINT32 CommunityIndex;
+  UINT32 RegisterOffset;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioSetRxDisable (GpioPad, RxDisabled);
+  } else {
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    GetRegisterOffset (
+      GpioV2Dw0Reg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    AndValue = (UINT32)~(GPIOV2_PAD_RX_DISABLE_MASK << GPIOV2_PAD_RX_DISABLE_DW0_POS);
+    OrValue  = (RxDisabled & GPIOV2_PAD_RX_DISABLE_MASK) << GPIOV2_PAD_RX_DISABLE_DW0_POS;
+
+    P2sbPtr.Access.AndThenOr32 (
+      &(P2sbPtr.Access),
+      RegisterOffset,
+      AndValue,
+      OrValue
+    );
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will set GPIO enable or disable input inversion on rquested pad
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] InputInversion      GpioV2InputInversionEnable or GpioV2InputInversionDisable, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetInputInversion (
+  IN GPIOV2_PAD                  GpioPad,
+  IN GPIOV2_PAD_INPUT_INVERSION  InputInversion
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 AndValue;
+  UINT32 OrValue;
+  UINT32 CommunityIndex;
+  UINT32 RegisterOffset;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioSetInputInversion (GpioPad, InputInversion);
+  } else {
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    if (InputInversion != GpioV2InputInversionHardwareDefault) {
+
+      AndValue = (UINT32)~(GPIOV2_PAD_INPUT_INVERSION_MASK << GPIOV2_PAD_INPUT_INVERSION_DW0_POS);
+      OrValue  = ((InputInversion >> 1) & GPIOV2_PAD_INPUT_INVERSION_MASK) << GPIOV2_PAD_INPUT_INVERSION_DW0_POS;
+
+      GetRegisterOffset (
+        GpioV2Dw0Reg,
+        GpioPad,
+        &RegisterOffset
+      );
+
+      P2sbPtr.Access.AndThenOr32 (
+        &(P2sbPtr.Access),
+        RegisterOffset,
+        AndValue,
+        OrValue
+      );
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will Get GPIO enable or disable input inversion on rquested pad
+
+  @param[in]  GpioPad             GPIO pad
+  @param[Out] Inverted            Buffer for Boolean value
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetInputInversion (
+  IN GPIOV2_PAD                  GpioPad,
+  OUT BOOLEAN                    *Inverted
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32  CommunityIndex;
+  UINT32  RegisterOffset;
+  BOOLEAN PadValid;
+  UINT32  Data;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioGetInputInversion (GpioPad, Inverted);
+  } else {
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    IsPadValid (GpioPad, &PadValid);
+    if (PadValid != TRUE) {
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    GetRegisterOffset (
+        GpioV2Dw0Reg,
+        GpioPad,
+        &RegisterOffset
+      );
+
+    Data = P2sbPtr.Access.Read32 (
+      &(P2sbPtr.Access),
+      RegisterOffset
+    );
+
+    if ((Data >> GPIOV2_PAD_INPUT_INVERSION_DW0_POS) & GPIOV2_PAD_INPUT_INVERSION_MASK) {
+      *Inverted = TRUE;
+    }
+    else {
+      *Inverted = FALSE;
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will set GPIO Lock (register PADCFGLOCK)
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] Lock                GpioV2Unlock - Unlock pad, GpioV2Lock - Lock pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+SetLock (
+  IN GPIOV2_PAD                GpioPad,
+  IN GPIOV2_PAD_LOCK           Lock
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 AndValue;
+  UINT32 OrValue;
+  UINT32 PadIndex;
+  UINT32 CommunityIndex;
+  UINT32 RegisterOffset;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioSetLock (GpioPad, Lock);
+  } else {
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+
+    if (Lock != GpioV2LockHardwareDefault) {
+      AndValue = ~(GPIOV2_PAD_LOCK_MASK << PadIndex);
+      OrValue  = ((Lock >> 1) & GPIOV2_PAD_LOCK_MASK) << PadIndex;
+
+      GetRegisterOffset (
+        GpioV2PadCfgLockReg,
+        GpioPad,
+        &RegisterOffset
+      );
+
+      P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+      P2sbPtr.Access.AndThenOr32 (
+        &(P2sbPtr.Access),
+        RegisterOffset,
+        AndValue,
+        OrValue
+      );
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will get GPIO Lock (register PADCFGLOCK)
+
+  @param[in]  GpioPad             GPIO pad
+  @param[out] Lock                Buffer for GPIOV2_PAD_LOCK
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetLock (
+  IN  GPIOV2_PAD                   GpioPad,
+  OUT GPIOV2_PAD_LOCK              *Lock
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 PadIndex;
+  UINT32 CommunityIndex;
+  UINT32 RegisterOffset;
+  UINT32 RegisterValue;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioGetLock (GpioPad, Lock);
+  } else {
+    if (Lock == NULL) {
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+    }
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    GetRegisterOffset (
+      GpioV2PadCfgLockReg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    RegisterValue = P2sbPtr.Access.Read32 (
+      &(P2sbPtr.Access),
+      RegisterOffset
+    );
+
+    if ((RegisterValue >> PadIndex) & GPIOV2_PAD_LOCK_MASK) {
+      *Lock = GpioV2Lock;
+    } else {
+      *Lock = GpioV2Unlock;
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will set GPIO Lock Tx (register PADCFGLOCKTX)
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] LockTx              GpioV2Unlock - Unlock output state of Gpio Pad, GpioV2Lock - Lock output state of Gpio Pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+SetLockTx (
+  IN GPIOV2_PAD                  GpioPad,
+  IN GPIOV2_PAD_LOCK             LockTx
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 AndValue;
+  UINT32 OrValue;
+  UINT32 PadIndex;
+  UINT32 CommunityIndex;
+  UINT32 RegisterOffset;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioSetLockTx (GpioPad, LockTx);
+  } else {
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    if (LockTx != GpioV2LockHardwareDefault) {
+      GetRegisterOffset (
+        GpioV2PadCfgLockTxReg,
+        GpioPad,
+        &RegisterOffset
+      );
+
+      AndValue = ~(GPIOV2_PAD_LOCK_MASK << PadIndex);
+      OrValue  = ((LockTx >> 1) & GPIOV2_PAD_LOCK_MASK) << PadIndex;
+
+      P2sbPtr.Access.AndThenOr32 (
+        &(P2sbPtr.Access),
+        RegisterOffset,
+        AndValue,
+        OrValue
+      );
+    }
+  }
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will get GPIO Lock Tx (register PADCFGLOCKTX)
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] Lock                Buffer for GPIOV2_PAD_LOCK
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetLockTx (
+  IN GPIOV2_PAD                   GpioPad,
+  IN GPIOV2_PAD_LOCK              *Lock
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           PadIndex;
+  UINT32           CommunityIndex;
+  UINT32           RegisterOffset;
+  UINT32           RegisterValue;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioGetLockTx (GpioPad, Lock);
+  } else {
+    if (Lock == NULL) {
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+    }
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+      GetRegisterOffset (
+        GpioV2PadCfgLockTxReg,
+        GpioPad,
+        &RegisterOffset
+      );
+
+    RegisterValue = P2sbPtr.Access.Read32 (
+      &(P2sbPtr.Access),
+      RegisterOffset
+    );
+
+    if ((RegisterValue >> PadIndex) & GPIOV2_PAD_LOCK_MASK) {
+      *Lock = GpioV2Lock;
+    } else {
+      *Lock = GpioV2Unlock;
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets NMI Enable for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] NmiEn                NMI Enable, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetNmiEn (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  NmiEn
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 AndValue;
+  UINT32 OrValue;
+  UINT32 CommunityIndex;
+  UINT32 PadIndex;
+  UINT32 RegisterOffset;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioSetNmiEn (GpioPad, NmiEn);
+  } else {
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    GetRegisterOffset (
+      GpioV2NmiEnReg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    AndValue = (UINT32)~(GPIOV2_PAD_NMI_EN_MASK << PadIndex);
+    if (NmiEn) {
+      OrValue = 0x01 << PadIndex;
+    } else {
+      OrValue = 0x0;
+    }
+
+    P2sbPtr.Access.AndThenOr32 (
+      &(P2sbPtr.Access),
+      RegisterOffset,
+      AndValue,
+      OrValue
+    );
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets SMI Enable configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] SmiEn                SMI Enable, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetSmiEn (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  SmiEn
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 AndValue;
+  UINT32 OrValue;
+  UINT32 CommunityIndex;
+  UINT32 PadIndex;
+  UINT32 RegisterOffset;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioSetSmiEn (GpioPad, SmiEn);
+  } else {
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    GetRegisterOffset (
+      GpioV2SmiEnReg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    AndValue = (UINT32)~(GPIOV2_PAD_SMI_EN_MASK << PadIndex);
+    OrValue  = (SmiEn & GPIOV2_PAD_SMI_EN_MASK) << PadIndex;
+
+    P2sbPtr.Access.AndThenOr32 (
+      &(P2sbPtr.Access),
+      RegisterOffset,
+      AndValue,
+      OrValue
+    );
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets GPI GPE Enable configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] GpiIe                GPI GPE Enable, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetGpiGpeEn (
+  IN GPIOV2_PAD              GpioPad,
+  IN BOOLEAN                 GpiGpeEn
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 AndValue;
+  UINT32 OrValue;
+  UINT32 CommunityIndex;
+  UINT32 PadIndex;
+  UINT32 RegisterOffset;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioSetGpiGpeEn (GpioPad, GpiGpeEn);
+  } else {
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    GetRegisterOffset (
+      GpioV2GpiGpeEnReg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    AndValue = (UINT32)~(GPIOV2_PAD_GPI_GPE_EN_MASK << PadIndex);
+    OrValue  = (GpiGpeEn & GPIOV2_PAD_GPI_GPE_EN_MASK) << PadIndex;
+
+    P2sbPtr.Access.AndThenOr32 (
+      &(P2sbPtr.Access),
+      RegisterOffset,
+      AndValue,
+      OrValue
+    );
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure reads current GPI GPE Enable configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] GpiIe                GPI GPE Enable, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetGpiGpeEn (
+  IN GPIOV2_PAD              GpioPad,
+  IN BOOLEAN                 *GpiGpeEn
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 CommunityIndex;
+  UINT32 PadIndex;
+  UINT32 RegisterOffset;
+  UINT32 RegisterValue;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioGetGpiGpeEn (GpioPad, GpiGpeEn);
+  } else {
+    if (GpiGpeEn == NULL) {
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    GetRegisterOffset (
+      GpioV2GpiGpeEnReg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    RegisterValue = P2sbPtr.Access.Read32 (
+      &(P2sbPtr.Access),
+      RegisterOffset
+    );
+
+    if ((RegisterValue >> PadIndex) & (GPIOV2_PAD_GPI_GPE_EN_MASK)) {
+      *GpiGpeEn = TRUE;
+    } else {
+      *GpiGpeEn = FALSE;
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets Gpi Enable configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] GpiIe                GPI Enable, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetGpiIe (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  GpiIe
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 AndValue;
+  UINT32 OrValue;
+  UINT32 CommunityIndex;
+  UINT32 PadIndex;
+  UINT32 RegisterOffset;
+  P2SB_SIDEBAND_REGISTER_ACCESS  P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioSetGpiIe (GpioPad, GpiIe);
+  } else {
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    GetRegisterOffset (
+      GpioV2GpiIeReg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    AndValue = (UINT32)~(GPIOV2_PAD_GPI_IE_MASK << PadIndex);
+    OrValue  = (GpiIe & GPIOV2_PAD_GPI_IE_MASK) << PadIndex;
+
+    P2sbPtr.Access.AndThenOr32 (
+      &(P2sbPtr.Access),
+      RegisterOffset,
+      AndValue,
+      OrValue
+    );
+  }
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure reads current Gpi Enable configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] GpiIe                Pointer to a buffer for GPI Enable
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetGpiIe (
+  IN GPIOV2_PAD              GpioPad,
+  IN BOOLEAN                 *GpiIe
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 CommunityIndex;
+  UINT32 PadIndex;
+  UINT32 RegisterOffset;
+  UINT32 RegisterValue;
+  P2SB_SIDEBAND_REGISTER_ACCESS   P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioGetGpiIe (GpioPad, GpiIe);
+  } else {
+    if (GpiIe == NULL) {
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    GetRegisterOffset (
+      GpioV2GpiIeReg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    RegisterValue = P2sbPtr.Access.Read32 (
+      &(P2sbPtr.Access),
+      RegisterOffset
+    );
+
+    if ((RegisterValue >> PadIndex) & (GPIOV2_PAD_GPI_IE_MASK)) {
+      *GpiIe = TRUE;
+    } else {
+      *GpiIe = FALSE;
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure reads current Gpi Status for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] GpiIe                Pointer to a buffer for GPI Enable
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetGpiIs (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  *GpiIs
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 CommunityIndex;
+  UINT32 PadIndex;
+  UINT32 RegisterOffset;
+  UINT32 RegisterValue;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (IsHardGpio (GpioPad)) {
+    return VirtualGpioGetGpiIs (GpioPad, GpiIs);
+  } else {
+    if (GpiIs == NULL) {
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    GetRegisterOffset (
+      GpioV2GpiIsReg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    RegisterValue = P2sbPtr.Access.Read32 (
+      &(P2sbPtr.Access),
+      RegisterOffset
+    );
+
+    if ((RegisterValue >> PadIndex) & (GPIOV2_PAD_GPI_IE_MASK)) {
+      *GpiIs = TRUE;
+    } else {
+      *GpiIs = FALSE;
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets GPIROUTNMI bit (17th bit in DW0) for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Enable               TRUE or FALSE, either enable or disable 17 bit in DW0
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetRouteNmi (
+  IN GPIOV2_PAD           GpioPad,
+  IN BOOLEAN              Enable
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 AndValue;
+  UINT32 OrValue;
+  UINT32 CommunityIndex;
+  UINT32 RegisterOffset;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioSetRouteNmi (GpioPad, Enable);
+  } else {
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    AndValue = (UINT32)~(GPIOV2_PAD_GPIROUTNMI_DW0_MASK << GPIOV2_PAD_GPIROUTNMI_DW0_POS);
+    if (Enable) {
+      OrValue = 0x1 << GPIOV2_PAD_GPIROUTNMI_DW0_POS;
+    } else {
+      OrValue = 0x0;
+    }
+
+    GetRegisterOffset (
+      GpioV2Dw0Reg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    P2sbPtr.Access.AndThenOr32 (
+      &(P2sbPtr.Access),
+      RegisterOffset,
+      AndValue,
+      OrValue
+    );
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets GPIROUTSMI bit (18th bit in DW0) for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Enable               TRUE or FALSE, either enable or disable 18 bit in DW0
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetRouteSmi (
+  IN GPIOV2_PAD           GpioPad,
+  IN BOOLEAN              Enable
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 AndValue;
+  UINT32 OrValue;
+  UINT32 CommunityIndex;
+  UINT32 RegisterOffset;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioSetRouteSmi (GpioPad, Enable);
+  } else {
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    AndValue = (UINT32)~(GPIOV2_PAD_GPIROUTSMI_DW0_MASK << GPIOV2_PAD_GPIROUTSMI_DW0_POS);
+    if (Enable) {
+      OrValue = 0x1 << GPIOV2_PAD_GPIROUTSMI_DW0_POS;
+    } else {
+      OrValue = 0x0;
+    }
+
+    GetRegisterOffset (
+      GpioV2Dw0Reg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    P2sbPtr.Access.AndThenOr32 (
+      &(P2sbPtr.Access),
+      RegisterOffset,
+      AndValue,
+      OrValue
+    );
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets GPIROUTIOXAPIC bit (20th bit in DW0) for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Enable               TRUE or FALSE, either enable or disable 20th bit in DW0
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetRouteIoxApic (
+  IN GPIOV2_PAD           GpioPad,
+  IN BOOLEAN              Enable
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 AndValue;
+  UINT32 OrValue;
+  UINT32 CommunityIndex;
+  UINT32 RegisterOffset;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioSetRouteIoxApic (GpioPad, Enable);
+  } else {
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    AndValue = (UINT32)~(GPIOV2_PAD_GPIROUTIOXAPIC_DW0_MASK << GPIOV2_PAD_GPIROUTIOXAPIC_DW0_POS);
+    if (Enable) {
+      OrValue = 0x1 << GPIOV2_PAD_GPIROUTIOXAPIC_DW0_POS;
+    } else {
+      OrValue = 0x0;
+    }
+
+    GetRegisterOffset (
+      GpioV2Dw0Reg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    P2sbPtr.Access.AndThenOr32 (
+      &(P2sbPtr.Access),
+      RegisterOffset,
+      AndValue,
+      OrValue
+    );
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets RxEv configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] RxEvCfg              RxEv configuration
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetRxEvCfg (
+  IN GPIOV2_PAD           GpioPad,
+  IN GPIOV2_RXEVCFG       RxEvCfg
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 AndValue;
+  UINT32 OrValue;
+  UINT32 CommunityIndex;
+  UINT32 RegisterOffset;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioSetRxEvCfg (GpioPad, RxEvCfg);
+  } else {
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    if (RxEvCfg != GpioV2IntRxEvCfgDefault) {
+      CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+      P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+      AndValue = (UINT32)~(GPIOV2_PAD_RXEV_MASK << GPIOV2_PAD_RXEV_DW0_POS);
+      OrValue  = ((RxEvCfg >> 1) & GPIOV2_PAD_RXEV_MASK) << GPIOV2_PAD_RXEV_DW0_POS;
+
+      GetRegisterOffset (
+        GpioV2Dw0Reg,
+        GpioPad,
+        &RegisterOffset
+      );
+
+      P2sbPtr.Access.AndThenOr32 (
+        &(P2sbPtr.Access),
+        RegisterOffset,
+        AndValue,
+        OrValue
+      );
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets GPIROUTSCI bit (19th bit in DW0) for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Enable               TRUE or FALSE, either enable or disable 19 bit in DW0
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+SetRouteSci (
+  IN GPIOV2_PAD           GpioPad,
+  IN BOOLEAN              Enable
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 AndValue;
+  UINT32 OrValue;
+  UINT32 CommunityIndex;
+  UINT32 RegisterOffset;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioSetRouteSci (GpioPad, Enable);
+  } else {
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    AndValue = (UINT32)~(GPIOV2_PAD_GPIROUTSCI_DW0_MASK << GPIOV2_PAD_GPIROUTSCI_DW0_POS);
+    if (Enable) {
+      OrValue = 0x1 << GPIOV2_PAD_GPIROUTSCI_DW0_POS;
+    } else {
+      OrValue = 0x0;
+    }
+
+    GetRegisterOffset (
+      GpioV2Dw0Reg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    P2sbPtr.Access.AndThenOr32 (
+      &(P2sbPtr.Access),
+      RegisterOffset,
+      AndValue,
+      OrValue
+    );
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets Reset Configuration for requested Gpio Pad
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] ResetConfig         Reset Configuration - please refer to GpioV2Pad.h (GPIOV2_RESET_CONFIG)
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+SetResetConfig (
+  IN GPIOV2_PAD               GpioPad,
+  IN GPIOV2_RESET_CONFIG      ResetConfig
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 AndValue;
+  UINT32 OrValue;
+  UINT32 CommunityIndex;
+  UINT32 RegisterOffset;
+  UINT8  PadRstIndex;
+  GPIOV2_RESET_CONFIG *PadRstCfgToGpioResetConfigMap;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioSetResetConfig (GpioPad, ResetConfig);
+  } else {
+    static GPIOV2_RESET_CONFIG  GppPadRstCfgToGpioResetConfigMap[] = {
+      GpioV2ResetResume,
+      GpioV2ResetHostDeep,
+      GpioV2ResetHost,
+      GpioV2ResetGlobal
+    };
+    static GPIOV2_RESET_CONFIG  GpdPadRstCfgToGpioResetConfigMap[] = {
+      GpioV2DswReset,
+      GpioV2ResetHostDeep,
+      GpioV2ResetHost,
+      GpioV2ResetResume
+    };
+
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    if (ResetConfig != GpioV2ResetDefault) {
+      GetRegisterOffset (
+        GpioV2Dw0Reg,
+        GpioPad,
+        &RegisterOffset
+      );
+      if (GpioGetCommunities(CommunityIndex)->IsComDsw) {
+        PadRstCfgToGpioResetConfigMap = GpdPadRstCfgToGpioResetConfigMap;
+      } else {
+        PadRstCfgToGpioResetConfigMap = GppPadRstCfgToGpioResetConfigMap;
+      }
+      for (PadRstIndex = 0; PadRstIndex <= (GPIOV2_PAD_RESET_CONFIG_MASK + 1); PadRstIndex++) {
+        if (PadRstIndex == (GPIOV2_PAD_RESET_CONFIG_MASK + 1)) {
+          DEBUG ((DEBUG_ERROR, "[%a] ResetConfig = %d has not been found in mapping table!\n", __FUNCTION__, ResetConfig));
+          return EFI_NOT_FOUND;
+        } else if (PadRstCfgToGpioResetConfigMap[PadRstIndex] == ResetConfig) {
+          break;
+        }
+      }
+
+
+      AndValue = (UINT32)~(GPIOV2_PAD_RESET_CONFIG_MASK << GPIOV2_PAD_RESET_CONFIG_DW0_POS);
+      OrValue  = (PadRstIndex & GPIOV2_PAD_RESET_CONFIG_MASK) << GPIOV2_PAD_RESET_CONFIG_DW0_POS;
+
+      P2sbPtr.Access.AndThenOr32 (
+        &(P2sbPtr.Access),
+        RegisterOffset,
+        AndValue,
+        OrValue
+      );
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure reads current Reset Configuration for requested Gpio Pad
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] ResetConfig         Pointer to a buffer for Reset Configuration
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+GetResetConfig (
+  IN GPIOV2_PAD               GpioPad,
+  IN GPIOV2_RESET_CONFIG      *ResetConfig
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 CommunityIndex;
+  UINT32 RegisterOffset;
+  UINT32 RegisterValue;
+  UINT8  Padrstcfg;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioGetResetConfig (GpioPad, ResetConfig);
+  } else {
+
+    static GPIOV2_RESET_CONFIG  GppPadRstCfgToGpioResetConfigMap[] = {
+      GpioV2ResetResume,
+      GpioV2ResetHostDeep,
+      GpioV2ResetHost,
+      GpioV2ResetGlobal
+    };
+    static GPIOV2_RESET_CONFIG  GpdPadRstCfgToGpioResetConfigMap[] = {
+      GpioV2DswReset,
+      GpioV2ResetHostDeep,
+      GpioV2ResetHost,
+      GpioV2ResetResume
+    };
+
+    if (ResetConfig == NULL) {
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    GetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+    P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+    GetRegisterOffset (
+      GpioV2Dw0Reg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    RegisterValue = P2sbPtr.Access.Read32 (
+      &(P2sbPtr.Access),
+      RegisterOffset
+    );
+
+    // Please refer to enum GPIOV2_RESET_CONFIG in GpioV2Pad.h file
+    Padrstcfg = (RegisterValue >> GPIOV2_PAD_RESET_CONFIG_DW0_POS) & GPIOV2_PAD_RESET_CONFIG_MASK;
+    if (GpioGetCommunities(CommunityIndex)->IsComDsw) {
+      *ResetConfig = GpdPadRstCfgToGpioResetConfigMap[Padrstcfg];
+    } else {
+      *ResetConfig = GppPadRstCfgToGpioResetConfigMap[Padrstcfg];
+    }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets termination configuration for requested Gpio Pad
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] TerminationConfig   Termination configuration, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+  @retval EFI_ACCESS_DENIED       Pad is not owned by Host.
+**/
+EFI_STATUS
+EFIAPI
+SetTerminationConfig (
+  IN GPIOV2_PAD                 GpioPad,
+  IN GPIOV2_TERMINATION_CONFIG  TerminationConfig
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32 AndValue;
+  UINT32 OrValue;
+  UINT32 RegisterOffset;
+  UINT32 CommunityIndex;
+  P2SB_SIDEBAND_REGISTER_ACCESS P2sbPtr;
+
+  if (!IsHardGpio (GpioPad)) {
+    return VirtualGpioSetTerminationConfig (GpioPad, TerminationConfig);
+  } else {
+      GetOwnership (GpioPad, &Ownership);
+      if (Ownership != GpioV2PadOwnHost) {
+        return EFI_ACCESS_DENIED;
+      }
+
+      if (TerminationConfig != GpioV2TermDefault) {
+        GetRegisterOffset (
+          GpioV2Dw1Reg,
+          GpioPad,
+          &RegisterOffset
+        );
+
+        CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+        P2sbPtr = GetP2sbAddress(CommunityIndex);
+
+        AndValue = (UINT32)~(GPIOV2_PAD_TERMINATION_CONFIG_MASK << GPIOV2_PAD_TERMINATION_CONFIG_DW1_POS);
+        OrValue  = ((TerminationConfig >> 1) & GPIOV2_PAD_TERMINATION_CONFIG_MASK) << GPIOV2_PAD_TERMINATION_CONFIG_DW1_POS;
+
+        P2sbPtr.Access.AndThenOr32 (
+          &(P2sbPtr.Access),
+          RegisterOffset,
+          AndValue,
+          OrValue
+        );
+      }
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This function retreives Global Group Index from GPIOV2_PAD_GROUP.
+  Global Group Index is used in ASL code in ACPI interface.
+  Please refer to OneSiliconPkg\Fru\XXX\Include\AcpiTables\Dsdt\GpioGroupsXXX.asl file.
+
+  @param[in]  GpioGroup           Gpio Group
+  @param[out] GlobalGroupIndex    buffer for Global Group Index
+
+  @retval EFI_SUCCESS                    The function completed successfully
+  @retval EFI_INVALID_PARAMETER          Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+GetGlobalGroupIndex (
+  IN   GPIOV2_PAD_GROUP            GpioGroup,
+  OUT  UINT32                      *GlobalGroupIndex
+  )
+{
+  UINT32             CommunityIndex;
+  UINT32             CommunityIndexMax;
+  BOOLEAN            IsValid;
+
+  if (GlobalGroupIndex == NULL) {
+    ASSERT (FALSE);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  IsGroupValid (GpioGroup, &IsValid);
+  if (IsValid != TRUE) {
+    ASSERT(FALSE);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  CommunityIndexMax = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioGroup);
+
+  *GlobalGroupIndex = GPIOV2_PAD_GET_GROUP_INDEX (GpioGroup);
+  for (CommunityIndex = 0; CommunityIndex < CommunityIndexMax; CommunityIndex++) {
+    *GlobalGroupIndex += GpioGetCommunities(CommunityIndex)->GroupsNum;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Store unlock data.
+
+  @param[in] GpioPad        GPIO pad
+  @param[in] LockCfg        Pad config lock policy
+  @param[in] LockTx         Pad Tx lock policy
+**/
+VOID
+GpioV2StoreUnlockData (
+  IN GPIOV2_PAD        GpioPad,
+  IN GPIOV2_PAD_LOCK   LockCfg,
+  IN GPIOV2_PAD_LOCK   LockTx
+  )
+{
+  UINT32 Index;
+  UINT32 ComIndex;
+  UINT32 GrpIndex;
+  UINT32  GlobalGroupIndex;
+  CHAR8   PadName[GPIOV2_NAME_LENGTH_MAX];
+
+  ComIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+  GrpIndex = GPIOV2_PAD_GET_GROUP_INDEX (GpioPad);
+
+  GlobalGroupIndex = GrpIndex;
+  for (Index = 0; Index < ComIndex; Index++) {
+    GlobalGroupIndex += 1;
+  }
+
+  GetPadName (GpioPad, sizeof (PadName), PadName);
+  DEBUG ((DEBUG_INFO, "[GPIOV2] [UNLOCK] [SELECT] %a ", PadName));
+  if (LockCfg == GpioV2Unlock) {
+    DEBUG ((DEBUG_INFO, "CFG"));
+  }
+
+  if (LockTx == GpioV2Unlock) {
+    DEBUG ((DEBUG_INFO, " TX"));
+  }
+  DEBUG ((DEBUG_INFO, "\n"));
+}
+
+/**
+  This procedure will set GPIO mode for HDA SNDW functionality
+
+  @param[in] GpioPad              Gpio Pad
+  @param[in] PadConfig            Gpio Pad configuration - please refer to GPIOV2_CONFIG in GpioV2Config.h
+
+  @retval EFI_SUCCESS              The function completed successfully
+  @retval EFI_INVALID_PARAMETER    Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+ConfigurePad (
+  IN GPIOV2_PAD              GpioPad,
+  IN GPIOV2_CONFIG           *PadConfig
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  EFI_STATUS       Status = EFI_SUCCESS;
+  CHAR8            PadName[GPIOV2_NAME_LENGTH_MAX];
+  BOOLEAN          PadValid;
+
+  IsPadValid(GpioPad, &PadValid);
+
+  if (!PadValid) {
+    DEBUG ((DEBUG_WARN, "[GPIOV2] %a PadIsNot Valid\n", __FUNCTION__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  GetOwnership(GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  //
+  // First, set proper CS# before programming Pad.
+  //
+  if (!IsHardGpio (GpioPad)) {
+    Status = VirtualGpioSetCs (GpioPad, PadConfig);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  }
+
+  GetPadName (GpioPad, sizeof (PadName), PadName);
+  SetPadMode (GpioPad, PadConfig->PadMode);
+
+  if ((PadConfig->InterruptConfig >> 1) & (GpioV2IntSmi >> 1)) {
+    SetHostOwnership (GpioPad, GpioV2HostOwnGpio);
+  } else {
+    SetHostOwnership (GpioPad, PadConfig->HostOwn);
+  }
+
+  //
+  // Make sure we set a Tx state before setting a direction to avoid glitches on the GPIO line.
+  // A glitch can happen if by default Tx of the GPIO pad is disabled and Tx state is set to drive
+  // the pad low but signal on the board is pulled up. When SBL wants to take control over the GPIO pad
+  // and enable the Tx and set the Tx state to high to match the platform default signal state we need to make
+  // sure tha Tx is programed to high before we enable Tx otherwise signal on the board will experience a
+  // very quick glitch which can lead to a number of problems.
+  //
+  SetTx (GpioPad, PadConfig->OutputState);
+
+  if (PadConfig->Direction != GpioV2DirDefault) {
+    switch (PadConfig->Direction) {
+      case GpioV2DirInOut:
+        SetTxDisable (GpioPad, FALSE);
+        SetRxDisable (GpioPad, FALSE);
+        SetInputInversion (GpioPad, GpioV2InputInversionDisable);
+        break;
+      case GpioV2DirInInvOut:
+        SetTxDisable (GpioPad, FALSE);
+        SetRxDisable (GpioPad, FALSE);
+        SetInputInversion (GpioPad, GpioV2InputInversionEnable);
+        break;
+      case GpioV2DirIn:
+        SetTxDisable (GpioPad, TRUE);
+        SetRxDisable (GpioPad, FALSE);
+        SetInputInversion (GpioPad, GpioV2InputInversionDisable);
+        break;
+      case GpioV2DirInInv:
+        SetTxDisable (GpioPad, TRUE);
+        SetRxDisable (GpioPad, FALSE);
+        SetInputInversion (GpioPad, GpioV2InputInversionEnable);
+        break;
+      case GpioV2DirOut:
+        SetTxDisable (GpioPad, FALSE);
+        SetRxDisable ( GpioPad, TRUE);
+        SetInputInversion (GpioPad, GpioV2InputInversionDisable);
+        break;
+      case GpioV2DirNone:
+        SetTxDisable (GpioPad, TRUE);
+        SetRxDisable (GpioPad, TRUE);
+        SetInputInversion (GpioPad, GpioV2InputInversionDisable);
+        break;
+      case GpioV2DirDefault:
+      default:
+        break;
+    }
+  }
+  if (PadConfig->InterruptConfig != GpioV2IntDefault) {
+
+    //
+    // All Interrupt/wake events turned off by default
+    //
+    SetNmiEn (GpioPad, FALSE);
+    SetSmiEn (GpioPad, FALSE);
+    SetGpiGpeEn (GpioPad, FALSE);
+    SetGpiIe (GpioPad, FALSE);
+
+    if ((PadConfig->InterruptConfig >> 1) & (GpioV2IntNmi >> 1)) {
+      SetNmiEn (GpioPad, TRUE);
+      SetRouteNmi (GpioPad, TRUE);
+    }
+
+    if ((PadConfig->InterruptConfig >> 1) & (GpioV2IntSmi >> 1)) {
+      SetSmiEn (GpioPad, TRUE);
+      SetRouteSmi (GpioPad, TRUE);
+    }
+
+    if ((PadConfig->InterruptConfig >> 1) & (GpioV2IntSci >> 1)) {
+      SetGpiGpeEn (GpioPad, TRUE);
+      SetRouteSci (GpioPad, TRUE);
+    }
+
+    if ((PadConfig->InterruptConfig >> 1) & (GpioV2IntApic >> 1)) {
+      SetGpiIe (GpioPad, TRUE);
+      SetRouteIoxApic (GpioPad, TRUE);
+    }
+
+    if ((PadConfig->InterruptConfig >> 1) & (GpioV2IntLevel >> 1)) {
+      SetRxEvCfg (GpioPad, GpioV2IntRxEvCfgLevel);
+
+    } else if ((PadConfig->InterruptConfig >> 1) & (GpioV2IntEdge >> 1)) {
+      SetRxEvCfg (GpioPad, GpioV2IntRxEvCfgEdge);
+
+    } else if ((PadConfig->InterruptConfig >> 1) & (GpioV2IntLvlEdgDis >> 1)) {
+      SetRxEvCfg (GpioPad, GpioV2IntRxEvCfgDisable);
+
+    } else if ((PadConfig->InterruptConfig >> 1) & (GpioV2IntBothEdge >> 1)) {
+      SetRxEvCfg (GpioPad, GpioV2IntRxEvCfgLevelEdge);
+    }
+  }
+  SetResetConfig (GpioPad, PadConfig->ResetConfig);
+
+  SetTerminationConfig (GpioPad, PadConfig->TerminationConfig);
+  //
+  // Store unlock data
+  //
+  if ( ((PadConfig->Direction == GpioV2DirOut) || (PadConfig->Direction == GpioV2DirInOut) ||  (PadConfig->Direction == GpioV2DirInInvOut)) &&
+       (PadConfig->PadMode == GpioV2PadModeGpio) &&
+       (PadConfig->LockTx == GpioV2LockHardwareDefault) ) {
+    GpioV2StoreUnlockData (GpioPad,
+                           PadConfig->LockConfig,
+                           GpioV2Unlock );
+  } else if ( (PadConfig->LockConfig == GpioV2Unlock) ||
+              (PadConfig->LockTx == GpioV2Unlock) ) {
+    GpioV2StoreUnlockData (GpioPad,
+                          PadConfig->LockConfig,
+                          PadConfig->LockTx );
+  }
+
+  if (PadConfig->OtherSettings != GpioV2RxRaw1Default) {
+    // TO BE DONE
+  }
+
+  return Status;
+}
+
+/**
+  This procedure will configure all GPIO pads based on GpioPadsConfigTable
+
+  @param[in] GpioPadsConfigTable     Pointer to PadInitConfigTable
+  @param[in] GpioPadsConfigTableSize Size of PadInitConfigTable
+
+  @retval Status
+**/
+EFI_STATUS
+EFIAPI
+ConfigurePads (
+  IN GPIOV2_INIT_CONFIG       *GpioPadsConfigTable,
+  IN UINT32                   GpioPadsConfigTableSize
+  )
+{
+  UINT32       Index;
+  EFI_STATUS   Status;
+  Status = EFI_SUCCESS;
+
+  for (Index = 0; Index < GpioPadsConfigTableSize; Index++) {
+    Status = ConfigurePad (
+               GpioPadsConfigTable[Index].GpioPad,
+               &GpioPadsConfigTable[Index].GpioConfig
+               );
+    if (Status != EFI_SUCCESS) {
+      ASSERT(FALSE);
+      break;
+    }
+  }
+
+  return Status;
+}
+
+/**
+  This procedure will initialize configuration for all GPIO based on GpioPadsConfigTable
+
+  @param[in] GpioPadsConfigTable     Pointer to PadInitConfigTable
+  @param[in] GpioPadsConfigTableSize Size of PadInitConfigTable
+
+  @retval Status
+**/
+EFI_STATUS
+GpioV2ConfigurePads (
+  IN GPIOV2_INIT_CONFIG       *GpioPadsConfigTable,
+  IN UINT32                   GpioPadsConfigTableSize
+  )
+{
+  EFI_STATUS                Status;
+
+  if ((GpioPadsConfigTable == NULL) || (GpioPadsConfigTableSize == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // All pads in PadInitConfigTable should belong to the same ChipsetId.
+  //
+  Status = GetGpioV2ServicesFromPad (GpioPadsConfigTable[0].GpioPad);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  return ConfigurePads (GpioPadsConfigTable, GpioPadsConfigTableSize);
+
+}
+
+/**
+  Retreive PadInfo embedded inside DW of GPIO CFG DATA.
+  Prepare a PadInfo DWORD first, add into the GpioTable,
+  followed by DW0 and DW1 directly from GPIO CFG DATA.
+  This format of GpioTable is what the Gpio library expects.
+
+  @param    GpioTable   Pointer to the GpioTable to be updated
+  @param    GpioCfgHdr  Pointer to the cfg data header
+  @param    Offset      Index of a particulr pin's DW0, DW1 in GpioCfg
+
+  @retval   GpioTable   Pointer to fill the next gpio item
+**/
+STATIC
+UINT8 *
+FillGpioTable (
+  IN  UINT8          *GpioTable,
+  IN  ARRAY_CFG_HDR  *GpioCfgHdr,
+  IN  UINT32          Offset
+
+)
+{
+  GPIO_PAD           *GpioPad;
+  UINT8              *GpioData;
+  UINT8              *GpioCfg;
+  // UINT8              *print;
+
+  GpioData  = ((UINT8 *)GpioCfgHdr) + GpioCfgHdr->HeaderSize + Offset;
+  GpioCfg   = GpioTable + sizeof(GPIO_PAD);
+  GpioPad   = (GPIO_PAD *) GpioTable;
+  DEBUG((DEBUG_INFO, "Inside filltable, GpioCfgHdr->ItemSize: %d\n", GpioCfgHdr->ItemSize));
+  CopyMem (GpioCfg, GpioData, GpioCfgHdr->ItemSize);
+
+  //
+  // Get the DW and extract PadInfo
+  //
+  GpioGetGpioPadFromCfgDw ((UINT32 *)GpioCfg, GpioPad);
+
+  GpioTable += (sizeof(GPIO_PAD) + GpioCfgHdr->ItemSize);
+
+  return GpioTable;
+}
+
+/**
+  Print the output of the GPIO Config table that was read from CfgData.
+
+  @param GpioPinNum           Number of GPIO entries in the table.
+
+  @param GpioConfData         GPIO Config Data that was read from the Configuration region either from internal or external source.
+
+**/
+VOID
+PrintGpioV2ConfigTable (
+  IN UINT32              GpioPinNum,
+  IN VOID*               GpioConfData
+)
+{
+  GPIOV2_INIT_CONFIG  *GpioInitConf;
+  UINT32            *PadDataPtr;
+  UINT32             Index;
+
+  GpioInitConf = (GPIOV2_INIT_CONFIG *)GpioConfData;
+  for (Index  = 0; Index < GpioPinNum; Index++) {
+    PadDataPtr = (UINT32 *)&GpioInitConf->GpioConfig;
+    DEBUG ((DEBUG_INFO, "GPIO PAD: 0x%08X   DATA: 0x%08X 0x%08X\n", GpioInitConf->GpioPad, PadDataPtr[0], PadDataPtr[1]));
+    GpioInitConf++;
+  }
+}
+
+/**
+  Configure the GPIO pins, available as part of platform specific GPIO CFG DATA.
+  If the pins are not part of GPIO CFG DATA, call GpioConfigurePads() directly
+  with the appropriate arguments.
+
+  @param    Tag         Tag ID of the Gpio Cfg data item
+  @param    Entries     Number of entries in Gpio Table
+  @param    DataBuffer  Pointer to the Gpio Table to be programmed
+
+  @retval EFI_SUCCESS                   The function completed successfully
+  @retval EFI_NOT_FOUND                 If Gpio Config Data cant be found
+**/
+EFI_STATUS
+EFIAPI
+ConfigureGpioV2 (
+  IN  UINT16  Tag,
+  IN GPIOV2_INIT_CONFIG                 *DataBuffer,
+  IN UINT16                             GpioTableCount
+  )
+{
+  ARRAY_CFG_HDR  *GpioCfgCurrHdr;
+  ARRAY_CFG_HDR  *GpioCfgBaseHdr;
+  ARRAY_CFG_HDR  *GpioCfgHdr;
+  UINT32         GpioEntries;
+  UINT32         Index;
+  UINT32         Offset;
+  UINT8          *GpioCfgDataBuffer;
+  UINT8          *GpioTable;
+  EFI_STATUS     Status;
+
+  //
+  // If no Tag provided, check for GpioTable info;
+  // If    Tag provided, GpioTable params are don't care
+  //
+  if (Tag == CDATA_NO_TAG) {
+    Status = GpioV2ConfigurePads (DataBuffer, GpioTableCount);
+    ASSERT_EFI_ERROR (Status);
+    return EFI_SUCCESS;
+  }
+
+  //
+  // Find the GPIO CFG HDR
+  //
+  GpioCfgCurrHdr = (ARRAY_CFG_HDR *)FindConfigDataByTag (Tag);
+  if (GpioCfgCurrHdr == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  GpioEntries    = 0;
+  GpioCfgBaseHdr = NULL;
+
+  //
+  // Find the GPIO CFG Data based on Platform ID
+  // GpioTableData is the start of the GPIO entries
+  //
+  if (GpioCfgCurrHdr->BaseTableId < 16) {
+    GpioCfgBaseHdr = (ARRAY_CFG_HDR *)FindConfigDataByPidTag (GpioCfgCurrHdr->BaseTableId, Tag);
+    if (GpioCfgBaseHdr == NULL) {
+      DEBUG ((GPIO_DEBUG_ERROR, "Cannot find base GPIO table for platform ID %d\n", GpioCfgCurrHdr->BaseTableId));
+      return EFI_NOT_FOUND;
+    }
+    if (GpioCfgCurrHdr->ItemSize != GpioCfgBaseHdr->ItemSize) {
+      DEBUG ((GPIO_DEBUG_ERROR, "Inconsistent GPIO item size\n"));
+      return EFI_LOAD_ERROR;
+    }
+    GpioCfgHdr = GpioCfgBaseHdr;
+  }
+  else {
+    GpioCfgHdr = GpioCfgCurrHdr;
+  }
+
+  Offset     = 0;
+  GpioTable  = (UINT8 *)AllocateTemporaryMemory (0);  //allocate new buffer
+  if (GpioTable == NULL) {
+    DEBUG ((GPIO_DEBUG_ERROR, "Cannot allocate buffer for GpioTable\n"));
+    return EFI_OUT_OF_RESOURCES;
+  }
+  GpioCfgDataBuffer = GpioTable;
+  for (Index = 0; Index  < GpioCfgHdr->ItemCount; Index++) {
+    if (GpioCfgCurrHdr->BaseTableBitMask[Index >> 3] & (1 << (Index & 7))) {
+      GpioTable = FillGpioTable (GpioTable, GpioCfgHdr, Offset);
+      GpioEntries++;
+    }
+    Offset += GpioCfgHdr->ItemSize;
+  }
+
+  Offset = 0;
+  if (GpioCfgBaseHdr != NULL) {
+    for (Index = 0; Index  < GpioCfgCurrHdr->ItemCount; Index++) {
+      GpioTable = FillGpioTable (GpioTable, GpioCfgCurrHdr, Offset);
+      GpioEntries++;
+      Offset += GpioCfgCurrHdr->ItemSize;
+    }
+  }
+
+  DEBUG_CODE_BEGIN ();
+  PrintGpioV2ConfigTable (GpioEntries, GpioCfgDataBuffer);
+  DEBUG_CODE_END ();
+
+  GpioV2ConfigurePads ((GPIOV2_INIT_CONFIG *)GpioCfgDataBuffer, GpioEntries);
+
+  DEBUG ((GPIO_DEBUG_INFO, "GpioInit(0x%p:%d) Done\n", GpioCfgDataBuffer, GpioEntries));
+  return EFI_SUCCESS;
+}

--- a/Silicon/CommonSocPkg/Library/GpioV2Lib/GpioV2Lib.inf
+++ b/Silicon/CommonSocPkg/Library/GpioV2Lib/GpioV2Lib.inf
@@ -1,0 +1,44 @@
+## @file
+#
+#  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = GpioV2Lib
+  FILE_GUID                      = 51DB362F-C2A4-450F-81DA-03AB9FBCB3EE
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = GpioV2Lib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 IPF
+#
+
+[Sources]
+  GpioV2Init.c
+  GpioV2Virtual.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCorePkg/BootloaderCorePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+  Silicon/CommonSocPkg/CommonSocPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  IoLib
+  MemoryAllocationLib
+  GpioSiLib
+  PchSbiAccessLib
+  SortLib
+  PcdLib
+  HobLib
+  HobBuildLib
+
+[Pcd]
+

--- a/Silicon/CommonSocPkg/Library/GpioV2Lib/GpioV2Virtual.c
+++ b/Silicon/CommonSocPkg/Library/GpioV2Lib/GpioV2Virtual.c
@@ -1,0 +1,1416 @@
+/** @file
+  Routines for IBL GPIO virtual pads
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include "Library/GpioV2Virtual.h"
+#include <Uefi/UefiBaseType.h>
+#include <Library/GpioTopologyLib.h>
+#include "Library/GpioV2Lib.h"
+#include "Register/GpioV2VirtualRegs.h"
+#include "Library/IoLib.h"
+
+
+/**
+  This procedure retrieves register offset
+
+  @param[in]  Register            Register for which user want to retrieve offset. Please refer to GpioV2Pad.h
+  @param[in]  GpioPad             Gpio Pad. Please refer to GpioPinsYYY.h - where YYY name of the platform (eg. MTL, EBG, ...)
+  @param[out] RegisterOffset      Pointer to a buffer for register offset
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+VirtualGpioGetRegisterOffset (
+  IN  GPIOV2_REGISTER     Register,
+  IN  GPIOV2_PAD          GpioPad,
+  OUT UINT32              *RegisterOffset
+  )
+{
+  UINT32             CommunityIndex;
+  UINT32             GroupIndex;
+  UINT32             PadIndex;
+
+  ASSERT (RegisterOffset != NULL);
+  if (RegisterOffset == NULL)  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *RegisterOffset = 0;
+
+  CommunityIndex = GPIOV2_PAD_GET_COMMUNITY_INDEX (GpioPad);
+  GroupIndex = GPIOV2_PAD_GET_GROUP_INDEX (GpioPad);
+  PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+  switch (Register) {
+    case GpioV2PadCfgLockReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.PadCfgLock + (PadIndex / 32) * 0x4;
+      break;
+    case GpioV2GpiIsReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.GpiIs + (PadIndex / 32) * 0x4;
+      break;
+    case GpioV2GpiIeReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.GpiIe + (PadIndex / 32) * 0x4;
+      break;
+    case GpioV2GpiGpeStsReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.GpiGpeSts + (PadIndex / 32) * 0x4;
+      break;
+    case GpioV2GpiGpeEnReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.GpiGpeEn + (PadIndex / 32) * 0x4;
+      break;
+    case GpioV2SmiStsReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.SmiSts + (PadIndex / 32) * 0x4;
+      break;
+    case GpioV2SmiEnReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.SmiEn + (PadIndex / 32) * 0x4;
+      break;
+    case GpioV2NmiStsReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.NmiSts + (PadIndex / 32) * 0x4;
+      break;
+    case GpioV2NmiEnReg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.NmiEn + (PadIndex / 32) * 0x4;
+      break;
+    case GpioV2Dw0Reg:
+      *RegisterOffset = SocGpioGetGroups(CommunityIndex,GroupIndex).RegisterOffsets.Dw0 + PadIndex * 0x4;
+      break;
+    default:
+      ASSERT(FALSE);
+      return EFI_INVALID_PARAMETER;
+  }
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets host ownership configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Ownership            Host ownership, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetHostOwnership (
+  IN GPIOV2_PAD               GpioPad,
+  IN GPIOV2_HOSTSW_OWN        HostOnwership
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           AndValue;
+  UINT32           OrValue;
+  UINT32           RegisterOffset;
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+
+  VirtualGpioGetRegisterOffset (
+    GpioV2Dw0Reg,
+    GpioPad,
+    &RegisterOffset
+  );
+
+  AndValue = (UINT32)~(B_VGPIO_PCR_RX_PAD_HOSTSW_OWNERSHIP);
+  OrValue  = ((HostOnwership >> 1) << N_VGPIO_PCR_RX_PAD_HOSTSW_OWNERSHIP) & B_VGPIO_PCR_RX_PAD_HOSTSW_OWNERSHIP;
+
+  MmioAndThenOr32 (GetVgpioBaseAddress() + RegisterOffset, AndValue, OrValue);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure reads current ownership configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Ownership            Pointer to a buffer for ownership, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetOwnership (
+  IN  GPIOV2_PAD              GpioPad,
+  OUT GPIOV2_PAD_OWN          *Ownership
+  )
+{
+  UINT32  RegisterOffset;
+  UINT32  RegisterValue;
+
+  if (Ownership == NULL) {
+    ASSERT (FALSE);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  VirtualGpioGetRegisterOffset (
+    GpioV2Dw0Reg,
+    GpioPad,
+    &RegisterOffset
+  );
+
+  RegisterValue = MmioRead32 (GetVgpioBaseAddress() + RegisterOffset);
+
+  // Please refer to enum GPIOV2_PAD_OWN in GpioV2Pad.h file
+  *Ownership = GPIO_ASSIGN_VALUE ((RegisterValue & B_VGPIO_PCR_RX_PAD_OWNERSHIP) >> N_VGPIO_PCR_RX_PAD_OWNERSHIP);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets Gpio Pad output state
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] OutputState         GpioV2StateLow - output state low, GpioV2StateHigh - output state high
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetTx (
+  IN GPIOV2_PAD             GpioPad,
+  IN GPIOV2_PAD_STATE       OutputState
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           AndValue;
+  UINT32           OrValue;
+  UINT32           RegisterOffset;
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  if (OutputState != GpioV2StateDefault) {
+    VirtualGpioGetRegisterOffset (
+      GpioV2Dw0Reg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    AndValue = (UINT32)~(B_VGPIO_PCR_TX_STATE);
+    OrValue  = ((OutputState >> 1) << N_VGPIO_PCR_TX_STATE) & B_VGPIO_PCR_TX_STATE;
+
+     MmioAndThenOr32 (GetVgpioBaseAddress() + RegisterOffset, AndValue, OrValue);
+  }
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets TX buffer for requested Gpio Pad as enabled or disabled
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] TxDisabled          True - TX buffer disabled, False - TX buffer enabled
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetTxDisable (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  TxDisabled
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           AndValue;
+  UINT32           OrValue;
+  UINT32           RegisterOffset;
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  VirtualGpioGetRegisterOffset (
+    GpioV2Dw0Reg,
+    GpioPad,
+    &RegisterOffset
+  );
+
+  AndValue = (UINT32)~(B_VGPIO_PCR_TX_DISABLE);
+  OrValue  = (TxDisabled << N_VGPIO_PCR_TX_DISABLE) & B_VGPIO_PCR_TX_DISABLE;
+
+  MmioAndThenOr32 (GetVgpioBaseAddress() + RegisterOffset, AndValue,  OrValue);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets Rx buffer for requested Gpio Pad as enabled or disabled
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] TxDisabled          True - TX buffer disabled, False - TX buffer enabled
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetRxDisable (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  RxDisabled
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           AndValue;
+  UINT32           OrValue;
+  UINT32           RegisterOffset;
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  VirtualGpioGetRegisterOffset (
+    GpioV2Dw0Reg,
+    GpioPad,
+    &RegisterOffset
+  );
+
+  AndValue = (UINT32)~(B_VGPIO_PCR_RX_DISABLE);
+  OrValue  = (RxDisabled << N_VGPIO_PCR_RX_DISABLE) & B_VGPIO_PCR_RX_DISABLE;
+
+  MmioAndThenOr32 (GetVgpioBaseAddress() + RegisterOffset, AndValue,  OrValue);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will set GPIO enable or disable input inversion on requested pad
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] InputInversion      GpioV2InputInversionEnable or GpioV2InputInversionDisable, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetInputInversion (
+  IN GPIOV2_PAD                  GpioPad,
+  IN GPIOV2_PAD_INPUT_INVERSION  InputInversion
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  This procedure sets NMI Enable for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] NmiEn                NMI Enable, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetNmiEn (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  NmiEn
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           AndValue;
+  UINT32           OrValue;
+  UINT32           RegisterOffset;
+  UINT32           PadIndex;
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+
+  VirtualGpioGetRegisterOffset (
+    GpioV2NmiEnReg,
+    GpioPad,
+    &RegisterOffset
+    );
+
+  AndValue = (UINT32)~(GPIOV2_PAD_NMI_EN_MASK << (PadIndex % 32));
+  OrValue  = (NmiEn & GPIOV2_PAD_NMI_EN_MASK) << (PadIndex % 32);
+
+  MmioAndThenOr32 (GetVgpioBaseAddress() + RegisterOffset, AndValue,  OrValue);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets SMI Enable configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] SmiEn                SMI Enable, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetSmiEn (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  SmiEn
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           AndValue;
+  UINT32           OrValue;
+  UINT32           RegisterOffset;
+  UINT32           PadIndex;
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+
+  VirtualGpioGetRegisterOffset (
+    GpioV2SmiEnReg,
+    GpioPad,
+    &RegisterOffset
+    );
+
+  AndValue = (UINT32)~(GPIOV2_PAD_SMI_EN_MASK << (PadIndex % 32));
+  OrValue  = (SmiEn & GPIOV2_PAD_SMI_EN_MASK) << (PadIndex % 32);
+
+  MmioAndThenOr32 (GetVgpioBaseAddress() + RegisterOffset, AndValue,  OrValue);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets GPI GPE Enable configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] GpiIe                GPI GPE Enable, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetGpiGpeEn (
+  IN GPIOV2_PAD              GpioPad,
+  IN BOOLEAN                 GpiGpeEn
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           AndValue;
+  UINT32           OrValue;
+  UINT32           RegisterOffset;
+  UINT32           PadIndex;
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+
+  VirtualGpioGetRegisterOffset (
+    GpioV2GpiGpeEnReg,
+    GpioPad,
+    &RegisterOffset
+    );
+
+  AndValue = (UINT32)~(GPIOV2_PAD_GPI_GPE_EN_MASK << (PadIndex % 32));
+  OrValue  = (GpiGpeEn & GPIOV2_PAD_GPI_GPE_EN_MASK) << (PadIndex % 32);
+
+  MmioAndThenOr32 (GetVgpioBaseAddress() + RegisterOffset, AndValue,  OrValue);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets Gpi Enable configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] GpiIe                GPI Enable, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetGpiIe (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  GpiIe
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           AndValue;
+  UINT32           OrValue;
+  UINT32           RegisterOffset;
+  UINT32           PadIndex;
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+
+  VirtualGpioGetRegisterOffset (
+    GpioV2GpiIeReg,
+    GpioPad,
+    &RegisterOffset
+    );
+
+  AndValue = (UINT32)~(GPIOV2_PAD_GPI_IE_MASK << (PadIndex % 32));
+  OrValue  = (GpiIe & GPIOV2_PAD_GPI_IE_MASK) << (PadIndex % 32);
+
+  MmioAndThenOr32 (GetVgpioBaseAddress() + RegisterOffset, AndValue,  OrValue);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets GPIROUTNMI bit (17th bit in DW0) for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Enable               TRUE or FALSE, either enable or disable 17 bit in DW0
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetRouteNmi (
+  IN GPIOV2_PAD           GpioPad,
+  IN BOOLEAN              Enable
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  GPIOV2_CONFIG    PadConfig;
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  if (Enable) {
+    PadConfig.InterruptConfig = GpioV2IntNmi;
+  } else {
+    PadConfig.InterruptConfig = GpioV2IntDis;
+  }
+
+  return VirtualGpioSetInterruptOrLevelType (GpioPad, &PadConfig);
+}
+
+/**
+  This procedure will configure VGPIO INTERRUPT_OR_EVENT_TYPE field.
+
+  @param[in] GpioPad              Gpio Pad
+  @param[in] PadConfig            Gpio Pad configuration - please refer to GPIOV2_CONFIG in GpioV2Config.h
+
+  @retval EFI_SUCCESS              The function completed successfully
+  @retval EFI_INVALID_PARAMETER    Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetInterruptOrLevelType (
+  IN GPIOV2_PAD              GpioPad,
+  IN GPIOV2_CONFIG           *PadConfig
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           RegisterOffset;
+  UINT32           OrValue;
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  VirtualGpioGetRegisterOffset (
+    GpioV2Dw0Reg,
+    GpioPad,
+    &RegisterOffset
+    );
+
+  OrValue = 0;
+
+  if (PadConfig->InterruptConfig != GpioV2IntDefault) {
+    if (PadConfig->InterruptConfig == GpioV2IntDis) {
+      OrValue |= V_VGPIO_PCR_INT_TYPE_DIS;
+    } else if ((PadConfig->InterruptConfig >> 1) & (GpioV2IntApic >> 1)) {
+      OrValue |= V_VGPIO_PCR_INT_TYPE_IRQ;
+    } else if ((PadConfig->InterruptConfig >> 1) & (GpioV2IntNmi >> 1)) {
+      OrValue |= V_VGPIO_PCR_INT_TYPE_NMI;
+    } else if ((PadConfig->InterruptConfig >> 1) & (GpioV2IntSmi >> 1)) {
+      OrValue |= V_VGPIO_PCR_INT_TYPE_SMI;
+    } else if ((PadConfig->InterruptConfig >> 1) & (GpioV2IntSci >> 1)) {
+      OrValue |= V_VGPIO_PCR_INT_TYPE_SCI;
+    }
+    MmioAndThenOr32 (GetVgpioBaseAddress() + RegisterOffset, (UINT32)~(B_VGPIO_PCR_INT_TYPE),  (OrValue << N_VGPIO_PCR_INT_TYPE));
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets GPIROUTSMI bit (18th bit in DW0) for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Enable               TRUE or FALSE, either enable or disable 18 bit in DW0
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetRouteSmi (
+  IN GPIOV2_PAD           GpioPad,
+  IN BOOLEAN              Enable
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  GPIOV2_CONFIG    PadConfig;
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  if (Enable) {
+    PadConfig.InterruptConfig = GpioV2IntSmi;
+  } else {
+    PadConfig.InterruptConfig = GpioV2IntDis;
+  }
+
+  return VirtualGpioSetInterruptOrLevelType (GpioPad, &PadConfig);
+}
+
+/**
+  This procedure sets GPIROUTSCI bit (19th bit in DW0) for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Enable               TRUE or FALSE, either enable or disable 19 bit in DW0
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetRouteSci (
+  IN GPIOV2_PAD           GpioPad,
+  IN BOOLEAN              Enable
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  GPIOV2_CONFIG    PadConfig;
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  if (Enable) {
+    PadConfig.InterruptConfig = GpioV2IntSci;
+  } else {
+    PadConfig.InterruptConfig = GpioV2IntDis;
+  }
+
+  return VirtualGpioSetInterruptOrLevelType (GpioPad, &PadConfig);
+}
+
+/**
+  This procedure sets GPIROUTIOXAPIC bit (20th bit in DW0) for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Enable               TRUE or FALSE, either enable or disable 20th bit in DW0
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetRouteIoxApic (
+  IN GPIOV2_PAD           GpioPad,
+  IN BOOLEAN              Enable
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  GPIOV2_CONFIG    PadConfig;
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  if (Enable) {
+    PadConfig.InterruptConfig = GpioV2IntApic;
+  } else {
+    PadConfig.InterruptConfig = GpioV2IntDis;
+  }
+
+  return VirtualGpioSetInterruptOrLevelType (GpioPad, &PadConfig);
+}
+
+/**
+  This procedure sets RxEv configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] RxEvCfg              RxEv configuration
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetRxEvCfg (
+  IN GPIOV2_PAD           GpioPad,
+  IN GPIOV2_RXEVCFG       RxEvCfg
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           AndValue;
+  UINT32           OrValue;
+  UINT32           RegisterOffset;
+
+  if (RxEvCfg != GpioV2IntRxEvCfgDefault) {
+
+    if ((RxEvCfg != GpioV2IntRxEvCfgLevel) && (RxEvCfg != GpioV2IntRxEvCfgDisable)) {
+      return EFI_UNSUPPORTED;
+    }
+
+    VirtualGpioGetOwnership (GpioPad, &Ownership);
+    if (Ownership != GpioV2PadOwnHost) {
+      return EFI_ACCESS_DENIED;
+    }
+
+    VirtualGpioGetRegisterOffset (
+      GpioV2Dw0Reg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    AndValue = (UINT32)~(B_VGPIO_PCR_RX_LVL_EDG);
+    OrValue  = ((RxEvCfg >> 1) << N_VGPIO_PCR_RX_LVL_EDG) & B_VGPIO_PCR_RX_LVL_EDG;
+
+    MmioAndThenOr32 (GetVgpioBaseAddress() + RegisterOffset, AndValue,  OrValue);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets Reset Configuration for requested Gpio Pad
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] ResetConfig         Reset Configuration - please refer to GpioV2Pad.h (GPIOV2_RESET_CONFIG)
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetResetConfig (
+  IN GPIOV2_PAD               GpioPad,
+  IN GPIOV2_RESET_CONFIG      ResetConfig
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           AndValue;
+  UINT32           OrValue;
+  UINT32           RegisterOffset;
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  if (ResetConfig != GpioV2ResetDefault) {
+    VirtualGpioGetRegisterOffset (
+      GpioV2Dw0Reg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    AndValue = (UINT32)~(B_VGPIO_PCR_PAD_RESET_CONFIG);
+    OrValue  = ((ResetConfig >> 1) << N_VGPIO_PCR_PAD_RESET_CONFIG) & B_VGPIO_PCR_PAD_RESET_CONFIG;
+
+    MmioAndThenOr32 (GetVgpioBaseAddress() + RegisterOffset, AndValue,  OrValue);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will set GPIO mode
+
+  @param[in] GpioPad              Gpio Pad. Please refer to GpioPinsYYY.h - where YYY name of the platform (eg. MTL, EBG, ...)
+  @param[in] PadModeValue         GPIO pad mode value
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetPadMode (
+  IN GPIOV2_PAD              GpioPad,
+  IN GPIOV2_PAD_MODE         PadMode
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  This procedure reads current GPIO Pad Mode
+
+  @param[in] GpioPad             GPIO Pad. Please refer to GpioPinsYYY.h - where YYY name of the platform (eg. MTL, EBG, ...)
+  @param[in] PadMode             Pointer to a buffer for GPIO Pad Mode
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetPadMode (
+  IN GPIOV2_PAD            GpioPad,
+  IN GPIOV2_PAD_MODE       *PadMode
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  This procedure reads current host ownership configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] Ownership            Pointer to a buffer for ownership, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetHostOwnership (
+  IN  GPIOV2_PAD              GpioPad,
+  OUT GPIOV2_HOSTSW_OWN       *HostOwnership
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           RegisterOffset;
+  UINT32           RegisterValue;
+
+  if (HostOwnership == NULL) {
+    ASSERT (FALSE);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  VirtualGpioGetRegisterOffset (
+    GpioV2Dw0Reg,
+    GpioPad,
+    &RegisterOffset
+  );
+
+  RegisterValue = MmioRead32 (GetVgpioBaseAddress() + RegisterOffset);
+
+  // Please refer to enum GPIOV2_HOSTSW_OWN in GpioV2Pad.h file
+  *HostOwnership = GPIO_ASSIGN_VALUE ((RegisterValue & B_VGPIO_PCR_RX_PAD_HOSTSW_OWNERSHIP) >> N_VGPIO_PCR_RX_PAD_HOSTSW_OWNERSHIP);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure reads current Gpio Pad output state
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] OutputState         Pointer to a buffer for output state
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetTx (
+  IN GPIOV2_PAD             GpioPad,
+  IN GPIOV2_PAD_STATE       *OutputState
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           RegisterValue;
+  UINT32           RegisterOffset;
+
+  if (OutputState == NULL) {
+    ASSERT (FALSE);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  VirtualGpioGetRegisterOffset (
+    GpioV2Dw0Reg,
+    GpioPad,
+    &RegisterOffset
+  );
+
+  RegisterValue = MmioRead32 (GetVgpioBaseAddress() + RegisterOffset);
+
+  if (RegisterValue & B_VGPIO_PCR_TX_STATE) {
+    *OutputState = GpioV2StateHigh;
+  } else {
+    *OutputState = GpioV2StateLow;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure reads current Gpio Pad input state
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] InputState          Pointer to a buffer for input state
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetRx (
+  IN GPIOV2_PAD           GpioPad,
+  IN GPIOV2_PAD_STATE     *InputState
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           RegisterValue;
+  UINT32           RegisterOffset;
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  VirtualGpioGetRegisterOffset (
+    GpioV2Dw0Reg,
+    GpioPad,
+    &RegisterOffset
+  );
+
+  RegisterValue = MmioRead32 (GetVgpioBaseAddress() + RegisterOffset);
+
+  if (RegisterValue & B_VGPIO_PCR_RX_STATE) {
+    *InputState = GpioV2StateHigh;
+  } else {
+    *InputState = GpioV2StateLow;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure reads if TX buffer for requested Gpio Pad is enabled or disabled
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] TxDisabled          Pointer to a buffer for enabled/disabled information
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetTxDisable (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  *TxDisabled
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           RegisterOffset;
+  UINT32           RegisterValue;
+
+  if (TxDisabled == NULL) {
+    ASSERT (FALSE);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  VirtualGpioGetRegisterOffset (
+    GpioV2Dw0Reg,
+    GpioPad,
+    &RegisterOffset
+  );
+
+  RegisterValue = MmioRead32 (GetVgpioBaseAddress() + RegisterOffset);
+
+  if (RegisterValue & B_VGPIO_PCR_TX_DISABLE) {
+    *TxDisabled = TRUE;
+  } else {
+    *TxDisabled = FALSE;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure reads if RX buffer for requested Gpio Pad is enabled or disabled
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] RxDisabled          Pointer to a buffer for enabled/disabled information
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetRxDisable (
+  IN GPIOV2_PAD              GpioPad,
+  IN BOOLEAN                 *RxDisabled
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           RegisterOffset;
+  UINT32           RegisterValue;
+
+  if (RxDisabled == NULL) {
+    ASSERT (FALSE);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  VirtualGpioGetRegisterOffset (
+    GpioV2Dw0Reg,
+    GpioPad,
+    &RegisterOffset
+  );
+
+  RegisterValue = MmioRead32 (GetVgpioBaseAddress() + RegisterOffset);
+
+  if (RegisterValue & B_VGPIO_PCR_RX_DISABLE) {
+    *RxDisabled = TRUE;
+  } else {
+    *RxDisabled = FALSE;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will Get GPIO enable or disable input inversion on requested pad
+
+  IBL Virtaul GPIO does not support inversion, function return state as not inverted.
+
+  @param[in]  GpioPad             GPIO pad
+  @param[Out] Data                Enabled / Disabled
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetInputInversion (
+  IN  GPIOV2_PAD                 GpioPad,
+  OUT BOOLEAN                    *Inverted
+  )
+{
+  *Inverted = FALSE;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will set GPIO Lock (register PADCFGLOCK)
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] Lock                GpioV2Unlock - Unlock pad, GpioV2Lock - Lock pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetLock (
+  IN GPIOV2_PAD                GpioPad,
+  IN GPIOV2_PAD_LOCK           Lock
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           AndValue;
+  UINT32           OrValue;
+  UINT32           PadIndex;
+  UINT32           RegisterOffset;
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+
+  if (Lock != GpioV2LockHardwareDefault) {
+
+    VirtualGpioGetRegisterOffset (
+      GpioV2PadCfgLockReg,
+      GpioPad,
+      &RegisterOffset
+    );
+
+    AndValue = ~(GPIOV2_PAD_LOCK_MASK << PadIndex % 32);
+    OrValue  = ((Lock >> 1) & GPIOV2_PAD_LOCK_MASK) << PadIndex % 32;
+
+    MmioAndThenOr32 (GetVgpioBaseAddress() + RegisterOffset, AndValue, OrValue);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will get GPIO Lock (register PADCFGLOCK)
+
+  @param[in]  GpioPad             GPIO pad
+  @param[out] Lock                GpioV2Unlock - Unlock pad, GpioV2Lock - Lock pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetLock (
+  IN  GPIOV2_PAD                GpioPad,
+  OUT GPIOV2_PAD_LOCK           *Lock
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           PadIndex;
+  UINT32           RegisterValue;
+  UINT32           RegisterOffset;
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+
+  VirtualGpioGetRegisterOffset (
+    GpioV2PadCfgLockReg,
+    GpioPad,
+    &RegisterOffset
+  );
+
+  RegisterValue = MmioRead32 (GetVgpioBaseAddress() + RegisterOffset);
+
+  if ((RegisterValue >> PadIndex) & GPIOV2_PAD_LOCK_MASK) {
+    *Lock = GpioV2Lock;
+  } else {
+    *Lock = GpioV2Unlock;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure will set GPIO Lock Tx (register PADCFGLOCKTX)
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] LockTx              GpioV2Unlock - Unlock output state of Gpio Pad, GpioV2Lock - Lock output state of Gpio Pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetLockTx (
+  IN GPIOV2_PAD                  GpioPad,
+  IN GPIOV2_PAD_LOCK             LockTx
+  )
+{
+  //
+  // VGPIOs have no seperate PADCFGLOCKTX register. TX is locked via PADCFGLOCK.
+  // Use SetLock here to seamlessly handle this difference.
+  //
+  return VirtualGpioSetLock (GpioPad, LockTx);
+}
+
+/**
+  This procedure will get GPIO Lock TX
+
+  Virtual GPIO does not have Lock TX bit
+  Lock TX state is based on Lock pad state
+
+  @param[in]  GpioPad             GPIO pad
+  @param[out] LockTx              GpioV2Unlock - Unlock output state of Gpio Pad, GpioV2Lock - Lock output state of Gpio Pad
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetLockTx (
+  IN  GPIOV2_PAD                  GpioPad,
+  OUT GPIOV2_PAD_LOCK             *LockTx
+  )
+{
+  return VirtualGpioGetLock (GpioPad, LockTx);
+}
+
+/**
+  This procedure reads current GPI GPE Enable configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] GpiIe                GPI GPE Enable, TRUE or FALSE
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetGpiGpeEn (
+  IN GPIOV2_PAD              GpioPad,
+  IN BOOLEAN                 *GpiGpeEn
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           RegisterOffset;
+  UINT32           PadIndex;
+  UINT32           RegisterValue;
+
+  PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  VirtualGpioGetRegisterOffset (
+    GpioV2GpiGpeEnReg,
+    GpioPad,
+    &RegisterOffset
+    );
+
+  RegisterValue = MmioRead32 (GetVgpioBaseAddress() + RegisterOffset);
+
+  if ((RegisterValue >> (PadIndex % 32)) & GPIOV2_PAD_GPI_GPE_EN_MASK) {
+    *GpiGpeEn = TRUE;
+  } else {
+    *GpiGpeEn = FALSE;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure reads current Gpi Enable configuration for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] GpiIe                Pointer to a buffer for GPI Enable
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetGpiIe (
+  IN GPIOV2_PAD              GpioPad,
+  IN BOOLEAN                 *GpiIe
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           RegisterOffset;
+  UINT32           PadIndex;
+  UINT32           RegisterValue;
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+
+  VirtualGpioGetRegisterOffset (
+    GpioV2GpiIeReg,
+    GpioPad,
+    &RegisterOffset
+    );
+
+  RegisterValue = MmioRead32 (GetVgpioBaseAddress() + RegisterOffset);
+
+  if ((RegisterValue >> (PadIndex % 32)) & GPIOV2_PAD_GPI_IE_MASK) {
+    *GpiIe = TRUE;
+  } else {
+    *GpiIe = FALSE;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure reads current Gpi Status for requested Gpio Pad
+
+  @param[in] GpioPad              GPIO pad
+  @param[in] GpiIe                Pointer to a buffer for GPI Enable
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetGpiIs (
+  IN GPIOV2_PAD               GpioPad,
+  IN BOOLEAN                  *GpiIs
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           RegisterOffset;
+  UINT32           PadIndex;
+  UINT32           RegisterValue;
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  PadIndex = GPIOV2_PAD_GET_PAD_INDEX (GpioPad);
+
+  VirtualGpioGetRegisterOffset (
+    GpioV2GpiIsReg,
+    GpioPad,
+    &RegisterOffset
+    );
+
+  RegisterValue = MmioRead32 (GetVgpioBaseAddress() + RegisterOffset);
+
+  if ((RegisterValue >> (PadIndex % 32)) & GPIOV2_PAD_GPI_IS_MASK) {
+    *GpiIs = TRUE;
+  } else {
+    *GpiIs = FALSE;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure reads current Reset Configuration for requested Gpio Pad
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] ResetConfig         Pointer to a buffer for Reset Configuration
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioGetResetConfig (
+  IN GPIOV2_PAD               GpioPad,
+  IN GPIOV2_RESET_CONFIG      *ResetConfig
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           RegisterOffset;
+  UINT32           RegisterValue;
+
+  if (ResetConfig == NULL) {
+    ASSERT (FALSE);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  VirtualGpioGetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  VirtualGpioGetRegisterOffset (
+    GpioV2Dw0Reg,
+    GpioPad,
+    &RegisterOffset
+  );
+
+  RegisterValue = MmioRead32 (GetVgpioBaseAddress() + RegisterOffset);
+
+  // Please refer to enum GPIOV2_RESET_CONFIG in GpioV2Pad.h file
+  *ResetConfig = GPIO_ASSIGN_VALUE ((RegisterValue & B_VGPIO_PCR_PAD_RESET_CONFIG) >> N_VGPIO_PCR_PAD_RESET_CONFIG);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  This procedure sets termination configuration for requested Gpio Pad
+
+  @param[in] GpioPad             GPIO pad
+  @param[in] TerminationConfig   Termination configuration, please refer to GpioV2Pad.h
+
+  @retval EFI_SUCCESS             The function completed successfully
+  @retval EFI_INVALID_PARAMETER   Invalid group or pad number
+**/
+EFI_STATUS
+EFIAPI
+VirtualGpioSetTerminationConfig (
+  IN GPIOV2_PAD                 GpioPad,
+  IN GPIOV2_TERMINATION_CONFIG  TerminationConfig
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  This procedure will configure VGPIO CS setting.
+
+  @param[in] GpioPad              Gpio Pad
+  @param[in] PadConfig            Gpio Pad configuration - please refer to GPIOV2_CONFIG in GpioV2Config.h
+
+  @retval EFI_SUCCESS              The function completed successfully
+  @retval EFI_INVALID_PARAMETER    Invalid group or pad number
+**/
+EFI_STATUS
+VirtualGpioSetCs (
+  IN GPIOV2_PAD              GpioPad,
+  IN GPIOV2_CONFIG           *PadConfig
+  )
+{
+  GPIOV2_PAD_OWN   Ownership;
+  UINT32           RegisterOffset;
+  UINT32           Value;
+  EFI_STATUS       Status;
+  BOOLEAN          TxDisabled;
+
+  if (PadConfig == NULL) {
+    ASSERT (FALSE);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  GetOwnership (GpioPad, &Ownership);
+  if (Ownership != GpioV2PadOwnHost) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  VirtualGpioGetRegisterOffset (
+    GpioV2Dw0Reg,
+    GpioPad,
+    &RegisterOffset
+    );
+
+  Value = (MmioRead32 (GetVgpioBaseAddress() + RegisterOffset) & B_VGPIO_PCR_OUT_CS) >> N_VGPIO_PCR_OUT_CS;
+  if (Value == PadConfig->VgpioCs) {
+    return EFI_SUCCESS;
+  }
+
+  switch (PadConfig->VgpioCs) {
+    case GpioV2VgpioCs0:
+      Value = V_VGPIO_PCR_OUT_CS_0;
+      break;
+    case GpioV2VgpioCs1:
+      Value = V_VGPIO_PCR_OUT_CS_1;
+      break;
+    default:
+      return EFI_INVALID_PARAMETER;
+  }
+
+  // To make CS selection, make sure TX Disable bit is set to 1
+  Status = VirtualGpioGetTxDisable (GpioPad, &TxDisabled);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+  if (!TxDisabled) {
+    Status = VirtualGpioSetTxDisable (GpioPad, TRUE);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  }
+
+  MmioAndThenOr32 (
+    RegisterOffset,
+    (UINT32)~(B_VGPIO_PCR_OUT_CS),
+    (Value << N_VGPIO_PCR_OUT_CS)
+    );
+
+  if (!TxDisabled) {
+    VirtualGpioSetTxDisable (GpioPad, FALSE);
+  }
+
+  return EFI_SUCCESS;
+}

--- a/Silicon/CommonSocPkg/Library/PchP2sbLib/PchP2sbLib.c
+++ b/Silicon/CommonSocPkg/Library/PchP2sbLib/PchP2sbLib.c
@@ -1,0 +1,769 @@
+/** @file
+  P2SB sideband access lib
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/IoLib.h>
+#include <Library/DebugLib.h>
+#include <Library/SocInfoLib.h>
+#include <Library/PciSegmentLib.h>
+#include <Library/PchSbiAccessLib.h>
+#include <Library/P2SbSidebandAccessLib.h>
+#include <Register/P2sbRegs.h>
+#include <IndustryStandard/Pci30.h>
+#include <Library/GpioTopologyLib.h>
+#include <Library/BaseMemoryLib.h>
+
+#define P2SB_PCR_ADDRESS(MmioBase, Pid, Offset)  ((UINTN) MmioBase | (UINT32) (((Offset) & 0x0F0000) << 8) | ((UINT8)(Pid) << 16) | (UINT16) ((Offset) & 0xFFFF))
+
+#define SA_SEG_NUM          0x00
+
+/**
+  Full function for executing P2SB SBI message
+  Take care of that there is no lock protection when using SBI programming in both POST time and SMI.
+  It will clash with POST time SBI programming when SMI happen.
+  Programmer MUST do the save and restore opration while using the PchSbiExecution inside SMI
+  to prevent from racing condition.
+  This function will reveal P2SB and hide P2SB if it's originally hidden. If more than one SBI access
+  needed, it's better to unhide the P2SB before calling and hide it back after done.
+
+  When the return value is "EFI_SUCCESS", the "Response" do not need to be checked as it would have been
+  SBI_SUCCESS. If the return value is "EFI_DEVICE_ERROR", then this would provide additional information
+  when needed.
+
+  @param[in] P2sbBase                   P2SB PCI config base
+  @param[in] Pid                        Port ID of the SBI message
+  @param[in] Offset                     Offset of the SBI message
+  @param[in] Opcode                     Opcode
+  @param[in] Posted                     Posted message
+  @param[in] Fbe                        First byte enable
+  @param[in] Bar                        Bar
+  @param[in] Fid                        Function ID
+  @param[in, out] Data32                Read/Write data
+  @param[out] Response                  Response
+
+  @retval EFI_SUCCESS                   Successfully completed.
+  @retval EFI_DEVICE_ERROR              Transaction fail
+  @retval EFI_INVALID_PARAMETER         Invalid parameter
+  @retval EFI_TIMEOUT                   Timeout while waiting for response
+**/
+EFI_STATUS
+P2SbSbiExecutionEx (
+  IN     UINT64           P2sbBase,
+  IN     P2SB_PID         Pid,
+  IN     UINT64           Offset,
+  IN     PCH_SBI_OPCODE  Opcode,
+  IN     BOOLEAN          Posted,
+  IN     UINT16           Fbe,
+  IN     UINT16           Bar,
+  IN     UINT16           Fid,
+  IN OUT UINT32           *Data32,
+  OUT    UINT8            *Response
+  )
+{
+  INT32   Timeout;
+  UINT16  SbiStat;
+
+  //
+  // Check opcode valid
+  //
+  switch (Opcode) {
+    case MemoryRead:
+    case MemoryWrite:
+    case PciConfigRead:
+    case PciConfigWrite:
+    case PrivateControlRead:
+    case PrivateControlWrite:
+    case GpioLockUnlock:
+      break;
+    default:
+      return EFI_INVALID_PARAMETER;
+      break;
+  }
+
+  if (PciSegmentRead16 (P2sbBase + PCI_VENDOR_ID_OFFSET) == 0xFFFF) {
+    ASSERT (FALSE);
+    return EFI_DEVICE_ERROR;
+  }
+  ///
+  /// BWG Section 2.2.1
+  /// 1. Poll P2SB PCI offset D8h[0] = 0b
+  /// Make sure the previous opeartion is completed.
+  ///
+  Timeout = 0xFFFFFFF;
+  SbiStat = 0;
+  while (Timeout > 0) {
+    SbiStat = PciSegmentRead16 (P2sbBase + R_P2SB_CFG_SBISTAT_V2);
+    if ((SbiStat & B_P2SB_CFG_SBISTAT_INITRDY) == 0) {
+      break;
+    }
+    Timeout--;
+  }
+  if (Timeout == 0) {
+    return EFI_TIMEOUT;
+  }
+  //
+  // Initial Response status
+  //
+  *Response = SBI_INVALID_RESPONSE;
+  ///
+  /// 2. Write P2SB PCI offset D0h[31:0] with Address and Destination Port ID
+  ///
+  PciSegmentWrite32 (P2sbBase + R_P2SB_CFG_SBIADDR_V2, (UINT32) ((Pid << 24) | (UINT16) Offset));
+  ///
+  /// 3. Write P2SB PCI offset DCh[31:0] with extended address, which is expected to be 0 in CNL PCH.
+  ///
+  PciSegmentWrite32 (P2sbBase + R_P2SB_CFG_SBIEXTADDR_V2, (UINT32) RShiftU64 (Offset, 16));
+  ///
+  /// 5. Set P2SB PCI offset D8h[15:8] = 00000110b for read
+  ///    Set P2SB PCI offset D8h[15:8] = 00000111b for write
+  //
+  // Set SBISTAT[15:8] to the opcode passed in
+  // Set SBISTAT[7] to the posted passed in
+  //
+  PciSegmentAndThenOr16 (
+    (P2sbBase + R_P2SB_CFG_SBISTAT_V2),
+    (UINT16) ~(B_P2SB_CFG_SBISTAT_OPCODE_V2 | B_P2SB_CFG_SBISTAT_POSTED),
+    (UINT16) ((Opcode << 8) | (Posted << 7))
+    );
+  ///
+  /// 6. Write P2SB PCI offset DAh[15:0] = F000h
+  ///
+  //
+  // Set RID[15:0] = Fbe << 12 | Bar << 8 | Fid
+  //
+  PciSegmentWrite16 (
+    (P2sbBase + R_P2SB_CFG_SBIRID_V2),
+    (((Fbe & 0x000F) << 12) | ((Bar & 0x0007) << 8) | (Fid & 0x00FF))
+    );
+
+  switch (Opcode) {
+    case MemoryWrite:
+    case PciConfigWrite:
+    case PrivateControlWrite:
+    case GpioLockUnlock:
+      ///
+      /// 4. Write P2SB PCI offset D4h[31:0] with the intended data accordingly
+      ///
+      PciSegmentWrite32 ((P2sbBase + R_P2SB_CFG_SBIDATA_V2), *Data32);
+      break;
+    default:
+      ///
+      /// 4. Write P2SB PCI offset D4h[31:0] with dummy data such as 0,
+      /// because all D0-DFh register range must be touched in CNL PCH
+      /// for a successful SBI transaction.
+      ///
+      PciSegmentWrite32 ((P2sbBase + R_P2SB_CFG_SBIDATA_V2), 0);
+      break;
+  }
+  ///
+  /// 7. Set P2SB PCI offset D8h[0] = 1b, Poll P2SB PCI offset D8h[0] = 0b
+  ///
+  //
+  // Set SBISTAT[0] = 1b, trigger the SBI operation
+  //
+  PciSegmentOr16 (P2sbBase + R_P2SB_CFG_SBISTAT_V2, (UINT16) B_P2SB_CFG_SBISTAT_INITRDY);
+  //
+  // Poll SBISTAT[0] = 0b, Polling for Busy bit
+  //
+  Timeout = 0xFFFFFFF;
+  while (Timeout > 0) {
+    SbiStat = PciSegmentRead16 (P2sbBase + R_P2SB_CFG_SBISTAT_V2);
+    if ((SbiStat & B_P2SB_CFG_SBISTAT_INITRDY) == 0) {
+      break;
+    }
+    Timeout--;
+  }
+  if (Timeout == 0) {
+    //
+    // If timeout, it's fatal error.
+    //
+    return EFI_TIMEOUT;
+  } else {
+    ///
+    /// 8. Check if P2SB PCI offset D8h[2:1] = 00b for successful transaction
+    ///
+    *Response = (UINT8) ((SbiStat & B_P2SB_CFG_SBISTAT_RESPONSE_V2) >> N_P2SB_CFG_SBISTAT_RESPONSE);
+    if (*Response == SBI_SUCCESSFUL) {
+      switch (Opcode) {
+        case MemoryRead:
+        case PciConfigRead:
+        case PrivateControlRead:
+          ///
+          /// 9. Read P2SB PCI offset D4h[31:0] for SBI data
+          ///
+          *Data32 = PciSegmentRead32 (P2sbBase + R_P2SB_CFG_SBIDATA_V2);
+          break;
+        default:
+          break;
+      }
+      return EFI_SUCCESS;
+    } else if (*Response == SBI_POWERDOWN) {
+      return EFI_NO_RESPONSE;
+    } else {
+      return EFI_DEVICE_ERROR;
+    }
+  }
+}
+
+/**
+  Execute P2SB SBI message
+  Take care of that there is no lock protection when using SBI programming in both POST time and SMI.
+  It will clash with POST time SBI programming when SMI happen.
+  Programmer MUST do the save and restore opration while using the PchSbiExecution inside SMI
+  to prevent from racing condition.
+  This function will reveal P2SB and hide P2SB if it's originally hidden. If more than one SBI access
+  needed, it's better to unhide the P2SB before calling and hide it back after done.
+
+  When the return value is "EFI_SUCCESS", the "Response" do not need to be checked as it would have been
+  SBI_SUCCESS. If the return value is "EFI_DEVICE_ERROR", then this would provide additional information
+  when needed.
+
+  @param[in] P2sbBase                   P2SB PCI config base
+  @param[in] Pid                        Port ID of the SBI message
+  @param[in] Offset                     Offset of the SBI message
+  @param[in] Opcode                     Opcode
+  @param[in] Posted                     Posted message
+  @param[in, out] Data32                Read/Write data
+  @param[out] Response                  Response
+
+  @retval EFI_SUCCESS                   Successfully completed.
+  @retval EFI_DEVICE_ERROR              Transaction fail
+  @retval EFI_INVALID_PARAMETER         Invalid parameter
+  @retval EFI_TIMEOUT                   Timeout while waiting for response
+**/
+EFI_STATUS
+P2SbSbiExecution (
+  IN     UINT64          P2sbBase,
+  IN     P2SB_PID        Pid,
+  IN     UINT64          Offset,
+  IN     PCH_SBI_OPCODE  Opcode,
+  IN     BOOLEAN         Posted,
+  IN OUT UINT32          *Data32,
+  OUT    UINT8           *Response
+  )
+{
+  return P2SbSbiExecutionEx (
+           P2sbBase,
+           Pid,
+           Offset,
+           Opcode,
+           Posted,
+           0x000F,
+           0x0000,
+           0x0000,
+           Data32,
+           Response
+           );
+}
+
+#ifndef MDEPKG_NDEBUG
+/**
+  Checks if the offset is valid for a given memory access width. Offset must align to width size.
+
+  @param[in]  Offset  Offset of a register
+  @param[in]  Size    Size of memory access in bytes
+
+  @retval FALSE  Offset is not valid for a given memory access
+  @retval TRUE   Offset is valid
+**/
+STATIC
+BOOLEAN
+P2SbIsPcrOffsetValid (
+  IN UINT32  Offset,
+  IN UINTN   Size
+  )
+{
+  if (!IsP2sb20bPcrSupported ()) {
+    if (((Offset & (Size - 1)) != 0) || (Offset > 0xFFFF)) {
+      DEBUG ((DEBUG_WARN, "PCR offset error. Invalid Offset: %x Size: %x", Offset, Size));
+      return FALSE;
+    } else {
+      return TRUE;
+    }
+  } else {
+    if (((Offset & (Size - 1)) != 0) || (Offset > 0xFFFFF)) {
+      DEBUG ((DEBUG_WARN, "PCR offset error. Invalid Offset: %x Size: %x", Offset, Size));
+      return FALSE;
+    } else {
+      return TRUE;
+    }
+  }
+}
+#endif
+
+/**
+  Reads an 8-bit register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+
+  @return The 8-bit register value specified by Offset
+**/
+UINT8
+P2SbSidebandRead8 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset
+  )
+{
+  P2SB_SIDEBAND_REGISTER_ACCESS  *Private;
+
+  Private = (P2SB_SIDEBAND_REGISTER_ACCESS *) This;
+
+  switch (Private->AccessMethod) {
+    case P2SbMmioAccess:
+      Offset = Offset + Private->Offset;
+      ASSERT (Private->P2SbCtrl.Mmio);
+      return MmioRead8 (P2SB_PCR_ADDRESS (Private->P2SbCtrl.Mmio, Private->P2SbPid, Offset));
+    default:
+      DEBUG ((DEBUG_ERROR, "P2SB: Incorrect access method %d\n", Private->AccessMethod));
+      return 0xFF;
+  }
+}
+
+/**
+  Writes an 8-bit register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+  @param[in] Value   Value to write to register
+
+  @return The 8-bit register value written to register
+**/
+UINT8
+P2SbSidebandWrite8 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT8            Value
+  )
+{
+  P2SB_SIDEBAND_REGISTER_ACCESS  *Private;
+
+  Private = (P2SB_SIDEBAND_REGISTER_ACCESS *) This;
+
+
+  switch (Private->AccessMethod) {
+    case P2SbMmioAccess:
+      Offset = Offset + Private->Offset;
+      ASSERT (Private->P2SbCtrl.Mmio);
+      MmioWrite8 (P2SB_PCR_ADDRESS (Private->P2SbCtrl.Mmio, Private->P2SbPid, Offset), Value);
+      //
+      // Readback to flush the write cycle and ensure ordering with primary
+      //
+      return MmioRead8 (P2SB_PCR_ADDRESS (Private->P2SbCtrl.Mmio, Private->P2SbPid, Offset));
+    default:
+      DEBUG ((DEBUG_ERROR, "P2SB: Incorrect access method %d\n", Private->AccessMethod));
+      return 0xFF;
+  }
+}
+
+/**
+  Performs an 8-bit or on the register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+  @param[in] OrData  Data with which register should be OR-ed
+
+  @return The 8-bit register value written to register
+**/
+UINT8
+P2SbSidebandOr8 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT8            OrData
+  )
+{
+  UINT8  Value;
+
+  Value = P2SbSidebandRead8 (This, Offset);
+  Value |= OrData;
+  return P2SbSidebandWrite8 (This, Offset, Value);
+}
+
+/**
+  Performs an 8-bit and on the register
+
+  @param[in] This     Pointer to REGISTER_ACCESS
+  @param[in] Offset   Offset of the register in the register bank
+  @param[in] AndData  Data with which register should be AND-ed
+
+  @return The 8-bit register value written to register
+**/
+UINT8
+P2SbSidebandAnd8 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT8            AndData
+  )
+{
+  UINT8  Value;
+
+  Value = P2SbSidebandRead8 (This, Offset);
+  Value &= AndData;
+  return P2SbSidebandWrite8 (This, Offset, Value);
+}
+
+/**
+  Performs an 8-bit and then or on the register
+
+  @param[in] This     Pointer to REGISTER_ACCESS
+  @param[in] Offset   Offset of the register in the register bank
+  @param[in] AndData  Data with which register should be AND-ed
+  @param[in] OrData   Data with which register should be OR-ed
+
+  @return The 8-bit register value written to register
+**/
+UINT8
+P2SbSidebandAndThenOr8 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT8            AndData,
+  IN UINT8            OrData
+  )
+{
+  UINT8  Value;
+
+  Value = P2SbSidebandRead8 (This, Offset);
+  Value &= AndData;
+  Value |= OrData;
+  return P2SbSidebandWrite8 (This, Offset, Value);
+}
+
+/**
+  Reads a 16-bit register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+
+  @return The 16-bit register value specified by Offset
+**/
+UINT16
+P2SbSidebandRead16 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset
+  )
+{
+  P2SB_SIDEBAND_REGISTER_ACCESS  *Private;
+
+#ifndef MDEPKG_NDEBUG
+  ASSERT (P2SbIsPcrOffsetValid (Offset, 2));
+#endif
+
+  Private = (P2SB_SIDEBAND_REGISTER_ACCESS *) This;
+
+  switch (Private->AccessMethod) {
+    case P2SbMmioAccess:
+      Offset = Offset + Private->Offset;
+      ASSERT (Private->P2SbCtrl.Mmio);
+      return MmioRead16 (P2SB_PCR_ADDRESS (Private->P2SbCtrl.Mmio, Private->P2SbPid, Offset));
+    default:
+      DEBUG ((DEBUG_ERROR, "P2SB: Incorrect access method %d\n", Private->AccessMethod));
+      return 0xFFFF;
+  }
+}
+
+/**
+  Writes a 16-bit register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+  @param[in] Value   Value to write to register
+
+  @return The 16-bit register value written to register
+**/
+UINT16
+P2SbSidebandWrite16 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT16           Value
+  )
+{
+  P2SB_SIDEBAND_REGISTER_ACCESS  *Private;
+
+#ifndef MDEPKG_NDEBUG
+  ASSERT (P2SbIsPcrOffsetValid (Offset, 2));
+#endif
+
+  Private = (P2SB_SIDEBAND_REGISTER_ACCESS *) This;
+
+  switch (Private->AccessMethod) {
+    case P2SbMmioAccess:
+      Offset = Offset + Private->Offset;
+      ASSERT (Private->P2SbCtrl.Mmio);
+      MmioWrite16 (P2SB_PCR_ADDRESS (Private->P2SbCtrl.Mmio, Private->P2SbPid, Offset), Value);
+      //
+      // Readback to flush the write cycle and ensure ordering with primary
+      //
+      return MmioRead16 (P2SB_PCR_ADDRESS (Private->P2SbCtrl.Mmio, Private->P2SbPid, Offset));
+    default:
+      DEBUG ((DEBUG_ERROR, "P2SB: Incorrect access method %d\n", Private->AccessMethod));
+      return 0xFFFF;
+  }
+}
+
+/**
+  Performs a 16-bit or on the register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+  @param[in] OrData  Data with which register should be OR-ed
+
+  @return The 16-bit register value written to register
+**/
+UINT16
+P2SbSidebandOr16 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT16           OrData
+  )
+{
+  UINT16  Value;
+
+  Value = P2SbSidebandRead16 (This, Offset);
+  Value |= OrData;
+  return P2SbSidebandWrite16 (This, Offset, Value);
+}
+
+/**
+  Performs a 16-bit and on the register
+
+  @param[in] This     Pointer to REGISTER_ACCESS
+  @param[in] Offset   Offset of the register in the register bank
+  @param[in] AndData  Data with which register should be AND-ed
+
+  @return The 16-bit register value written to register
+**/
+UINT16
+P2SbSidebandAnd16 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT16           AndData
+  )
+{
+  UINT16  Value;
+
+  Value = P2SbSidebandRead16 (This, Offset);
+  Value &= AndData;
+  return P2SbSidebandWrite16 (This, Offset, Value);
+}
+
+/**
+  Performs a 16-bit and then or on the register
+
+  @param[in] This     Pointer to REGISTER_ACCESS
+  @param[in] Offset   Offset of the register in the register bank
+  @param[in] AndData  Data with which register should be AND-ed
+  @param[in] OrData   Data with which register should be OR-ed
+
+  @return The 16-bit register value written to register
+**/
+UINT16
+P2SbSidebandAndThenOr16 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT16           AndData,
+  IN UINT16           OrData
+  )
+{
+  UINT16  Value;
+
+  Value = P2SbSidebandRead16 (This, Offset);
+  Value &= AndData;
+  Value |= OrData;
+  return P2SbSidebandWrite16 (This, Offset, Value);
+}
+
+/**
+  Reads a 32-bit register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+
+  @return The 32-bit register value specified by Offset
+**/
+UINT32
+P2SbSidebandRead32 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset
+  )
+{
+  P2SB_SIDEBAND_REGISTER_ACCESS  *Private;
+
+  Private = (P2SB_SIDEBAND_REGISTER_ACCESS *) This;
+  Offset = Offset + Private->Offset;
+  switch (Private->AccessMethod) {
+     case P2SbMmioAccess:
+#ifndef MDEPKG_NDEBUG
+      ASSERT (P2SbIsPcrOffsetValid (Offset, 4));
+#endif
+      ASSERT (Private->P2SbCtrl.Mmio);
+      return MmioRead32 (P2SB_PCR_ADDRESS (Private->P2SbCtrl.Mmio, Private->P2SbPid, Offset));
+    default:
+      DEBUG ((DEBUG_ERROR, "P2SB: Incorrect access method %d\n", Private->AccessMethod));
+      return 0xFFFFFFFF;
+  }
+}
+
+/**
+  Writes a 32-bit register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+  @param[in] Value   Value to write to register
+
+  @return The 32-bit register value written to register
+**/
+UINT32
+P2SbSidebandWrite32 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT32           Value
+  )
+{
+  P2SB_SIDEBAND_REGISTER_ACCESS  *Private;
+
+  Private = (P2SB_SIDEBAND_REGISTER_ACCESS *) This;
+  Offset = Offset + Private->Offset;
+
+  switch (Private->AccessMethod) {
+    case P2SbMmioAccess:
+#ifndef MDEPKG_NDEBUG
+      ASSERT (P2SbIsPcrOffsetValid (Offset, 4));
+#endif
+      ASSERT (Private->P2SbCtrl.Mmio);
+      MmioWrite32 (P2SB_PCR_ADDRESS (Private->P2SbCtrl.Mmio, Private->P2SbPid, Offset), Value);
+      //
+      // Readback to flush the write cycle and ensure ordering with primary
+      //
+      return MmioRead32 (P2SB_PCR_ADDRESS (Private->P2SbCtrl.Mmio, Private->P2SbPid, Offset));
+    default:
+      DEBUG ((DEBUG_ERROR, "P2SB: Incorrect access method %d\n", Private->AccessMethod));
+      return 0xFFFFFFFF;
+  }
+}
+
+/**
+  Performs a 32-bit or on the register
+
+  @param[in] This    Pointer to REGISTER_ACCESS
+  @param[in] Offset  Offset of the register in the register bank
+  @param[in] OrData  Data with which register should be OR-ed
+
+  @return The 32-bit register value written to register
+**/
+UINT32
+P2SbSidebandOr32 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT32           OrData
+  )
+{
+  UINT32  Value;
+
+  Value = P2SbSidebandRead32 (This, Offset);
+  Value |= OrData;
+  return P2SbSidebandWrite32 (This, Offset, Value);
+}
+
+/**
+  Performs a 32-bit and on the register
+
+  @param[in] This     Pointer to REGISTER_ACCESS
+  @param[in] Offset   Offset of the register in the register bank
+  @param[in] AndData  Data with which register should be AND-ed
+
+  @return The 32-bit register value written to register
+**/
+UINT32
+P2SbSidebandAnd32 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT32           AndData
+  )
+{
+  UINT32  Value;
+
+  Value = P2SbSidebandRead32 (This, Offset);
+  Value &= AndData;
+  return P2SbSidebandWrite32 (This, Offset, Value);
+}
+
+/**
+  Performs a 32-bit and then or on the register
+
+  @param[in] This     Pointer to REGISTER_ACCESS
+  @param[in] Offset   Offset of the register in the register bank
+  @param[in] AndData  Data with which register should be AND-ed
+  @param[in] OrData   Data with which register should be OR-ed
+
+  @return The 32-bit register value written to register
+**/
+UINT32
+P2SbSidebandAndThenOr32 (
+  IN REGISTER_ACCESS  *This,
+  IN UINT32           Offset,
+  IN UINT32           AndData,
+  IN UINT32           OrData
+  )
+{
+  UINT32  Value;
+
+  Value = P2SbSidebandRead32 (This, Offset);
+  Value &= AndData;
+  Value |= OrData;
+  return P2SbSidebandWrite32 (This, Offset, Value);
+}
+
+/**
+  Builds P2SB sideband access.
+
+  @param[in]  P2SbPid             Port id
+  @param[in]  Fid                 Function id
+  @param[in]  RegisterSpace       Target register space
+  @param[in]  AccessMethod        Access method
+  @param[in]  PostedWrites        If TRUE writes sent through sideband msg will be posted
+  @param[out] P2SbSidebandAccess  On output an initialized sideband access descriptor
+
+  @retval TRUE   Access initialized successfuly
+  @retval FALSE  Failed to initialize access
+**/
+BOOLEAN
+BuildP2SbSidebandAccess (
+  IN P2SB_PID                        P2SbPid,
+  IN UINT16                          Fid,
+  IN P2SB_REGISTER_SPACE             RegisterSpace,
+  IN P2SB_SIDEBAND_ACCESS_METHOD     AccessMethod,
+  IN BOOLEAN                         PostedWrites,
+  OUT P2SB_SIDEBAND_REGISTER_ACCESS  *P2SbSidebandAccess
+  )
+{
+  P2SbSidebandAccess->Access.Read8        = P2SbSidebandRead8;
+  P2SbSidebandAccess->Access.Write8       = P2SbSidebandWrite8;
+  P2SbSidebandAccess->Access.Or8          = P2SbSidebandOr8;
+  P2SbSidebandAccess->Access.And8         = P2SbSidebandAnd8;
+  P2SbSidebandAccess->Access.AndThenOr8   = P2SbSidebandAndThenOr8;
+  P2SbSidebandAccess->Access.Read16       = P2SbSidebandRead16;
+  P2SbSidebandAccess->Access.Write16      = P2SbSidebandWrite16;
+  P2SbSidebandAccess->Access.Or16         = P2SbSidebandOr16;
+  P2SbSidebandAccess->Access.And16        = P2SbSidebandAnd16;
+  P2SbSidebandAccess->Access.AndThenOr16  = P2SbSidebandAndThenOr16;
+  P2SbSidebandAccess->Access.Read32       = P2SbSidebandRead32;
+  P2SbSidebandAccess->Access.Write32      = P2SbSidebandWrite32;
+  P2SbSidebandAccess->Access.Or32         = P2SbSidebandOr32;
+  P2SbSidebandAccess->Access.And32        = P2SbSidebandAnd32;
+  P2SbSidebandAccess->Access.AndThenOr32  = P2SbSidebandAndThenOr32;
+
+  P2SbSidebandAccess->AccessMethod        = AccessMethod;
+  P2SbSidebandAccess->P2SbPid             = P2SbPid;
+  P2SbSidebandAccess->Fid                 = Fid;
+  P2SbSidebandAccess->RegisterSpace       = RegisterSpace;
+  P2SbSidebandAccess->PostedWrites        = PostedWrites;
+  P2SbSidebandAccess->P2SbCtrl            = SocGetP2SbController();
+  P2SbSidebandAccess->Offset              = 0;
+
+  return TRUE;
+}

--- a/Silicon/CommonSocPkg/Library/PchP2sbLib/PchP2sbLib.inf
+++ b/Silicon/CommonSocPkg/Library/PchP2sbLib/PchP2sbLib.inf
@@ -1,0 +1,37 @@
+## @file
+#
+#  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = PchP2sbLib
+  FILE_GUID                      = 3EA3392B-3D6A-432C-A3CB-1961F0093993
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = PchP2sbLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 IPF
+#
+
+[Sources]
+  PchP2sbLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCorePkg/BootloaderCorePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+  Silicon/CommonSocPkg/CommonSocPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  IoLib
+  BasePciSegmentLibPci
+  PchInfoLib
+
+[Pcd]


### PR DESCRIPTION
GPIO V2 library uses sideband access to read and write a particular GPIO also adds support for Virtual GPIO (These GPIO can not have external connections,These are mainly used to integrate discrete GPIO devices present on board)