### PR TITLE
fix:[AZB] fix ACPI_BIOS_ERR issue in windows boot

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -542,9 +542,7 @@ BoardInit (
     /// Initialize the IGD OpRegion
     ///
     }
-#if !FixedPcdGetBool(PcdAzbSupport)
     IgdOpRegionPlatformInit ();
-#endif
 
     ///
     /// Initialize the HECI device (for test HeciInitLib only)


### PR DESCRIPTION
With an external graphics card, windows boot through ACPI_BIOS_ERROR. To fix it SaNvs.IgdOpRegionAddress needs to be set properly. In the AZB case, the IgdOpRegionPlatformInit() was not getting called due to the flag PcdAzbSupport.