### PR TITLE
feat: [ADL] Separate Fsp version by project

### DIFF
--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlN50.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlN50.py
@@ -69,13 +69,16 @@ class Board(AlderlakeBoardConfig.Board):
         self.STAGE1_STACK_SIZE    = 0x00002000
         self.STAGE1_DATA_SIZE     = 0x00014000
         self.FSP_M_STACK_TOP      = 0xFEF7FF00
-        self.STAGE1B_SIZE         = 0x000DA000
-        self.STAGE2_SIZE          = 0x000A0000
-        self.STAGE2_FD_BASE       = 0x000B0000
+        self.STAGE1B_SIZE         = 0x00200000
+        self.STAGE2_SIZE          = 0x000C2000
+        self.STAGE2_FD_BASE       = 0x01000000
         self.STAGE2_FD_SIZE       = 0x001F0000
 
-        self.EPAYLOAD_SIZE        = 0x00161000
-        self.PAYLOAD_SIZE         = 0x0002B000
+        self.PAYLOAD_SIZE         = 0x00030000
+        self.EPAYLOAD_SIZE        = 0x00230000
+
+        self.OS_LOADER_FD_SIZE    = 0x0005B000
+        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.ENABLE_FAST_BOOT = 0
         if self.ENABLE_FAST_BOOT:
@@ -90,7 +93,7 @@ class Board(AlderlakeBoardConfig.Board):
             self.STAGE1A_SIZE         = 0x00016000
             self.STAGE1B_SIZE         = 0x000E0000
             self.STAGE2_SIZE          = 0x000C0000
-            self.STAGE2_FD_SIZE       = 0x000E0000
+            self.STAGE2_FD_SIZE       = 0x000F0000
             self.PAYLOAD_SIZE         = 0x00024000
 
         self.PLD_HEAP_SIZE        = 0x09000000

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlP.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlP.py
@@ -27,6 +27,7 @@ class Board(AlderlakeBoardConfig.Board):
         self._EXTRA_INC_PATH      = ['Silicon/AlderlakePkg/Adlp/Include']
         self._FSP_PATH_NAME       = 'Silicon/AlderlakePkg/Adlp/FspBin'
         self.MICROCODE_INF_FILE   = 'Silicon/AlderlakePkg/Microcode/Microcode.inf'
+        self.FSP_INF_FILE         = 'Silicon/AlderlakePkg/FspBin/FspBinIpu.inf'
         self.ACPI_TABLE_INF_FILE  = 'Platform/AlderlakeBoardPkg/AcpiTables/AcpiTablesP.inf'
         self.ENABLE_TCC           = 0
         self._generated_cfg_file_prefix = ''

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlS.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlS.py
@@ -36,6 +36,7 @@ class Board(BaseBoard):
         self._EXTRA_INC_PATH      = ['Silicon/AlderlakePkg/Adls/Include']
         self._FSP_PATH_NAME       =  'Silicon/AlderlakePkg/Adls/FspBin'
         self.MICROCODE_INF_FILE   = 'Silicon/AlderlakePkg/Microcode/Microcode.inf'
+        self.FSP_INF_FILE         = 'Silicon/AlderlakePkg/FspBin/FspBinIpu.inf'
         self.ACPI_TABLE_INF_FILE  = 'Platform/AlderlakeBoardPkg/AcpiTables/AcpiTables.inf'
         self._LP_SUPPORT          = False
         self._N_SUPPORT           = False

--- a/Platform/AlderlakeBoardPkg/BoardConfigAzb.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAzb.py
@@ -38,6 +38,7 @@ class Board(BaseBoard):
         self._EXTRA_INC_PATH                  = ['Silicon/AlderlakePkg/Azb/Include']
         self._FSP_PATH_NAME                   = 'Silicon/AlderlakePkg/Azb/FspBin'
         self.MICROCODE_INF_FILE               = 'Silicon/AlderlakePkg/Microcode/MicrocodeAzb.inf'
+        self.FSP_INF_FILE                     = 'Silicon/AlderlakePkg/FspBin/FspBinAzb.inf'
         self._LP_SUPPORT                      = True
         self._N_SUPPORT                       = False
         self._AZB_SUPPORT                     = True

