### PR TITLE
feat: [RPL-S] Increase UEFI payload container size to accommodate PXE.

### DIFF
--- a/Platform/RaptorlakeBoardPkg/BoardConfigRpls.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRpls.py
@@ -116,7 +116,7 @@ class Board(BaseBoard):
         self.STAGE2_FD_SIZE       = 0x001F0000
 
         self.PAYLOAD_SIZE         = 0x00032000
-        self.EPAYLOAD_SIZE        = 0x00180000
+        self.EPAYLOAD_SIZE        = 0x00200000
 
         self.ENABLE_FAST_BOOT = 0
         try:


### PR DESCRIPTION
Increase the size of the UEFI payload container to accommodate increased payload size from Edk2 network driver and UNDI driver.