### PR TITLE
fix: [ADL/RPL] fill in 64bit MMIO resources in ACPI when enabled.

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
@@ -1228,8 +1228,8 @@ PlatformUpdateAcpiGnvs (
   UpdateCpuNvs (CpuNvs);
 
   //System Agent NVS Init
-  SaNvs->Mmio64Base               = 0;
-  SaNvs->Mmio64Length             = 0;
+  SaNvs->Mmio64Base               = PcdGet64 (PcdPciResourceMem64Base);
+  SaNvs->Mmio64Length             = RShiftU64 (PcdGet64 (PcdPciResourceMem64Base), 1);
   SaNvs->Mmio32Base               = PcdGet32(PcdPciResourceMem32Base);
   SaNvs->Mmio32Length             = ACPI_MMIO_BASE_ADDRESS - SaNvs->Mmio32Base;
   SaNvs->XPcieCfgBaseAddress      = (UINT32)(PcdGet64(PcdPciExpressBaseAddress));

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -88,6 +88,7 @@
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
   gPlatformModuleTokenSpaceGuid.PcdPciResourceIoBase
   gPlatformModuleTokenSpaceGuid.PcdPciResourceMem32Base
+  gPlatformModuleTokenSpaceGuid.PcdPciResourceMem64Base
   gPlatformModuleTokenSpaceGuid.PcdVariableRegionSize
   gPlatformModuleTokenSpaceGuid.PcdOsBootOptionNumber
   gPlatformModuleTokenSpaceGuid.PcdIntelGfxEnabled


### PR DESCRIPTION
When 64bit MMIO above 4GB is enabled, ACPI resource descriptor needs to be filled in to describe it.