### PR TITLE
feat: ADLN: Increase uefipld FD size for ADL-N

### DIFF
--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
@@ -116,7 +116,7 @@ class Board(BaseBoard):
         self.STAGE2_FD_SIZE       = 0x001F0000
 
         self.PAYLOAD_SIZE         = 0x00030000
-        self.EPAYLOAD_SIZE        = 0x001E0000
+        self.EPAYLOAD_SIZE        = 0x001F0000
 
         self.ENABLE_FAST_BOOT = 0
         if self.ENABLE_FAST_BOOT:


### PR DESCRIPTION
CI build failed.
File 'EPAYLOAD.bin' size 0x1EA1A0 is greater than padding size 0x161000 !