### PR TITLE
[ADL] copy MemInfoHob.h from GitHub FSP repo

### DIFF
--- a/Silicon/AlderlakePkg/FspBin/FspBin.inf
+++ b/Silicon/AlderlakePkg/FspBin/FspBin.inf
@@ -11,7 +11,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = 8c9996508c2af16257222f1aa404a2829473f552
+  COMMIT  = 8267065be80e5a326c915f214d7e097f4590ce38
 
 [UserExtensions.SBL."CopyList"]
 # For ADL-S
@@ -22,6 +22,7 @@
   AlderLakeFspBinPkg/IoT/AlderLakeS/Include/FsptUpd.h         : Silicon/AlderlakePkg/Adls/Include/FsptUpd.h
   AlderLakeFspBinPkg/IoT/AlderLakeS/Include/FspmUpd.h         : Silicon/AlderlakePkg/Adls/Include/FspmUpd.h
   AlderLakeFspBinPkg/IoT/AlderLakeS/Include/FspsUpd.h         : Silicon/AlderlakePkg/Adls/Include/FspsUpd.h
+  AlderLakeFspBinPkg/IoT/AlderLakeS/Include/MemInfoHob.h      : Silicon/AlderlakePkg/Adls/Include/MemInfoHob.h
   FSP_License.pdf                                             : Silicon/AlderlakePkg/Adls/FspBin/FSP_License.pdf
 # For ADL-P
   AlderLakeFspBinPkg/IoT/AlderLakeP/Fsp.fd                    : Silicon/AlderlakePkg/Adlp/FspBin/FspDbg.bin
@@ -31,6 +32,7 @@
   AlderLakeFspBinPkg/IoT/AlderLakeP/Include/FsptUpd.h         : Silicon/AlderlakePkg/Adlp/Include/FsptUpd.h
   AlderLakeFspBinPkg/IoT/AlderLakeP/Include/FspmUpd.h         : Silicon/AlderlakePkg/Adlp/Include/FspmUpd.h
   AlderLakeFspBinPkg/IoT/AlderLakeP/Include/FspsUpd.h         : Silicon/AlderlakePkg/Adlp/Include/FspsUpd.h
+  AlderLakeFspBinPkg/IoT/AlderLakeP/Include/MemInfoHob.h      : Silicon/AlderlakePkg/Adlp/Include/MemInfoHob.h
   FSP_License.pdf                                             : Silicon/AlderlakePkg/Adlp/FspBin/FSP_License.pdf
   AlderLakeFspBinPkg/IoT/AlderLakeP/VBT/VbtAdlP.json          : Platform/AlderlakeBoardPkg/VbtBin/VbtAdlP.json
 # For ADL-PS
@@ -41,6 +43,7 @@
   AlderLakeFspBinPkg/IoT/AlderLakePS/Include/FsptUpd.h                    : Silicon/AlderlakePkg/Adlps/Include/FsptUpd.h
   AlderLakeFspBinPkg/IoT/AlderLakePS/Include/FspmUpd.h                    : Silicon/AlderlakePkg/Adlps/Include/FspmUpd.h
   AlderLakeFspBinPkg/IoT/AlderLakePS/Include/FspsUpd.h                    : Silicon/AlderlakePkg/Adlps/Include/FspsUpd.h
+  AlderLakeFspBinPkg/IoT/AlderLakePS/Include/MemInfoHob.h                 : Silicon/AlderlakePkg/Adlps/Include/MemInfoHob.h
   FSP_License.pdf                                                         : Silicon/AlderlakePkg/Adlps/FspBin/FSP_License.pdf
 # For ADL-N
   AlderLakeFspBinPkg/IoT/AlderLakeN/Fsp.fd                               : Silicon/AlderlakePkg/Adln/FspBin/FspDbg.bin
@@ -50,6 +53,7 @@
   AlderLakeFspBinPkg/IoT/AlderLakeN/Include/FsptUpd.h                    : Silicon/AlderlakePkg/Adln/Include/FsptUpd.h
   AlderLakeFspBinPkg/IoT/AlderLakeN/Include/FspmUpd.h                    : Silicon/AlderlakePkg/Adln/Include/FspmUpd.h
   AlderLakeFspBinPkg/IoT/AlderLakeN/Include/FspsUpd.h                    : Silicon/AlderlakePkg/Adln/Include/FspsUpd.h
+  AlderLakeFspBinPkg/IoT/AlderLakeN/Include/MemInfoHob.h                 : Silicon/AlderlakePkg/Adln/Include/MemInfoHob.h
   FSP_License.pdf                                                        : Silicon/AlderlakePkg/Adln/FspBin/FSP_License.pdf
 # For AZB
   AlderLakeFspBinPkg/IoT/ArizonaBeach/Fsp.fd                             : Silicon/AlderlakePkg/Azb/FspBin/FspDbg.bin


### PR DESCRIPTION
The Silicon\AlderlakePkg\Include\MemInfoHob.h is not updated per platform, so copy the header file from GitHub FSP repo.