### PR TITLE
fix: [MTL] fix coverity issues

### DIFF
--- a/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/LowPowerSupport.c
+++ b/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/LowPowerSupport.c
@@ -274,8 +274,6 @@ UINT64 GetLowPowerS0IdleConstraint(VOID)
                                ((PepSerialIoI2c[3] && PepConfigData->PepI2c3)                          << 6) | // En/Dis BIT[6] I2C3
                                ((PepSerialIoI2c[4] && PepConfigData->PepI2c4)                          << 7) | // En/Dis BIT[7] I2C4
                                ((PepSerialIoI2c[5] && PepConfigData->PepI2c5)                          << 8) | // En/Dis BIT[8] I2C5
-                               ((UINT64)(PepSerialIoI2c[6] && PepConfigData->PepI2c6)                  << 9) | // En/Dis BIT[9] I2C6
-                               ((UINT64)(PepSerialIoI2c[7] && PepConfigData->PepI2c7)                  << 10) |  // En/Dis BIT[10] I2C7
                                ((PepSerialIoSpi[0] && PepConfigData->PepSpi)                           << 11) | // En/Dis BIT[11] SPI0
                                ((PepSerialIoSpi[1] && PepConfigData->PepSpi)                           << 12) | // En/Dis BIT[12] SPI1
                                ((PepSerialIoSpi[2] && PepConfigData->PepSpi)                           << 13) | // En/Dis BIT[13] SPI2

--- a/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1035,34 +1035,6 @@ PlatformUpdateAcpiTable (
     GlobalNvs->PchNvs.NHLA[0]  = (UINT64)(UINTN) Table;
     GlobalNvs->PchNvs.NHLL[0]  = Table->Length;
     DEBUG ((DEBUG_INFO, "NHLT Base 0x%08X, Size 0x%08X\n", (UINT32)(UINTN)GlobalNvs->PchNvs.NHLA[0], GlobalNvs->PchNvs.NHLL[0]));
-  } else if (Table->Signature == NhltSignaturesTable[1]) {
-    GlobalNvs->PchNvs.NHLA[1]  = (UINT64)(UINTN) Table;
-    GlobalNvs->PchNvs.NHLL[1]  = Table->Length;
-    DEBUG ((DEBUG_INFO, "NHL1 Base 0x%08X, Size 0x%08X\n", (UINT32)(UINTN)GlobalNvs->PchNvs.NHLA[1], GlobalNvs->PchNvs.NHLL[1]));
-  }else if (Table->Signature == NhltSignaturesTable[2]) {
-    GlobalNvs->PchNvs.NHLA[2]  = (UINT64)(UINTN) Table;
-    GlobalNvs->PchNvs.NHLL[2]  = Table->Length;
-    DEBUG ((DEBUG_INFO, "NHL2 Base 0x%08X, Size 0x%08X\n", (UINT32)(UINTN)GlobalNvs->PchNvs.NHLA[2], GlobalNvs->PchNvs.NHLL[2]));
-  }else if (Table->Signature == NhltSignaturesTable[3]) {
-    GlobalNvs->PchNvs.NHLA[3]  = (UINT64)(UINTN) Table;
-    GlobalNvs->PchNvs.NHLL[3]  = Table->Length;
-    DEBUG ((DEBUG_INFO, "NHL3 Base 0x%08X, Size 0x%08X\n", (UINT32)(UINTN)GlobalNvs->PchNvs.NHLA[3], GlobalNvs->PchNvs.NHLL[3]));
-  }else if (Table->Signature == NhltSignaturesTable[4]) {
-    GlobalNvs->PchNvs.NHLA[4]  = (UINT64)(UINTN) Table;
-    GlobalNvs->PchNvs.NHLL[4]  = Table->Length;
-    DEBUG ((DEBUG_INFO, "NHL4 Base 0x%08X, Size 0x%08X\n", (UINT32)(UINTN)GlobalNvs->PchNvs.NHLA[4], GlobalNvs->PchNvs.NHLL[4]));
-  }else if (Table->Signature == NhltSignaturesTable[5]) {
-    GlobalNvs->PchNvs.NHLA[5]  = (UINT64)(UINTN) Table;
-    GlobalNvs->PchNvs.NHLL[5]  = Table->Length;
-    DEBUG ((DEBUG_INFO, "NHL5 Base 0x%08X, Size 0x%08X\n", (UINT32)(UINTN)GlobalNvs->PchNvs.NHLA[5], GlobalNvs->PchNvs.NHLL[5]));
-  }else if (Table->Signature == NhltSignaturesTable[6]) {
-    GlobalNvs->PchNvs.NHLA[6]  = (UINT64)(UINTN) Table;
-    GlobalNvs->PchNvs.NHLL[6]  = Table->Length;
-    DEBUG ((DEBUG_INFO, "NHL6 Base 0x%08X, Size 0x%08X\n", (UINT32)(UINTN)GlobalNvs->PchNvs.NHLA[6], GlobalNvs->PchNvs.NHLL[6]));
-  }else if (Table->Signature == NhltSignaturesTable[7]) {
-    GlobalNvs->PchNvs.NHLA[7]  = (UINT64)(UINTN) Table;
-    GlobalNvs->PchNvs.NHLL[7]  = Table->Length;
-    DEBUG ((DEBUG_INFO, "NHL7 Base 0x%08X, Size 0x%08X\n", (UINT32)(UINTN)GlobalNvs->PchNvs.NHLA[7], GlobalNvs->PchNvs.NHLL[7]));
   }else if (Table->OemTableId == SIGNATURE_64 ('C', 'p', 'u', 'S', 's', 'd', 't', 0)) {
       DEBUG ((DEBUG_INFO, "Updated CPUSSDT Table in AcpiTable Entries\n"));
       PatchCpuSsdtTable (Table, GlobalNvs);


### PR DESCRIPTION
Size of PepSerialIoI2c array is 6 and NHLT table is 1 
Hence, removing cases where its possible to access out of bound index