### PR TITLE
fix: ASSERT on firmware update when capsule not found.

### DIFF
--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -1394,6 +1394,7 @@ InitFirmwareUpdate (
   FwUpdStatusOffset = PcdGet32(PcdFwUpdStatusBase);
   ResetRequired = FALSE;
   FwPolicy.Data = 0;
+  CapsuleImage = NULL;
 
   //
   // Get capsule image.
@@ -1452,7 +1453,9 @@ InitFirmwareUpdate (
   if (EFI_ERROR (Status)) {
     //
     // Error condition
-    FreePool(CapsuleImage);
+    if (CapsuleImage != NULL) {
+      FreePool(CapsuleImage);
+    }
     return Status;
   }
 


### PR DESCRIPTION
Commit 74e12f7 introduced a case where FreePool could be called with an unallocated pointer if no capsule image is found.