### PR TITLE
fix: [ADLN] increase RSVD_MEM_SIZE

### DIFF
--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
@@ -205,7 +205,7 @@ class Board(BaseBoard):
             acm_btm = (acm_btm & 0xFFFC0000)
             self.ACM_SIZE     = acm_top - acm_btm
 
-        self.LOADER_RSVD_MEM_SIZE = 0x500000
+        self.LOADER_RSVD_MEM_SIZE = 0xC00000
 
         # If mulitple VBT table support is required, list them as:
         #   {VbtImageId1 : VbtFileName1, VbtImageId2 : VbtFileName2, ...}

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlN50.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlN50.py
@@ -157,7 +157,7 @@ class Board(AlderlakeBoardConfig.Board):
             acm_btm = (acm_btm & 0xFFFC0000)
             self.ACM_SIZE     = acm_top - acm_btm
 
-        self.LOADER_RSVD_MEM_SIZE = 0x500000
+        self.LOADER_RSVD_MEM_SIZE = 0xC00000
 
         # If mulitple VBT table support is required, list them as:
         #   {VbtImageId1 : VbtFileName1, VbtImageId2 : VbtFileName2, ...}


### PR DESCRIPTION
While loading the DEBUG build universal payload size around 10MB, system hang with this log: ASSERT [Stage2] BootloaderCorePkg\Library\MemoryAllocationLib\MemoryAllocationLib.c(61): LdrGlobal->MemPoolCurrTop >= Bottom

fail on https://github.com/slimbootloader/slimbootloader/blob/c0530d37af2485df8f3e9734507d7524704648b9/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c#L846