### PR TITLE
fix: improve the DX for RsvdSmbusAddressTablePtr #2207

### DIFF
--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_Memory.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_Memory.yaml
@@ -2,7 +2,7 @@
 #
 #  Slim Bootloader CFGDATA Option File.
 #
-#  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2024, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -529,20 +529,13 @@
                      Enable/disable SMBus controller.
       length       : 0x01
       value        : 0x01
-  - PchNumRsvdSmbusAddresses :
-      name         : Number of RsvdSmbusAddressTable.
-      type         : EditNum, HEX, (0x0, 0xFF)
-      help         : >
-                     The number of elements in the RsvdSmbusAddressTable.
-      length       : 0x0001
-      value        : 0x04
   - RsvdSmbusAddressTablePtr :
-      name         : Point of RsvdSmbusAddressTable
+      name         : Reserved SMBUS address table
       type         : EditNum, HEX, (0x0, 0xFFFFFFFF)
       help         : >
                      Array of addresses reserved for non-ARP-capable SMBus devices.
-      length       : 0x0004
-      value        : 0xfffc3ff8
+      length       : 0x04
+      value        : { 0xA2, 0xA0, 0xA2, 0xA0 }
   - RealtimeMemoryTiming :
       name         : Realtime Memory Timing
       type         : Combo
@@ -1083,5 +1076,5 @@
       length       : 0x01
       value        : 0x00
   - Dummy        :
-      length      : 0x01
+      length      : 0x02
       value       : 0x00

