### PR TITLE
fix: Container header parsing failure in some cases.

### DIFF
--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
@@ -1,7 +1,7 @@
 /** @file
   Container library implementation.
 
-  Copyright (c) 2019 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -82,7 +82,7 @@ GetContainerHeaderSize (
     for (Index = 0; Index < ContainerHdr->Count; Index++) {
       CompEntry = (COMPONENT_ENTRY *)((UINT8 *)(CompEntry + 1) + CompEntry->HashSize);
       Offset = (UINT8 *)CompEntry - (UINT8 *)ContainerHdr;
-      if ((Offset < 0) || (Offset >= ContainerHdr->DataOffset)) {
+      if ((Offset < 0) || (Offset > ContainerHdr->DataOffset)) {
         Offset = 0;
         break;
       }


### PR DESCRIPTION
GetContainerHeaderSize() parses header component entries to find the offset of the end of the last component entry and checks this against ContainerHdr->DataOffset. However, there is a valid case where this can exactly equal to ContainerHdr->DataOffset, when the component alignment is small enough and there is no component auth data (AuthType is none). This check is changed to fail on greater than instead of greater or equal to cover this case. fixes #2053 