### PR TITLE
OsLoader: Mark multiboot module extra image as ran after appended

### DIFF
--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -1076,6 +1076,7 @@ SetupBootImages (
           (LoadedExtraImage->Flags & LOADED_IMAGE_MBMODULE)) {
         DEBUG ((DEBUG_INFO, "SetupBootImage Append ImageType-%d\n", Type));
         AppendMultibootModules (LoadedImage, LoadedExtraImage);
+        LoadedExtraImage->Flags |= LOADED_IMAGE_RUN_EXTRA;
       }
     }
   }


### PR DESCRIPTION
A multiboot module extra image is appended to boot image and never runs. So mark it as ran after appended. This elimates the "Extra image not loaded, or need pass it to OS in boot parameter" warning.