### PR TITLE
fix: [RPLP] increase RSVD_MEM_SIZE

### DIFF
--- a/Platform/RaptorlakeBoardPkg/BoardConfigRplp.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRplp.py
@@ -266,7 +266,7 @@ class Board(BaseBoard):
             acm_btm = (acm_btm & 0xFFFC0000)
             self.ACM_SIZE     = acm_top - acm_btm
 
-        self.LOADER_RSVD_MEM_SIZE = 0x500000
+        self.LOADER_RSVD_MEM_SIZE = 0xC00000
         # large BIST test patterns increase heap usage significantly. round to 1MB
         if (2*self.FUSA_SIZE & 0xFFFFF) != 0:
             self.LOADER_RSVD_MEM_SIZE += (2*self.FUSA_SIZE & ~0xFFFFF) + 0x100000


### PR DESCRIPTION
Fix ASSERT [Stage2] BootloaderCorePkg\Library\MemoryAllocationLib\MemoryAllocationLib.c(61):
    LdrGlobal->MemPoolCurrTop >= Bottom