### PR TITLE
fix: [Stage1B] Extending correct cfg data and hash length in tpm

### DIFF
--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
@@ -868,7 +868,7 @@ LoadComponentWithCallback (
       // Update component Call back info after authenticaton is done
       // This info will used by firmware stage to extend to TPM
       CbInfo.ComponentType    = ComponentId;
-      CbInfo.CompBuf          = CompBuf;
+      CbInfo.CompBuf          = CompData;
       CbInfo.CompLen          = SignedDataLen;
       CbInfo.HashAlg          = GetHashAlg(AuthType);
       CbInfo.HashData         = HashData;

--- a/BootloaderCorePkg/IncludePrivate/BootloaderCoreGlobal.h
+++ b/BootloaderCorePkg/IncludePrivate/BootloaderCoreGlobal.h
@@ -94,6 +94,10 @@ typedef struct {
   UINT8         ConfigDataHash[HASH_DIGEST_MAX];
   UINT8         KeyHashManifestHashValid;
   UINT8         KeyHashManifestHash[HASH_DIGEST_MAX];
+  UINT64        ExtCfgDataBlobBase;
+  UINT64        ExtCfgDataBlobLength;
+  UINT64        HashKeyDataBlobBase;
+  UINT64        HashKeyDataBlobLength;
 } STAGE1B_PARAM;
 
 typedef struct {


### PR DESCRIPTION
length of external config data and hash keys extended to the TPM was incorrect. This commit fixes this issue.