### PR TITLE
feat: [TGL] Support loading POSC binary

### DIFF
--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -176,6 +176,11 @@ class Board(BaseBoard):
             self.TCC_STREAM_SIZE = 0x00005000
             self.SIIPFW_SIZE += self.TCC_CCFG_SIZE + self.TCC_CRL_SIZE + self.TCC_STREAM_SIZE
 
+        self.ENABLE_PRE_OS_CHECKER = 0
+        if self.ENABLE_PRE_OS_CHECKER:
+            self.POSC_SIZE = 0x00028000
+            self.SIIPFW_SIZE += self.POSC_SIZE
+
         # to enable TSN, set 1 to self.ENABLE_TSN
         self.ENABLE_TSN = 0
         if self.ENABLE_TSN:
@@ -354,6 +359,7 @@ class Board(BaseBoard):
         bins = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'Binaries')
 
         CompFileCrlFw='crl.bin' if os.path.exists(os.path.join(bins, 'crl.bin')) else ''
+        CompFilePreOsChecker='PreOsChecker.bin' if os.path.exists(os.path.join(bins, 'PreOsChecker.bin')) else ''
 
         if self.ENABLE_TCC:
             container_list.append (
@@ -364,6 +370,11 @@ class Board(BaseBoard):
             )
             container_list.append (
               ('TCCT',  '',   'Lz4',   container_list_auth_type,   'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE,    0,   self.TCC_STREAM_SIZE,0),   # TCC Stream Config
+            )
+
+        if self.ENABLE_PRE_OS_CHECKER:
+            container_list.append (
+              ('POSC',CompFilePreOsChecker,      '',     container_list_auth_type,   'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE, 0,   self.POSC_SIZE,      0),   # Pre-OS Checker
             )
 
         if self.ENABLE_TSN:

--- a/Platform/TigerlakeBoardPkg/CfgData/CfgData_BootOption.yaml
+++ b/Platform/TigerlakeBoardPkg/CfgData/CfgData_BootOption.yaml
@@ -10,9 +10,12 @@
 
 - $ACTION      :
     page         : OS
-- !expand { BOOT_OPTION_TMPL : [ 0 ,   0    ,  16 ,    5   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 1 , 0x1F   ,  16 ,    5   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_rtcm' ] }
-- !expand { BOOT_OPTION_TMPL : [ 2 ,   0    ,  16 ,    6   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 3 , 0x1F   ,  16 ,    6   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_rtcm' ] }
-- !expand { BOOT_OPTION_TMPL : [ 4 ,   0    ,  16 ,    0   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 5 , 0x1F   ,  16 ,    0   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_rtcm' ] }
+- !expand { BOOT_OPTION_TMPL : [ 0 ,   0    ,  20 ,    5   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 1 , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
+- !expand { BOOT_OPTION_TMPL : [ 2 , 0x1F   ,  16 ,    5   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_rtcm' ] }
+- !expand { BOOT_OPTION_TMPL : [ 3 ,  0     ,  20 ,    6   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 4 , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
+- !expand { BOOT_OPTION_TMPL : [ 5 , 0x1F   ,  16 ,    6   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_rtcm' ] }
+- !expand { BOOT_OPTION_TMPL : [ 6 ,   0    ,  20 ,    0   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 7 , 0x9E   ,  16 ,    0   ,   0   ,    1  ,     1 ,     1 , '!IPFW/POSC' ] }
+- !expand { BOOT_OPTION_TMPL : [ 8 , 0x1F   ,  16 ,    0   ,   0   ,    0  ,     1 ,     1 , '/boot/sbl_rtcm' ] }

--- a/Platform/TigerlakeBoardPkg/Script/StitchIfwiConfig_tglu.py
+++ b/Platform/TigerlakeBoardPkg/Script/StitchIfwiConfig_tglu.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
+from StitchLoader import *
 
 extra_usage_txt = \
 """This is an IFWI stitch config script for Slim Bootloader For the FIT tool and
@@ -81,6 +82,11 @@ def get_component_replace_list():
        ('IFWI/BIOS/TS1/DACM',      'Input/DiagnosticAcm.bin',          'dummy',   ''),
        ]
 
+    # need to set ENABLE_PRE_OS_CHECKER = 1 in BoardConfig.py
+    if os.path.exists('IPFW/PreOsChecker.bin'):
+        replace_list.append (
+            ('IFWI/BIOS/NRD/IPFW/POSC', 'IPFW/PreOsChecker.bin',   'dummy',  'KEY_ID_CONTAINER_COMP_RSA3072', 0 ), # Pre-OS Checker
+        )
     return replace_list
 
 def check_parameter(para_list):


### PR DESCRIPTION
1. Enable the self.ENABLE_PRE_OS_CHECKER in Platform/TigerlakeBoardPkg/BoardConfig.py
2. Put the POSC binary in Platform/TigerlakeBoardPkg/Binaries/PreOsChecker.bin It will stitch in the SBL binary.
3. Assign the boot flag in dlt file: 
  BOOT_OPTION_CFG_DATA_0.BootFlags_0 | 20 
  BOOT_OPTION_CFG_DATA_2.BootFlags_2 | 20 
  BOOT_OPTION_CFG_DATA_4.BootFlags_4 | 20 
During booting, system will load POSC before enter kernel.