### PR TITLE
MultibootLib: Fix incorrect end address in AlignMultibootModules()

### DIFF
--- a/BootloaderCommonPkg/Library/MultibootLib/Multiboot.c
+++ b/BootloaderCommonPkg/Library/MultibootLib/Multiboot.c
@@ -339,6 +339,7 @@ AlignMultibootModules (
               Index, MbModule->Start, AlignedAddr));
       CopyMem (AlignedAddr, (CONST VOID *)(UINTN)MbModule->Start, (UINTN)ModuleSize);
       MbModule->Start = (UINT32)(UINTN)AlignedAddr;
+      MbModule->End = MbModule->Start + ModuleSize;
     }
   }
 


### PR DESCRIPTION
After moving multiboot module to a 4k-aligned address, the end address of that module should be changed accordingly.