### PR TITLE
fix: [ADLN/MTL] increased EPAYLOAD size for latest UefiPld

### DIFF
--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
@@ -116,7 +116,7 @@ class Board(BaseBoard):
         self.STAGE2_FD_SIZE       = 0x001F0000
 
         self.PAYLOAD_SIZE         = 0x00030000
-        self.EPAYLOAD_SIZE        = 0x001F0000
+        self.EPAYLOAD_SIZE        = 0x00230000
 
         self.ENABLE_FAST_BOOT = 0
         if self.ENABLE_FAST_BOOT:

--- a/Platform/MeteorlakeBoardPkg/BoardConfigMtlp.py
+++ b/Platform/MeteorlakeBoardPkg/BoardConfigMtlp.py
@@ -122,7 +122,7 @@ class Board(BaseBoard):
         self.STAGE2_FD_SIZE       = 0x001F0000
 
         self.PAYLOAD_SIZE         = 0x0002C000
-        self.EPAYLOAD_SIZE        = 0x00187000
+        self.EPAYLOAD_SIZE        = 0x00230000
 
         self.ENABLE_FAST_BOOT = 0
         if self.ENABLE_FAST_BOOT:


### PR DESCRIPTION
EPAYLOAD_SIZE increased to accommodate UEFI payload built based on edk2-stable202311