### PR TITLE
[ADLP] support CPU PCIe 1x8 for H-series CPU

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -453,7 +453,7 @@ BoardInit (
     Status = PcdSet32S (PcdFuncCpuInitHook, (UINT32)(UINTN) PlatformCpuInit);
 #if !FixedPcdGetBool(PcdAzbSupport)
     if (PcdGetBool (PcdFastBootEnabled) == FALSE) {
-      if (IsPchS ()) {
+      if (IsPchS () || IsPchP()) {
         Status = HsPhyLoadAndInit ();
         if (EFI_ERROR (Status)) {
           DEBUG ((DEBUG_WARN, "HsPhyInit failure, %r\n", Status));


### PR DESCRIPTION
The CPU PCIe 1x8 (B0:D1.F0) requres HsPhy.

Verified: H-series CPU (ADL-P 4+4+2 45W) on ADL-P RVP