### PR TITLE
fix:[MTL-P] Fixed S0ix on MTL-P

### DIFF
--- a/Platform/MeteorlakeBoardPkg/AcpiTables/Dsdt/Pep.asl
+++ b/Platform/MeteorlakeBoardPkg/AcpiTables/Dsdt/Pep.asl
@@ -1,7 +1,7 @@
 /** @file
   ACPI uPEP Support
 
-  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2023-2024, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -18,6 +18,12 @@ External(\_SB.PC00.SPIF.SPIS)
 External(SPCO,MethodObj)
 External(\_SB.PC00.RP01.DL23, MethodObj)
 External(\_SB.PC00.RP01.L23D, MethodObj)
+External(\_SB.PC00.RP09.DL23, MethodObj)
+External(\_SB.PC00.RP09.L23D, MethodObj)
+External(\_SB.PC00.RP10.DL23, MethodObj)
+External(\_SB.PC00.RP10.L23D, MethodObj)
+External(\_SB.PC00.RP11.DL23, MethodObj)
+External(\_SB.PC00.RP11.L23D, MethodObj)
 External (TMCS, IntObj)
 
 External(THCE) // TCSS XHCI Device Enable
@@ -710,9 +716,31 @@ Scope(\_SB)
             // call method specific to CS platforms when the system is in a
             // standby state with very limited SW activities
             \_SB.PC00.RP01.DL23()
-            Store(0x14040B, Index(RSTG, 0))
+            Store(0x141082, Index(RSTG, 0))
             Store(0x0, Index(RSTG, 1))
-            Store(0x14080B, Index(PWRG, 0))
+            Store(0x141085, Index(PWRG, 0))
+            Store(0x1, Index(PWRG, 1))
+            \PIN.ON(RSTG)
+            \_SB.PSD3 (1)
+            SPCO(0, 0)
+            \PIN.OFF (PWRG)
+            \_SB.SHPO (0, 0)
+
+            \_SB.PC00.RP09.DL23()
+            Store(0x14040D, Index(RSTG, 0))
+            Store(0x0, Index(RSTG, 1))
+            Store(0x141081, Index(PWRG, 0))
+            Store(0x1, Index(PWRG, 1))
+            \PIN.ON(RSTG)
+            \_SB.PSD3 (1)
+            SPCO(0, 0)
+            \PIN.OFF (PWRG)
+            \_SB.SHPO (0, 0)
+
+            \_SB.PC00.RP11.DL23()
+            Store(0x14040E, Index(RSTG, 0))
+            Store(0x0, Index(RSTG, 1))
+            Store(0x141086, Index(PWRG, 0))
             Store(0x1, Index(PWRG, 1))
             \PIN.ON(RSTG)
             \_SB.PSD3 (1)
@@ -750,9 +778,9 @@ Scope(\_SB)
           If (LEqual (S0ID, 1)) { //S0ID: >=1: CS 0: non-CS
             // call method specific to CS platforms when the system is in a
             // standby state with very limited SW activities
-            Store(0x14040B, Index(RSTG, 0))
+            Store(0x141082, Index(RSTG, 0))
             Store(0x0, Index(RSTG, 1))
-            Store(0x14080B, Index(PWRG, 0))
+            Store(0x140805, Index(PWRG, 0))
             Store(0x1, Index(PWRG, 1))
             \_SB.SHPO (0, 1)
             \_SB.CAGS (0)
@@ -762,6 +790,32 @@ Scope(\_SB)
             SPCO(0, 1)
             \PIN.OFF (RSTG)
             \_SB.PC00.RP01.L23D()
+
+            Store(0x14040D, Index(RSTG, 0))
+            Store(0x0, Index(RSTG, 1))
+            Store(0x141081, Index(PWRG, 0))
+            Store(0x1, Index(PWRG, 1))
+            \_SB.SHPO (0, 1)
+            \_SB.CAGS (0)
+            \_SB.PSD0 (1)
+            \PIN.ON (PWRG)
+            Sleep (PEP0)
+            SPCO(0, 1)
+            \PIN.OFF (RSTG)
+            \_SB.PC00.RP09.L23D()
+
+            Store(0x14040E, Index(RSTG, 0))
+            Store(0x0, Index(RSTG, 1))
+            Store(0x141086, Index(PWRG, 0))
+            Store(0x1, Index(PWRG, 1))
+            \_SB.SHPO (0, 1)
+            \_SB.CAGS (0)
+            \_SB.PSD0 (1)
+            \PIN.ON (PWRG)
+            Sleep (PEP0)
+            SPCO(0, 1)
+            \PIN.OFF (RSTG)
+            \_SB.PC00.RP11.L23D()
             \GUAM (0) // 0x00 - Power State On (CS Resiliency Exit)
           }
           // Call method to notify EC of Idle Resiliency exit

--- a/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020 - 2024, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -1699,39 +1699,39 @@ PlatformUpdateAcpiGnvs (
   PlatformNvs->PL1LimitCS = 0;
   PlatformNvs->PL1LimitCSValue = 4500;
 
-  PlatformNvs->PcieSlot1WakeGpio = GPIOV2_MTL_SOC_M_GPP_F19;
-  PlatformNvs->PcieSlot1RpNumber = 6;
-  PlatformNvs->PcieSlot1PowerEnableGpio = GPIOV2_MTL_SOC_M_GPP_D3;
+  PlatformNvs->PcieSlot1WakeGpio = 0;
+  PlatformNvs->PcieSlot1RpNumber = 0;
+  PlatformNvs->PcieSlot1PowerEnableGpio = 0;
   PlatformNvs->PcieSlot1PowerEnableGpioPolarity = 0;
-  PlatformNvs->PcieSlot1RstGpio = GPIOV2_MTL_SOC_M_GPP_A20;
+  PlatformNvs->PcieSlot1RstGpio = 0;
   PlatformNvs->PcieSlot1RstGpioPolarity = 0;
 
   PlatformNvs->PcieSlot2WakeGpio = 0;
-  PlatformNvs->PcieSlot2RpNumber = 15;
+  PlatformNvs->PcieSlot2RpNumber = 0;
   PlatformNvs->PcieSlot2PowerEnableGpio = 0;
   PlatformNvs->PcieSlot2PowerEnableGpioPolarity = 0;
   PlatformNvs->PcieSlot2RstGpio = 0;
   PlatformNvs->PcieSlot2RstGpioPolarity = 0;
 
-  PlatformNvs->PcieSlot3WakeGpio = 0;
-  PlatformNvs->PcieSlot3RpNumber = 0;
-  PlatformNvs->PcieSlot3PowerEnableGpio = 0;
-  PlatformNvs->PcieSlot3PowerEnableGpioPolarity = 0;
-  PlatformNvs->PcieSlot3RstGpio = 0;
+  PlatformNvs->PcieSlot3WakeGpio = GPIOV2_MTL_SOC_M_GPP_C2;
+  PlatformNvs->PcieSlot3RpNumber = 6;
+  PlatformNvs->PcieSlot3PowerEnableGpio = GPIOV2_MTL_SOC_M_GPP_A18;
+  PlatformNvs->PcieSlot3PowerEnableGpioPolarity = 1;
+  PlatformNvs->PcieSlot3RstGpio = GPIOV2_MTL_SOC_M_GPP_A19;
   PlatformNvs->PcieSlot3RstGpioPolarity = 0;
 
-  PlatformNvs->PcieSlot4WakeGpio = 0;
-  PlatformNvs->PcieSlot4RpNumber = 0;
-  PlatformNvs->PcieSlot4PowerEnableGpio = 0;
+  PlatformNvs->PcieSlot4WakeGpio = GPIOV2_MTL_SOC_M_GPP_F20;
+  PlatformNvs->PcieSlot4RpNumber = 15;
+  PlatformNvs->PcieSlot4PowerEnableGpio = GPIOV2_MTL_SOC_M_GPP_D3;
   PlatformNvs->PcieSlot4PowerEnableGpioPolarity = 0;
-  PlatformNvs->PcieSlot4RstGpio = 0;
+  PlatformNvs->PcieSlot4RstGpio = GPIOV2_MTL_SOC_M_GPP_B9;
   PlatformNvs->PcieSlot4RstGpioPolarity = 0;
 
-  PlatformNvs->PcieSlot5WakeGpio = 0;
+  PlatformNvs->PcieSlot5WakeGpio = GPIOV2_MTL_SOC_M_GPP_F19;
   PlatformNvs->PcieSlot5RpNumber = 0;
-  PlatformNvs->PcieSlot5PowerEnableGpio = 0;
-  PlatformNvs->PcieSlot5PowerEnableGpioPolarity = 0;
-  PlatformNvs->PcieSlot5RstGpio = 0;
+  PlatformNvs->PcieSlot5PowerEnableGpio = GPIOV2_MTL_SOC_M_GPP_B15;
+  PlatformNvs->PcieSlot5PowerEnableGpioPolarity = 1;
+  PlatformNvs->PcieSlot5RstGpio = GPIOV2_MTL_SOC_M_GPP_A20;
   PlatformNvs->PcieSlot5RstGpioPolarity = 0;
 
   PlatformNvs->PcieSlot6WakeGpio = 0;
@@ -1752,19 +1752,19 @@ PlatformUpdateAcpiGnvs (
   PlatformNvs->WlanRstGpio = GPIOV2_MTL_SOC_M_GPP_H2;
   PlatformNvs->WlanRootPortNumber = 8;
 
-  PlatformNvs->M2Ssd1PowerEnableGpio = GPIOV2_MTL_SOC_M_GPP_H11;
+  PlatformNvs->M2Ssd1PowerEnableGpio = GPIOV2_MTL_SOC_M_GPP_D5;
   PlatformNvs->M2Ssd1PowerEnableGpioPolarity = 1;
-  PlatformNvs->M2Ssd1RstGpio = GPIOV2_MTL_SOC_M_GPP_A11;
+  PlatformNvs->M2Ssd1RstGpio = GPIOV2_MTL_SOC_M_GPP_D2;
   PlatformNvs->M2Ssd1RstGpioPolarity = 0;
 
-  PlatformNvs->M2Ssd2PowerEnableGpio = GPIOV2_MTL_SOC_M_GPP_F5;
+  PlatformNvs->M2Ssd2PowerEnableGpio = GPIOV2_MTL_SOC_M_GPP_D1;
   PlatformNvs->M2Ssd2PowerEnableGpioPolarity = 1;
-  PlatformNvs->M2Ssd2RstGpio = GPIOV2_MTL_SOC_M_GPP_F20;
+  PlatformNvs->M2Ssd2RstGpio = GPIOV2_MTL_SOC_M_GPP_A13;
   PlatformNvs->M2Ssd2RstGpioPolarity = 0;
 
-  PlatformNvs->M2Ssd3PowerEnableGpio = GPIOV2_MTL_SOC_M_GPP_B15;
-  PlatformNvs->M2Ssd3PowerEnableGpioPolarity = 1;
-  PlatformNvs->M2Ssd3RstGpio = GPIOV2_MTL_SOC_M_GPP_A20;
+  PlatformNvs->M2Ssd3PowerEnableGpio = 0;
+  PlatformNvs->M2Ssd3PowerEnableGpioPolarity = 0;
+  PlatformNvs->M2Ssd3RstGpio = 0;
   PlatformNvs->M2Ssd3RstGpioPolarity = 0;
 
   PlatformNvs->M2Ssd4PowerEnableGpio = GPIOV2_MTL_SOC_M_GPP_D6;


### PR DESCRIPTION
1) Updated NVS value to match with MTL-P BIOS
2) Nvme device causing S0ix to fail. Added workaround in Pep.asl to
   power off NVME related root port (RP01, RP09 and RP11)