### PR TITLE
feat: Validate BMP headers to protect against LogoFAIL.

### DIFF
--- a/BootloaderCommonPkg/Include/Library/GraphicsLib.h
+++ b/BootloaderCommonPkg/Include/Library/GraphicsLib.h
@@ -1,7 +1,7 @@
 /** @file
   Basic graphics rendering support
 
-  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2024, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -101,6 +101,7 @@ GetBmpDisplayPos (
   buffer. Otherwise, it will be dispalyed into the actual frame buffer.
 
   @param  BmpImage      Pointer to BMP file
+  @param  BmpImageSize  Size of BMP file
   @param  GopBlt        Buffer for transferring BmpImage to the BLT memory buffer.
   @param  GopBltSize    Size of GopBlt in bytes.
   @param  GfxInfoHob    Pointer to graphics info HOB.
@@ -114,10 +115,11 @@ GetBmpDisplayPos (
 EFI_STATUS
 EFIAPI
 DisplayBmpToFrameBuffer (
-  IN  VOID      *BmpImage,
-  IN  VOID      *GopBlt,
-  IN  UINTN      GopBltSize,
-  IN  EFI_PEI_GRAPHICS_INFO_HOB *GfxInfoHob
+  IN     VOID      *BmpImage,
+  IN     UINT32    BmpImageSize,
+  IN     VOID      *GopBlt,
+  IN     UINTN     GopBltSize,
+  IN     EFI_PEI_GRAPHICS_INFO_HOB *GfxInfoHob
   );
 
 /**

--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -1,7 +1,7 @@
 ## @file
 # Provides bootloader driver related package definitions.
 #
-# Copyright (c) 2016 - 2023, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2024, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -197,7 +197,8 @@
   gPlatformModuleTokenSpaceGuid.PcdCfgDataIntBase         | 0xFF000000 | UINT32 | 0x20000182
   gPlatformModuleTokenSpaceGuid.PcdDeviceTreeBase         | 0xFF000000 | UINT32 | 0x20000183
   gPlatformModuleTokenSpaceGuid.PcdSplashLogoAddress      | 0xFF000000 | UINT32 | 0x20000184
-  gPlatformModuleTokenSpaceGuid.PcdFileDataBase           | 0xFF000000 | UINT32 | 0x20000185
+  gPlatformModuleTokenSpaceGuid.PcdSplashLogoSize         | 0xFFFFFFFF | UINT32 | 0x20000185
+  gPlatformModuleTokenSpaceGuid.PcdFileDataBase           | 0xFF000000 | UINT32 | 0x20000186
   gPlatformModuleTokenSpaceGuid.PcdVerInfoBase            | 0xFF000000 | UINT32 | 0x20000190
   gPlatformModuleTokenSpaceGuid.PcdCfgDataLoadSource      | 0x00000002 | UINT32 | 0x20000194
   gPlatformModuleTokenSpaceGuid.PcdPayloadReservedMemSize | 0x00004000 | UINT32 | 0x20000195

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -1,7 +1,7 @@
 ## @file
 # Provides driver and definitions to build bootloader.
 #
-# Copyright (c) 2016 - 2023, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2024, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -282,6 +282,7 @@
   gPlatformModuleTokenSpaceGuid.PcdVerInfoBase       | 0xFF000000
   gPlatformModuleTokenSpaceGuid.PcdFileDataBase      | 0xFF000000
   gPlatformModuleTokenSpaceGuid.PcdSplashLogoAddress | 0xFF000000
+  gPlatformModuleTokenSpaceGuid.PcdSplashLogoSize    | 0xFFFFFFFF
   gPlatformModuleTokenSpaceGuid.PcdCfgDataIntBase    | 0xFF000000
   gPlatformCommonLibTokenSpaceGuid.PcdEmmcMaxRwBlockNumber     | 0xFFFF
   gPlatformModuleTokenSpaceGuid.PcdPayloadReservedMemSize | $(PLD_RSVD_MEM_SIZE)

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiBgrt.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiBgrt.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2019 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019 - 2024, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -102,7 +102,7 @@ UpdateBgrt (
       BmpHdr->ImageSize = 0;
       BmpHdr->NumberOfColors  = 0;
       BmpHdr->ImportantColors = 0;
-      Status = DisplayBmpToFrameBuffer (OrgBmpHdr, &BmpHdr[1], ImageLen, GfxInfoHob);
+      Status = DisplayBmpToFrameBuffer (OrgBmpHdr, PcdGet32(PcdSplashLogoSize), &BmpHdr[1], ImageLen, GfxInfoHob);
       if (!EFI_ERROR(Status)) {
         Bgrt->ImageAddress = (UINTN)BmpHdr;
       }

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2017 - 2019, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2017 - 2024, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -61,6 +61,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdLowestSupportedFwVer
   gPlatformModuleTokenSpaceGuid.PcdLegacyEfSegmentEnabled
   gPlatformModuleTokenSpaceGuid.PcdSplashLogoAddress
+  gPlatformModuleTokenSpaceGuid.PcdSplashLogoSize
   gPlatformModuleTokenSpaceGuid.PcdSplashEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdCpuX2ApicEnabled
   gPlatformModuleTokenSpaceGuid.PcdAcpiTableTemplatePtr

--- a/BootloaderCorePkg/Stage2/Stage2.inf
+++ b/BootloaderCorePkg/Stage2/Stage2.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2016 - 2023, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2016 - 2024, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -134,6 +134,7 @@
   gPlatformModuleTokenSpaceGuid.PcdFlashSize
   gPlatformModuleTokenSpaceGuid.PcdSplashEnabled
   gPlatformModuleTokenSpaceGuid.PcdSplashLogoAddress
+  gPlatformModuleTokenSpaceGuid.PcdSplashLogoSize
   gPlatformModuleTokenSpaceGuid.PcdOsBootOptionNumber
   gPlatformModuleTokenSpaceGuid.PcdServiceNumber
   gPlatformModuleTokenSpaceGuid.PcdFlashBaseAddress

--- a/BootloaderCorePkg/Stage2/Stage2Support.c
+++ b/BootloaderCorePkg/Stage2/Stage2Support.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2016 - 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2016 - 2024, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -94,6 +94,7 @@ DisplaySplash (
 {
   EFI_STATUS                           Status;
   VOID                                *SplashLogoBmp;
+  UINT32                              SplashLogoBmpSize;
   EFI_PEI_GRAPHICS_INFO_HOB           *GfxInfoHob;
 
   // Get framebuffer info
@@ -104,8 +105,10 @@ DisplaySplash (
 
   // Convert image from BMP format and write to frame buffer
   SplashLogoBmp = (VOID *)(UINTN)PCD_GET32_WITH_ADJUST (PcdSplashLogoAddress);
+  SplashLogoBmpSize = PcdGet32(PcdSplashLogoSize);
   ASSERT (SplashLogoBmp != NULL);
-  Status = DisplayBmpToFrameBuffer (SplashLogoBmp, NULL, 0, GfxInfoHob);
+  ASSERT (SplashLogoBmpSize != 0);
+  Status = DisplayBmpToFrameBuffer (SplashLogoBmp, SplashLogoBmpSize, NULL, 0, GfxInfoHob);
 
   return Status;
 }

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -2,7 +2,7 @@
 ## @ BuildLoader.py
 # Build bootloader main script
 #
-# Copyright (c) 2016 - 2023, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2024, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 
 ##
@@ -733,9 +733,10 @@ class Build(object):
                 "<Stage2:__gPcd_BinaryPatch_PcdAcpiTablesAddress>, {7E374E25-8E01-4FEE-87F2-390C23C606CD:0x1C}, @Patch ACPI",
             )
         if self._board.ENABLE_SPLASH:
-            extra_cmd.append (
-                "<Stage2:__gPcd_BinaryPatch_PcdSplashLogoAddress>, {5E2D3BE9-AD72-4D1D-AAD5-6B08AF921590:0x1C}, @Patch Logo",
-            )
+            extra_cmd.extend ([
+                "<Stage2:__gPcd_BinaryPatch_PcdSplashLogoAddress>, {5E2D3BE9-AD72-4D1D-AAD5-6B08AF921590:0x1C}, @Patch Logo Address",
+                "<Stage2:__gPcd_BinaryPatch_PcdSplashLogoSize>, ([5E2D3BE9-AD72-4D1D-AAD5-6B08AF921590:0x14] & 0xFFFFFF) - 0x1C, @Patch Logo Size",
+            ])
         patch_fv(
             self._fv_dir,
             "STAGE2:STAGE2",


### PR DESCRIPTION
The SBL logo is verified as part of Stage2 verification, so untrusted logos won't be parsed, but it's still good to prevent dereferencing BMP header pointers that may fall outside of BMP file.