### PR TITLE
fix: [AZB] fix GPIO definition issue from linux

### DIFF
--- a/Platform/AlderlakeBoardPkg/BoardConfigAzb.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAzb.py
@@ -38,7 +38,7 @@ class Board(BaseBoard):
         self._EXTRA_INC_PATH                  = ['Silicon/AlderlakePkg/Azb/Include']
         self._FSP_PATH_NAME                   = 'Silicon/AlderlakePkg/Azb/FspBin'
         self.MICROCODE_INF_FILE               = 'Silicon/AlderlakePkg/Microcode/MicrocodeAzb.inf'
-        self._LP_SUPPORT                      = False
+        self._LP_SUPPORT                      = True
         self._N_SUPPORT                       = False
         self._AZB_SUPPORT                     = True
 


### PR DESCRIPTION
_LP_SUPPORT was disabled as a result,  GPIO programming was faulty from the Linux side. Enable the _LP_SUPPORT to select the proper ACPI to fix the issue.