### PR TITLE
fix: [MTL] CRB hang in UEFI payload when PCIe switch present.

### DIFF
--- a/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -370,9 +370,12 @@ BoardInit (
 
     break;
   case PostPciEnumeration:
-    Status = SetFrameBufferWriteCombining (0, MAX_UINT32);
-    if (EFI_ERROR(Status)) {
-      DEBUG ((DEBUG_INFO, "Failed to set GFX framebuffer as WC\n"));
+    // UEFI Payload will change cache type to UC based on PCI root bridge
+    if (GetPayloadId () != UEFI_PAYLOAD_ID_SIGNATURE) {
+      Status = SetFrameBufferWriteCombining (0, MAX_UINT32);
+      if (EFI_ERROR(Status)) {
+        DEBUG ((DEBUG_INFO, "Failed to set GFX framebuffer as WC\n"));
+      }
     }
     InterruptRoutingInit ();
     break;


### PR DESCRIPTION
Porting from https://github.com/slimbootloader/slimbootloader/pull/1892

Required for https://github.com/slimbootloader/slimbootloader/pull/2164 to avoid exception on uefipayload.