### PR TITLE
fix: [MTL] Removed unused ASL Includes

### DIFF
--- a/Platform/MeteorlakeBoardPkg/AcpiTables/Dsdt/MtlPchHda.asl
+++ b/Platform/MeteorlakeBoardPkg/AcpiTables/Dsdt/MtlPchHda.asl
@@ -47,17 +47,3 @@ Device (HDAS)
   include ("PchHda.asl")
   include ("HdaIda.asl")
 }
-
-Scope (HDAS.IDA) {
-  //
-  // High Definition Audio - SoundWire Controller
-  //
-  include ("HdaSoundWireCtrl.asl")
-
-  If (LNotEqual (UAOE,0)) {
-    //
-    // High Definition Audio - USB Audio Offload
-    //
-    include ("HdaUsbAudioOffload.asl")
-  }
-} // END Device (HDAS)

--- a/Platform/MeteorlakeBoardPkg/AcpiTables/Dsdt/MtlSoc.asl
+++ b/Platform/MeteorlakeBoardPkg/AcpiTables/Dsdt/MtlSoc.asl
@@ -374,19 +374,6 @@ If (LNotEqual (PCHS, PCH_S)) {
       include ("HdaIda.asl")
     }
 
-    Scope (HDAS.IDA) {
-      //
-      // High Definition Audio - SoundWire Controller
-      //
-      include ("HdaSoundWireCtrl.asl")
-
-      If (LNotEqual (UAOE,0)) {
-        //
-        // High Definition Audio - USB Audio Offload
-        //
-        include ("HdaUsbAudioOffload.asl")
-      }
-    } // END Device (HDAS)
 
     //
     // MEI 1 definition

--- a/Platform/MeteorlakeBoardPkg/AcpiTables/Dsdt/MtlSocCnvi.asl
+++ b/Platform/MeteorlakeBoardPkg/AcpiTables/Dsdt/MtlSocCnvi.asl
@@ -52,7 +52,6 @@ Scope (\_SB.PC00) {
       }
 
       #define R_CNVI_ACPI_PLRB R_CNVI_PCR_CNVI_PLDR_ABORT_SOC_M
-      Include ("CnviWifi.asl")
       #undef R_CNVI_ACPI_PLRB
     }
   }

--- a/Platform/MeteorlakeBoardPkg/AcpiTables/Dsdt/PcieMtl.asl
+++ b/Platform/MeteorlakeBoardPkg/AcpiTables/Dsdt/PcieMtl.asl
@@ -681,10 +681,5 @@ Scope (\_SB.PC00) {
       }
       Return (PD04)                                // PIC Mode
     }                                              // end _PRT
-    Scope(\_SB.PC00.RP12.PXSX) {
-      If (LNotEqual(DGBA, 0)) {
-        Include("PcieRpDgEdpFeatureHook.asl")
-      }
-    }
   }                                             // end "PCIE Root Port#12"
 }

--- a/Platform/MeteorlakeBoardPkg/AcpiTables/Dsdt/SerialIoDevices.asl
+++ b/Platform/MeteorlakeBoardPkg/AcpiTables/Dsdt/SerialIoDevices.asl
@@ -297,7 +297,6 @@ Scope(\_SB.PC00.SPI1)
     Store (SDS7, SPIP)
     Store (SERIAL_IO_SPI1, SPIX)
   }
-  Include ("SpiFingerprint.asl")
 }
 
 //-----------------------------
@@ -311,7 +310,6 @@ Scope(\_SB.PC00.SPI2)
     Store (SDS8, SPIP)
     Store (SERIAL_IO_SPI2, SPIX)
   }
-  Include ("SpiFingerprint.asl")
 }
 
 

