### PR TITLE
fix: [TGL] Disable Fusa by default

### DIFF
--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -75,7 +75,7 @@ class Board(BaseBoard):
         self.ENABLE_DTS           = 1
         self.ENABLE_PCIE_PM       = 1
         self.ENABLE_FAST_BOOT     = 0
-        self.HAVE_FUSA            = 1
+        self.HAVE_FUSA            = 0
         # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)
         self.ENABLE_SMM_REBASE     = 2
 

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1703,9 +1703,20 @@ UpdateOsBootMediumInfo (
   UINT16                                  Bus;
   volatile PCI_DEVICE_INDEPENDENT_REGION *PciDev;
   UINT8                                  Instance;
+  OS_BOOT_OPTION                         *BootOption;
+  UINT32                                 Idx;
 
   FillBootOptionListFromCfgData (OsBootOptionList);
 
+  // Disable PreOS checker if Fusa is not enabled.
+  if (!FeaturePcdGet (PcdFusaEnabled)) {
+    for (Idx = 0; Idx < OsBootOptionList->OsBootOptionCount; Idx++) {
+      BootOption = &(OsBootOptionList->OsBootOption[Idx]);
+      if ((BootOption->BootFlags & BOOT_FLAGS_PREOS) != 0) {
+        BootOption->BootFlags &= ~BOOT_FLAGS_PREOS;
+      }
+    }
+  }
   //
   // Depends on the PCI root bridge, pluged PCI devices, the bus number for NVMe device
   // might be different. so update the NVMe bus number in the device table.


### PR DESCRIPTION
To avoid the POSC module loading by default build.