### PR TITLE
[RPLS] Update FSP/ucode for MR2 release

### DIFF
--- a/Platform/RaptorlakeBoardPkg/BoardConfigRpls.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRpls.py
@@ -1,7 +1,7 @@
 ## @file
 # This file is used to provide board specific image information.
 #
-#  Copyright (c) 2021 - 2023, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2021 - 2024, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -23,7 +23,7 @@ class Board(BaseBoard):
         super(Board, self).__init__(*args, **kwargs)
 
         self.VERINFO_IMAGE_ID     = 'SB_RPLS'
-        self.VERINFO_PROJ_MAJOR_VER = 1
+        self.VERINFO_PROJ_MAJOR_VER = 2
         self.VERINFO_PROJ_MINOR_VER = 1
         self.VERINFO_SVN            = 1
         self.VERINFO_BUILD_DATE     = time.strftime("%m/%d/%Y")

--- a/Platform/RaptorlakeBoardPkg/Rpls/Fsp/FspBinRpls.inf
+++ b/Platform/RaptorlakeBoardPkg/Rpls/Fsp/FspBinRpls.inf
@@ -1,7 +1,7 @@
 ## @file
 #  File to describe FSP repo information
 #
-#  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2024, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -11,7 +11,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = 5030738932bca45dabad337d90da832f5a1431b5
+  COMMIT  = 43f7092a6156ace79a13e7c8793ce8578f69b216
 
 [UserExtensions.SBL."CopyList"]
 # For RPL-S
@@ -22,6 +22,7 @@
   RaptorLakeFspBinPkg/IoT/RaptorLakeS/Include/FsptUpd.h                  : Platform/RaptorlakeBoardPkg/Rpls/Fsp/FsptUpd.h
   RaptorLakeFspBinPkg/IoT/RaptorLakeS/Include/FspmUpd.h                  : Platform/RaptorlakeBoardPkg/Rpls/Fsp/FspmUpd.h
   RaptorLakeFspBinPkg/IoT/RaptorLakeS/Include/FspsUpd.h                  : Platform/RaptorlakeBoardPkg/Rpls/Fsp/FspsUpd.h
+  RaptorLakeFspBinPkg/IoT/RaptorLakeS/Include/MemInfoHob.h               : Platform/RaptorlakeBoardPkg/Rpls/Fsp/MemInfoHob.h
   RaptorLakeFspBinPkg/IoT/RaptorLakeS/Vbt/Vbt.bin                        : Platform/RaptorlakeBoardPkg/VbtBin/Vbt_rpls.dat
   RaptorLakeFspBinPkg/IoT/RaptorLakeS/Vbt/Vbt.json                       : Platform/RaptorlakeBoardPkg/VbtBin/Vbt.json
   FSP_License.pdf                                                        : Platform/RaptorlakeBoardPkg/Rpls/Fsp/FSP_License.pdf

--- a/Platform/RaptorlakeBoardPkg/Rpls/Microcode/MicrocodeRpls.inf
+++ b/Platform/RaptorlakeBoardPkg/Rpls/Microcode/MicrocodeRpls.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2020 - 2021, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2024, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 #
@@ -14,13 +14,13 @@
   VERSION_STRING       = 1.0
 
 [Sources]
-  m_32_b0671_0000010f.mcb  # RPL-S B0
+  m_32_b0671_0000011f.mcb  # RPL-S B0
   m_07_90672_0000002c.mcb  # ADLS  C0
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
-  COMMIT = 52e6bae7920f4f443ca860ed9726cf97caf9c368
+  COMMIT = 6b1adfb9b19c9f8830c614348ab11feee6eb8c68
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/RaptorLake/m_32_b0671_0000010f.pdb  : Platform/RaptorlakeBoardPkg/Rpls/Microcode/m_32_b0671_0000010f.mcb
+  Microcode/RaptorLake/m_32_b0671_0000011f.pdb  : Platform/RaptorlakeBoardPkg/Rpls/Microcode/m_32_b0671_0000011f.mcb
   Microcode/RaptorLake/m_07_90672_0000002c.pdb  : Platform/RaptorlakeBoardPkg/Rpls/Microcode/m_07_90672_0000002c.mcb


### PR DESCRIPTION
- update FSP version to IoT RPLS MR2 (0C00C650)
- Update platform version to 1.2
- Update ucode to 11f
- 
Signed-off-by: Randy <randy.lin@intel.com>