### PR TITLE
ahci: fix AhciWriteBlocks and update Ahci code

### DIFF
--- a/BootloaderCommonPkg/Library/AhciLib/AhciBlkIo.c
+++ b/BootloaderCommonPkg/Library/AhciLib/AhciBlkIo.c
@@ -1,7 +1,7 @@
 /** @file
   The file provides AHCI block I/O interfaces.
 
-  Copyright (c) 2010 - 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2010 - 2024, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -60,19 +60,16 @@ CreateNewDeviceInfo (
 
   if (DeviceType == EfiIdeHarddisk) {
     AtaData = &DeviceInfo->IdentifyData.AtaData;
-    if ((AtaData->Command_set_feature_enb_86 & LBA_48_BIT_ADDRESS_FEATURE_SET_SUPPORTED) != 0) {
-      CopyMem (
-        &DeviceInfo->TotalBlockNumber,
-        (UINT8 *)AtaData + 100,
-        4 * sizeof (UINT16)
-        );
+    // ATA8-ACS: section 7.16 IDENTIFY DEVICE data
+    if (AtaData->Command_set_supported_83 & BIT10) {
+      DeviceInfo->TotalBlockNumber = (UINT64) AtaData->Maximum_lba_for_48bit_addressing[0] |
+        LShiftU64((UINT64) AtaData->Maximum_lba_for_48bit_addressing[1], 16) |
+        LShiftU64((UINT64) AtaData->Maximum_lba_for_48bit_addressing[2], 32) |
+        LShiftU64((UINT64) AtaData->Maximum_lba_for_48bit_addressing[3], 48);
       DeviceInfo->DeviceFeature |= DEVICE_LBA_48_SUPPORT;
     } else {
-      CopyMem (
-        &DeviceInfo->TotalBlockNumber,
-        &AtaData->User_addressable_sectors_lo,
-        2 * sizeof (UINT16)
-        );
+      DeviceInfo->TotalBlockNumber = (UINT64) AtaData->User_addressable_sectors_lo |
+        LShiftU64((UINT64) AtaData->User_addressable_sectors_hi, 16);
     }
     DeviceInfo->BlockSize        = ATA_BLOCK_SIZE;
   } else if (DeviceType == EfiIdeCdrom) {

--- a/BootloaderCommonPkg/Library/AhciLib/AhciDevice.c
+++ b/BootloaderCommonPkg/Library/AhciLib/AhciDevice.c
@@ -1,7 +1,7 @@
 /** @file
   This file provides AHCI SATA device block access interfaces.
 
-  Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2024, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -84,7 +84,11 @@ AhciAtaDeviceReadWrite (
   //
   ZeroMem (&AtaCmdBlk, sizeof (EFI_ATA_COMMAND_BLOCK));
 
-  AtaCmdBlk.AtaCommand = (AtaDevice->DeviceFeature & DEVICE_LBA_48_SUPPORT) ? ATA_CMD_READ_DMA_EXT : ATA_CMD_READ_DMA;
+  if (Read) {
+    AtaCmdBlk.AtaCommand = (AtaDevice->DeviceFeature & DEVICE_LBA_48_SUPPORT) ? ATA_CMD_READ_DMA_EXT : ATA_CMD_READ_DMA;
+  } else {
+    AtaCmdBlk.AtaCommand = (AtaDevice->DeviceFeature & DEVICE_LBA_48_SUPPORT) ? ATA_CMD_WRITE_DMA_EXT : ATA_CMD_WRITE_DMA;
+  }
   AtaCmdBlk.AtaSectorNumber = (UINT8) StartLba;
   AtaCmdBlk.AtaCylinderLow = (UINT8) RShiftU64 (StartLba, 8);
   AtaCmdBlk.AtaCylinderHigh = (UINT8) RShiftU64 (StartLba, 16);

--- a/BootloaderCommonPkg/Library/AhciLib/AhciMode.h
+++ b/BootloaderCommonPkg/Library/AhciLib/AhciMode.h
@@ -1,7 +1,7 @@
 /** @file
   Header file for AHCI mode of ATA host controller.
 
-  Copyright (c) 2010 - 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2010 - 2024, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -99,7 +99,7 @@ typedef enum {
 #define EFI_AHCI_PORT_IS                       0x0010
 #define   EFI_AHCI_PORT_IS_DHRS                BIT0
 #define   EFI_AHCI_PORT_IS_PSS                 BIT1
-#define   EFI_AHCI_PORT_IS_SSS                 BIT2
+#define   EFI_AHCI_PORT_IS_DSS                 BIT2
 #define   EFI_AHCI_PORT_IS_SDBS                BIT3
 #define   EFI_AHCI_PORT_IS_UFS                 BIT4
 #define   EFI_AHCI_PORT_IS_DPS                 BIT5
@@ -116,6 +116,8 @@ typedef enum {
 #define   EFI_AHCI_PORT_IS_CPDS                BIT31
 #define   EFI_AHCI_PORT_IS_CLEAR               0xFFFFFFFF
 #define   EFI_AHCI_PORT_IS_FIS_CLEAR           0x0000000F
+#define   EFI_AHCI_PORT_IS_ERROR_MASK        (EFI_AHCI_PORT_IS_INFS | EFI_AHCI_PORT_IS_IFS | EFI_AHCI_PORT_IS_HBDS | EFI_AHCI_PORT_IS_HBFS | EFI_AHCI_PORT_IS_TFES)
+#define   EFI_AHCI_PORT_IS_FATAL_ERROR_MASK  (EFI_AHCI_PORT_IS_IFS | EFI_AHCI_PORT_IS_HBDS | EFI_AHCI_PORT_IS_HBFS | EFI_AHCI_PORT_IS_TFES)
 
 #define EFI_AHCI_PORT_IE                       0x0014
 #define EFI_AHCI_PORT_CMD                      0x0018
@@ -283,7 +285,19 @@ typedef struct {
   UINT16  Command_set_feature_enb_86; // word 86
   UINT16  Command_set_feature_default; // word 87
   UINT16  Ultra_dma_mode; // word 88
-  UINT16  Reserved_89_105[17];
+  UINT16  Time_for_security_erase_unit;
+  UINT16  Time_for_enhanced_security_erase_unit;
+  UINT16  Advanced_power_management_level;
+  UINT16  Master_password_identifier;
+  UINT16  Hardware_configuration_test_result;
+  UINT16  obsolete_94;
+  UINT16  Stream_minimum_request_size;
+  UINT16  Streaming_transfer_time_for_dma;
+  UINT16  Streaming_access_latency_for_dma_and_pio;
+  UINT16  Streaming_performance_granularity[2];  ///< word 98~99
+  UINT16  Maximum_lba_for_48bit_addressing[4];   ///< word 100~103
+  UINT16  Streaming_transfer_time_for_pio;
+  UINT16  Max_no_of_512byte_blocks_per_data_set_cmd;
   UINT16  Phy_logic_sector_support; // word 106
   UINT16  Reserved_107_116[10];
   UINT16  Logic_sector_size_lo; // word 117
@@ -447,6 +461,12 @@ typedef struct {
   UINT8    AhciCFisRsvd4[4];
   UINT8    AhciCFisRsvd5[44];
 } EFI_AHCI_COMMAND_FIS;
+
+typedef enum {
+  SataFisD2H = 0,
+  SataFisPioSetup,
+  SataFisDmaSetup
+} SATA_FIS_TYPE;
 
 //
 // ACMD: ATAPI command (12 or 16 bytes)

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
@@ -118,6 +118,9 @@ class Board(BaseBoard):
         self.PAYLOAD_SIZE         = 0x00030000
         self.EPAYLOAD_SIZE        = 0x00230000
 
+        self.OS_LOADER_FD_SIZE    = 0x0005B000
+        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
+
         self.ENABLE_FAST_BOOT = 0
         if self.ENABLE_FAST_BOOT:
             self.ENABLE_SPLASH              = 0

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlPs.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlPs.py
@@ -1,7 +1,7 @@
 ## @file
 # This file is used to provide board specific image information.
 #
-#  Copyright (c) 2022 - 2023, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2022 - 2024, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -37,5 +37,5 @@ class Board(AlderlakeBoardConfig.Board):
         # 0 - PCH UART0, 1 - PCH UART1, 2 - PCH UART2, 0xFF - EC UART 0x3F8
         self.DEBUG_PORT_NUMBER = 0x0
 
-        self.OS_LOADER_FD_SIZE = 0x00059000
+        self.OS_LOADER_FD_SIZE = 0x0005A000
         self.OS_LOADER_FD_NUMBLK = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE

--- a/Platform/RaptorlakeBoardPkg/BoardConfigRpls.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRpls.py
@@ -117,6 +117,8 @@ class Board(BaseBoard):
 
         self.PAYLOAD_SIZE         = 0x00032000
         self.EPAYLOAD_SIZE        = 0x00230000
+        self.OS_LOADER_FD_SIZE    = 0x00059000
+        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.ENABLE_FAST_BOOT = 0
         try:


### PR DESCRIPTION
This commit fixes two AHCI operations:

    1. AhciWriteBlocks: caused by wrong command
    2. AhciGetMediaInfo: caused by wrong offset

The patches also updates the EFI_ATA_IDENTIFY_DATA to align with the ATA8-ACS.

In addition, this commit ports the following changes from EDK2, to enhance the command completion and trace:

    1. cc28ab7a1d7: MdeModulePkg/AtaAtapiPassThru: Check IS to check for command completion
    2. b465a811006: MdeModulePkg/AtaAtapiPassThru: Add SATA error recovery flow
    3. 64e25d4b062: MdeModulePkg/AtaAtapiPassThru: Restart failed packets
    4. 91d95113d07: MdeModulePkg/AtaAtapiPassThru: Trace ATA packets
    5. 4c7ce0d285b: MdeModulePkg AtaAtapiPassThru: Skip the potential NULL pointer access

Last, the commit adjusts OS_LOADER_FD_SIZE for several platforms for x64 build
Verified: Using BlockIoTest to test with SATA SSD disk on TGL-UP3