--- a/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020 - 2024, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -451,8 +451,8 @@ UpdateFspConfig (
 
   // Smbus
   Fspmcfg->SmbusEnable               = MemCfgData->SmbusEnable;
-  Fspmcfg->PchNumRsvdSmbusAddresses  = MemCfgData->PchNumRsvdSmbusAddresses;
-  Fspmcfg->RsvdSmbusAddressTablePtr  = MemCfgData->RsvdSmbusAddressTablePtr;
+  Fspmcfg->PchNumRsvdSmbusAddresses  = sizeof (MemCfgData->RsvdSmbusAddressTablePtr) / sizeof (MemCfgData->RsvdSmbusAddressTablePtr[0]);
+  Fspmcfg->RsvdSmbusAddressTablePtr  = (UINT32)(UINTN)MemCfgData->RsvdSmbusAddressTablePtr;
 
   // Overclocking Cfg
   Fspmcfg->RealtimeMemoryTiming = MemCfgData->RealtimeMemoryTiming;

--- a/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLibAzb.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLibAzb.c
@@ -244,8 +244,8 @@ UpdateFspConfig (
 
   // Smbus
   Fspmcfg->SmbusEnable                = MemCfgData->SmbusEnable;
-  Fspmcfg->PchNumRsvdSmbusAddresses   = MemCfgData->PchNumRsvdSmbusAddresses;
-  Fspmcfg->RsvdSmbusAddressTablePtr   = MemCfgData->RsvdSmbusAddressTablePtr;
+  Fspmcfg->PchNumRsvdSmbusAddresses   = sizeof (MemCfgData->RsvdSmbusAddressTablePtr) / sizeof (MemCfgData->RsvdSmbusAddressTablePtr[0]);
+  Fspmcfg->RsvdSmbusAddressTablePtr   = (UINT32)(UINTN)MemCfgData->RsvdSmbusAddressTablePtr;
 
   // Overclocking Cfg
   Fspmcfg->RealtimeMemoryTiming       = MemCfgData->RealtimeMemoryTiming;

--- a/Platform/MeteorlakeBoardPkg/CfgData/CfgData_Memory.yaml
+++ b/Platform/MeteorlakeBoardPkg/CfgData/CfgData_Memory.yaml
@@ -2,7 +2,7 @@
 #
 #  Slim Bootloader CFGDATA Option File.
 #
-#  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2024, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -536,20 +536,13 @@
                      Enable/disable SMBus controller.
       length       : 0x01
       value        : 0x01
-    - PchNumRsvdSmbusAddresses :
-        name         : Number of RsvdSmbusAddressTable.
-        type         : EditNum, HEX, (0x0, 0xFF)
-        help         : >
-                       The number of elements in the RsvdSmbusAddressTable.
-        length       : 0x0001
-        value        : 0x04
-    - RsvdSmbusAddressTablePtr :
-        name         : Point of RsvdSmbusAddressTable
-        type         : EditNum, HEX, (0x0, 0xFFFFFFFF)
-        help         : >
-                       Array of addresses reserved for non-ARP-capable SMBus devices.
-        length       : 0x0004
-        value        : 0xfffc3ff8
+  - RsvdSmbusAddressTablePtr :
+      name         : Point of RsvdSmbusAddressTable
+      type         : EditNum, HEX, (0x0, 0xFFFFFFFF)
+      help         : >
+                     Reserved SMBUS address table
+      length       : 0x04
+      value        : { 0xA2, 0xA0, 0xA2, 0xA0 }
   - RealtimeMemoryTiming :
       name         : Realtime Memory Timing
       type         : Combo
@@ -999,5 +992,5 @@
       length       : 0x20
       value        : {0:0D,  0x03FFFFE0, 0x03FFFFE0, 0x03FFFFE0, 0x03FFFFE0, 0x03FFFFE0, 0x03FFFFE0, 0x03FFFFE0, 0x03FFFFE0 }
   - Dummy        :
-      length      : 0x03
+      length      : 0x04
       value       : 0x00

--- a/Platform/MeteorlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/MeteorlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020 - 2024, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -271,8 +271,8 @@ UpdateFspConfig (
 
   // Smbus
   Fspmcfg->SmbusEnable                = MemCfgData->SmbusEnable;
-  Fspmcfg->PchNumRsvdSmbusAddresses   = MemCfgData->PchNumRsvdSmbusAddresses;
-  Fspmcfg->RsvdSmbusAddressTablePtr   = MemCfgData->RsvdSmbusAddressTablePtr;
+  Fspmcfg->PchNumRsvdSmbusAddresses   = sizeof (MemCfgData->RsvdSmbusAddressTablePtr) / sizeof (MemCfgData->RsvdSmbusAddressTablePtr[0]);
+  Fspmcfg->RsvdSmbusAddressTablePtr   = (UINT32)(UINTN)MemCfgData->RsvdSmbusAddressTablePtr;
 
   // Overclocking Cfg
   Fspmcfg->RealtimeMemoryTiming       = MemCfgData->RealtimeMemoryTiming;

--- a/Platform/RaptorlakeBoardPkg/CfgData/CfgData_Memory.yaml
+++ b/Platform/RaptorlakeBoardPkg/CfgData/CfgData_Memory.yaml
@@ -2,7 +2,7 @@
 #
 #  Slim Bootloader CFGDATA Option File.
 #
-#  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2024, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -529,20 +529,13 @@
                      Enable/disable SMBus controller.
       length       : 0x01
       value        : 0x01
-  - PchNumRsvdSmbusAddresses :
-      name         : Number of RsvdSmbusAddressTable.
-      type         : EditNum, HEX, (0x0, 0xFF)
-      help         : >
-                     The number of elements in the RsvdSmbusAddressTable.
-      length       : 0x0001
-      value        : 0x04
   - RsvdSmbusAddressTablePtr :
-      name         : Point of RsvdSmbusAddressTable
+      name         : Reserved SMBUS address table
       type         : EditNum, HEX, (0x0, 0xFFFFFFFF)
       help         : >
                      Array of addresses reserved for non-ARP-capable SMBus devices.
-      length       : 0x0004
-      value        : 0xfffc3ff8
+      length       : 0x04
+      value        : { 0xA2, 0xA0, 0xA2, 0xA0 }
   - RealtimeMemoryTiming :
       name         : Realtime Memory Timing
       type         : Combo
@@ -1083,5 +1076,5 @@
       length       : 0x01
       value        : 0x00
   - Dummy        :
-      length      : 0x01
+      length      : 0x02
       value       : 0x00

--- a/Platform/RaptorlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/RaptorlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020 - 2024, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -338,8 +338,8 @@ UpdateFspConfig (
 
   // Smbus
   Fspmcfg->SmbusEnable               = MemCfgData->SmbusEnable;
-  Fspmcfg->PchNumRsvdSmbusAddresses  = MemCfgData->PchNumRsvdSmbusAddresses;
-  Fspmcfg->RsvdSmbusAddressTablePtr  = MemCfgData->RsvdSmbusAddressTablePtr;
+  Fspmcfg->PchNumRsvdSmbusAddresses  = sizeof (MemCfgData->RsvdSmbusAddressTablePtr) / sizeof (MemCfgData->RsvdSmbusAddressTablePtr[0]);
+  Fspmcfg->RsvdSmbusAddressTablePtr  = (UINT32)(UINTN)MemCfgData->RsvdSmbusAddressTablePtr;
 
   // Overclocking Cfg
   Fspmcfg->RealtimeMemoryTiming = MemCfgData->RealtimeMemoryTiming;


### PR DESCRIPTION
The patch improves the dev experience for configuring FSP-M UPDs: RsvdSmbusAddressTablePtr and PchNumRsvdSmbusAddresses: Prior to this patch, developers had to apply a memory patch at address 0xfffc3ff8, which was cumbersome and inconvenient. With the introduction of this patch, developers can now directly modify the DLT, simplifying the configuration steps and improving workflow efficiency.