### PR TITLE
Support bootloader a/b slot for Firmwareupdate Payload

### DIFF
--- a/BootloaderCommonPkg/Include/Library/PartitionLib.h
+++ b/BootloaderCommonPkg/Include/Library/PartitionLib.h
@@ -30,6 +30,7 @@ typedef enum {
 typedef struct {
   UINT64                        StartBlock;
   UINT64                        LastBlock;
+  CHAR16                        PartitionName[36];
 } LOGICAL_BLOCK_DEVICE;
 
 typedef struct {

--- a/BootloaderCommonPkg/Library/PartitionLib/PartitionLib.c
+++ b/BootloaderCommonPkg/Library/PartitionLib/PartitionLib.c
@@ -198,6 +198,7 @@ FindMbrPartitions (
       BlockDev                    = & (PartBlockDev->BlockDevice[PartBlockDev->BlockDeviceCount]);
       BlockDev->StartBlock        = UNPACK_UINT32 (Mbr->Partition[Index].StartingLBA);
       BlockDev->LastBlock         = BlockDev->StartBlock + UNPACK_INT32 (Mbr->Partition[Index].SizeInLBA) - 1;
+      ZeroMem (BlockDev->PartitionName, sizeof (BlockDev->PartitionName));
       PartBlockDev->BlockDeviceCount++;
     }
   }
@@ -427,6 +428,7 @@ FindGptPartitions (
       BlockDev                    = & (PartBlockDev->BlockDevice[PartBlockDev->BlockDeviceCount]);
       BlockDev->StartBlock        = GptEntries[Index].StartingLBA;
       BlockDev->LastBlock         = GptEntries[Index].EndingLBA;
+      StrCpyS (BlockDev->PartitionName, sizeof(BlockDev->PartitionName), GptEntries[Index].PartitionName);
       DEBUG ((DEBUG_INFO, "Part %02d: %12s ", PartBlockDev->BlockDeviceCount, GptEntries[Index].PartitionName));
       DEBUG ((DEBUG_INFO, "0x%08x--0x%08x, LBA count: 0x%x\n", (UINT32)BlockDev->StartBlock, \
               (UINT32)BlockDev->LastBlock, (UINT32) (BlockDev->LastBlock - BlockDev->StartBlock + 1)));

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -435,6 +435,7 @@
       PayloadSupportLib       | PayloadPkg/Library/PayloadSupportLib/PayloadSupportLib.inf
       BootloaderLib           | PayloadPkg/Library/PayloadLib/PayloadLib.inf
       PlatformHookLib         | PayloadPkg/Library/PlatformHookLib/PlatformHookLib.inf
+      AbSupportLib            | PayloadPkg/Library/AbSupportLib/AbSupportLib.inf
       FirmwareUpdateLib       | $(SOC_FWU_LIB_INF_FILE)
   }
 !endif

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
@@ -50,6 +50,7 @@
   ConfigDataLib
   ContainerLib
   StringSupportLib
+  AbSupportLib
   BootOptionLib
   TimerLib
   BootGuardLib

--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_CapsuleInformation.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_CapsuleInformation.yaml
@@ -19,7 +19,7 @@
       help         : >
                      Specify boot device
       length       : 0x01
-      value        : 5
+      value        : 6
   - DevInstance  :
       name         : Boot Device instance
       type         : Combo
@@ -54,7 +54,7 @@
       help         : >
                      Image is loaded from file system instead of raw data
       length       : 0x01
-      value        : 2
+      value        : 0
   - FileName     :
       name         : Capsule File Name
       type         : EditText


### PR DESCRIPTION
Firmwareupadte Payload needs support bootloader a/b slots. The SBL update package is put to bootloader partition and will be updated during the OTA.