### PR TITLE
feat: [TGL] add ResetSystemLib (#2118)

### DIFF
--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -1,7 +1,7 @@
 ## @file
 # This file is used to provide board specific image information.
 #
-#  Copyright (c) 2018 - 2023, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2018 - 2024, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -277,6 +277,7 @@ class Board(BaseBoard):
             'PchP2sbLib|Silicon/$(PCH_PKG_NAME)/Library/PchP2sbLib/PchP2sbLib.inf',
             'PchSbiAccessLib|Silicon/CommonSocPkg/Library/PchSbiAccessLib/PchSbiAccessLib.inf',
             'PlatformHookLib|Silicon/$(SILICON_PKG_NAME)/Library/PlatformHookLib/PlatformHookLib.inf',
+            'ResetSystemLib|Platform/$(BOARD_PKG_NAME)/Library/ResetSystemLib/ResetSystemLib.inf',
             'TccLib|Silicon/CommonSocPkg/Library/TccLib/TccLib.inf',
             'PchSpiLib|Silicon/CommonSocPkg/Library/PchSpiLib/PchSpiLib.inf',
             'SpiFlashLib|Silicon/CommonSocPkg/Library/SpiFlashLib/SpiFlashLib.inf',

--- a/Platform/TigerlakeBoardPkg/Library/ResetSystemLib/ResetSystemLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/ResetSystemLib/ResetSystemLib.c
@@ -1,0 +1,149 @@
+/** @file
+  Reset System Library
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/IoLib.h>
+#include <Library/ResetSystemLib.h>
+#include <Library/PcdLib.h>
+#include <Register/PmcRegs.h>
+#include <PchAccess.h>
+#include <FspEas/FspApi.h>
+#include <PlatformBase.h>
+
+//
+// Reset Control Register
+//
+#define R_RST_CNT                     0xCF9 ///< Reset Control
+#define V_RST_CNT_FULLRESET           0x0E
+#define V_RST_CNT_HARDRESET           0x06
+
+
+/**
+  Calling this function causes a system-wide reset. This sets
+  all circuitry within the system to its initial state. This type of reset
+  is asynchronous to system operation and operates without regard to
+  cycle boundaries.
+
+  System reset should not return, if it returns, it means the system does
+  not support cold reset.
+**/
+VOID
+ResetCold (
+  VOID
+  )
+{
+  IoWrite8 ((UINTN) R_RST_CNT, V_RST_CNT_FULLRESET);
+}
+
+/**
+  Calling this function causes a system-wide initialization. The processors
+  are set to their initial state, and pending cycles are not corrupted.
+
+  System reset should not return, if it returns, it means the system does
+  not support warm reset.
+**/
+VOID
+ResetWarm (
+  VOID
+  )
+{
+  IoWrite8 ((UINTN) R_RST_CNT, V_RST_CNT_HARDRESET);
+}
+
+/**
+  Calling this function causes the system to enter a power state equivalent
+  to the ACPI G2/S5 or G3 states.
+
+  System shutdown should not return, if it returns, it means the system does
+  not support shut down reset.
+**/
+VOID
+ResetShutdown (
+  VOID
+  )
+{
+  UINT32         Data32;
+  ///
+  /// Firstly, GPE0_EN should be disabled to avoid any GPI waking up the system from S5
+  ///
+  IoWrite32 (ACPI_BASE_ADDRESS + R_ACPI_IO_GPE0_EN_127_96, 0);
+
+  ///
+  /// Secondly, PwrSts register must be cleared
+  ///
+  /// Write a "1" to bit[8] of power button status register at
+  /// (PM_BASE + PM1_STS_OFFSET) to clear this bit
+  ///
+  IoWrite16 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_STS, B_ACPI_IO_PM1_STS_PWRBTN);
+
+  ///
+  /// Finally, transform system into S5 sleep state
+  ///
+  Data32 = IoRead32 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_CNT);
+
+  Data32 = (UINT32) ((Data32 &~(B_ACPI_IO_PM1_CNT_SLP_TYP + B_ACPI_IO_PM1_CNT_SLP_EN)) | V_ACPI_IO_PM1_CNT_S5);
+
+  IoWrite32 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_CNT, Data32);
+
+  Data32 = Data32 | B_ACPI_IO_PM1_CNT_SLP_EN;
+
+  IoWrite32 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_CNT, Data32);
+}
+
+/**
+  Calling this function causes the system to enter a power state for platform specific.
+
+**/
+VOID
+ResetPlatformSpecific (
+  VOID
+  )
+{
+  IoWrite8 ((UINTN) R_RST_CNT, V_RST_CNT_FULLRESET);
+}
+
+/**
+  Resets the entire platform.
+
+  @param[in] ResetType          The type of reset to perform.
+
+**/
+VOID
+EFIAPI
+ResetSystem (
+  IN EFI_RESET_TYPE   ResetType
+  )
+{
+  switch (ResetType) {
+  case EfiResetWarm:
+    ResetWarm ();
+    break;
+
+  case EfiResetCold:
+    ResetCold ();
+    break;
+
+  case EfiResetShutdown:
+    ResetShutdown ();
+    break;
+
+  case EfiResetPlatformSpecific:
+    ResetPlatformSpecific ();
+
+  default:
+    break;
+  }
+
+  //
+  // Coming here, either we are waiting while system reset is in progress
+  // or reset failed and we are in dead loop
+  //
+  CpuDeadLoop();
+}

