### PR TITLE
fix: [TGL] FSP returns incorrect number of phases for SiInit

### DIFF
--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1246,6 +1246,14 @@ UpdateFspConfig (
   UINT8                MaxPcieRootPorts;
   UINT32              *HdaVerbTablePtr;
   UINT8                HdaVerbTableNum;
+  FSP_INFO_HEADER      *FspHeader;
+  UINT32               FspsBase;
+
+  FspsBase = PcdGet32 (PcdFSPSBase);
+  FspHeader = (FSP_INFO_HEADER *)(UINTN)(FspsBase + FSP_INFO_HEADER_OFF);
+  // TGL FSP doesn't correctly support MultiPhase Si Init.
+  FspHeader->FspMultiPhaseSiInitEntryOffset = 0;
+
   FspsUpd    = (FSPS_UPD *)FspsUpdPtr;
   FspsConfig = &FspsUpd->FspsConfig;
 

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -113,3 +113,4 @@
   gPlatformModuleTokenSpaceGuid.PcdEnableDts
   gPlatformModuleTokenSpaceGuid.PcdEnablePciePm
   gPlatformModuleTokenSpaceGuid.PcdPciResourceMem64Base
+  gPlatformModuleTokenSpaceGuid.PcdFSPSBase


### PR DESCRIPTION
MultiPhaseSiInit was fixed in pull #2171 to correctly interpret NumberOfPhases as 1-based instead of zero based. This exposed an issue in TGL where FSP returns that there is 1 phase supported in MultiPhaseSi init, but it actually supports zero phases. The bug fixed by #2171 was masking this issue.

The workaround in TGL is to override the FSP-S Info header so it appears to SBL that MultiPhaseSiInit isn't supported (since it isn't supported properly) so the MultiPhaseSiInit is skipped entirely.