### PR TITLE
fix: Remove check for physical root bridge device before scanning.

### DIFF
--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
@@ -1664,7 +1664,6 @@ PciScanRootBridges (
   OUT       UINT8                  *RootBridgeCount
   )
 {
-  UINT32                            Address;
   UINT16                            Bus;
   UINT8                             SubBusNumber;
   PCI_IO_DEVICE                    *Bridge;
@@ -1730,27 +1729,24 @@ PciScanRootBridges (
       Bus = Index;
     }
 
-    Address = PCI_EXPRESS_LIB_ADDRESS (Bus, 0, 0, 0);
-    if (PciExpressRead16 (Address) != 0xFFFF) {
-      Root = CreatePciIoDevice (NULL, NULL, (UINT8)Bus, 0, 0);
-      Root->Decodes = RootBridgeDecodes;
-      Root->BusNumberRanges.BusBase  = (UINT8)Bus;
-      Root->BusNumberRanges.BusLimit = BusLimit;
+    Root = CreatePciIoDevice (NULL, NULL, (UINT8)Bus, 0, 0);
+    Root->Decodes = RootBridgeDecodes;
+    Root->BusNumberRanges.BusBase  = (UINT8)Bus;
+    Root->BusNumberRanges.BusLimit = BusLimit;
 
+    SubBusNumber = (UINT8)Bus;
+    PciScanBus (Root, (UINT8)Bus, &SubBusNumber, NULL);
+    if (Bus == PCI_MAX_BUS) {
       SubBusNumber = (UINT8)Bus;
-      PciScanBus (Root, (UINT8)Bus, &SubBusNumber, NULL);
-      if (Bus == PCI_MAX_BUS) {
-        SubBusNumber = (UINT8)Bus;
-      }
-      Root->BusNumberRanges.BusLimit = SubBusNumber;
-      Root->Address |= BIT31;
+    }
+    Root->BusNumberRanges.BusLimit = SubBusNumber;
+    Root->Address |= BIT31;
 
-      InsertPciDevice (Bridge, Root);
-      Count++;
+    InsertPciDevice (Bridge, Root);
+    Count++;
 
-      if (EnumPolicy->BusScanType != BusScanTypeList) {
-        Index = SubBusNumber;
-      }
+    if (EnumPolicy->BusScanType != BusScanTypeList) {
+      Index = SubBusNumber;
     }
   }
   *RootBridges = Bridge;


### PR DESCRIPTION
Not all root bridges have a physical device at dev 0 func 0 of the root bus, and this requirement prevents some platforms from being fully scanned. From this point, PciEnumerationLib doesn't access the root bridge configuration space at all, so this is an unnecessary check.

Instead, root bus scanning will continue without dev 0 func 0 present. If no devices are found on the root bus, scanning will continue to the next root bridge.