--- a/Platform/MeteorlakeBoardPkg/AcpiTables/Dsdt/WwanFlash.asl
+++ b/Platform/MeteorlakeBoardPkg/AcpiTables/Dsdt/WwanFlash.asl
@@ -18,62 +18,50 @@ Scope(\_SB) {
       If (LEqual(WWRP, 1)) {
         #undef WWAN_PCIE_ROOT_PORT
         #define WWAN_PCIE_ROOT_PORT \_SB.PC00.RP01
-        Include ("WwanFlashReset.asl")
       }
       If (LEqual(WWRP, 2)) {
         #undef WWAN_PCIE_ROOT_PORT
         #define WWAN_PCIE_ROOT_PORT \_SB.PC00.RP02
-        Include ("WwanFlashReset.asl")
       }
       If (LEqual(WWRP, 3)) {
         #undef WWAN_PCIE_ROOT_PORT
         #define WWAN_PCIE_ROOT_PORT \_SB.PC00.RP03
-        Include ("WwanFlashReset.asl")
       }
       If (LEqual(WWRP, 4)) {
         #undef WWAN_PCIE_ROOT_PORT
         #define WWAN_PCIE_ROOT_PORT \_SB.PC00.RP04
-        Include ("WwanFlashReset.asl")
       }
       If (LEqual(WWRP, 5)) {
         #undef WWAN_PCIE_ROOT_PORT
         #define WWAN_PCIE_ROOT_PORT \_SB.PC00.RP05
-        Include ("WwanFlashReset.asl")
       }
       If (LEqual(WWRP, 6)) {
         #undef WWAN_PCIE_ROOT_PORT
         #define WWAN_PCIE_ROOT_PORT \_SB.PC00.RP06
-        Include ("WwanFlashReset.asl")
       }
       If (LEqual(WWRP, 7)) {
         #undef WWAN_PCIE_ROOT_PORT
         #define WWAN_PCIE_ROOT_PORT \_SB.PC00.RP07
-        Include ("WwanFlashReset.asl")
       }
       If (LEqual(WWRP, 8)) {
         #undef WWAN_PCIE_ROOT_PORT
         #define WWAN_PCIE_ROOT_PORT \_SB.PC00.RP08
-        Include ("WwanFlashReset.asl")
       }
       If (LEqual(WWRP, 9)) {
         #undef WWAN_PCIE_ROOT_PORT
         #define WWAN_PCIE_ROOT_PORT \_SB.PC00.RP09
-        Include ("WwanFlashReset.asl")
       }
       If (LEqual(WWRP, 13)) {
         #undef WWAN_PCIE_ROOT_PORT
         #define WWAN_PCIE_ROOT_PORT \_SB.PC00.RP13
-        Include ("WwanFlashReset.asl")
       }
       If (LEqual(WWRP, 17)) {
         #undef WWAN_PCIE_ROOT_PORT
         #define WWAN_PCIE_ROOT_PORT \_SB.PC00.RP17
-        Include ("WwanFlashReset.asl")
       }
       If (LEqual(WWRP, 21)) {
         #undef WWAN_PCIE_ROOT_PORT
         #define WWAN_PCIE_ROOT_PORT \_SB.PC00.RP21
-        Include ("WwanFlashReset.asl")
       }
       If (LEqual (Local0, 1)) {
         Release (\WWMT)

--- a/Platform/MeteorlakeBoardPkg/AcpiTables/Ssdt/MtlPSCrbRtd3.asl
+++ b/Platform/MeteorlakeBoardPkg/AcpiTables/Ssdt/MtlPSCrbRtd3.asl
@@ -229,9 +229,7 @@ External(\_SB.PC00.HDAS.VDID)
 
 // PCIe root ports - END
 
-// USB - START
-  Include ("Rtd3Xdci.asl")
-// USB - END
+
 
 If (LNotEqual(GBES,0)) {
   Scope(\_SB.PC00.GLAN)
@@ -254,7 +252,6 @@ If (LNotEqual(GBES,0)) {
 //
 // Human Interface Devices Start
 //
-  Include ("Rtd3MPRvpLpss.asl")
 Include ("Rtd3Hdas.asl")
 
 //GPE Event handling - Start


### PR DESCRIPTION
Remove unused ASL Includes which is causing build failure after basetool updates