--- a/Silicon/AlderlakePkg/FspBin/FspBin.inf
+++ b/Silicon/AlderlakePkg/FspBin/FspBin.inf
@@ -14,28 +14,6 @@
   COMMIT  = 41e45901ce203fd454edc99077e4cc426e90fb8b
 
 [UserExtensions.SBL."CopyList"]
-# For ADL-S
-  AlderLakeFspBinPkg/IoT/AlderLakeS/Fsp.fd                    : Silicon/AlderlakePkg/Adls/FspBin/FspDbg.bin
-  AlderLakeFspBinPkg/IoT/AlderLakeS/Fsp.fd                    : Silicon/AlderlakePkg/Adls/FspBin/FspRel.bin
-  AlderLakeFspBinPkg/IoT/AlderLakeS/Fsp.bsf                   : Silicon/AlderlakePkg/Adls/FspBin/Fsp.bsf
-  AlderLakeFspBinPkg/IoT/AlderLakeS/Include/FspUpd.h          : Silicon/AlderlakePkg/Adls/Include/FspUpd.h
-  AlderLakeFspBinPkg/IoT/AlderLakeS/Include/FsptUpd.h         : Silicon/AlderlakePkg/Adls/Include/FsptUpd.h
-  AlderLakeFspBinPkg/IoT/AlderLakeS/Include/FspmUpd.h         : Silicon/AlderlakePkg/Adls/Include/FspmUpd.h
-  AlderLakeFspBinPkg/IoT/AlderLakeS/Include/FspsUpd.h         : Silicon/AlderlakePkg/Adls/Include/FspsUpd.h
-  AlderLakeFspBinPkg/IoT/AlderLakeS/Include/MemInfoHob.h      : Silicon/AlderlakePkg/Adls/Include/MemInfoHob.h
-  FSP_License.pdf                                             : Silicon/AlderlakePkg/Adls/FspBin/FSP_License.pdf
-  AlderLakeFspBinPkg/IoT/AlderLakeS/VBT/Vbt.json              : Platform/AlderlakeBoardPkg/VbtBin/VbtAdlS.json
-# For ADL-P
-  AlderLakeFspBinPkg/IoT/AlderLakeP/Fsp.fd                    : Silicon/AlderlakePkg/Adlp/FspBin/FspDbg.bin
-  AlderLakeFspBinPkg/IoT/AlderLakeP/Fsp.fd                    : Silicon/AlderlakePkg/Adlp/FspBin/FspRel.bin
-  AlderLakeFspBinPkg/IoT/AlderLakeP/Fsp.bsf                   : Silicon/AlderlakePkg/Adlp/FspBin/Fsp.bsf
-  AlderLakeFspBinPkg/IoT/AlderLakeP/Include/FspUpd.h          : Silicon/AlderlakePkg/Adlp/Include/FspUpd.h
-  AlderLakeFspBinPkg/IoT/AlderLakeP/Include/FsptUpd.h         : Silicon/AlderlakePkg/Adlp/Include/FsptUpd.h
-  AlderLakeFspBinPkg/IoT/AlderLakeP/Include/FspmUpd.h         : Silicon/AlderlakePkg/Adlp/Include/FspmUpd.h
-  AlderLakeFspBinPkg/IoT/AlderLakeP/Include/FspsUpd.h         : Silicon/AlderlakePkg/Adlp/Include/FspsUpd.h
-  AlderLakeFspBinPkg/IoT/AlderLakeP/Include/MemInfoHob.h      : Silicon/AlderlakePkg/Adlp/Include/MemInfoHob.h
-  FSP_License.pdf                                             : Silicon/AlderlakePkg/Adlp/FspBin/FSP_License.pdf
-  AlderLakeFspBinPkg/IoT/AlderLakeP/VBT/VbtAdlP.json          : Platform/AlderlakeBoardPkg/VbtBin/VbtAdlP.json
 # For ADL-PS
   AlderLakeFspBinPkg/IoT/AlderLakePS/Fsp.fd                               : Silicon/AlderlakePkg/Adlps/FspBin/FspDbg.bin
   AlderLakeFspBinPkg/IoT/AlderLakePS/Fsp.fd                               : Silicon/AlderlakePkg/Adlps/FspBin/FspRel.bin
