### PR TITLE
[MTL Test SKU] Resolve MPInit hang

### DIFF
--- a/BootloaderCommonPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.c
+++ b/BootloaderCommonPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.c
@@ -276,6 +276,7 @@ SendIpi (
     //
     MsrValue = LShiftU64 ((UINT64) ApicId, 32) | IcrLow;
     AsmWriteMsr64 (X2APIC_MSR_ICR_ADDRESS, MsrValue);
+    MicroSecondDelay (100);
   }
 }
 


### PR DESCRIPTION
Resolve a hard hang seen during boot when X2APIC is enabled.