### PR TITLE
[TGL] fix Stage1B stack corruption

### DIFF
--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -117,15 +117,16 @@ class Board(BaseBoard):
 
         if self.RELEASE_MODE:
             self.STAGE1A_SIZE         = 0x0000D000
-            self.STAGE1B_SIZE         = 0x000B1000
+            self.STAGE1B_SIZE         = 0x000B7000
             self.STAGE2_SIZE          = 0x00080000
             self.STAGE2_FD_SIZE       = 0x000E0000
-            self.PAYLOAD_SIZE         = 0x00024000
+            self.PAYLOAD_SIZE         = 0x00026000
         else:
             self.STAGE1A_SIZE         = 0x00016000
             self.STAGE1B_SIZE         = 0x00180000
             self.STAGE2_SIZE          = 0x00110000
             self.STAGE2_FD_SIZE       = 0x00200000
+            self.OS_LOADER_FD_SIZE    = 0x00059000
             self.PAYLOAD_SIZE         = 0x00080000
 
         if self.ENABLE_SOURCE_DEBUG:

--- a/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
+++ b/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
@@ -63,3 +63,6 @@
   gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootEnabled
   gPlatformModuleTokenSpaceGuid.PcdFastBootEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled
+  gPlatformModuleTokenSpaceGuid.PcdStage1StackBaseOffset
+  gPlatformModuleTokenSpaceGuid.PcdStage1StackSize
+  gPlatformModuleTokenSpaceGuid.PcdStage1DataSize


### PR DESCRIPTION
This commit updates the stack settings from hardcoded values to runtime calculated ones to prevent potential stack corruption in Stage1B for certain customizations.

Additionally, the commit enlarges the FD sizes for STAGE1B_SIZE and PAYLOAD_SIZE to accommodate the new changes. It also increases the sizes for STAGE2_SIZE and OS_LOADER_FD_SIZE to support 64-bit Linux builds.

Verified: TGL LPDDR4 RVP with the following smoke tests:
  - OSLoader (debug, fsp debug, release, 64-bit) to Yocto
  - Uefi payload (debug, fsp debug, release, 64-bit) to Windows