### PR TITLE
feat: Add BoardConfig field to control Stage1B remap

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -236,6 +236,7 @@
   gPlatformModuleTokenSpaceGuid.PcdPciEnumEnabled         | TRUE       | BOOLEAN | 0x20000206
   gPlatformModuleTokenSpaceGuid.PcdStage1BXip             | TRUE       | BOOLEAN | 0x20000207
   gPlatformModuleTokenSpaceGuid.PcdStage1AXip             | TRUE       | BOOLEAN | 0x20000208
+  gPlatformModuleTokenSpaceGuid.PcdRemapStage1B           | FALSE      | BOOLEAN | 0x20000226
   gPlatformModuleTokenSpaceGuid.PcdLoadImageUseFsp        | FALSE      | BOOLEAN | 0x20000209
   gPlatformModuleTokenSpaceGuid.PcdVtdEnabled             | FALSE      | BOOLEAN | 0x2000020B
   gPlatformModuleTokenSpaceGuid.PcdS3DebugEnabled         | FALSE      | BOOLEAN | 0x2000020D

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -330,6 +330,7 @@
   gPlatformModuleTokenSpaceGuid.PcdPciEnumEnabled         | $(ENABLE_PCI_ENUM)
   gPlatformModuleTokenSpaceGuid.PcdStage1AXip             | $(STAGE1A_XIP)
   gPlatformModuleTokenSpaceGuid.PcdStage1BXip             | $(STAGE1B_XIP)
+  gPlatformModuleTokenSpaceGuid.PcdRemapStage1B           | $(REMAP_STAGE1B)
   gPlatformModuleTokenSpaceGuid.PcdLoadImageUseFsp        | $(ENABLE_FSP_LOAD_IMAGE)
   gPlatformModuleTokenSpaceGuid.PcdSplashEnabled          | $(ENABLE_SPLASH)
   gPlatformModuleTokenSpaceGuid.PcdFramebufferInitEnabled | $(ENABLE_FRAMEBUFFER_INIT)

--- a/BootloaderCorePkg/Library/StageLib/StageLib.inf
+++ b/BootloaderCorePkg/Library/StageLib/StageLib.inf
@@ -33,7 +33,6 @@
   PagingLib
 
 [Pcd]
-  gPlatformModuleTokenSpaceGuid.PcdStage1BXip
   gPlatformModuleTokenSpaceGuid.PcdStage1BFdBase
   gPlatformModuleTokenSpaceGuid.PcdStage1BFdSize
-  gPlatformModuleTokenSpaceGuid.PcdFastBootEnabled
+  gPlatformModuleTokenSpaceGuid.PcdRemapStage1B

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -212,6 +212,7 @@ class BaseBoard(object):
         self.FSP_M_STACK_TOP       = 0
         self.STAGE1A_XIP           = 1
         self.STAGE1B_XIP           = 1
+        self.REMAP_STAGE1B         = 0
         self.STAGE1_STACK_BASE_OFFSET = 0
         self.STAGE2_XIP            = 0
         self.STAGE2_LOAD_HIGH      = 1

--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -134,6 +134,7 @@ class Board(BaseBoard):
         self.STAGE1A_XIP          = 0
         self.STAGE1A_LOAD_BASE    = 0xFEF00000
         self.STAGE1B_XIP          = 0
+        self.REMAP_STAGE1B        = 1
         self.STAGE1B_LOAD_BASE    = 0xFEF10000
         self.STAGE1B_FD_BASE      = 0xFEF80000
         self.STAGE1B_FD_SIZE      = 0x0006D000

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -144,6 +144,7 @@ class Board(BaseBoard):
             self.STAGE1A_LOAD_BASE  = FREE_TEMP_RAM_TOP
 
         self.STAGE1B_XIP          = EXECUTE_IN_PLACE
+        self.REMAP_STAGE1B        = not EXECUTE_IN_PLACE
         if not self.STAGE1B_XIP:
             # For Stage1B, it can be compressed if STAGE1B_XIP is 0
             # If so, STAGE1B_FD_BASE/STAGE1B_FD_SIZE need to be defined


### PR DESCRIPTION
Adding new Board Config item REMAP_STAGE1B to control remapping Stage1B into permanent memory after FSP-M. Decouple this from ENABLE_FAST_BOOT and STAGE1B_XIP. This makes it simpler to enable this remap when the slight performance boost may be needed, and leave it disabled by default.