### PR TITLE
Switch to HS clock frequency before switching bus width for DDR mode

### DIFF
--- a/BootloaderCommonPkg/Library/MmcAccessLib/MmcAccessLibGeneric.c
+++ b/BootloaderCommonPkg/Library/MmcAccessLib/MmcAccessLibGeneric.c
@@ -970,9 +970,27 @@ MmcSwitchToHighSpeed (
   UINT8               HostCtrl1;
   UINT8               HostCtrl2;
 
-  Status = MmcSwitchBusWidth (Private, Rca, IsDdr, BusWidth);
-  if (EFI_ERROR (Status)) {
-    return Status;
+  HsTiming = 1;
+  if (IsDdr) {
+    Status = MmcSwitchClockFreq (Private, Rca, HsTiming, ClockFreq);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    Status = MmcSwitchBusWidth (Private, Rca, IsDdr, BusWidth);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  } else {
+    Status = MmcSwitchBusWidth (Private, Rca, IsDdr, BusWidth);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    Status = MmcSwitchClockFreq (Private, Rca, HsTiming, ClockFreq);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
   }
 
   //
@@ -1003,12 +1021,6 @@ MmcSwitchToHighSpeed (
     HostCtrl2 = 0;
   }
   Status = SdMmcHcOrMmio (Private->SdMmcHcBase, SD_MMC_HC_HOST_CTRL2, sizeof (HostCtrl2), &HostCtrl2);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  HsTiming = 1;
-  Status = MmcSwitchClockFreq (Private, Rca, HsTiming, ClockFreq);
 
   return Status;
 }


### PR DESCRIPTION
This addresses an issue noticed when attempting to initialise the eMMC in DDR, 52MHz, 8-bit bus width mode. Specifically, the error occurred as the switch routine for the bus_width mode in the device's EXT_CSD was deemed unsuccessful. The relevant error logs are shown below: 
```shell
MmcSetBusMode: HsTiming 1 ClockFreq 52 BusWidth 8 Ddr TRUE
MmcCheckSwitchStatus: The switch operation fails as DevStatus is 0x00000980
MmcCheckSwitchStatus: Check status fails with Device Error
MmcSetBusMode: Switch to HighSpeed Device Error
MmcSetBusMode Fail Status = 0x80000007
``` 

Please refer to the JEDEC Embedded Multi-Media Card Electrical Standard (5.1) JESD84-B51 Section 7.4.67 (pg. 203) Table 145: "HS_TIMING must be set to “0x1” before setting BUS_WIDTH for dual data rate operation 
(values 5 or 6)". 

This commit fixes the implementation to comply with the above standards by first switching to the high speed interface mode, and then switching the bus width mode for HS DDR operation - leaving the routine in it's original state for HS SDR switching operation. This fixed the issue I was experiencing switching to DDR 52MHz 8-bit bus width mode, and the MmcSwitchToHighSpeed() returned successfully.

I also successfully tested with the following modes on an ALD-N after the fix: 
- DDR 52MHz 4-bit bus width
- SDR 52MHz 8-bit bus width
- SDR 52MHz 4-bit bus width