@@ -58,12 +36,3 @@
   AlderLakeFspBinPkg/IoT/AlderLakeN/Include/MemInfoHob.h                 : Silicon/AlderlakePkg/Adln/Include/MemInfoHob.h
   FSP_License.pdf                                                        : Silicon/AlderlakePkg/Adln/FspBin/FSP_License.pdf
   AlderLakeFspBinPkg/IoT/AlderLakeN/Vbt/VbtAdlP.json                     : Platform/AlderlakeBoardPkg/VbtBin/VbtAdlN.json
-# For AZB
-  AlderLakeFspBinPkg/IoT/ArizonaBeach/Fsp.fd                             : Silicon/AlderlakePkg/Azb/FspBin/FspDbg.bin
-  AlderLakeFspBinPkg/IoT/ArizonaBeach/Fsp.fd                             : Silicon/AlderlakePkg/Azb/FspBin/FspRel.bin
-  AlderLakeFspBinPkg/IoT/ArizonaBeach/Fsp.bsf                            : Silicon/AlderlakePkg/Azb/FspBin/Fsp.bsf
-  AlderLakeFspBinPkg/IoT/ArizonaBeach/Include/FspUpd.h                   : Silicon/AlderlakePkg/Azb/Include/FspUpd.h
-  AlderLakeFspBinPkg/IoT/ArizonaBeach/Include/FsptUpd.h                  : Silicon/AlderlakePkg/Azb/Include/FsptUpd.h
-  AlderLakeFspBinPkg/IoT/ArizonaBeach/Include/FspmUpd.h                  : Silicon/AlderlakePkg/Azb/Include/FspmUpd.h
-  AlderLakeFspBinPkg/IoT/ArizonaBeach/Include/FspsUpd.h                  : Silicon/AlderlakePkg/Azb/Include/FspsUpd.h
-  FSP_License.pdf                                                        : Silicon/AlderlakePkg/Azb/FspBin/FSP_License.pdf

--- a/Silicon/AlderlakePkg/FspBin/FspBinAzb.inf
+++ b/Silicon/AlderlakePkg/FspBin/FspBinAzb.inf
@@ -1,0 +1,25 @@
+## @file
+#  File to describe FSP repo information
+#
+#  Copyright (c) 2020 - 2024, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+
+[UserExtensions.SBL."CloneRepo"]
+  REPO    = https://github.com/intel/FSP.git
+  COMMIT  = 41e45901ce203fd454edc99077e4cc426e90fb8b
+
+[UserExtensions.SBL."CopyList"]
+# For AZB
+  AlderLakeFspBinPkg/IoT/ArizonaBeach/Fsp.fd                             : Silicon/AlderlakePkg/Azb/FspBin/FspDbg.bin
+  AlderLakeFspBinPkg/IoT/ArizonaBeach/Fsp.fd                             : Silicon/AlderlakePkg/Azb/FspBin/FspRel.bin
+  AlderLakeFspBinPkg/IoT/ArizonaBeach/Fsp.bsf                            : Silicon/AlderlakePkg/Azb/FspBin/Fsp.bsf
+  AlderLakeFspBinPkg/IoT/ArizonaBeach/Include/FspUpd.h                   : Silicon/AlderlakePkg/Azb/Include/FspUpd.h
+  AlderLakeFspBinPkg/IoT/ArizonaBeach/Include/FsptUpd.h                  : Silicon/AlderlakePkg/Azb/Include/FsptUpd.h
+  AlderLakeFspBinPkg/IoT/ArizonaBeach/Include/FspmUpd.h                  : Silicon/AlderlakePkg/Azb/Include/FspmUpd.h
+  AlderLakeFspBinPkg/IoT/ArizonaBeach/Include/FspsUpd.h                  : Silicon/AlderlakePkg/Azb/Include/FspsUpd.h
+  FSP_License.pdf                                                        : Silicon/AlderlakePkg/Azb/FspBin/FSP_License.pdf