--- a/Platform/TigerlakeBoardPkg/Library/ResetSystemLib/ResetSystemLib.inf
+++ b/Platform/TigerlakeBoardPkg/Library/ResetSystemLib/ResetSystemLib.inf
@@ -1,0 +1,43 @@
+## @file
+#   Library instance for ResetSystem library class for PCAT systems
+#
+#  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = ResetSystemLib
+  FILE_GUID                      = fb70c204-3f48-4256-a94a-07b43b6dd4da
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = ResetSystemLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 IPF
+#
+
+[Sources]
+  ResetSystemLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+  BootloaderCorePkg/BootloaderCorePkg.dec
+  Silicon/TigerlakePkg/TigerlakePkg.dec
+  Silicon/TigerlakePchPkg/TigerlakePchPkg.dec
+  IntelFsp2Pkg/IntelFsp2Pkg.dec
+
+[LibraryClasses]
+  DebugLib
+  IoLib
+  BaseLib
+
+[Guids]
+  gPlatformModuleTokenSpaceGuid
+
+[Pcd]
+  gPlatformModuleTokenSpaceGuid.PcdFspResetStatus

--- a/Silicon/TigerlakePchPkg/Include/Register/PmcRegs.h
+++ b/Silicon/TigerlakePchPkg/Include/Register/PmcRegs.h
@@ -30,7 +30,7 @@
   - RegisterName:
     Full register name.
 
-  Copyright (c) 1999 - 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 1999 - 2024, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -65,6 +65,7 @@
 #define B_ACPI_IO_PM1_EN_PWRBTN                  BIT8
 
 #define R_ACPI_IO_PM1_CNT                        0x04
+#define B_ACPI_IO_PM1_CNT_SLP_EN                 BIT13
 #define B_ACPI_IO_PM1_CNT_SCI_EN                 BIT0
 #define B_ACPI_IO_PM1_CNT_SLP_TYP                (BIT12 | BIT11 | BIT10)
 #define V_ACPI_IO_PM1_CNT_S0                     0


### PR DESCRIPTION
The patch installs reset handlers for FSP requested reboot.

The implementation of ResetShutdown and ResetPlatformSpecific are different from the common lib (i.e., BootloaderCommonPkg/Library/ResetSystemLib), so it results in a platform-specific implementation.

Verified with Issue #2118.
