### PR TITLE
fix: [Common] Fix debug message to print cpu state

### DIFF
--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
@@ -565,7 +565,7 @@ MpInit (
 
       for (Index = 1; Index < mSysCpuTask.CpuCount; Index++) {
         if (mSysCpuTask.CpuTask[Index].State != EnumCpuReady) {
-          DEBUG ((DEBUG_ERROR, " CPU %2d is not ready yet! State = %d\n", Index,
+          DEBUG ((DEBUG_ERROR, " CPU %2d with APIC ID %d is not ready yet! State = %d\n", Index,
                   mSysCpuInfo.CpuInfo[Index].ApicId, mSysCpuTask.CpuTask[Index].State));
         }
       }


### PR DESCRIPTION
Fixed debug message to print cpu index, APIC ID and cpu state in order.