### PR TITLE
[EHL] trigger SMI handler in S3 resume

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -1100,18 +1100,19 @@ GetPlatformPowerState (
   ///
   IoAndThenOr32 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_STS, (UINT32)~B_ACPI_IO_PM1_EN_PWRBTN_EN, B_ACPI_IO_PM1_STS_WAK );
 
-  //Clear RTC_EN bit as it cause SMI storm
-  IoAnd32 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_STS, (UINT32)~B_ACPI_IO_PM1_EN_RTC_EN);
-
   if ((MmioRead8 (PCH_PWRM_BASE_ADDRESS + R_PMC_PWRM_GEN_PMCON_B) & B_PMC_PWRM_GEN_PMCON_B_RTC_PWR_STS) != 0) {
     BootMode = BOOT_WITH_FULL_CONFIGURATION;
 
     ///
     /// Clear Wake Status and Sleep Type
     ///
-    IoWrite16 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_STS, B_ACPI_IO_PM1_STS_WAK);
     IoAndThenOr16 (ACPI_BASE_ADDRESS + R_ACPI_IO_PM1_CNT, (UINT16) ~B_ACPI_IO_PM1_CNT_SLP_TYP, V_ACPI_IO_PM1_CNT_S0);
   }
+
+  ///
+  /// Disable Power Management Event EN
+  ///
+  IoAnd32 (ACPI_BASE_ADDRESS + R_ACPI_IO_GPE0_EN_127_96, (UINT32)~B_ACPI_IO_GPE0_EN_127_96_PME_B0);
 
   return BootMode;
 }

--- a/Silicon/ElkhartlakePkg/Include/Register/PmcRegs.h
+++ b/Silicon/ElkhartlakePkg/Include/Register/PmcRegs.h
@@ -52,6 +52,7 @@
 // ACPI and legacy I/O register offsets from ACPIBASE
 //
 #define R_ACPI_IO_PM1_STS                        0x00
+#define B_ACPI_IO_PM1_STS_RTC_EN                 BIT26
 #define B_ACPI_IO_PM1_STS_WAK                    BIT15
 #define B_ACPI_IO_PM1_STS_PRBTNOR                BIT11
 #define B_ACPI_IO_PM1_STS_RTC                    BIT10
@@ -70,7 +71,7 @@
 #define V_ACPI_IO_PM1_CNT_S3                     (BIT12 | BIT10)
 #define V_ACPI_IO_PM1_CNT_S4                     (BIT12 | BIT11)
 #define V_ACPI_IO_PM1_CNT_S5                     (BIT12 | BIT11 | BIT10)
-
+#define B_ACPI_IO_PM1_CNT_SCI_EN                 BIT0
 
 #define R_ACPI_IO_SMI_EN                              0x30
 #define B_ACPI_IO_SMI_EN_APMC                         BIT5
@@ -89,14 +90,13 @@
 
 #define R_ACPI_IO_GPE_CNTL                            0x40
 
-
 #define R_ACPI_IO_OC_WDT_CTL                          0x54
 
-#define R_ACPI_IO_GPE0_STS_127_96                  0x6C
-#define B_ACPI_IO_GPE0_STS_127_96_SMB_WAK          BIT7
+#define R_ACPI_IO_GPE0_STS_127_96                     0x6C
+#define B_ACPI_IO_GPE0_STS_127_96_SMB_WAK             BIT7
 
-#define R_ACPI_IO_GPE0_EN_127_96                   0x7C
-
+#define R_ACPI_IO_GPE0_EN_127_96                      0x7C
+#define B_ACPI_IO_GPE0_EN_127_96_PME_B0               BIT13
 
 //
 // TCO register I/O map

--- a/Silicon/ElkhartlakePkg/Include/Register/RtcRegs.h
+++ b/Silicon/ElkhartlakePkg/Include/Register/RtcRegs.h
@@ -40,6 +40,7 @@ Conventions:
 #define R_RTC_IO_TARGET                          0x71
 #define R_RTC_IO_REGA                            0x0A
 #define R_RTC_IO_REGB                            0x0B
+#define R_RTC_IO_REGC                            0x0C
 #define R_RTC_IO_REGD                            0x0D
 
 //

--- a/Silicon/ElkhartlakePkg/Library/Stage2SocInitLib/Stage2SocInitLib.c
+++ b/Silicon/ElkhartlakePkg/Library/Stage2SocInitLib/Stage2SocInitLib.c
@@ -40,42 +40,6 @@ GetAcpiGnvsSize (
 }
 
 /**
-  Clear SMBUS status and SMB_WAK_STS of GPE0
-**/
-VOID
-EFIAPI
-ClearSmbusStatus (
-  VOID
-)
-{
-  UINTN                       SmbusRegBase;
-  UINT16                      SmbusIoBase;
-
-  SmbusRegBase = PCI_LIB_ADDRESS (
-                   DEFAULT_PCI_BUS_NUMBER_PCH,
-                   PCI_DEVICE_NUMBER_PCH_SMBUS,
-                   PCI_FUNCTION_NUMBER_PCH_SMBUS,
-                   0
-                   );
-
-  if (PciRead32 (SmbusRegBase) == 0xFFFFFFFF) {
-    return;
-  }
-
-  SmbusIoBase = PciRead16 (SmbusRegBase + R_SMBUS_CFG_BASE) & B_SMBUS_CFG_BASE_BAR;
-  if (SmbusIoBase == 0) {
-    return;
-  }
-
-  PciOr8 (SmbusRegBase + PCI_COMMAND_OFFSET, EFI_PCI_COMMAND_IO_SPACE);
-  //
-  // Clear SMBUS status and SMB_WAK_STS of GPE0
-  //
-  IoWrite8 (SmbusIoBase + R_SMBUS_IO_HSTS, B_SMBUS_IO_SMBALERT_STS);
-  IoWrite32 (ACPI_BASE_ADDRESS + R_ACPI_IO_GPE0_STS_127_96, B_ACPI_IO_GPE0_STS_127_96_SMB_WAK);
-}
-
-/**
  Update GPIO address and length to global NVS data.
 
  @param [in] GnvsIn Pointer to Global NVS data.


### PR DESCRIPTION
This commit resolves the issue where the SMI handler was not being triggered during S3 resume. The problem was due to the functions RestoreS3RegInfo and TriggerPayloadSwSmi not being called.

In addition, the commit also:
       1. unset the PME_B0_EN as UEFI Payload does not have its handler
       2. remove the ClearSmbuStatus() because
          - the HSTS.B_SMBUS_IO_SMBALERT_STS in SMBUS (B0:D31:F4) should be
            handled and cleared by device driver or an appropriate SMI handler.
          - the ClearSmi() will clear GPE0_STS_127_96.SMB_WAK_STS if it is set
       3. unset (FSPS) PeiGraphicsPeimInit and GraphicsConfigPtr during S3 resume
       4. narrow the var scope of mSmmBaseInfo and mS3SaveReg
       5. add required bitfield declaration

Verified with:
       1. UEFI Payload + Ubuntu on EHL CRB (release build)
       2. OSLoader (release build)
      when FEATURES_CFG_DATA.Features.S0ix = 0
