### PR TITLE
fix: [ADL/RPL] ITE8659 HwMon initialization fails.

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/SioChip.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/SioChip.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -740,8 +740,15 @@ It8659HwMonStart(
   )
 {
   EFI_SIO_ACPI_DEVICE_ID  HwMonDevice;
+  UINT32                  HwMonDecodeRange;
 
   DEBUG ((DEBUG_INFO, "SIO It8659fHwMonStart\n"));
+
+  // Need to enable eSPI decode for HwMon IO range
+  HwMonDecodeRange = (0xF << 16) | HWMON_BASE_ADDRESS | B_ESPI_CFG_ESPI_LGIR1_LDE;
+  // Generic decode range 2
+  PciSegmentWrite32((UINTN)(LpcPciCfgBase() + R_ESPI_CFG_ESPI_LGIR1 + 4), HwMonDecodeRange);
+  MmioWrite32 (PCH_PCR_ADDRESS(PID_DMI, R_PCH_DMI_PCR_LPCLGIR2), HwMonDecodeRange);
 
   //mIoWrite8 = S3IoWrite8;
   HwMonDevice.HID = EISA_PNP_ID(0xc08);

--- a/Silicon/AlderlakePkg/Include/Register/PchRegsLpc.h
+++ b/Silicon/AlderlakePkg/Include/Register/PchRegsLpc.h
@@ -1,7 +1,7 @@
 /** @file
   Register names for PCH LPC/eSPI device
 
-  Copyright (c) 2021-2022, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2021-2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -21,6 +21,14 @@
 #define B_LPC_CFG_IOE_CBE                         BIT1            ///< Com Port B Enable, Enables decoding of the COMB range to LPC. Range is selected LIOD.CB.
 #define B_LPC_CFG_IOE_CAE                         BIT0            ///< Com Port A Enable, Enables decoding of the COMA range to LPC. Range is selected LIOD.CA.
 #define B_LPC_CFG_IOE_ME2                         BIT13
+
+#define R_ESPI_CFG_ESPI_LGIR1                     0x84                      ///< LPC Generic IO Range 1
+#define B_ESPI_CFG_ESPI_LGIR1_LDE                 BIT0
+
+#define R_PCH_DMI_PCR_LPCLGIR1                    0x2730                       ///< LPC Generic I/O Range 1
+#define R_PCH_DMI_PCR_LPCLGIR2                    0x2734                       ///< LPC Generic I/O Range 2
+#define R_PCH_DMI_PCR_LPCLGIR3                    0x2738                       ///< LPC Generic I/O Range 3
+#define R_PCH_DMI_PCR_LPCLGIR4                    0x273C                       ///< LPC Generic I/O Range 4
 
 #define R_LPC_CFG_BC                              0xDC            ///< Bios Control
 


### PR DESCRIPTION
As part of ITE8659 SIO init, HwMon device is enabled, but eSPI decode was not enabled for the IO address range.