### PR TITLE
fix: FSP 2.4 issues

### DIFF
--- a/BootloaderCorePkg/Library/FspApiLib/FspMemoryInit.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspMemoryInit.c
@@ -57,9 +57,9 @@ CallFspMemoryInit (
   DefaultMemoryInitUpd = (UINT8 *)(UINTN)(FspHeader->ImageBase + FspHeader->CfgRegionOffset);
   CopyMem (&FspmUpd, DefaultMemoryInitUpd, FspHeader->CfgRegionSize);
 
+  FspmUpdCommon = (FSPM_UPD_COMMON *)FspmUpd;
   /* Update architectural UPD fields */
-  if (FspHeader->SpecVersion < 0x24) {
-    FspmUpdCommon = (FSPM_UPD_COMMON *)FspmUpd;
+  if (FspmUpdCommon->FspUpdHeader.Revision < FSP_HEADER_REVISION_3) {
     FspmUpdCommon->FspmArchUpd.BootLoaderTolumSize  = 0;
     FspmUpdCommon->FspmArchUpd.BootMode             = (UINT32)GetBootMode();
     FspmUpdCommon->FspmArchUpd.NvsBufferPtr         = (UINT32)(UINTN)FindNvsData();
@@ -142,7 +142,7 @@ FspMultiPhaseMemInitHandler(VOID)
   // Loop through all phases. Break on error status or FSP_STATUS_* not
   // handled by variable services handler
   for (MultiPhaseInitParams.PhaseIndex = 1;
-    MultiPhaseInitParams.PhaseIndex < GetNumPhasesParams.NumberOfPhases &&
+    MultiPhaseInitParams.PhaseIndex <= GetNumPhasesParams.NumberOfPhases &&
       !EFI_ERROR(Status) &&
       !(Status & ENCODE_RESET_REQUEST(0));
     MultiPhaseInitParams.PhaseIndex++)

--- a/BootloaderCorePkg/Library/FspApiLib/FspSiliconInit.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspSiliconInit.c
@@ -96,7 +96,7 @@ FspMultiPhaseSiliconInitHandler(VOID)
   // Loop through all phases. Break on error status or FSP_STATUS_* not
   // handled by variable services handler
   for (MultiPhaseInitParams.PhaseIndex = 1;
-    MultiPhaseInitParams.PhaseIndex < GetNumPhasesParams.NumberOfPhases &&
+    MultiPhaseInitParams.PhaseIndex <= GetNumPhasesParams.NumberOfPhases &&
       !EFI_ERROR(Status) &&
       !(Status & ENCODE_RESET_REQUEST(0));
     MultiPhaseInitParams.PhaseIndex++)


### PR DESCRIPTION
1) Some FSP 2.4 implementations are non-conforming and use FSPM_ARCH_UPD instead of FSPM_ARCH2_UPD as indicated by the specification. Logic is changed to check FSPM UPD header revision for structure version instead of FSP spec revision.

2) MultiPhase FSP PhaseIndex is one-based so loop comparisons need to take this into account. Side effect is that the last phase may be missed. No current platform FSP is utilizing this.