### PR TITLE
OsLoader: Handle module align flag for multiboot images in ELF format

### DIFF
--- a/BootloaderCommonPkg/Include/Library/MultibootLib.h
+++ b/BootloaderCommonPkg/Include/Library/MultibootLib.h
@@ -297,6 +297,20 @@ SetupMultibootInfo (
   );
 
 /**
+  Align multiboot modules if requested by header.
+
+  @param[in,out] MultiBoot    Point to loaded Multiboot image structure
+
+  @retval  RETURN_SUCCESS     Align modules successfully
+  @retval  Others             There is error when align image
+**/
+EFI_STATUS
+EFIAPI
+CheckAndAlignMultibootModules (
+  IN OUT MULTIBOOT_IMAGE     *MultiBoot
+  );
+
+/**
   ASM inline function that goes from payload to a Multiboot enabled OS.
   @param[in]  State  Boot state structure
  **/
@@ -343,6 +357,20 @@ SetupMultiboot2Image (
 VOID
 EFIAPI
 SetupMultiboot2Info (
+  IN OUT MULTIBOOT_IMAGE     *MultiBoot
+  );
+
+/**
+  Align multiboot modules if requested by module alignment tag.
+
+  @param[in,out] MultiBoot    Point to loaded Multiboot image structure
+
+  @retval  RETURN_SUCCESS     Align modules successfully
+  @retval  Others             There is error when align image
+**/
+EFI_STATUS
+EFIAPI
+CheckAndAlignMultiboot2Modules (
   IN OUT MULTIBOOT_IMAGE     *MultiBoot
   );
 

--- a/BootloaderCommonPkg/Library/MultibootLib/Multiboot.c
+++ b/BootloaderCommonPkg/Library/MultibootLib/Multiboot.c
@@ -346,6 +346,41 @@ AlignMultibootModules (
   return RETURN_SUCCESS;
 }
 
+/**
+  Align multiboot modules if requested by header.
+
+  @param[in,out] MultiBoot    Point to loaded Multiboot image structure
+
+  @retval  RETURN_SUCCESS     Align modules successfully
+  @retval  Others             There is error when align image
+**/
+EFI_STATUS
+EFIAPI
+CheckAndAlignMultibootModules (
+  IN OUT MULTIBOOT_IMAGE     *MultiBoot
+  )
+{
+  EFI_STATUS                 Status;
+  CONST MULTIBOOT_HEADER     *MbHeader;
+
+  if (MultiBoot == NULL) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  MbHeader = GetMultibootHeader (MultiBoot->BootFile.Addr);
+  if (MbHeader == NULL) {
+    return RETURN_LOAD_ERROR;
+  }
+
+  if ((MbHeader->Flags & MULTIBOOT_HEADER_MODS_ALIGNED) != 0) {
+    // Modules should be page (4KB) aligned
+    Status = AlignMultibootModules (MultiBoot);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+  }
+  return EFI_SUCCESS;
+}
 
 /**
   Setup Multiboot image and its boot info.

--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -497,10 +497,16 @@ SetupBootImage (
       EntryPoint = PayloadInfo.EntryPoint;
       if (IsMultiboot (BootFile->Addr)) {
         DEBUG ((DEBUG_INFO, "and Image is Multiboot format\n"));
-        SetupMultibootInfo (MultiBoot);
+        Status = CheckAndAlignMultibootModules (MultiBoot);
+        if (!EFI_ERROR (Status)) {
+          SetupMultibootInfo (MultiBoot);
+        }
       } else if (IsMultiboot2 (BootFile->Addr)) {
         DEBUG ((DEBUG_INFO, "and Image is Multiboot-2 format\n"));
-        SetupMultiboot2Info (MultiBoot);
+        Status = CheckAndAlignMultiboot2Modules (MultiBoot);
+        if (!EFI_ERROR (Status)) {
+          SetupMultiboot2Info (MultiBoot);
+        }
       }
       MultiBoot->BootState.EntryPoint = (UINT32)(UINTN)EntryPoint;
     }


### PR DESCRIPTION
There is a flag in both multiboot and multiboot2 image indicating modules must be loaded to page boundaries. Currently this flag is not handled when loading multiboot images in ELF format. Check this flag and move the loaded modules if needed before SetupMultibootInfo().