### PR TITLE
fix: Remove deprecated python imp module

### DIFF
--- a/Platform/AlderlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/AlderlakeBoardPkg/Script/StitchIfwi.py
@@ -9,7 +9,7 @@
 import sys
 import os
 import re
-import imp
+from importlib.machinery import SourceFileLoader
 import struct
 import argparse
 import zipfile
@@ -217,7 +217,7 @@ def main():
 
     args = ap.parse_args()
 
-    stitch_cfg_file = imp.load_source('StitchIfwiConfig', args.config_file)
+    stitch_cfg_file = SourceFileLoader('StitchIfwiConfig', args.config_file).load_module()
     if args.work_dir == '':
         print ("Please specify stitch work directory")
         print ('%s' % stitch_cfg_file.extra_usage_txt)

--- a/Platform/CommonBoardPkg/Script/BtgSign.py
+++ b/Platform/CommonBoardPkg/Script/BtgSign.py
@@ -9,7 +9,6 @@
 import sys
 import os
 import re
-import imp
 import struct
 import argparse
 import zipfile

--- a/Platform/CommonBoardPkg/Script/security_stitch_help.py
+++ b/Platform/CommonBoardPkg/Script/security_stitch_help.py
@@ -9,7 +9,6 @@
 import sys
 import os
 import re
-import imp
 import struct
 import shutil
 import glob

--- a/Platform/ElkhartlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/ElkhartlakeBoardPkg/Script/StitchIfwi.py
@@ -9,7 +9,7 @@
 import sys
 import os
 import re
-import imp
+from importlib.machinery import SourceFileLoader
 import struct
 import argparse
 import zipfile
@@ -210,7 +210,7 @@ def main():
 
     args = ap.parse_args()
 
-    stitch_cfg_file = imp.load_source('StitchIfwiConfig', args.config_file)
+    stitch_cfg_file = SourceFileLoader('StitchIfwiConfig', args.config_file).load_module()
     if args.work_dir == '':
         print ("Please specify stitch work directory")
         print ('%s' % stitch_cfg_file.extra_usage_txt)

--- a/Platform/IdavilleBoardPkg/Script/BtGUtility.py
+++ b/Platform/IdavilleBoardPkg/Script/BtGUtility.py
@@ -9,7 +9,6 @@
 import sys
 import os
 import re
-import imp
 import struct
 import argparse
 import zipfile

--- a/Platform/MeteorlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/MeteorlakeBoardPkg/Script/StitchIfwi.py
@@ -9,7 +9,7 @@
 import sys
 import os
 import re
-import imp
+from importlib.machinery import SourceFileLoader
 import struct
 import argparse
 import zipfile
@@ -216,7 +216,7 @@ def main():
 
     args = ap.parse_args()
 
-    stitch_cfg_file = imp.load_source('StitchIfwiConfig', args.config_file)
+    stitch_cfg_file = SourceFileLoader('StitchIfwiConfig', args.config_file).load_module()
     if args.work_dir == '':
         print ("Please specify stitch work directory")
         print ('%s' % stitch_cfg_file.extra_usage_txt)

--- a/Platform/MeteorlakeBoardPkg/Script/security_stitch_help_mtl.py
+++ b/Platform/MeteorlakeBoardPkg/Script/security_stitch_help_mtl.py
@@ -9,7 +9,6 @@
 import sys
 import os
 import re
-import imp
 import struct
 import shutil
 import glob

--- a/Platform/RaptorlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/RaptorlakeBoardPkg/Script/StitchIfwi.py
@@ -9,7 +9,7 @@
 import sys
 import os
 import re
-import imp
+from importlib.machinery import SourceFileLoader
 import struct
 import argparse
 import zipfile
@@ -217,7 +217,7 @@ def main():
 
     args = ap.parse_args()
 
-    stitch_cfg_file = imp.load_source('StitchIfwiConfig', args.config_file)
+    stitch_cfg_file = SourceFileLoader('StitchIfwiConfig', args.config_file).load_module()
     if args.work_dir == '':
         print ("Please specify stitch work directory")
         print ('%s' % stitch_cfg_file.extra_usage_txt)

--- a/Platform/TigerlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/TigerlakeBoardPkg/Script/StitchIfwi.py
@@ -9,7 +9,7 @@
 import sys
 import os
 import re
-import imp
+from importlib.machinery import SourceFileLoader
 import struct
 import argparse
 import zipfile
@@ -176,7 +176,7 @@ def main():
 
     args = ap.parse_args()
 
-    stitch_cfg_file = imp.load_source('StitchIfwiConfig', args.config_file)
+    stitch_cfg_file = SourceFileLoader('StitchIfwiConfig', args.config_file).load_module()
     if args.work_dir == '':
         print ("Please specify stitch work directory")
         print ('%s' % stitch_cfg_file.extra_usage_txt)


### PR DESCRIPTION
Python imp module is removed in 3.12+ and will cause a build error. Replace with importlib.machinery.SourceFileLoader.