### PR TITLE
Revert "fix: [TPM] correcting cfg data and key hash"

### DIFF
--- a/BootloaderCommonPkg/Library/TpmLib/TpmLib.c
+++ b/BootloaderCommonPkg/Library/TpmLib/TpmLib.c
@@ -973,6 +973,7 @@ ExtendStageHash (
   TPMI_ALG_HASH               MbTmpAlgHash;
   UINT8                       *HashPtr;
   RETURN_STATUS               Status;
+  EFI_PLATFORM_FIRMWARE_BLOB  Blob;
 
   //Convert Measured boot Hash Mask to HASH_ALG_TYPE (CryptoLib)
   MbHashType   = GetCryptoHashAlg(PcdGet32(PcdMeasuredBootHashMask));
@@ -1006,9 +1007,12 @@ ExtendStageHash (
                               EV_COMPACT_HASH, sizeof("LinuxLoaderPkg: OS Image"), (UINT8 *)"LinuxLoaderPkg: OS Image");
       } else {
         // Record base and length in event log
+        Blob.BlobBase = (UINT64)(UINTN)CbInfo->CompBuf;
+        Blob.BlobLength = CbInfo->CompLen;
+
         // TPM Extend for Stage components and payloads
         TpmExtendPcrAndLogEvent (0, MbTmpAlgHash, HashPtr,
-                              EV_EFI_PLATFORM_FIRMWARE_BLOB, CbInfo->CompLen, (UINT8 *)CbInfo->CompBuf);
+                              EV_EFI_PLATFORM_FIRMWARE_BLOB, sizeof(Blob), (UINT8 *)&Blob);
       }
     } else {
       DEBUG((DEBUG_INFO, "Stage2 TPM PCR(0) extend failed!! \n"));

--- a/BootloaderCorePkg/Stage1B/Stage1B.c
+++ b/BootloaderCorePkg/Stage1B/Stage1B.c
@@ -676,6 +676,8 @@ ContinueFunc (
   TPMI_ALG_HASH               MbTmpAlgHash;
   HASH_STORE_TABLE            *KeyHashBlob;
   CDATA_BLOB                  *CfgDataBlob;
+  EFI_PLATFORM_FIRMWARE_BLOB  KeyHashFwBlob;
+  EFI_PLATFORM_FIRMWARE_BLOB  CfgDataFwBlob;
 
   Stage1bParam   = (STAGE1B_PARAM *)Context1;
   OldLdrGlobal = (LOADER_GLOBAL_DATA *)Context2;
@@ -723,23 +725,27 @@ ContinueFunc (
         // Extend External Config Data hash
         if (Stage1bParam->ConfigDataHashValid == 1) {
           CfgDataBlob = LdrGlobal->CfgDataPtr;
+          CfgDataFwBlob.BlobBase = (UINT64)(UINTN)CfgDataBlob;
+          CfgDataFwBlob.BlobLength = CfgDataBlob->UsedLength;
           TpmExtendPcrAndLogEvent (1,
                     MbTmpAlgHash,
                     Stage1bParam->ConfigDataHash,
                     EV_PLATFORM_CONFIG_FLAGS,
-                    (UINT32)CfgDataBlob->UsedLength,
-                    (UINT8 *)CfgDataBlob);
+                    sizeof(CfgDataFwBlob),
+                    (UINT8 *)&CfgDataFwBlob);
         }
 
         // Extend Key hash manifest digest
         if (Stage1bParam->KeyHashManifestHashValid == 1) {
           KeyHashBlob = LdrGlobal->HashStorePtr;
+          KeyHashFwBlob.BlobBase = (UINT64)(UINTN)KeyHashBlob;
+          KeyHashFwBlob.BlobLength = KeyHashBlob->UsedLength;
           TpmExtendPcrAndLogEvent (0,
                     MbTmpAlgHash,
                     Stage1bParam->KeyHashManifestHash,
                     EV_EFI_PLATFORM_FIRMWARE_BLOB,
-                    (UINT32)KeyHashBlob->UsedLength,
-                    (UINT8 *)KeyHashBlob);
+                    sizeof(KeyHashFwBlob),
+                    (UINT8 *)&KeyHashFwBlob);
         }
     }
   }


### PR DESCRIPTION
This reverts commit 2f277eb9f1bacac9e51b705e81dd1fde3c41d44d.