### PR TITLE
Update FPDT Table

### DIFF
--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiFpdt.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiFpdt.c
@@ -12,6 +12,7 @@
 #include <Library/BootloaderCoreLib.h>
 #include <Library/AcpiInitLib.h>
 #include <Library/TimeStampLib.h>
+#include "AcpiInitLibInternal.h"
 
 BOOT_PERFORMANCE_TABLE mBootPerformanceTableTemplate = {
   {
@@ -198,6 +199,7 @@ UpdateFpdtS3Table (
   DEBUG ((DEBUG_VERBOSE, "FPDT: S3Resume->ResumeCount   = %d\n",  S3Resume->ResumeCount));
   DEBUG ((DEBUG_VERBOSE, "FPDT: S3Resume->FullResume    = %ld\n", S3Resume->FullResume));
 
+  AcpiPlatformChecksum ((UINT8 *)Fpdt, Fpdt->Header.Length);
   return  EFI_SUCCESS;
 }
 
@@ -285,6 +287,7 @@ UpdateFpdtSblTable (
         SblPerfTable->SblPerfRecord.Stage1Time, SblPerfTable->SblPerfRecord.Stage2Time,
         SblPerfTable->SblPerfRecord.OsLoaderTime));
 
+  AcpiPlatformChecksum ((UINT8 *)Fpdt, Fpdt->Header.Length);
   return EFI_SUCCESS;
 }
 
@@ -292,15 +295,13 @@ UpdateFpdtSblTable (
   Update Firmware Performance Data Table (FPDT).
 
   @param[in] Table          Pointer of ACPI FPDT Table.
-  @param[out] ExtraSize     Extra size the table needed.
 
   @retval EFI_SUCCESS       Update ACPI FPDT table successfully.
   @retval Others            Failed to update FPDT table.
  **/
 EFI_STATUS
 UpdateFpdt (
-  IN  UINT8                           *Table,
-  OUT UINT32                          *ExtraSize
+  IN  UINT8                           *Table
   )
 {
   FIRMWARE_PERFORMANCE_TABLE          *Fpdt;
@@ -329,10 +330,7 @@ UpdateFpdt (
     CopyMem (SblPerfTable, &mSblPerfTableTemplate, sizeof (mSblPerfTableTemplate));
     UpdateFpdtBootTable (BootPerfTable);
 
-    if (ExtraSize != NULL) {
-      *ExtraSize = (UINT32)((UINT8 *) (SblPerfTable + 1) - Table - Fpdt->Header.Length);
-    }
-
+    Fpdt->Header.Length = (UINT32)((UINT8 *) (SblPerfTable + 1) - Table);
   }
 
   return  EFI_SUCCESS;

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
@@ -500,7 +500,6 @@ AcpiInit (
   UINT32                    SectionLen;
   UINT32                    UpdateRdstXsdt;
   EFI_STATUS                Status;
-  UINT32                    ExtraSize;
   UINT32                    Round;
   UINT32                    StartIdx;
   UINT32                    EndIdx;
@@ -586,7 +585,6 @@ AcpiInit (
       CopyMem  (Current, Table, Table->Length);
 
       UpdateRdstXsdt = 0;
-      ExtraSize      = 0;
       Status = PlatformUpdateAcpiTable (Current);
       if (!EFI_ERROR(Status)) {
         UpdateRdstXsdt = 1;
@@ -621,7 +619,7 @@ AcpiInit (
           break;
         case EFI_ACPI_5_0_FIRMWARE_PERFORMANCE_DATA_TABLE_SIGNATURE:
           // FPDT
-          Status = UpdateFpdt (Current, &ExtraSize);
+          Status = UpdateFpdt (Current);
           break;
         case EFI_FIRMWARE_UPDATE_STATUS_TABLE_SIGNATURE:
           // FWST
@@ -654,8 +652,7 @@ AcpiInit (
             );
         }
 
-        TotalSize = ((EFI_ACPI_COMMON_HEADER *)Current)->Length + ExtraSize;
-        Current += TotalSize;
+        Current += ((EFI_ACPI_COMMON_HEADER *)Current)->Length;
       } else {
         DEBUG ((DEBUG_INFO, "Not adding ACPI table \n"));
         Current = Previous;

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLibInternal.h
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLibInternal.h
@@ -61,15 +61,26 @@ UpdateBgrt (
   Update Firmware Performance Data Table (FPDT).
 
   @param[in]  Table         Pointer of ACPI FPDT Table.
-  @param[out] ExtraSize     Extra size the table needed.
 
   @retval EFI_SUCCESS       Update ACPI FPDT table successfully.
   @retval Others            Failed to update FPDT table.
  **/
 EFI_STATUS
 UpdateFpdt (
-  IN  UINT8                             *Table,
-  OUT UINT32                            *ExtraSize
+  IN  UINT8                             *Table
+  );
+
+/**
+  This function calculates and updates an UINT8 checksum.
+
+  @param[in]  Buffer          Pointer to buffer to checksum
+  @param[in]  Size            Number of bytes to checksum
+
+**/
+VOID
+AcpiPlatformChecksum (
+  IN UINT8      *Buffer,
+  IN UINTN      Size
   );
 
 #endif


### PR DESCRIPTION
Update the FPDT header length to include the length of boot records. This way we could easily get all the boot records from dumped ACPI FPDT table.