### PR TITLE
[RPLS] Update FSP/UCODE for MR3 release

### DIFF
--- a/Platform/RaptorlakeBoardPkg/BoardConfigRpls.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRpls.py
@@ -23,8 +23,8 @@ class Board(BaseBoard):
         super(Board, self).__init__(*args, **kwargs)
 
         self.VERINFO_IMAGE_ID     = 'SB_RPLS'
-        self.VERINFO_PROJ_MAJOR_VER = 2
-        self.VERINFO_PROJ_MINOR_VER = 1
+        self.VERINFO_PROJ_MAJOR_VER = 1
+        self.VERINFO_PROJ_MINOR_VER = 3
         self.VERINFO_SVN            = 1
         self.VERINFO_BUILD_DATE     = time.strftime("%m/%d/%Y")
 

--- a/Silicon/RaptorlakePkg/Rpls/Fsp/FspBinRpls.inf
+++ b/Silicon/RaptorlakePkg/Rpls/Fsp/FspBinRpls.inf
@@ -11,7 +11,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = 43f7092a6156ace79a13e7c8793ce8578f69b216
+  COMMIT  = 61c069aa8035d04dd4df3ab2333c8bb1c9ed8c1e
 
 [UserExtensions.SBL."CopyList"]
 # For RPL-S

--- a/Silicon/RaptorlakePkg/Rpls/Microcode/MicrocodeRpls.inf
+++ b/Silicon/RaptorlakePkg/Rpls/Microcode/MicrocodeRpls.inf
@@ -14,13 +14,13 @@
   VERSION_STRING       = 1.0
 
 [Sources]
-  m_32_b0671_0000011f.mcb  # RPL-S B0
-  m_07_90672_0000002c.mcb  # ADLS  C0
+  m_32_b0671_00000120.mcb  # RPL-S B0
+  m_07_90672_00000034.mcb  # ADLS  C0
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
-  COMMIT = 6b1adfb9b19c9f8830c614348ab11feee6eb8c68
+  COMMIT = 00aeffb6c4209b76f1713387cfcbc74ad6818127
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/RaptorLake/m_32_b0671_0000011f.pdb  : Silicon/RaptorlakePkg/Rpls/Microcode/m_32_b0671_0000011f.mcb
-  Microcode/RaptorLake/m_07_90672_0000002c.pdb  : Silicon/RaptorlakePkg/Rpls/Microcode/m_07_90672_0000002c.mcb
+  Microcode/RaptorLake/m_32_b0671_00000120.pdb  : Silicon/RaptorlakePkg/Rpls/Microcode/m_32_b0671_00000120.mcb
+  Microcode/AlderLake/m_07_90672_00000034.pdb   : Silicon/RaptorlakePkg/Rpls/Microcode/m_07_90672_00000034.mcb


### PR DESCRIPTION
- FSP version: IoT RPL-S MR3 (0C.00.CC.20)
- Microcode version: 120
- VBT version: 250
- platform version: 1.3