### PR TITLE
fix: [RPL-P] Epayload size too small for UEFI payload with PXE support.

### DIFF
--- a/Platform/RaptorlakeBoardPkg/BoardConfigRplp.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRplp.py
@@ -124,7 +124,7 @@ class Board(BaseBoard):
             self.STAGE2_SIZE += 0x4000
 
         self.PAYLOAD_SIZE         = 0x00030000
-        self.EPAYLOAD_SIZE        = 0x00180000
+        self.EPAYLOAD_SIZE        = 0x00200000
 
         self.OS_LOADER_FD_SIZE    = 0x0005A000
         self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE


### PR DESCRIPTION
EPAYLOAD size was accidentally reverted during upstream. Increasing it back to 2MB.