### PR TITLE
fix: [Common] Fix coverity issues

### DIFF
--- a/MdePkg/Include/Library/DebugLib.h
+++ b/MdePkg/Include/Library/DebugLib.h
@@ -343,7 +343,7 @@ UnitTestDebugAssert (
     #undef _ASSERT
   #endif
   #if defined(__KLOCWORK__) || defined(__COVERITY__)
-    #define ASSERT(Expression)    _ASSERT (Expression)
+    #define ASSERT(Expression)    do { if (!(Expression)) abort(); } while (0)
   #elif defined (__clang__) && defined (__FILE_NAME__)
     #define _ASSERT(Expression)  UnitTestDebugAssert (__FILE_NAME__, DEBUG_LINE_NUMBER, DEBUG_EXPRESSION_STRING (Expression))
   #else
@@ -352,7 +352,7 @@ UnitTestDebugAssert (
 #else
 
   #if defined(__KLOCWORK__) || defined(__COVERITY__)
-    #define ASSERT(Expression)    _ASSERT (Expression)
+    #define ASSERT(Expression)    do { if (!(Expression)) abort(); } while (0)
   #elif defined (__clang__) && defined (__FILE_NAME__)
     #define _ASSERT(Expression)  DebugAssert (__FILE_NAME__, DEBUG_LINE_NUMBER, DEBUG_EXPRESSION_STRING (Expression))
   #else
@@ -397,8 +397,9 @@ UnitTestDebugAssert (
   @param  Expression  Boolean expression.
 
 **/
-#if !defined (MDEPKG_NDEBUG)
-#define ASSERT(Expression)        \
+#if !defined(__KLOCWORK__) && !defined(__COVERITY__)
+  #if !defined (MDEPKG_NDEBUG)
+  #define ASSERT(Expression)        \
     do {                            \
       if (DebugAssertEnabled ()) {  \
         if (!(Expression)) {        \
@@ -407,8 +408,9 @@ UnitTestDebugAssert (
         }                           \
       }                             \
     } while (FALSE)
-#else
-#define ASSERT(Expression)
+  #else
+  #define ASSERT(Expression)
+  #endif
 #endif
 
 /**


### PR DESCRIPTION
Address following coverity issues
1. Untrusted loop bound (CWE 606)
2. Dereference after and before null check (CWE 476)
3. Out-of-bounds read (CWD 125)