--- a/Silicon/AlderlakePkg/FspBin/FspBinIpu.inf
+++ b/Silicon/AlderlakePkg/FspBin/FspBinIpu.inf
@@ -1,0 +1,38 @@
+## @file
+#  File to describe FSP repo information
+#
+#  Copyright (c) 2020 - 2024, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+
+[UserExtensions.SBL."CloneRepo"]
+  REPO    = https://github.com/intel/FSP.git
+  COMMIT  = 41e45901ce203fd454edc99077e4cc426e90fb8b
+
+[UserExtensions.SBL."CopyList"]
+# For ADL-S
+  AlderLakeFspBinPkg/IoT/AlderLakeS/Fsp.fd                    : Silicon/AlderlakePkg/Adls/FspBin/FspDbg.bin
+  AlderLakeFspBinPkg/IoT/AlderLakeS/Fsp.fd                    : Silicon/AlderlakePkg/Adls/FspBin/FspRel.bin
+  AlderLakeFspBinPkg/IoT/AlderLakeS/Fsp.bsf                   : Silicon/AlderlakePkg/Adls/FspBin/Fsp.bsf
+  AlderLakeFspBinPkg/IoT/AlderLakeS/Include/FspUpd.h          : Silicon/AlderlakePkg/Adls/Include/FspUpd.h
+  AlderLakeFspBinPkg/IoT/AlderLakeS/Include/FsptUpd.h         : Silicon/AlderlakePkg/Adls/Include/FsptUpd.h
+  AlderLakeFspBinPkg/IoT/AlderLakeS/Include/FspmUpd.h         : Silicon/AlderlakePkg/Adls/Include/FspmUpd.h
+  AlderLakeFspBinPkg/IoT/AlderLakeS/Include/FspsUpd.h         : Silicon/AlderlakePkg/Adls/Include/FspsUpd.h
+  AlderLakeFspBinPkg/IoT/AlderLakeS/Include/MemInfoHob.h      : Silicon/AlderlakePkg/Adls/Include/MemInfoHob.h
+  FSP_License.pdf                                             : Silicon/AlderlakePkg/Adls/FspBin/FSP_License.pdf
+  AlderLakeFspBinPkg/IoT/AlderLakeS/VBT/Vbt.json              : Platform/AlderlakeBoardPkg/VbtBin/VbtAdlS.json
+# For ADL-P
+  AlderLakeFspBinPkg/IoT/AlderLakeP/Fsp.fd                    : Silicon/AlderlakePkg/Adlp/FspBin/FspDbg.bin
+  AlderLakeFspBinPkg/IoT/AlderLakeP/Fsp.fd                    : Silicon/AlderlakePkg/Adlp/FspBin/FspRel.bin
+  AlderLakeFspBinPkg/IoT/AlderLakeP/Fsp.bsf                   : Silicon/AlderlakePkg/Adlp/FspBin/Fsp.bsf
+  AlderLakeFspBinPkg/IoT/AlderLakeP/Include/FspUpd.h          : Silicon/AlderlakePkg/Adlp/Include/FspUpd.h
+  AlderLakeFspBinPkg/IoT/AlderLakeP/Include/FsptUpd.h         : Silicon/AlderlakePkg/Adlp/Include/FsptUpd.h
+  AlderLakeFspBinPkg/IoT/AlderLakeP/Include/FspmUpd.h         : Silicon/AlderlakePkg/Adlp/Include/FspmUpd.h
+  AlderLakeFspBinPkg/IoT/AlderLakeP/Include/FspsUpd.h         : Silicon/AlderlakePkg/Adlp/Include/FspsUpd.h
+  AlderLakeFspBinPkg/IoT/AlderLakeP/Include/MemInfoHob.h      : Silicon/AlderlakePkg/Adlp/Include/MemInfoHob.h
+  FSP_License.pdf                                             : Silicon/AlderlakePkg/Adlp/FspBin/FSP_License.pdf
+  AlderLakeFspBinPkg/IoT/AlderLakeP/VBT/VbtAdlP.json          : Platform/AlderlakeBoardPkg/VbtBin/VbtAdlP.json


### PR DESCRIPTION
When the fsp.git commit id is updated,
it will update all platform fsp versions without testing. 
Also adjust the fd size in adln50 project to avoid build break.