### PR TITLE
fix: Only register root bridges with actual devices, not empty ones.

### DIFF
--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
@@ -1742,8 +1742,11 @@ PciScanRootBridges (
     Root->BusNumberRanges.BusLimit = SubBusNumber;
     Root->Address |= BIT31;
 
-    InsertPciDevice (Bridge, Root);
-    Count++;
+    // Only add Root Bridges with actual devices, not empty ones.
+    if (Root->ChildList.ForwardLink != &Root->ChildList) {
+      InsertPciDevice (Bridge, Root);
+      Count++;
+    }
 
     if (EnumPolicy->BusScanType != BusScanTypeList) {
       Index = SubBusNumber;


### PR DESCRIPTION
Registering logical root bridges with no devices can cause unexpected behavior for platforms that use _PCI_ENUM_BUS_SCAN_TYPE = "range", since all empty buses in the range will be compared against the resource allocation table entries.