### PR TITLE
[MTL] fix stitch scripts

### DIFF
--- a/Platform/MeteorlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/MeteorlakeBoardPkg/Script/StitchIfwi.py
@@ -1,7 +1,7 @@
 ## @ StitchIfwi.py
-#  This is a python stitching script for Slim Bootloader ADL build
+#  This is a python stitching script for Slim Bootloader MTL build
 #
-# Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved. <BR>
+# Copyright (c) 2020 - 2024, Intel Corporation. All rights reserved. <BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -29,9 +29,12 @@ sys.dont_write_bytecode = True
 # sign_bin_flag can be set to false to avoid signing process. Applicable for Btg profile 0
 sign_bin_flag = True
 
-sblopen_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../../../../', 'SblOpen')
+sblopen_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../'))
+
 if not os.path.exists (sblopen_dir):
     sblopen_dir = os.getenv('SBL_SOURCE', '')
+if not os.path.exists (sblopen_dir):
+    raise  Exception("Please set env 'SBL_SOURCE' to SBL open source root folder")
 
 sys.path.append (os.path.join(sblopen_dir, "BootloaderCorePkg" , "Tools"))
 
@@ -90,15 +93,9 @@ def replace_component (ifwi_src_path, flash_path, file_path, comp_alg, pri_key, 
     replace_comp = replace_comps[0]
     if comp_name:
         # extract container image
-        container_file = os.path.join(work_dir, 'CTN_%s.bin') % comp_name
+        container_file = os.path.join(work_dir, 'Temp', 'CTN_%s.bin') % comp_name
         gen_file_from_object (container_file, ifwi_bin[replace_comp.offset:replace_comp.offset + replace_comp.length])
         comp_file     = os.path.join(work_dir, file_path)
-        sblopen_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../../../../', 'SblOpen')
-        if not os.path.exists (sblopen_dir):
-            sblopen_dir = os.getenv('SBL_SOURCE', '')
-
-        if not os.path.exists (sblopen_dir):
-           raise  Exception("Please set env 'SBL_SOURCE' to SBL open source root folder")
 
         if os.name == 'nt':
             tool_bin_dir  = os.path.join(sblopen_dir, "BaseTools", "Bin", "Win32")

--- a/Platform/MeteorlakeBoardPkg/Script/StitchLoader.py
+++ b/Platform/MeteorlakeBoardPkg/Script/StitchLoader.py
@@ -1,5 +1,5 @@
 ## @ StitchLoader.py
-#  This is a python stitching script for Slim Bootloader WHL/CFL build
+#  This is a python stitching script for Slim Bootloader MTL build
 #
 # Copyright (c) 2019, Intel Corporation. All rights reserved. <BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -12,7 +12,7 @@ from   ctypes import *
 from   functools import reduce
 
 sys.dont_write_bytecode = True
-sblopen_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../../../../', 'SblOpen')
+sblopen_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../'))
 if not os.path.exists (sblopen_dir):
     sblopen_dir = os.getenv('SBL_SOURCE', '')
 sys.path.append (os.path.join(sblopen_dir, "BootloaderCorePkg" , "Tools"))


### PR DESCRIPTION
The commit refactors stitch scripts to not assume "SblOpen" is the the root of SBL source. It also corrects minor typos, including incorrect usage of WHL/CFL/ADL identifiers.