### PR TITLE
fix: [Common] build failed with VS2015

### DIFF
--- a/BaseTools/Scripts/PatchCheck.py
+++ b/BaseTools/Scripts/PatchCheck.py
@@ -504,11 +504,11 @@ class GitDiffCheck:
                                   'but DEBUG_' + mo.group(1) +
                                   ' is now recommended', line)
 
-        rp_file = os.path.realpath(self.filename)
-        rp_script = os.path.realpath(__file__)
-        if line.find('__FUNCTION__') != -1 and rp_file != rp_script:
-            self.added_line_error('__FUNCTION__ was used, but __func__ '
-                                  'is now recommended', line)
+        #rp_file = os.path.realpath(self.filename)
+        #rp_script = os.path.realpath(__file__)
+        #if line.find('__FUNCTION__') != -1 and rp_file != rp_script:
+        #    self.added_line_error('__FUNCTION__ was used, but __func__ '
+        #                          'is now recommended', line)
 
     split_diff_re = re.compile(r'''
                                    (?P<cmd>

--- a/MdePkg/Library/BaseLib/SafeString.c
+++ b/MdePkg/Library/BaseLib/SafeString.c
@@ -17,7 +17,7 @@
     if (!(Expression)) { \
       DEBUG ((DEBUG_VERBOSE, \
         "%a(%d) %a: SAFE_STRING_CONSTRAINT_CHECK(%a) failed.  Return %r\n", \
-        __FILE__, DEBUG_LINE_NUMBER, __func__, DEBUG_EXPRESSION_STRING (Expression), Status)); \
+        __FILE__, DEBUG_LINE_NUMBER, __FUNCTION__, DEBUG_EXPRESSION_STRING (Expression), Status)); \
       return Status; \
     } \
   } while (FALSE)


### PR DESCRIPTION
The current BaseTools aligned with edk2-stable202311 introduces the replacement of __FUNCTION__ with __func__, which causes compiler failure since VS2015 don't support __func__. This patch reverts the change and its checker to continue the VS2015 support.

Reference commit IDs from edk2 repo: b17a3a1 and c9fb11f