### PR TITLE
fix:[ARL-S] Fixed S0ix issue on ARL-S0ix

### DIFF
--- a/Platform/ArrowlakeBoardPkg/AcpiTables/Dsdt/Rtd3Defines.h
+++ b/Platform/ArrowlakeBoardPkg/AcpiTables/Dsdt/Rtd3Defines.h
@@ -37,6 +37,7 @@
 
 #define PEP_TCSS_CONS_INDEX (22)
 #define PEP_GNA_CONS_INDEX (23)
+#define PEP_VMD_CONS_INDEX (24)
 #define PEP_HECI3_CONS_INDEX (25)
 
 #define PEP_AUDIO_CONS_INDEX (26)

--- a/Platform/ArrowlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/ArrowlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -450,6 +450,7 @@ UpdateFspConfig (
 
   if (FeaturesCfgData != NULL) {
     if (FeaturesCfgData->Features.S0ix == 1) {
+       Fspmcfg->InternalGfx        = 0;
       Fspmcfg->PchIshEnable       = 0;
       Fspmcfg->TcssXdciEn         = 0;
       Fspmcfg->TcssDma0En         = 0;
@@ -525,8 +526,21 @@ UpdateFspConfig (
       Fspmcfg->EnablePwrDn = 0x0;
       Fspmcfg->EnablePwrDnLpddr = 0x0;
       Fspmcfg->SrefCfgEna = 0x0;
+      Fspmcfg->DmiGen4UsPortTxPreset[0] = 0x1;
+      Fspmcfg->DmiGen4UsPortTxPreset[1] = 0x1;
+      Fspmcfg->DmiGen4UsPortTxPreset[2] = 0x1;
+      Fspmcfg->DmiGen4UsPortTxPreset[3] = 0x1;
+      Fspmcfg->DmiGen4UsPortTxPreset[4] = 0x1;
+      Fspmcfg->DmiGen4UsPortTxPreset[5] = 0x1;
+      Fspmcfg->DmiGen4UsPortTxPreset[6] = 0x1;
+      Fspmcfg->DmiGen4UsPortTxPreset[7] = 0x1;
+      Fspmcfg->FClkFrequency = 0x0;
+      Fspmcfg->TdcTimeWindow[0] = 0x0;
+      Fspmcfg->TdcTimeWindow[1] = 0x0;
+      Fspmcfg->TdcTimeWindow[2] = 0x0;
+      Fspmcfg->UsbTcPortEnPreMem = 0x0;
       Fspmcfg->WdtDisableAndLock = 0x1; // Remove this later if any issues
       break;
   }
-}
 
+}

--- a/Platform/ArrowlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/ArrowlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -36,6 +36,7 @@
 #include <Library/ContainerLib.h>
 #include "TsnSubRegion.h"
 #include <Library/MtlSocInfoLib.h>
+#include <Library/PciePm.h>
 
 #define CPU_PCIE_DT_HALO_MAX_ROOT_PORT     3
 #define CPU_PCIE_ULT_ULX_MAX_ROOT_PORT     3
@@ -788,21 +789,175 @@ UpdateFspConfig (
       FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[1] = 0x5;
       FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[2] = 0x5;
       FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[4] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[5] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[6] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[7] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[8] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[9] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[10] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[11] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[12] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[13] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[14] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[15] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[16] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[17] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[18] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[19] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[20] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[21] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[22] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[23] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[24] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[25] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[26] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[27] = 0x5;
+      FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[28] = 0x5;
       FspsConfig->PcieGen4EqPh3Preset3List[0] = 0x8;
       FspsConfig->PcieGen4EqPh3Preset3List[1] = 0x8;
       FspsConfig->PcieGen4EqPh3Preset3List[2] = 0x8;
       FspsConfig->PcieGen4EqPh3Preset3List[4] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset3List[5] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[6] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[7] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[8] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[9] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[10] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[11] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[12] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[13] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[14] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[15] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[16] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[17] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[18] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[19] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[20] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[21] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[22] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[23] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[24] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[25] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[26] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[27] = 0x7;
+      FspsConfig->PcieGen4EqPh3Preset3List[28] = 0x7;
       FspsConfig->PcieGen4EqPh3Preset4List[0] = 0x9;
       FspsConfig->PcieGen4EqPh3Preset4List[1] = 0x9;
       FspsConfig->PcieGen4EqPh3Preset4List[2] = 0x9;
       FspsConfig->PcieGen4EqPh3Preset4List[4] = 0x9;
+      FspsConfig->PcieGen4EqPh3Preset4List[5] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[6] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[7] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[8] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[9] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[10] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[11] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[12] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[13] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[14] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[15] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[16] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[17] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[18] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[19] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[20] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[21] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[22] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[23] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[24] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[25] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[26] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[27] = 0x8;
+      FspsConfig->PcieGen4EqPh3Preset4List[28] = 0x8;
       FspsConfig->PcieGen4EqPh1UpTxPreset[0] = 0x7;
       FspsConfig->PcieGen4EqPh1UpTxPreset[1] = 0x7;
       FspsConfig->PcieGen4EqPh1UpTxPreset[2] = 0x7;
       FspsConfig->PcieGen4EqPh1UpTxPreset[4] = 0x7;
+      FspsConfig->Usb2OverCurrentPin[0] = 0x3;
+      FspsConfig->Usb2OverCurrentPin[5] = 0x3;
+      FspsConfig->Usb3OverCurrentPin[1] = 0x1;
+      FspsConfig->Usb3OverCurrentPin[3] = 0x2;
+      FspsConfig->Usb3OverCurrentPin[5] = 0x0;
+      FspsConfig->Usb3OverCurrentPin[7] = 0x4;
+      FspsConfig->Usb3OverCurrentPin[8] = 0x1;
+      FspsConfig->Usb3OverCurrentPin[9] = 0x1;
       FspsConfig->Usb4CmMode                 = 0x0;
     break;
   }
+
+
+  FspsConfig->PcieRpLtrEnable[0] = 0x1;
+  FspsConfig->PcieRpLtrEnable[2] = 0x1;
+  FspsConfig->PcieRpLtrEnable[3] = 0x1;
+  FspsConfig->PcieRpLtrEnable[4] = 0x1;
+  FspsConfig->PcieRpLtrEnable[5] = 0x1;
+  FspsConfig->PcieRpAspm[0] = 0x4;
+  FspsConfig->PcieRpAspm[1] = 0x4;
+  FspsConfig->PcieRpAspm[2] = 0x4;
+  FspsConfig->PchPmSlpS3MinAssert = 0x3;
+  FspsConfig->PchPmSlpSusMinAssert = 0x4;
+  FspsConfig->PchPmSlpAMinAssert = 0x4;
+  FspsConfig->EnableTimedGpio0 = 0x0;
+  FspsConfig->EnableTimedGpio1 = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[0] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[1] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[2] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[3] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[4] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[5] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[6] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[7] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[8] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[9] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[10] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[11] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[12] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[13] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[14] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[15] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[16] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[17] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[18] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[19] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[20] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[21] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[22] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[23] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[24] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[25] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[26] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[27] = 0x0;
+  FspsConfig->PcieRpAdvancedErrorReporting[28] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[0] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[1] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[2] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[3] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[4] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[5] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[6] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[7] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[8] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[9] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[10] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[11] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[12] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[13] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[14] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[15] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[16] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[17] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[18] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[19] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[20] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[21] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[22] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[23] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[24] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[25] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[26] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[27] = 0x0;
+  FspsConfig->PcieEnablePeerMemoryWrite[28] = 0x0;
+  StoreRpConfig (FspsConfig);
 
   // S0ix configuration
   if (FeaturesCfgData != NULL) {
@@ -821,9 +976,13 @@ UpdateFspConfig (
       FspsConfig->PchFivrDynPm = 1;
       FspsConfig->D3HotEnable = 0;
       FspsConfig->D3ColdEnable = 1;
+      FspsConfig->ThermalMonitor = 0;
+      FspsConfig->VmdEnable = 0;
+      FspsConfig->C1StateAutoDemotion = 0;
+      FspsConfig->C1StateUnDemotion = 0;
+      FspsConfig->PkgCStateDemotion = 0;
+      FspsConfig->PkgCStateUnDemotion = 0;
       DEBUG ((DEBUG_INFO, "Stage 2 S0ix config applied.\n"));
     }
   }
 }
-
-

--- a/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/LowPowerSupport.c
+++ b/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/LowPowerSupport.c
@@ -17,6 +17,7 @@
 #include <Library/ConfigDataLib.h>
 #include <Library/DebugLib.h>
 #include <IndustryStandard/Pci30.h>
+#include <CpuPcieInfo.h>
 #include <Library/BaseMemoryLib.h>
 
 #define PCI_MAX_FUNC    7
@@ -157,6 +158,10 @@ UINT64 GetLowPowerS0IdleConstraint(VOID)
     //
     if (PciRead16 (PCI_SEGMENT_LIB_ADDRESS (0, GNA_BUS_NUM, GNA_DEV_NUM, GNA_FUN_NUM, PCI_VENDOR_ID_OFFSET)) == 0xFFFF) {
       PepConfigData->PepGna = 0;
+    }
+
+    if (PciRead16 (PCI_SEGMENT_LIB_ADDRESS (0, SA_PEG_BUS_NUM, SA_PEG1_DEV_NUM, SA_PEG0_FUN_NUM, PCI_VENDOR_ID_OFFSET)) == 0xFFFF) {
+      PepConfigData->PepPcieDg = 0;
     }
     //
     //Disable PEP constraint if VMD B0:D14:F0 device is not present

--- a/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -21,6 +21,8 @@
 #include "GpioTableArlSPostMem.h"
 #include "GpioTableArlhPostMem.h"
 #include "GpioTableArlhRvpPostMem.h"
+#include <Library/PciePm.h>
+#include <Library/PlatformInfo.h>
 #include <Library/MtlPchGpioTopologyLib.h>
 #include <Library/MtlSocInfoLib.h>
 
@@ -428,6 +430,7 @@ BoardInit (
     PlatformPrePciEnumeration();
     break;
   case PostPciEnumeration:
+    PciePmConfig ();
     Status = SetFrameBufferWriteCombining (0, MAX_UINT32);
     if (EFI_ERROR(Status)) {
       DEBUG ((DEBUG_INFO, "Failed to set GFX framebuffer as WC\n"));
@@ -880,7 +883,6 @@ PatchCpuSsdtTable (
 **/
 STATIC
 UINT32
-EFIAPI
 CalculateRelativePower (
   IN  UINT16  BaseRatio,
   IN  UINT16  CurrRatio,
@@ -1633,8 +1635,8 @@ PlatformUpdateAcpiGnvs (
       MtlPchNvs->RpAddress[RpNumber] = Data32;
       DEBUG ((DEBUG_INFO, "MtlPchNvs->RpAddress[%d] = 0x%08X\n", RpNumber, MtlPchNvs->RpAddress[RpNumber]));
 
-      MtlPchNvs->PcieLtrMaxSnoopLatency[RpNumber]   = 0x0;
-      MtlPchNvs->PcieLtrMaxNoSnoopLatency[RpNumber] = 0x0;
+      MtlPchNvs->PcieLtrMaxSnoopLatency[RpNumber]   = 0x100F;
+      MtlPchNvs->PcieLtrMaxNoSnoopLatency[RpNumber] = 0x100F;
     }
     MtlPchNvs->GEI0 = 0x2;
     MtlPchNvs->GEI1 = 0x3;

--- a/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -73,6 +73,7 @@
   HeciMeExtLib
   GpioV2Lib
   MtlPchPcieRpLib
+  PciePm
 
 [Guids]
   gOsConfigDataGuid

--- a/Silicon/ArrowlakePkg/Include/CpuPcieInfo.h
+++ b/Silicon/ArrowlakePkg/Include/CpuPcieInfo.h
@@ -1,0 +1,25 @@
+/** @file
+  This file contains definitions of PCIe controller information
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _CPU_PCIE_INFO_H_
+#define _CPU_PCIE_INFO_H_
+
+
+/**
+PCIe controller configuration.
+**/
+
+
+//
+// Device 1 Memory Mapped IO Register Offset Equates
+//
+#define SA_PEG_BUS_NUM     0x00
+#define SA_PEG_DEV_NUM     0x01
+#define SA_PEG0_DEV_NUM    SA_PEG_DEV_NUM
+#define SA_PEG0_FUN_NUM    0x00
+#define SA_PEG1_DEV_NUM    SA_PEG_DEV_NUM
+#define SA_PEG3_DEV_NUM    0x06
+#endif

--- a/Silicon/ArrowlakePkg/Include/Library/PchPcieRpConfig.h
+++ b/Silicon/ArrowlakePkg/Include/Library/PchPcieRpConfig.h
@@ -1,0 +1,388 @@
+/** @file
+  PCH Pcie root port policy
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _PCH_PCIERP_CONFIG_H_
+#define _PCH_PCIERP_CONFIG_H_
+
+#include <PchLimits.h>
+#include <MemInfoHob.h>
+#include <PcieConfig.h>
+
+/**
+ Making any structure change after API Lock
+ will need to maintain backward compatibility, bump up
+ structure revision and update below history table\n
+  <b>Revision 1</b>:  - Initial version.
+  <b>Revision 2</b>:
+    - Moved EnablePort8xhDecode policy to PCIE_COMMON_CONFIG
+    - Add DmiPowerGatingDis
+**/
+#define PCH_PCIE_CONFIG_REVISION  2
+
+/**
+ Making any structure change after API Lock
+ will need to maintain backward compatibility, bump up
+ structure revision and update below history table\n
+  <b>Revision 1</b>:  - Initial version.
+**/
+#define PCH_PCIE_RP_PREMEM_CONFIG_REVISION 1
+
+/**
+ Making any structure change after API Lock
+ will need to maintain backward compatibility, bump up
+ structure revision and update below history table\n
+  <b>Revision 1</b>:  - Initial version.
+**/
+#define PCIE_RP_DXE_CONFIG_REVISION 1
+
+extern EFI_GUID gPchPcieConfigGuid;
+extern EFI_GUID gPcieRpPreMemConfigGuid;
+
+#pragma pack (push,1)
+
+/**
+  PCIe device table entry
+
+  The PCIe device table is being used to override PCIe device ASPM settings.
+  Last entry VendorId must be 0.
+**/
+typedef struct {
+  UINT16  VendorId;                    ///< The vendor Id of Pci Express card ASPM setting override, 0xFFFF means any Vendor ID
+  UINT16  DeviceId;                    ///< The Device Id of Pci Express card ASPM setting override, 0xFFFF means any Device ID
+  UINT8   RevId;                       ///< The Rev Id of Pci Express card ASPM setting override, 0xFF means all steppings
+  UINT8   BaseClassCode;               ///< The Base Class Code of Pci Express card ASPM setting override, 0xFF means all base class
+  UINT8   SubClassCode;                ///< The Sub Class Code of Pci Express card ASPM setting override, 0xFF means all sub class
+  UINT8   EndPointAspm;                ///< Override device ASPM (see: PCH_PCIE_ASPM_CONTROL)
+                                       ///< Bit 1 must be set in OverrideConfig for this field to take effect
+  UINT16  OverrideConfig;              ///< The override config bitmap (see: PCH_PCIE_OVERRIDE_CONFIG).
+  /**
+    The L1Substates Capability Offset Override. (applicable if bit 2 is set in OverrideConfig)
+    This field can be zero if only the L1 Substate value is going to be override.
+  **/
+  UINT16  L1SubstatesCapOffset;
+  /**
+    L1 Substate Capability Mask. (applicable if bit 2 is set in OverrideConfig)
+    Set to zero then the L1 Substate Capability [3:0] is ignored, and only L1s values are override.
+    Only bit [3:0] are applicable. Other bits are ignored.
+  **/
+  UINT8   L1SubstatesCapMask;
+  /**
+    L1 Substate Port Common Mode Restore Time Override. (applicable if bit 2 is set in OverrideConfig)
+    L1sCommonModeRestoreTime and L1sTpowerOnScale can have a valid value of 0, but not the L1sTpowerOnValue.
+    If L1sTpowerOnValue is zero, all L1sCommonModeRestoreTime, L1sTpowerOnScale, and L1sTpowerOnValue are ignored,
+    and only L1SubstatesCapOffset is override.
+  **/
+  UINT8   L1sCommonModeRestoreTime;
+  /**
+    L1 Substate Port Tpower_on Scale Override. (applicable if bit 2 is set in OverrideConfig)
+    L1sCommonModeRestoreTime and L1sTpowerOnScale can have a valid value of 0, but not the L1sTpowerOnValue.
+    If L1sTpowerOnValue is zero, all L1sCommonModeRestoreTime, L1sTpowerOnScale, and L1sTpowerOnValue are ignored,
+    and only L1SubstatesCapOffset is override.
+  **/
+  UINT8   L1sTpowerOnScale;
+  /**
+    L1 Substate Port Tpower_on Value Override. (applicable if bit 2 is set in OverrideConfig)
+    L1sCommonModeRestoreTime and L1sTpowerOnScale can have a valid value of 0, but not the L1sTpowerOnValue.
+    If L1sTpowerOnValue is zero, all L1sCommonModeRestoreTime, L1sTpowerOnScale, and L1sTpowerOnValue are ignored,
+    and only L1SubstatesCapOffset is override.
+  **/
+  UINT8   L1sTpowerOnValue;
+
+  /**
+    SnoopLatency bit definition
+    Note: All Reserved bits must be set to 0
+
+    BIT[15]     - When set to 1b, indicates that the values in bits 9:0 are valid
+                  When clear values in bits 9:0 will be ignored
+    BITS[14:13] - Reserved
+    BITS[12:10] - Value in bits 9:0 will be multiplied with the scale in these bits
+                  000b - 1 ns
+                  001b - 32 ns
+                  010b - 1024 ns
+                  011b - 32,768 ns
+                  100b - 1,048,576 ns
+                  101b - 33,554,432 ns
+                  110b - Reserved
+                  111b - Reserved
+    BITS[9:0]   - Snoop Latency Value. The value in these bits will be multiplied with
+                  the scale in bits 12:10
+
+    This field takes effect only if bit 3 is set in OverrideConfig.
+  **/
+  UINT16  SnoopLatency;
+  /**
+    NonSnoopLatency bit definition
+    Note: All Reserved bits must be set to 0
+
+    BIT[15]     - When set to 1b, indicates that the values in bits 9:0 are valid
+                  When clear values in bits 9:0 will be ignored
+    BITS[14:13] - Reserved
+    BITS[12:10] - Value in bits 9:0 will be multiplied with the scale in these bits
+                  000b - 1 ns
+                  001b - 32 ns
+                  010b - 1024 ns
+                  011b - 32,768 ns
+                  100b - 1,048,576 ns
+                  101b - 33,554,432 ns
+                  110b - Reserved
+                  111b - Reserved
+    BITS[9:0]   - Non Snoop Latency Value. The value in these bits will be multiplied with
+                  the scale in bits 12:10
+
+    This field takes effect only if bit 3 is set in OverrideConfig.
+  **/
+  UINT16  NonSnoopLatency;
+
+  /**
+    Forces LTR override to be permanent
+    The default way LTR override works is:
+      rootport uses LTR override values provided by BIOS until connected device sends an LTR message, then it will use values from the message
+    This settings allows force override of LTR mechanism. If it's enabled, then:
+      rootport will use LTR override values provided by BIOS forever; LTR messages sent from connected device will be ignored
+  **/
+  UINT8  ForceLtrOverride;
+  UINT8  Reserved[3];
+} PCH_PCIE_DEVICE_OVERRIDE;
+
+
+typedef enum {
+  PchPcieOverrideDisabled             = 0,
+  PchPcieL1L2Override                 = 0x01,
+  PchPcieL1SubstatesOverride          = 0x02,
+  PchPcieL1L2AndL1SubstatesOverride   = 0x03,
+  PchPcieLtrOverride                  = 0x04
+} PCH_PCIE_OVERRIDE_CONFIG;
+
+///
+/// The values before AutoConfig match the setting of PCI Express Base Specification 1.1, please be careful for adding new feature
+///
+typedef enum {
+  PchPcieAspmDisabled,
+  PchPcieAspmL0s,
+  PchPcieAspmL1,
+  PchPcieAspmL0sL1,
+  PchPcieAspmAutoConfig,
+  PchPcieAspmMax
+} PCH_PCIE_ASPM_CONTROL;
+
+/**
+  Refer to PCH EDS for the PCH implementation values corresponding
+  to below PCI-E spec defined ranges
+**/
+typedef enum {
+  PchPcieL1SubstatesDisabled,
+  PchPcieL1SubstatesL1_1,
+  PchPcieL1SubstatesL1_1_2,
+  PchPcieL1SubstatesMax
+} PCH_PCIE_L1SUBSTATES_CONTROL;
+
+enum PCH_PCIE_MAX_PAYLOAD {
+  PchPcieMaxPayload128 = 0,
+  PchPcieMaxPayload256,
+  PchPcieMaxPayload512,
+  PchPcieMaxPayload64 = 7,
+  PchPcieMaxPayloadMax
+};
+
+#define PCH_PCIE_NO_SUCH_CLOCK  0xFF
+#define PCH_PCIE_NO_GPIO_MUXING 0x00
+
+typedef enum {
+  PchClockUsagePchPcie0      = 0,
+  PchClockUsagePchPcie1      = 1,
+  PchClockUsagePchPcie2      = 2,
+  PchClockUsagePchPcie3      = 3,
+  PchClockUsagePchPcie4      = 4,
+  PchClockUsagePchPcie5      = 5,
+  PchClockUsagePchPcie6      = 6,
+  PchClockUsagePchPcie7      = 7,
+  PchClockUsagePchPcie8      = 8,
+  PchClockUsagePchPcie9      = 9,
+  PchClockUsagePchPcie10     = 10,
+  PchClockUsagePchPcie11     = 11,
+  PchClockUsagePchPcie12     = 12,
+  PchClockUsagePchPcie13     = 13,
+  PchClockUsagePchPcie14     = 14,
+  PchClockUsagePchPcie15     = 15,
+  PchClockUsagePchPcie16     = 16,
+  PchClockUsagePchPcie17     = 17,
+  PchClockUsagePchPcie18     = 18,
+  PchClockUsagePchPcie19     = 19,
+  PchClockUsagePchPcie20     = 20,
+  PchClockUsagePchPcie21     = 21,
+  PchClockUsagePchPcie22     = 22,
+  PchClockUsagePchPcie23     = 23,
+  /**
+    Quantity of PCH and CPU PCIe ports, as well as their encoding in this enum, may change between
+    silicon generations and series. Do not assume that PCH port 0 will be always encoded by 0.
+    Instead, it is recommended to use (PchClockUsagePchPcie0 + PchPortIndex) style to be forward-compatible
+  **/
+  PchClockUsageCpuPcie0      = 0x40,
+  PchClockUsageCpuPcie1      = 0x41,
+  PchClockUsageCpuPcie2      = 0x42,
+  PchClockUsageCpuPcie3      = 0x43,
+
+  PchClockUsageLan           = 0x70,
+  PchClockUsageUnspecified   = 0x80, ///< In use for a purpose not listed above
+  PchClockUsageNotUsed       = 0xFF
+} PCH_PCIE_CLOCK_USAGE;
+
+/**
+  PCH_PCIE_CLOCK describes PCIe source clock generated by PCH.
+**/
+typedef struct {
+  UINT8   Usage;             ///< Purpose of given clock (see PCH_PCIE_CLOCK_USAGE). Default: Unused, 0xFF
+  UINT8   ClkReq;            ///< ClkSrc - ClkReq mapping. Default: 1:1 mapping with Clock numbers
+  UINT8   RsvdBytes[2];      ///< Reserved byte
+  UINT32  ClkReqGpioPinMux;  /// Muxed GPIO details. Refer GPIO_*_MUXING_SRC_CLKREQ_x*
+} PCH_PCIE_CLOCK;
+
+///
+/// The PCH_DMI_LANE_CONFIG block describes specific lane configuration
+///
+typedef struct {
+  UINT32   DmiTranCoOverEn            : 2;    ///< Enable/Disable Lane Transmitter Coefficient
+  UINT32   Rsvd1                      : 6;    ///< Reserved
+  UINT32   DmiTranCoOverPostCur       : 6;    ///< Lane Transmitter Post-Cursor Coefficient Override
+  UINT32   Rsvd2                      : 2;    ///< Reserved
+  UINT32   DmiTranCoOverPreCur        : 6;    ///< Lane Transmitter Pre-Cursor Coefficient Override
+  UINT32   Rsvd3                      : 2;    ///< Reserved
+  UINT32   DmiUpPortTranPreset        : 4;    ///< Upstream Port Lane Transmitter Preset
+  UINT32   Rsvd4                      : 4;    ///< Reserved
+} DMI_LANE_CONFIG;
+
+typedef struct {
+  DMI_LANE_CONFIG   Lane[PCH_MAX_DMI_LANES];               ///< DMI Lanes configuration
+  DMI_LANE_CONFIG   LaneGen4[PCH_MAX_DMI_LANES];           ///< DMI Lanes configuration
+  UINT32            DmiUpPortTranPresetEn  :  2;           ///< 0: POR setting, 1: force enable, 2: force disable.
+  UINT32            DmiRtlepceb            :  2;           ///< DMI Remote Transmit Link Equalization Preset/Coefficient Evaluation Bypass (RTLEPCEB)
+  /**
+   When CNP is paired with SKL CPU, TX SAI Filtering Check performed for cycles
+   targeting MEUMA (ie. VCm upstream). As part of this check,
+   IOSF Root Space attribute is check to ensure that it is RS3.
+   Setting valid only when DMI VCm is enabled.
+   0: POR setting, 1: force enable, 2: force disable.
+   */
+  UINT32            TestDmiMeUmaRootSpaceCheck :  2;
+  UINT32            Rsvdbits                   : 26;
+  UINT8             MvcEnabled;                            ///< Enable/Disable MultiVC Option. 0: Disable; 1: Enable
+  UINT8             Reserved[3];
+} DMI_PREMEM_CONFIG;
+
+/**
+  The PCH_PCI_EXPRESS_ROOT_PORT_CONFIG describe the feature and capability of each PCH PCIe root port.
+**/
+typedef struct {
+  PCIE_ROOT_PORT_COMMON_CONFIG  PcieRpCommonConfig; ///an instance of Pcie Common Config
+  UINT8  ExtSync;              ///< Indicate whether the extended synch is enabled. <b>0: Disable</b>; 1: Enable.
+  //
+  // Error handlings
+  //
+  UINT8  SystemErrorEnable;    ///< Indicate whether the System Error is enabled. <b>0: Disable</b>; 1: Enable.
+  /**
+    The Multiple VC (MVC) supports hardware to avoid HoQ block for latency sensitive TC.
+    Currently it is only applicable to Root Ports with 2pX4 port configuration with 2 VCs,or
+    DMI port configuration with 3 VCs. For Root Ports 2pX4 configuration, two RPs (RP0,
+    RP2) shall support two PCIe VCs (VC0 & VC1) and the other RPs (RP1, RP3) shall be
+    disabled.
+    <b>0: Disable</b>; 1: Enable
+  **/
+  UINT8  MvcEnabled;
+  /**
+    Virtual Pin Port is industry standard introduced to PCIe Hot Plug support in systems
+    when GPIO pins expansion is needed. It is server specific feature.
+    <b>0x00: Default</b>; 0xFF: Disabled
+  **/
+  UINT8   VppPort;
+  UINT8   VppAddress;                               ///< PCIe Hot Plug VPP SMBus Address. Default is zero.
+  UINT8   MultiVc;
+  UINT8   Vc1Ctrl;
+  UINT8   VcMCtrl;
+  UINT8   MeUmaRootSpaceCheck;
+  UINT8   RsvdBytes0[3];                            ///< Reserved bytes
+} PCH_PCIE_ROOT_PORT_CONFIG;
+
+typedef struct _CONFIG_BLOCK_HEADER {
+  EFI_HOB_GUID_TYPE GuidHob;                      ///< Offset 0-23  GUID extension HOB header
+  UINT8             Revision;                     ///< Offset 24    Revision of this config block
+  UINT8             Attributes;                   ///< Offset 25    The main revision for config block
+  UINT8             Reserved[2];                  ///< Offset 26-27 Reserved for future use
+} CONFIG_BLOCK_HEADER;
+/**
+  The PCH_PCIE_CONFIG block describes the expected configuration of the PCH PCI Express controllers
+  <b>Revision 1</b>:
+  - Initial version.
+  <b>Revision 2</b>:
+  - Moved EnablePort8xhDecode policy to PCIE_COMMON_CONFIG
+  <b>Revision 3</b>:
+  - Add DmiPowerGatingDis
+**/
+typedef struct {
+  CONFIG_BLOCK_HEADER   Header;                   ///< Config Block Header
+  ///
+  /// These members describe the configuration of each PCH PCIe root port.
+  ///
+  PCIE_COMMON_CONFIG                PcieCommonConfig;
+  PCH_PCIE_ROOT_PORT_CONFIG         RootPort[PCH_MAX_PCIE_ROOT_PORTS];
+  PCH_PCIE_ROOT_PORT_CONFIG         DmiPort;
+
+  ///
+  /// <b>(Test)</b> The Index of PCIe Port that is selected for Port8xh Decode (0 Based)
+  ///
+  UINT8                             PchPciePort8xhDecodePortIndex;
+  UINT8                             DmiPowerReduction;
+  UINT8                             DmiPowerGatingDis;
+  UINT8                             RsvdBytes0;
+} PCH_PCIE_CONFIG;
+
+/**
+  The PCH_PCIE_RP_PREMEM_CONFIG block describes early configuration of the PCH PCI Express controllers
+  <b>Revision 1</b>:
+  - Initial version.
+**/
+typedef struct {
+  CONFIG_BLOCK_HEADER   Header;                                ///< Config Block Header
+  /**
+    Root Port enabling mask.
+    Bit0 presents RP1, Bit1 presents RP2, and so on.
+    0: Disable; <b>1: Enable</b>.
+  **/
+  UINT32                RpEnabledMask;
+  /// Configuration of PCIe source clocks
+  ///
+  PCH_PCIE_CLOCK        PcieClock[PCH_MAX_PCIE_CLOCKS];
+
+  /**
+    Per Controller Bifurcation Configuration
+    <b>0: Disabled</b>; 1: 4x1; 2: 1x2_2x1; 3: 2x2; 4: 1x4; 5: 4x2; 6: 1x4_2x2; 7: 2x2_1x4; 8: 2x4; 9: 1x8 (see: PCIE_BIFURCATION_CONFIG)
+  **/
+  UINT8                 Bifurcation[PCH_MAX_PCIE_CONTROLLERS];
+  UINT8                 Rsvd[(4 - PCH_MAX_PCIE_CONTROLLERS % 4)];
+  DMI_PREMEM_CONFIG     PchDmiPrememConfig;
+} PCH_PCIE_RP_PREMEM_CONFIG;
+
+/**
+  The PCIE_RP_DXE_CONFIG block describes the expected configuration of the PCH PCI Express controllers in DXE phase
+
+  <b>Revision 1</b>:
+  - Init version
+**/
+typedef struct {
+  CONFIG_BLOCK_HEADER      Header;                     ///< Config Block Header
+
+  /**
+    PCIe device override table
+    The PCIe device table is being used to override PCIe device ASPM settings.
+    And it's only used in DXE phase.
+    Please refer to PCIE_DEVICE_OVERRIDE structure for the table.
+    Last entry VendorId must be 0.
+  **/
+  PCIE_DEVICE_OVERRIDE     *PcieDeviceOverrideTablePtr;
+} PCIE_RP_DXE_CONFIG;
+
+#pragma pack (pop)
+
+#endif // _PCH_PCIERP_CONFIG_H_

--- a/Silicon/ArrowlakePkg/Include/Library/PchPcieRpLib.h
+++ b/Silicon/ArrowlakePkg/Include/Library/PchPcieRpLib.h
@@ -1,0 +1,163 @@
+/** @file
+  Header file for PchPcieRpLib.
+
+@copyright
+  INTEL CONFIDENTIAL
+  Copyright 2014 - 2021 Intel Corporation.
+
+  The source code contained or described herein and all documents related to the
+  source code ("Material") are owned by Intel Corporation or its suppliers or
+  licensors. Title to the Material remains with Intel Corporation or its suppliers
+  and licensors. The Material may contain trade secrets and proprietary and
+  confidential information of Intel Corporation and its suppliers and licensors,
+  and is protected by worldwide copyright and trade secret laws and treaty
+  provisions. No part of the Material may be used, copied, reproduced, modified,
+  published, uploaded, posted, transmitted, distributed, or disclosed in any way
+  without Intel's prior express written permission.
+
+  No license under any patent, copyright, trade secret or other intellectual
+  property right is granted to or conferred upon you by disclosure or delivery
+  of the Materials, either expressly, by implication, inducement, estoppel or
+  otherwise. Any license under such intellectual property rights must be
+  express and approved by Intel in writing.
+
+  Unless otherwise agreed by Intel in writing, you may not remove or alter
+  this notice or any other notice embedded in Materials by Intel or
+  Intel's suppliers or licensors in any way.
+
+  This file contains an 'Intel Peripheral Driver' and is uniquely identified as
+  "Intel Reference Module" and is licensed for Intel CPUs and chipsets under
+  the terms of your license agreement with Intel or your vendor. This file may
+  be modified by the user, subject to additional terms of the license agreement.
+
+@par Specification Reference:
+**/
+#ifndef _PCH_PCIERP_LIB_H_
+#define _PCH_PCIERP_LIB_H_
+
+#include <Uefi.h>
+#include <PcrDefine.h>
+
+/**
+  PCIe controller bifurcation configuration.
+**/
+typedef enum {
+  PcieBifurcationDefault = 0,
+  PcieBifurcation4x1,
+  PcieBifurcation1x2_2x1,
+  PcieBifurcation2x2,
+  PcieBifurcation1x4,
+  PcieBifurcation4x2,
+  PcieBifurcation1x4_2x2,
+  PcieBifurcation2x2_1x4,
+  PcieBifurcation2x4,
+  PcieBifurcation1x8,
+  PcieBifurcationUnknown,
+  PcieBifurcationMax
+} PCIE_BIFURCATION_CONFIG;
+
+/**
+  This function returns PID according to PCIe controller index
+
+  @param[in] ControllerIndex     PCIe controller index
+
+  @retval P2SB_PID    Returns PID for SBI Access
+**/
+P2SB_PID
+PchGetPcieControllerSbiPid (
+  IN UINT32  ControllerIndex
+  );
+
+/**
+  This function returns PID according to Root Port Number
+
+  @param[in] RpIndex     Root Port Index (0-based)
+
+  @retval P2SB_PID    Returns PID for SBI Access
+**/
+P2SB_PID
+GetRpSbiPid (
+  IN UINTN  RpIndex
+  );
+
+/**
+  Get Pch Pcie Root Port Device and Function Number by Root Port physical Number
+
+  @param[in]  RpNumber            Root port physical number. (0-based)
+  @param[out] RpDev               Return corresponding root port device number.
+  @param[out] RpFun               Return corresponding root port function number.
+
+  @retval EFI_SUCCESS
+**/
+EFI_STATUS
+EFIAPI
+GetPchPcieRpDevFun (
+  IN  UINTN   RpNumber,
+  OUT UINTN   *RpDev,
+  OUT UINTN   *RpFun
+  );
+
+/**
+  Get Root Port physical Number by Pch Pcie Root Port Device and Function Number
+
+  @param[in]  RpDev                 Root port device number.
+  @param[in]  RpFun                 Root port function number.
+  @param[out] RpNumber              Return corresponding physical Root Port index (0-based)
+
+  @retval     EFI_SUCCESS           Physical root port is retrieved
+  @retval     EFI_INVALID_PARAMETER RpDev and/or RpFun are invalid
+  @retval     EFI_UNSUPPORTED       Root port device and function is not assigned to any physical root port
+**/
+EFI_STATUS
+EFIAPI
+GetPchPcieRpNumber (
+  IN  UINTN   RpDev,
+  IN  UINTN   RpFun,
+  OUT UINTN   *RpNumber
+  );
+
+/**
+  Gets pci segment base address of PCIe root port.
+
+  @param RpIndex    Root Port Index (0 based)
+  @return PCIe port base address.
+**/
+UINT64
+PchPcieBase (
+  IN  UINT32   RpIndex
+  );
+
+/**
+  Checks which CLK_REQ signal is assigned to given CLK_SRC
+
+  @param ClkSrc    number of CLK_SRC, 0-based
+  @retval          number of CLK_REQ, 0-based
+**/
+UINT8
+GetClkReqForClkSrc (
+  IN UINT8 ClkSrc
+  );
+
+/**
+  Determines whether L0s is supported on current stepping.
+
+  @return TRUE if L0s is supported, FALSE otherwise
+**/
+BOOLEAN
+PchIsPcieL0sSupported (
+  VOID
+  );
+
+/**
+  Some early PCH steppings require Native ASPM to be disabled due to hardware issues:
+   - RxL0s exit causes recovery
+   - Disabling PCIe L0s capability disables L1
+  Use this function to determine affected steppings.
+
+  @return TRUE if Native ASPM is supported, FALSE otherwise
+**/
+BOOLEAN
+PchIsPcieNativeAspmSupported (
+  VOID
+  );
+#endif // _PCH_PCIERP_LIB_H_

--- a/Silicon/ArrowlakePkg/Include/Library/PcieRpLib.h
+++ b/Silicon/ArrowlakePkg/Include/Library/PcieRpLib.h
@@ -1,0 +1,107 @@
+/** @file
+  This file contains definitions of PCIe controller information
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef _PCIE_RP_LIB_
+#define _PCIE_RP_LIB_
+
+#include <PcieConfig.h>
+
+typedef struct {
+  UINT32 MaxSnoopLatencyValue         : 10;
+  UINT32 MaxSnoopLatencyScale         : 3;
+  UINT32 MaxSnoopLatencyRequirement   : 1;
+  UINT32 MaxNoSnoopLatencyValue       : 10;
+  UINT32 MaxNoSnoopLatencyScale       : 3;
+  UINT32 MaxNoSnoopLatencyRequirement : 1;
+  UINT32 ForceOverride                : 1;
+  UINT32 Reserved                     : 7;
+} LTR_OVERRIDE;
+
+/**
+  Get PCIe port number for enabled Root Port.
+
+  @param[in] RpBase    Root Port pci segment base address
+
+  @retval Root Port number (1 based)
+**/
+UINT32
+PciePortNum (
+  IN     UINT64  RpBase
+  );
+
+/**
+  Get PCIe root port index
+  @param[in] RpBase    Root Port pci segment base address
+  @return Root Port index (0 based)
+**/
+UINT32
+PciePortIndex (
+  IN     UINT64  RpBase
+  );
+
+/**
+  This function checks whether PHY lane power gating is enabled on the port.
+
+  @param[in] RpBase                 Root Port base address
+
+  @retval TRUE                      PHY power gating is enabled
+  @retval FALSE                     PHY power gating disabled
+**/
+BOOLEAN
+PcieIsPhyLanePgEnabled (
+  IN     UINT64  RpBase
+  );
+
+/**
+  Configures LTR override in Root Port's proprietary registers.
+
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+  @param[in] LtrConfig                      Root Port LTR configuration
+  @param[in] AspmOverride                   combination of LTR override values from all devices under this Root Port
+**/
+VOID
+ConfigureRpLtrOverride (
+  UINT64           RpBase,
+  UINT32           DevNum,
+  LTR_OVERRIDE     *TreeLtr,
+  PCIE_LTR_CONFIG  *LtrConfig
+  );
+
+VOID
+SpecComplaintLtrOverride (
+  UINT64           RpBase,
+  UINT32           PortIndex,
+  UINT32           PchPwrmBase
+  );
+
+/**
+  This function configures EOI message forwarding for PCIe port.
+  If there's an IoAPIC behind this port, forwarding will be enabled
+  Otherwise it will be disabled to minimize bus traffic
+
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+  @param[in] IoApicPresent  TRUE if there's IoAPIC behind this Root Port
+**/
+VOID
+ConfigureEoiForwarding (
+  UINT64   RpBase,
+  BOOLEAN  IoApicPresent
+  );
+
+/**
+  Configures proprietary parts of L1 substates configuration in Root Port
+
+  @param[in] RpSbdf       segment:bus:device:function coordinates of Root Port
+  @param[in] LtrCapable   TRUE if Root Port is LTR capable
+**/
+VOID
+L1ssProprietaryConfiguration (
+  UINT64  RpBase,
+  BOOLEAN LtrCapable,
+  BOOLEAN L1LowCapable
+  );
+#endif

--- a/Silicon/ArrowlakePkg/Include/PchLimits.h
+++ b/Silicon/ArrowlakePkg/Include/PchLimits.h
@@ -8,6 +8,21 @@
 #ifndef _PCH_LIMITS_H_
 #define _PCH_LIMITS_H_
 
+//
+// PCIe limits
+//
+#define PCH_MAX_PCIE_ROOT_PORTS             24
+#define PCH_MAX_PCIE_CONTROLLERS            6
+
+//
+// PCIe clocks limits
+//
+#define PCH_MAX_PCIE_CLOCKS                 16
+
+//
+// DMI lanes
+//
+#define PCH_MAX_DMI_LANES                   8
 
 //
 // SATA limits

--- a/Silicon/ArrowlakePkg/Include/PchPcieRpInfo.h
+++ b/Silicon/ArrowlakePkg/Include/PchPcieRpInfo.h
@@ -1,0 +1,26 @@
+/** @file
+  Pcie Root Port info header
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef _PCH_PCIERP_INFO_H_
+#define _PCH_PCIERP_INFO_H_
+
+//
+// Number of PCIe ports per PCIe controller
+//
+#define PCH_PCIE_CONTROLLER_PORTS                     4u
+
+//
+// Number of PCIe lanes per PCIe port
+//
+#define PCH_PCIE_LANES_PER_PORT                       1
+
+//
+// Number of PCIe lanes per PCIe controller
+//
+#define PCH_PCIE_LANES_PER_CONTROLLER                 (PCH_PCIE_CONTROLLER_PORTS * PCH_PCIE_LANES_PER_PORT)
+
+#endif

--- a/Silicon/ArrowlakePkg/Include/PcieConfig.h
+++ b/Silicon/ArrowlakePkg/Include/PcieConfig.h
@@ -1,0 +1,410 @@
+/** @file
+  PCIe Config Block
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _PCIE_CONFIG_H_
+#define _PCIE_CONFIG_H_
+
+#define PCIE_LINK_EQ_COEFFICIENTS_MAX 10
+#define PCIE_LINK_EQ_PRESETS_MAX 11
+
+#pragma pack (push,1)
+
+enum PCIE_COMPLETION_TIMEOUT {
+  PcieCompletionTO_Default,
+  PcieCompletionTO_50_100us,
+  PcieCompletionTO_1_10ms,
+  PcieCompletionTO_16_55ms,
+  PcieCompletionTO_65_210ms,
+  PcieCompletionTO_260_900ms,
+  PcieCompletionTO_1_3P5s,
+  PcieCompletionTO_4_13s,
+  PcieCompletionTO_17_64s,
+  PcieCompletionTO_Disabled
+};
+
+typedef enum {
+  PcieAuto,
+  PcieGen1,
+  PcieGen2,
+  PcieGen3,
+  PcieGen4,
+  PcieGen5
+} PCIE_SPEED;
+
+typedef enum {
+  PcieDisabled,
+  PcieL1SUB_1,
+  PcieL1SUB_1_2
+}L1_SUBSTATES;
+
+/**
+  Represent lane specific PCIe Gen3 equalization parameters.
+**/
+typedef struct {
+  UINT8   Cm;                 ///< Coefficient C-1
+  UINT8   Cp;                 ///< Coefficient C+1
+  UINT8   Rsvd0[2];           ///< Reserved bytes
+} PCIE_EQ_PARAM;
+
+typedef struct {
+  UINT16  LtrMaxSnoopLatency;                     ///< <b>(Test)</b> Latency Tolerance Reporting, Max Snoop Latency.
+  UINT16  LtrMaxNoSnoopLatency;                   ///< <b>(Test)</b> Latency Tolerance Reporting, Max Non-Snoop Latency.
+  UINT8   SnoopLatencyOverrideMode;               ///< <b>(Test)</b> Latency Tolerance Reporting, Snoop Latency Override Mode.
+  UINT8   SnoopLatencyOverrideMultiplier;         ///< <b>(Test)</b> Latency Tolerance Reporting, Snoop Latency Override Multiplier.
+  UINT16  SnoopLatencyOverrideValue;              ///< <b>(Test)</b> Latency Tolerance Reporting, Snoop Latency Override Value.
+  UINT8   NonSnoopLatencyOverrideMode;            ///< <b>(Test)</b> Latency Tolerance Reporting, Non-Snoop Latency Override Mode.
+  UINT8   NonSnoopLatencyOverrideMultiplier;      ///< <b>(Test)</b> Latency Tolerance Reporting, Non-Snoop Latency Override Multiplier.
+  UINT16  NonSnoopLatencyOverrideValue;           ///< <b>(Test)</b> Latency Tolerance Reporting, Non-Snoop Latency Override Value.
+  UINT8   LtrConfigLock;                          ///< <b>0: Disable</b>; 1: Enable.
+  UINT8   ForceLtrOverride;
+  UINT8   LtrOverrideSpecComplaint;
+  UINT8   RsvdByte1;
+} PCIE_LTR_CONFIG;
+
+/**
+  Specifies the form factor that the slot
+  implements. For custom form factors that
+  do not require any special handling please
+  set PcieFormFactorOther.
+**/
+typedef enum {
+  PcieFormFactorOther = 0,
+  PcieFormFactorCem,
+  PcieFormFactorMiniPci,
+  PcieFormFactorM2,
+  PcieFormFactorOcuLink,
+  PcieFormFactorExpressModule, // Also known as Server IO module(SIOM)
+  PcieFormFactorExpressCard,
+  PcieFormFactorU2 // Also known as SF-8639
+} PCIE_FORM_FACTOR;
+
+typedef enum {
+  PcieLinkHardwareEq = 0,  ///< Hardware is responsible for performing coefficient/preset search.
+  PcieLinkFixedEq          ///< No coefficient/preset search is performed. Fixed values are used.
+} PCIE_LINK_EQ_METHOD;
+
+typedef enum {
+  PcieLinkEqPresetMode = 0,   ///< Use presets during PCIe link equalization
+  PcieLinkEqCoefficientMode   ///< Use coefficients during PCIe link equalization
+} PCIE_LINK_EQ_MODE;
+
+typedef struct {
+  UINT32  PreCursor;    ///< Pre-cursor coefficient
+  UINT32  PostCursor;   ///< Post-cursor coefficient
+} PCIE_LINK_EQ_COEFFICIENTS;
+
+/**
+  PCIe Link EQ Platform Settings
+**/
+typedef struct {
+  UINT8                      PcieLinkEqMethod;               ///< Tells BIOS which link EQ method should be used for this port. Please refer to PCIE_LINK_EQ_METHOD for details of supported methods. Default: PcieLinkHardwareEq
+  UINT8                      PcieLinkEqMode;                 ///< Tells BIOS which mode should be used for PCIe link EQ. Please refer to PCIE_LINK_EQ_MODE for details of supported modes. Default: depends on SoC
+  /**
+    Specifies if BIOS should perform local transmitter override during phase 2 of EQ process.
+    If enabled value in Ph2LocalTxOverridePreset must be valid.
+    <b>0: Disabled</b>; 1: Enabled
+  **/
+  UINT8                      LocalTxOverrideEn;
+  UINT8                      RemoteTransmitterOverrideEnable;
+  UINT8                      DefaultPresetEnable[PCIE_LINK_EQ_PRESETS_MAX];       ///< Specifies if default settings should remain in use
+  UINT8                      HapcsSearchEnable;              ///< Specifies setting for Hardware Autonomous Preset/Coefficient Search mechanism
+  /**
+    Specifies the preset that should be used during local transmitter override during phase 2 of EQ process.
+    Used only if LocalTxOverrideEn is TRUE. Will be applied to all PCIe lanes of the root port.
+    Valid up to the PCIE_LINK_EQ_PRESET_MAX value. <b>Default: 0<\b>
+  **/
+  UINT32                     Ph2LocalTxOverridePreset;
+  UINT32                     PCETTimer;                  ///< PCET Timer value for single PCIe speed.
+  UINT8                      RemotePresetCoeffoverride;  ///< Remote Transmitter Preset Coefficient Override for single PCIe speed.
+  /**
+  PCIe Equalization Phase 3 Enable Control
+    - <b>Disabled</b>       (0x0) : Disable phase 3 (Default)
+     - Enabled               (0x1) : Enable phase 3
+  **/
+  UINT8                      EqPh3Bypass;
+  /**
+  PCIe Equalization Phase 2-3 Enable Control
+  - <b>Disabled</b>       (0x0) : Disable Phase 2 - Phase 3 (Default)
+  - Enabled               (0x1) : Enable Phase 2 - Phase 3
+  **/
+  UINT8                      EqPh23Bypass;
+  UINT8                      TsLockTimer;                 ///< 8.0GT/s Training Sequence Wait Latency For Presets / Coefficients Evaluation - Gen3 TS Lock Timer
+  /**
+  PCIe Equalization Phase Enable Control
+  - <b>Disabled</b>       (0x0) : Disable Phase (Default)
+  - Enabled               (0x1) : Enable Phase
+  **/
+  UINT8                      EqPhBypass;
+  UINT8                      Rsvd[2];
+  /**
+    Tells BIOS how many presets/coefficients should be used during link EQ.
+    Entries in the Ph3CoefficientsList or Ph3PresetList(depending on chosen mode) need to be valid up to the number specified in this field.
+  **/
+  UINT8                      Ph3NoOfPresetOrCoeff;
+  PCIE_LINK_EQ_COEFFICIENTS  Ph3CoefficientsList[PCIE_LINK_EQ_COEFFICIENTS_MAX];  ///< List of the PCIe coefficients to be used during equalization process. Only valid if PcieLinkEqMode is PcieLinkEqCoefficientMode
+  UINT32                     Ph3PresetList[PCIE_LINK_EQ_PRESETS_MAX];             ///< List of the PCIe preset values to be used during equalization process. Only valid if PcieLinkEqMode is PcieLinkEqPresetMode
+  UINT32                     EndPointPresetList[PCIE_LINK_EQ_PRESETS_MAX];        ///< List of the PCIe preset values to be used during equalization process. Only valid if PcieLinkEqMode is PcieLinkEqPresetMode
+  UINT32                     HintList[PCIE_LINK_EQ_PRESETS_MAX];                  ///< List of the Hint values to be used during equalization process for preset calculation.
+  UINT32                     Ph1DpTxPreset;                                       ///< Specifies the value of the downstream port transmitter preset to be used during phase 1 of the equalization process. Will be applied to all lanes
+  UINT32                     Ph1UpTxPreset;                                       ///< Specifies the value of the upstream port transmitter preset to be used during phase 1 of the equalization process. Will be applied to all lanes
+} PCIE_LINK_EQ_PLATFORM_SETTINGS;
+
+//Note: This structure will be expanded to hold all common PCIe policies between SA and PCH RootPort
+typedef struct {
+  UINT32  HotPlug                         :  1;   ///< Indicate whether the root port is hot plug available. <b>0: Disable</b>; 1: Enable.
+  UINT32  PmSci                           :  1;   ///< Indicate whether the root port power manager SCI is enabled. 0: Disable; <b>1: Enable</b>.
+  UINT32  TransmitterHalfSwing            :  1;   ///< Indicate whether the Transmitter Half Swing is enabled. <b>0: Disable</b>; 1: Enable.
+  UINT32  AcsEnabled                      :  1;   ///< Indicate whether the ACS is enabled. 0: Disable; <b>1: Enable</b>.
+  //
+  // Error handlings
+  //
+  UINT32  AdvancedErrorReporting          :  1;   ///< Indicate whether the Advanced Error Reporting is enabled. <b>0: Disable</b>; 1: Enable.
+  UINT32  UnsupportedRequestReport        :  1;   ///< Indicate whether the Unsupported Request Report is enabled. <b>0: Disable</b>; 1: Enable.
+  UINT32  FatalErrorReport                :  1;   ///< Indicate whether the Fatal Error Report is enabled. <b>0: Disable</b>; 1: Enable.
+  UINT32  NoFatalErrorReport              :  1;   ///< Indicate whether the No Fatal Error Report is enabled. <b>0: Disable</b>; 1: Enable.
+  UINT32  CorrectableErrorReport          :  1;   ///< Indicate whether the Correctable Error Report is enabled. <b>0: Disable</b>; 1: Enable.
+  UINT32  SystemErrorOnFatalError         :  1;   ///< Indicate whether the System Error on Fatal Error is enabled. <b>0: Disable</b>; 1: Enable.
+  UINT32  SystemErrorOnNonFatalError      :  1;   ///< Indicate whether the System Error on Non Fatal Error is enabled. <b>0: Disable</b>; 1: Enable.
+  UINT32  SystemErrorOnCorrectableError   :  1;   ///< Indicate whether the System Error on Correctable Error is enabled. <b>0: Disable</b>; 1: Enable.
+  /**
+    Max Payload Size supported, Default <b>128B</b>, see enum CPU_PCIE_MAX_PAYLOAD
+    Changes Max Payload Size Supported field in Device Capabilities of the root port.
+  **/
+  UINT32  MaxPayload                      :  3;
+  UINT32  DpcEnabled                      :  1;   ///< Downstream Port Containment. 0: Disable; <b>1: Enable</b>
+  UINT32  RpDpcExtensionsEnabled          :  1;   ///< RP Extensions for Downstream Port Containment. 0: Disable; <b>1: Enable</b>
+  /**
+    Indicates how this root port is connected to endpoint. 0: built-in device; <b>1: slot</b>
+    Built-in is incompatible with hotplug-capable ports.
+  **/
+  UINT32  SlotImplemented                 :  1;
+  UINT32  PtmEnabled                      :  1;   ///< Enables PTM capability
+  UINT32  RsvdBits0                       : 13;   ///< Reserved bits.
+  UINT32  SlotPowerLimitScale             :  2;   ///< <b>(Test)</b> Specifies scale used for slot power limit value. Leave as 0 to set to default. Default is <b>zero</b>.
+  UINT32  SlotPowerLimitValue             : 12;   //< <b>(Test)</b> Specifies upper limit on power supplies by slot. Leave as 0 to set to default. Default is <b>zero</b>.
+  /**
+    Probe CLKREQ# signal before enabling CLKREQ# based power management.
+    Conforming device shall hold CLKREQ# low until CPM is enabled. This feature attempts
+    to verify CLKREQ# signal is connected by testing pad state before enabling CPM.
+    In particular this helps to avoid issues with open-ended PCIe slots.
+    This is only applicable to non hot-plug ports.
+    <b>0: Disable</b>; 1: Enable.
+  **/
+  UINT32  ClkReqDetect                    :  1;
+  /**
+    Set if the slot supports manually operated retention latch.
+  **/
+  UINT32  MrlSensorPresent                :  1;
+  UINT32  RelaxedOrder                    :  1;
+  UINT32  NoSnoop                         :  1;
+  ///
+  /// This member describes whether Peer Memory Writes are enabled on the platform. <b>0: Disable</b>; 1: Enable.
+  ///
+  UINT32  EnablePeerMemoryWrite           :  1;
+  ///
+  /// This member describes whether the PCI Express Clock Gating for each root port
+  /// is enabled by platform modules. <b>0: Disable</b>; 1: Enable.
+  ///
+  UINT32  ClockGating                     :  1;
+  ///
+  /// This member describes whether the PCI Express Power Gating for each root port
+  /// is enabled by platform modules. <b>0: Disable</b>; 1: Enable.
+  ///
+  UINT32  PowerGating                     :  1;
+  UINT32  PcieFomsCp                      :  3;    ///< FOM Score Board Control Policy
+  UINT32  LedManagement                   :  1;   ///< Indicate whether the VMD Led Management is enabled in root port. <b>0: Disable</b>; 1: Enable.
+  UINT32  RsvdBits1                       :  7;   ///< Reserved bits.
+  UINT16  PhysicalSlotNumber;                     ///< Indicates the slot number for the root port. Default is the value as root port index.
+  /**
+    PCIe Gen3 Equalization Phase 3 Method (see CPU_PCIE_EQ_METHOD).
+    0: DEPRECATED, hardware equalization; <b>1: hardware equalization</b>; 4: Fixed Coefficients
+  **/
+  UINT8   Gen3EqPh3Method;
+  UINT8   CompletionTimeout;                      ///< The completion timeout configuration of the root port (see: CPU_PCIE_COMPLETION_TIMEOUT). Default is <b>PchPcieCompletionTO_Default</b>.
+  /**
+  <b>(Test)</b>
+  Forces LTR override to be permanent
+  The default way LTR override works is:
+  rootport uses LTR override values provided by BIOS until connected device sends an LTR message, then it will use values from the message
+  This settings allows force override of LTR mechanism. If it's enabled, then:
+  rootport will use LTR override values provided by BIOS forever; LTR messages sent from connected device will be ignored
+  **/
+  PCIE_LTR_CONFIG               PcieRpLtrConfig;            ///< <b>(Test)</b> Latency Tolerance Reporting Policies including LTR limit and Override
+  //
+  // Power Management
+  //
+  UINT8   Aspm;                                   ///< The ASPM configuration of the root port (see: CPU_PCIE_ASPM_CONTROL). Default is <b>PchPcieAspmAutoConfig</b>.
+  UINT8   L1Substates;                            ///< The L1 Substates configuration of the root port (see: CPU_PCIE_L1SUBSTATES_CONTROL). Default is <b>PchPcieL1SubstatesL1_1_2</b>.
+  UINT8   L1ExitLatency;                          ///< L1 Exit Latency
+  UINT8   LtrEnable;                              ///< Latency Tolerance Reporting Mechanism. <b>0: Disable</b>; 1: Enable.
+  UINT8   EnableCpm;                              ///< Enables Clock Power Management; even if disabled, CLKREQ# signal can still be controlled by L1 PM substates mechanism
+  UINT8   PcieSpeed;                              ///< Contains speed of PCIe bus (see: PCIE_SPEED)
+    /**
+    The number of milliseconds reference code will wait for link to exit Detect state for enabled ports
+    before assuming there is no device and potentially disabling the port.
+    It's assumed that the link will exit detect state before root port initialization (sufficient time
+    elapsed since PLTRST de-assertion) therefore default timeout is zero. However this might be useful
+    if device power-up seqence is controlled by BIOS or a specific device requires more time to detect.
+    In case of non-common clock enabled the default timout is 15ms.
+    <b>Default: 0</b>
+  **/
+  UINT16  DetectTimeoutMs;
+  UINT8   FormFactor; // Please check PCIE_FORM_FACTOR for supported values
+  UINT8   L1Low;                                  ///< L1.LOW enable/disable. <b>0: Disable</b>; 1: Enable.
+  UINT8   LinkDownGpios;
+  ///
+  /// <b>0: Use project default equalization settings</b>; 1: Use equalization settings from PcieLinkEqPlatformSettings
+  ///
+  UINT8   OverrideEqualizationDefaults;
+  UINT8   PcieCfgDump;
+  UINT8   Rsvd[11];
+  PCIE_LINK_EQ_PLATFORM_SETTINGS    PcieGen3LinkEqPlatformSettings;  ///< Global PCIe Gen3 link EQ settings that BIOS will use during PCIe link EQ for every port.
+  PCIE_LINK_EQ_PLATFORM_SETTINGS    PcieGen4LinkEqPlatformSettings;  ///< Global PCIe Gen4 link EQ settings that BIOS will use during PCIe link EQ for every port.
+  PCIE_LINK_EQ_PLATFORM_SETTINGS    PcieGen5LinkEqPlatformSettings;  ///< Global PCIe Gen5 link EQ settings that BIOS will use during PCIe link EQ for every port.
+} PCIE_ROOT_PORT_COMMON_CONFIG;
+
+/**
+  PCIe Common Config
+  @note This structure will be expanded to hold all common PCIe policies between SA and PCH
+**/
+typedef struct {
+  /**
+    RpFunctionSwap allows BIOS to use root port function number swapping when root port of function 0 is disabled.
+    A PCIE device can have higher functions only when Function0 exists. To satisfy this requirement,
+    BIOS will always enable Function0 of a device that contains more than 0 enabled root ports.
+    - <b>Enabled: One of enabled root ports get assigned to Function0.</b>
+      This offers no guarantee that any particular root port will be available at a specific DevNr:FuncNr location
+    - Disabled: Root port that corresponds to Function0 will be kept visible even though it might be not used.
+      That way rootport - to - DevNr:FuncNr assignment is constant. This option will impact ports 1, 9, 17.
+      NOTE: This option will not work if ports 1, 9, 17 are fused or configured for RST PCIe storage or disabled through policy
+            In other words, it only affects ports that would become hidden because they have no device connected.
+      NOTE: Disabling function swap may have adverse impact on power management. This option should ONLY
+            be used when each one of root ports 1, 9, 17:
+        - is configured as PCIe and has correctly configured ClkReq signal, or
+        - does not own any mPhy lanes (they are configured as SATA or USB)
+  **/
+  UINT32  RpFunctionSwap                   :  1;
+  /**
+    Compliance Test Mode shall be enabled when using Compliance Load Board.
+    <b>0: Disable</b>, 1: Enable
+  **/
+  UINT32  ComplianceTestMode               :  1;
+  UINT32  RsvdBits0                        : 30;   ///< Reserved bits
+  ///
+  /// <b>(Test)</b> This member describes whether PCIE root port Port 8xh Decode is enabled. <b>0: Disable</b>; 1: Enable.
+  ///
+  UINT8  EnablePort8xhDecode;
+  UINT8  RsvdBytes0[3];
+} PCIE_COMMON_CONFIG;
+
+/**
+  PCIe device table entry entry
+
+  The PCIe device table is being used to override PCIe device ASPM settings.
+  To take effect table consisting of such entries must be instelled as PPI
+  on gPchPcieDeviceTablePpiGuid.
+  Last entry VendorId must be 0.
+**/
+typedef struct {
+  UINT16  VendorId;                    ///< The vendor Id of Pci Express card ASPM setting override, 0xFFFF means any Vendor ID
+  UINT16  DeviceId;                    ///< The Device Id of Pci Express card ASPM setting override, 0xFFFF means any Device ID
+  UINT8   RevId;                       ///< The Rev Id of Pci Express card ASPM setting override, 0xFF means all steppings
+  UINT8   BaseClassCode;               ///< The Base Class Code of Pci Express card ASPM setting override, 0xFF means all base class
+  UINT8   SubClassCode;                ///< The Sub Class Code of Pci Express card ASPM setting override, 0xFF means all sub class
+  UINT8   EndPointAspm;                ///< Override device ASPM (see: PCH_PCIE_ASPM_CONTROL)
+                                       ///< Bit 1 must be set in OverrideConfig for this field to take effect
+  UINT16  OverrideConfig;              ///< The override config bitmap (see: PCH_PCIE_OVERRIDE_CONFIG).
+  /**
+    The L1Substates Capability Offset Override. (applicable if bit 2 is set in OverrideConfig)
+    This field can be zero if only the L1 Substate value is going to be override.
+  **/
+  UINT16  L1SubstatesCapOffset;
+  /**
+    L1 Substate Capability Mask. (applicable if bit 2 is set in OverrideConfig)
+    Set to zero then the L1 Substate Capability [3:0] is ignored, and only L1s values are override.
+    Only bit [3:0] are applicable. Other bits are ignored.
+  **/
+  UINT8   L1SubstatesCapMask;
+  /**
+    L1 Substate Port Common Mode Restore Time Override. (applicable if bit 2 is set in OverrideConfig)
+    L1sCommonModeRestoreTime and L1sTpowerOnScale can have a valid value of 0, but not the L1sTpowerOnValue.
+    If L1sTpowerOnValue is zero, all L1sCommonModeRestoreTime, L1sTpowerOnScale, and L1sTpowerOnValue are ignored,
+    and only L1SubstatesCapOffset is override.
+  **/
+  UINT8   L1sCommonModeRestoreTime;
+  /**
+    L1 Substate Port Tpower_on Scale Override. (applicable if bit 2 is set in OverrideConfig)
+    L1sCommonModeRestoreTime and L1sTpowerOnScale can have a valid value of 0, but not the L1sTpowerOnValue.
+    If L1sTpowerOnValue is zero, all L1sCommonModeRestoreTime, L1sTpowerOnScale, and L1sTpowerOnValue are ignored,
+    and only L1SubstatesCapOffset is override.
+  **/
+  UINT8   L1sTpowerOnScale;
+  /**
+    L1 Substate Port Tpower_on Value Override. (applicable if bit 2 is set in OverrideConfig)
+    L1sCommonModeRestoreTime and L1sTpowerOnScale can have a valid value of 0, but not the L1sTpowerOnValue.
+    If L1sTpowerOnValue is zero, all L1sCommonModeRestoreTime, L1sTpowerOnScale, and L1sTpowerOnValue are ignored,
+    and only L1SubstatesCapOffset is override.
+  **/
+  UINT8   L1sTpowerOnValue;
+
+  /**
+    SnoopLatency bit definition
+    Note: All Reserved bits must be set to 0
+
+    BIT[15]     - When set to 1b, indicates that the values in bits 9:0 are valid
+                  When clear values in bits 9:0 will be ignored
+    BITS[14:13] - Reserved
+    BITS[12:10] - Value in bits 9:0 will be multiplied with the scale in these bits
+                  000b - 1 ns
+                  001b - 32 ns
+                  010b - 1024 ns
+                  011b - 32,768 ns
+                  100b - 1,048,576 ns
+                  101b - 33,554,432 ns
+                  110b - Reserved
+                  111b - Reserved
+    BITS[9:0]   - Snoop Latency Value. The value in these bits will be multiplied with
+                  the scale in bits 12:10
+
+    This field takes effect only if bit 3 is set in OverrideConfig.
+  **/
+  UINT16  SnoopLatency;
+  /**
+    NonSnoopLatency bit definition
+    Note: All Reserved bits must be set to 0
+
+    BIT[15]     - When set to 1b, indicates that the values in bits 9:0 are valid
+                  When clear values in bits 9:0 will be ignored
+    BITS[14:13] - Reserved
+    BITS[12:10] - Value in bits 9:0 will be multiplied with the scale in these bits
+                  000b - 1 ns
+                  001b - 32 ns
+                  010b - 1024 ns
+                  011b - 32,768 ns
+                  100b - 1,048,576 ns
+                  101b - 33,554,432 ns
+                  110b - Reserved
+                  111b - Reserved
+    BITS[9:0]   - Non Snoop Latency Value. The value in these bits will be multiplied with
+                  the scale in bits 12:10
+
+    This field takes effect only if bit 3 is set in OverrideConfig.
+  **/
+  UINT16  NonSnoopLatency;
+
+  /**
+    Forces LTR override to be permanent
+    The default way LTR override works is:
+      rootport uses LTR override values provided by BIOS until connected device sends an LTR message, then it will use values from the message
+    This settings allows force override of LTR mechanism. If it's enabled, then:
+      rootport will use LTR override values provided by BIOS forever; LTR messages sent from connected device will be ignored
+  **/
+  UINT8  ForceLtrOverride;
+  UINT8  Reserved[3];
+} PCIE_DEVICE_OVERRIDE;
+
+#pragma pack (pop)
+#endif // _PCIE_CONFIG_H_

--- a/Silicon/ArrowlakePkg/Include/PcieRegs.h
+++ b/Silicon/ArrowlakePkg/Include/PcieRegs.h
@@ -21,44 +21,439 @@
 
 
 //
-// PTM Extended Capability Register (CAPID:001Fh)
+// PCI type 0 Header
 //
-#define  B_PCIE_EX_PTMCAP_PTMRC                   BIT2 ///< PTM Root Capable
-#define  B_PCIE_EX_PTMCAP_PTMRSPC                 BIT1 ///< PTM Responder Capable
-
-//
-// Base Address Offset
-//
-#define B_PCI_BAR_MEMORY_TYPE_MASK                (BIT1 | BIT2)
-#define B_PCI_BAR_MEMORY_TYPE_64                  BIT2
-
+#define R_PCI_PI_OFFSET                           0x09
+#define R_PCI_SCC_OFFSET                          0x0A
+#define R_PCI_BCC_OFFSET                          0x0B
 
 #define R_PCI_BAR0_OFFSET                         0x10
+#define B_PCI_BAR0_MMT_OFFSET                     1
+#define B_PCI_BAR0_MMT_OFFSET_MASK                0x06
+#define V_PCI_BAR0_MMT                            2
+#define R_PCI_BAR1_OFFSET                         0x14
+#define R_PCI_BAR4_OFFSET                         0x20
+#define R_PCI_BAR5_OFFSET                         0x24
 
+//
+// PCI type 1 Header
+//
+#define R_PCI_BRIDGE_BNUM                         0x18 ///< Bus Number Register
+#define B_PCI_BRIDGE_BNUM_SBBN                    0x00FF0000 ///< Subordinate Bus Number
+#define B_PCI_BRIDGE_BNUM_SCBN                    0x0000FF00 ///< Secondary Bus Number
+#define B_PCI_BRIDGE_BNUM_PBN                     0x000000FF ///< Primary Bus Number
+#define B_PCI_BRIDGE_BNUM_SBBN_SCBN               (B_PCI_BRIDGE_BNUM_SBBN | B_PCI_BRIDGE_BNUM_SCBN)
 
+#define R_PCI_BRIDGE_IOBL                         0x1C ///< I/O Base and Limit Register
+
+#define R_PCI_BRIDGE_MBL                          0x20 ///< Memory Base and Limit Register
+#define B_PCI_BRIDGE_MBL_ML                       0xFFF00000 ///< Memory Limit
+#define B_PCI_BRIDGE_MBL_MB                       0x0000FFF0 ///< Memory Base
+
+#define R_PCI_BRIDGE_PMBL                         0x24 ///< Prefetchable Memory Base and Limit Register
+#define B_PCI_BRIDGE_PMBL_PML                     0xFFF00000 ///< Prefetchable Memory Limit
+#define B_PCI_BRIDGE_PMBL_I64L                    0x000F0000 ///< 64-bit Indicator
+#define B_PCI_BRIDGE_PMBL_PMB                     0x0000FFF0 ///< Prefetchable Memory Base
+#define B_PCI_BRIDGE_PMBL_I64B                    0x0000000F ///< 64-bit Indicator
+
+#define R_PCI_BRIDGE_PMBU32                       0x28 ///< Prefetchable Memory Base Upper 32-Bit Register
+#define B_PCI_BRIDGE_PMBU32                       0xFFFFFFFF
+
+#define R_PCI_BRIDGE_PMLU32                       0x2C ///< Prefetchable Memory Limit Upper 32-Bit Register
+#define B_PCI_BRIDGE_PMLU32                       0xFFFFFFFF
+
+//
+// PCI type 2 Header
+//
+#define R_PCI_CARDBUS_BRIDGE_SVID                 0x40 ///< Subsystem Vendor ID
+
+//
+// PCIE capabilities register
+//
+#define R_PCIE_CAP_ID_OFFSET                      0x00 ///< Capability ID
+#define R_PCIE_CAP_NEXT_PRT_OFFSET                0x01 ///< Next Capability Capability ID Pointer
+
+//
+// PCI Express Capability List Register (CAPID:10h)
+//
+#define R_PCIE_XCAP_OFFSET                        0x02 ///< PCI Express Capabilities Register (Offset 02h)
+#define S_PCIE_XCAP                               2
+#define B_PCIE_XCAP_CV_MASK                       0xF
+#define B_PCIE_XCAP_SI                            BIT8 ///< Slot Implemented
+#define B_PCIE_XCAP_DT                            (BIT7 | BIT6 | BIT5 | BIT4) ///< Device/Port Type
+#define N_PCIE_XCAP_DT                            4
+
+#define R_PCIE_DCAP_OFFSET                        0x04 ///< Device Capabilities Register (Offset 04h)
+#define S_PCIE_DCAP                               4
+#define B_PCIE_DCAP_RBER                          BIT15 ///< Role-Based Error Reporting
+#define B_PCIE_DCAP_E1AL                          (BIT11 | BIT10 | BIT9) ///< Endpoint L1 Acceptable Latency
+#define N_PCIE_DCAP_E1AL                          9
+#define B_PCIE_DCAP_E0AL                          (BIT8 | BIT7 | BIT6) ///< Endpoint L0s Acceptable Latency
+#define N_PCIE_DCAP_E0AL                          6
+#define B_PCIE_DCAP_MPS                           (BIT2 | BIT1 | BIT0) ///< Max_Payload_Size Supported
+#define B_PCIE_DCAP_ETFS                          BIT5
+
+#define R_PCIE_DCTL_OFFSET                        0x08 ///< Device Control Register (Offset 08h)
+#define B_PCIE_DCTL_MRRS                          (BIT14 | BIT13 | BIT12) ///<Max Read Request Size
+#define N_PCIE_DCTL_MRRS                          12
+#define V_PCIE_DCTL_MRRS_256B                     0x1
+#define B_PCIE_DCTL_NS                            BIT11 ///< Enable No Snoop
+#define B_PCIE_DCTL_ETFE                          BIT8 ///< Extended Tag Field Enable
+#define B_PCIE_DCTL_MPS                           (BIT7 | BIT6 | BIT5) ///< Max_Payload_Size
+#define N_PCIE_DCTL_MPS                           5
+#define B_PCIE_DCTL_RO                            BIT4 ///< Enable Relaxed Ordering
+#define B_PCIE_DCTL_URE                           BIT3 ///< Unsupported Request Reporting Enable
+#define B_PCIE_DCTL_FEE                           BIT2 ///< Fatal Error Reporting Enable
+#define B_PCIE_DCTL_NFE                           BIT1 ///< Non-Fatal Error Reporting Enable
+#define B_PCIE_DCTL_CEE                           BIT0 ///< Correctable Error Reporting Enable
+
+#define R_PCIE_DSTS_OFFSET                        0x0A ///< Device Status Register (Offset 0Ah)
+#define B_PCIE_DSTS_TDP                           BIT5 ///< Transactions Pending
+#define B_PCIE_DSTS_APD                           BIT4 ///< AUX Power Detected
+#define B_PCIE_DSTS_URD                           BIT3 ///< Unsupported Request Detected
+#define B_PCIE_DSTS_FED                           BIT2 ///< Fatal Error Detected
+#define B_PCIE_DSTS_NFED                          BIT1 ///< Non-Fatal Error Detected
+#define B_PCIE_DSTS_CED                           BIT0 ///< Correctable Error Detected
+
+#define R_PCIE_LCAP_OFFSET                        0x0C ///< Link Capabilities Register (Offset 0Ch)
+#define B_PCIE_LCAP_ASPMOC                        BIT22 ///< ASPM Optionality Compliance
+#define B_PCIE_LCAP_CPM                           BIT18 ///< Clock Power Management
+#define B_PCIE_LCAP_EL1                           (BIT17 | BIT16 | BIT15) ///< L1 Exit Latency
+#define N_PCIE_LCAP_EL1                           15
+#define B_PCIE_LCAP_EL0                           (BIT14 | BIT13 | BIT12) ///< L0s Exit Latency
+#define N_PCIE_LCAP_EL0                           12
+#define B_PCIE_LCAP_APMS                          (BIT11 | BIT10) ///< Active State Power Management (ASPM) Support
+#define B_PCIE_LCAP_APMS_L0S                      BIT10
+#define B_PCIE_LCAP_APMS_L1                       BIT11
+#define N_PCIE_LCAP_APMS                          10
+#define B_PCIE_LCAP_MLW                           0x000003F0 ///< Maximum Link Width
+#define N_PCIE_LCAP_MLW                           4
+#define B_PCIE_LCAP_MLS                           (BIT3 | BIT2 | BIT1 | BIT0) ///< Max Link Speed
+#define V_PCIE_LCAP_MLS_GEN3                      3
+#define V_PCIE_LCAP_MLS_GEN4                      4
+#define V_PCIE_LCAP_MLS_GEN5                      5
+
+#define R_PCIE_LCTL_OFFSET                        0x10 ///< Link Control Register (Offset 10h)
+#define B_PCIE_LCTL_ECPM                          BIT8 ///< Enable Clock Power Management
+#define B_PCIE_LCTL_ES                            BIT7 ///< Extended Synch
+#define B_PCIE_LCTL_CCC                           BIT6 ///< Common Clock Configuration
+#define B_PCIE_LCTL_RL                            BIT5 ///< Retrain Link
+#define B_PCIE_LCTL_LD                            BIT4 ///< Link Disable
+#define B_PCIE_LCTL_ASPM                          (BIT1 | BIT0) ///< Active State Power Management (ASPM) Control
+#define V_PCIE_LCTL_ASPM_L0S                      1
+#define V_PCIE_LCTL_ASPM_L1                       2
+#define V_PCIE_LCTL_ASPM_L0S_L1                   3
+
+#define R_PCIE_LSTS_OFFSET                        0x12 ///< Link Status Register (Offset 12h)
+#define B_PCIE_LSTS_LA                            BIT13 ///< Data Link Layer Link Active
+#define B_PCIE_LSTS_SCC                           BIT12 ///< Slot Clock Configuration
+#define B_PCIE_LSTS_LT                            BIT11 ///< Link Training
+#define B_PCIE_LSTS_NLW                           0x03F0 ///< Negotiated Link Width
+#define N_PCIE_LSTS_NLW                           4
+#define V_PCIE_LSTS_NLW_1                         0x0010
+#define V_PCIE_LSTS_NLW_2                         0x0020
+#define V_PCIE_LSTS_NLW_4                         0x0040
+#define B_PCIE_LSTS_CLS                           0x000F ///< Current Link Speed
+#define V_PCIE_LSTS_CLS_GEN1                      1
+#define V_PCIE_LSTS_CLS_GEN2                      2
+#define V_PCIE_LSTS_CLS_GEN3                      3
+
+#define R_PCIE_SLCAP_OFFSET                       0x14 ///< Slot Capabilities Register (Offset 14h)
+#define S_PCIE_SLCAP                              4
+#define B_PCIE_SLCAP_PSN                          0xFFF80000 ///< Physical Slot Number
+#define N_PCIE_SLCAP_PSN                          19         ///< Physical Slot Number
+#define B_PCIE_SLCAP_SLS                          0x00018000 ///< Slot Power Limit Scale
+#define N_PCIE_SLCAP_SLS                          15         ///< Slot Power Limit Scale
+#define B_PCIE_SLCAP_SLV                          0x00007F80 ///< Slot Power Limit Value
+#define N_PCIE_SLCAP_SLV                          7          ///< Slot Power Limit Value
+#define B_PCIE_SLCAP_HPC                          BIT6       ///< Hot-Plug Capable
+#define B_PCIE_SLCAP_HPS                          BIT5       ///< Hot-Plug Surprise
+#define B_PCIE_SLCAP_PIP                          BIT4       ///< Power indicator present
+#define B_PCIE_SLCAP_AIP                          BIT3       ///< Attention indicator present
+#define B_PCIE_SLCAP_MRLSP                        BIT2       ///< MRL Sensor present
+#define B_PCIE_SLCAP_PCP                          BIT1       ///< Power controller present
+#define B_PCIE_SLCAP_ABP                          BIT0       ///< Attention button present
+
+#define R_PCIE_SLCTL_OFFSET                       0x18 ///< Slot Control Register (Offset 18h)
+#define S_PCIE_SLCTL                              2
+#define B_PCIE_SLCTL_HPE                          BIT5 ///< Hot Plug Interrupt Enable
+#define B_PCIE_SLCTL_PDE                          BIT3 ///< Presence Detect Changed Enable
+
+#define R_PCIE_SLSTS_OFFSET                       0x1A ///< Slot Status Register (Offset 1Ah)
+#define S_PCIE_SLSTS                              2
+#define B_PCIE_SLSTS_PDS                          BIT6 ///< Presence Detect State
+#define B_PCIE_SLSTS_PDC                          BIT3 ///< Presence Detect Changed
+
+#define R_PCIE_RCTL_OFFSET                        0x1C ///< Root Control Register (Offset 1Ch)
+#define S_PCIE_RCTL                               2
+#define B_PCIE_RCTL_PIE                           BIT3 ///< PME Interrupt Enable
+#define B_PCIE_RCTL_SFE                           BIT2 ///< System Error on Fatal Error Enable
+#define B_PCIE_RCTL_SNE                           BIT1 ///< System Error on Non-Fatal Error Enable
+#define B_PCIE_RCTL_SCE                           BIT0 ///< System Error on Correctable Error Enable
+
+#define R_PCIE_RSTS_OFFSET                        0x20 ///< Root Status Register (Offset 20h)
+#define S_PCIE_RSTS                               4
+
+#define R_PCIE_DCAP2_OFFSET                       0x24 ///< Device Capabilities 2 Register (Offset 24h)
+#define B_PCIE_DCAP2_OBFFS                        (BIT19 | BIT18) ///< OBFF Supported
+#define B_PCIE_DCAP2_OBFFS_MASK                   0xC0000
+#define B_PCIE_DCAP2_LTRMS                        BIT11 ///< LTR Mechanism Supported
+#define B_PCIE_DCAP2_PX10BTCS                     BIT16 ///< 10-Bit Tag Completer Support
+#define B_PCIE_DCAP2_PX10BTRS                     BIT17 ///< 10-Bit Tag Requester Support
+
+#define R_PCIE_DCTL2_OFFSET                       0x28 ///< Device Control 2 Register (Offset 28h)
+#define B_PCIE_DCTL2_OBFFEN                       (BIT14 | BIT13) ///< OBFF Enable
+#define N_PCIE_DCTL2_OBFFEN                       13
+#define V_PCIE_DCTL2_OBFFEN_DIS                   0 ///< Disabled
+#define V_PCIE_DCTL2_OBFFEN_WAKE                  3 ///< Enabled using WAKE# signaling
+#define B_PCIE_DCTL2_PX10BTRE                     BIT12 ///< 10-Bit Tag Requester Enable
 #define B_PCIE_DCTL2_LTREN                        BIT10 ///< LTR Mechanism Enable
+#define B_PCIE_DCTL2_AEB                          BIT7  ///< AtomicOP Egress Blocking Enable
+#define B_PCIE_DCTL2_CTD                          BIT4 ///< Completion Timeout Disable
+#define B_PCIE_DCTL2_CTV                          (BIT3 | BIT2 | BIT1 | BIT0) ///< Completion Timeout Value
+#define V_PCIE_DCTL2_CTV_DEFAULT                  0x0
+#define V_PCIE_DCTL2_CTV_40MS_50MS                0x5
+#define V_PCIE_DCTL2_CTV_160MS_170MS              0x6
+#define V_PCIE_DCTL2_CTV_400MS_500MS              0x9
+#define V_PCIE_DCTL2_CTV_1P6S_1P7S                0xA
 
+#define R_PCIE_LCAP2_OFFSET                       0x2C
+#define B_PCIE_LCAP2_TRPDS                        BIT24
+#define B_PCIE_LCAP2_RPDS                         BIT23
+#define B_PCIE_LCAP2_LSOSRSS                      0x7F0000
+#define N_PCIE_LCAP2_LSOSRSS                      16
+#define B_PCIE_LCAP2_LSOSGSSV                     0xFE00
+#define N_PCIE_LCAP2_LSOSGSSV                     9
+#define B_PCIE_LCAP2_CS                           BIT8
+#define N_PCIE_LCAP2_CS                           8
+#define B_PCIE_LCAP2_SLSV                         BIT1
+#define N_PCIE_LCAP2_SLSV                         1
+
+#define R_PCIE_LCTL2_OFFSET                       0x30 ///< Link Control 2 Register (Offset 30h)
+#define B_PCIE_LCTL2_SD                           BIT6 ///< Selectable de-emphasis (0 = -6dB, 1 = -3.5dB)
+#define B_PCIE_LCTL2_TLS                          (BIT3 | BIT2 | BIT1 | BIT0) ///< Target Link Speed
+#define V_PCIE_LCTL2_TLS_GEN1                     1
+#define V_PCIE_LCTL2_TLS_GEN2                     2
+#define V_PCIE_LCTL2_TLS_GEN3                     3
+#define V_PCIE_LCTL2_TLS_GEN4                     4
+#define V_PCIE_LCTL2_TLS_GEN5                     5
+
+#define R_PCIE_LSTS2_OFFSET                       0x32 ///< Link Status 2 Register (Offset 32h)
+#define B_PCIE_LSTS2_LER                          BIT5 ///< Link Equalization Request
+#define B_PCIE_LSTS2_EQP3S                        BIT4 ///< Equalization Phase 3 Successful
+#define B_PCIE_LSTS2_EQP2S                        BIT3 ///< Equalization Phase 2 Successful
+#define B_PCIE_LSTS2_EQP1S                        BIT2 ///< Equalization Phase 1 Successful
+#define B_PCIE_LSTS2_EC                           BIT1 ///< Equalization Complete
+#define B_PCIE_LSTS2_CDL                          BIT0 ///< Current De-emphasis Level
+
+#define R_PCIE_CCFG_OFFSET                        0x90
+
+#define R_PCIE_IPCS_OFFSET                        0xB0
 
 #define  V_PCIE_SVCAP_CID                        0x0D
 #define  V_PCIE_MID_CID                          0x05
 #define  V_PCIE_XCAP_CV                          0x02
 #define  V_PCIE_CLIST_CID                        0x10
 
+//
+// PCI Power Management Capability (CAPID:01h)
+//
+#define R_PCIE_PMC_OFFSET                         0x02 ///< Power Management Capabilities Register
+#define S_PCIE_PMC                                2
+#define B_PCIE_PMC_PMES                           (BIT15 | BIT14 | BIT13 | BIT12 | BIT11) ///< PME Support
+#define B_PCIE_PMC_PMEC                           BIT3 ///< PME Clock
+
+#define R_PCIE_PMCS_OFFST                         0x04 ///< Power Management Status/Control Register
+#define S_PCIE_PMCS                               4
+#define B_PCIE_PMCS_BPCE                          BIT23 ///< Bus Power/Clock Control Enable
+#define B_PCIE_PMCS_B23S                          BIT22 ///< B2/B3 Support
+#define B_PCIE_PMCS_PMES                          BIT15 ///< PME_Status
+#define B_PCIE_PMCS_PMEE                          BIT8 ///< PME Enable
+#define B_PCIE_PMCS_NSR                           BIT3 ///< No Soft Reset
+#define B_PCIE_PMCS_PS                            (BIT1 | BIT0) ///< Power State
+#define V_PCIE_PMCS_PS_D0                         0
+#define V_PCIE_PMCS_PS_D3H                        3
+
+//
+// PCI Subsystem Vendor Capability
+//
+#define PCI_CAP_ID_SUBSYSTEM_VENDOR               0x0D
+#define R_PCIE_SUBSYSTEM_VENDOR_ID_OFFSET         0x04 ///< Subsystem Vendor IDs
+
+
+//
+// PCIE Extension Capability Register
+//
+#define B_PCIE_EXCAP_NCO                          0xFFF00000 ///< Next Capability Offset
+#define N_PCIE_EXCAP_NCO                          20
+#define V_PCIE_EXCAP_NCO_LISTEND                  0
+#define B_PCIE_EXCAP_CV                           0x000F0000 ///< Capability Version
+#define N_PCIE_EXCAP_CV                           16
+#define B_PCIE_EXCAP_CID                          0x0000FFFF ///< Capability ID
+
+//
+// Advanced Error Reporting Capability (CAPID:0001h)
+//
+#define V_PCIE_EX_AEC_CID                         0x0001 ///< Capability ID
+#define R_PCIE_EX_UEM_OFFSET                      0x08 ///< Uncorrectable Error Mask Register
+#define B_PCIE_EX_UEM_CT                          BIT14 ///< Completion Timeout Mask
+#define B_PCIE_EX_UEM_UC                          BIT16 ///< Unexpected Completion
+
+//
+//VC capabilty register (CAPID:0002h)
+//
+#define V_PCIE_EX_VC_CID                          0x0002 ///< Capability ID
+
+//
+// ACS Extended Capability (CAPID:000Dh)
+//
+#define V_PCIE_EX_ACS_CID                         0x000D ///< Capability ID
+#define R_PCIE_EX_ACSCAPR_OFFSET                  0x04 ///< ACS Capability Register
+#define B_PCIE_ACSCAPR_U                          BIT4
+
+//#define R_PCIE_EX_ACSCTLR_OFFSET                  0x08 ///< ACS Control Register (NOTE: register size in PCIE spce is not match the PCH register size)
+
+
+//
+// Latency Tolerance Reporting Extended Capability Registers (CAPID:0018h)
+//
+#define R_PCIE_LTRECH_CID                         0x0018
+
+#define R_PCIE_LTRECH_MSLR_OFFSET                 0x04
+#define B_PCIE_LTRECH_MSLR_VALUE                  0x3FF
+#define N_PCIE_LTRECH_MSLR_VALUE                  0
+#define B_PCIE_LTRECH_MSLR_SCALE                  0x1C00
+#define N_PCIE_LTRECH_MSLR_SCALE                  10
+
+#define R_PCIE_LTRECH_MNSLR_OFFSET                0x06
+#define B_PCIE_LTRECH_MNSLR_VALUE                 0x3FF
+#define N_PCIE_LTRECH_MNSLR_VALUE                 0
+#define B_PCIE_LTRECH_MNSLR_SCALE                 0x1C00
+#define N_PCIE_LTRECH_MNSLR_SCALE                 10
+
+//
+// Secondary PCI Express Extended Capability Header (CAPID:0019h)
+//
+#define V_PCIE_EX_SPE_CID                         0x0019 ///< Capability ID
+#define R_PCIE_EX_LCTL3_OFFSET                    0x04 ///< Link Control 3 Register
+#define B_PCIE_EX_LCTL3_PE                        BIT0 ///< Perform Equalization
+#define R_PCIE_EX_LES_OFFSET                      0x08 ///< Lane Error Status
+#define R_PCIE_EX_L01EC_OFFSET                    0x0C ///< Lane 0 and Lan 1 Equalization Control Register (Offset 0Ch)
+#define B_PCIE_EX_L01EC_UPL1TP                    0x0F000000 ///< Upstream Port Lane 1 Transmitter Preset
+#define N_PCIE_EX_L01EC_UPL1TP                    24
+#define B_PCIE_EX_L01EC_DPL1TP                    0x000F0000 ///< Downstream Port Lane 1 Transmitter Preset
+#define N_PCIE_EX_L01EC_DPL1TP                    16
+#define B_PCIE_EX_L01EC_UPL0TP                    0x00000F00 ///< Upstream Port Transmitter Preset
+#define N_PCIE_EX_L01EC_UPL0TP                    8
+#define B_PCIE_EX_L01EC_DPL0TP                    0x0000000F ///< Downstream Port Transmitter Preset
+#define N_PCIE_EX_L01EC_DPL0TP                    0
+
+#define R_PCIE_EX_L23EC_OFFSET                    0x10 ///< Lane 2 and Lane 3 Equalization Control Register (Offset 10h)
+#define B_PCIE_EX_L23EC_UPL3TP                    0x0F000000 ///< Upstream Port Lane 3 Transmitter Preset
+#define N_PCIE_EX_L23EC_UPL3TP                    24
+#define B_PCIE_EX_L23EC_DPL3TP                    0x000F0000 ///< Downstream Port Lane 3 Transmitter Preset
+#define N_PCIE_EX_L23EC_DPL3TP                    16
+#define B_PCIE_EX_L23EC_UPL2TP                    0x00000F00 ///< Upstream Port Lane 2 Transmitter Preset
+#define N_PCIE_EX_L23EC_UPL2TP                    8
+#define B_PCIE_EX_L23EC_DPL2TP                    0x0000000F ///< Downstream Port Lane 2 Transmitter Preset
+#define N_PCIE_EX_L23EC_DPL2TP                    0
+
+//
+// Downstream Port Containment Extended Capability register (CAPID:001Dh)
+//
+#define V_PCIE_EX_DPC_CID                         0x001D ///< Capability ID
+#define R_PCIE_EX_DPC_CAP_OFFSET                  0x04
+#define R_PCIE_EX_DPCCAPR_OFFSET                  0x4
+#define R_PCIE_EX_DPCCTRL_OFFSET                  0x6
+#define R_PCIE_EX_DPCSR_OFFSET                    0x8
+#define R_PCIE_EX_DPCESIDR_OFFSET                 0xA
+#define R_PCIE_EX_RPPIOSR_OFFSET                  0xC
+#define R_PCIE_EX_RPPIOMR_OFFSET                  0x10
+#define R_PCIE_EX_RPPIOVR_OFFSET                  0x14
+#define R_PCIE_EX_RPPIOSER_OFFSET                 0x18
+#define R_PCIE_EX_RPPIOER_OFFSET                  0x1C
+#define R_PCIE_EX_RPPIOHLR_OFFSET                 0x20
+
+//
+// L1 Sub-States Extended Capability Register (CAPID:001Eh)
+//
+#define V_PCIE_EX_L1S_CID                        0x001E ///< Capability ID
+#define R_PCIE_EX_L1SCAP_OFFSET                  0x04 ///< L1 Sub-States Capabilities
+#define B_PCIE_EX_L1SCAP_PTV                     0x00F80000 //< Port Tpower_on value
+#define V_PCIE_EX_L1SCAP_PTV_50us                5
+#define N_PCIE_EX_L1SCAP_PTV                     19
+#define B_PCIE_EX_L1SCAP_PTPOS                   0x00030000 //< Port Tpower_on scale
+#define N_PCIE_EX_L1SCAP_PTPOS                   16
+#define B_PCIE_EX_L1SCAP_CMRT                    0x0000FF00 //< Common Mode Restore time
+#define N_PCIE_EX_L1SCAP_CMRT                    8
+#define V_PCIE_EX_L1SCAP_PTPOS_2us               0
+#define V_PCIE_EX_L1SCAP_PTPOS_10us              1
+#define V_PCIE_EX_L1SCAP_PTPOS_100us             2
+#define B_PCIE_EX_L1SCAP_L1SSES                  BIT5 ///< CLKREQ Acceleration Supported
+#define B_PCIE_EX_L1SCAP_L1PSS                   BIT4 ///< L1 PM substates supported
+#define B_PCIE_EX_L1SCAP_AL1SS                   BIT3 ///< ASPM L1.1 supported
+#define B_PCIE_EX_L1SCAP_AL12S                   BIT2 ///< ASPM L1.2 supported
+#define B_PCIE_EX_L1SCAP_PPL11S                  BIT1 ///< PCI-PM L1.1 supported
+#define B_PCIE_EX_L1SCAP_PPL12S                  BIT0 ///< PCI-PM L1.2 supported
+#define R_PCIE_EX_L1SCTL1_OFFSET                 0x08 ///< L1 Sub-States Control 1
+#define B_PCIE_EX_L1SCTL1_L1SSEIE                BIT4
+#define B_PCIE_EX_L1SCTL1_L12LTRTLSV             0xE0000000 ///< L1.2 LTR Threshold Latency Scale Value
+#define N_PCIE_EX_L1SCTL1_L12LTRTLSV             29
+#define B_PCIE_EX_L1SCTL1_L12LTRTLV              0x03FF0000 ///< L1.2 LTR Threshold Latency Value
+#define N_PCIE_EX_L1SCTL1_L12LTRTLV              16
+#define R_PCIE_EX_L1SCTL2_OFFSET                 0x0C ///< L1 Sub-States Control 2
+#define N_PCIE_EX_L1SCTL2_POWT                   3
+#define B_PCIE_EX_CTRL2_PMETOFD                  BIT6
 
 //
 // PTM Extended Capability Register (CAPID:001Fh)
 //
+#define V_PCIE_EX_PTM_CID                         0x001F ///< Capability ID
+#define R_PCIE_EX_PTMCAP_OFFSET                   0x04 ///< PTM Capabilities
 #define  B_PCIE_EX_PTMCAP_PTMRC                   BIT2 ///< PTM Root Capable
 #define  B_PCIE_EX_PTMCAP_PTMRSPC                 BIT1 ///< PTM Responder Capable
+#define R_PCIE_EX_PTMCTL_OFFSET                   0x08 ///< PTM Control Register
 
 //
 // Base Address Offset
 //
+#define R_BASE_ADDRESS_OFFSET_0                   0x0010 ///< Base Address Register 0
+#define R_BASE_ADDRESS_OFFSET_1                   0x0014 ///< Base Address Register 1
+#define R_BASE_ADDRESS_OFFSET_2                   0x0018 ///< Base Address Register 2
+#define R_BASE_ADDRESS_OFFSET_3                   0x001C ///< Base Address Register 3
+#define R_BASE_ADDRESS_OFFSET_4                   0x0020 ///< Base Address Register 4
+#define R_BASE_ADDRESS_OFFSET_5                   0x0024 ///< Base Address Register 5
 #define B_PCI_BAR_MEMORY_TYPE_MASK                (BIT1 | BIT2)
 #define B_PCI_BAR_MEMORY_TYPE_64                  BIT2
 
+//
+// Data Link Feature Extended Capability Header (CAPID:0025h)
+//
+#define V_PCIE_EX_DLFECH_CID                      0x0025 ///< Capability ID
+
+//
+// Physical Layer 16.0 GT/s Extended Capability Header (CAPID:0026h)
+//
+#define V_PCIE_EX_PL16GECH_CID                    0x0026 ///< Capability ID
+
+//
+// Physical Layer 16.0 GT/s Margining Extended Capability Header (CAPID:0027h)
+//
+#define V_PCIE_EX_PL16MECH_CID                    0x0027 ///< Capability ID
+
+//
+// Physical Layer 32.0 GT/s Extended Capability Header (CAPID:002Ah)
+//
+#define V_PCIE_EX_G5ECH_CID                       0x002A ///< Capability ID
+
+//
+// Alternate Protocol Extended Capability Header (CAPID:002Bh)
+//
+#define V_PCIE_EX_APEC_CID                        0x002B ///< Capability ID
 
 //
 // PCI Express Extended Capability Header
 //
+#define R_PCIE_CFG_EXCAP_OFFSET                   0x100
+
 #endif

--- a/Silicon/ArrowlakePkg/Include/Register/PchPcieRpRegs.h
+++ b/Silicon/ArrowlakePkg/Include/Register/PchPcieRpRegs.h
@@ -38,15 +38,157 @@
 #define _PCH_REGS_PCIE_H_
 
 
+#define V_PCH_PCIE_CFG_VENDOR_ID                  V_PCH_INTEL_VENDOR_ID
+
+#define R_PCH_PCIE_CFG_MID                            0x80
+#define S_PCH_PCIE_CFG_MID                            2
+#define R_PCH_PCIE_CFG_MC                             0x82
+#define S_PCH_PCIE_CFG_MC                             2
+#define R_PCH_PCIE_CFG_MA                             0x84
+#define S_PCH_PCIE_CFG_MA                             4
+#define R_PCH_PCIE_CFG_MD                             0x88
+#define S_PCH_PCIE_CFG_MD                             2
+
+#define R_PCH_PCIE_CFG_SVCAP                          0x90
+#define R_PCH_PCIE_CFG_SIP17_SVCAP                    0x98
+#define S_PCH_PCIE_CFG_SVCAP                          2
+#define R_PCH_PCIE_CFG_SVID                           0x94
+#define S_PCH_PCIE_CFG_SVID                           4
+
+#define R_PCH_PCIE_CFG_PMCAP                          0xA0
+#define R_PCH_PCIE_CFG_PMCS                           (R_PCH_PCIE_CFG_PMCAP + R_PCIE_PMCS_OFFST)
+#define B_PCH_PCIE_CFG_PMCS_PS_MASK                   0x3
+#define V_PCH_PCIE_CFG_PMCS_PS_D3H                    0x3
+
+#define R_PCH_PCIE_CFG_MPC2                           0xD4
+#define B_PCH_PCIE_CFG_MPC2_L1SSESE                   BIT30
+#define B_PCH_PCIE_CFG_MPC2_PLLWAIT                   (BIT26 | BIT25 | BIT24)
+#define B_PCH_PCIE_CFG_MPC2_DISPLLEWL1SE              BIT16
+#define S_PCH_PCIE_CFG_MPC2                           4
+#define B_PCH_PCIE_CFG_MPC2_PTNFAE                    BIT12
+#define B_PCH_PCIE_CFG_MPC2_LSTP                      BIT6
+#define B_PCH_PCIE_CFG_MPC2_IEIME                     BIT5
+#define B_PCH_PCIE_CFG_MPC2_ASPMCOEN                  BIT4
+#define B_PCH_PCIE_CFG_MPC2_ASPMCO                    (BIT3 | BIT2)
+#define V_PCH_PCIE_CFG_MPC2_ASPMCO_DISABLED           0
+#define V_PCH_PCIE_CFG_MPC2_ASPMCO_L0S                (1 << 2)
+#define V_PCH_PCIE_CFG_MPC2_ASPMCO_L1                 (2 << 2)
+#define V_PCH_PCIE_CFG_MPC2_ASPMCO_L0S_L1             (3 << 2)
+#define B_PCH_PCIE_CFG_MPC2_EOIFD                     BIT1
+
 #define R_PCH_PCIE_CFG_MPC                            0xD8
+#define S_PCH_PCIE_CFG_MPC                            4
+#define B_PCH_PCIE_CFG_MPC_PMCE                       BIT31
+#define B_PCH_PCIE_CFG_MPC_HPCE                       BIT30
+#define B_PCH_PCIE_CFG_MPC_MMBNCE                     BIT27
+#define B_PCH_PCIE_CFG_MPC_P8XDE                      BIT26
+#define B_PCH_PCIE_CFG_MPC_IRRCE                      BIT25
+#define B_PCH_PCIE_CFG_MPC_SRL                        BIT23
+#define B_PCH_PCIE_CFG_MPC_UCEL                       (BIT20 | BIT19 | BIT18)
+#define N_PCH_PCIE_CFG_MPC_UCEL                       18
+#define B_PCH_PCIE_CFG_MPC_CCEL                       (BIT17 | BIT16 | BIT15)
+#define N_PCH_PCIE_CFG_MPC_CCEL                       15
+#define B_PCH_PCIE_CFG_MPC_PCIESD                     (BIT14 | BIT13)
+#define N_PCH_PCIE_CFG_MPC_PCIESD                     13
+#define V_PCH_PCIE_CFG_MPC_PCIESD_GEN1                1
+#define V_PCH_PCIE_CFG_MPC_PCIESD_GEN2                2
+#define V_PCH_PCIE_CFG_MPC_PCIESD_GEN3                3
+#define V_PCH_PCIE_CFG_MPC_PCIESD_GEN4                4
+#define B_PCH_PCIE_CFG_MPC_MCTPSE                     BIT3
+#define B_PCH_PCIE_CFG_MPC_HPME                       BIT1
+#define N_PCH_PCIE_CFG_MPC_HPME                       1
+#define B_PCH_PCIE_CFG_MPC_PMME                       BIT0
+#define N_PCH_PCIE_CFG_MPC_PMME                       0
 
 #define R_PCH_PCIE_CFG_SMSCS                          0xDC
+#define S_PCH_PCIE_CFG_SMSCS                          4
+#define B_PCH_PCIE_CFG_SMSCS_PMCS                     BIT31
+#define N_PCH_PCIE_CFG_SMSCS_LERSMIS                  5
+#define N_PCH_PCIE_CFG_SMSCS_HPLAS                    4
+#define N_PCH_PCIE_CFG_SMSCS_HPPDM                    1
+#define B_PCH_PCIE_CFG_SMSCS_PMMS                     BIT0
+#define N_PCH_PCIE_CFG_SMSCS_PMMS                     0
 
 #define R_PCH_PCIE_CFG_SPR                            0xE0
 
+#define R_PCH_PCIE_CFG_RPDCGEN                        0xE1
+#define S_PCH_PCIE_CFG_RPDCGEN                        1
+#define B_PCH_PCIE_CFG_RPDCGEN_RPSCGEN                BIT7
+#define B_PCH_PCIE_CFG_RPDCGEN_PTOCGE                 BIT6
+#define B_PCH_PCIE_CFG_RPDCGEN_LCLKREQEN              BIT5
+#define B_PCH_PCIE_CFG_RPDCGEN_BBCLKREQEN             BIT4
+#define B_PCH_PCIE_CFG_RPDCGEN_SRDBCGEN               BIT2
+#define B_PCH_PCIE_CFG_RPDCGEN_RPDLCGEN               BIT1
+#define B_PCH_PCIE_CFG_RPDCGEN_RPDBCGEN               BIT0
 
 #define R_PCH_PCIE_CFG_RPPGEN                         0xE2
+#define B_PCH_PCIE_CFG_RPPGEN_PTOTOP                  BIT6
+#define B_PCH_PCIE_CFG_RPPGEN_SEOSCGE                 BIT4
 
+#define R_PCH_PCIE_CFG_PWRCTL                         0xE8
+#define B_PCH_PCIE_CFG_PWRCTL_LTSSMRTC                BIT20
+#define B_PCH_PCIE_CFG_PWRCTL_WPDMPGEP                BIT17
+#define B_PCH_PCIE_CFG_PWRCTL_DBUPI                   BIT15
+#define B_PCH_PCIE_CFG_PWRCTL_TXSWING                 BIT13
+#define B_PCH_PCIE_CFG_PWRCTL_RPL1SQPOL               BIT1
+#define B_PCH_PCIE_CFG_PWRCTL_RPDTSQPOL               BIT0
+
+#define R_PCH_PCIE_CFG_DC                             0xEC
+#define B_PCH_PCIE_CFG_DC_PCIBEM                      BIT2
+#define B_PCH_PCIE_CFG_DC_COM                         BIT13
+
+#define R_PCH_PCIE_CFG_IPCS                           0xF0
+#define B_PCH_PCIE_CFG_IPCS_IMPS                      (BIT10 | BIT9 | BIT8)
+#define N_PCH_PCIE_CFG_IPCS_IMPS                      8
+#define V_PCH_PCIE_CFG_IPCS_IMPS_64B                  7
+#define V_PCH_PCIE_CFG_IPCS_IMPS_256B                 1
+
+#define R_PCH_PCIE_CFG_PHYCTL2                        0xF5
+#define B_PCH_PCIE_CFG_PHYCTL2_TDFT                   (BIT7 | BIT6)
+#define B_PCH_PCIE_CFG_PHYCTL2_TXCFGCHGWAIT           (BIT5 | BIT4)
+#define N_PCH_PCIE_CFG_PHYCTL2_TXCFGCHGWAIT           4
+#define B_PCH_PCIE_CFG_PHYCTL2_PXPG3PLLOFFEN          BIT1
+#define B_PCH_PCIE_CFG_PHYCTL2_PXPG2PLLOFFEN          BIT0
+
+#define R_PCH_PCIE_CFG_IOSFSBCS                       0xF7
+#define B_PCH_PCIE_CFG_IOSFSBCS_SCPTCGE               BIT6
+#define B_PCH_PCIE_CFG_IOSFSBCS_SIID                  (BIT3 | BIT2)
+
+#define R_PCH_PCIE_CFG_STRPFUSECFG                    0xFC
+#define B_PCH_PCIE_CFG_STRPFUSECFG_PXIP               (BIT27 | BIT26 | BIT25 | BIT24)
+#define N_PCH_PCIE_CFG_STRPFUSECFG_PXIP               24
+#define B_PCH_PCIE_CFG_STRPFUSECFG_RPC_SIP17          (BIT16 | BIT15 | BIT14)
+#define B_PCH_PCIE_CFG_STRPFUSECFG_RPC                (BIT15 | BIT14)
+#define V_PCH_PCIE_CFG_STRPFUSECFG_RPC_1_1_1_1        0
+#define V_PCH_PCIE_CFG_STRPFUSECFG_RPC_2_1_1          1
+#define V_PCH_PCIE_CFG_STRPFUSECFG_RPC_2_2            2
+#define V_PCH_PCIE_CFG_STRPFUSECFG_RPC_4              3
+#define V_PCH_PCIE_CFG_STRPFUSECFG_RPC_4_SIP17        4
+#define V_PCH_PCIE_CFG_STRPFUSECFG_RPC_16             7
+#define N_PCH_PCIE_CFG_STRPFUSECFG_RPC                14
+#define B_PCH_PCIE_CFG_STRPFUSECFG_MODPHYIOPMDIS      BIT9
+#define B_PCH_PCIE_CFG_STRPFUSECFG_PLLSHTDWNDIS       BIT8
+#define B_PCH_PCIE_CFG_STRPFUSECFG_STPGATEDIS         BIT7
+#define B_PCH_PCIE_CFG_STRPFUSECFG_ASPMDIS            BIT6
+#define B_PCH_PCIE_CFG_STRPFUSECFG_LDCGDIS            BIT5
+#define B_PCH_PCIE_CFG_STRPFUSECFG_LTCGDIS            BIT4
+#define B_PCH_PCIE_CFG_STRPFUSECFG_CDCGDIS            BIT3
+#define B_PCH_PCIE_CFG_STRPFUSECFG_DESKTOPMOB         BIT2
+
+//
+//PCI Express Extended Capability Registers
+//
+
+#define R_PCH_PCIE_CFG_EXCAP_OFFSET                   0x100
+
+#define R_PCH_PCIE_CFG_EX_AECH                        0x100 ///< Advanced Error Reporting Capability Header
+#define V_PCH_PCIE_CFG_EX_AEC_CV                      0x1
+#define R_PCH_PCIE_CFG_EX_UEM                         (R_PCH_PCIE_CFG_EX_AECH + R_PCIE_EX_UEM_OFFSET) // Uncorrectable Error Mask
+
+#define R_PCH_PCIE_CFG_EX_CES                         0x110 ///< Correctable Error Status
+#define B_PCH_PCIE_CFG_EX_CES_BD                      BIT7  ///< Bad DLLP Status
+#define B_PCH_PCIE_CFG_EX_CES_BT                      BIT6  ///< Bad TLP Status
+#define B_PCH_PCIE_CFG_EX_CES_RE                      BIT0  ///< Receiver Error Status
 
 #define  R_PCH_PCIE_CFG_L1SCTL2                       0x20C ///< L1 Sub-States Control 2
 #define  B_PCH_PCIE_CFG_L1SCTL2_POWT                  BIT3
@@ -58,33 +200,271 @@
 #define  B_PCH_PCIE_CFG_L1SCTL2_TPOS_MASK             0x00000003
 #define  V_PCH_PCIE_CFG_L1SCTL2_TPOS                  0x2
 
+//CES.RE, CES.BT, CES.BD
+
+#define R_PCH_PCIE_CFG_EX_ACSECH                      0x220 ///< ACS Extended Capability Header
+#define V_PCH_PCIE_CFG_EX_ACS_CV                      0x1
+#define R_PCH_PCIE_CFG_EX_ACSCAPR                     (R_PCH_PCIE_CFG_EX_ACSECH + R_PCIE_EX_ACSCAPR_OFFSET)
+
+#define R_PCH_PCIE_CFG_EX_PTMECH                      0x150 ///< PTM Extended Capability Header
+#define V_PCH_PCIE_CFG_EX_PTM_CV                      0x1
+#define R_PCH_PCIE_CFG_EX_PTMCAPR                     (R_PCH_PCIE_CFG_EX_PTMECH + R_PCIE_EX_PTMCAP_OFFSET)
+
+#define R_PCH_PCIE_CFG_PVCCR1                         0x284
+#define B_PCH_PCIE_CFG_PVCCR1_EVCC_MASK               0x7
+#define V_PCH_PCIE_CFG_PVCCR1_EVCC_2_VC               0x1
+
+#define R_PCH_PCIE_CFG_V0VCRC                         0x290
+#define B_PCH_PCIE_CFG_V0VCRC_MTS_MASK                0x7F0000
+
+#define R_PCH_PCIE_CFG_VC0CTL                         0x294 ///< Virtual Channel 0 Resource Control
+#define B_PCH_PCIE_CFG_VC0CTL_TVM_MASK                0xFE
+#define B_PCH_PCIE_CFG_VC0CTL_TVM_OFFSET              1
+#define B_PCH_PCIE_CFG_VC0CTL_TVM_NO_VC               0x7F
+#define B_PCH_PCIE_CFG_VC0CTL_TVM_EN_VC               0x1F
+#define B_PCH_PCIE_CFG_VC0CTL_ETVM_MASK               0x3F
+#define B_PCH_PCIE_CFG_VC0CTL_ETVM_OFFSET             10
 
 #define R_PCH_PCIE_CFG_V1VCRC                         0x29C
+#define B_PCH_PCIE_CFG_V1VCRC_MTS_MASK                0x7F0000
 
+#define R_PCH_PCIE_CFG_VC1CTL                         0x2A0
+#define B_PCH_PCIE_CFG_VC1CTL_TVM_MASK                0xFE
+#define B_PCH_PCIE_CFG_VC1CTL_TVM                     BIT1
+#define B_PCH_PCIE_CFG_VC1CTL_TVM_OFFSET              1
+#define V_PCH_PCIE_CFG_VC1CTL_TVM                     0x7F
+#define B_PCH_PCIE_CFG_VC1CTL_ETVM_MASK               0x1F
+#define B_PCH_PCIE_CFG_VC1CTL_ETVM_OFFSET             10
+#define B_PCH_PCIE_CFG_VC1CTL_ID_MASK                 0xF000000
+#define B_PCH_PCIE_CFG_VC1CTL_ID_OFFSET               24
+#define V_PCH_PCIE_CFG_VC1CTL_ID_ONE                  1
+#define B_PCH_PCIE_CFG_VC1CTL_EN_OFFSET               0x80000000
+#define B_PCH_PCIE_CFG_VC1CTL_EN                      BIT31
+
+#define R_PCH_PCIE_CFG_VC1STS                         0x2A6
+#define B_PCH_PCIE_CFG_VC1STS_NP                      BIT1
+
+#define R_PCH_PCIE_CFG_VC0STS                         0x2A9
+#define B_PCH_PCIE_CFG_VC0STS_NP                      BIT1
 
 #define R_PCH_PCIE_CFG_V1VCRC                         0x29C
+#define R_PCH_PCIE_CFG_V1VCRC_MTS_MASK                0x7F
+#define R_PCH_PCIE_CFG_V1VCRC_MTS_OFFSET              16
 
+#define R_PCH_PCIE_CFG_EX_L1SECH                      0x200 ///< L1 Sub-States Extended Capability Header
+#define V_PCH_PCIE_CFG_EX_L1S_CV                      0x1
+#define R_PCH_PCIE_CFG_EX_L1SCAP                      (R_PCH_PCIE_CFG_EX_L1SECH + R_PCIE_EX_L1SCAP_OFFSET)
+#define R_PCH_PCIE_CFG_EX_L1SCTL1                     (R_PCH_PCIE_CFG_EX_L1SECH + R_PCIE_EX_L1SCTL1_OFFSET)
+#define R_PCH_PCIE_CFG_EX_L1SCTL2                     (R_PCH_PCIE_CFG_EX_L1SECH + R_PCIE_EX_L1SCTL2_OFFSET)
 
+#define R_PCH_PCIE_CFG_EX_DPCECH                      0xA00 ///< Downstream Port Containment
+#define V_PCH_PCIE_CFG_EX_DPCECH_CV                   0x1
+
+#define R_PCH_PCIE_CFG_PCIERTP1                       0x300
+#define R_PCH_PCIE_CFG_PCIERTP2                       0x304
 #define R_PCH_PCIE_CFG_G4L0SCTL                       0x310
+#define R_PCH_PCIE_CFG_PCIENFTS                       0x314
+#define R_PCH_PCIE_CFG_PCIEL0SC                       0x318
 #define R_PCH_PCIE_CFG_G4L0SCTL                       0x310
+#define R_PCH_PCIE_CFG_G5L0SCTL                      0x1E00
 
+#define R_PCH_PCIE_CFG_PCIECFG2                       0x320
+#define B_PCH_PCIE_CFG_PCIECFG2_LBWSSTE               BIT30
+#define B_PCH_PCIE_CFG_PCIECFG2_RLLG3R                BIT27
+#define B_PCH_PCIE_CFG_PCIECFG2_CROAOV                BIT24
+#define B_PCH_PCIE_CFG_PCIECFG2_CROAOE                BIT23
+#define B_PCH_PCIE_CFG_PCIECFG2_CRSREN                BIT22
+#define B_PCH_PCIE_CFG_PCIECFG2_PMET                  (BIT21 | BIT20)
+#define V_PCH_PCIE_CFG_PCIECFG2_PMET                  1
+#define N_PCH_PCIE_CFG_PCIECFG2_PMET                  20
+
+#define R_PCH_PCIE_CFG_PCIEDBG                        0x324
+#define B_PCH_PCIE_CFG_PCIEDBG_LBWSSTE                BIT30
+#define B_PCH_PCIE_CFG_PCIEDBG_USSP                   (BIT27 | BIT26)
+#define B_PCH_PCIE_CFG_PCIEDBG_LGCLKSQEXITDBTIMERS    (BIT25 | BIT24)
+#define B_PCH_PCIE_CFG_PCIEDBG_CTONFAE                BIT14
+#define B_PCH_PCIE_CFG_PCIEDBG_LDSWQRP                BIT13
+#define B_PCH_PCIE_CFG_PCIEDBG_SQOL0                  BIT7
+#define B_PCH_PCIE_CFG_PCIEDBG_SPCE                   BIT5
+#define B_PCH_PCIE_CFG_PCIEDBG_LR                     BIT4
+
+#define R_PCH_PCIE_CFG_PCIESTS1                              0x328
+#define B_PCH_PCIE_CFG_PCIESTS1_LTSMSTATE                    0xFF000000
+#define N_PCH_PCIE_CFG_PCIESTS1_LTSMSTATE                    24
+#define V_PCH_PCIE_CFG_PCIESTS1_LTSMSTATE_DETRDY             0x01
+#define V_PCH_PCIE_CFG_PCIESTS1_LTSMSTATE_DETRDYECINP1CG     0x0E
+#define V_PCH_PCIE_CFG_PCIESTS1_LTSMSTATE_L0                 0x33
+#define V_PCH_PCIE_CFG_PCIESTS1_LTSMSTATE_DISWAIT            0x5E
+#define V_PCH_PCIE_CFG_PCIESTS1_LTSMSTATE_DISWAITPG          0x60
+#define V_PCH_PCIE_CFG_PCIESTS1_LTSMSTATE_RECOVERYSPEEDREADY 0x6C
+#define V_PCH_PCIE_CFG_PCIESTS1_LTSMSTATE_RECOVERYLNK2DETECT 0x6F
+
+
+#define B_PCH_PCIE_CFG_PCIESTS1_LNKSTAT               (BIT22 | BIT21 | BIT20 | BIT19)
+#define N_PCH_PCIE_CFG_PCIESTS1_LNKSTAT               19
+#define V_PCH_PCIE_CFG_PCIESTS1_LNKSTAT_L0            0x7
+
+#define R_PCH_PCIE_CFG_PCIESTS2                       0x32C
+#define B_PCH_PCIE_CFG_PCIESTS2_P4PNCCWSSCMES         BIT31
+#define B_PCH_PCIE_CFG_PCIESTS2_P3PNCCWSSCMES         BIT30
+#define B_PCH_PCIE_CFG_PCIESTS2_P2PNCCWSSCMES         BIT29
+#define B_PCH_PCIE_CFG_PCIESTS2_P1PNCCWSSCMES         BIT28
+#define B_PCH_PCIE_CFG_PCIESTS2_CLRE                  0x0000F000
+#define N_PCH_PCIE_CFG_PCIESTS2_CLRE                  12
+
+#define R_PCH_PCIE_CFG_PCIEALC                        0x338
+#define B_PCH_PCIE_CFG_PCIEALC_ITLRCLD                BIT29
+#define B_PCH_PCIE_CFG_PCIEALC_ILLRCLD                BIT28
+#define B_PCH_PCIE_CFG_PCIEALC_BLKDQDA                BIT26
+#define B_PCH_PCIE_CFG_PCIEALC_BLKDQDASD              BIT25
+#define B_PCH_PCIE_CFG_PCIEALC_RTD3PDSP_SIP17         BIT21
+#define B_PCH_PCIE_CFG_PCIEALC_RTD3PDSP               BIT20
+#define B_PCH_PCIE_CFG_SIP17_PCIEALC_RTD3PDSP         BIT21 /// From SIP17 register layout is changed
+#define B_PCH_PCIE_CFG_SIP17_PCIEALC_PDSP             BIT20 /// From SIP17 register layout is changed
+
+#define R_PCH_PCIE_CFG_PTMPD                          0x390 ///< PTM Propagation Delay
+#define R_PCH_PCIE_CFG_PTMLLMT                        0x394 ///< PTM Lower Local Host Time
+#define R_PCH_PCIE_CFG_PTMULMT                        0x398 ///< PTM Upper Local Host Time
+#define R_PCH_PCIE_CFG_PTMPSDC1                       0x39C ///< PTM Pipe Stage Delay Configuration 1
+#define R_PCH_PCIE_CFG_PTMPSDC2                       0x3A0 ///< PTM Pipe Stage Delay Configuration 2
+#define R_PCH_PCIE_CFG_PTMPSDC3                       0x3A4 ///< PTM Pipe Stage Delay Configuration 3
+#define R_PCH_PCIE_CFG_PTMPSDC4                       0x3A8 ///< PTM Pipe Stage Delay Configuration 4
+#define R_PCH_PCIE_CFG_PTMPSDC5                       0x3AC ///< PTM Pipe Stage Delay Configuration 5
+#define R_PCH_PCIE_CFG_PTMECFG                        0x3B0 ///< PTM Extended Configuration
+#define B_PCH_PCIE_CFG_PTMECFG_IOSFMADP               0xF   ///< IOSF Max Allowed Delay programming. bit0~bit3
 
 #define R_PCH_PCIE_CFG_LTROVR                         0x400
+#define B_PCH_PCIE_CFG_LTROVR_LTRNSROVR               BIT31 ///< LTR Non-Snoop Requirement Bit Override
+#define B_PCH_PCIE_CFG_LTROVR_LTRSROVR                BIT15 ///< LTR Snoop Requirement Bit Override
 
 #define R_PCH_PCIE_CFG_LTROVR2                        0x404
+#define B_PCH_PCIE_CFG_LTROVR2_FORCE_OVERRIDE         BIT3 ///< LTR Force Override Enable
+#define B_PCH_PCIE_CFG_LTROVR2_LOCK                   BIT2 ///< LTR Override Lock
+#define B_PCH_PCIE_CFG_LTROVR2_LTRNSOVREN             BIT1 ///< LTR Non-Snoop Override Enable
+#define B_PCH_PCIE_CFG_LTROVR2_LTRSOVREN              BIT0 ///< LTR Snoop Override Enable
 
+#define R_PCH_PCIE_CFG_PHYCTL4                        0x408
+#define B_PCH_PCIE_CFG_PHYCTL4_SQDIS                  BIT27
 
+#define R_PCH_PCIE_CFG_TNPT                           0x418 ///< Thermal and Power Throttling
+#define B_PCH_PCIE_CFG_TNPT_DRXLTE                    BIT1
+#define B_PCH_PCIE_CFG_TNPT_DTXLTE                    BIT0
+#define N_PCH_PCIE_CFG_TNPT_TP                        24
+#define V_PCH_PCIE_CFG_TNPT_TP_3_MS                   0x2
+#define R_PCH_PCIE_CFG_PCIEPMECTL                     0x420
+#define B_PCH_PCIE_CFG_PCIEPMECTL_FDPPGE              BIT31
+#define B_PCH_PCIE_CFG_PCIEPMECTL_DLSULPPGE           BIT30
+#define B_PCH_PCIE_CFG_PCIEPMECTL_DLSULDLSD           BIT29
+#define B_PCH_PCIE_CFG_PCIEPMECTL_L1LE                BIT17
+#define B_PCH_PCIE_CFG_PCIEPMECTL_L1LTRTLV            (BIT13 | BIT12 | BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 | BIT5 | BIT4)
+#define N_PCH_PCIE_CFG_PCIEPMECTL_L1LTRTLV            4
+#define V_PCH_PCIE_CFG_PCIEPMECTL_L1LTRTLV            0x32
+#define B_PCH_PCIE_CFG_PCIEPMECTL_L1FSOE              BIT0
+
+#define R_PCH_PCIE_CFG_PCIEPMECTL2                    0x424
+#define B_PCH_PCIE_CFG_PCIEPMECTL2_CPMCSRE            BIT27
+#define B_PCH_PCIE_CFG_PCIEPMECTL2_CPGEXH             BIT14
+#define N_PCH_PCIE_CFG_PCIEPMECTL2_CPGEXH_OFFSET      14
+#define B_PCH_PCIE_CFG_PCIEPMECTL2_CPGEXH_MASK        (BIT14 | BIT15)
+#define V_PCH_PCIE_CFG_PCIEPMECTL2_CPGEXH_5US         0x1
+#define B_PCH_PCIE_CFG_PCIEPMECTL2_CPGENH             BIT12
+#define N_PCH_PCIE_CFG_PCIEPMECTL2_CPGENH_OFFSET      12
+#define B_PCH_PCIE_CFG_PCIEPMECTL2_CPGENH_MASK        (BIT12 | BIT13)
+#define B_PCH_PCIE_CFG_PCIEPMECTL2_PHYCLPGE           BIT11
+#define B_PCH_PCIE_CFG_PCIEPMECTL2_FDCPGE             BIT8
+#define B_PCH_PCIE_CFG_PCIEPMECTL2_DETSCPGE           BIT7
+#define B_PCH_PCIE_CFG_PCIEPMECTL2_L23RDYSCPGE        BIT6
+#define B_PCH_PCIE_CFG_PCIEPMECTL2_DISSCPGE           BIT5
+#define B_PCH_PCIE_CFG_PCIEPMECTL2_L1SCPGE            BIT4
+
+#define R_PCH_PCIE_CFG_PCE                            0x428
+#define B_PCH_PCIE_CFG_PCE_HAE                        BIT5
+#define B_PCH_PCIE_CFG_PCE_SE                         BIT3
+#define B_PCH_PCIE_CFG_PCE_PMCRE                      BIT0
+
+#define R_PCH_PCIE_CFG_PGCBCTL1                       0x42C
+
+#define R_PCH_PCIE_CFG_PCIEPMECTL3                    0x434
+#define B_PCH_PCIE_CFG_PCIEPMECTL3_L1PGAUTOPGEN       BIT4
+#define B_PCH_PCIE_CFG_PCIEPMECTL3_OSCCGH             BIT2
+#define B_PCH_PCIE_CFG_PCIEPMECTL3_OSCCGH_OFFSET      2
+#define B_PCH_PCIE_CFG_PCIEPMECTL3_OSCCGH_MASK        (BIT3 | BIT2)
+#define V_PCH_PCIE_CFG_PCIEPMECTL3_OSCCGH_1US         1
 #define B_PCH_PCIE_CFG_PCIEPMECTL3_PMREQCPGEXH        BIT0
+#define B_PCH_PCIE_CFG_PCIEPMECTL3_PMREQCPGEXH_MASK   0x3
 #define B_PCH_PCIE_CFG_PCIEPMECTL3_PMREQCPGEXH_OFFSET 0
+#define V_PCH_PCIE_CFG_PCIEPMECTL3_PMREQCPGEXH        0x1
 
+#define R_PCH_PCIE_CFG_RTPCL2                         0x458
+#define B_PCH_PCIE_CFG_RTPCL2_RTPOSTCL3PL             0x3F000
+#define B_PCH_PCIE_CFG_RTPCL2_RTPRECL3PL6             0xFC0
+#define B_PCH_PCIE_CFG_RTPCL2_RTPOSTCL2PL5            0x3F
 
-#define R_PCH_PCIE_CFG_G4L0SCTL                       0x310
-#define R_PCH_PCIE_CFG_G4L0SCTL                       0x310
+#define R_PCH_PCIE_CFG_RTPCL3                         0x45C
+#define B_PCH_PCIE_CFG_RTPCL3_RTPRECL7                0x3F000000
+#define B_PCH_PCIE_CFG_RTPCL3_RTPOSTCL6               0xFC0000
+#define B_PCH_PCIE_CFG_RTPCL3_RTPRECL6                0x3F000
+#define B_PCH_PCIE_CFG_RTPCL3_RTPOSTCL5               0xFC0
+#define B_PCH_PCIE_CFG_RTPCL3_RTPRECL5PL10            0x3F
 
+#define R_PCH_PCIE_CFG_RTPCL4                         0x460
+#define B_PCH_PCIE_CFG_RTPCL4_RTPOSTCL9               0x3F000000
+#define B_PCH_PCIE_CFG_RTPCL4_RTPRECL9                0xFC0000
+#define B_PCH_PCIE_CFG_RTPCL4_RTPOSTCL8               0x3F000
+#define B_PCH_PCIE_CFG_RTPCL4_RTPRECL8                0xFC0
+#define B_PCH_PCIE_CFG_RTPCL4_RTPOSTCL7               0x3F
 
-#define B_PCH_PCIE_CFG_PCIEPMECTL3_PMREQCPGEXH        BIT0
-#define B_PCH_PCIE_CFG_PCIEPMECTL3_PMREQCPGEXH_OFFSET 0
+#define R_PCH_PCIE_CFG_LTCO2                          0x474
+#define B_PCH_PCIE_CFG_LTCO2_L3TCOE                   BIT25
+#define B_PCH_PCIE_CFG_LTCO2_L2TCOE                   BIT24
+#define B_PCH_PCIE_CFG_LTCO2_L3TPOSTCO                0xFC0000
+#define B_PCH_PCIE_CFG_LTCO2_L3TPRECO                 0x3F000
+#define B_PCH_PCIE_CFG_LTCO2_L2TPOSTCO                0xFC0
+#define B_PCH_PCIE_CFG_LTCO2_L2TPRECO                 0x3F
 
+#define R_PCH_PCIE_CFG_G3L0SCTL                       0x478
+#define B_PCH_PCIE_CFG_G3L0SCTL_G3UCNFTS              0x0000FF00
+#define B_PCH_PCIE_CFG_G3L0SCTL_G3CCNFTS              0x000000FF
+
+#define R_PCH_PCIE_CFG_GDR                            0x690
+#define B_PCH_PCIE_CFG_GDR_GPIOALD                    BIT10
+
+#define R_PCH_PCIE_ACGR3S2                              0xC50
+#define B_PCH_PCIE_ACGR3S2_G5EBM                        BIT20
+#define B_PCH_PCIE_ACGR3S2_G4EBM                        BIT9
+#define B_PCH_PCIE_ACGR3S2_G3EBM                        BIT8
+#define B_PCH_PCIE_ACGR3S2_G2EBM                        BIT7
+#define B_PCH_PCIE_ACGR3S2_G1EBM                        BIT6
+#define B_PCH_PCIE_ACGR3S2_SRT                          BIT5
+
+#define R_PCH_PCIE_CFG_VNNREMCTL                        0xC70
+#define B_PCH_PCIE_CFG_VNNREMCTL_LRSLFVNNRE             (BIT1 | BIT0)
+#define V_PCH_PCIE_CFG_VNNREMCTL_LRSLFVNNRE_4_OSC_CLK   0x0
+#define V_PCH_PCIE_CFG_VNNREMCTL_LRSLFVNNRE_8_OSC_CLK   0x1
+#define V_PCH_PCIE_CFG_VNNREMCTL_LRSLFVNNRE_16_OSC_CLK  0x2
+#define V_PCH_PCIE_CFG_VNNREMCTL_LRSLFVNNRE_32_OSC_CLK  0x3
+#define B_PCH_PCIE_CFG_VNNREMCTL_ISPLFVNNRE             (BIT3 | BIT2)
+#define N_PCH_PCIE_CFG_VNNREMCTL_ISPLFVNNRE             2
+#define V_PCH_PCIE_CFG_VNNREMCTL_ISPLFVNNRE_8_OSC_CLK   0x0
+#define V_PCH_PCIE_CFG_VNNREMCTL_ISPLFVNNRE_16_OSC_CLK  0x1
+#define V_PCH_PCIE_CFG_VNNREMCTL_ISPLFVNNRE_32_OSC_CLK  0x2
+#define V_PCH_PCIE_CFG_VNNREMCTL_ISPLFVNNRE_64_OSC_CLK  0x3
+#define B_PCH_PCIE_CFG_VNNREMCTL_LDVNNRE                BIT4
+#define B_PCH_PCIE_CFG_VNNREMCTL_RTD3VNNRE              BIT5
+#define B_PCH_PCIE_CFG_VNNREMCTL_DNPVNNRE               BIT6
+#define B_PCH_PCIE_CFG_VNNREMCTL_HPVNNRE                BIT7
+#define B_PCH_PCIE_CFG_VNNREMCTL_FDVNNRE                BIT8
+
+#define R_PCH_PCIE_CFG_VNNRSNRC1                        0xC74
+
+#define R_PCH_PCIE_AECR1G3                              0xC80
+#define B_PCH_PCIE_AECR1G3_DTCGCM                       BIT14
+#define B_PCH_PCIE_AECR1G3_TPSE                         BIT10
+#define B_PCH_PCIE_AECR1G3_L1OFFRDYHEWT                 BIT7
+#define B_PCH_PCIE_AECR1G3_L1OFFRDYHEWTEN               BIT6
+
+#define R_PCH_PCIE_CFG_EINJCTL                          0xCA8
+#define B_PCH_PCIE_CFG_EINJCTL_EINJDIS                  BIT0
 
 #define  R_PCH_PCIE_RXMC1                               0xC90
 #define  B_PCH_PCIE_RXMC1_MSRVS                         BIT26
@@ -136,14 +516,60 @@
 //
 // PCIE PCRs (PID:SPA SPB SPC SPD SPE SPF)
 //
+#define R_SPX_PCR_PCD                         0                       ///< Port configuration and disable
 #define B_SPX_PCR_PCD_RP1FN                   (BIT2 | BIT1 | BIT0)    ///< Port 1 Function Number
+#define B_SPX_PCR_PCD_RP1CH                   BIT3                    ///< Port 1 config hide
+#define B_SPX_PCR_PCD_RP2FN                   (BIT6 | BIT5 | BIT4)    ///< Port 2 Function Number
+#define B_SPX_PCR_PCD_RP2CH                   BIT7                    ///< Port 2 config hide
+#define B_SPX_PCR_PCD_RP3FN                   (BIT10 | BIT9 | BIT8)   ///< Port 3 Function Number
+#define B_SPX_PCR_PCD_RP3CH                   BIT11                   ///< Port 3 config hide
+#define B_SPX_PCR_PCD_RP4FN                   (BIT14 | BIT13 | BIT12) ///< Port 4 Function Number
+#define B_SPX_PCR_PCD_RP4CH                   BIT15                   ///< Port 4 config hide
 #define S_SPX_PCR_PCD_RP_FIELD                4                       ///< 4 bits for each RP FN
+#define B_SPX_PCR_PCD_P1D                     BIT16                   ///< Port 1 disable
+#define B_SPX_PCR_PCD_P2D                     BIT17                   ///< Port 2 disable
+#define B_SPX_PCR_PCD_P3D                     BIT18                   ///< Port 3 disable
+#define B_SPX_PCR_PCD_P4D                     BIT19                   ///< Port 4 disable
+#define B_SPX_PCR_PCD_SRL                     BIT31                   ///< Secured Register Lock
 
+#define R_SPX_PCR_PCIEHBP                     0x0004                  ///< PCI Express high-speed bypass
+#define B_SPX_PCR_PCIEHBP_PCIEHBPME           BIT0                    ///< PCIe HBP mode enable
+#define B_SPX_PCR_PCIEHBP_PCIEGMO             (BIT2 | BIT1)           ///< PCIe gen mode override
+#define B_SPX_PCR_PCIEHBP_PCIETIL0O           BIT3                    ///< PCIe transmitter-in-L0 override
+#define B_SPX_PCR_PCIEHBP_PCIERIL0O           BIT4                    ///< PCIe receiver-in-L0 override
+#define B_SPX_PCR_PCIEHBP_PCIELRO             BIT5                    ///< PCIe link recovery override
+#define B_SPX_PCR_PCIEHBP_PCIELDO             BIT6                    ///< PCIe link down override
+#define B_SPX_PCR_PCIEHBP_PCIESSM             BIT7                    ///< PCIe SKP suppression mode
+#define B_SPX_PCR_PCIEHBP_PCIESST             BIT8                    ///< PCIe suppress SKP transmission
+#define B_SPX_PCR_PCIEHBP_PCIEHBPPS           (BIT13 | BIT12)         ///< PCIe HBP port select
+#define B_SPX_PCR_PCIEHBP_CRCSEL              (BIT15 | BIT14)         ///< CRC select
+#define B_SPX_PCR_PCIEHBP_PCIEHBPCRC          0xFFFF0000              ///< PCIe HBP CRC
+
+#define R_SPX_PCR_IMRAMBL                     0x10                    ///< IMR access memory base and limit
+#define B_SPX_PCR_IMRAMBL_RS3BN               0x000000FF              ///< Bus Number for RS3
+#define N_SPX_PCR_IMRAMBL_RS3BN               0
+#define B_SPX_PCR_IMRAMBL_IAMB                0x000FFF00              ///< IMR access memory base, lower bits
+#define N_SPX_PCR_IMRAMBL_IAMB                8
+#define B_SPX_PCR_IMRAMBL_IAML                0xFFF00000              ///< IMR access memory limit, lower bits
+#define N_SPX_PCR_IMRAMBL_IAML                20
+
+#define R_SPX_PCR_IMRAMBU32                   0x14                    ///< IMR access memory base, upper bits
+
+#define R_SPX_PCR_IMRAMLU32                   0x18                    ///< IMR access memory limit, upper bits
+
+#define R_SPX_PCR_IMRAMLE                     0x1C                    ///< IMR access memory lock & enable
+#define B_SPX_PCR_IMRAMLE_IAE1                BIT0                    ///< IMR access enable for port 1 of given controller
+#define B_SPX_PCR_IMRAMLE_IAE2                BIT1                    ///< IMR access enable for port 1 of given controller
+#define B_SPX_PCR_IMRAMLE_IAE3                BIT2                    ///< IMR access enable for port 1 of given controller
+#define B_SPX_PCR_IMRAMLE_IAE4                BIT3                    ///< IMR access enable for port 1 of given controller
+#define B_SPX_PCR_IMRAMLE_SRL                 BIT31                   ///< IMR register lock
 
 #define R_SPX_SIP16_PCR_PCD                   0x3E00                  ///< Port configuration and disable
 
 //
-// Number of PCIe ports per PCIe controller
+// ICC PCR (PID: ICC)
 //
-#define PCH_PCIE_CONTROLLER_PORTS                     4u
+#define R_ICC_PCR_TMCSRCCLK                   0x1000                  ///< Timing Control SRC Clock Register
+#define R_ICC_PCR_TMCSRCCLK2                  0x1004                  ///< Timing Control SRC Clock Register 2
+#define R_ICC_PCR_MSKCKRQ                     0x100C                  ///< Mask Control CLKREQ
 #endif

--- a/Silicon/ArrowlakePkg/Include/Register/PcieSipRegs.h
+++ b/Silicon/ArrowlakePkg/Include/Register/PcieSipRegs.h
@@ -1,0 +1,2282 @@
+/** @file
+  Register names for PCIe SIP specific registers
+
+  Conventions:
+
+  - Register definition format:
+  Prefix_[GenerationName]_[ComponentName]_SubsystemName_RegisterSpace_RegisterName
+  - Prefix:
+  Definitions beginning with "R_" are registers
+  Definitions beginning with "B_" are bits within registers
+  Definitions beginning with "V_" are meaningful values within the bits
+  Definitions beginning with "S_" are register size
+  Definitions beginning with "N_" are the bit position
+  - [GenerationName]:
+  Three letter acronym of the generation is used (e.g. SKL,KBL,CNL etc.).
+  Register name without GenerationName applies to all generations.
+  - [ComponentName]:
+  This field indicates the component name that the register belongs to (e.g. PCH, SA etc.)
+  Register name without ComponentName applies to all components.
+  Register that is specific to -H denoted by "_PCH_H_" in component name.
+  Register that is specific to -LP denoted by "_PCH_LP_" in component name.
+  - SubsystemName:
+  This field indicates the subsystem name of the component that the register belongs to
+    (e.g. PCIE, USB, SATA, GPIO, PMC etc.).
+  - RegisterSpace:
+  MEM - MMIO space register of subsystem.
+  IO  - IO space register of subsystem.
+  PCR - Private configuration register of subsystem.
+  CFG - PCI configuration space register of subsystem.
+  - RegisterName:
+  Full register name.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef _PCIE_SIP_RP_REGS_H_
+#define _PCIE_SIP_RP_REGS_H_
+
+#include <PcieRegs.h>
+
+
+#define R_PCIE_PCR_PCD                        0x00003e00U      ///< Port Configuration And Disable
+#define B_PCIE_PCR_PCD_RP0FN                  ( BIT2 | BIT1 | BIT0 ) ///< Port 1 Function Number
+#define N_PCIE_PCR_PCD_RP0FN                  0
+#define B_PCIE_PCR_PCD_RP0CH                  BIT3             ///< Port 1 Config Hide
+#define N_PCIE_PCR_PCD_RP0CH                  3
+#define B_PCIE_PCR_PCD_RP1FN                  ( BIT6 | BIT5 | BIT4 ) ///< Port 2 Function Number
+#define N_PCIE_PCR_PCD_RP1FN                  4
+#define B_PCIE_PCR_PCD_RP1CH                  BIT7             ///< Port 2 Config Hide
+#define N_PCIE_PCR_PCD_RP1CH                  7
+#define B_PCIE_PCR_PCD_RP2FN                  ( BIT10 | BIT9 | BIT8 ) ///< Port 3 Function Number
+#define N_PCIE_PCR_PCD_RP2FN                  8
+#define B_PCIE_PCR_PCD_RP2CH                  BIT11            ///< Port 3 Config Hide
+#define N_PCIE_PCR_PCD_RP2CH                  11
+#define B_PCIE_PCR_PCD_RP3FN                  ( BIT14 | BIT13 | BIT12 ) ///< Port 4 Function Number
+#define N_PCIE_PCR_PCD_RP3FN                  12
+#define B_PCIE_PCR_PCD_RP3CH                  BIT15            ///< Port 4 Config Hide
+#define N_PCIE_PCR_PCD_RP3CH                  15
+#define B_PCIE_PCR_PCD_P0D                    BIT16            ///< Port 1 Disable
+#define N_PCIE_PCR_PCD_P0D                    16
+#define B_PCIE_PCR_PCD_P1D                    BIT17            ///< Port 2 Disable
+#define N_PCIE_PCR_PCD_P1D                    17
+#define B_PCIE_PCR_PCD_P2D                    BIT18            ///< Port 3 Disable
+#define N_PCIE_PCR_PCD_P2D                    18
+#define B_PCIE_PCR_PCD_P3D                    BIT19            ///< Port 4 Disable
+#define N_PCIE_PCR_PCD_P3D                    19
+#define B_PCIE_PCR_PCD_P4D                    BIT20            ///< Port 5 Disable
+#define N_PCIE_PCR_PCD_P4D                    20
+#define B_PCIE_PCR_PCD_P5D                    BIT21            ///< Port 6 Disable
+#define N_PCIE_PCR_PCD_P5D                    21
+#define B_PCIE_PCR_PCD_P6D                    BIT22            ///< Port 7 Disable
+#define N_PCIE_PCR_PCD_P6D                    22
+#define B_PCIE_PCR_PCD_P7D                    BIT23            ///< Port 8 Disable
+#define N_PCIE_PCR_PCD_P7D                    23
+#define B_PCIE_PCR_PCD_P8D                    BIT24            ///< Port 9 Disable
+#define N_PCIE_PCR_PCD_P8D                    24
+#define B_PCIE_PCR_PCD_P9D                    BIT25            ///< Port 10 Disable
+#define N_PCIE_PCR_PCD_P9D                    25
+#define B_PCIE_PCR_PCD_P10D                   BIT26            ///< Port 11 Disable
+#define N_PCIE_PCR_PCD_P10D                   26
+#define B_PCIE_PCR_PCD_P11D                   BIT27            ///< Port 12 Disable
+#define N_PCIE_PCR_PCD_P11D                   27
+#define B_PCIE_PCR_PCD_P12D                   BIT28            ///< Port 13 Disable
+#define N_PCIE_PCR_PCD_P12D                   28
+#define B_PCIE_PCR_PCD_P13D                   BIT29            ///< Port 14 Disable
+#define N_PCIE_PCR_PCD_P13D                   29
+#define B_PCIE_PCR_PCD_P14D                   BIT30            ///< Port 15 Disable
+#define N_PCIE_PCR_PCD_P14D                   30
+#define B_PCIE_PCR_PCD_P15D                   BIT31            ///< Port 16 Disable
+#define N_PCIE_PCR_PCD_P15D                   31
+
+#define R_PCIE_PCR_IMRAMBL                    0x00003e10U      ///< IMR Access Memory Base And Limit
+#define B_PCIE_PCR_IMRAMBL_RS3BN              ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< RS3 Bus Number
+#define N_PCIE_PCR_IMRAMBL_RS3BN              0
+#define B_PCIE_PCR_IMRAMBL_IAMB               0x000fff00U      ///< IMR Access Memory Base
+#define N_PCIE_PCR_IMRAMBL_IAMB               8
+#define B_PCIE_PCR_IMRAMBL_IAML               0xfff00000U      ///< IMR Access Memory Limit
+#define N_PCIE_PCR_IMRAMBL_IAML               20
+
+#define R_PCIE_PCR_IMRAMBU32                  0x00003e14U      ///< IMR Access Memory Base Upper 32
+
+#define R_PCIE_PCR_IMRAMLU32                  0x00003e18U      ///< IMR Access Memory Limit Upper 32
+
+#define R_PCIE_PCR_IMRLE                      0x00003e1cU      ///< IMR Lock And Enable
+#define B_PCIE_PCR_IMRLE_IAE1                 BIT0             ///< IMR Access Enable 1
+#define N_PCIE_PCR_IMRLE_IAE1                 0
+#define B_PCIE_PCR_IMRLE_IAE2                 BIT1             ///< IMR Access Enable 2
+#define N_PCIE_PCR_IMRLE_IAE2                 1
+#define B_PCIE_PCR_IMRLE_IAE3                 BIT2             ///< IMR Access Enable 3
+#define N_PCIE_PCR_IMRLE_IAE3                 2
+#define B_PCIE_PCR_IMRLE_IAE4                 BIT3             ///< IMR Access Enable 4
+#define N_PCIE_PCR_IMRLE_IAE4                 3
+#define B_PCIE_PCR_IMRLE_IAE5                 BIT4             ///< IMR Access Enable 5
+#define N_PCIE_PCR_IMRLE_IAE5                 4
+#define B_PCIE_PCR_IMRLE_IAE6                 BIT5             ///< IMR Access Enable 6
+#define N_PCIE_PCR_IMRLE_IAE6                 5
+#define B_PCIE_PCR_IMRLE_IAE7                 BIT6             ///< IMR Access Enable 7
+#define N_PCIE_PCR_IMRLE_IAE7                 6
+#define B_PCIE_PCR_IMRLE_IAE8                 BIT7             ///< IMR Access Enable 8
+#define N_PCIE_PCR_IMRLE_IAE8                 7
+#define B_PCIE_PCR_IMRLE_IAE9                 BIT8             ///< IMR Access Enable 9
+#define N_PCIE_PCR_IMRLE_IAE9                 8
+#define B_PCIE_PCR_IMRLE_IAE10                BIT9             ///< IMR Access Enable 10
+#define N_PCIE_PCR_IMRLE_IAE10                9
+#define B_PCIE_PCR_IMRLE_IAE11                BIT10            ///< IMR Access Enable 11
+#define N_PCIE_PCR_IMRLE_IAE11                10
+#define B_PCIE_PCR_IMRLE_IAE12                BIT11            ///< IMR Access Enable 12
+#define N_PCIE_PCR_IMRLE_IAE12                11
+#define B_PCIE_PCR_IMRLE_IAE13                BIT12            ///< IMR Access Enable 13
+#define N_PCIE_PCR_IMRLE_IAE13                12
+#define B_PCIE_PCR_IMRLE_IAE14                BIT13            ///< IMR Access Enable 14
+#define N_PCIE_PCR_IMRLE_IAE14                13
+#define B_PCIE_PCR_IMRLE_IAE15                BIT14            ///< IMR Access Enable 15
+#define N_PCIE_PCR_IMRLE_IAE15                14
+#define B_PCIE_PCR_IMRLE_IAE16                BIT15            ///< IMR Access Enable 16
+#define N_PCIE_PCR_IMRLE_IAE16                15
+#define B_PCIE_PCR_IMRLE_SRL                  BIT31            ///< Secured Register Lock
+#define N_PCIE_PCR_IMRLE_SRL                  31
+
+#define R_PCIE_PCR_SRL                        0x00003e24U      ///< Secured Register Lock
+#define B_PCIE_PCR_SRL_SRL                    BIT0             ///< Secured Register Lock
+#define N_PCIE_PCR_SRL_SRL                    0
+
+#define R_PCIE_PCR_BAR0P0                     0x00004e00U      ///< Base Address Register 0 Port 0
+#define B_PCIE_PCR_BAR0P0_MSI                 BIT0             ///< Memory Space Indicator
+#define N_PCIE_PCR_BAR0P0_MSI                 0
+#define B_PCIE_PCR_BAR0P0_MMT                 ( BIT2 | BIT1 )  ///< Memory Mapping Type
+#define N_PCIE_PCR_BAR0P0_MMT                 1
+#define B_PCIE_PCR_BAR0P0_P                   BIT3             ///< Prefetchable
+#define N_PCIE_PCR_BAR0P0_P                   3
+#define B_PCIE_PCR_BAR0P0_LBA                 0xffff0000U      ///< Lower Base Address
+#define N_PCIE_PCR_BAR0P0_LBA                 16
+
+#define R_PCIE_PCR_BAR1P0                     0x00004e04U      ///< Base Address Register 1 Port 0
+
+#define R_PCIE_MEM_IPSCE                      0x000010e0U      ///< IP Straps Config Extention
+#define B_PCIE_MEM_IPSCE_RXROM                ( BIT19 | BIT18 ) ///< Receive Completion Relaxed Ordering Mode
+#define N_PCIE_MEM_IPSCE_RXROM                18
+#define V_PCIE_MEM_IPSCE_RXROM                0x2
+#define B_PCIE_MEM_IPSCE_TXROM                ( BIT17 | BIT16 )
+
+#define R_PCIE_MEM_FCTL                       0x00001300U      ///< Feature Control
+#define B_PCIE_MEM_FCTL_CRSPSEL               BIT12            ///< Completion Timer Timeout Policy
+#define N_PCIE_MEM_FCTL_CRSPSEL               12
+
+#define R_PCIE_MEM_FCUCTL                     0x00001304U      ///< FC Update Control
+#define B_PCIE_MEM_FCUCTL_FC_CP_FCM           BIT20            ///< Flow Control Completion Finite Credit Mode
+#define N_PCIE_MEM_FCUCTL_FC_CP_FCM           20
+#define B_PCIE_MEM_FCUCTL_FC_CP_FCM_VC1       BIT27            ///< Flow Control Completion Finite Credit Mode VC1
+#define N_PCIE_MEM_FCUCTL_FC_CP_FCM_VC1       27
+#define B_PCIE_MEM_FCUCTL_FC_CP_FCM_VCM       BIT28            ///< Flow Control Completion Finite Credit Mode VCM
+#define N_PCIE_MEM_FCUCTL_FC_CP_FCM_VCM       28
+
+#define R_PCIE_MEM_TXCRSTOCTL                 0x00001320U      ///< Transmit Timeout and Configuration Retry Timeout
+#define B_PCIE_MEM_TXCRSTOCTL_TXNPCTODIS      BIT3             ///< Transmit Non-Posted Completion Timeout Disable
+#define N_PCIE_MEM_TXCRSTOCTL_TXNPCTODIS      3
+#define B_PCIE_MEM_TXCRSTOCTL_CRS_TO_DIS      BIT15
+#define N_PCIE_MEM_TXCRSTOCTL_CRS_TO_DIS      15
+
+#define R_PCIE_MEM_LLPC                       0x0000132cU      ///< Link Layer Policy Control
+#define B_PCIE_MEM_LLPC_AL1NTP                BIT6             ///< ASPM L1 Nak latency Timer Policies
+#define N_PCIE_MEM_LLPC_AL1NTP                6
+
+#define R_PCIE_MEM_FCTL2                      0x00001330U      ///< Feature Control 2
+#define B_PCIE_MEM_FCTL2_RPTOT                ( BIT6 | BIT5 | BIT4 ) ///< Reset Prep Timeout Timer
+#define N_PCIE_MEM_FCTL2_RPTOT                4
+#define B_PCIE_MEM_FCTL2_HRTCTL               ( BIT9 | BIT8 | BIT7 ) ///< Hot Reset Timer Control
+#define N_PCIE_MEM_FCTL2_HRTCTL               7
+#define B_PCIE_MEM_FCTL2_HPICTL               BIT10            ///< Hot Plug Interrupt Control
+#define N_PCIE_MEM_FCTL2_HPICTL               10
+#define B_PCIE_MEM_FCTL2_BLKNAT               BIT11
+#define N_PCIE_MEM_FCTL2_BLKNAT               11
+#define B_PCIE_MEM_FCTL2_RXCPPREALLOCEN       BIT27            ///< Receive Completion Preallocation Enable
+#define N_PCIE_MEM_FCTL2_RXCPPREALLOCEN       27
+
+#define R_PCIE_MEM_RPR                        0x00001334U      ///< Reset Policy
+#define B_PCIE_MEM_RPR_WRM                    ( BIT3 | BIT2 )  ///< Warm Reset Mode
+#define N_PCIE_MEM_RPR_WRM                    2
+#define B_PCIE_MEM_RPR_CRM                    ( BIT5 | BIT4 )  ///< Cold Reset Mode
+#define N_PCIE_MEM_RPR_CRM                    4
+#define B_PCIE_MEM_RPR_S3SM                   ( BIT7 | BIT6 )  ///< S3 Sleep Mode
+#define N_PCIE_MEM_RPR_S3SM                   6
+#define B_PCIE_MEM_RPR_S4SM                   ( BIT9 | BIT8 )  ///< S4 Sleep Mode
+#define N_PCIE_MEM_RPR_S4SM                   8
+#define B_PCIE_MEM_RPR_S5SM                   ( BIT11 | BIT10 ) ///< S5 Sleep Mode
+#define N_PCIE_MEM_RPR_S5SM                   10
+#define B_PCIE_MEM_RPR_DMTO                   ( BIT13 | BIT12 ) ///< Default Mode Timeout
+#define N_PCIE_MEM_RPR_DMTO                   12
+#define B_PCIE_MEM_RPR_WRMTO                  ( BIT15 | BIT14 ) ///< Warm Reset Mode Timeout
+#define N_PCIE_MEM_RPR_WRMTO                  14
+#define B_PCIE_MEM_RPR_CRMTO                  ( BIT17 | BIT16 ) ///< Cold Reset Mode Timeout
+#define N_PCIE_MEM_RPR_CRMTO                  16
+#define B_PCIE_MEM_RPR_S3SMTO                 ( BIT19 | BIT18 ) ///< S3 Sleep Mode Timeout
+#define N_PCIE_MEM_RPR_S3SMTO                 18
+#define B_PCIE_MEM_RPR_S4SMTO                 ( BIT21 | BIT20 ) ///< S4 Sleep Mode Timeout
+#define N_PCIE_MEM_RPR_S4SMTO                 20
+#define B_PCIE_MEM_RPR_S5SMTO                 ( BIT23 | BIT22 ) ///< S5 Sleep Mode Timeout
+#define N_PCIE_MEM_RPR_S5SMTO                 22
+
+#define R_PCIE_MEM_DCGEN1                     0x00001350U      ///< DCG Enable 1
+#define B_PCIE_MEM_DCGEN1_PXKGULDCGEN         BIT0             ///< PXKG Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN1_PXKGULDCGEN         0
+#define B_PCIE_MEM_DCGEN1_PXCULDCGEN          BIT1             ///< PXC Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN1_PXCULDCGEN          1
+#define B_PCIE_MEM_DCGEN1_PXLRULDCGEN         BIT8             ///< PXLR Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN1_PXLRULDCGEN         8
+#define B_PCIE_MEM_DCGEN1_PXLTULDCGEN         BIT9             ///< PXLT Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN1_PXLTULDCGEN         9
+#define B_PCIE_MEM_DCGEN1_PXLIULDCGEN         BIT10            ///< PXLI Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN1_PXLIULDCGEN         10
+#define B_PCIE_MEM_DCGEN1_PXLSULDCGEN         BIT11            ///< PXLS Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN1_PXLSULDCGEN         11
+#define B_PCIE_MEM_DCGEN1_PXCP2ULDCGEN        BIT12            ///< PXCP2 Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN1_PXCP2ULDCGEN        12
+#define B_PCIE_MEM_DCGEN1_PXTRULDCGEN         BIT16            ///< PXTR Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN1_PXTRULDCGEN         16
+#define B_PCIE_MEM_DCGEN1_PXTRSULDCGEN        BIT17            ///< PXTRS Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN1_PXTRSULDCGEN        17
+#define B_PCIE_MEM_DCGEN1_PXTRSSULDCGEN       BIT18            ///< PXTRSS Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN1_PXTRSSULDCGEN       18
+#define B_PCIE_MEM_DCGEN1_PXCP3ULDCGEN        BIT19            ///< PXCP3 Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN1_PXCP3ULDCGEN        19
+#define B_PCIE_MEM_DCGEN1_PXTTULDCGEN         BIT24            ///< PXTT Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN1_PXTTULDCGEN         24
+#define B_PCIE_MEM_DCGEN1_PXTTSULDCGEN        BIT25            ///< PXTTS Unit Link Clock PXTTSS DCG Enable
+#define N_PCIE_MEM_DCGEN1_PXTTSULDCGEN        25
+#define B_PCIE_MEM_DCGEN1_PXTTSSULDCGEN       BIT26            ///< PXTTS Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN1_PXTTSSULDCGEN       26
+#define B_PCIE_MEM_DCGEN1_PXCP4ULDCGEN        BIT27            ///< PXCP4 Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN1_PXCP4ULDCGEN        27
+
+#define R_PCIE_MEM_DCGEN2                     0x00001354U      ///< DCG Enable 2
+#define B_PCIE_MEM_DCGEN2_PXPIULDCGEN         BIT0             ///< PXPI Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN2_PXPIULDCGEN         0
+#define B_PCIE_MEM_DCGEN2_PXPSULDCGEN         BIT1             ///< PXPS Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN2_PXPSULDCGEN         1
+#define B_PCIE_MEM_DCGEN2_PXPBULDCGEN         BIT2             ///< PXPB Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN2_PXPBULDCGEN         2
+#define B_PCIE_MEM_DCGEN2_PXFIULDCGEN         BIT3             ///< PXFI Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN2_PXFIULDCGEN         3
+#define B_PCIE_MEM_DCGEN2_PXFTULDCGEN         BIT4             ///< PXFT Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN2_PXFTULDCGEN         4
+#define B_PCIE_MEM_DCGEN2_PXFRULDCGEN         BIT5             ///< PXFR Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN2_PXFRULDCGEN         5
+#define B_PCIE_MEM_DCGEN2_PXCP5ULDCGEN        BIT6             ///< PXCP5 Unit Link Clock DCG Enable
+#define N_PCIE_MEM_DCGEN2_PXCP5ULDCGEN        6
+
+#define R_PCIE_MEM_DCGM1                      0x00001358U      ///< DCG Mode 1
+#define B_PCIE_MEM_DCGM1_PXKGULDCGM           BIT0             ///< PXKG Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM1_PXKGULDCGM           0
+#define B_PCIE_MEM_DCGM1_PXCULDCGM            BIT1             ///< PXC Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM1_PXCULDCGM            1
+#define B_PCIE_MEM_DCGM1_PXLRULDCGM           BIT8             ///< PXLR Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM1_PXLRULDCGM           8
+#define B_PCIE_MEM_DCGM1_PXLTULDCGM           BIT9             ///< PXLT Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM1_PXLTULDCGM           9
+#define B_PCIE_MEM_DCGM1_PXLIULDCGM           BIT10            ///< PXLI Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM1_PXLIULDCGM           10
+#define B_PCIE_MEM_DCGM1_PXLSULDCGM           BIT11            ///< PXLS Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM1_PXLSULDCGM           11
+#define B_PCIE_MEM_DCGM1_PXCP2ULDCGM          BIT12            ///< PXCP2 Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM1_PXCP2ULDCGM          12
+#define B_PCIE_MEM_DCGM1_PXTRULDCGM           BIT16            ///< PXTR Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM1_PXTRULDCGM           16
+#define B_PCIE_MEM_DCGM1_PXTRSULDCGM          BIT17            ///< PXTRS Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM1_PXTRSULDCGM          17
+#define B_PCIE_MEM_DCGM1_PXTRSSULDCGM         BIT18            ///< PXTRSS Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM1_PXTRSSULDCGM         18
+#define B_PCIE_MEM_DCGM1_PXCP3ULDCGM          BIT19            ///< PXCP3 Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM1_PXCP3ULDCGM          19
+#define B_PCIE_MEM_DCGM1_PXTTULDCGM           BIT24            ///< PXTT Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM1_PXTTULDCGM           24
+#define B_PCIE_MEM_DCGM1_PXTTSULDCGM          BIT25            ///< PXTTS Unit Link Clock PXTTSS DCG Mode
+#define N_PCIE_MEM_DCGM1_PXTTSULDCGM          25
+#define B_PCIE_MEM_DCGM1_PXTTSSULDCGM         BIT26            ///< PXTTS Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM1_PXTTSSULDCGM         26
+#define B_PCIE_MEM_DCGM1_PXCP4ULDCGM          BIT27            ///< PXCP4 Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM1_PXCP4ULDCGM          27
+
+#define R_PCIE_MEM_DCGM2                      0x0000135cU      ///< DCG Mode 2
+#define B_PCIE_MEM_DCGM2_PXPIULDCGM           BIT0             ///< PXPI Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM2_PXPIULDCGM           0
+#define B_PCIE_MEM_DCGM2_PXPSULDCGM           BIT1             ///< PXPS Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM2_PXPSULDCGM           1
+#define B_PCIE_MEM_DCGM2_PXPBULDCGM           BIT2             ///< PXPB Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM2_PXPBULDCGM           2
+#define B_PCIE_MEM_DCGM2_PXFIULDCGM           BIT3             ///< PXFI Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM2_PXFIULDCGM           3
+#define B_PCIE_MEM_DCGM2_PXFTULDCGM           BIT4             ///< PXFT Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM2_PXFTULDCGM           4
+#define B_PCIE_MEM_DCGM2_PXFRULDCGM           BIT5             ///< PXFR Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM2_PXFRULDCGM           5
+#define B_PCIE_MEM_DCGM2_PXCP5ULDCGM          BIT6             ///< PXCP5 Unit Link Clock DCG Mode
+#define N_PCIE_MEM_DCGM2_PXCP5ULDCGM          6
+
+#define R_PCIE_MEM_DCGEN3                     0x00001360U      ///< DCG Enable 3
+#define B_PCIE_MEM_DCGEN3_PXEUPDCGEN          BIT0             ///< PXE Unit Prim Clock DCG Enable
+#define N_PCIE_MEM_DCGEN3_PXEUPDCGEN          0
+#define B_PCIE_MEM_DCGEN3_PXBUPDCGEN          BIT1             ///< PXB Unit Prim Clock DCG Enable
+#define N_PCIE_MEM_DCGEN3_PXBUPDCGEN          1
+#define B_PCIE_MEM_DCGEN3_PXCUPDCGEN          BIT2             ///< PXC Unit Prim Port Clock DCG Enable
+#define N_PCIE_MEM_DCGEN3_PXCUPDCGEN          2
+#define B_PCIE_MEM_DCGEN3_PXCUPSRCDCGEN       BIT4             ///< PXC Unit Prim Shared Resource Clock DCG Enable
+#define N_PCIE_MEM_DCGEN3_PXCUPSRCDCGEN       4
+#define B_PCIE_MEM_DCGEN3_PXCUPSNRDCGEN       BIT5             ///< PXC Unit Prim SnR DCG Enable
+#define N_PCIE_MEM_DCGEN3_PXCUPSNRDCGEN       5
+#define B_PCIE_MEM_DCGEN3_PXSRUSSNRDCGEN      BIT6             ///< PXSR Unit Side SnR DCG Enable
+#define N_PCIE_MEM_DCGEN3_PXSRUSSNRDCGEN      6
+#define B_PCIE_MEM_DCGEN3_PXLRUPDCGEN         BIT8             ///< PXLR Unit Prim Clock DCG Enable
+#define N_PCIE_MEM_DCGEN3_PXLRUPDCGEN         8
+#define B_PCIE_MEM_DCGEN3_PXLTUPDCGEN         BIT9             ///< PXLT Unit Prim Clock DCG Enable
+#define N_PCIE_MEM_DCGEN3_PXLTUPDCGEN         9
+#define B_PCIE_MEM_DCGEN3_PXLIUPDCGEN         BIT10            ///< PXLI Unit Prim Clock DCG Enable
+#define N_PCIE_MEM_DCGEN3_PXLIUPDCGEN         10
+#define B_PCIE_MEM_DCGEN3_PXCP2UPDCGEN        BIT12            ///< PXCP2 Unit Prim Clock DCG Enable
+#define N_PCIE_MEM_DCGEN3_PXCP2UPDCGEN        12
+#define B_PCIE_MEM_DCGEN3_PXTRUPDCGEN         BIT16            ///< PXTR Unit Prim Clock DCG Enable
+#define N_PCIE_MEM_DCGEN3_PXTRUPDCGEN         16
+#define B_PCIE_MEM_DCGEN3_PXTRSUPDCGEN        BIT17            ///< PXTRS Unit Prim Clock DCG Enable
+#define N_PCIE_MEM_DCGEN3_PXTRSUPDCGEN        17
+#define B_PCIE_MEM_DCGEN3_PXTRSSUPDCGEN       BIT18            ///< PXTRSS Unit Prim Clock DCG Enable
+#define N_PCIE_MEM_DCGEN3_PXTRSSUPDCGEN       18
+#define B_PCIE_MEM_DCGEN3_PXTOUPDCGEN         BIT19            ///< PXTO Unit Prim Clock DCG Enable
+#define N_PCIE_MEM_DCGEN3_PXTOUPDCGEN         19
+#define B_PCIE_MEM_DCGEN3_PXCP3UPDCGEN        BIT20            ///< PXCP3 Unit Prim Clock DCG Enable
+#define N_PCIE_MEM_DCGEN3_PXCP3UPDCGEN        20
+#define B_PCIE_MEM_DCGEN3_PXTTUPDCGEN         BIT24            ///< PXTT Unit Prim Clock DCG Enable
+#define N_PCIE_MEM_DCGEN3_PXTTUPDCGEN         24
+#define B_PCIE_MEM_DCGEN3_PXTTSUPDCGEN        BIT25            ///< PXTTS Unit Prim Clock DCG Enable
+#define N_PCIE_MEM_DCGEN3_PXTTSUPDCGEN        25
+#define B_PCIE_MEM_DCGEN3_PXTTSSUPDCGEN       BIT26            ///< PXTTSS Unit Prim Clock DCG Enable
+#define N_PCIE_MEM_DCGEN3_PXTTSSUPDCGEN       26
+#define B_PCIE_MEM_DCGEN3_PXCP4UPDCGEN        BIT27            ///< PXCP4 Unit Prim Clock DCG Enable
+#define N_PCIE_MEM_DCGEN3_PXCP4UPDCGEN        27
+
+#define R_PCIE_MEM_DCGM3                      0x00001368U      ///< DCG Mode 3
+#define B_PCIE_MEM_DCGM3_PXEUPDCGM            BIT0             ///< PXE Unit Prim Clock DCG Mode
+#define N_PCIE_MEM_DCGM3_PXEUPDCGM            0
+#define B_PCIE_MEM_DCGM3_PXBUPDCGM            BIT1             ///< PXB Unit Prim Clock DCG Mode
+#define N_PCIE_MEM_DCGM3_PXBUPDCGM            1
+#define B_PCIE_MEM_DCGM3_PXCUPDCGM            BIT2             ///< PXC Unit Prim Clock DCG Mode
+#define N_PCIE_MEM_DCGM3_PXCUPDCGM            2
+#define B_PCIE_MEM_DCGM3_PXCUPSRCDCGM         BIT4             ///< PXC Unit Prim Shared Resource Clock DCG Mode
+#define N_PCIE_MEM_DCGM3_PXCUPSRCDCGM         4
+#define B_PCIE_MEM_DCGM3_PXCUPSNRDCGM         BIT5             ///< PXC Unit Prim SnR DCG Mode
+#define N_PCIE_MEM_DCGM3_PXCUPSNRDCGM         5
+#define B_PCIE_MEM_DCGM3_PXSRUSSNRDCGM        BIT6             ///< PXSR Unit Side SnR DCG Mode
+#define N_PCIE_MEM_DCGM3_PXSRUSSNRDCGM        6
+#define B_PCIE_MEM_DCGM3_PXLRUPDCGM           BIT8             ///< PXLR Unit Prim Clock DCG Mode
+#define N_PCIE_MEM_DCGM3_PXLRUPDCGM           8
+#define B_PCIE_MEM_DCGM3_PXLTUPDCGM           BIT9             ///< PXLT Unit Prim Clock DCG Mode
+#define N_PCIE_MEM_DCGM3_PXLTUPDCGM           9
+#define B_PCIE_MEM_DCGM3_PXLIUPDCGM           BIT10            ///< PXLI Unit Prim Clock DCG Mode
+#define N_PCIE_MEM_DCGM3_PXLIUPDCGM           10
+#define B_PCIE_MEM_DCGM3_PXCP2UPDCGM          BIT12            ///< PXCP2 Unit Prim Clock DCG Mode
+#define N_PCIE_MEM_DCGM3_PXCP2UPDCGM          12
+#define B_PCIE_MEM_DCGM3_PXTRUPDCGM           BIT16            ///< PXTR Unit Prim Clock DCG Mode
+#define N_PCIE_MEM_DCGM3_PXTRUPDCGM           16
+#define B_PCIE_MEM_DCGM3_PXTRSUPDCGM          BIT17            ///< PXTRS Unit Prim Clock DCG Mode
+#define N_PCIE_MEM_DCGM3_PXTRSUPDCGM          17
+#define B_PCIE_MEM_DCGM3_PXTRSSUPDCGM         BIT18            ///< PXTRSS Unit Prim Clock DCG Mode
+#define N_PCIE_MEM_DCGM3_PXTRSSUPDCGM         18
+#define B_PCIE_MEM_DCGM3_PXTOUPDCGM           BIT19            ///< PXTO Unit Prim Clock DCG Mode
+#define N_PCIE_MEM_DCGM3_PXTOUPDCGM           19
+#define B_PCIE_MEM_DCGM3_PXCP3UPDCGM          BIT20            ///< PXCP3 Unit Prim Clock DCG Mode
+#define N_PCIE_MEM_DCGM3_PXCP3UPDCGM          20
+#define B_PCIE_MEM_DCGM3_PXTTUPDCGM           BIT24            ///< PXTT Unit Prim Clock DCG Mode
+#define N_PCIE_MEM_DCGM3_PXTTUPDCGM           24
+#define B_PCIE_MEM_DCGM3_PXTTSUPDCGM          BIT25            ///< PXTTS Unit Prim Clock DCG Mode
+#define N_PCIE_MEM_DCGM3_PXTTSUPDCGM          25
+#define B_PCIE_MEM_DCGM3_PXTTSSUPDCGM         BIT26            ///< PXTTSS Unit Prim Clock DCG Mode
+#define N_PCIE_MEM_DCGM3_PXTTSSUPDCGM         26
+#define B_PCIE_MEM_DCGM3_PXCP4UPDCGM          BIT27            ///< PXCP4 Unit Prim Clock DCG Mode
+#define N_PCIE_MEM_DCGM3_PXCP4UPDCGM          27
+
+#define R_PCIE_MEM_IPCLKCTR                   0x00001370U      ///< IP Clock Control
+#define B_PCIE_MEM_IPCLKCTR_PXDCGE            BIT2             ///< PXD Clock Gate Enable
+#define N_PCIE_MEM_IPCLKCTR_PXDCGE            2
+#define B_PCIE_MEM_IPCLKCTR_MDPCCEN           BIT3             ///< Mild DCG Prim Clock Coupling Enable
+#define N_PCIE_MEM_IPCLKCTR_MDPCCEN           3
+
+#define R_PCIE_MEM_LOCKREGCTL                 0x00001400U      ///< Lock Register Control
+#define B_PCIE_MEM_LOCKREGCTL_G5EQCTL         BIT0             ///< Secured Gen 5 Equalization Register Lock
+#define N_PCIE_MEM_LOCKREGCTL_G5EQCTL         0
+
+#define R_PCIE_MEM_LPHYCP1                    0x00001410U      ///< Log Phy Control Policy 1
+#define B_PCIE_MEM_LPHYCP1_RXADPSVH           BIT2             ///< Receiver Adaptation Status Violation Handling
+#define N_PCIE_MEM_LPHYCP1_RXADPSVH           2
+#define B_PCIE_MEM_LPHYCP1_RXADPHM            BIT3             ///< Receiver Adaptation Handshake Mapping
+#define N_PCIE_MEM_LPHYCP1_RXADPHM            3
+#define B_PCIE_MEM_LPHYCP1_RXEQFNEVC          BIT4             ///< Receiver Equalization Final Evaluation Control
+#define N_PCIE_MEM_LPHYCP1_RXEQFNEVC          4
+#define B_PCIE_MEM_LPHYCP1_PIPEMBIP           BIT6             ///< PIPE Message Bus Initialization Policy
+#define N_PCIE_MEM_LPHYCP1_PIPEMBIP           6
+#define B_PCIE_MEM_LPHYCP1_RXADPRECE          BIT9             ///< Receiver Adaptation Recovery Enable
+#define N_PCIE_MEM_LPHYCP1_RXADPRECE          9
+#define B_PCIE_MEM_LPHYCP1_BPRXSTNDBYHSRECAL  BIT12            ///< Bypass RxStandby Handshake during Recal
+#define N_PCIE_MEM_LPHYCP1_BPRXSTNDBYHSRECAL  12
+
+#define R_PCIE_MEM_UPDLPHYCP                  0x00001414U      ///< Upstream Port DMI Log Phy Control Policy
+#define B_PCIE_MEM_UPDLPHYCP_UPDLLSMFLD       BIT0             ///< Upstream Port DMI LPIF+ L1 State Map For L1.Deep
+#define N_PCIE_MEM_UPDLPHYCP_UPDLLSMFLD       0
+#define B_PCIE_MEM_UPDLPHYCP_UPDLTCDC         BIT1             ///< Upstream Port DMI LPIF+ L1.6 TX Cmm Disable Control
+#define N_PCIE_MEM_UPDLPHYCP_UPDLTCDC         1
+#define B_PCIE_MEM_UPDLPHYCP_TXCMMDISLNCTL    BIT2             ///< Tx Cmm Disable Lanes Control
+#define N_PCIE_MEM_UPDLPHYCP_TXCMMDISLNCTL    2
+
+#define R_PCIE_MEM_RXL0SESQCP4                0x0000142cU      ///< RXL0s Exit Squelch Control Policy 4
+#define B_PCIE_MEM_RXL0SESQCP4_G1LBWSST       ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Gen 1 Low Bandwidth Squelch Settling Timer
+#define N_PCIE_MEM_RXL0SESQCP4_G1LBWSST       0
+#define B_PCIE_MEM_RXL0SESQCP4_G2LBWSST       ( BIT15 | BIT14 | BIT13 | BIT12 | BIT11 | BIT10 | BIT9 | BIT8 ) ///< Gen 2 Low Bandwidth Squelch Settling Timer
+#define N_PCIE_MEM_RXL0SESQCP4_G2LBWSST       8
+#define B_PCIE_MEM_RXL0SESQCP4_G3LBWSST       ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 | BIT17 | BIT16 ) ///< Gen 3 Low Bandwidth Squelch Settling Timer
+#define N_PCIE_MEM_RXL0SESQCP4_G3LBWSST       16
+#define B_PCIE_MEM_RXL0SESQCP4_G4LBWSST       ( BIT31 | BIT30 | BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Gen 4 Low Bandwidth Squelch Settling Timer
+#define N_PCIE_MEM_RXL0SESQCP4_G4LBWSST       24
+
+#define R_PCIE_MEM_RXL0SESQCP5                0x00001430U
+#define B_PCIE_MEM_RXL0SESQCP5_G5LBWSST       ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 )
+#define N_PCIE_MEM_RXL0SESQCP5_G5LBWSST       0
+
+#define R_PCIE_MEM_LPHYCP4                    0x00001434U      ///< Log Phy Control Policy 4
+#define B_PCIE_MEM_LPHYCP4_LGCLKSQEXITDBTIMERS ( BIT2 | BIT1 | BIT0 ) ///< Link Clock Domain Squelch Exit Debounce Timers
+#define N_PCIE_MEM_LPHYCP4_LGCLKSQEXITDBTIMERS 0
+#define B_PCIE_MEM_LPHYCP4_OSCCLKSQEXITDBTIMERS ( BIT5 | BIT4 | BIT3 ) ///< OSC Clock Domain Squelch Exit Debounce Timers
+#define N_PCIE_MEM_LPHYCP4_OSCCLKSQEXITDBTIMERS 3
+#define B_PCIE_MEM_LPHYCP4_LGUSSP             ( BIT7 | BIT6 )  ///< LG Clock Un-Squelch Sampling Period
+#define N_PCIE_MEM_LPHYCP4_LGUSSP             6
+#define B_PCIE_MEM_LPHYCP4_OSUSSP             ( BIT9 | BIT8 )  ///< OSC Clock Un-Squelch Sampling Period
+#define N_PCIE_MEM_LPHYCP4_OSUSSP             8
+#define B_PCIE_MEM_LPHYCP4_PLLBUSDRC          BIT10            ///< PLL Bring Up Sequence During Rate Change
+#define N_PCIE_MEM_LPHYCP4_PLLBUSDRC          10
+#define B_PCIE_MEM_LPHYCP4_REEFRXL0SED        BIT11            ///< RxElecidle Exit Evaluation For RxL0s Entry Disable
+#define N_PCIE_MEM_LPHYCP4_REEFRXL0SED        11
+#define B_PCIE_MEM_LPHYCP4_DPMDNDBFE          BIT12            ///< Data Parity Mask During Non Data Block For 128b130b Encoding
+#define N_PCIE_MEM_LPHYCP4_DPMDNDBFE          12
+#define B_PCIE_MEM_LPHYCP4_TLSPDRS            BIT13            ///< Target Link Speed Policy During Recovery Substates
+#define B_PCIE_MEM_LPHYCP4_G1AREDRL0S         BIT16            ///< Gen 1 Async RxElecidle Detector For RXL0s
+#define N_PCIE_MEM_LPHYCP4_G1AREDRL0S         16
+#define B_PCIE_MEM_LPHYCP4_G2AREDRL0S         BIT17            ///< Gen 2 Async RxElecidle Detector For RXL0s
+#define N_PCIE_MEM_LPHYCP4_G2AREDRL0S         17
+#define B_PCIE_MEM_LPHYCP4_G3AREDRL0S         BIT18            ///< Gen 3 Async RxElecidle Detector For RXL0s
+#define N_PCIE_MEM_LPHYCP4_G3AREDRL0S         18
+#define B_PCIE_MEM_LPHYCP4_G4AREDRL0S         BIT19            ///< Gen 4 Async RxElecidle Detector For RXL0s
+#define N_PCIE_MEM_LPHYCP4_G4AREDRL0S         19
+#define B_PCIE_MEM_LPHYCP4_G5AREDRL0S         BIT20            ///< Gen 5 Async RxElecidle Detector For RXL0s
+#define N_PCIE_MEM_LPHYCP4_G5AREDRL0S         20
+#define B_PCIE_MEM_LPHYCP4_RXL0SEG12FTSE      ( BIT25 | BIT24 ) ///< RxL0s Exit Gen 1/2 FTS Timeout Extension
+#define N_PCIE_MEM_LPHYCP4_RXL0SEG12FTSE      24
+#define B_PCIE_MEM_LPHYCP4_RXVLDRXL0SSP       ( BIT28 | BIT27 | BIT26 ) ///< RX Valid Trigger RXL0s Exit Suppression Period
+#define N_PCIE_MEM_LPHYCP4_RXVLDRXL0SSP       26
+
+#define R_PCIE_MEM_IORCCP1                    0x0000144cU      ///< IO Recal Control Policy 1
+#define B_PCIE_MEM_IORCCP1_DISORCL12REC       BIT0             ///< Disable Offset Re-Calibration Request from L1 to Recovery
+#define N_PCIE_MEM_IORCCP1_DISORCL12REC       0
+#define B_PCIE_MEM_IORCCP1_DRCORRP            BIT1             ///< Disable Recovery / Configurations Offset Re-calibration Request Policy
+#define N_PCIE_MEM_IORCCP1_DRCORRP            1
+#define B_PCIE_MEM_IORCCP1_DISORCRODI         BIT2             ///< Disable Offset Re-Calibration Request On Downconfigure / Inactive Lanes
+#define N_PCIE_MEM_IORCCP1_DISORCRODI         2
+#define B_PCIE_MEM_IORCCP1_ORTS               BIT3             ///< Offset Recalibrations Trigger Status
+#define N_PCIE_MEM_IORCCP1_ORTS               3
+#define B_PCIE_MEM_IORCCP1_ORRPGM             ( BIT15 | BIT14 | BIT13 | BIT12 | BIT11 | BIT10 | BIT9 | BIT8 ) ///< Offset Re-Calibration Request Per Gen Mask
+#define N_PCIE_MEM_IORCCP1_ORRPGM             8
+#define B_PCIE_MEM_IORCCP1_G1ORRRXECC         ( BIT18 | BIT17 | BIT16 ) ///< Gen 1 Offset Re-Calibrations RX Error Collapsing Count
+#define N_PCIE_MEM_IORCCP1_G1ORRRXECC         16
+#define B_PCIE_MEM_IORCCP1_G2ORRRXECC         ( BIT21 | BIT20 | BIT19 ) ///< Gen 2 Offset Re-Calibrations RX Error Collapsing Count
+#define N_PCIE_MEM_IORCCP1_G2ORRRXECC         19
+#define B_PCIE_MEM_IORCCP1_G3ORRRXECC         ( BIT24 | BIT23 | BIT22 ) ///< Gen 3 Offset Re-Calibrations RX Error Collapsing Count
+#define N_PCIE_MEM_IORCCP1_G3ORRRXECC         22
+#define B_PCIE_MEM_IORCCP1_G4ORRRXECC         ( BIT27 | BIT26 | BIT25 ) ///< Gen 4 Offset Re-Calibrations RX Error Collapsing Count
+#define N_PCIE_MEM_IORCCP1_G4ORRRXECC         25
+#define B_PCIE_MEM_IORCCP1_G5ORRRXECC         ( BIT30 | BIT29 | BIT28 ) ///< Gen 5 Offset Re-Calibrations RX Error Collapsing Count
+#define N_PCIE_MEM_IORCCP1_G5ORRRXECC         28
+
+#define R_PCIE_MEM_PHYPG                      0x00001590U      ///< PHY Power Gating
+#define B_PCIE_MEM_PHYPG_DETPHYPGE            BIT0             ///< Detect PHY Power Gating Enable
+#define N_PCIE_MEM_PHYPG_DETPHYPGE            0
+#define B_PCIE_MEM_PHYPG_DISPHYPGE            BIT1             ///< Disabled PHY Power Gating Enable
+#define N_PCIE_MEM_PHYPG_DISPHYPGE            1
+#define B_PCIE_MEM_PHYPG_L23PHYPGE            BIT2             ///< L23 PHY Power Gating Enable
+#define N_PCIE_MEM_PHYPG_L23PHYPGE            2
+#define B_PCIE_MEM_PHYPG_DUCFGPHYPGE          BIT3             ///< Downconfigure PHY Power Gating Enable
+#define N_PCIE_MEM_PHYPG_DUCFGPHYPGE          3
+#define B_PCIE_MEM_PHYPG_DLPPGP               BIT4             ///< Downconfigure Lanes Phy Power Gating Policy
+#define N_PCIE_MEM_PHYPG_DLPPGP               4
+#define B_PCIE_MEM_PHYPG_ULPPGP               BIT5             ///< Unconfigure Lanes Phy Power Gating Policy
+#define N_PCIE_MEM_PHYPG_ULPPGP               5
+#define B_PCIE_MEM_PHYPG_UNCFGPHYPGE          BIT6             ///< Unconfigure PHY Power Gating Enable
+#define N_PCIE_MEM_PHYPG_UNCFGPHYPGE          6
+
+#define R_PCIE_MEM_PIPEPDCTL                  0x00001594U      ///< PIPE Power Down Control
+#define B_PCIE_MEM_PIPEPDCTL_DETNOPGPDCTL     ( BIT3 | BIT2 | BIT1 | BIT0 ) ///< Detect without Power Gating Power Down Control
+#define N_PCIE_MEM_PIPEPDCTL_DETNOPGPDCTL     0
+#define B_PCIE_MEM_PIPEPDCTL_DETPGPDCTL       ( BIT7 | BIT6 | BIT5 | BIT4 ) ///< Detect with Power Gating Power Down Control
+#define N_PCIE_MEM_PIPEPDCTL_DETPGPDCTL       4
+#define B_PCIE_MEM_PIPEPDCTL_L23NOPGPDCTL     ( BIT11 | BIT10 | BIT9 | BIT8 ) ///< L23 without Power Gating Power Down Control
+#define N_PCIE_MEM_PIPEPDCTL_L23NOPGPDCTL     8
+#define B_PCIE_MEM_PIPEPDCTL_L23PGPDCTL       ( BIT15 | BIT14 | BIT13 | BIT12 ) ///< L23 with Power Gating Power Down Control
+#define N_PCIE_MEM_PIPEPDCTL_L23PGPDCTL       12
+#define B_PCIE_MEM_PIPEPDCTL_DISNOPGPDCTL     ( BIT19 | BIT18 | BIT17 | BIT16 ) ///< Disabled without Power Gating Power Down Control
+#define N_PCIE_MEM_PIPEPDCTL_DISNOPGPDCTL     16
+#define B_PCIE_MEM_PIPEPDCTL_DISPGPDCTL       ( BIT23 | BIT22 | BIT21 | BIT20 ) ///< Disabled with Power Gating Power Down Control
+#define N_PCIE_MEM_PIPEPDCTL_DISPGPDCTL       20
+#define B_PCIE_MEM_PIPEPDCTL_L1PGNOPGPDCTL    ( BIT27 | BIT26 | BIT25 | BIT24 ) ///< L1 Powergateable without Power Gating Power Down Control
+#define N_PCIE_MEM_PIPEPDCTL_L1PGNOPGPDCTL    24
+#define B_PCIE_MEM_PIPEPDCTL_L1PGUPGPDCTL     ( BIT31 | BIT30 | BIT29 | BIT28 ) ///< L1 Powergateable with Power Gating Power Down Control
+#define N_PCIE_MEM_PIPEPDCTL_L1PGUPGPDCTL     28
+
+#define R_PCIE_MEM_PIPEPDCTL2                 0x00001598U      ///< PIPE Power Down Control 2
+#define B_PCIE_MEM_PIPEPDCTL2_L1UPNOPGPDCTL   ( BIT3 | BIT2 | BIT1 | BIT0 ) ///< L1 Unpowergateable without Power Gating Power Down Control
+#define N_PCIE_MEM_PIPEPDCTL2_L1UPNOPGPDCTL   0
+#define B_PCIE_MEM_PIPEPDCTL2_L1D1UPUPGPDCTL  ( BIT7 | BIT6 | BIT5 | BIT4 ) ///< L1.1 Unpowergateable with Un Power Gating Power Down Control
+#define N_PCIE_MEM_PIPEPDCTL2_L1D1UPUPGPDCTL  4
+#define B_PCIE_MEM_PIPEPDCTL2_L1D1PGNOPGPDCTL ( BIT11 | BIT10 | BIT9 | BIT8 ) ///< L1.1 Powergateable without Power Gating Power Down Control
+#define N_PCIE_MEM_PIPEPDCTL2_L1D1PGNOPGPDCTL 8
+#define B_PCIE_MEM_PIPEPDCTL2_L1D1PGPGPDCTL   ( BIT15 | BIT14 | BIT13 | BIT12 ) ///< L1.1 Powergateable with Power Gating Power Down Control
+#define N_PCIE_MEM_PIPEPDCTL2_L1D1PGPGPDCTL   12
+#define B_PCIE_MEM_PIPEPDCTL2_L1D2NOPGPDCTL   ( BIT19 | BIT18 | BIT17 | BIT16 ) ///< L1.2 without Power Gating Power Down Control
+#define N_PCIE_MEM_PIPEPDCTL2_L1D2NOPGPDCTL   16
+#define B_PCIE_MEM_PIPEPDCTL2_L1D2PGPDCTL     ( BIT23 | BIT22 | BIT21 | BIT20 ) ///< L1.2 with Power Gating Power Down Control
+#define N_PCIE_MEM_PIPEPDCTL2_L1D2PGPDCTL     20
+#define B_PCIE_MEM_PIPEPDCTL2_DUCFGNOPGPDCTL  ( BIT27 | BIT26 | BIT25 | BIT24 ) ///< Down and Unconfigure without Power Gating Power Down Control
+#define N_PCIE_MEM_PIPEPDCTL2_DUCFGNOPGPDCTL  24
+#define B_PCIE_MEM_PIPEPDCTL2_DUCFGPGPDCTL    ( BIT31 | BIT30 | BIT29 | BIT28 ) ///< Down and Unconfigure with Power Gating Power Down Control
+#define N_PCIE_MEM_PIPEPDCTL2_DUCFGPGPDCTL    28
+
+#define R_PCIE_MEM_PIPEPDCTL3                 0x0000159cU      ///< PIPE Power Down Control 3
+#define B_PCIE_MEM_PIPEPDCTL3_L1DLOWNOPGPDCTL ( BIT3 | BIT2 | BIT1 | BIT0 ) ///< L1.Low without Power Gating Power Down Control
+#define N_PCIE_MEM_PIPEPDCTL3_L1DLOWNOPGPDCTL 0
+#define B_PCIE_MEM_PIPEPDCTL3_L1DLOWPGPDCTL   ( BIT7 | BIT6 | BIT5 | BIT4 ) ///< L1.Low with Power Gating Power Down Control
+#define N_PCIE_MEM_PIPEPDCTL3_L1DLOWPGPDCTL   4
+
+#define R_PCIE_MEM_PIPEPDCTLEXT               0x000015a0U      ///< PIPE Power Down Control Extension
+#define B_PCIE_MEM_PIPEPDCTLEXT_P2TP2TCD      BIT1             ///< P2 to P2 Transition Clock Domain
+#define N_PCIE_MEM_PIPEPDCTLEXT_P2TP2TCD      1
+#define B_PCIE_MEM_PIPEPDCTLEXT_P2TP2TP       BIT2             ///< P2 to P2 Transition Policy
+#define N_PCIE_MEM_PIPEPDCTLEXT_P2TP2TP       2
+#define B_PCIE_MEM_PIPEPDCTLEXT_P2UGTPGSM     BIT3             ///< P2 Unpower Gating To Power Gating Synchronize Mode
+#define N_PCIE_MEM_PIPEPDCTLEXT_P2UGTPGSM     3
+#define B_PCIE_MEM_PIPEPDCTLEXT_LSDPMRFM      ( BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 | BIT5 | BIT4 ) ///< Link State Deeppm Request Forwarding Mask
+#define N_PCIE_MEM_PIPEPDCTLEXT_LSDPMRFM      4
+#define B_PCIE_MEM_PIPEPDCTLEXT_PDDPMRFM      0xffff0000U      ///< Powerdown Deeppm Request Forwarding Mask
+#define N_PCIE_MEM_PIPEPDCTLEXT_PDDPMRFM      16
+
+#define R_PCIE_MEM_MPHYCAPCFG                 0x000015a8U      ///< MAC PHY Capability Configurations
+#define B_PCIE_MEM_MPHYCAPCFG_MLSOSGSSVCC     ( BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< MACPHY Lower SKP OS Generation Supported Speeds Vector Capability Configurations
+#define N_PCIE_MEM_MPHYCAPCFG_MLSOSGSSVCC     0
+#define B_PCIE_MEM_MPHYCAPCFG_MLSOSRSSVCC     ( BIT13 | BIT12 | BIT11 | BIT10 | BIT9 | BIT8 | BIT7 ) ///< MACPHY Lower SKP OS Reception Supported Speeds Vector Capability Configurations
+#define N_PCIE_MEM_MPHYCAPCFG_MLSOSRSSVCC     7
+
+#define R_PCIE_MEM_RPDEC1                     0x00001780U      ///< Reset Prep Decode 1
+#define B_PCIE_MEM_RPDEC1_RPWRERT             ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Reset Prep Warm Reset Encoding Reset Type
+#define N_PCIE_MEM_RPDEC1_RPWRERT             0
+#define B_PCIE_MEM_RPDEC1_RPWREPT             ( BIT15 | BIT14 | BIT13 | BIT12 | BIT11 | BIT10 | BIT9 | BIT8 ) ///< Reset Prep Warm Reset Encoding Prep Type
+#define N_PCIE_MEM_RPDEC1_RPWREPT             8
+#define B_PCIE_MEM_RPDEC1_RPCRERT             ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 | BIT17 | BIT16 ) ///< Reset Prep Cold Reset Encoding Reset Type
+#define N_PCIE_MEM_RPDEC1_RPCRERT             16
+#define B_PCIE_MEM_RPDEC1_RPCREPT             ( BIT31 | BIT30 | BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Reset Prep Cold Reset Encoding Prep Type
+#define N_PCIE_MEM_RPDEC1_RPCREPT             24
+
+#define R_PCIE_MEM_RPDEC2                     0x00001784U      ///< Reset Prep Decode 2
+#define B_PCIE_MEM_RPDEC2_RPS3ERT             ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Reset Prep S3 Encoding Reset Type
+#define N_PCIE_MEM_RPDEC2_RPS3ERT             0
+#define B_PCIE_MEM_RPDEC2_RPS3EPT             ( BIT15 | BIT14 | BIT13 | BIT12 | BIT11 | BIT10 | BIT9 | BIT8 ) ///< Reset Prep S3 Encoding Prep Type
+#define N_PCIE_MEM_RPDEC2_RPS3EPT             8
+#define B_PCIE_MEM_RPDEC2_RPS4ERT             ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 | BIT17 | BIT16 ) ///< Reset Prep S4 Encoding Reset Type
+#define N_PCIE_MEM_RPDEC2_RPS4ERT             16
+#define B_PCIE_MEM_RPDEC2_RPS4EPT             ( BIT31 | BIT30 | BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Reset Prep S4 Encoding Prep Type
+#define N_PCIE_MEM_RPDEC2_RPS4EPT             24
+
+#define R_PCIE_MEM_RPDEC3                     0x00001788U      ///< Reset Prep Decode 3
+#define B_PCIE_MEM_RPDEC3_RPS5ERT             ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Reset Prep S5 Encoding Reset Type
+#define N_PCIE_MEM_RPDEC3_RPS5ERT             0
+#define B_PCIE_MEM_RPDEC3_RPS5EPT             ( BIT15 | BIT14 | BIT13 | BIT12 | BIT11 | BIT10 | BIT9 | BIT8 ) ///< Reset Prep S5 Encoding Prep Type
+#define N_PCIE_MEM_RPDEC3_RPS5EPT             8
+#define B_PCIE_MEM_RPDEC3_RPDH                ( BIT18 | BIT17 | BIT16 ) ///< Reset Prep Default Handling
+#define N_PCIE_MEM_RPDEC3_RPDH                16
+
+#define R_PCIE_MEM_DECCTL                     0x00001904U      ///< Decoder Control
+#define B_PCIE_MEM_DECCTL_ATSCE               BIT0             ///< ATS Check Enable
+#define N_PCIE_MEM_DECCTL_ATSCE               0
+#define B_PCIE_MEM_DECCTL_BUSNUMZCHK          BIT1             ///< Bus Number Zero Check
+#define N_PCIE_MEM_DECCTL_BUSNUMZCHK          1
+#define B_PCIE_MEM_DECCTL_MTRXLTC             BIT2             ///< Malform Receive LT Cycle
+#define N_PCIE_MEM_DECCTL_MTRXLTC             2
+#define B_PCIE_MEM_DECCTL_OUTBEXPCPLCHKEN     BIT3             ///< Outbound Expected Completion Check Enable
+#define N_PCIE_MEM_DECCTL_OUTBEXPCPLCHKEN     3
+#define B_PCIE_MEM_DECCTL_DROPCPLATNZCE       BIT4             ///< Drop Completion for AT Not Zero Check Enable
+#define N_PCIE_MEM_DECCTL_DROPCPLATNZCE       4
+#define B_PCIE_MEM_DECCTL_LCRXINT             BIT6             ///< Local Consume Receive Interrupt
+#define N_PCIE_MEM_DECCTL_LCRXINT             6
+#define B_PCIE_MEM_DECCTL_VDMATAC             BIT7             ///< VDM Address Translation Attribute Check
+#define N_PCIE_MEM_DECCTL_VDMATAC             7
+#define B_PCIE_MEM_DECCTL_URVDME16DW          BIT8             ///< Unsupported Request VDM exceeding 16DW
+#define N_PCIE_MEM_DECCTL_URVDME16DW          8
+#define B_PCIE_MEM_DECCTL_URRXUVDMINTELVID    BIT9             ///< UR Received Unknown VDM from Intel Vendor ID
+#define N_PCIE_MEM_DECCTL_URRXUVDMINTELVID    9
+#define B_PCIE_MEM_DECCTL_URRXUVDMUVID        BIT10            ///< UR Received Unknown VDM from Unknown Vendor ID
+#define N_PCIE_MEM_DECCTL_URRXUVDMUVID        10
+#define B_PCIE_MEM_DECCTL_URRXURTRCVDM        BIT11            ///< UR Received Unknown Route To Root Complex VDM
+#define N_PCIE_MEM_DECCTL_URRXURTRCVDM        11
+#define B_PCIE_MEM_DECCTL_URRXULTVDM          BIT12            ///< UR Received Unknown Locally Terminated VDM
+#define N_PCIE_MEM_DECCTL_URRXULTVDM          12
+#define B_PCIE_MEM_DECCTL_URRXURAVDM          BIT13            ///< UR Received Unknown Routed by Address VDM
+#define N_PCIE_MEM_DECCTL_URRXURAVDM          13
+#define B_PCIE_MEM_DECCTL_URRXURIDVDM         BIT14            ///< UR Received Unknown Routed by ID VDM
+#define N_PCIE_MEM_DECCTL_URRXURIDVDM         14
+#define B_PCIE_MEM_DECCTL_URRXUORVDM          BIT15            ///< UR Received Unknown Other Routing VDM
+#define N_PCIE_MEM_DECCTL_URRXUORVDM          15
+#define B_PCIE_MEM_DECCTL_URRXVMCTPBFRC       BIT16            ///< UR Received Valid MCTP which is Broadcast From Root Complex
+#define N_PCIE_MEM_DECCTL_URRXVMCTPBFRC       16
+#define B_PCIE_MEM_DECCTL_ICHKINVREQRMSGRBID  BIT17            ///< Ignore checking Invalidate Request Message to be Routed by ID
+#define N_PCIE_MEM_DECCTL_ICHKINVREQRMSGRBID  17
+#define B_PCIE_MEM_DECCTL_RXMCTPDECEN         BIT18            ///< Receive MCTP Decode Enable
+#define N_PCIE_MEM_DECCTL_RXMCTPDECEN         18
+#define B_PCIE_MEM_DECCTL_RXVDMDECE           BIT19            ///< Receive VDMs Decode Enable
+#define N_PCIE_MEM_DECCTL_RXVDMDECE           19
+#define B_PCIE_MEM_DECCTL_RXGPEDECEN          BIT20            ///< Receive GPE Decode Enable
+#define N_PCIE_MEM_DECCTL_RXGPEDECEN          20
+#define B_PCIE_MEM_DECCTL_RXSBEMCAPDECEN      BIT21            ///< Receive SBEM_CAP Decode Enable
+#define N_PCIE_MEM_DECCTL_RXSBEMCAPDECEN      21
+#define B_PCIE_MEM_DECCTL_RXADLEDDECEN        BIT22            ///< Receive ASRT_LED/ DSRT_LED Decode Enable
+#define N_PCIE_MEM_DECCTL_RXADLEDDECEN        22
+#define B_PCIE_MEM_DECCTL_RXLTRMDECH          BIT23            ///< Receive LTR Message Decode Enable Handling
+#define N_PCIE_MEM_DECCTL_RXLTRMDECH          23
+#define B_PCIE_MEM_DECCTL_LCRXERRMSG          BIT24            ///< Local Consume Receive Error Message
+#define N_PCIE_MEM_DECCTL_LCRXERRMSG          24
+#define B_PCIE_MEM_DECCTL_LCRXPTMREQ          BIT26            ///< Local Consume Receive PTM_REQ
+#define N_PCIE_MEM_DECCTL_LCRXPTMREQ          26
+#define B_PCIE_MEM_DECCTL_URRXUVDMRBFRC       BIT27            ///< UR Received Unknown VDM Routed by Broadcast from Root Complex
+#define N_PCIE_MEM_DECCTL_URRXUVDMRBFRC       27
+#define B_PCIE_MEM_DECCTL_URRXUVDMRGRTRC      BIT28            ///< UR Received Unknown VDM Routed by Gather and Route to Root Complex
+#define N_PCIE_MEM_DECCTL_URRXUVDMRGRTRC      28
+#define B_PCIE_MEM_DECCTL_RXMCTPBRCDECEN      BIT29            ///< Receive MCTP Broadcast From Root Complex Decode Enable
+#define N_PCIE_MEM_DECCTL_RXMCTPBRCDECEN      29
+#define B_PCIE_MEM_DECCTL_URRXMCTPNTCO        BIT30            ///< UR Receive MCTP Not TC0
+#define N_PCIE_MEM_DECCTL_URRXMCTPNTCO        30
+#define B_PCIE_MEM_DECCTL_RXIMDECEN           BIT31            ///< Receive Invalidate Message Decode Enable
+#define N_PCIE_MEM_DECCTL_RXIMDECEN           31
+
+#define R_PCIE_MEM_PIDECCTL                   0x0000190cU      ///< Primary Interface Decoder Control
+#define B_PCIE_MEM_PIDECCTL_CPLBNCHK          BIT0             ///< Completion Bus Number Check
+#define N_PCIE_MEM_PIDECCTL_CPLBNCHK          0
+
+#define R_PCIE_MEM_PTMPSDC1                   0x00001920U      ///< PTM Pipe Stage Delay Configuration 1
+
+#define R_PCIE_MEM_PTMPSDC2                   0x00001924U      ///< PTM Pipe Stage Delay Configuration 2
+
+#define R_PCIE_MEM_PTMPSDC3                   0x00001928U      ///< PTM Pipe Stage Delay Configuration 3
+
+#define R_PCIE_MEM_PTMPSDC4                   0x0000192cU      ///< PTM Pipe Stage Delay Configuration 4
+
+#define R_PCIE_MEM_PTMPSDC5                   0x00001930U      ///< PTM Pipe Stage Delay Configuration 5
+
+#define R_PCIE_MEM_PTMPSDC6                   0x00001934U      ///< PTM Pipe Stage Delay Configuration 6
+
+#define R_PCIE_MEM_PTMPSDC9                   0x00001940U      ///< PTM Pipe Stage Delay Configuration 9
+
+#define R_PCIE_MEM_G5L0SCTL                   0x00001e00U      ///< GEN5 L0s Control
+#define B_PCIE_MEM_G5L0SCTL_G5CCNFTS          ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Gen5 Common Clock N_FTS
+#define N_PCIE_MEM_G5L0SCTL_G5CCNFTS          0
+#define B_PCIE_MEM_G5L0SCTL_G5UCNFTS          ( BIT15 | BIT14 | BIT13 | BIT12 | BIT11 | BIT10 | BIT9 | BIT8 ) ///< Gen5 Unique Clock N_FTS
+#define N_PCIE_MEM_G5L0SCTL_G5UCNFTS          8
+#define B_PCIE_MEM_G5L0SCTL_G5L0SIC           ( BIT23 | BIT22 ) ///< Gen5 L0s Entry Idle Control
+#define N_PCIE_MEM_G5L0SCTL_G5L0SIC           22
+#define B_PCIE_MEM_G5L0SCTL_G5ASL0SPL         ( BIT31 | BIT30 | BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Gen5Active State L0s Preparation Latency
+#define N_PCIE_MEM_G5L0SCTL_G5ASL0SPL         24
+
+#define R_PCIE_MEM_PX32EQCFG1                 0x00001e04U      ///< 32GT/s Equalization Configuration 1
+#define B_PCIE_MEM_PX32EQCFG1_PX32GMFLNTL     BIT0             ///< 32.0 GT/s Multi-Fragment Linear and Nine-Tile List Enable
+#define N_PCIE_MEM_PX32EQCFG1_PX32GMFLNTL     0
+#define B_PCIE_MEM_PX32EQCFG1_PX32GMEQSMMFLNTL BIT1             ///< 32.0 GT/s Multi-EQ Search Mode, Multi fragment linear and nine tile list Enable
+#define N_PCIE_MEM_PX32EQCFG1_PX32GMEQSMMFLNTL 1
+#define B_PCIE_MEM_PX32EQCFG1_PX32GHAPCCPIE   BIT2             ///< 32.0 GT/s Hardware Autonomous Preset/Coefficient Count Per-Iteration Extention
+#define N_PCIE_MEM_PX32EQCFG1_PX32GHAPCCPIE   2
+#define B_PCIE_MEM_PX32EQCFG1_PX32GHAPCCPI    ( BIT6 | BIT5 | BIT4 | BIT3 ) ///< 32.0 GT/s Hardware Autonomous Preset/Coefficient Count Per-Iteration
+#define N_PCIE_MEM_PX32EQCFG1_PX32GHAPCCPI    3
+#define B_PCIE_MEM_PX32EQCFG1_PX32GEQTS2IRRC  BIT7             ///< 32.0 GT/s EQ TS2 in Recovery.ReceiverConfig Enable
+#define N_PCIE_MEM_PX32EQCFG1_PX32GEQTS2IRRC  7
+#define B_PCIE_MEM_PX32EQCFG1_PX32GRWTNEVE    ( BIT11 | BIT10 | BIT9 | BIT8 ) ///< 32.0 GT/s  Receiver Wait Time For New Equalization Value Evaluation
+#define N_PCIE_MEM_PX32EQCFG1_PX32GRWTNEVE    8
+#define B_PCIE_MEM_PX32EQCFG1_PX32GHAED       BIT12            ///< 32.0 GT/s Hardware Autonomous Equalization Done
+#define N_PCIE_MEM_PX32EQCFG1_PX32GHAED       12
+#define B_PCIE_MEM_PX32EQCFG1_PX32GRTPCOE     BIT15            ///< 32.0 GT/s Remote Transmitter Preset Coefficient Override Enable
+#define N_PCIE_MEM_PX32EQCFG1_PX32GRTPCOE     15
+#define B_PCIE_MEM_PX32EQCFG1_PX32GRTLEPCEB   BIT16            ///< 32.0 GT/s Remote Transmit Link Equalization Preset/Coefficient Evaluation Bypass
+#define N_PCIE_MEM_PX32EQCFG1_PX32GRTLEPCEB   16
+#define B_PCIE_MEM_PX32EQCFG1_PX32GLEP3B      BIT17            ///< 32.0 GT/s Link Equalization 3 Bypass
+#define N_PCIE_MEM_PX32EQCFG1_PX32GLEP3B      17
+#define B_PCIE_MEM_PX32EQCFG1_PX32GLEP23B     BIT18            ///< 32.0 GT/s Link Equalization Phase 2 and 3 Bypass
+#define N_PCIE_MEM_PX32EQCFG1_PX32GLEP23B     18
+#define B_PCIE_MEM_PX32EQCFG1_PX32GREIC       BIT20            ///< 32.0GT/s Reset EIEOS Interval Count
+#define N_PCIE_MEM_PX32EQCFG1_PX32GREIC       20
+#define B_PCIE_MEM_PX32EQCFG1_PX32GTSWLPCE    ( BIT29 | BIT28 | BIT27 ) ///< 32.0GT/s Training Sequence Wait Latency For Presets / Coefficients Evaluation
+#define N_PCIE_MEM_PX32EQCFG1_PX32GTSWLPCE    27
+
+#define R_PCIE_MEM_PX32GRTPCL1                0x00001e08U      ///< 32 GT/s Remote Transmitter Preset Coefficient List 1
+#define B_PCIE_MEM_PX32GRTPCL1_RTPRECL0PL0    ( BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Remote Transmitter Pre-Cursor Coefficient List 0/Preset List 0
+#define N_PCIE_MEM_PX32GRTPCL1_RTPRECL0PL0    0
+#define B_PCIE_MEM_PX32GRTPCL1_RTPOSTCL0PL1   ( BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 ) ///< Remote Transmitter Post-Cursor Coefficient List 0/Preset List 1
+#define N_PCIE_MEM_PX32GRTPCL1_RTPOSTCL0PL1   6
+#define B_PCIE_MEM_PX32GRTPCL1_RTPRECL1PL2    ( BIT17 | BIT16 | BIT15 | BIT14 | BIT13 | BIT12 ) ///< Remote Transmitter Pre-Cursor Coefficient List 1/Preset List 2
+#define N_PCIE_MEM_PX32GRTPCL1_RTPRECL1PL2    12
+#define B_PCIE_MEM_PX32GRTPCL1_RTPOSTCL1PL3   ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 ) ///< Remote Transmitter Post-Cursor Coefficient List 1/Preset List 3
+#define N_PCIE_MEM_PX32GRTPCL1_RTPOSTCL1PL3   18
+#define B_PCIE_MEM_PX32GRTPCL1_RTPRECL2PL4    ( BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Remote Transmitter Pre-Cursor Coefficient List 2/Preset List 4
+#define N_PCIE_MEM_PX32GRTPCL1_RTPRECL2PL4    24
+#define B_PCIE_MEM_PX32GRTPCL1_PCM            BIT31            ///< Preset/Coefficient Mode
+#define N_PCIE_MEM_PX32GRTPCL1_PCM            31
+
+#define R_PCIE_MEM_PX32EQCFG2                 0x00001e24U      ///< 32GT/s Equalization Configuration 2
+#define B_PCIE_MEM_PX32EQCFG2_REWMET          ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Receiver Eye Margin Error Threshold
+#define N_PCIE_MEM_PX32EQCFG2_REWMET          0
+#define B_PCIE_MEM_PX32EQCFG2_REWMETM         ( BIT9 | BIT8 )  ///< Receiver Eye Margin Error Threshold Multiplier
+#define N_PCIE_MEM_PX32EQCFG2_REWMETM         8
+#define B_PCIE_MEM_PX32EQCFG2_MPEME           BIT10            ///< Mid-Point Equalization Mechanism Enable
+#define N_PCIE_MEM_PX32EQCFG2_MPEME           10
+#define B_PCIE_MEM_PX32EQCFG2_NTEME           BIT11            ///< Nine-Tiles Equalization Mechanism Enable
+#define N_PCIE_MEM_PX32EQCFG2_NTEME           11
+#define B_PCIE_MEM_PX32EQCFG2_HAPCSB          ( BIT15 | BIT14 | BIT13 | BIT12 ) ///< Hardware Autonomous Preset/Coefficient Search Bound
+#define N_PCIE_MEM_PX32EQCFG2_HAPCSB          12
+#define B_PCIE_MEM_PX32EQCFG2_PCET            ( BIT19 | BIT18 | BIT17 | BIT16 ) ///< Preset/Coefficient Evaluation Timeout
+#define N_PCIE_MEM_PX32EQCFG2_PCET            16
+#define B_PCIE_MEM_PX32EQCFG2_NTSS            ( BIT22 | BIT21 | BIT20 ) ///< Nine-Tiles Step Size
+#define N_PCIE_MEM_PX32EQCFG2_NTSS            20
+#define B_PCIE_MEM_PX32EQCFG2_EMD             BIT23            ///< Equalization Margining Disable
+#define N_PCIE_MEM_PX32EQCFG2_EMD             23
+#define B_PCIE_MEM_PX32EQCFG2_NTIC            ( BIT31 | BIT30 | BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Nine-Tiles Iteration Count
+#define N_PCIE_MEM_PX32EQCFG2_NTIC            24
+
+#define R_PCIE_MEM_PX32GP0P1PCM               0x00001e28U      ///< 32.0 GT/s P0 And P1 Preset-Coefficient Mapping
+
+#define R_PCIE_MEM_PX32GP1P2P3PCM             0x00001e2cU      ///< 32.0 GT/s P1, P2 And P3 Preset-Coefficient Mapping
+
+#define R_PCIE_MEM_PX32GP3P4PCM               0x00001e30U      ///< 32.0 GT/s P3 And P4 Preset-Coefficient Mapping
+
+#define R_PCIE_MEM_PX32GP5P6PCM               0x00001e34U      ///< 32.0 GT/s P5 And P6 Preset-Coefficient Mapping
+
+#define R_PCIE_MEM_PX32GP6P7P8PCM             0x00001e38U      ///< 32.0 GT/s P6, P7 And P8 Preset-Coefficient Mapping
+
+#define R_PCIE_MEM_PX32GP8P9PCM               0x00001e3cU      ///< 32.0 GT/s P8 And P9 Preset-Coefficient Mapping
+
+#define R_PCIE_MEM_PX32GP10PCM                0x00001e40U      ///< 32.0 GT/s P10 Preset-Coefficient Mapping
+
+#define R_PCIE_MEM_PX32GLFFS                  0x00001e44U      ///< 32.0 GT/s LF And FS
+
+#define R_PCIE_MEM_PX32GLTCO1                 0x00001e48U      ///< 32 GT/s Local Transmitter Coefficient Override 1
+#define B_PCIE_MEM_PX32GLTCO1_L0TPRECO        ( BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Lane 0 Transmitter Pre-Cursor Coefficient Override
+#define N_PCIE_MEM_PX32GLTCO1_L0TPRECO        0
+#define B_PCIE_MEM_PX32GLTCO1_L0TPOSTCO       ( BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 ) ///< Lane 0 Transmitter Post-Cursor Coefficient Override
+#define N_PCIE_MEM_PX32GLTCO1_L0TPOSTCO       6
+#define B_PCIE_MEM_PX32GLTCO1_L1TPRECO        ( BIT17 | BIT16 | BIT15 | BIT14 | BIT13 | BIT12 ) ///< Lane 1 Transmitter Pre-Cursor Coefficient Override
+#define N_PCIE_MEM_PX32GLTCO1_L1TPRECO        12
+#define B_PCIE_MEM_PX32GLTCO1_L1TPOSTCO       ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 ) ///< Lane 1 Transmitter Post-Cursor Coefficient Override
+#define N_PCIE_MEM_PX32GLTCO1_L1TPOSTCO       18
+#define B_PCIE_MEM_PX32GLTCO1_L0TCOE          BIT24            ///< Lane 0 Transmitter Coefficient Override Enable
+#define N_PCIE_MEM_PX32GLTCO1_L0TCOE          24
+#define B_PCIE_MEM_PX32GLTCO1_L1TCOE          BIT25            ///< Lane 1 Transmitter Coefficient Override Enable
+#define N_PCIE_MEM_PX32GLTCO1_L1TCOE          25
+
+#define R_PCIE_MEM_PX32GLTCO2                 0x00001e4CU      ///< 32 GT/s Local Transmitter Coefficient Override 2
+#define B_PCIE_MEM_PX32GLTCO2_L2TPRECO        ( BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Lane 2 Transmitter Pre-Cursor Coefficient Override
+#define N_PCIE_MEM_PX32GLTCO2_L2TPRECO        0
+#define B_PCIE_MEM_PX32GLTCO2_L2TPOSTCO       ( BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 ) ///< Lane 2 Transmitter Post-Cursor Coefficient Override
+#define N_PCIE_MEM_PX32GLTCO2_L2TPOSTCO       6
+#define B_PCIE_MEM_PX32GLTCO2_L3TPRECO        ( BIT17 | BIT16 | BIT15 | BIT14 | BIT13 | BIT12 ) ///< Lane 3 Transmitter Pre-Cursor Coefficient Override
+#define N_PCIE_MEM_PX32GLTCO2_L3TPRECO        12
+#define B_PCIE_MEM_PX32GLTCO2_L3TPOSTCO       ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 ) ///< Lane 3 Transmitter Post-Cursor Coefficient Override
+#define N_PCIE_MEM_PX32GLTCO2_L3TPOSTCO       18
+#define B_PCIE_MEM_PX32GLTCO2_L2TCOE          BIT24            ///< Lane 2 Transmitter Coefficient Override Enable
+#define N_PCIE_MEM_PX32GLTCO2_L2TCOE          24
+#define B_PCIE_MEM_PX32GLTCO2_L3TCOE          BIT25            ///< Lane 3 Transmitter Coefficient Override Enable
+#define N_PCIE_MEM_PX32GLTCO2_L3TCOE          25
+
+#define R_PCIE_MEM_PX32GLTCO3                 0x00001e50U      ///< 32 GT/s Local Transmitter Coefficient Override 3
+#define B_PCIE_MEM_PX32GLTCO3_L4TPRECO        ( BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Lane 4 Transmitter Pre-Cursor Coefficient Override
+#define N_PCIE_MEM_PX32GLTCO3_L4TPRECO        0
+#define B_PCIE_MEM_PX32GLTCO3_L4TPOSTCO       ( BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 ) ///< Lane 4 Transmitter Post-Cursor Coefficient Override
+#define N_PCIE_MEM_PX32GLTCO3_L4TPOSTCO       6
+#define B_PCIE_MEM_PX32GLTCO3_L5TPRECO        ( BIT17 | BIT16 | BIT15 | BIT14 | BIT13 | BIT12 ) ///< Lane 5 Transmitter Pre-Cursor Coefficient Override
+#define N_PCIE_MEM_PX32GLTCO3_L5TPRECO        12
+#define B_PCIE_MEM_PX32GLTCO3_L5TPOSTCO       ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 ) ///< Lane 5 Transmitter Post-Cursor Coefficient Override
+#define N_PCIE_MEM_PX32GLTCO3_L5TPOSTCO       18
+#define B_PCIE_MEM_PX32GLTCO3_L4TCOE          BIT24            ///< Lane 4 Transmitter Coefficient Override Enable
+#define N_PCIE_MEM_PX32GLTCO3_L4TCOE          24
+#define B_PCIE_MEM_PX32GLTCO3_L5TCOE          BIT25            ///< Lane 5 Transmitter Coefficient Override Enable
+#define N_PCIE_MEM_PX32GLTCO3_L5TCOE          25
+
+#define R_PCIE_MEM_PX32GLTCO4                 0x00001e54U      ///< 32 GT/s Local Transmitter Coefficient Override 3
+#define B_PCIE_MEM_PX32GLTCO4_L6TPRECO        ( BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Lane 6 Transmitter Pre-Cursor Coefficient Override
+#define N_PCIE_MEM_PX32GLTCO4_L6TPRECO        0
+#define B_PCIE_MEM_PX32GLTCO4_L6TPOSTCO       ( BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 ) ///< Lane 6 Transmitter Post-Cursor Coefficient Override
+#define N_PCIE_MEM_PX32GLTCO4_L6TPOSTCO       6
+#define B_PCIE_MEM_PX32GLTCO4_L7TPRECO        ( BIT17 | BIT16 | BIT15 | BIT14 | BIT13 | BIT12 ) ///< Lane 7 Transmitter Pre-Cursor Coefficient Override
+#define N_PCIE_MEM_PX32GLTCO4_L7TPRECO        12
+#define B_PCIE_MEM_PX32GLTCO4_L7TPOSTCO       ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 ) ///< Lane 7 Transmitter Post-Cursor Coefficient Override
+#define N_PCIE_MEM_PX32GLTCO4_L7TPOSTCO       18
+#define B_PCIE_MEM_PX32GLTCO4_L6TCOE          BIT24            ///< Lane 6 Transmitter Coefficient Override Enable
+#define N_PCIE_MEM_PX32GLTCO4_L6TCOE          24
+#define B_PCIE_MEM_PX32GLTCO4_L7TCOE          BIT25            ///< Lane 7 Transmitter Coefficient Override Enable
+#define N_PCIE_MEM_PX32GLTCO4_L7TCOE          25
+
+#define R_PCIE_CFG_CMD                        0x00000004U      ///< Device Command
+#define B_PCIE_CFG_CMD_SEE                    BIT8             ///< SERR Enable
+#define N_PCIE_CFG_CMD_SEE                    8
+
+#define R_PCIE_CFG_BAR0                       0x00000010U      ///< Base Address Register 0
+#define B_PCIE_CFG_BAR0_MMT                   ( BIT2 | BIT1 )  ///< Memory Mapping Type
+#define N_PCIE_CFG_BAR0_MMT                   1
+#define V_PCIE_CFG_BAR0_MMT                   0x2
+#define B_PCIE_CFG_BAR0_P                     BIT3             ///< Prefetchable Memory
+#define N_PCIE_CFG_BAR0_P                     3
+
+#define R_PCIE_CFG_CAPP                       0x00000034U      ///< Capabilities List Pointer
+#define B_PCIE_CFG_CAPP_PTR                   ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Capabilities Pointer
+#define N_PCIE_CFG_CAPP_PTR                   0
+
+#define R_PCIE_CFG_BCTRL                      0x0000003eU      ///< Bridge Control
+#define B_PCIE_CFG_BCTRL_SE                   BIT1             ///< SERR Enable
+#define N_PCIE_CFG_BCTRL_SE                   1
+
+#define R_PCIE_CFG_CLIST                      0x00000040U      ///< Capabilities List
+#define B_PCIE_CFG_CLIST_CID                  ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Capability ID
+#define N_PCIE_CFG_CLIST_CID                  0
+#define B_PCIE_CFG_CLIST_NEXT                 ( BIT15 | BIT14 | BIT13 | BIT12 | BIT11 | BIT10 | BIT9 | BIT8 ) ///< Next Capability
+#define N_PCIE_CFG_CLIST_NEXT                 8
+
+#define R_PCIE_CFG_XCAP                       0x00000042U      ///< PCI Express Capabilities
+#define B_PCIE_CFG_XCAP_CV                    ( BIT3 | BIT2 | BIT1 | BIT0 ) ///< Capability Version
+#define N_PCIE_CFG_XCAP_CV                    0
+#define B_PCIE_CFG_XCAP_DT                    ( BIT7 | BIT6 | BIT5 | BIT4 ) ///< Device / Port Type
+#define N_PCIE_CFG_XCAP_DT                    4
+#define B_PCIE_CFG_XCAP_SI                    BIT8             ///< Slot Implemented
+#define N_PCIE_CFG_XCAP_SI                    8
+#define B_PCIE_CFG_XCAP_IMN                   ( BIT13 | BIT12 | BIT11 | BIT10 | BIT9 ) ///< Interrupt Message Number
+#define N_PCIE_CFG_XCAP_IMN                   9
+
+#define R_PCIE_CFG_DCAP                       0x00000044U      ///< Device Capabilities
+#define B_PCIE_CFG_DCAP_MPS                   ( BIT2 | BIT1 | BIT0 ) ///< Max Payload Size Supported
+#define N_PCIE_CFG_DCAP_MPS                   0
+
+#define R_PCIE_CFG_DCTL                       0x00000048U      ///< Device Control
+#define B_PCIE_CFG_DCTL_CEE                   BIT0             ///< Correctable Error Reporting Enable
+#define N_PCIE_CFG_DCTL_CEE                   0
+#define B_PCIE_CFG_DCTL_NFE                   BIT1             ///< Non-Fatal Error Reporting Enable
+#define N_PCIE_CFG_DCTL_NFE                   1
+#define B_PCIE_CFG_DCTL_FEE                   BIT2             ///< Fatal Error Reporting Enable
+#define N_PCIE_CFG_DCTL_FEE                   2
+#define B_PCIE_CFG_DCTL_URE                   BIT3             ///< Unsupported Request Reporting Enable
+#define N_PCIE_CFG_DCTL_URE                   3
+#define B_PCIE_CFG_DCTL_ERO                   BIT4             ///< Enable Relaxed Ordering
+#define N_PCIE_CFG_DCTL_ERO                   4
+#define B_PCIE_CFG_DCTL_MPS                   ( BIT7 | BIT6 | BIT5 ) ///< Max Payload Size
+#define N_PCIE_CFG_DCTL_MPS                   5
+#define B_PCIE_CFG_DCTL_MRRS                  ( BIT14 | BIT13 | BIT12 ) ///< Max Read Request Size
+#define N_PCIE_CFG_DCTL_MRRS                  12
+
+#define R_PCIE_CFG_DSTS                       0x0000004aU      ///< Device Status
+
+#define R_PCIE_CFG_LCAP                       0x0000004cU      ///< Link Capabilities
+#define B_PCIE_CFG_LCAP_MLS                   ( BIT3 | BIT2 | BIT1 | BIT0 ) ///< Max Link Speed
+#define N_PCIE_CFG_LCAP_MLS                   0
+#define B_PCIE_CFG_LCAP_MLW                   ( BIT9 | BIT8 | BIT7 | BIT6 | BIT5 | BIT4 ) ///< Maximum Link Width
+#define N_PCIE_CFG_LCAP_MLW                   4
+#define B_PCIE_CFG_LCAP_APMS                  ( BIT11 | BIT10 ) ///< Active State Link PM Support
+#define N_PCIE_CFG_LCAP_APMS                  10
+#define B_PCIE_CFG_LCAP_EL0                   ( BIT14 | BIT13 | BIT12 ) ///< L0s Exit Latency
+#define N_PCIE_CFG_LCAP_EL0                   12
+#define B_PCIE_CFG_LCAP_EL1                   ( BIT17 | BIT16 | BIT15 ) ///< L1 Exit Latency
+#define N_PCIE_CFG_LCAP_EL1                   15
+#define B_PCIE_CFG_LCAP_ASPMOC                BIT22            ///< ASPM Optionality Compliance
+#define N_PCIE_CFG_LCAP_ASPMOC                22
+#define B_PCIE_CFG_LCAP_PN                    ( BIT31 | BIT30 | BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Port Number
+#define N_PCIE_CFG_LCAP_PN                    24
+
+#define R_PCIE_CFG_LCTL                       0x00000050U      ///< Link Control
+#define B_PCIE_CFG_LCTL_ASPM                  ( BIT1 | BIT0 )  ///< Active State Link PM Control
+#define N_PCIE_CFG_LCTL_ASPM                  0
+#define B_PCIE_CFG_LCTL_LD                    BIT4             ///< Link Disable
+#define N_PCIE_CFG_LCTL_LD                    4
+#define B_PCIE_CFG_LCTL_RL                    BIT5             ///< Retrain Link
+#define N_PCIE_CFG_LCTL_RL                    5
+#define B_PCIE_CFG_LCTL_CCC                   BIT6             ///< Common Clock Configuration
+#define N_PCIE_CFG_LCTL_CCC                   6
+
+#define R_PCIE_CFG_LSTS                       0x00000052U      ///< Link Status
+#define B_PCIE_CFG_LSTS_CLS                   ( BIT3 | BIT2 | BIT1 | BIT0 ) ///< Current Link Speed
+#define N_PCIE_CFG_LSTS_CLS                   0
+#define B_PCIE_CFG_LSTS_NLW                   ( BIT9 | BIT8 | BIT7 | BIT6 | BIT5 | BIT4 ) ///< Negotiated Link Width
+#define N_PCIE_CFG_LSTS_NLW                   4
+#define B_PCIE_CFG_LSTS_LT                    BIT11            ///< Link Training
+#define N_PCIE_CFG_LSTS_LT                    11
+#define B_PCIE_CFG_LSTS_SCC                   BIT12            ///< Slot Clock Configuration
+#define N_PCIE_CFG_LSTS_SCC                   12
+#define B_PCIE_CFG_LSTS_LA                    BIT13            ///< Link Active
+#define N_PCIE_CFG_LSTS_LA                    13
+
+#define R_PCIE_CFG_SLCAP                      0x00000054U      ///< Slot Capabilities
+
+#define R_PCIE_CFG_SLCTL                      0x00000058U      ///< Slot Control
+
+#define R_PCIE_CFG_SLSTS                      0x0000005aU      ///< Slot Status
+
+#define R_PCIE_CFG_RCTL                       0x0000005cU      ///< Root Control
+#define B_PCIE_CFG_RCTL_CRSSVE                BIT4             ///< CRS Software Visibility Enable
+#define N_PCIE_CFG_RCTL_CRSSVE                4
+
+#define R_PCIE_CFG_RSTS                       0x00000060U      ///< Root Status
+
+#define R_PCIE_CFG_DCAP2                      0x00000064U      ///< Device Capabilities 2
+#define B_PCIE_CFG_DCAP2_ARS                  BIT6             ///< Atomic Routing Supported
+#define N_PCIE_CFG_DCAP2_ARS                  6
+#define B_PCIE_CFG_DCAP2_AC32BS               BIT7             ///< AtomicOp Completer 32-bit Supported
+#define N_PCIE_CFG_DCAP2_AC32BS               7
+#define B_PCIE_CFG_DCAP2_AC64BS               BIT8             ///< AtomicOp Completer 64-bit Supported
+#define N_PCIE_CFG_DCAP2_AC64BS               8
+#define B_PCIE_CFG_DCAP2_AC128BS              BIT9             ///< CAS Completer 128-bit Supported
+#define N_PCIE_CFG_DCAP2_AC128BS              9
+#define B_PCIE_CFG_DCAP2_LTRMS                BIT11            ///< LTR Mechanism Supported
+#define N_PCIE_CFG_DCAP2_LTRMS                11
+#define B_PCIE_CFG_DCAP2_PX10BTCS             BIT16            ///< 10-Bit Tag Completer Supported
+#define N_PCIE_CFG_DCAP2_PX10BTCS             16
+#define B_PCIE_CFG_DCAP2_PX10BTRS             BIT17            ///< 10-Bit Tag Requester Supported
+#define N_PCIE_CFG_DCAP2_PX10BTRS             17
+#define B_PCIE_CFG_DCAP2_OBFFS                ( BIT19 | BIT18 ) ///< Optimized Buffer Flush/Fill Supported
+#define N_PCIE_CFG_DCAP2_OBFFS                18
+#define B_PCIE_CFG_DCAP2_EFFS                 BIT20
+#define N_PCIE_CFG_DCAP2_EFFS                 20
+
+#define R_PCIE_CFG_DCTL2                      0x00000068U      ///< Device Control 2
+#define B_PCIE_CFG_DCTL2_CTD                  BIT4             ///< Completion Timeout Disable
+#define N_PCIE_CFG_DCTL2_CTD                  4
+#define B_PCIE_CFG_DCTL2_AFE                  BIT5             ///< ARI Forwarding Enable
+#define N_PCIE_CFG_DCTL2_AFE                  5
+#define B_PCIE_CFG_DCTL2_ARE                  BIT6             ///< AtomicOp Requester Enable
+#define N_PCIE_CFG_DCTL2_ARE                  6
+#define B_PCIE_CFG_DCTL2_AEB                  BIT7             ///< AtomicOp Egress Blocking
+#define N_PCIE_CFG_DCTL2_AEB                  7
+#define B_PCIE_CFG_DCTL2_LTREN                BIT10
+#define B_PCIE_CFG_DCTL2_PX10BTRE             BIT12            ///< 10-Bit Tag Requester Enable
+#define N_PCIE_CFG_DCTL2_PX10BTRE             12
+
+#define R_PCIE_CFG_LCAP2                      0x0000006cU      ///< Link Capabilities 2
+#define B_PCIE_CFG_LCAP2_SLSV                 ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 ) ///< Supported Link Speeds Vector
+
+#define R_PCIE_CFG_LCTL2                      0x00000070U      ///< Link Control 2
+#define B_PCIE_CFG_LCTL2_TLS                  ( BIT3 | BIT2 | BIT1 | BIT0 ) ///< Target Link Speed
+#define N_PCIE_CFG_LCTL2_TLS                  0
+
+#define R_PCIE_CFG_LSTS2                      0x00000072U      ///< Link Status 2
+#define B_PCIE_CFG_LSTS2_EQP3S                BIT4             ///< Equalization Phase 3 Successful
+#define N_PCIE_CFG_LSTS2_EQP3S                4
+
+#define R_PCIE_CFG_MID                        0x00000080U      ///< Message Signaled Interrupt Identifiers
+#define B_PCIE_CFG_MID_CID                    ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Capability ID
+#define N_PCIE_CFG_MID_CID                    0
+#define B_PCIE_CFG_MID_NEXT                   ( BIT15 | BIT14 | BIT13 | BIT12 | BIT11 | BIT10 | BIT9 | BIT8 ) ///< Next Pointer
+#define N_PCIE_CFG_MID_NEXT                   8
+
+#define R_PCIE_CFG_MC                         0x00000082U      ///< Message Signaled Interrupt Message
+
+#define R_PCIE_CFG_MA                         0x00000084U      ///< Message Signaled Interrupt Message Address
+
+#define R_PCIE_CFG_MD                         0x0000008cU      ///< Message Signaled Interrupt Message Data
+
+#define R_PCIE_CFG_SVCAP                      0x00000098U      ///< Subsystem Vendor Capability
+#define B_PCIE_CFG_SVCAP_CID                  ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Capability Identifier
+#define N_PCIE_CFG_SVCAP_CID                  0
+#define B_PCIE_CFG_SVCAP_NEXT                 ( BIT15 | BIT14 | BIT13 | BIT12 | BIT11 | BIT10 | BIT9 | BIT8 ) ///< Next Capability
+#define N_PCIE_CFG_SVCAP_NEXT                 8
+
+#define R_PCIE_CFG_SVID                       0x0000009cU      ///< Subsystem Vendor IDs
+
+#define R_PCIE_CFG_PMCAP                      0x000000a0U      ///< Power Management Capability
+#define B_PCIE_CFG_PMCAP_CID                  ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Capability Identifier
+#define N_PCIE_CFG_PMCAP_CID                  0
+#define B_PCIE_CFG_PMCAP_NEXT                 ( BIT15 | BIT14 | BIT13 | BIT12 | BIT11 | BIT10 | BIT9 | BIT8 ) ///< Next Capability
+#define N_PCIE_CFG_PMCAP_NEXT                 8
+
+#define R_PCIE_CFG_PMCS                       0x000000a4U      ///< PCI Power Management Control
+
+#define R_PCIE_CFG_CCFG                       0x000000d0U      ///< Channel Configuration
+#define B_PCIE_CFG_CCFG_UPRS                  ( BIT2 | BIT1 | BIT0 ) ///< Upstream Posted Request Size
+#define N_PCIE_CFG_CCFG_UPRS                  0
+#define B_PCIE_CFG_CCFG_UNRS                  ( BIT6 | BIT5 | BIT4 ) ///< Upstream Non-Posted Request Size
+#define N_PCIE_CFG_CCFG_UNRS                  4
+#define B_PCIE_CFG_CCFG_UNRD                  ( BIT13 | BIT12 ) ///< Upstream Non-Posted Request Delay
+#define N_PCIE_CFG_CCFG_UNRD                  12
+#define B_PCIE_CFG_CCFG_DCGEISMA              BIT15            ///< Dynamic Clock Gating Enable on ISM Active
+#define N_PCIE_CFG_CCFG_DCGEISMA              15
+#define B_PCIE_CFG_CCFG_NPAP                  BIT16            ///< Non-Posted Pre-Allocation Policy
+#define N_PCIE_CFG_CCFG_NPAP                  16
+#define B_PCIE_CFG_CCFG_UNSD                  BIT23            ///< Upstream Non-Posted Split Disable
+#define N_PCIE_CFG_CCFG_UNSD                  23
+#define B_PCIE_CFG_CCFG_UPSD                  BIT24            ///< Upstream Posted Split Disable
+#define N_PCIE_CFG_CCFG_UPSD                  24
+#define B_PCIE_CFG_CCFG_UPMWPD                BIT25            ///< Upstream Posted Memory Write Peer Disable
+#define N_PCIE_CFG_CCFG_UPMWPD                25
+#define B_PCIE_CFG_CCFG_UMRPD                 BIT26            ///< Upstream Memory Read Peer Disable
+#define N_PCIE_CFG_CCFG_UMRPD                 26
+#define B_PCIE_CFG_CCFG_IORE                  BIT30            ///< I/O Receive Enabled
+#define N_PCIE_CFG_CCFG_IORE                  30
+#define B_PCIE_CFG_CCFG_CRE                   BIT31            ///< Config Receive Enabled
+#define N_PCIE_CFG_CCFG_CRE                   31
+
+#define R_PCIE_CFG_MPC2                       0x000000d4U      ///< Miscellaneous Port Configuration 2
+#define B_PCIE_CFG_MPC2_EOIFD                 BIT1             ///< EOI Forwarding Disable
+#define N_PCIE_CFG_MPC2_EOIFD                 1
+#define B_PCIE_CFG_MPC2_ASPMCO                ( BIT3 | BIT2 )  ///< ASPM Control Override
+#define N_PCIE_CFG_MPC2_ASPMCO                2
+#define B_PCIE_CFG_MPC2_ASPMCOEN              BIT4             ///< ASPM Control Override Enable
+#define N_PCIE_CFG_MPC2_ASPMCOEN              4
+#define B_PCIE_CFG_MPC2_IEIME                 BIT5             ///< Infer Electrical Idle Mechanism Enable
+#define N_PCIE_CFG_MPC2_IEIME                 5
+#define B_PCIE_CFG_MPC2_LSTP                  BIT6             ///< Link Speed Training Policy
+#define N_PCIE_CFG_MPC2_LSTP                  6
+#define B_PCIE_CFG_MPC2_CAM                   BIT8             ///< Credit Allocated Update Mode
+#define N_PCIE_CFG_MPC2_CAM                   8
+#define B_PCIE_CFG_MPC2_TLPF                  BIT9             ///< Transaction Layer Packet Fast Transmit Mode
+#define N_PCIE_CFG_MPC2_TLPF                  9
+#define B_PCIE_CFG_MPC2_PTNFAE                BIT12            ///< Poisoned TLP Non-Fatal Advisory Error Enable
+#define N_PCIE_CFG_MPC2_PTNFAE                12
+#define B_PCIE_CFG_MPC2_ORCE                  ( BIT15 | BIT14 ) ///< Offset Re-Calibration Enable
+#define N_PCIE_CFG_MPC2_ORCE                  14
+#define B_PCIE_CFG_MPC2_DISPLLEWL1SE          BIT16            ///< Disable PLL Early Wake on L1 Substate Exit
+#define N_PCIE_CFG_MPC2_DISPLLEWL1SE          16
+#define B_PCIE_CFG_MPC2_GEN3PLLC              BIT20            ///< Reserved
+#define N_PCIE_CFG_MPC2_GEN3PLLC              20
+#define B_PCIE_CFG_MPC2_GEN2PLLC              BIT21            ///< Reserved
+#define N_PCIE_CFG_MPC2_GEN2PLLC              21
+#define B_PCIE_CFG_MPC2_RUD                   BIT23            ///< Reserved
+#define N_PCIE_CFG_MPC2_RUD                   23
+#define B_PCIE_CFG_MPC2_PLLWAIT               ( BIT26 | BIT25 | BIT24 ) ///< PLL Wait
+#define N_PCIE_CFG_MPC2_PLLWAIT               24
+#define B_PCIE_CFG_MPC2_L1SSESE               BIT30            ///< L1 Substate Exit SCI Enable
+#define N_PCIE_CFG_MPC2_L1SSESE               30
+
+#define R_PCIE_CFG_MPC                        0x000000d8U      ///< Miscellaneous Port Configuration
+#define B_PCIE_CFG_MPC_PMME                   BIT0             ///< Power Management SMI Enable
+#define N_PCIE_CFG_MPC_PMME                   0
+#define B_PCIE_CFG_MPC_HPME                   BIT1             ///< Hot Plug SMI Enable
+#define N_PCIE_CFG_MPC_HPME                   1
+#define B_PCIE_CFG_MPC_BT                     BIT2             ///< Bridge Type
+#define N_PCIE_CFG_MPC_BT                     2
+#define B_PCIE_CFG_MPC_MCTPSE                 BIT3             ///< MCTP Support Enable
+#define N_PCIE_CFG_MPC_MCTPSE                 3
+#define B_PCIE_CFG_MPC_FCP                    ( BIT6 | BIT5 | BIT4 ) ///< Flow Control Update Policy
+#define N_PCIE_CFG_MPC_FCP                    4
+#define B_PCIE_CFG_MPC_PCIESD                 ( BIT14 | BIT13 | BIT12 ) ///< PCIe Speed Disable
+#define N_PCIE_CFG_MPC_PCIESD                 12
+#define B_PCIE_CFG_MPC_CCEL                   ( BIT17 | BIT16 | BIT15 ) ///< Common Clock Exit Latency
+#define N_PCIE_CFG_MPC_CCEL                   15
+#define B_PCIE_CFG_MPC_UCEL                   ( BIT20 | BIT19 | BIT18 ) ///< Unique Clock Exit Latency
+#define N_PCIE_CFG_MPC_UCEL                   18
+#define B_PCIE_CFG_MPC_FCDL1E                 BIT21            ///< Flow Control During L1 Entry
+#define N_PCIE_CFG_MPC_FCDL1E                 21
+#define B_PCIE_CFG_MPC_BMERCE                 BIT24            ///< BME Receive Check Enable
+#define N_PCIE_CFG_MPC_BMERCE                 24
+#define B_PCIE_CFG_MPC_IRRCE                  BIT25            ///< Invalid Receive Range Check Enable
+#define N_PCIE_CFG_MPC_IRRCE                  25
+#define B_PCIE_CFG_MPC_P8XDE                  BIT26            ///< Port8xh Decode Enable
+#define N_PCIE_CFG_MPC_P8XDE                  26
+#define B_PCIE_CFG_MPC_MMBNCE                 BIT27            ///< MCTP Message Bus Number Check Enable
+#define N_PCIE_CFG_MPC_MMBNCE                 27
+#define B_PCIE_CFG_MPC_HPCE                   BIT30            ///< Hot Plug SCI Enable
+#define N_PCIE_CFG_MPC_HPCE                   30
+#define B_PCIE_CFG_MPC_PMCE                   BIT31            ///< Power Management SCI Enable
+#define N_PCIE_CFG_MPC_PMCE                   31
+
+#define R_PCIE_CFG_SMSCS                      0x000000dcU      ///< SMI And SCI Status
+#define B_PCIE_CFG_SMSCS_PMMS                 BIT0             ///< Power Management SMI Status
+#define N_PCIE_CFG_SMSCS_PMMS                 0
+#define B_PCIE_CFG_SMSCS_HPPDM                BIT1             ///< Hot Plug Presence Detect SMI Status
+#define N_PCIE_CFG_SMSCS_HPPDM                1
+#define B_PCIE_CFG_SMSCS_HPLAS                BIT4             ///< Hot Plug Link Active State Changed SMI Status
+#define N_PCIE_CFG_SMSCS_HPLAS                4
+#define B_PCIE_CFG_SMSCS_LERSMIS              BIT5             ///< Link Equalization Request SMI Status
+#define N_PCIE_CFG_SMSCS_LERSMIS              5
+#define B_PCIE_CFG_SMSCS_PMCS                 BIT31            ///< Power Management SCI Status
+#define N_PCIE_CFG_SMSCS_PMCS                 31
+
+#define R_PCIE_CFG_SPR                        0x000000e0U      ///< Scratch Pad Register
+
+#define R_PCIE_CFG_RPDCGEN                    0x000000e1U      ///< Root Port Dynamic Clock Gate Enable
+#define B_PCIE_CFG_RPDCGEN_RPDBCGEN           BIT0             ///< Root Port Dynamic Backbone Clock Gate Enable
+#define N_PCIE_CFG_RPDCGEN_RPDBCGEN           0
+#define B_PCIE_CFG_RPDCGEN_RPDLCGEN           BIT1             ///< Root Port Dynamic Link Clock Gate Enable
+#define N_PCIE_CFG_RPDCGEN_RPDLCGEN           1
+#define B_PCIE_CFG_RPDCGEN_SRDBCGEN           BIT2             ///< Shared Resource Dynamic Backbone Clock Gate Enable
+#define N_PCIE_CFG_RPDCGEN_SRDBCGEN           2
+#define B_PCIE_CFG_RPDCGEN_BBCLKREQEN         BIT4             ///< Backbone CLKREQ Enable
+#define N_PCIE_CFG_RPDCGEN_BBCLKREQEN         4
+#define B_PCIE_CFG_RPDCGEN_LCLKREQEN          BIT5             ///< Link CLKREQ Enable
+#define N_PCIE_CFG_RPDCGEN_LCLKREQEN          5
+#define B_PCIE_CFG_RPDCGEN_PTOCGE             BIT6             ///< Partition/Trunk Oscillator Clock Gate Enable
+#define N_PCIE_CFG_RPDCGEN_PTOCGE             6
+
+#define R_PCIE_CFG_RPPGEN                     0x000000e2U      ///< Root Port Power Gating Enable
+#define B_PCIE_CFG_RPPGEN_MDLSWPR             BIT0             ///< mod-PHY Data Lane Suspend Well Power Request
+#define N_PCIE_CFG_RPPGEN_MDLSWPR             0
+#define B_PCIE_CFG_RPPGEN_L23R2DT             BIT3             ///< L23_Rdy to Detect Transition
+#define N_PCIE_CFG_RPPGEN_L23R2DT             3
+#define B_PCIE_CFG_RPPGEN_SEOSCGE             BIT4             ///< Sideband Endpoint Oscillator/Side Clock Gating Enable
+#define N_PCIE_CFG_RPPGEN_SEOSCGE             4
+
+#define R_PCIE_CFG_PWRCTL                     0x000000e8U      ///< Power Control
+#define B_PCIE_CFG_PWRCTL_RPDTSQPOL           BIT0             ///< Root Port Detect Squelch Polling
+#define N_PCIE_CFG_PWRCTL_RPDTSQPOL           0
+#define B_PCIE_CFG_PWRCTL_RPL1SQPOL           BIT1             ///< Root Port L1 Squelch Polling
+#define N_PCIE_CFG_PWRCTL_RPL1SQPOL           1
+#define B_PCIE_CFG_PWRCTL_RPSEWL              ( BIT3 | BIT2 )  ///< Root Port Squelch Exit Wait Latency
+#define N_PCIE_CFG_PWRCTL_RPSEWL              2
+#define B_PCIE_CFG_PWRCTL_TXSWING             BIT13            ///< Analog PHY Transmitter Voltage Swing
+#define N_PCIE_CFG_PWRCTL_TXSWING             13
+#define B_PCIE_CFG_PWRCTL_DBUPI               BIT15            ///< De-skew Buffer Unload Pointer Increment
+#define N_PCIE_CFG_PWRCTL_DBUPI               15
+#define B_PCIE_CFG_PWRCTL_DLP                 BIT16            ///< Down-configured Lanes Policy
+#define N_PCIE_CFG_PWRCTL_DLP                 16
+#define B_PCIE_CFG_PWRCTL_WPDMPGEP            BIT17            ///< Wake PLL On Detect mod-PHY Power Gating Exit Policy
+#define N_PCIE_CFG_PWRCTL_WPDMPGEP            17
+#define B_PCIE_CFG_PWRCTL_LTSSMRTC            BIT20            ///< LTSSM Received TSx Count
+#define N_PCIE_CFG_PWRCTL_LTSSMRTC            20
+#define B_PCIE_CFG_PWRCTL_LIFECF              BIT23            ///< Logical Idle Framing Error Check Filter
+#define N_PCIE_CFG_PWRCTL_LIFECF              23
+#define B_PCIE_CFG_PWRCTL_DARECE              BIT28            ///< Delayed Ack for Recovery Entry
+#define N_PCIE_CFG_PWRCTL_DARECE              28
+
+#define R_PCIE_CFG_DC                         0x000000ecU      ///< Decode Control
+#define B_PCIE_CFG_DC_PCIBEM                  BIT2             ///< PCI Bus Emulation Mode
+#define N_PCIE_CFG_DC_PCIBEM                  2
+#define B_PCIE_CFG_DC_RCRBNRCE                BIT4             ///< RCRB MMIO Range Claim Enable
+#define N_PCIE_CFG_DC_RCRBNRCE                4
+#define B_PCIE_CFG_DC_COM                     BIT13            ///< Completion Ordering Mode
+#define N_PCIE_CFG_DC_COM                     13
+#define B_PCIE_CFG_DC_DCT0C                   BIT14            ///< Downstream Config Type 0 Conversion
+#define N_PCIE_CFG_DC_DCT0C                   14
+#define B_PCIE_CFG_DC_DCT1C                   BIT15            ///< Downstream Config Type 1 Conversion
+#define N_PCIE_CFG_DC_DCT1C                   15
+
+#define R_PCIE_CFG_IPCS                       0x000000f0U      ///< IOSF Primary Control
+#define B_PCIE_CFG_IPCS_IMRS                  ( BIT6 | BIT5 | BIT4 ) ///< IOSF Max Read Request Size
+#define N_PCIE_CFG_IPCS_IMRS                  4
+#define B_PCIE_CFG_IPCS_IMPS                  ( BIT10 | BIT9 | BIT8 ) ///< IOSF_Max_Payload_Size
+#define N_PCIE_CFG_IPCS_IMPS                  8
+
+#define R_PCIE_CFG_PHYCTL2                    0x000000f5U      ///< Physical Layer And AFE Control 2
+#define B_PCIE_CFG_PHYCTL2_PXPG2PLLOFFEN      BIT0             ///< PCI Express GEN2 PLL Off Enable
+#define N_PCIE_CFG_PHYCTL2_PXPG2PLLOFFEN      0
+#define B_PCIE_CFG_PHYCTL2_PXPG3PLLOFFEN      BIT1             ///< PCI Express GEN3 PLL Off Enable
+#define N_PCIE_CFG_PHYCTL2_PXPG3PLLOFFEN      1
+#define B_PCIE_CFG_PHYCTL2_TXCFGCHGWAIT       ( BIT5 | BIT4 )  ///< Transmit Configuration Change Wait Time
+#define N_PCIE_CFG_PHYCTL2_TXCFGCHGWAIT       4
+#define B_PCIE_CFG_PHYCTL2_TDFT               ( BIT7 | BIT6 )  ///< Transmit Datapath Flush Timer
+#define N_PCIE_CFG_PHYCTL2_TDFT               6
+
+#define R_PCIE_CFG_PHYCTL3                    0x000000f6U      ///< Physical Layer And AFE Control 3
+#define B_PCIE_CFG_PHYCTL3_SQDIRCTRL          BIT1             ///< Squelch Direction
+#define N_PCIE_CFG_PHYCTL3_SQDIRCTRL          1
+#define B_PCIE_CFG_PHYCTL3_SQDIROVREN         BIT2             ///< Squelch Direction Override Enable
+#define N_PCIE_CFG_PHYCTL3_SQDIROVREN         2
+
+#define R_PCIE_CFG_IOSFSBCS                   0x000000f7U      ///< IOSF Sideband Control And Status
+#define B_PCIE_CFG_IOSFSBCS_SIID              ( BIT3 | BIT2 )  ///< IOSF Sideband Interface Idle Counter
+#define N_PCIE_CFG_IOSFSBCS_SIID              2
+#define B_PCIE_CFG_IOSFSBCS_SCPTCGE           BIT6             ///< Side Clock Partition/Trunk Clock Gating Enable
+#define N_PCIE_CFG_IOSFSBCS_SCPTCGE           6
+
+#define R_PCIE_CFG_STRPFUSECFG                0x000000fcU      ///< Strap And Fuse Configuration
+#define B_PCIE_CFG_STRPFUSECFG_DESKTOPMOB     BIT2             ///< Desktop or Mobile Fuse
+#define N_PCIE_CFG_STRPFUSECFG_DESKTOPMOB     2
+#define B_PCIE_CFG_STRPFUSECFG_CDCGDIS        BIT3             ///< Core Dynamic Clock Gating Disable Fuse
+#define N_PCIE_CFG_STRPFUSECFG_CDCGDIS        3
+#define B_PCIE_CFG_STRPFUSECFG_LTCGDIS        BIT4             ///< Link Trunk Clock Gating Disable Fuse
+#define N_PCIE_CFG_STRPFUSECFG_LTCGDIS        4
+#define B_PCIE_CFG_STRPFUSECFG_LDCGDIS        BIT5             ///< Link Dynamic Clock Gating Disable Fuse
+#define N_PCIE_CFG_STRPFUSECFG_LDCGDIS        5
+#define B_PCIE_CFG_STRPFUSECFG_ASPMDIS        BIT6             ///< ASPM Disable Fuse
+#define N_PCIE_CFG_STRPFUSECFG_ASPMDIS        6
+#define B_PCIE_CFG_STRPFUSECFG_PLLSHTDWNDIS   BIT8             ///< PLL Shut Down Disable Fuse
+#define N_PCIE_CFG_STRPFUSECFG_PLLSHTDWNDIS   8
+#define B_PCIE_CFG_STRPFUSECFG_MPHYIOPMDIS    BIT9             ///< mPHY I/O PM Disable Fuse
+#define N_PCIE_CFG_STRPFUSECFG_MPHYIOPMDIS    9
+#define B_PCIE_CFG_STRPFUSECFG_LR             BIT13            ///< Lane Reversal
+#define N_PCIE_CFG_STRPFUSECFG_LR             13
+#define B_PCIE_CFG_STRPFUSECFG_RPC            ( BIT16 | BIT15 | BIT14 ) ///< Root Port Configuration  Strap
+#define N_PCIE_CFG_STRPFUSECFG_RPC            14
+#define B_PCIE_CFG_STRPFUSECFG_PXIP           ( BIT27 | BIT26 | BIT25 | BIT24 ) ///< PCI Express Interrupt Pin
+#define N_PCIE_CFG_STRPFUSECFG_PXIP           24
+#define B_PCIE_CFG_STRPFUSECFG_SERM           BIT29            ///< Server Error Reporting Mode
+#define N_PCIE_CFG_STRPFUSECFG_SERM           29
+
+#define R_PCIE_CFG_AECH                       0x00000100U      ///< Advanced Error Extended
+#define B_PCIE_CFG_AECH_CID                   0x0000ffffU      ///< Capability ID/
+#define N_PCIE_CFG_AECH_CID                   0
+#define B_PCIE_CFG_AECH_CV                    ( BIT19 | BIT18 | BIT17 | BIT16 ) ///< Capability Version
+#define N_PCIE_CFG_AECH_CV                    16
+#define B_PCIE_CFG_AECH_NCO                   0xfff00000U      ///< Next Capability Offset
+#define N_PCIE_CFG_AECH_NCO                   20
+
+#define R_PCIE_CFG_UEM                        0x00000108U      ///< Uncorrectable Error Mask
+#define B_PCIE_CFG_UEM_PT                     BIT12            ///< Poisoned TLP Mask
+#define N_PCIE_CFG_UEM_PT                     12
+#define B_PCIE_CFG_UEM_CM                     BIT15            ///< Completer Abort Mask
+#define N_PCIE_CFG_UEM_CM                     15
+#define B_PCIE_CFG_UEM_URE                    BIT20            ///< Unsupported Request Error Mask
+#define N_PCIE_CFG_UEM_URE                    20
+#define B_PCIE_CFG_UEM_PTLPEBM                BIT26            ///< Poisoned TLP Egress Blocked Mask
+#define N_PCIE_CFG_UEM_PTLPEBM                26
+
+#define R_PCIE_CFG_PTMECH                     0x00000150U      ///< PTM Extended Capability Header
+#define B_PCIE_CFG_PTMECH_CID                 0x0000ffffU      ///< Capability ID
+#define N_PCIE_CFG_PTMECH_CID                 0
+#define B_PCIE_CFG_PTMECH_CV                  ( BIT19 | BIT18 | BIT17 | BIT16 ) ///< Capability Version
+#define N_PCIE_CFG_PTMECH_CV                  16
+#define B_PCIE_CFG_PTMECH_NCO                 0xfff00000U      ///< Next Capability Offset
+#define N_PCIE_CFG_PTMECH_NCO                 20
+
+#define R_PCIE_CFG_PTMCAPR                    0x00000154U      ///< PTM Capability Register
+#define B_PCIE_CFG_PTMCAPR_PTMREQC            BIT0             ///< PTM Requester Capable
+#define N_PCIE_CFG_PTMCAPR_PTMREQC            0
+#define B_PCIE_CFG_PTMCAPR_PTMRSPC            BIT1             ///< PTM Responder Capable
+#define N_PCIE_CFG_PTMCAPR_PTMRSPC            1
+#define B_PCIE_CFG_PTMCAPR_PTMRC              BIT2             ///< PTM Root Capable
+#define N_PCIE_CFG_PTMCAPR_PTMRC              2
+#define B_PCIE_CFG_PTMCAPR_PTMPDAC            BIT4             ///< PTM Propagation Delay Adaptation Capable
+#define N_PCIE_CFG_PTMCAPR_PTMPDAC            4
+
+#define R_PCIE_CFG_PTMCTLR                    0x00000158U      ///< PTM Control Register
+#define B_PCIE_CFG_PTMCTLR_PTME               BIT0             ///< PTM Enable
+#define N_PCIE_CFG_PTMCTLR_PTME               0
+#define B_PCIE_CFG_PTMCTLR_RS                 BIT1             ///< Root Select
+#define N_PCIE_CFG_PTMCTLR_RS                 1
+
+#define R_PCIE_CFG_L1SECH                     0x00000200U      ///< L1 Sub-States Extended Capability Header
+#define B_PCIE_CFG_L1SECH_PCIEEC              0x0000ffffU      ///< PCI Express Extended Capability ID
+#define N_PCIE_CFG_L1SECH_PCIEEC              0
+#define B_PCIE_CFG_L1SECH_CV                  ( BIT19 | BIT18 | BIT17 | BIT16 ) ///< Capability Version
+#define N_PCIE_CFG_L1SECH_CV                  16
+#define B_PCIE_CFG_L1SECH_NCO                 0xfff00000U      ///< Next Capability Offset
+#define N_PCIE_CFG_L1SECH_NCO                 20
+
+#define R_PCIE_CFG_L1SCAP                     0x00000204U      ///< L1 Sub-States Capabilities
+#define B_PCIE_CFG_L1SCAP_PPL12S              BIT0             ///< PCI-PM L1.2 Supported
+#define N_PCIE_CFG_L1SCAP_PPL12S              0
+#define B_PCIE_CFG_L1SCAP_PPL11S              BIT1             ///< PCI-PM L1.1 Supported
+#define N_PCIE_CFG_L1SCAP_PPL11S              1
+#define B_PCIE_CFG_L1SCAP_AL12S               BIT2             ///< ASPM L1.2 Supported
+#define N_PCIE_CFG_L1SCAP_AL12S               2
+#define B_PCIE_CFG_L1SCAP_AL11S               BIT3             ///< ASPM L1.1 Supported
+#define N_PCIE_CFG_L1SCAP_AL11S               3
+#define B_PCIE_CFG_L1SCAP_L1PSS               BIT4             ///< L1 PM Substates Supported
+#define N_PCIE_CFG_L1SCAP_L1PSS               4
+#define B_PCIE_CFG_L1SCAP_PCMRT               ( BIT15 | BIT14 | BIT13 | BIT12 | BIT11 | BIT10 | BIT9 | BIT8 ) ///< Port Common Mode Restore Time
+#define N_PCIE_CFG_L1SCAP_PCMRT               8
+#define B_PCIE_CFG_L1SCAP_PTPOS               ( BIT17 | BIT16 ) ///< Port Tpower_on Scale
+#define N_PCIE_CFG_L1SCAP_PTPOS               16
+#define B_PCIE_CFG_L1SCAP_PTV                 ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 ) ///< Port Tpower_on Value
+#define N_PCIE_CFG_L1SCAP_PTV                 19
+
+#define R_PCIE_CFG_L1SCTL1                    0x00000208U      ///< L1 Sub-States Control 1
+#define B_PCIE_CFG_L1SCTL1_L12LTRTLSV         ( BIT31 | BIT30 | BIT29 )
+#define N_PCIE_CFG_L1SCTL1_L12LTRTLSV         29
+#define V_PCIE_CFG_L1SCTL1_L12LTRTLSV         0x2
+#define B_PCIE_CFG_L1SCTL1_L12LTRTLV_MASK     0x3FF0000
+#define N_PCIE_CFG_L1SCTL1_L12LTRTLV          16
+#define V_PCIE_CFG_L1SCTL1_L12LTRTLV          0xE6
+#define B_PCIE_CFG_L1SCTL1_L1SSEIE            BIT4             ///< CLKREQ Acceleration Interrupt Enable
+#define N_PCIE_CFG_L1SCTL1_L1SSEIE            4
+#define B_PCIE_CFG_L1SCTL1_CMRT               ( BIT15 | BIT14 | BIT13 | BIT12 | BIT11 | BIT10 | BIT9 | BIT8 ) ///< Common Mode Restore Time
+#define N_PCIE_CFG_L1SCTL1_CMRT               8
+#define B_PCIE_CFG_L1SCTL1_AL11E              BIT3
+#define B_PCIE_CFG_L1SCTL1_AL12E              BIT2
+#define B_PCIE_CFG_L1SCTL1_PPL11E             BIT1
+#define B_PCIE_CFG_L1SCTL1_PPL12E             BIT0
+
+#define R_PCIE_CFG_L1SCTL2                    0x0000020cU      ///< L1 Sub-States Control 2
+#define B_PCIE_CFG_L1SCTL2_TPOS               ( BIT1 | BIT0 )  ///< Tpower_on Scale
+#define N_PCIE_CFG_L1SCTL2_TPOS               0
+#define B_PCIE_CFG_L1SCTL2_POWT               ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 ) ///< Power On Wait Time
+#define N_PCIE_CFG_L1SCTL2_POWT               3
+
+#define R_PCIE_CFG_ACSECH                     0x00000220U      ///< ACS Extended Capability Header
+#define B_PCIE_CFG_ACSECH_CID                 0x0000ffffU      ///< Capability ID
+#define N_PCIE_CFG_ACSECH_CID                 0
+#define B_PCIE_CFG_ACSECH_CV                  ( BIT19 | BIT18 | BIT17 | BIT16 ) ///< Capability Version
+#define N_PCIE_CFG_ACSECH_CV                  16
+#define B_PCIE_CFG_ACSECH_NCO                 0xfff00000U      ///< Next Capability Offset
+#define N_PCIE_CFG_ACSECH_NCO                 20
+
+#define R_PCIE_CFG_ACSCAPR                    0x00000224U      ///< ACS Capability Register
+
+#define R_PCIE_CFG_VCCH                       0x00000280U      ///< Virtual Channel Capability Header
+#define B_PCIE_CFG_VCCH_CID                   0x0000ffffU      ///< PCI Express Extended Capability ID
+#define N_PCIE_CFG_VCCH_CID                   0
+#define B_PCIE_CFG_VCCH_CV                    ( BIT19 | BIT18 | BIT17 | BIT16 ) ///< Capability Version
+#define N_PCIE_CFG_VCCH_CV                    16
+#define B_PCIE_CFG_VCCH_NCO                   0xfff00000U      ///< Next Capability Offset
+#define N_PCIE_CFG_VCCH_NCO                   20
+
+#define R_PCIE_CFG_PVCCR1                     0x00000284U      ///< Port VC Capability Register 1
+#define B_PCIE_CFG_PVCCR1_EVCC                ( BIT2 | BIT1 | BIT0 ) ///< Extended VC Count
+#define N_PCIE_CFG_PVCCR1_EVCC                0
+
+#define R_PCIE_CFG_V0VCRC                     0x00000290U      ///< Virtual Channel 0 Resource Capability
+#define B_PCIE_CFG_V0VCRC_MTS                 ( BIT22 | BIT21 | BIT20 | BIT19 | BIT18 | BIT17 | BIT16 ) ///< Maximum Time Slots
+#define N_PCIE_CFG_V0VCRC_MTS                 16
+
+#define R_PCIE_CFG_V0CTL                      0x00000294U      ///< Virtual Channel 0 Resource Control
+
+#define R_PCIE_CFG_V0STS                      0x0000029aU      ///< Virtual Channel 0 Resource Status
+#define B_PCIE_CFG_V0STS_NP                   BIT1             ///< VC Negotiation Pending
+#define N_PCIE_CFG_V0STS_NP                   1
+
+#define R_PCIE_CFG_V1VCRC                     0x0000029cU      ///< Virtual Channel 1  Resource Capability
+#define B_PCIE_CFG_V1VCRC_MTS                 ( BIT22 | BIT21 | BIT20 | BIT19 | BIT18 | BIT17 | BIT16 ) ///< Maximum Time Slots
+#define N_PCIE_CFG_V1VCRC_MTS                 16
+
+#define R_PCIE_CFG_V1CTL                      0x000002a0U      ///< Virtual Channel 1 Resource Control
+#define B_PCIE_CFG_V1CTL_ID                   ( BIT27 | BIT26 | BIT25 | BIT24 ) ///< Virtual Channel Identifier
+#define N_PCIE_CFG_V1CTL_ID                   24
+
+#define R_PCIE_CFG_V1STS                      0x000002a6U      ///< Virtual Channel 1 Resource Status
+#define B_PCIE_CFG_V1STS_NP                   BIT1             ///< VC Negotiation Pending
+#define N_PCIE_CFG_V1STS_NP                   1
+
+#define R_PCIE_CFG_PCIERTP1                   0x00000300U      ///< PCI Express Replay Timer Policy 1
+#define B_PCIE_CFG_PCIERTP1_G1X4              ( BIT3 | BIT2 | BIT1 | BIT0 ) ///< Gen 1 x4
+#define N_PCIE_CFG_PCIERTP1_G1X4              0
+
+#define R_PCIE_CFG_G4L0SCTL                   0x00000310U      ///< GEN4 L0s Control
+#define B_PCIE_CFG_G4L0SCTL_G4CCNFTS          ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Gen4 Common Clock N_FTS
+#define N_PCIE_CFG_G4L0SCTL_G4CCNFTS          0
+#define B_PCIE_CFG_G4L0SCTL_G4UCNFTS          ( BIT15 | BIT14 | BIT13 | BIT12 | BIT11 | BIT10 | BIT9 | BIT8 ) ///< Gen4 Unique Clock N_FTS
+#define N_PCIE_CFG_G4L0SCTL_G4UCNFTS          8
+#define B_PCIE_CFG_G4L0SCTL_G4L0SIC           ( BIT23 | BIT22 ) ///< Gen4 L0s Entry Idle Control
+#define N_PCIE_CFG_G4L0SCTL_G4L0SIC           22
+#define B_PCIE_CFG_G4L0SCTL_G4ASL0SPL         ( BIT31 | BIT30 | BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Gen4Active State L0s Preparation Latency
+#define N_PCIE_CFG_G4L0SCTL_G4ASL0SPL         24
+
+#define R_PCIE_CFG_PCIENFTS                   0x00000314U      ///< PCI Express NFTS
+#define B_PCIE_CFG_PCIENFTS_G1CCNFTS          ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Gen 1 Common Clock N_FTS
+#define N_PCIE_CFG_PCIENFTS_G1CCNFTS          0
+#define B_PCIE_CFG_PCIENFTS_G1UCNFTS          ( BIT15 | BIT14 | BIT13 | BIT12 | BIT11 | BIT10 | BIT9 | BIT8 ) ///< Gen1 Unique Clock N_FTS
+#define N_PCIE_CFG_PCIENFTS_G1UCNFTS          8
+#define B_PCIE_CFG_PCIENFTS_G2CCNFTS          ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 | BIT17 | BIT16 ) ///< Gen2 Common Clock N_FTS
+#define N_PCIE_CFG_PCIENFTS_G2CCNFTS          16
+#define B_PCIE_CFG_PCIENFTS_G2UCNFTS          ( BIT31 | BIT30 | BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Gen2 Unique Clock N_FTS
+#define N_PCIE_CFG_PCIENFTS_G2UCNFTS          24
+
+#define R_PCIE_CFG_PCIEL0SC                   0x00000318U      ///< PCI Express L0s Control
+#define B_PCIE_CFG_PCIEL0SC_G1ASL0SPL         ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 | BIT17 | BIT16 ) ///< Gen1 Active State L0s Preparation Latency
+#define N_PCIE_CFG_PCIEL0SC_G1ASL0SPL         16
+#define B_PCIE_CFG_PCIEL0SC_G2ASL0SPL         ( BIT31 | BIT30 | BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Gen2 Active State L0s Preparation Latency
+#define N_PCIE_CFG_PCIEL0SC_G2ASL0SPL         24
+
+#define R_PCIE_CFG_PCIECFG2                   0x00000320U      ///< PCI Express Configuration 2
+#define B_PCIE_CFG_PCIECFG2_PMET              ( BIT21 | BIT20 ) ///< PME Timeout
+#define N_PCIE_CFG_PCIECFG2_PMET              20
+#define B_PCIE_CFG_PCIECFG2_CRSREN            BIT22            ///< Completion Retry Status Replay Enable
+#define N_PCIE_CFG_PCIECFG2_CRSREN            22
+#define B_PCIE_CFG_PCIECFG2_CROAOE            BIT23            ///< Completion Relaxed Ordering Attribute Override Enable
+#define N_PCIE_CFG_PCIECFG2_CROAOE            23
+#define B_PCIE_CFG_PCIECFG2_CROAOV            BIT24            ///< Completion Relaxed Ordering Attribute Override Value
+#define N_PCIE_CFG_PCIECFG2_CROAOV            24
+#define B_PCIE_CFG_PCIECFG2_RRCP              BIT29            ///< RXL0s Receiver Control Policy
+#define N_PCIE_CFG_PCIECFG2_RRCP              29
+
+#define R_PCIE_CFG_PCIEDBG                    0x00000324U      ///< PCI Express Debug And Configuration
+#define B_PCIE_CFG_PCIEDBG_DTCA               BIT4             ///< Disable TC Aliasing
+#define N_PCIE_CFG_PCIEDBG_DTCA               4
+#define B_PCIE_CFG_PCIEDBG_SPCE               BIT5             ///< Squelch Propagation Control Enable
+#define N_PCIE_CFG_PCIEDBG_SPCE               5
+#define B_PCIE_CFG_PCIEDBG_SQOL0              BIT7             ///< Squelch Off in L0
+#define N_PCIE_CFG_PCIEDBG_SQOL0              7
+#define B_PCIE_CFG_PCIEDBG_LDSWQRP            BIT13            ///< Link Down SWQ Reset Policy
+#define N_PCIE_CFG_PCIEDBG_LDSWQRP            13
+#define B_PCIE_CFG_PCIEDBG_CTONFAE            BIT14            ///< Completion Time-Out Non-Fatal Advisory Error Enable
+#define N_PCIE_CFG_PCIEDBG_CTONFAE            14
+
+#define R_PCIE_CFG_PCIESTS1                   0x00000328U      ///< PCI Express Status 1
+#define B_PCIE_CFG_PCIESTS1_LNKSTAT           ( BIT22 | BIT21 | BIT20 | BIT19 ) ///< Link Status
+#define N_PCIE_CFG_PCIESTS1_LNKSTAT           19
+#define B_PCIE_CFG_PCIESTS1_LTSMSTATE         ( BIT31 | BIT30 | BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< LTSM State
+#define N_PCIE_CFG_PCIESTS1_LTSMSTATE         24
+
+#define R_PCIE_CFG_PCIESTS2                   0x0000032cU      ///< PCI Express Status 2
+#define B_PCIE_CFG_PCIESTS2_P1PNCCWSSCMES     BIT28            ///< PCIe Port 1 Non-Common Clock With SSC Mode Enable Strap
+#define N_PCIE_CFG_PCIESTS2_P1PNCCWSSCMES     28
+#define B_PCIE_CFG_PCIESTS2_P2PNCCWSSCMES     BIT29            ///< PCIe Port 2 Non-Common Clock With SSC Mode Enable Strap
+#define N_PCIE_CFG_PCIESTS2_P2PNCCWSSCMES     29
+#define B_PCIE_CFG_PCIESTS2_P3PNCCWSSCMES     BIT30            ///< PCIe Port 3 Non-Common Clock With SSC Mode Enable Strap
+#define N_PCIE_CFG_PCIESTS2_P3PNCCWSSCMES     30
+#define B_PCIE_CFG_PCIESTS2_P4PNCCWSSCMES     BIT31            ///< PCIe Port 4 Non-Common Clock With SSC Mode Enable Strap
+#define N_PCIE_CFG_PCIESTS2_P4PNCCWSSCMES     31
+
+#define R_PCIE_CFG_PCIEALC                    0x00000338U      ///< PCI Express Additional Link Control
+#define B_PCIE_CFG_PCIEALC_ONPRASPML1P        BIT11            ///< Outstanding Non-Posted Request ASPM L1 Prevention
+#define N_PCIE_CFG_PCIEALC_ONPRASPML1P        11
+#define B_PCIE_CFG_PCIEALC_PDSP               BIT20            ///< Present Detect State Policy
+#define N_PCIE_CFG_PCIEALC_PDSP               20
+#define B_PCIE_CFG_PCIEALC_RTD3PDSP           BIT21            ///< RTD3 Present Detect State Policy
+#define N_PCIE_CFG_PCIEALC_RTD3PDSP           21
+#define B_PCIE_CFG_PCIEALC_SSRRS              BIT23            ///< Survivability Sync Reset in Recovery state
+#define N_PCIE_CFG_PCIEALC_SSRRS              23
+#define B_PCIE_CFG_PCIEALC_SSRLD              BIT24            ///< Survivability Sync Reset during Link Down
+#define N_PCIE_CFG_PCIEALC_SSRLD              24
+#define B_PCIE_CFG_PCIEALC_BLKDQDASD          BIT25            ///< Block Detect.Quiet -> Detect.Active Strap Default
+#define N_PCIE_CFG_PCIEALC_BLKDQDASD          25
+#define B_PCIE_CFG_PCIEALC_BLKDQDA            BIT26            ///< Block Detect.Quiet -> Detect.Active
+#define N_PCIE_CFG_PCIEALC_BLKDQDA            26
+#define B_PCIE_CFG_PCIEALC_ILLRCLD            BIT28            ///< Initialize Link Layer Receiver Control on Link Down
+#define N_PCIE_CFG_PCIEALC_ILLRCLD            28
+#define B_PCIE_CFG_PCIEALC_ITLRCLD            BIT29            ///< Initialize Transaction Layer Receiver Control on Link Down
+#define N_PCIE_CFG_PCIEALC_ITLRCLD            29
+
+#define R_PCIE_CFG_PTMPD                      0x00000390U      ///< PTM Propagation Delay
+
+#define R_PCIE_CFG_PTMLLMT                    0x00000394U      ///< PTM Lower Local Master Time
+
+#define R_PCIE_CFG_PTMULMT                    0x00000398U      ///< PTM Upper Local Master Time
+
+#define R_PCIE_CFG_PTMECFG                    0x000003b0U      ///< PTM Extended Config
+#define B_PCIE_CFG_PTMECFG_IOSFMADP           ( BIT3 | BIT2 | BIT1 | BIT0 ) ///< IOSF Max Allowed Delay programming
+#define N_PCIE_CFG_PTMECFG_IOSFMADP           0
+#define B_PCIE_CFG_PTMECFG_PTMRNOPAD          ( BIT5 | BIT4 )  ///< PTM Request Number Of Periodic ACK DLLP
+#define N_PCIE_CFG_PTMECFG_PTMRNOPAD          4
+#define B_PCIE_CFG_PTMECFG_PTMRPAE            BIT6             ///< PTM Request Periodic ACK Enable
+#define N_PCIE_CFG_PTMECFG_PTMRPAE            6
+#define B_PCIE_CFG_PTMECFG_PGTSCFE            BIT8             ///< Periodic Global Time Stamp Counter Fetch Enable
+#define N_PCIE_CFG_PTMECFG_PGTSCFE            8
+#define B_PCIE_CFG_PTMECFG_PLTLFF             ( BIT20 | BIT19 | BIT18 ) ///< Periodic Local TSC Link Fetch Frequency
+#define N_PCIE_CFG_PTMECFG_PLTLFF             18
+
+#define R_PCIE_CFG_LTROVR                     0x00000400U      ///< Latency Tolerance Reporting Override
+#define B_PCIE_CFG_LTROVR_LTRSLOVRV           0x000003ffU      ///< LTR Snoop Latency Override Value
+#define N_PCIE_CFG_LTROVR_LTRSLOVRV           0
+#define B_PCIE_CFG_LTROVR_LTRSLSOVRV          ( BIT12 | BIT11 | BIT10 ) ///< LTR Snoop Latency Scale Override Value
+#define N_PCIE_CFG_LTROVR_LTRSLSOVRV          10
+#define B_PCIE_CFG_LTROVR_LTRSROVR            BIT15            ///< LTR Snoop Requirement Bit Override
+#define N_PCIE_CFG_LTROVR_LTRSROVR            15
+#define B_PCIE_CFG_LTROVR_LTRNSLOVRV          0x03ff0000U      ///< LTR Non-Snoop Latency Override Value
+#define N_PCIE_CFG_LTROVR_LTRNSLOVRV          16
+#define B_PCIE_CFG_LTROVR_LTRNSLSOVRV         ( BIT28 | BIT27 | BIT26 ) ///< LTR Non-Snoop Latency Scale Override Value
+#define N_PCIE_CFG_LTROVR_LTRNSLSOVRV         26
+#define B_PCIE_CFG_LTROVR_LTRNSROVR           BIT31            ///< LTR Non-Snoop Requirement Bit Override
+#define N_PCIE_CFG_LTROVR_LTRNSROVR           31
+
+#define R_PCIE_CFG_LTROVR2                    0x00000404U      ///< Latency Tolerance Reporting Override 2
+#define B_PCIE_CFG_LTROVR2_LTRSOVREN          BIT0             ///< LTR Snoop Override Enable
+#define N_PCIE_CFG_LTROVR2_LTRSOVREN          0
+#define B_PCIE_CFG_LTROVR2_LTRNSOVREN         BIT1             ///< LTR Non-Snoop Override Enable
+#define N_PCIE_CFG_LTROVR2_LTRNSOVREN         1
+#define B_PCIE_CFG_LTROVR2_LTROVRPLCY         BIT3             ///< LTR Override Policy
+#define N_PCIE_CFG_LTROVR2_LTROVRPLCY         3
+
+#define R_PCIE_CFG_PHYCTL4                    0x00000408U      ///< Physical Layer And AFE Control 4
+#define B_PCIE_CFG_PHYCTL4_SQDIS              BIT27            ///< Squelch Disable
+#define N_PCIE_CFG_PHYCTL4_SQDIS              27
+
+#define R_PCIE_CFG_TNPT                       0x00000418U      ///< Thermal And Power Throttling
+#define B_PCIE_CFG_TNPT_DTXLTE                BIT0             ///< Dynamic TX Link Throttling Enable
+#define N_PCIE_CFG_TNPT_DTXLTE                0
+#define B_PCIE_CFG_TNPT_DRXLTE                BIT1             ///< Dynamic RX Link Throttling Enable
+#define N_PCIE_CFG_TNPT_DRXLTE                1
+#define B_PCIE_CFG_TNPT_TT                    ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 | BIT17 | BIT16 ) ///< Throttle Time
+#define N_PCIE_CFG_TNPT_TT                    16
+#define B_PCIE_CFG_TNPT_TP                    ( BIT31 | BIT30 | BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Throttle Period
+#define N_PCIE_CFG_TNPT_TP                    24
+
+#define R_PCIE_CFG_PCIEPMECTL                 0x00000420U      ///< PCIe PM Extension Control
+#define B_PCIE_CFG_PCIEPMECTL_L1FSOE          BIT0             ///< L1 Full Squelch OFF Enable
+#define N_PCIE_CFG_PCIEPMECTL_L1FSOE          0
+#define B_PCIE_CFG_PCIEPMECTL_L1SNZCREWD      BIT3             ///< L1.SNOOZ/L1.LOW Clock Request Early Wake Disable
+#define N_PCIE_CFG_PCIEPMECTL_L1SNZCREWD      3
+#define B_PCIE_CFG_PCIEPMECTL_L1LTRTLV        0x00003ff0U      ///< L1.LOW LTR Threshold Latency Value
+#define N_PCIE_CFG_PCIEPMECTL_L1LTRTLV        4
+#define B_PCIE_CFG_PCIEPMECTL_L1LTRTLSV       ( BIT16 | BIT15 | BIT14 ) ///< L1.LOW LTR Threshold Latency ScaleValue
+#define N_PCIE_CFG_PCIEPMECTL_L1LTRTLSV       14
+#define B_PCIE_CFG_PCIEPMECTL_L1LE            BIT17            ///< L1.LOW Enable
+#define N_PCIE_CFG_PCIEPMECTL_L1LE            17
+#define B_PCIE_CFG_PCIEPMECTL_POFFWT          ( BIT19 | BIT18 ) ///< Power Off Wait Time
+#define N_PCIE_CFG_PCIEPMECTL_POFFWT          18
+#define B_PCIE_CFG_PCIEPMECTL_IPACPE          BIT20            ///< IP-Accessible Context Propagation Enable
+#define N_PCIE_CFG_PCIEPMECTL_IPACPE          20
+#define B_PCIE_CFG_PCIEPMECTL_IPIEP           BIT21            ///< IP-Inaccessible Entry Policy
+#define N_PCIE_CFG_PCIEPMECTL_IPIEP           21
+#define B_PCIE_CFG_PCIEPMECTL_L1OCREWD        BIT28            ///< L1.OFF Clock Request Early Wake Disable
+#define N_PCIE_CFG_PCIEPMECTL_L1OCREWD        28
+#define B_PCIE_CFG_PCIEPMECTL_DLSULDLSD       BIT29            ///< Disabled, Detect, L23_Rdy State,Un-Configured Lane and Down-Configured Lane Squelch Disable
+#define N_PCIE_CFG_PCIEPMECTL_DLSULDLSD       29
+#define B_PCIE_CFG_PCIEPMECTL_DLSULPPGE       BIT30            ///< Disabled, Detect and L23_Rdy State PHY Lane Power Gating Enable
+#define N_PCIE_CFG_PCIEPMECTL_DLSULPPGE       30
+#define B_PCIE_CFG_PCIEPMECTL_FDPPGE          BIT31            ///< Function Disable PHY Power Gating Enable
+#define N_PCIE_CFG_PCIEPMECTL_FDPPGE          31
+
+#define R_PCIE_CFG_PCIEPMECTL2                0x00000424U      ///< PCIe PM Extension Control 2
+#define B_PCIE_CFG_PCIEPMECTL2_L1SCPGE        BIT4             ///< L1 State Controller Power Gating Enable
+#define N_PCIE_CFG_PCIEPMECTL2_L1SCPGE        4
+#define B_PCIE_CFG_PCIEPMECTL2_DISSCPGE       BIT5             ///< Disabled State Controller Power Gating Enable
+#define N_PCIE_CFG_PCIEPMECTL2_DISSCPGE       5
+#define B_PCIE_CFG_PCIEPMECTL2_L23RDYSCPGE    BIT6             ///< L23_Rdy State Controller Power Gating Enable
+#define N_PCIE_CFG_PCIEPMECTL2_L23RDYSCPGE    6
+#define B_PCIE_CFG_PCIEPMECTL2_DETSCPGE       BIT7             ///< Detect State Controller Power Gating Enable
+#define N_PCIE_CFG_PCIEPMECTL2_DETSCPGE       7
+#define B_PCIE_CFG_PCIEPMECTL2_FDCPGE         BIT8             ///< Function Disable Controller Power Gating Enable
+#define N_PCIE_CFG_PCIEPMECTL2_FDCPGE         8
+#define B_PCIE_CFG_PCIEPMECTL2_L1SPHYDLPGE    BIT9             ///< Reserved
+#define N_PCIE_CFG_PCIEPMECTL2_L1SPHYDLPGE    9
+#define B_PCIE_CFG_PCIEPMECTL2_PHYCLPGE       BIT11            ///< PHY Common Lane Power Gating Enable
+#define N_PCIE_CFG_PCIEPMECTL2_PHYCLPGE       11
+#define B_PCIE_CFG_PCIEPMECTL2_CPGENH         ( BIT13 | BIT12 ) ///< Controller Power Gating Entry Hysteresis
+#define N_PCIE_CFG_PCIEPMECTL2_CPGENH         12
+#define B_PCIE_CFG_PCIEPMECTL2_CPGEXH         ( BIT15 | BIT14 ) ///< Controller Power Gating Exit Hysteresis
+#define N_PCIE_CFG_PCIEPMECTL2_CPGEXH         14
+#define B_PCIE_CFG_PCIEPMECTL2_CPMCSRE        BIT27            ///< Chassis PMC Save and Restore Enable
+#define N_PCIE_CFG_PCIEPMECTL2_CPMCSRE        27
+
+#define R_PCIE_CFG_PCE                        0x00000428U      ///< Power Control Enable
+#define B_PCIE_CFG_PCE_PMCRE                  BIT0             ///< PMC Request Enable
+#define N_PCIE_CFG_PCE_PMCRE                  0
+#define B_PCIE_CFG_PCE_SE                     BIT3             ///< Sleep Enable
+#define N_PCIE_CFG_PCE_SE                     3
+#define B_PCIE_CFG_PCE_HAE                    BIT5             ///< Hardware Autonomous Enable
+#define N_PCIE_CFG_PCE_HAE                    5
+
+#define R_PCIE_CFG_PGCBCTL1                   0x0000042cU      ///< PGCB Control 1
+#define B_PCIE_CFG_PGCBCTL1_TACCRSTUP         ( BIT11 | BIT10 ) ///< cfg_taccrstup
+#define N_PCIE_CFG_PGCBCTL1_TACCRSTUP         10
+
+#define R_PCIE_CFG_PCIEPMECTL3                0x00000434U      ///< PCIe PM Extension Control 3
+#define B_PCIE_CFG_PCIEPMECTL3_PMREQCPGEXH    ( BIT1 | BIT0 )  ///< PM  Request Controller Power Gating Exit Hysteresis
+#define N_PCIE_CFG_PCIEPMECTL3_PMREQCPGEXH    0
+#define B_PCIE_CFG_PCIEPMECTL3_OSCCGH         ( BIT3 | BIT2 )  ///< Osc Clock Gate Hysterisis
+#define N_PCIE_CFG_PCIEPMECTL3_OSCCGH         2
+#define B_PCIE_CFG_PCIEPMECTL3_L1PGAUTOPGEN   BIT4             ///< L1.PG Auto Power Gate Enable
+#define N_PCIE_CFG_PCIEPMECTL3_L1PGAUTOPGEN   4
+
+#define R_PCIE_CFG_EQCFG1                     0x00000450U      ///< Equalization Configuration 1
+#define B_PCIE_CFG_EQCFG1_TUPP                BIT1             ///< Transmitter Use Preset Policy
+#define N_PCIE_CFG_EQCFG1_TUPP                1
+#define B_PCIE_CFG_EQCFG1_HAPCCPIE            BIT5             ///< Hardware Autonomous Preset/Coefficient Count Per-Iteration Extention
+#define N_PCIE_CFG_EQCFG1_HAPCCPIE            5
+#define B_PCIE_CFG_EQCFG1_EQTS2IRRC           BIT7             ///< EQ TS2 in Recovery.ReceiverConfig Enable
+#define N_PCIE_CFG_EQCFG1_EQTS2IRRC           7
+#define B_PCIE_CFG_EQCFG1_RWTNEVE             ( BIT11 | BIT10 | BIT9 | BIT8 ) ///< Receiver Wait Time For New Equalization Value Evaluation
+#define N_PCIE_CFG_EQCFG1_RWTNEVE             8
+#define B_PCIE_CFG_EQCFG1_HAED                BIT12            ///< Hardware Autonomous Equalization Done
+#define N_PCIE_CFG_EQCFG1_HAED                12
+#define B_PCIE_CFG_EQCFG1_HPCMQE              BIT13            ///< Hardware Preset to Coefficient Mapping Query Enable
+#define N_PCIE_CFG_EQCFG1_HPCMQE              13
+#define B_PCIE_CFG_EQCFG1_RTPCOE              BIT15            ///< Remote Transmitter Preset Coefficient Override Enable
+#define N_PCIE_CFG_EQCFG1_RTPCOE              15
+#define B_PCIE_CFG_EQCFG1_RTLEPCEB            BIT16            ///< Remote Transmit Link Equalization Preset/Coefficient Evaluation Bypass
+#define N_PCIE_CFG_EQCFG1_RTLEPCEB            16
+#define B_PCIE_CFG_EQCFG1_LEP3B               BIT17            ///< Link Equalization 3 Bypass
+#define N_PCIE_CFG_EQCFG1_LEP3B               17
+#define B_PCIE_CFG_EQCFG1_LEP23B              BIT18            ///< Link Equalization Phase 2 and 3 Bypass
+#define N_PCIE_CFG_EQCFG1_LEP23B              18
+#define B_PCIE_CFG_EQCFG1_LEB                 BIT19            ///< Link Equalization Bypass
+#define N_PCIE_CFG_EQCFG1_LEB                 19
+#define B_PCIE_CFG_EQCFG1_LERSMIE             BIT21            ///< Link Equalization Request SMI Enable
+#define N_PCIE_CFG_EQCFG1_LERSMIE             21
+#define B_PCIE_CFG_EQCFG1_REIFECE             BIT23            ///< Recovery Entry and Idle Framing Error Count Enable
+#define N_PCIE_CFG_EQCFG1_REIFECE             23
+#define B_PCIE_CFG_EQCFG1_REC                 ( BIT31 | BIT30 | BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Recovery Entry Count
+#define N_PCIE_CFG_EQCFG1_REC                 24
+
+#define R_PCIE_CFG_RTPCL1                     0x00000454U      ///< Remote Transmitter Preset Coefficient List 1
+#define B_PCIE_CFG_RTPCL1_RTPRECL0PL0         ( BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Remote Transmitter Pre-Cursor Coefficient List 0/Preset List 0
+#define N_PCIE_CFG_RTPCL1_RTPRECL0PL0         0
+#define B_PCIE_CFG_RTPCL1_RTPOSTCL0PL1        ( BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 ) ///< Remote Transmitter Post-Cursor Coefficient List 0/Preset List 1
+#define N_PCIE_CFG_RTPCL1_RTPOSTCL0PL1        6
+#define B_PCIE_CFG_RTPCL1_RTPRECL1PL2         ( BIT17 | BIT16 | BIT15 | BIT14 | BIT13 | BIT12 ) ///< Remote Transmitter Pre-Cursor Coefficient List 1/Preset List 2
+#define N_PCIE_CFG_RTPCL1_RTPRECL1PL2         12
+#define B_PCIE_CFG_RTPCL1_RTPOSTCL1PL3        ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 ) ///< Remote Transmitter Post-Cursor Coefficient List 1/Preset List 3
+#define N_PCIE_CFG_RTPCL1_RTPOSTCL1PL3        18
+#define B_PCIE_CFG_RTPCL1_RTPRECL2PL4         ( BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Remote Transmitter Pre-Cursor Coefficient List 2/Preset List 4
+#define N_PCIE_CFG_RTPCL1_RTPRECL2PL4         24
+#define B_PCIE_CFG_RTPCL1_PCM                 BIT31            ///< Preset/Coefficient Mode
+#define N_PCIE_CFG_RTPCL1_PCM                 31
+
+#define R_PCIE_CFG_RTPCL2                     0x00000458U      ///< Remote Transmitter Preset Coefficient List 2
+#define B_PCIE_CFG_RTPCL2_RTPOSTCL2PL5        ( BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Remote Transmitter Post-Cursor Coefficient List 2/Preset List 5
+#define N_PCIE_CFG_RTPCL2_RTPOSTCL2PL5        0
+#define B_PCIE_CFG_RTPCL2_RTPRECL3PL6         ( BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 ) ///< Remote Transmitter Pre-Cursor Coefficient List 3/Preset List 6
+#define N_PCIE_CFG_RTPCL2_RTPRECL3PL6         6
+#define B_PCIE_CFG_RTPCL2_RTPOSTCL3PL7        ( BIT17 | BIT16 | BIT15 | BIT14 | BIT13 | BIT12 ) ///< Remote Transmitter Post-Cursor Coefficient List 3/Preset List 7
+#define N_PCIE_CFG_RTPCL2_RTPOSTCL3PL7        12
+#define B_PCIE_CFG_RTPCL2_RTPRECL4PL8         ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 ) ///< Remote Transmitter Pre-Cursor Coefficient List 4/Preset List 8
+#define N_PCIE_CFG_RTPCL2_RTPRECL4PL8         18
+#define B_PCIE_CFG_RTPCL2_RTPOSTCL4PL9        ( BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Remote Transmitter Post-Cursor Coefficient List 4/Preset List 9
+#define N_PCIE_CFG_RTPCL2_RTPOSTCL4PL9        24
+
+#define R_PCIE_CFG_RTPCL3                     0x0000045cU      ///< Remote Transmitter Preset Coefficient List 3
+#define B_PCIE_CFG_RTPCL3_RTPRECL5PL10        ( BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Remote Transmitter Pre-Cursor Coefficient List 5/Preset List 10
+#define N_PCIE_CFG_RTPCL3_RTPRECL5PL10        0
+#define B_PCIE_CFG_RTPCL3_RTPOSTCL5           ( BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 ) ///< Remote Transmitter Post-Cursor Coefficient List 5
+#define N_PCIE_CFG_RTPCL3_RTPOSTCL5           6
+#define B_PCIE_CFG_RTPCL3_RTPRECL6            ( BIT17 | BIT16 | BIT15 | BIT14 | BIT13 | BIT12 ) ///< Remote Transmitter Pre-Cursor Coefficient List 6
+#define N_PCIE_CFG_RTPCL3_RTPRECL6            12
+#define B_PCIE_CFG_RTPCL3_RTPOSTCL6           ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 ) ///< Remote Transmitter Post-Cursor Coefficient List 6
+#define N_PCIE_CFG_RTPCL3_RTPOSTCL6           18
+#define B_PCIE_CFG_RTPCL3_RTPRECL7            ( BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Remote Transmitter Pre-Cursor Coefficient List 7
+#define N_PCIE_CFG_RTPCL3_RTPRECL7            24
+
+#define R_PCIE_CFG_RTPCL4                     0x00000460U      ///< Remote Transmitter Preset Coefficient List 4
+#define B_PCIE_CFG_RTPCL4_RTPOSTCL7           ( BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Remote Transmitter Post-Cursor Coefficient List 7
+#define N_PCIE_CFG_RTPCL4_RTPOSTCL7           0
+#define B_PCIE_CFG_RTPCL4_RTPRECL8            ( BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 ) ///< Remote Transmitter Pre-Cursor Coefficient List 8
+#define N_PCIE_CFG_RTPCL4_RTPRECL8            6
+#define B_PCIE_CFG_RTPCL4_RTPOSTCL8           ( BIT17 | BIT16 | BIT15 | BIT14 | BIT13 | BIT12 ) ///< Remote Transmitter Post-Cursor Coefficient List 8
+#define N_PCIE_CFG_RTPCL4_RTPOSTCL8           12
+#define B_PCIE_CFG_RTPCL4_RTPRECL9            ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 ) ///< Remote Transmitter Pre-Cursor Coefficient List 9
+#define N_PCIE_CFG_RTPCL4_RTPRECL9            18
+#define B_PCIE_CFG_RTPCL4_RTPOSTCL9           ( BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Remote Transmitter Post-Cursor Coefficient List 9
+#define N_PCIE_CFG_RTPCL4_RTPOSTCL9           24
+
+#define R_PCIE_CFG_FOMS                       0x00000464U      ///< Figure Of Merit Status
+#define B_PCIE_CFG_FOMS_FOMSV                 0x00ffffffU      ///< Figure of Merit Scoreboard Value
+#define N_PCIE_CFG_FOMS_FOMSV                 0
+#define B_PCIE_CFG_FOMS_LN                    ( BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Lane Number
+#define N_PCIE_CFG_FOMS_LN                    24
+#define B_PCIE_CFG_FOMS_IDX                   ( BIT31 | BIT30 | BIT29 ) ///< Index
+#define N_PCIE_CFG_FOMS_IDX                   29
+
+#define R_PCIE_CFG_HAEQ                       0x00000468U      ///< Hardware Autonomous Equalization Control
+#define B_PCIE_CFG_HAEQ_DL                    ( BIT15 | BIT14 | BIT13 | BIT12 | BIT11 | BIT10 | BIT9 | BIT8 ) ///< Dwelling Latency
+#define N_PCIE_CFG_HAEQ_DL                    8
+#define B_PCIE_CFG_HAEQ_MACFOMC               BIT19            ///< MAC FOM Control
+#define N_PCIE_CFG_HAEQ_MACFOMC               19
+#define B_PCIE_CFG_HAEQ_HAPCCPI               ( BIT31 | BIT30 | BIT29 | BIT28 ) ///< Hardware Autonomous Preset/Coefficient Count Per-Iteration
+#define N_PCIE_CFG_HAEQ_HAPCCPI               28
+
+#define R_PCIE_CFG_LTCO1                      0x00000470U      ///< Local Transmitter Coefficient Override 1
+#define B_PCIE_CFG_LTCO1_L0TPRECO             ( BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Lane 0 Transmitter Pre-Cursor Coefficient Override
+#define N_PCIE_CFG_LTCO1_L0TPRECO             0
+#define B_PCIE_CFG_LTCO1_L0TPOSTCO            ( BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 ) ///< Lane 0 Transmitter Post-Cursor Coefficient Override
+#define N_PCIE_CFG_LTCO1_L0TPOSTCO            6
+#define B_PCIE_CFG_LTCO1_L1TPRECO             ( BIT17 | BIT16 | BIT15 | BIT14 | BIT13 | BIT12 ) ///< Lane 1 Transmitter Pre-Cursor Coefficient Override
+#define N_PCIE_CFG_LTCO1_L1TPRECO             12
+#define B_PCIE_CFG_LTCO1_L1TPOSTCO            ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 ) ///< Lane 1 Transmitter Post-Cursor Coefficient Override
+#define N_PCIE_CFG_LTCO1_L1TPOSTCO            18
+#define B_PCIE_CFG_LTCO1_L0TCOE               BIT24            ///< Lane 0 Transmitter Coefficient Override Enable
+#define N_PCIE_CFG_LTCO1_L0TCOE               24
+#define B_PCIE_CFG_LTCO1_L1TCOE               BIT25            ///< Lane 1 Transmitter Coefficient Override Enable
+#define N_PCIE_CFG_LTCO1_L1TCOE               25
+
+#define R_PCIE_CFG_LTCO2                      0x00000474U      ///< Local Transmitter Coefficient Override 2
+#define B_PCIE_CFG_LTCO2_L2TPRECO             ( BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Lane 2 Transmitter Pre-Cursor Coefficient Override
+#define N_PCIE_CFG_LTCO2_L2TPRECO             0
+#define B_PCIE_CFG_LTCO2_L2TPOSTCO            ( BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 ) ///< Lane 2 Transmitter Post-Cursor Coefficient Override
+#define N_PCIE_CFG_LTCO2_L2TPOSTCO            6
+#define B_PCIE_CFG_LTCO2_L3TPRECO             ( BIT17 | BIT16 | BIT15 | BIT14 | BIT13 | BIT12 ) ///< Lane 3 Transmitter Pre-Cursor Coefficient Override
+#define N_PCIE_CFG_LTCO2_L3TPRECO             12
+#define B_PCIE_CFG_LTCO2_L3TPOSTCO            ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 ) ///< Lane 3 Transmitter Post-Cursor Coefficient Override
+#define N_PCIE_CFG_LTCO2_L3TPOSTCO            18
+#define B_PCIE_CFG_LTCO2_L2TCOE               BIT24            ///< Lane 2 Transmitter Coefficient Override Enable
+#define N_PCIE_CFG_LTCO2_L2TCOE               24
+#define B_PCIE_CFG_LTCO2_L3TCOE               BIT25            ///< Lane 3 Transmitter Coefficient Override Enable
+#define N_PCIE_CFG_LTCO2_L3TCOE               25
+
+#define R_PCIE_CFG_G3L0SCTL                   0x00000478U      ///< GEN3 L0s Control
+#define B_PCIE_CFG_G3L0SCTL_G3CCNFTS          ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Gen3 Common Clock N_FTS
+#define N_PCIE_CFG_G3L0SCTL_G3CCNFTS          0
+#define B_PCIE_CFG_G3L0SCTL_G3UCNFTS          ( BIT15 | BIT14 | BIT13 | BIT12 | BIT11 | BIT10 | BIT9 | BIT8 ) ///< Gen3 Unique Clock N_FTS
+#define N_PCIE_CFG_G3L0SCTL_G3UCNFTS          8
+#define B_PCIE_CFG_G3L0SCTL_G3L0SIC           ( BIT23 | BIT22 ) ///< Gen3 L0s Entry Idle Control
+#define N_PCIE_CFG_G3L0SCTL_G3L0SIC           22
+#define B_PCIE_CFG_G3L0SCTL_G3ASL0SPL         ( BIT31 | BIT30 | BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Gen3 Active State L0s Preparation Latency
+#define N_PCIE_CFG_G3L0SCTL_G3ASL0SPL         24
+
+#define R_PCIE_CFG_EQCFG2                     0x0000047cU      ///< Equalization Configuration 2
+#define B_PCIE_CFG_EQCFG2_REWMET              ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Receiver Eye Margin Error Threshold
+#define N_PCIE_CFG_EQCFG2_REWMET              0
+#define B_PCIE_CFG_EQCFG2_REWMETM             ( BIT9 | BIT8 )  ///< Receiver Eye Margin Error Threshold Multiplier
+#define N_PCIE_CFG_EQCFG2_REWMETM             8
+#define B_PCIE_CFG_EQCFG2_MPEME               BIT10            ///< Mid-Point Equalization Mechanism Enable
+#define N_PCIE_CFG_EQCFG2_MPEME               10
+#define B_PCIE_CFG_EQCFG2_NTEME               BIT11            ///< Nine-Tiles Equalization Mechanism Enable
+#define N_PCIE_CFG_EQCFG2_NTEME               11
+#define B_PCIE_CFG_EQCFG2_HAPCSB              ( BIT15 | BIT14 | BIT13 | BIT12 ) ///< Hardware Autonomous Preset/Coefficient Search Bound
+#define N_PCIE_CFG_EQCFG2_HAPCSB              12
+#define B_PCIE_CFG_EQCFG2_PCET                ( BIT19 | BIT18 | BIT17 | BIT16 ) ///< Preset/Coefficient Evaluation Timeout
+#define N_PCIE_CFG_EQCFG2_PCET                16
+#define B_PCIE_CFG_EQCFG2_NTSS                ( BIT22 | BIT21 | BIT20 ) ///< Nine-Tiles Step Size
+#define N_PCIE_CFG_EQCFG2_NTSS                20
+
+#define R_PCIE_CFG_MM                         0x00000480U      ///< Monitor Mux
+#define B_PCIE_CFG_MM_MSS                     ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Monitor Signal Select
+#define N_PCIE_CFG_MM_MSS                     0
+#define B_PCIE_CFG_MM_MSST                    0xffffff00U      ///< Monitor Signal State
+#define N_PCIE_CFG_MM_MSST                    8
+
+#define R_PCIE_CFG_CDM                        0x00000484U      ///< Controller Debug And Monitor
+#define B_PCIE_CFG_CDM_MCS                    ( BIT3 | BIT2 | BIT1 | BIT0 ) ///< Monitor Category Select
+#define N_PCIE_CFG_CDM_MCS                    0
+#define B_PCIE_CFG_CDM_MSS                    ( BIT7 | BIT6 | BIT5 | BIT4 ) ///< Monitor Segment Select
+#define N_PCIE_CFG_CDM_MSS                    4
+
+#define R_PCIE_CFG_EQCFG4                     0x0000048cU      ///< Equalization Configuration 4
+#define B_PCIE_CFG_EQCFG4_PX16GMFLNTL         BIT0             ///< 16GT/s Multi-Fragment Linear and Nine-Tile List Enable
+#define N_PCIE_CFG_EQCFG4_PX16GMFLNTL         0
+#define B_PCIE_CFG_EQCFG4_PX16GHAPCCPIE       BIT2             ///< 16.0 GT/s Hardware Autonomous Preset/Coefficient Count Per-Iteration Extention
+#define N_PCIE_CFG_EQCFG4_PX16GHAPCCPIE       2
+#define B_PCIE_CFG_EQCFG4_PX16GHAPCCPI        ( BIT6 | BIT5 | BIT4 | BIT3 ) ///< 16GT/s Hardware Autonomous Preset/Coefficient Count Per-Iteration
+#define N_PCIE_CFG_EQCFG4_PX16GHAPCCPI        3
+#define B_PCIE_CFG_EQCFG4_PX16GEQTS2IRRC      BIT7             ///< 16GT/s EQ TS2 in Recovery.ReceiverConfig Enable
+#define N_PCIE_CFG_EQCFG4_PX16GEQTS2IRRC      7
+#define B_PCIE_CFG_EQCFG4_PX16GRWTNEVE        ( BIT11 | BIT10 | BIT9 | BIT8 ) ///< 16GT/s  Receiver Wait Time For New Equalization Value Evaluation
+#define N_PCIE_CFG_EQCFG4_PX16GRWTNEVE        8
+#define B_PCIE_CFG_EQCFG4_PX16GHAED           BIT12            ///< 16GT/s Hardware Autonomous Equalization Done
+#define N_PCIE_CFG_EQCFG4_PX16GHAED           12
+#define B_PCIE_CFG_EQCFG4_PX16GRTPCOE         BIT15            ///< 16GT/s Remote Transmitter Preset Coefficient Override Enable
+#define N_PCIE_CFG_EQCFG4_PX16GRTPCOE         15
+#define B_PCIE_CFG_EQCFG4_PX16GRTLEPCEB       BIT16            ///< 16GT/s Remote Transmit Link Equalization Preset/Coefficient Evaluation Bypass
+#define N_PCIE_CFG_EQCFG4_PX16GRTLEPCEB       16
+#define B_PCIE_CFG_EQCFG4_PX16GLEP3B          BIT17            ///< 16.0 GT/s Link Equalization 3 Bypass
+#define N_PCIE_CFG_EQCFG4_PX16GLEP3B          17
+#define B_PCIE_CFG_EQCFG4_PX16GLEP23B         BIT18            ///< 16.0 GT/s Link Equalization Phase 2 and 3 Bypass
+#define N_PCIE_CFG_EQCFG4_PX16GLEP23B         18
+#define B_PCIE_CFG_EQCFG4_FOMSCP              ( BIT23 | BIT22 | BIT21 ) ///< FOM Scoreboard Control Policy
+#define N_PCIE_CFG_EQCFG4_FOMSCP              21
+#define B_PCIE_CFG_EQCFG4_PX8GTSWLPCE         ( BIT26 | BIT25 | BIT24 ) ///< 8.0GT/s Training Sequence Wait Latency For Presets / Coefficients Evaluation
+#define N_PCIE_CFG_EQCFG4_PX8GTSWLPCE         24
+#define B_PCIE_CFG_EQCFG4_PX16GTSWLPCE        ( BIT29 | BIT28 | BIT27 ) ///< 16.0GT/s Training Sequence Wait Latency For Presets / Coefficients Evaluation
+#define N_PCIE_CFG_EQCFG4_PX16GTSWLPCE        27
+
+#define R_PCIE_CFG_CTRL1                      0x000004a0U      ///< Control 1
+#define B_PCIE_CFG_CTRL1_L1RCEP               BIT8             ///< DMI L1 Root Port Exit Policy
+#define N_PCIE_CFG_CTRL1_L1RCEP               8
+#define B_PCIE_CFG_CTRL1_L1PL                 ( BIT11 | BIT10 | BIT9 )            ///< DMI L1 Preparation Latency
+#define N_PCIE_CFG_CTRL1_L1PL                 9
+#define V_PCIE_CFG_CTRL1_L1PL                 0x3
+#define B_PCIE_CFG_CTRL1_L1RC                 BIT12            ///< DMI L1 Root Port Control
+#define N_PCIE_CFG_CTRL1_L1RC                 12
+#define B_PCIE_CFG_CTRL1_L0SPFCUF             ( BIT16 | BIT15 ) ///< L0s Periodic Flow Control Update Frequency
+#define N_PCIE_CFG_CTRL1_L0SPFCUF             15
+
+#define R_PCIE_CFG_CTRL2                      0x000004a4U      ///< Control 2
+#define B_PCIE_CFG_CTRL2_PMETOFD              BIT6             ///< PMETO Timeout Fix Disable
+#define N_PCIE_CFG_CTRL2_PMETOFD              6
+#define B_PCIE_CFG_CTRL2_CLWSWPT              ( BIT24 | BIT23 | BIT22 )
+#define N_PCIE_CFG_CTRL2_CLWSWPT              22
+
+#define R_PCIE_CFG_IOSFC3TC                   0x000004c8U      ///< IOSF Channel 3 Transaction Credit
+#define B_PCIE_CFG_IOSFC3TC_C0CPCC            ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Channel 0 Completion Command Credit
+#define N_PCIE_CFG_IOSFC3TC_C0CPCC            0
+#define B_PCIE_CFG_IOSFC3TC_C0CPDC            ( BIT15 | BIT14 | BIT13 | BIT12 | BIT11 | BIT10 | BIT9 | BIT8 ) ///< Channel 0 Completion Data Credit
+#define N_PCIE_CFG_IOSFC3TC_C0CPDC            8
+
+#define R_PCIE_CFG_PX16GRTPCL1                0x000004dcU      ///< 16 GT/s Remote Transmitter Preset Coefficient List 1
+#define B_PCIE_CFG_PX16GRTPCL1_RTPRECL0PL0    ( BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Remote Transmitter Pre-Cursor Coefficient List 0/Preset List 0
+#define N_PCIE_CFG_PX16GRTPCL1_RTPRECL0PL0    0
+#define B_PCIE_CFG_PX16GRTPCL1_RTPOSTCL0PL1   ( BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 ) ///< Remote Transmitter Post-Cursor Coefficient List 0/Preset List 1
+#define N_PCIE_CFG_PX16GRTPCL1_RTPOSTCL0PL1   6
+#define B_PCIE_CFG_PX16GRTPCL1_RTPRECL1PL2    ( BIT17 | BIT16 | BIT15 | BIT14 | BIT13 | BIT12 ) ///< Remote Transmitter Pre-Cursor Coefficient List 1/Preset List 2
+#define N_PCIE_CFG_PX16GRTPCL1_RTPRECL1PL2    12
+#define B_PCIE_CFG_PX16GRTPCL1_RTPOSTCL1PL3   ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 ) ///< Remote Transmitter Post-Cursor Coefficient List 1/Preset List 3
+#define N_PCIE_CFG_PX16GRTPCL1_RTPOSTCL1PL3   18
+#define B_PCIE_CFG_PX16GRTPCL1_RTPRECL2PL4    ( BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Remote Transmitter Pre-Cursor Coefficient List 2/Preset List 4
+#define N_PCIE_CFG_PX16GRTPCL1_RTPRECL2PL4    24
+#define B_PCIE_CFG_PX16GRTPCL1_PCM            BIT31            ///< Preset/Coefficient Mode
+#define N_PCIE_CFG_PX16GRTPCL1_PCM            31
+
+#define R_PCIE_CFG_PX16GRTPCL2                0x000004e0U      ///< 16 GT/s Remote Transmitter Preset Coefficient List 2
+#define B_PCIE_CFG_PX16GRTPCL2_RTPOSTCL2PL5   ( BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Remote Transmitter Post-Cursor Coefficient List 2/Preset List 5
+#define N_PCIE_CFG_PX16GRTPCL2_RTPOSTCL2PL5   0
+#define B_PCIE_CFG_PX16GRTPCL2_RTPRECL3PL6    ( BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 ) ///< Remote Transmitter Pre-Cursor Coefficient List 3/Preset List 6
+#define N_PCIE_CFG_PX16GRTPCL2_RTPRECL3PL6    6
+#define B_PCIE_CFG_PX16GRTPCL2_RTPOSTCL3PL7   ( BIT17 | BIT16 | BIT15 | BIT14 | BIT13 | BIT12 ) ///< Remote Transmitter Post-Cursor Coefficient List 3/Preset List 7
+#define N_PCIE_CFG_PX16GRTPCL2_RTPOSTCL3PL7   12
+#define B_PCIE_CFG_PX16GRTPCL2_RTPRECL4PL8    ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 ) ///< Remote Transmitter Pre-Cursor Coefficient List 4/Preset List 8
+#define N_PCIE_CFG_PX16GRTPCL2_RTPRECL4PL8    18
+#define B_PCIE_CFG_PX16GRTPCL2_RTPOSTCL4PL9   ( BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Remote Transmitter Post-Cursor Coefficient List 4/Preset List 9
+#define N_PCIE_CFG_PX16GRTPCL2_RTPOSTCL4PL9   24
+
+#define R_PCIE_CFG_PX16GRTPCL3                0x000004e4U      ///< 16 GT/s Remote Transmitter Preset Coefficient List 3
+#define B_PCIE_CFG_PX16GRTPCL3_RTPRECL5PL10   ( BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Remote Transmitter Pre-Cursor Coefficient List 5/Preset List 10
+#define N_PCIE_CFG_PX16GRTPCL3_RTPRECL5PL10   0
+#define B_PCIE_CFG_PX16GRTPCL3_RTPOSTCL5      ( BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 ) ///< Remote Transmitter Post-Cursor Coefficient List 5
+#define N_PCIE_CFG_PX16GRTPCL3_RTPOSTCL5      6
+#define B_PCIE_CFG_PX16GRTPCL3_RTPRECL6       ( BIT17 | BIT16 | BIT15 | BIT14 | BIT13 | BIT12 ) ///< Remote Transmitter Pre-Cursor Coefficient List 6
+#define N_PCIE_CFG_PX16GRTPCL3_RTPRECL6       12
+#define B_PCIE_CFG_PX16GRTPCL3_RTPOSTCL6      ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 ) ///< Remote Transmitter Post-Cursor Coefficient List 6
+#define N_PCIE_CFG_PX16GRTPCL3_RTPOSTCL6      18
+#define B_PCIE_CFG_PX16GRTPCL3_RTPRECL7       ( BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Remote Transmitter Pre-Cursor Coefficient List 7
+#define N_PCIE_CFG_PX16GRTPCL3_RTPRECL7       24
+
+#define R_PCIE_CFG_PX16GRTPCL4                0x000004e8U      ///< 16 GT/s Remote Transmitter Preset Coefficient List 4
+#define B_PCIE_CFG_PX16GRTPCL4_RTPOSTCL7      ( BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Remote Transmitter Post-Cursor Coefficient List 7
+#define N_PCIE_CFG_PX16GRTPCL4_RTPOSTCL7      0
+#define B_PCIE_CFG_PX16GRTPCL4_RTPRECL8       ( BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 ) ///< Remote Transmitter Pre-Cursor Coefficient List 8
+#define N_PCIE_CFG_PX16GRTPCL4_RTPRECL8       6
+#define B_PCIE_CFG_PX16GRTPCL4_RTPOSTCL8      ( BIT17 | BIT16 | BIT15 | BIT14 | BIT13 | BIT12 ) ///< Remote Transmitter Post-Cursor Coefficient List 8
+#define N_PCIE_CFG_PX16GRTPCL4_RTPOSTCL8      12
+#define B_PCIE_CFG_PX16GRTPCL4_RTPRECL9       ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 ) ///< Remote Transmitter Pre-Cursor Coefficient List 9
+#define N_PCIE_CFG_PX16GRTPCL4_RTPRECL9       18
+#define B_PCIE_CFG_PX16GRTPCL4_RTPOSTCL9      ( BIT29 | BIT28 | BIT27 | BIT26 | BIT25 | BIT24 ) ///< Remote Transmitter Post-Cursor Coefficient List 9
+#define N_PCIE_CFG_PX16GRTPCL4_RTPOSTCL9      24
+
+#define R_PCIE_CFG_EQCFG5                     0x000004f8U      ///< Equalization Configuration 5
+#define B_PCIE_CFG_EQCFG5_REWMET              ( BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Receiver Eye Margin Error Threshold
+#define N_PCIE_CFG_EQCFG5_REWMET              0
+#define B_PCIE_CFG_EQCFG5_REWMETM             ( BIT9 | BIT8 )  ///< Receiver Eye Margin Error Threshold Multiplier
+#define N_PCIE_CFG_EQCFG5_REWMETM             8
+#define B_PCIE_CFG_EQCFG5_MPEME               BIT10            ///< Mid-Point Equalization Mechanism Enable
+#define N_PCIE_CFG_EQCFG5_MPEME               10
+#define B_PCIE_CFG_EQCFG5_NTEME               BIT11            ///< Nine-Tiles Equalization Mechanism Enable
+#define N_PCIE_CFG_EQCFG5_NTEME               11
+#define B_PCIE_CFG_EQCFG5_HAPCSB              ( BIT15 | BIT14 | BIT13 | BIT12 ) ///< Hardware Autonomous Preset/Coefficient Search Bound
+#define N_PCIE_CFG_EQCFG5_HAPCSB              12
+#define B_PCIE_CFG_EQCFG5_PCET                ( BIT19 | BIT18 | BIT17 | BIT16 ) ///< Preset/Coefficient Evaluation Timeout
+#define N_PCIE_CFG_EQCFG5_PCET                16
+
+#define R_PCIE_CFG_L0P0P1PCM                  0x00000500U      ///< Lane 0 P0 And P1 Preset-Coefficient Mapping
+
+#define R_PCIE_CFG_L0P1P2P3PCM                0x00000504U      ///< Lane 0 P1, P2 And P3 Preset-Coefficient Mapping
+
+#define R_PCIE_CFG_L0P3P4PCM                  0x00000508U      ///< Lane 0 P3 And P4 Preset-Coefficient Mapping
+
+#define R_PCIE_CFG_L0P5P6PCM                  0x0000050cU      ///< Lane 0 P5 And P6 Preset-Coefficient Mapping
+
+#define R_PCIE_CFG_L0P6P7P8PCM                0x00000510U      ///< Lane 0 P6, P7 And P8 Preset-Coefficient Mapping
+
+#define R_PCIE_CFG_L0P8P9PCM                  0x00000514U      ///< Lane 0 P8 And P9 Preset-Coefficient Mapping
+
+#define R_PCIE_CFG_L0P10PCM                   0x00000518U      ///< Lane 0 P10 Preset-Coefficient Mapping
+
+#define R_PCIE_CFG_L0LFFS                     0x0000051cU      ///< Lane 0 LF And FS
+
+#define R_PCIE_CFG_PX16GP0P1PCM               0x00000520U      ///< 16.0 GT/s P0 And P1 Preset-Coefficient Mapping
+
+#define R_PCIE_CFG_PX16GP1P2P3PCM             0x00000524U      ///< 16.0 GT/s P1, P2 And P3 Preset-Coefficient Mapping
+
+#define R_PCIE_CFG_PX16GP3P4PCM               0x00000528U      ///< 16.0 GT/s P3 And P4 Preset-Coefficient Mapping
+
+#define R_PCIE_CFG_PX16GP5P6PCM               0x0000052cU      ///< 16.0 GT/s P5 And P6 Preset-Coefficient Mapping
+
+#define R_PCIE_CFG_PX16GP6P7P8PCM             0x00000530U      ///< 16.0 GT/s P6, P7 And P8 Preset-Coefficient Mapping
+
+#define R_PCIE_CFG_PX16GP8P9PCM               0x00000534U      ///< 16.0 GT/s P8 And P9 Preset-Coefficient Mapping
+
+#define R_PCIE_CFG_PX16GP10PCM                0x00000538U      ///< 16.0 GT/s P10 Preset-Coefficient Mapping
+
+#define R_PCIE_CFG_PX16GLFFS                  0x0000053cU      ///< 16.0 GT/s LF And FS
+
+#define R_PCIE_CFG_COCTL                      0x00000594U      ///< Coalescing Control
+#define B_PCIE_CFG_COCTL_PWCE                 BIT0             ///< Posted Write Chaining Enable
+#define N_PCIE_CFG_COCTL_PWCE                 0
+#define B_PCIE_CFG_COCTL_DDCE                 BIT1             ///< Completion Chaining Enable
+#define N_PCIE_CFG_COCTL_DDCE                 1
+#define B_PCIE_CFG_COCTL_CT                   ( BIT9 | BIT8 | BIT7 | BIT6 | BIT5 | BIT4 | BIT3 | BIT2 ) ///< Chain Timer
+#define N_PCIE_CFG_COCTL_CT                   2
+#define B_PCIE_CFG_COCTL_CTE                  BIT10            ///< Chain Timer Enable
+#define N_PCIE_CFG_COCTL_CTE                  10
+#define B_PCIE_CFG_COCTL_ROAOP                BIT11            ///< Relaxed Order Attribute Override Policy
+#define N_PCIE_CFG_COCTL_ROAOP                11
+#define B_PCIE_CFG_COCTL_MAGPARCD             BIT12            ///< Maximum Addressable GPA Range Check Disable
+#define N_PCIE_CFG_COCTL_MAGPARCD             12
+#define B_PCIE_CFG_COCTL_PCLM                 ( BIT14 | BIT13 ) ///< Posted Chain Limit Mode
+#define N_PCIE_CFG_COCTL_PCLM                 13
+#define B_PCIE_CFG_COCTL_NPCLM                ( BIT16 | BIT15 ) ///< Non-Posted Chain Limit Mode
+#define N_PCIE_CFG_COCTL_NPCLM                15
+#define B_PCIE_CFG_COCTL_CHAINBARBE           BIT18            ///< Chain Bit Arbitration Enable
+#define N_PCIE_CFG_COCTL_CHAINBARBE           18
+
+#define R_PCIE_CFG_LTCO3                      0x00000598U      ///< Local Transmitter Coefficient Override 3
+
+#define R_PCIE_CFG_LTCO4                      0x0000059cU      ///< Local Transmitter Coefficient Override 4
+
+#define R_PCIE_CFG_LTCO5                      0x000005a0U      ///< Local Transmitter Coefficient Override 5
+
+#define R_PCIE_CFG_LTCO6                      0x000005a4U      ///< Local Transmitter Coefficient Override 6
+
+#define R_PCIE_CFG_LTCO7                      0x000005a8U      ///< Local Transmitter Coefficient Override 7
+
+#define R_PCIE_CFG_LTCO8                      0x000005acU      ///< Local Transmitter Coefficient Override 8
+
+#define R_PCIE_CFG_ADVMCTRL                   0x000005bcU      ///< Advance Mode Control
+#define B_PCIE_CFG_ADVMCTRL_PMREQBLKPGRSPT    ( BIT7 | BIT6 | BIT5 ) ///< PM_REQ Block and Power Gate Response Time
+#define N_PCIE_CFG_ADVMCTRL_PMREQBLKPGRSPT    5
+#define B_PCIE_CFG_ADVMCTRL_RLLG12R           BIT10            ///< Reset Link Layer in Gen1, 2 Recovery
+#define N_PCIE_CFG_ADVMCTRL_RLLG12R           10
+#define B_PCIE_CFG_ADVMCTRL_RRLLCL            BIT11            ///< Reset Receiver Link Layer Common Logic
+#define N_PCIE_CFG_ADVMCTRL_RRLLCL            11
+#define B_PCIE_CFG_ADVMCTRL_G3STFER           BIT13            ///< Gen3 Short TLP Framing Error Reporting
+#define N_PCIE_CFG_ADVMCTRL_G3STFER           13
+#define B_PCIE_CFG_ADVMCTRL_RXL0DC            BIT15            ///< RxL0 De-Assertion Control
+#define N_PCIE_CFG_ADVMCTRL_RXL0DC            15
+#define B_PCIE_CFG_ADVMCTRL_PMREQCWC          ( BIT18 | BIT17 | BIT16 ) ///< PM_REQ Clock Wake Control
+#define N_PCIE_CFG_ADVMCTRL_PMREQCWC          16
+#define B_PCIE_CFG_ADVMCTRL_EIOSMASKRX        BIT19            ///< EIOS Mask Receiver Datapath
+#define N_PCIE_CFG_ADVMCTRL_EIOSMASKRX        19
+#define B_PCIE_CFG_ADVMCTRL_EIOSDISDS         BIT20            ///< EIOS Disable DeSkew
+#define N_PCIE_CFG_ADVMCTRL_EIOSDISDS         20
+#define B_PCIE_CFG_ADVMCTRL_INRXL0CTRL        BIT22            ///< InRxL0 Control
+#define N_PCIE_CFG_ADVMCTRL_INRXL0CTRL        22
+#define B_PCIE_CFG_ADVMCTRL_CCBE              BIT23            ///< Completion Coalescing Break Event
+#define N_PCIE_CFG_ADVMCTRL_CCBE              23
+#define B_PCIE_CFG_ADVMCTRL_F10BTSE           BIT24            ///< Fabric 10-bit Tag Support Enable
+#define N_PCIE_CFG_ADVMCTRL_F10BTSE           24
+
+#define R_PCIE_CFG_PGTHRES                    0x000005c0U      ///< Power Gating Threshold
+#define B_PCIE_CFG_PGTHRES_L1PGLTREN          BIT0             ///< L1 Power Gating LTR Enable
+#define N_PCIE_CFG_PGTHRES_L1PGLTREN          0
+#define B_PCIE_CFG_PGTHRES_L1PGLTRTLV         0x03ff0000U      ///< L1 Power Gating LTR Threshold Latency Value
+#define N_PCIE_CFG_PGTHRES_L1PGLTRTLV         16
+#define B_PCIE_CFG_PGTHRES_L1PGLTRTLSV        ( BIT31 | BIT30 | BIT29 ) ///< L1 Power Gating LTR Threshold Latency Scale Value
+#define N_PCIE_CFG_PGTHRES_L1PGLTRTLSV        29
+
+#define R_PCIE_CFG_HWSNR                      0x000005f0U      ///< Hardware Save And Restore
+#define B_PCIE_CFG_HWSNR_BEPW                 ( BIT3 | BIT2 | BIT1 | BIT0 ) ///< Bank Enable Pulse Width
+#define N_PCIE_CFG_HWSNR_BEPW                 0
+#define B_PCIE_CFG_HWSNR_REPW                 ( BIT7 | BIT6 | BIT5 | BIT4 ) ///< Restore Enable Pulse Width
+#define N_PCIE_CFG_HWSNR_REPW                 4
+#define B_PCIE_CFG_HWSNR_EEH                  ( BIT9 | BIT8 )  ///< Entry and Exit Hysteresis
+#define N_PCIE_CFG_HWSNR_EEH                  8
+#define B_PCIE_CFG_HWSNR_READY4PG             BIT10            ///< Ready for Power Gating
+#define N_PCIE_CFG_HWSNR_READY4PG             10
+
+#define R_PCIE_CFG_PGCTRL                     0x000005f4U      ///< Power Gating Control
+#define B_PCIE_CFG_PGCTRL_PMREQBLKRSPT        ( BIT2 | BIT1 | BIT0 ) ///< PM_REQ Block Response Time
+#define N_PCIE_CFG_PGCTRL_PMREQBLKRSPT        0
+#define V_PCIE_CFG_PGCTRL_PMREQBLKRSPT_10us   2
+#define V_PCIE_CFG_PGCTRL_PMREQBLKRSPT_25us   5
+
+#define R_PCIE_CFG_PX16GLTCO1                 0x00000600U      ///< 16 GT/s Local Transmitter Coefficient Override 1
+#define B_PCIE_CFG_PX16GLTCO1_L0TPRECO        ( BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Lane 0 Transmitter Pre-Cursor Coefficient Override
+#define N_PCIE_CFG_PX16GLTCO1_L0TPRECO        0
+#define B_PCIE_CFG_PX16GLTCO1_L0TPOSTCO       ( BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 ) ///< Lane 0 Transmitter Post-Cursor Coefficient Override
+#define N_PCIE_CFG_PX16GLTCO1_L0TPOSTCO       6
+#define B_PCIE_CFG_PX16GLTCO1_L1TPRECO        ( BIT17 | BIT16 | BIT15 | BIT14 | BIT13 | BIT12 ) ///< Lane 1 Transmitter Pre-Cursor Coefficient Override
+#define N_PCIE_CFG_PX16GLTCO1_L1TPRECO        12
+#define B_PCIE_CFG_PX16GLTCO1_L1TPOSTCO       ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 ) ///< Lane 1 Transmitter Post-Cursor Coefficient Override
+#define N_PCIE_CFG_PX16GLTCO1_L1TPOSTCO       18
+#define B_PCIE_CFG_PX16GLTCO1_L0TCOE          BIT24            ///< Lane 0 Transmitter Coefficient Override Enable
+#define N_PCIE_CFG_PX16GLTCO1_L0TCOE          24
+#define B_PCIE_CFG_PX16GLTCO1_L1TCOE          BIT25            ///< Lane 1 Transmitter Coefficient Override Enable
+#define N_PCIE_CFG_PX16GLTCO1_L1TCOE          25
+
+#define R_PCIE_CFG_PX16GLTCO2                 0x00000604U      ///< 16 GT/s Local Transmitter Coefficient Override 2
+#define B_PCIE_CFG_PX16GLTCO2_L2TPRECO        ( BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Lane 2 Transmitter Pre-Cursor Coefficient Override
+#define N_PCIE_CFG_PX16GLTCO2_L2TPRECO        0
+#define B_PCIE_CFG_PX16GLTCO2_L2TPOSTCO       ( BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 ) ///< Lane 2 Transmitter Post-Cursor Coefficient Override
+#define N_PCIE_CFG_PX16GLTCO2_L2TPOSTCO       6
+#define B_PCIE_CFG_PX16GLTCO2_L3TPRECO        ( BIT17 | BIT16 | BIT15 | BIT14 | BIT13 | BIT12 ) ///< Lane 3 Transmitter Pre-Cursor Coefficient Override
+#define N_PCIE_CFG_PX16GLTCO2_L3TPRECO        12
+#define B_PCIE_CFG_PX16GLTCO2_L3TPOSTCO       ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 ) ///< Lane 3 Transmitter Post-Cursor Coefficient Override
+#define N_PCIE_CFG_PX16GLTCO2_L3TPOSTCO       18
+#define B_PCIE_CFG_PX16GLTCO2_L2TCOE          BIT24            ///< Lane 2 Transmitter Coefficient Override Enable
+#define N_PCIE_CFG_PX16GLTCO2_L2TCOE          24
+#define B_PCIE_CFG_PX16GLTCO2_L3TCOE          BIT25            ///< Lane 3 Transmitter Coefficient Override Enable
+#define N_PCIE_CFG_PX16GLTCO2_L3TCOE          25
+
+#define R_PCIE_CFG_PX16GLTCO3                 0x00000608U      ///< 16 GT/s Local Transmitter Coefficient Override 3
+#define B_PCIE_CFG_PX16GLTCO3_L4TPRECO        ( BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Lane 4 Transmitter Pre-Cursor Coefficient Override
+#define N_PCIE_CFG_PX16GLTCO3_L4TPRECO        0
+#define B_PCIE_CFG_PX16GLTCO3_L4TPOSTCO       ( BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 ) ///< Lane 4 Transmitter Post-Cursor Coefficient Override
+#define N_PCIE_CFG_PX16GLTCO3_L4TPOSTCO       6
+#define B_PCIE_CFG_PX16GLTCO3_L5TPRECO        ( BIT17 | BIT16 | BIT15 | BIT14 | BIT13 | BIT12 ) ///< Lane 5 Transmitter Pre-Cursor Coefficient Override
+#define N_PCIE_CFG_PX16GLTCO3_L5TPRECO        12
+#define B_PCIE_CFG_PX16GLTCO3_L5TPOSTCO       ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 ) ///< Lane 5 Transmitter Post-Cursor Coefficient Override
+#define N_PCIE_CFG_PX16GLTCO3_L5TPOSTCO       18
+#define B_PCIE_CFG_PX16GLTCO3_L4TCOE          BIT24            ///< Lane 4 Transmitter Coefficient Override Enable
+#define N_PCIE_CFG_PX16GLTCO3_L4TCOE          24
+#define B_PCIE_CFG_PX16GLTCO3_L5TCOE          BIT25            ///< Lane 5 Transmitter Coefficient Override Enable
+#define N_PCIE_CFG_PX16GLTCO3_L5TCOE          25
+
+#define R_PCIE_CFG_PX16GLTCO4                 0x0000060CU      ///< 16 GT/s Local Transmitter Coefficient Override 4
+#define B_PCIE_CFG_PX16GLTCO4_L6TPRECO        ( BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Lane 6 Transmitter Pre-Cursor Coefficient Override
+#define N_PCIE_CFG_PX16GLTCO4_L6TPRECO        0
+#define B_PCIE_CFG_PX16GLTCO4_L6TPOSTCO       ( BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 ) ///< Lane 6 Transmitter Post-Cursor Coefficient Override
+#define N_PCIE_CFG_PX16GLTCO4_L6TPOSTCO       6
+#define B_PCIE_CFG_PX16GLTCO4_L7TPRECO        ( BIT17 | BIT16 | BIT15 | BIT14 | BIT13 | BIT12 ) ///< Lane 7 Transmitter Pre-Cursor Coefficient Override
+#define N_PCIE_CFG_PX16GLTCO4_L7TPRECO        12
+#define B_PCIE_CFG_PX16GLTCO4_L7TPOSTCO       ( BIT23 | BIT22 | BIT21 | BIT20 | BIT19 | BIT18 ) ///< Lane 7 Transmitter Post-Cursor Coefficient Override
+#define N_PCIE_CFG_PX16GLTCO4_L7TPOSTCO       18
+#define B_PCIE_CFG_PX16GLTCO4_L6TCOE          BIT24            ///< Lane 6 Transmitter Coefficient Override Enable
+#define N_PCIE_CFG_PX16GLTCO4_L6TCOE          24
+#define B_PCIE_CFG_PX16GLTCO4_L7TCOE          BIT25            ///< Lane 7 Transmitter Coefficient Override Enable
+#define N_PCIE_CFG_PX16GLTCO4_L7TCOE          25
+
+#define R_PCIE_CFG_GDR                        0x00000690U      ///< General Debug Register
+#define B_PCIE_CFG_GDR_GPIOALD                BIT10            ///< GPIO Assertion on Link Down
+#define N_PCIE_CFG_GDR_GPIOALD                10
+
+#define R_PCIE_CFG_ACRG3                      0x000006ccU      ///< Advance Control Register Group 3
+#define B_PCIE_CFG_ACRG3_ADESKEW_DIS          BIT10            ///< Adapted Deskew Disable
+#define N_PCIE_CFG_ACRG3_ADESKEW_DIS          10
+#define B_PCIE_CFG_ACRG3_CBGM                 BIT21            ///< Chain Bit Generation Mode
+#define N_PCIE_CFG_ACRG3_CBGM                 21
+#define B_PCIE_CFG_ACRG3_CPGWAKECTRL          ( BIT23 | BIT22 ) ///< CPG Wake Control
+#define N_PCIE_CFG_ACRG3_CPGWAKECTRL          22
+#define B_PCIE_CFG_ACRG3_RRXDME               BIT27            ///<  Redo Receiver Detection Mechanism Enable
+#define N_PCIE_CFG_ACRG3_RRXDME               27
+
+#define R_PCIE_CFG_DPCECH                     0x00000a00U      ///< DPC Extended Capability Header
+#define B_PCIE_CFG_DPCECH_CID                 0x0000ffffU      ///< Capability ID
+#define N_PCIE_CFG_DPCECH_CID                 0
+#define B_PCIE_CFG_DPCECH_CV                  ( BIT19 | BIT18 | BIT17 | BIT16 ) ///< Capability Version
+#define N_PCIE_CFG_DPCECH_CV                  16
+#define B_PCIE_CFG_DPCECH_NCO                 0xfff00000U      ///< Next Capability Offset
+#define N_PCIE_CFG_DPCECH_NCO                 20
+
+#define R_PCIE_CFG_DPCCAPR                    0x00000a04U      ///< DPC Capability Register
+#define B_PCIE_CFG_DPCCAPR_RPEFDPC            BIT5
+#define N_PCIE_CFG_DPCCAPR_RPEFDPC            5
+
+#define R_PCIE_CFG_SPEECH                     0x00000a30U      ///< Secondary PCI Express Extended Capability Header
+#define B_PCIE_CFG_SPEECH_PCIEECID            0x0000ffffU      ///< PCI Express Extended Capability ID
+#define N_PCIE_CFG_SPEECH_PCIEECID            0
+#define B_PCIE_CFG_SPEECH_CV                  ( BIT19 | BIT18 | BIT17 | BIT16 ) ///< Capability Version
+#define N_PCIE_CFG_SPEECH_CV                  16
+#define V_PCIE_CFG_SPEECH_CV                  0x1
+#define B_PCIE_CFG_SPEECH_NCO                 0xfff00000U      ///< Next Capability Offset
+#define N_PCIE_CFG_SPEECH_NCO                 20
+
+#define R_PCIE_CFG_LCTL3                      0x00000a34U      ///< Link Control 3
+#define B_PCIE_CFG_LCTL3_PE                   BIT0             ///< Perform Equalization
+#define N_PCIE_CFG_LCTL3_PE                   0
+
+#define R_PCIE_CFG_LES                        0x00000a38U      ///< Lane Error Status
+
+#define R_PCIE_CFG_L01EC                      0x00000a3cU      ///< Lane 0 And Lane 1 Equalization Control
+
+#define R_PCIE_CFG_L23EC                      0x00000a40U      ///< Lane 2 And Lane 3 Equalization Control
+
+#define R_PCIE_CFG_L45EC                      0x00000a44U      ///< Lane 4 And Lane 5 Equalization Control
+
+#define R_PCIE_CFG_L67EC                      0x00000a48U      ///< Lane 6 And Lane 7 Equalization Control
+
+#define R_PCIE_CFG_DLFECH                     0x00000a90U      ///< Data Link Feature Extended Capability Header
+#define B_PCIE_CFG_DLFECH_PCIECID             0x0000ffffU      ///< PCI Express Extended Capability ID
+#define N_PCIE_CFG_DLFECH_PCIECID             0
+#define B_PCIE_CFG_DLFECH_CV                  ( BIT19 | BIT18 | BIT17 | BIT16 ) ///< Capability Version
+#define N_PCIE_CFG_DLFECH_CV                  16
+#define B_PCIE_CFG_DLFECH_NCO                 0xfff00000U      ///< Next Capability Offset
+#define N_PCIE_CFG_DLFECH_NCO                 20
+
+#define R_PCIE_CFG_DLFCAP                     0x00000a94U      ///< Data Link Feature Capabilities Register
+#define B_PCIE_CFG_DLFCAP_LSFCS               BIT0             ///< Local Scaled Flow Control Supported
+#define N_PCIE_CFG_DLFCAP_LSFCS               0
+
+#define R_PCIE_CFG_PL16GECH                   0x00000a9cU      ///< Physical Layer 16.0 GT/s Extended Capability Header
+#define B_PCIE_CFG_PL16GECH_PCIECID           0x0000ffffU      ///< PCI Express Extended Capability ID
+#define N_PCIE_CFG_PL16GECH_PCIECID           0
+#define B_PCIE_CFG_PL16GECH_CV                ( BIT19 | BIT18 | BIT17 | BIT16 ) ///< Capability Version
+#define N_PCIE_CFG_PL16GECH_CV                16
+#define B_PCIE_CFG_PL16GECH_NCO               0xfff00000U      ///< Next Capability Offset
+#define N_PCIE_CFG_PL16GECH_NCO               20
+
+#define R_PCIE_CFG_PL16S                      0x00000aa8U      ///< Physical Layer 16.0 GT/s Status Register
+#define B_PCIE_CFG_PL16S_EQP3SG4              BIT3             ///< Equalization 16.0 GT/s Phase 3 Successful
+#define N_PCIE_CFG_PL16S_EQP3SG4              3
+
+#define R_PCIE_CFG_PL16L01EC                  0x00000abcU      ///< Physical Layer 16.0 GT/s Lane 01 Equalization Control Register
+
+#define R_PCIE_CFG_PL16L23EC                  0x00000abeU      ///< Physical Layer 16.0 GT/s Lane 23 Equalization Control Register
+
+#define R_PCIE_CFG_PL16L45EC                  0x00000ac0U      ///< Physical Layer 16.0 GT/s Lane 45 Equalization Control Register
+
+#define R_PCIE_CFG_PL16L67EC                  0x00000ac2U      ///< Physical Layer 16.0 GT/s Lane 67 Equalization Control Register
+
+#define R_PCIE_CFG_PL16L89EC                  0x00000ac4U      ///< Physical Layer 16.0 GT/s Lane 89 Equalization Control Register
+
+#define R_PCIE_CFG_PL16L1011EC                0x00000ac6U      ///< Physical Layer 16.0 GT/s Lane 1011 Equalization Control Register
+
+#define R_PCIE_CFG_PL16L1213EC                0x00000ac8U      ///< Physical Layer 16.0 GT/s Lane 1213 Equalization Control Register
+
+#define R_PCIE_CFG_PL16L1415EC                0x00000acaU      ///< Physical Layer 16.0 GT/s Lane 1415 Equalization Control Register
+
+#define R_PCIE_CFG_G5ECH                      0x00000adcU      ///< Physical Layer 32.0 GT/s Extended Capability Header
+#define B_PCIE_CFG_G5ECH_ECID                 0x0000ffffU      ///< PCI Express Extended Capability ID
+#define N_PCIE_CFG_G5ECH_ECID                 0
+#define B_PCIE_CFG_G5ECH_CV                   ( BIT19 | BIT18 | BIT17 | BIT16 ) ///< Capability Version
+#define N_PCIE_CFG_G5ECH_CV                   16
+#define B_PCIE_CFG_G5ECH_NCO                  0xfff00000U      ///<  Next Capability Offset
+#define N_PCIE_CFG_G5ECH_NCO                  20
+
+#define R_PCIE_CFG_G5CAP                      0x00000ae0U      /// Physical Layer  32.0 GT/s Capability Register
+#define B_PCIE_CFG_G5STS_EQBYPSUP             BIT0             /// Equalization bypass to highest rate Supported
+
+#define R_PCIE_CFG_G5CTL                      0x00000ae4U      /// Physical Layer  32.0 GT/s Control Register
+#define B_PCIE_CFG_G5STS_EQBYPDIS             BIT0             /// Equalization bypass to highest rate Disable
+
+#define R_PCIE_CFG_G5STS                      0x00000ae8U      ///< Physical Layer  32.0 GT/s Status Register
+#define B_PCIE_CFG_G5STS_EQ32PH3SUCC          BIT3             ///< Equalization 32.0 GT/s Phase 3 Successfu
+#define N_PCIE_CFG_G5STS_EQ32PH3SUCC          3
+
+#define R_PCIE_CFG_G5LANEEQCTL_0              0x00000afcU      ///< 32.0 GT/s Lane 0123 Equalization Control Register
+
+#define R_PCIE_CFG_APEC                       0x00000b0cU      ///< Alternate Protocol Extended Capability Header
+#define B_PCIE_CFG_APEC_PCIECID               0x0000ffffU      ///< PCI Express Extended Capability ID
+#define N_PCIE_CFG_APEC_PCIECID               0
+#define B_PCIE_CFG_APEC_CV                    ( BIT19 | BIT18 | BIT17 | BIT16 ) ///< Capability Version
+#define N_PCIE_CFG_APEC_CV                    16
+#define B_PCIE_CFG_APEC_NCO                   0xfff00000U      ///<  Next Capability Offset
+#define N_PCIE_CFG_APEC_NCO                   20
+
+#define R_PCIE_CFG_ACGR3S2                    0x00000c50U      ///< Advance Control Register Group 3 Set 2
+#define B_PCIE_CFG_ACGR3S2_LSTPTLS            ( BIT3 | BIT2 | BIT1 | BIT0 ) ///< LSTP Target Link Speed
+#define N_PCIE_CFG_ACGR3S2_LSTPTLS            0
+#define B_PCIE_CFG_ACGR3S2_DRXTERMDQ          BIT4             ///< Disabled RxTermination in Detect.Quiet
+#define N_PCIE_CFG_ACGR3S2_DRXTERMDQ          4
+#define B_PCIE_CFG_ACGR3S2_SRT                BIT5             ///< Simplified Replay Timer
+#define N_PCIE_CFG_ACGR3S2_SRT                5
+#define B_PCIE_CFG_ACGR3S2_G1EBM              BIT6             ///< Gen 1 Elastic Buffer Mode
+#define N_PCIE_CFG_ACGR3S2_G1EBM              6
+#define B_PCIE_CFG_ACGR3S2_G2EBM              BIT7             ///< Gen 2 Elastic Buffer Mode
+#define N_PCIE_CFG_ACGR3S2_G2EBM              7
+#define B_PCIE_CFG_ACGR3S2_G3EBM              BIT8             ///< Gen 3 Elastic Buffer Mode
+#define N_PCIE_CFG_ACGR3S2_G3EBM              8
+#define B_PCIE_CFG_ACGR3S2_G4EBM              BIT9             ///< Gen 4 Elastic Buffer Mode
+#define N_PCIE_CFG_ACGR3S2_G4EBM              9
+#define B_PCIE_CFG_ACGR3S2_G5EBM              BIT20            ///< Gen 5 Elastic Buffer Mode
+#define N_PCIE_CFG_ACGR3S2_G5EBM              20
+
+#define R_PCIE_CFG_LTRSUBL1STD                0x00000c5cU      ///< LTR Subtraction for L1.Standard
+
+#define R_PCIE_CFG_LTRSUBL11                  0x00000c60U      ///< LTR Subtraction for L1.1 Power Gate
+
+#define R_PCIE_CFG_LTRSUBL12                  0x00000c64U      ///< LTR Subtraction for L1.2
+#define B_PCIE_CFG_LTRSUBL12_LTRSLSUBV        0x000003ffU      ///< LTR Snoop Latency Subtraction Value
+#define N_PCIE_CFG_LTRSUBL12_LTRSLSUBV        0
+#define B_PCIE_CFG_LTRSUBL12_LTRSLSSUBV       ( BIT12 | BIT11 | BIT10 ) ///< LTR Snoop Latency Scale Subtraction Value
+#define N_PCIE_CFG_LTRSUBL12_LTRSLSSUBV       10
+#define B_PCIE_CFG_LTRSUBL12_LTRSLSUBEN       BIT15            ///< LTR Snoop Latency Subtraction Enable
+#define N_PCIE_CFG_LTRSUBL12_LTRSLSUBEN       15
+#define B_PCIE_CFG_LTRSUBL12_LTRNSLSUBV       0x03ff0000U      ///< LTR Non-Snoop Latency Subtraction Value
+#define N_PCIE_CFG_LTRSUBL12_LTRNSLSUBV       16
+#define B_PCIE_CFG_LTRSUBL12_LTRNSLSSUBV      ( BIT28 | BIT27 | BIT26 ) ///< LTR Non-Snoop Latency Scale Subtraction Value
+#define N_PCIE_CFG_LTRSUBL12_LTRNSLSSUBV      26
+#define B_PCIE_CFG_LTRSUBL12_LTRNSLSUBEN      BIT31            ///< LTR Non-Snoop Latency Subtraction Enable
+#define N_PCIE_CFG_LTRSUBL12_LTRNSLSUBEN      31
+
+#define R_PCIE_CFG_LTRSUBL11NPG               0x00000c68U      ///< LTR Subtraction for L1.1 No Power Gate
+
+#define R_PCIE_CFG_VNNREMCTL                  0x00000c70U      ///< VNN Removal Control
+#define B_PCIE_CFG_VNNREMCTL_LRSLFVNNRE       ( BIT1 | BIT0 )  ///< Link Reset Suppression Latency For VNN Removal Exit
+#define N_PCIE_CFG_VNNREMCTL_LRSLFVNNRE       0
+#define B_PCIE_CFG_VNNREMCTL_ISPLFVNNRE       ( BIT3 | BIT2 )  ///< Internal States Propagation Latency For VNN Removal Exit
+#define N_PCIE_CFG_VNNREMCTL_ISPLFVNNRE       2
+
+#define R_PCIE_CFG_VNNRSNRC1                  0x00000c74U      ///< VNN Removal Save And Restore Hardware Contexts 1
+
+#define R_PCIE_CFG_RXQC                       0x00000c7cU      ///< Receive Queue Configurations
+#define B_PCIE_CFG_RXQC_V0RQPCOC              ( BIT1 | BIT0 )  ///< VC0 Receive Queue Posted Credit Offset Control
+#define N_PCIE_CFG_RXQC_V0RQPCOC              0
+#define B_PCIE_CFG_RXQC_V0RQNPCOC             ( BIT3 | BIT2 )  ///< VC0 Receive Queue Non-Posted Credit Offset Control
+#define N_PCIE_CFG_RXQC_V0RQNPCOC             2
+#define B_PCIE_CFG_RXQC_V1RQPCOC              ( BIT7 | BIT6 )  ///< VC1 Receive Queue Posted Credit Offset Control
+#define N_PCIE_CFG_RXQC_V1RQPCOC              6
+#define B_PCIE_CFG_RXQC_V1RQNPCOC             ( BIT9 | BIT8 )  ///< VC1 Receive Queue Non-Posted Credit Offset Control
+#define N_PCIE_CFG_RXQC_V1RQNPCOC             8
+#define B_PCIE_CFG_RXQC_VMRQPCOC              ( BIT13 | BIT12 ) ///< VCm Receive Queue Posted Credit Offset Control
+#define N_PCIE_CFG_RXQC_VMRQPCOC              12
+#define B_PCIE_CFG_RXQC_VMRQNPCOC             ( BIT15 | BIT14 ) ///< VCm Receive Queue Non-Posted Credit Offset Control
+#define N_PCIE_CFG_RXQC_VMRQNPCOC             14
+
+#define R_PCIE_CFG_AECR1G3                    0x00000c80U      ///< Advance Extended Control Register 1 Group 3
+#define B_PCIE_CFG_AECR1G3_DCDCCTDT           BIT0             ///< Disable Config.Dskew to Config.Complete transition delay timer
+#define N_PCIE_CFG_AECR1G3_DCDCCTDT           0
+#define B_PCIE_CFG_AECR1G3_L1OFFRDYHEWTEN     BIT6             ///< L1OFFRDY Host Exit Wait Time Enable
+#define N_PCIE_CFG_AECR1G3_L1OFFRDYHEWTEN     6
+#define B_PCIE_CFG_AECR1G3_L1OFFRDYHEWT       ( BIT9 | BIT8 | BIT7 ) ///< L1OFFRDY Host Exit Wait Time
+#define N_PCIE_CFG_AECR1G3_L1OFFRDYHEWT       7
+#define B_PCIE_CFG_AECR1G3_TPSE               BIT10            ///< Transmitted Preset Sticky Enable
+#define N_PCIE_CFG_AECR1G3_TPSE               10
+#define B_PCIE_CFG_AECR1G3_DTCGCM             BIT14            ///< Dynamic and Trunk Clock Gating Coupling Mode
+#define N_PCIE_CFG_AECR1G3_DTCGCM             14
+#define B_PCIE_CFG_AECR1G3_FCPTODIS           BIT23            ///< FCP Timeout Mechanism Disabled
+#define N_PCIE_CFG_AECR1G3_FCPTODIS           23
+#define B_PCIE_CFG_AECR1G3_REQTMBOF           BIT31            ///< RxEqTrain Message Bus Offset Mapping
+#define N_PCIE_CFG_AECR1G3_REQTMBOF           31
+
+#define R_PCIE_CFG_AECR2G3                    0x00000c84U      ///< Advance Extended Control Register 2 Group 3
+#define N_PCIE_CFG_AECR2G3_RSVD_RW2           8
+#define V_PCIE_CFG_AECR2G3_RSVD_RW2           0x2
+
+#define R_PCIE_CFG_LPCRE                      0x00000c88U      ///< Lock Policy Control Register Extension
+#define B_PCIE_CFG_LPCRE_IPCL                 BIT0             ///< IP Capability Lock
+#define N_PCIE_CFG_LPCRE_IPCL                 0
+#define B_PCIE_CFG_LPCRE_IPVCCAPL             BIT8             ///< IP VC Capability Lock
+#define N_PCIE_CFG_LPCRE_IPVCCAPL             8
+
+#define R_PCIE_CFG_LPCR                       0x00000c8cU      ///< Lock Policy Control Register
+#define B_PCIE_CFG_LPCR_SRL                   BIT0             ///< Secured Register Lock
+#define N_PCIE_CFG_LPCR_SRL                   0
+#define B_PCIE_CFG_LPCR_SERL                  BIT8             ///< Secure Equalization Register Lock
+#define N_PCIE_CFG_LPCR_SERL                  8
+#define B_PCIE_CFG_LPCR_LTRCFGLOCK            BIT16            ///< LTR Configuration Lock
+#define N_PCIE_CFG_LPCR_LTRCFGLOCK            16
+#define B_PCIE_CFG_LPCR_DIDOVR_LOCK           BIT24            ///< Device ID Override Lock
+#define N_PCIE_CFG_LPCR_DIDOVR_LOCK           24
+
+#define R_PCIE_CFG_RXMC1                      0x00000c90U      ///< RX Margin Control 1
+#define B_PCIE_CFG_RXMC1_MIESS                BIT0             ///< Margin Independent Error Sampler Support
+#define N_PCIE_CFG_RXMC1_MIESS                0
+#define B_PCIE_CFG_RXMC1_MIUDVMS              BIT1             ///< Margin Independent Up Down Voltage Margin Support
+#define N_PCIE_CFG_RXMC1_MIUDVMS              1
+#define B_PCIE_CFG_RXMC1_MILRTS               BIT2             ///< Margin Independent Left Right Timing Support
+#define N_PCIE_CFG_RXMC1_MILRTS               2
+#define B_PCIE_CFG_RXMC1_MVS                  BIT3             ///< Margin Voltage Support
+#define N_PCIE_CFG_RXMC1_MVS                  3
+#define B_PCIE_CFG_RXMC1_MMNOLS               ( BIT8 | BIT7 | BIT6 | BIT5 | BIT4 ) ///<  Margin Max Number Of Lanes Support
+#define N_PCIE_CFG_RXMC1_MMNOLS               4
+#define B_PCIE_CFG_RXMC1_MSRM                 BIT9             ///< Margin Sample Reporting Method
+#define N_PCIE_CFG_RXMC1_MSRM                 9
+#define B_PCIE_CFG_RXMC1_VMSLOP               ( BIT12 | BIT11 ) ///< Voltage Margin Steps Limit On PIPE
+#define N_PCIE_CFG_RXMC1_VMSLOP               11
+#define B_PCIE_CFG_RXMC1_TMSLOP               ( BIT14 | BIT13 ) ///< Time Margin Steps Limit On PIPE
+#define N_PCIE_CFG_RXMC1_TMSLOP               13
+#define B_PCIE_CFG_RXMC1_MSRTS                ( BIT25 | BIT24 | BIT23 | BIT22 | BIT21 | BIT20 ) ///< Margin Sampling Rate Timing Support
+#define N_PCIE_CFG_RXMC1_MSRTS                20
+#define B_PCIE_CFG_RXMC1_MSRVS                ( BIT31 | BIT30 | BIT29 | BIT28 | BIT27 | BIT26 ) ///< Margin Sampling Rate Voltage Support
+#define N_PCIE_CFG_RXMC1_MSRVS                26
+
+#define R_PCIE_CFG_RXMC2                      0x00000c94U      ///< RX Margin Control 2
+#define B_PCIE_CFG_RXMC2_MMVOS                ( BIT5 | BIT4 | BIT3 | BIT2 | BIT1 | BIT0 ) ///< Margin Max Voltage Offset Support
+#define N_PCIE_CFG_RXMC2_MMVOS                0
+#define B_PCIE_CFG_RXMC2_MNOVSS               ( BIT12 | BIT11 | BIT10 | BIT9 | BIT8 | BIT7 | BIT6 ) ///< Margin Number Of Voltage Steps Support
+#define N_PCIE_CFG_RXMC2_MNOVSS               6
+#define B_PCIE_CFG_RXMC2_MMTOS                ( BIT18 | BIT17 | BIT16 | BIT15 | BIT14 | BIT13 ) ///< Margin Max Timing Offset Support
+#define N_PCIE_CFG_RXMC2_MMTOS                13
+#define B_PCIE_CFG_RXMC2_MNOTSS               ( BIT24 | BIT23 | BIT22 | BIT21 | BIT20 | BIT19 ) ///< Margin Number Of Timing Steps Support
+#define N_PCIE_CFG_RXMC2_MNOTSS               19
+
+#define R_PCIE_CFG_EINJCTL                    0x00000ca8U      ///< EINJ Control
+#define B_PCIE_CFG_EINJCTL_EINJDIS            BIT0             ///< Error Injection Disable
+#define N_PCIE_CFG_EINJCTL_EINJDIS            0
+
+#define R_PCIE_CFG_PL16MECH                   0x00000edcU      ///< Physical Layer 16.0 GT/s Margining Extended Capability Header
+#define B_PCIE_CFG_PL16MECH_PCIECID           0x0000ffffU      ///< PCI Express Extended Capability ID
+#define N_PCIE_CFG_PL16MECH_PCIECID           0
+#define B_PCIE_CFG_PL16MECH_CV                ( BIT19 | BIT18 | BIT17 | BIT16 ) ///< Capability Version
+#define N_PCIE_CFG_PL16MECH_CV                16
+#define B_PCIE_CFG_PL16MECH_NCO               0xfff00000U      ///< Next Capability Offset
+#define N_PCIE_CFG_PL16MECH_NCO               20
+
+#define R_PCIE_CFG_PL16MPCPSB01               0x00000ee0U      ///< Physical Layer 16.0 GT/s Margining Port Capabilities and Port Status Byte 0 & 1
+#define B_PCIE_CFG_PL16MPCPSB01_MARGINDRISW   BIT0             ///< Margining uses Driver Software
+#define N_PCIE_CFG_PL16MPCPSB01_MARGINDRISW   0
+
+#define R_PCIE_CFG_MEMBARCTL                  0xF00
+#define R_PCIE_CFG_MEMBARCTL_MEMBAREN         BIT0
+
+#define R_PCIE_CFG_PCIERTP2                   0x304
+#define B_PCIE_CFG_PCIERTP2_G3X1              BIT8
+#define B_PCIE_CFG_PCIERTP2_G3X1_OFFSET       8
+#define B_PCIE_CFG_PCIERTP2_G3X1_MASK         0xF00
+#define B_PCIE_CFG_PCIERTP2_G3X2              BIT4
+#define B_PCIE_CFG_PCIERTP2_G3X2_OFFSET       4
+#define B_PCIE_CFG_PCIERTP2_G3X2_MASK         0xF0
+#define B_PCIE_CFG_PCIERTP2_G3X4              BIT0
+#define B_PCIE_CFG_PCIERTP2_G3X4_OFFSET       0
+#define B_PCIE_CFG_PCIERTP2_G3X4_MASK         0xF
+
+#define R_PCIE_RCRB_TXMDEC1                   0x17A0
+#define B_PCIE_RCRB_CRIDBNCD                  BIT0
+#define B_PCIE_RCRB_MRBIDBNCD                 BIT1
+#endif

--- a/Silicon/ArrowlakePkg/Library/BasePchPciBdfLib/PchPciBdfLib.c
+++ b/Silicon/ArrowlakePkg/Library/BasePchPciBdfLib/PchPciBdfLib.c
@@ -1445,6 +1445,20 @@ PchPcieRpFuncNumber (
   return (UINT8)Function;
 }
 
+UINT64
+PchPcieRpPciCfgBase (
+  IN  UINT32   RpIndex
+  )
+{
+  return PCI_SEGMENT_LIB_ADDRESS (
+          DEFAULT_PCI_SEGMENT_NUMBER_PCH,
+          DEFAULT_PCI_BUS_NUMBER_PCH,
+          PchPcieRpDevNumber (RpIndex),
+          PchPcieRpFuncNumber (RpIndex),
+          0
+          );
+}
+
 /**
   Get HECI1 PCI device number
 

--- a/Silicon/ArrowlakePkg/Library/BasePcieHelperLib/BasePcieHelperLib.c
+++ b/Silicon/ArrowlakePkg/Library/BasePcieHelperLib/BasePcieHelperLib.c
@@ -1,0 +1,377 @@
+/** @file
+  This file contains routines that support PCI Express initialization
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#include <Library/DebugLib.h>
+#include <Library/PcieHelperLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <PcieRegs.h>
+#include <Register/PcieSipRegs.h>
+#include <Register/SaRegsHostBridge.h>
+#include <CpuRegs.h>
+#include <Register/Cpuid.h>
+#include <Library/PciLib.h>
+
+#define ASPM_L1_NO_LIMIT 0xFF
+#define LINK_RETRAIN_WAIT_TIME 1000 // microseconds
+
+/**
+  Finds the Offset to a given Capabilities ID
+  Each capability has an ID and a pointer to next Capability, so they form a linked list.
+  This function walks the list of Capabilities present in device's pci cfg. If requested capability
+  can be found, its offset is returned.
+  If the capability can't be found or if device doesn't exist, function returns 0
+  CAPID list:
+    0x01 = PCI Power Management Interface
+    0x04 = Slot Identification
+    0x05 = MSI Capability
+    0x10 = PCI Express Capability
+
+  @param[in] DeviceBase           device's base address
+  @param[in] CapId                CAPID to search for
+
+  @retval 0                       CAPID not found (this includes situation where device doesn't exit)
+  @retval Other                   CAPID found, Offset of desired CAPID
+**/
+UINT8
+PcieBaseFindCapId (
+  IN UINT64  DeviceBase,
+  IN UINT8   CapId
+  )
+{
+  UINT8  CapHeaderOffset;
+  UINT8  CapHeaderId;
+  UINT16 Data16;
+  //
+  // We do not explicitly check if device exists to save time and avoid unnecessary PCI access
+  // If the device doesn't exist, check for CapHeaderId != 0xFF will fail and function will return offset 0
+  //
+  if ((PciSegmentRead8 (DeviceBase + PCI_PRIMARY_STATUS_OFFSET) & EFI_PCI_STATUS_CAPABILITY) == 0x00) {
+    ///
+    /// Function has no capability pointer
+    ///
+    return 0;
+  } else {
+    ///
+    /// Check the header layout to determine the Offset of Capabilities Pointer Register
+    ///
+    if ((PciSegmentRead8 (DeviceBase + PCI_HEADER_TYPE_OFFSET) & HEADER_LAYOUT_CODE) == (HEADER_TYPE_CARDBUS_BRIDGE)) {
+      ///
+      /// If CardBus bridge, start at Offset 0x14
+      ///
+      CapHeaderOffset = EFI_PCI_CARDBUS_BRIDGE_CAPABILITY_PTR;
+    } else {
+      ///
+      /// Otherwise, start at Offset 0x34
+      ///
+      CapHeaderOffset = PCI_CAPBILITY_POINTER_OFFSET;
+    }
+    ///
+    /// Get Capability Header, A pointer value of 00h is used to indicate the last capability in the list.
+    ///
+    CapHeaderId     = 0;
+    CapHeaderOffset = PciSegmentRead8 (DeviceBase + CapHeaderOffset) & ((UINT8) ~(BIT0 | BIT1));
+    while (CapHeaderOffset != 0 && CapHeaderId != 0xFF) {
+      Data16 = PciSegmentRead16 (DeviceBase + CapHeaderOffset);
+      CapHeaderId = (UINT8)(Data16 & 0xFF);
+      if (CapHeaderId == CapId) {
+        if (CapHeaderOffset > PCI_MAXLAT_OFFSET) {
+          ///
+          /// Return valid capability offset
+          ///
+          return CapHeaderOffset;
+        } else {
+          ASSERT ((FALSE));
+          return 0;
+        }
+      }
+      ///
+      /// Each capability must be DWORD aligned.
+      /// The bottom two bits of all pointers (including the initial pointer at 34h) are reserved
+      /// and must be implemented as 00b although software must mask them to allow for future uses of these bits.
+      ///
+      CapHeaderOffset = (UINT8)(Data16 >> 8);
+    }
+    return 0;
+  }
+}
+
+/**
+  Find the Offset to a given Capabilities ID
+  CAPID list:
+    0x01 = PCI Power Management Interface
+    0x04 = Slot Identification
+    0x05 = MSI Capability
+    0x10 = PCI Express Capability
+
+  @param[in] Segment              Pci Segment Number
+  @param[in] Bus                  Pci Bus Number
+  @param[in] Device               Pci Device Number
+  @param[in] Function             Pci Function Number
+  @param[in] CapId                CAPID to search for
+
+  @retval 0                       CAPID not found
+  @retval Other                   CAPID found, Offset of desired CAPID
+**/
+UINT8
+PcieFindCapId (
+  IN UINT8   Segment,
+  IN UINT8   Bus,
+  IN UINT8   Device,
+  IN UINT8   Function,
+  IN UINT8   CapId
+  )
+{
+  UINT64 DeviceBase;
+
+  DeviceBase = PCI_SEGMENT_LIB_ADDRESS (Segment, Bus, Device, Function, 0);
+  return PcieBaseFindCapId (DeviceBase, CapId);
+}
+
+/**
+  Search and return the offset of desired Pci Express Capability ID
+  CAPID list:
+    0x0001 = Advanced Error Reporting Capability
+    0x0002 = Virtual Channel Capability
+    0x0003 = Device Serial Number Capability
+    0x0004 = Power Budgeting Capability
+
+  @param[in] DeviceBase           device base address
+  @param[in] CapId                Extended CAPID to search for
+
+  @retval 0                       CAPID not found, this includes situation where device doesn't exist
+  @retval Other                   CAPID found, Offset of desired CAPID
+**/
+UINT16
+PcieBaseFindExtendedCapId (
+  IN UINT64  DeviceBase,
+  IN UINT16  CapId
+  )
+{
+  UINT16  CapHeaderOffset;
+  UINT16  CapHeaderId;
+  ///
+  /// Start to search at Offset 0x100
+  /// Get Capability Header, A pointer value of 00h is used to indicate the last capability in the list.
+  ///
+  CapHeaderId     = 0;
+  CapHeaderOffset = R_PCIE_CFG_EXCAP_OFFSET;
+  while (CapHeaderOffset != 0 && CapHeaderId != MAX_UINT16) {
+    CapHeaderId = PciSegmentRead16 (DeviceBase + CapHeaderOffset);
+    if (CapHeaderId == CapId) {
+      return CapHeaderOffset;
+    }
+    ///
+    /// Each capability must be DWORD aligned.
+    /// The bottom two bits of all pointers are reserved and must be implemented as 00b
+    /// although software must mask them to allow for future uses of these bits.
+    ///
+    CapHeaderOffset = (PciSegmentRead16 (DeviceBase + CapHeaderOffset + 2) >> 4) & ((UINT16) ~(BIT0 | BIT1));
+  }
+
+  return 0;
+}
+
+/**
+  Search and return the offset of desired Pci Express Capability ID
+  CAPID list:
+    0x0001 = Advanced Error Reporting Capability
+    0x0002 = Virtual Channel Capability
+    0x0003 = Device Serial Number Capability
+    0x0004 = Power Budgeting Capability
+
+  @param[in] Segment              Pci Segment Number
+  @param[in] Bus                  Pci Bus Number
+  @param[in] Device               Pci Device Number
+  @param[in] Function             Pci Function Number
+  @param[in] CapId                Extended CAPID to search for
+
+  @retval 0                       CAPID not found, this includes situation where device doesn't exist
+  @retval Other                   CAPID found, Offset of desired CAPID
+**/
+UINT16
+PcieFindExtendedCapId (
+  IN UINT8   Segment,
+  IN UINT8   Bus,
+  IN UINT8   Device,
+  IN UINT8   Function,
+  IN UINT16  CapId
+  )
+{
+  UINT64  DeviceBase;
+
+  DeviceBase = PCI_SEGMENT_LIB_ADDRESS (Segment, Bus, Device, Function, 0);
+  return PcieBaseFindExtendedCapId (DeviceBase, CapId);
+}
+
+/**
+  Checks if PCI device at given address exists
+
+  @param[in] Base            device's base address
+
+  @retval TRUE if exists
+**/
+BOOLEAN
+IsDevicePresent (
+  UINT64 Base
+  )
+{
+  if (PciSegmentRead16 (Base) == 0xFFFF) {
+    return FALSE;
+  }
+  return TRUE;
+}
+
+/**
+  Checks if device is a multifunction device
+  Besides comparing Multifunction bit (BIT7) it checks if contents of HEADER_TYPE register
+  make sense (header != 0xFF) to prevent false positives when called on devices which do not exist
+
+  @param[in] Base            device's base address
+
+  @retval TRUE if multifunction; FALSE otherwise
+**/
+BOOLEAN
+IsMultifunctionDevice (
+  UINT64 Base
+  )
+{
+  UINT8 HeaderType;
+  HeaderType = PciSegmentRead8(Base + PCI_HEADER_TYPE_OFFSET);
+  if ((HeaderType == 0xFF) || ((HeaderType & HEADER_TYPE_MULTI_FUNCTION) == 0)) {
+    return FALSE;
+  }
+  return TRUE;
+}
+
+/**
+  Checks device's Slot Clock Configuration
+
+  @param[in] Base            device's base address
+  @param[in] PcieCapOffset   devices Pci express capability list register offset
+
+  @retval TRUE when device uses slot clock, FALSE otherwise
+**/
+BOOLEAN
+GetScc (
+  UINT64    Base,
+  UINT8     PcieCapOffset
+  )
+{
+  return !!(PciSegmentRead16 (Base + PcieCapOffset + R_PCIE_LSTS_OFFSET) & B_PCIE_LSTS_SCC);
+}
+
+/**
+  Sets Common Clock Configuration bit for given device.
+
+  @param[in] PcieCapOffset   devices Pci express capability list register offset
+  @param[in] Base            device's base address
+**/
+VOID
+EnableCcc (
+  UINT64    Base,
+  UINT8     PcieCapOffset
+  )
+{
+  PciSegmentOr8 (Base + PcieCapOffset + R_PCIE_LCTL_OFFSET, B_PCIE_LCTL_CCC);
+}
+
+/**
+  Retrains link behind given device.
+  It only makes sense to call it for downstream ports. If called for upstream port nothing will happen.
+  If WaitUntilDone is TRUE function will wait until link retrain had finished, otherwise it will return immediately.
+  Link must finish retrain before software can access the device on the other side. If it's not going to access it
+  then considerable time can be saved by not waiting here.
+
+  @param[in] Base             device's base address
+  @param[in] PcieCapOffset    devices Pci express capability list register offset
+  @param[in] WaitUntilDone    when TRUE, function waits until link has retrained
+**/
+VOID
+RetrainLink (
+  UINT64  Base,
+  UINT8   PcieCapOffset,
+  BOOLEAN WaitUntilDone
+  )
+{
+  UINT16 LinkTraining;
+  UINT32 TimeoutUs;
+
+  TimeoutUs = LINK_RETRAIN_WAIT_TIME;
+  //
+  // Before triggering link retrain make sure it's not already retraining. Otherwise
+  // settings recently entered in LCTL register might go unnoticed
+  //
+  do {
+    LinkTraining = (PciSegmentRead16 (Base + PcieCapOffset + R_PCIE_LSTS_OFFSET) & B_PCIE_LSTS_LT);
+    TimeoutUs--;
+  } while (LinkTraining && (TimeoutUs != 0));
+
+  PciSegmentOr8 (Base + PcieCapOffset + R_PCIE_LCTL_OFFSET, B_PCIE_LCTL_RL);
+
+  TimeoutUs = LINK_RETRAIN_WAIT_TIME;
+  if (WaitUntilDone) {
+    do {
+      LinkTraining = (PciSegmentRead16 (Base + PcieCapOffset + R_PCIE_LSTS_OFFSET) & B_PCIE_LSTS_LT);
+      TimeoutUs--;
+    } while (LinkTraining && (TimeoutUs != 0));
+  }
+}
+
+/**
+  This function assigns Subordinate Bus Number and Secondary Bus Number.
+
+  @param[in] RpBase      Root Port PCI base address
+  @param[in] Segment     PCIe Root port PCI Segment
+  @param[in] TempPciBus  Temporary PCI bus number
+  @retval UINT64         Assigned sub bus base address
+**/
+UINT64
+PcieRpSetSubordSecondBus (
+  IN UINT64 RpBase,
+  IN UINT8  Segment,
+  IN UINT8  TempPciBus
+  )
+{
+  UINT64  EpBase;
+
+  //
+  // Assign bus numbers to the root port
+  //
+  PciSegmentAndThenOr32 (
+    RpBase + PCI_BRIDGE_PRIMARY_BUS_REGISTER_OFFSET,
+    (UINT32) ~B_PCI_BRIDGE_BNUM_SBBN_SCBN,
+    ((UINT32) (TempPciBus << 8)) | ((UINT32) (TempPciBus << 16))
+    );
+  //
+  // A config write is required in order for the device to re-capture the Bus number,
+  // according to PCI Express Base Specification, 2.2.6.2
+  // Write to a read-only register VendorID to not cause any side effects.
+  //
+  EpBase  = PCI_SEGMENT_LIB_ADDRESS (Segment, TempPciBus, 0, 0, 0);
+  PciSegmentWrite16 (EpBase + PCI_VENDOR_ID_OFFSET, 0);
+
+  if ( PciSegmentRead32 (EpBase + PCI_VENDOR_ID_OFFSET) == 0xFFFFFFFF) {
+    DEBUG ((DEBUG_WARN, "PCIe device (BAR: %lx) assigned to temp bus (S:%02x B:%02x ) not present\n", EpBase, Segment, TempPciBus));
+  }
+
+  return EpBase;
+}
+
+/**
+  Clear Subordinate Bus Number and Secondary Bus Number.
+
+  @param[in] RpBase     Root Port PCI base address
+**/
+VOID
+PcieRpClearSubordSecondBus (
+  IN UINT64 RpBase
+  )
+{
+  PciSegmentAnd32 (
+    RpBase + PCI_BRIDGE_PRIMARY_BUS_REGISTER_OFFSET,
+    (UINT32) ~B_PCI_BRIDGE_BNUM_SBBN_SCBN
+    );
+}

--- a/Silicon/ArrowlakePkg/Library/BasePcieHelperLib/BasePcieHelperLib.inf
+++ b/Silicon/ArrowlakePkg/Library/BasePcieHelperLib/BasePcieHelperLib.inf
@@ -1,0 +1,37 @@
+## @file
+# Component description file for the BasePcieHelperLib
+#
+#  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+
+[Defines]
+INF_VERSION = 0x00010017
+BASE_NAME = BasePcieHelperLib
+FILE_GUID = 568F5812-A9A8-4A4A-AD4D-471DD5F0BC11
+VERSION_STRING = 1.0
+MODULE_TYPE = BASE
+LIBRARY_CLASS = BasePcieHelperLib
+#
+# The following information is for reference only and not required by the build tools.
+#
+# VALID_ARCHITECTURES = IA32 X64 IPF EBC
+#
+
+
+
+[LibraryClasses]
+DebugLib
+PciSegmentLib
+
+
+[Packages]
+MdePkg/MdePkg.dec
+Silicon/CommonSocPkg/CommonSocPkg.dec
+Silicon/ArrowlakePkg/ArrowlakePkg.dec
+
+
+[Sources]
+BasePcieHelperLib.c

--- a/Silicon/ArrowlakePkg/Library/MtlPchPcieRpLib/MtlPchPcieRpLib.c
+++ b/Silicon/ArrowlakePkg/Library/MtlPchPcieRpLib/MtlPchPcieRpLib.c
@@ -17,6 +17,7 @@
 #include <Register/PchRegs.h>
 #include <Register/PchPcieRpRegs.h>
 #include <Register/PchRegsPcr.h>
+#include <Include/PchPcieRpInfo.h>
 #include <Register/MtlPchBdfAssignment.h>
 #include <Include/PcrDefine.h>
 #include <Library/MtlPchGpioTopologyLib.h>

--- a/Silicon/ArrowlakePkg/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.c
+++ b/Silicon/ArrowlakePkg/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.c
@@ -1,0 +1,2475 @@
+/** @file
+  This file contains routines that support PCI Express initialization
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#include "PciExpressHelpersLibrary.h"
+#include <Library/BaseMemoryLib.h>
+#include <Library/PcieHelperLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PciSegmentLib.h>
+#include <Library/PchInfoLib.h>
+#include <Library/PcieRpLib.h>
+#include <Register/PcieSipRegs.h>
+#include <CpuPcieInfo.h>
+#include <Register/SaRegsHostBridge.h>
+
+#define ASPM_L1_NO_LIMIT 0xFF
+#define ASPM_L0s_NO_LIMIT 0x7
+#define LINK_RETRAIN_WAIT_TIME 1000 // microseconds
+
+typedef union {
+  struct {
+    UINT32  RequesterCapable       : 1;
+    UINT32  ResponderCapable       : 1;
+    UINT32  RootCapable            : 1;
+    UINT32  Reserved               : 5;
+    UINT32  LocalClockGranularity  : 8;
+    UINT32  Reserved2              : 16;
+  } Bits;
+  UINT32  Uint32;
+} PTM_CAPS;
+
+typedef struct {
+  UINT32                          Size;
+  const PCH_PCIE_DEVICE_OVERRIDE* Table;
+} OVERRIDE_TABLE;
+
+typedef enum {
+  DevTypePci,
+  DevTypePcieEndpoint,
+  DevTypePcieUpstream,
+  DevTypePcieDownstream,
+  DevTypeMax
+} PCI_DEV_TYPE;
+
+typedef union {
+  struct {
+    UINT32 Enable                 : 1;
+    UINT32 RootSelect             : 1;
+    UINT32 Reserved               : 6;
+    UINT32 EffectiveGranularity   : 8;
+    UINT32 Reserved2              : 16;
+  } Bits;
+  UINT32  Uint32;
+} PTM_CTRL;
+
+#define MSLV_BIT_OFFSET   0
+#define MSLS_BIT_OFFSET  10
+#define MNSLV_BIT_OFFSET 13
+#define MNSLS_BIT_OFFSET 23
+
+//
+// This structure keeps in one place all data relevant to enabling L0s and L1.
+// L0s latencies are encoded in the same way as in hardware registers. The only operation
+// that will be performed on them is comparison
+// L1 latencies are decoded to microseconds, because they will be used in subtractions and additions
+//
+typedef struct {
+  UINT32  L0sSupported          : 1;
+  UINT32  L1Supported           : 1;
+  UINT32  L0sAcceptableLatency  : 3; // encoded as in hardware register
+  UINT32  L1AcceptableLatencyUs : 8; // decoded to microseconds
+  UINT32  LinkL0sExitLatency    : 3; // encoded as in hardware register
+  UINT32  LinkL1ExitLatencyUs   : 8; // decoded to microseconds
+} ASPM_CAPS;
+
+typedef struct {
+  UINT32     AspmL11  : 1;
+  UINT32     AspmL12  : 1;
+  UINT32     PmL11    : 1;
+  UINT32     PmL12    : 1;
+  UINT32     Cmrt     : 8; // Common Mode Restore Time
+  UINT32     TpoScale : 2; // T power_on scale
+  UINT32     TpoValue : 6; // T power_on value
+} L1SS_CAPS;
+
+typedef union {
+  struct {
+    INT32      Reserved0           : 16;
+    UINT32     CompleterSupported  : 1;
+    UINT32     RequesterSupported  : 1;
+    } Bits;
+    UINT32 Uint32;
+} TENBITTAG_CAPS;
+
+#define MAX_SBDF_TABLE_SIZE 50 //arbitrary table size; big enough to accomodate even full length TBT chain.
+
+typedef struct {
+  UINT32 Count;
+  SBDF   Entry [MAX_SBDF_TABLE_SIZE];
+} SBDF_TABLE;
+
+/**
+ *
+/**
+  Converts device's segment:bus:device:function coordinates to flat address
+
+  @param[in] Sbdf   device's segment:bus:device:function coordinates
+
+  @retval    address of device's PCI cfg space
+**/
+UINT64
+SbdfToBase (
+  SBDF Sbdf
+  )
+{
+  return PCI_SEGMENT_LIB_ADDRESS (Sbdf.Seg, Sbdf.Bus, Sbdf.Dev, Sbdf.Func, 0);
+}
+
+/*
+  Converts Tpower_on from value:scale notation to microseconds
+
+  @param[in] TpoScale   T power on scale
+  @param[in] TpoValue   T power on value
+
+  @retval    number of microseconds
+*/
+UINT32
+TpoToUs (
+  UINT32 TpoScale,
+  UINT32 TpoValue
+  )
+{
+  static const UINT8 TpoScaleMultiplier[] = {2, 10, 100};
+
+  ASSERT (TpoScale < TpoScaleMax);
+  if (TpoScale >= TpoScaleMax) {
+    return 0;
+  }
+  return (TpoScaleMultiplier[TpoScale] * TpoValue);
+}
+
+/**
+  Get max PCIe link speed supported by the root port.
+
+  @param[in] RpBase    Root Port base address
+
+  @retval Max link speed
+**/
+UINT32
+GetMaxLinkSpeed (
+  UINT64 RpBase
+  )
+{
+  return PciSegmentRead32 (RpBase + R_PCIE_CFG_LCAP) & B_PCIE_LCAP_MLS;
+}
+
+/**
+  Get max link width.
+
+  @param[in] RpDev  Pointer to the root port device
+  @retval           Max link width, 0 when failed
+**/
+UINT32
+GetMaxLinkWidth (
+  UINT64 RpBase
+  )
+{
+  UINT32 LinkWidth;
+
+  LinkWidth = (PciSegmentRead32 (RpBase + R_PCIE_CFG_LCAP) & B_PCIE_LCAP_MLW) >> N_PCIE_LCAP_MLW;
+
+  return LinkWidth;
+}
+
+/**
+  Get max payload size supported by device.
+
+  @param[in] Sbdf   device's segment:bus:device:function coordinates
+
+  @retval    Max payload size, encoded in the same way as in register (0=128b, 1=256b, etc)
+**/
+STATIC
+UINT8
+GetMps (
+  SBDF Sbdf
+  )
+{
+  return (PciSegmentRead16 (SbdfToBase (Sbdf) + Sbdf.PcieCap + R_PCIE_DCAP_OFFSET) & B_PCIE_DCAP_MPS);
+}
+
+/**
+  Sets Maximum Payload Size to be used by device
+
+  @param[in] Sbdf   device's segment:bus:device:function coordinates
+  @param[in] Mps    Max payload size, encoded in the same way as in register (0=128b, 1=256b, etc)
+**/
+STATIC
+VOID
+SetMps (
+  SBDF  Sbdf,
+  UINT8  Mps
+  )
+{
+  PciSegmentAndThenOr16 (SbdfToBase (Sbdf) + Sbdf.PcieCap + R_PCIE_DCTL_OFFSET, (UINT16) ~B_PCIE_DCTL_MPS, Mps << N_PCIE_DCTL_MPS);
+}
+
+/**
+  Enables LTR feature in given device
+
+  @param[in] Sbdf            device's segment:bus:device:function coordinates
+**/
+STATIC
+VOID
+EnableLtr (
+  SBDF Sbdf
+  )
+{
+  DEBUG ((DEBUG_INFO, "Enable Ltr %02x:%02x:%02x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+  if (Sbdf.PcieCap == 0) {
+    return;
+  }
+  PciSegmentOr32 (SbdfToBase (Sbdf) + Sbdf.PcieCap + R_PCIE_DCTL2_OFFSET, B_PCIE_DCTL2_LTREN);
+}
+
+/**
+  Sets Maximum Read Request Size to be used by device
+  @param[in] Sbdf   device's segment:bus:device:function coordinates
+**/
+STATIC
+VOID
+SetMrrs (
+  SBDF       Sbdf
+  )
+{
+  UINT32       Data32;
+  UINT32       MaxLinkSpeed;
+  UINT32       MaxLinkWidth;
+
+  DEBUG ((DEBUG_INFO, "SetMrrs %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+
+  Data32 = PciSegmentRead32 (SbdfToBase (Sbdf) + Sbdf.PcieCap + R_PCIE_LCAP_OFFSET);
+  MaxLinkSpeed = Data32 & B_PCIE_LCAP_MLS;
+  MaxLinkWidth = (Data32 & B_PCIE_LCAP_MLW) >> N_PCIE_LCAP_MLW;
+
+  if ((MaxLinkSpeed == V_PCIE_LCAP_MLS_GEN5) && (MaxLinkWidth == 16)) {
+    PciSegmentAndThenOr16 (SbdfToBase (Sbdf) + Sbdf.PcieCap + R_PCIE_DCTL_OFFSET, (UINT16) ~B_PCIE_DCTL_MRRS, V_PCIE_DCTL_MRRS_256B << N_PCIE_DCTL_MRRS);
+  }
+}
+
+/**
+  Returns information about type of device.
+
+  @param[out] Sbdf            device's segment:bus:device:function coordinates
+
+  @retval     one of: not a PCIe device (legacy PCI), PCIe endpoint, PCIe upstream port or PCIe downstream port (including rootport)
+**/
+PCI_DEV_TYPE
+GetDeviceType (
+  SBDF Sbdf
+  )
+{
+  UINT8 DeviceType;
+
+  if (Sbdf.PcieCap == 0) {
+    return DevTypePci;
+  }
+  DeviceType = (UINT8) ((PciSegmentRead16 (SbdfToBase (Sbdf) + Sbdf.PcieCap + R_PCIE_XCAP_OFFSET) & B_PCIE_XCAP_DT) >> N_PCIE_XCAP_DT);
+  if (DeviceType == PCIE_DEVICE_PORT_TYPE_UPSTREAM_PORT) {
+    return DevTypePcieUpstream;
+  } else if (DeviceType == PCIE_DEVICE_PORT_TYPE_DOWNSTREAM_PORT || DeviceType == PCIE_DEVICE_PORT_TYPE_ROOT_PORT) {
+    return DevTypePcieDownstream;
+  } else {
+    return DevTypePcieEndpoint;
+  }
+}
+
+/**
+  Initializes Dev:Func numbers for use in FindNextPcieChild or FindNextLegalSbdf functions.
+
+  @param[out] Sbdf            device's segment:bus:device:function coordinates
+**/
+STATIC
+VOID
+InitChildFinder (
+  OUT SBDF *Sbdf
+  )
+{
+  //
+  // Initialize Dev/Func to maximum values, so that when FindNextLegalSbdf ()
+  // is called on those input parameters, it will return 1st legal address (Dev 0 Func 0).
+  //
+  Sbdf->Dev = PCI_MAX_DEVICE;
+  Sbdf->Func = PCI_MAX_FUNC;
+}
+
+/**
+  Checks the device is a bridge and has non-zero secondary bus number assigned.
+  If so, it returns TRUE and initializes ChildSbdf with such values that
+  allow searching for devices on the secondary bus.
+  ChildSbdf will be mangled even if this function returns FALSE.
+
+  Legal bus assignment is assumed. This function doesn't check subordinate bus numbers of
+  the the device it was called on or any bridges between it and root complex
+
+  @param[in]  Sbdf       device's segment:bus:device:function coordinates
+  @param[out] ChildSbdf  SBDF initialized in such way that calling FindNextPcieChild( ) on it will find all children devices
+
+  @retval TRUE if device is a bridge and has a bus behind it; FALSE otherwise
+**/
+STATIC
+BOOLEAN
+HasChildBus (
+  SBDF   Sbdf,
+  SBDF   *ChildSbdf
+  )
+{
+  UINT32 Data32;
+  UINT64 Base;
+  UINT8  SecondaryBus;
+
+  ChildSbdf->Seg = Sbdf.Seg;
+  InitChildFinder (ChildSbdf);
+
+  Base = SbdfToBase (Sbdf);
+
+  if (PciSegmentRead8 (Base + R_PCI_BCC_OFFSET) != PCI_CLASS_BRIDGE) {
+    DEBUG ((DEBUG_INFO, "HasChildBus %02:%02:%02: no\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+    return FALSE;
+  }
+  Data32 = PciSegmentRead32 (Base + PCI_BRIDGE_PRIMARY_BUS_REGISTER_OFFSET);
+  SecondaryBus = (UINT8)((Data32 & B_PCI_BRIDGE_BNUM_SCBN) >> 8);
+  ChildSbdf->Bus = SecondaryBus;
+  if (SecondaryBus == 0) {
+    DEBUG ((DEBUG_INFO, "HasChildBus %02x:%02x:%02x: no\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+    return FALSE;
+  } else {
+    DEBUG ((DEBUG_INFO, "HasChildBus %02x:%02x:%02x: yes, %x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func, SecondaryBus));
+    return TRUE;
+  }
+}
+
+/**
+  Sets LTR limit in a device.
+
+  @param[in] Base            device's base address
+  @param[in] Ltr             LTR limit
+**/
+STATIC
+VOID
+SetLtrLimit (
+  UINT64    Base,
+  LTR_LIMIT Ltr
+  )
+{
+  UINT16 LtrCapOffset;
+  UINT16 Data16;
+
+  LtrCapOffset = PcieBaseFindExtendedCapId (Base, R_PCIE_LTRECH_CID);
+  if (LtrCapOffset == 0) {
+    return;
+  }
+  Data16 = (UINT16)((Ltr.MaxSnoopLatencyValue << N_PCIE_LTRECH_MSLR_VALUE) | (Ltr.MaxSnoopLatencyScale << N_PCIE_LTRECH_MSLR_SCALE));
+  PciSegmentWrite16(Base + LtrCapOffset + R_PCIE_LTRECH_MSLR_OFFSET, Data16);
+
+  Data16 = (UINT16)((Ltr.MaxNoSnoopLatencyValue << N_PCIE_LTRECH_MNSLR_VALUE) | (Ltr.MaxNoSnoopLatencyScale << N_PCIE_LTRECH_MNSLR_SCALE));
+  PciSegmentWrite16(Base + LtrCapOffset + R_PCIE_LTRECH_MNSLR_OFFSET, Data16);
+}
+
+/**
+  Checks if device at given address exists and is a PCI Express device.
+  PCI express devices are distinguished from PCI by having Capability ID 0x10
+  If the device is PCI express then its SDBF structure gets updated with pointer to
+  the PCIe Capability. This is an optimization feature. It greatly decreases the number
+  of bus accesses, since most features configured by this library depend on registers
+  whose location is relative to PCIe capability.
+
+  @param[in,out] Sbdf   on entry, segment:bus:device:function coordinates
+                        on exit, PcieCap offset is updated
+
+  @retval               TRUE when PCIe device exists; FALSE if it's not PCIe or there's no device at all
+**/
+BOOLEAN
+IsPcieDevice (
+  SBDF *Sbdf
+  )
+{
+  UINT8 PcieCapOffset;
+  UINT64         Base;
+
+  Base = SbdfToBase(*Sbdf);
+
+  if (PciSegmentRead16 (Base) == 0xFFFF) {
+    return FALSE;
+  }
+
+  PcieCapOffset = PcieBaseFindCapId (Base, EFI_PCI_CAPABILITY_ID_PCIEXP);
+  if (PcieCapOffset == 0) {
+    DEBUG ((DEBUG_INFO, "IsPcieDevice %02x:%02x:%02x - legacy\n", Sbdf->Bus, Sbdf->Dev, Sbdf->Func));
+    return FALSE;
+  } else {
+    Sbdf->PcieCap = PcieCapOffset;
+    DEBUG ((DEBUG_INFO, "IsPcieDevice %02x:%02x:%02x - yes\n", Sbdf->Bus, Sbdf->Dev, Sbdf->Func));
+    return TRUE;
+  }
+}
+
+/**
+  Returns TRUE and Dev:Func numbers where a PCIe device could legally be located, or FALSE if there
+  no such coordinates left.
+
+  Segment and Bus fields of SBDF structure are input only and determine which bus will be scanned.
+  This function should be called in a while() loop. It replaces the less efficient method of
+  using nested FOR loops that iterate over all device and function numbers. It is optimized for
+  the amount of bus access. If function0 doesn't exist or doesn't have Multifunction bit set,
+  then higher function numbers are skipped. If parent of this bus is a downstream port, then
+  Device numbers 1-31 get skipped too (there can be only Dev0 behind downstream ports)
+  If device/function number == 0x1F/0x7, this function returns first possible address, that is 0:0
+  Any other device number means Dev:Func contain address of last found child device
+  and this function should search for next one
+
+  @param[in]     ParentDevType  type of bridge who's partent of this bus
+  @param[in,out] Sbdf           On entry: location returned previously from this function
+                                          Dev:Func value of 1F:07 means search should start from the beginning
+                                On exit:  if legal Dev:Func combination was found, that Dev:Func is returned
+                                          otherwise, Dev:Func are initialized to 1F:07 for convenience
+
+  @retval TRUE when next legal Dev:Func address was found; FALSE otherwise
+**/
+STATIC
+BOOLEAN
+FindNextLegalSbdf (
+  IN     PCI_DEV_TYPE ParentDevType,
+  IN OUT SBDF         *Sbdf
+  )
+{
+  UINT8  MaxDev;
+  UINT64 Func0Base;
+
+  if (ParentDevType == DevTypePcieEndpoint) {
+    return FALSE;
+  }
+  if (ParentDevType == DevTypePcieUpstream) {
+    MaxDev = PCI_MAX_DEVICE;
+  } else {
+    MaxDev = 0;
+  }
+  Func0Base = PCI_SEGMENT_LIB_ADDRESS (Sbdf->Seg, Sbdf->Bus, Sbdf->Dev, 0, 0);
+  if ((Sbdf->Dev == PCI_MAX_DEVICE) && Sbdf->Func == PCI_MAX_FUNC) {
+    Sbdf->Dev = 0;
+    Sbdf->Func = 0;
+    return TRUE;
+  } else if ((Sbdf->Func == PCI_MAX_FUNC) || (Sbdf->Func == 0 && !IsMultifunctionDevice (Func0Base))) {
+  //
+  // if it's the last function of a device, then return Func0 of new device or FALSE in case there are no more devices
+  //
+    if (Sbdf->Dev == MaxDev) {
+      InitChildFinder (Sbdf);
+      return FALSE;
+    }
+    (Sbdf->Dev)++;
+    Sbdf->Func = 0;
+    return TRUE;
+  } else {
+    (Sbdf->Func)++;
+    return TRUE;
+  }
+}
+
+/**
+  Finds next PCIe (not legacy PCI) device behind given device
+  If device/function number == 0x1F/0x7, this function searches for children from scratch
+  Any other device number means Dev:Func contain address of last found child device
+  and this function should search for next one
+
+  @param[in]     ParentDevType  type of bridge who's partent of this bus
+  @param[in,out] Sbdf           On entry: location returned previously from this function
+                                          Dev:Func value of 0x1F:0x07 means search should start from the beginning
+                                On exit:  if PCIe device was found, its SBDF coordinates are returned
+                                          otherwise, Dev:Func are initialized to 0x1F:0x07 for convenience
+  @retval TRUE when next PCIe device was found; FALSE otherwise
+**/
+BOOLEAN
+FindNextPcieChild (
+  IN     PCI_DEV_TYPE ParentDevType,
+  IN OUT SBDF   *Sbdf
+  )
+{
+  while ( FindNextLegalSbdf (ParentDevType, Sbdf)) {
+    if (IsPcieDevice (Sbdf)) {
+      return TRUE;
+    }
+  }
+  return FALSE;
+}
+
+/**
+  Checks if given device supports Clock Power Management
+
+  @param[in] Sbdf     segment:bus:device:function coordinates of a device
+
+  @retval TRUE when device supports it, FALSE otherwise
+**/
+STATIC
+BOOLEAN
+IsCpmSupported (
+  SBDF Sbdf
+  )
+{
+  return !!(PciSegmentRead32 (SbdfToBase (Sbdf) + Sbdf.PcieCap + R_PCIE_LCAP_OFFSET) & B_PCIE_LCAP_CPM);
+}
+
+/**
+  Sets Enable Clock Power Management bit for given device
+
+  @param[in] Sbdf            segment:bus:device:function coordinates of a device
+**/
+STATIC
+VOID
+EnableCpm (
+  SBDF Sbdf
+  )
+{
+  PciSegmentOr16 (SbdfToBase (Sbdf) + Sbdf.PcieCap + R_PCIE_LCTL_OFFSET, B_PCIE_LCTL_ECPM);
+}
+
+/**
+  Checks if given device is an IoAPIC
+
+  @param[in] Base            device's base address
+
+  @retval TRUE if it's an IoAPIC
+**/
+BOOLEAN
+IsIoApicDevice (
+  UINT64 Base
+  )
+{
+  UINT8 BaseClassCode;
+  UINT8 SubClassCode;
+  UINT8 ProgInterface;
+
+  BaseClassCode = PciSegmentRead8 (Base + PCI_CLASSCODE_OFFSET + 2);
+  SubClassCode  = PciSegmentRead8 (Base + PCI_CLASSCODE_OFFSET + 1);
+  ProgInterface = PciSegmentRead8 (Base + PCI_CLASSCODE_OFFSET);
+  if ((BaseClassCode == PCI_CLASS_SYSTEM_PERIPHERAL) &&
+      (SubClassCode == PCI_SUBCLASS_PIC) &&
+      ((ProgInterface == PCI_IF_APIC_CONTROLLER) ||
+       (ProgInterface == PCI_IF_APIC_CONTROLLER2))) {
+    return TRUE;
+  }
+  return FALSE;
+}
+
+/**
+  There are some devices which support L1 substates, but due to silicon bugs the corresponding register
+  cannot be found by scanning PCIe capabilities. This function checks list of such devices and if one
+  is found, returns its L1ss capability register offset
+
+  @param[in] Base       base address of device
+  @param[in] Override   table of devices that need override
+
+  @retval               offset to L1ss capability register
+**/
+UINT16
+GetOverrideL1ssCapsOffset (
+  UINT64         Base,
+  OVERRIDE_TABLE *Override
+  )
+{
+  UINT16 DeviceId;
+  UINT16 VendorId;
+  UINT8  Revision;
+  UINT32 Index;
+
+  VendorId = PciSegmentRead16 (Base + PCI_VENDOR_ID_OFFSET);
+  DeviceId = PciSegmentRead16 (Base + PCI_DEVICE_ID_OFFSET);
+  Revision = PciSegmentRead8  (Base + PCI_REVISION_ID_OFFSET);
+
+  for (Index = 0; Index < Override->Size; Index++) {
+    if (((Override->Table[Index].OverrideConfig & PchPcieL1SubstatesOverride) == PchPcieL1SubstatesOverride) &&
+        (Override->Table[Index].VendorId == VendorId) &&
+        (Override->Table[Index].DeviceId == DeviceId) &&
+        (Override->Table[Index].RevId == Revision || Override->Table[Index].RevId == 0xFF)) {
+      return Override->Table[Index].L1SubstatesCapOffset;
+    }
+  }
+  return 0;
+}
+
+/**
+  There are some devices whose implementation of L1 substates is partially broken. This function checks
+  list of such devices and if one is found, overrides their L1ss-related capabilities
+
+  @param[in]     Base       base address of device
+  @param[in]     Override   table of devices that need override
+  @param[in,out] L1ss       on entry, capabilities read from register; on exit, capabilities modified according ot override table
+**/
+STATIC
+VOID
+OverrideL1ssCaps (
+  UINT64         Base,
+  OVERRIDE_TABLE *Override,
+  L1SS_CAPS      *L1ss
+  )
+{
+  UINT16 DeviceId;
+  UINT16 VendorId;
+  UINT8  Revision;
+  UINT32 Index;
+
+  VendorId = PciSegmentRead16 (Base + PCI_VENDOR_ID_OFFSET);
+  DeviceId = PciSegmentRead16 (Base + PCI_DEVICE_ID_OFFSET);
+  Revision = PciSegmentRead8  (Base + PCI_REVISION_ID_OFFSET);
+
+  for (Index = 0; Index < Override->Size; Index++) {
+    if (((Override->Table[Index].OverrideConfig & PchPcieL1SubstatesOverride) == PchPcieL1SubstatesOverride) &&
+        (Override->Table[Index].VendorId == VendorId) &&
+        (Override->Table[Index].DeviceId == DeviceId) &&
+        (Override->Table[Index].RevId == Revision || Override->Table[Index].RevId == 0xFF)) {
+
+      L1ss->PmL12   &= !!(Override->Table[Index].L1SubstatesCapMask & B_PCIE_EX_L1SCAP_PPL12S);
+      L1ss->PmL11   &= !!(Override->Table[Index].L1SubstatesCapMask & B_PCIE_EX_L1SCAP_PPL11S);
+      L1ss->AspmL12 &= !!(Override->Table[Index].L1SubstatesCapMask & B_PCIE_EX_L1SCAP_AL12S);
+      L1ss->AspmL11 &= !!(Override->Table[Index].L1SubstatesCapMask & B_PCIE_EX_L1SCAP_AL1SS);
+      if (Override->Table[Index].L1sTpowerOnValue != 0) {
+        L1ss->Cmrt = Override->Table[Index].L1sCommonModeRestoreTime;
+        L1ss->TpoScale = Override->Table[Index].L1sTpowerOnScale;
+        L1ss->TpoValue = Override->Table[Index].L1sTpowerOnValue;
+      }
+      return;
+    }
+  }
+}
+
+/**
+  Returns L1 sub states capabilities of a device
+
+  @param[in] Base   base address of a device
+
+  @retval L1SS_CAPS structure filled with device's capabilities
+**/
+STATIC
+L1SS_CAPS
+GetL1ssCaps (
+  UINT64         Base,
+  OVERRIDE_TABLE *Override
+  )
+{
+  L1SS_CAPS Capabilities = {0};
+  UINT16    PcieCapOffset;
+  UINT32    CapsRegister;
+
+  PcieCapOffset = GetOverrideL1ssCapsOffset (Base, Override);
+  if (PcieCapOffset == 0) {
+    PcieCapOffset = PcieBaseFindExtendedCapId (Base, V_PCIE_EX_L1S_CID);
+  }
+  if (PcieCapOffset == 0) {
+    return Capabilities;
+  }
+  CapsRegister = PciSegmentRead32 (Base + PcieCapOffset + R_PCIE_EX_L1SCAP_OFFSET);
+  if (CapsRegister & B_PCIE_EX_L1SCAP_L1PSS) {
+    //
+    // Skip L1.1 checking since some device only indecate L1.2 support.
+    // [1604452805]
+    //
+    Capabilities.PmL11 = !!(CapsRegister & B_PCIE_EX_L1SCAP_PPL11S);
+    Capabilities.PmL12 = !!(CapsRegister & B_PCIE_EX_L1SCAP_PPL12S);
+    Capabilities.AspmL12 = !!(CapsRegister & B_PCIE_EX_L1SCAP_AL12S);
+    Capabilities.AspmL11 = !!(CapsRegister & B_PCIE_EX_L1SCAP_AL1SS);
+    Capabilities.Cmrt = (CapsRegister & B_PCIE_EX_L1SCAP_CMRT) >> N_PCIE_EX_L1SCAP_CMRT;
+    Capabilities.TpoValue = (CapsRegister & B_PCIE_EX_L1SCAP_PTV) >> N_PCIE_EX_L1SCAP_PTV;
+    Capabilities.TpoScale = (CapsRegister & B_PCIE_EX_L1SCAP_PTPOS) >> N_PCIE_EX_L1SCAP_PTPOS;
+  }
+  OverrideL1ssCaps (Base, Override, &Capabilities);
+  return Capabilities;
+}
+
+/**
+  Returns combination of two sets of L1 substate capabilities
+  Given feature is supported by the link only if both sides support it
+  Time parameters for link (Cmrt and Tpo) depend on the bigger value between two sides
+
+  @param[in] L1ssA      L1 substate capabilities of first device
+  @param[in] L1ssB      L1 substate capabilities of second device
+
+  @retval Link's L1 substate capabilities
+**/
+STATIC
+L1SS_CAPS
+CombineL1ss (
+  L1SS_CAPS L1ssA,
+  L1SS_CAPS L1ssB
+  )
+{
+  L1SS_CAPS Combined;
+
+  Combined.PmL12 = L1ssA.PmL12 && L1ssB.PmL12;
+  Combined.PmL11 = L1ssA.PmL11 && L1ssB.PmL11;
+  Combined.AspmL12 = L1ssA.AspmL12 && L1ssB.AspmL12;
+  Combined.AspmL11 = L1ssA.AspmL11 && L1ssB.AspmL11;
+  Combined.Cmrt = MAX (L1ssA.Cmrt, L1ssB.Cmrt);
+  if (TpoToUs (L1ssA.TpoScale, L1ssA.TpoValue) > TpoToUs (L1ssB.TpoScale, L1ssB.TpoValue)) {
+    Combined.TpoScale = L1ssA.TpoScale;
+    Combined.TpoValue = L1ssA.TpoValue;
+  } else {
+    Combined.TpoScale = L1ssB.TpoScale;
+    Combined.TpoValue = L1ssB.TpoValue;
+  }
+  return Combined;
+}
+
+/**
+  Configures L1 substate feature in a device
+
+  @param[in] Sbdf     segment:bus:device:function coordinates of a device
+  @param[in] L1ss     configuration to be programmed
+  @param[in] Override table of devices that require special handling
+**/
+STATIC
+VOID
+SetL1ss (
+  SBDF           Sbdf,
+  L1SS_CAPS      L1ss,
+  OVERRIDE_TABLE *Override,
+  BOOLEAN   IsCpuPcie
+
+  )
+{
+  UINT16    PcieCapOffset;
+  UINT32    Ctrl1Register;
+  UINT32    Ctrl2Register;
+  UINT64    Base;
+
+  Base = SbdfToBase(Sbdf);
+  Ctrl1Register = 0;
+  Ctrl2Register = 0;
+
+  PcieCapOffset = GetOverrideL1ssCapsOffset (Base, Override);
+  if (PcieCapOffset == 0) {
+    PcieCapOffset = PcieBaseFindExtendedCapId (Base, V_PCIE_EX_L1S_CID);
+  }
+  if (PcieCapOffset == 0) {
+    return;
+  }
+  Ctrl1Register |= (L1ss.PmL12 ? B_PCIE_EX_L1SCAP_PPL12S : 0);
+  Ctrl1Register |= (L1ss.PmL11 ? B_PCIE_EX_L1SCAP_PPL11S : 0);
+  Ctrl1Register |= (L1ss.AspmL12 ? B_PCIE_EX_L1SCAP_AL12S : 0);
+  Ctrl1Register |= (L1ss.AspmL11 ? B_PCIE_EX_L1SCAP_AL1SS : 0);
+  if ((GetDeviceType (Sbdf) == DevTypePcieDownstream)) {
+    Ctrl1Register |= (L1ss.Cmrt << N_PCIE_EX_L1SCAP_CMRT);
+  }
+  ///
+  /// BWG 1.3 Section 5.5.7.6 LTR Threshold Latency
+  /// Set L1.2 LTR threshold using formula (TpoToUs (L1ss.TpoScale, L1ss.TpoValue) + L1ss.Cmrt + 10)
+  ///
+  Ctrl1Register |= ((TpoToUs (L1ss.TpoScale, L1ss.TpoValue) + L1ss.Cmrt + 10) << N_PCIE_EX_L1SCTL1_L12LTRTLV);
+  Ctrl1Register |= (2 << N_PCIE_EX_L1SCTL1_L12LTRTLSV);
+
+
+
+
+  Ctrl2Register |= (L1ss.TpoScale);
+  Ctrl2Register |= (L1ss.TpoValue << N_PCIE_EX_L1SCTL2_POWT);
+
+  //
+  // Set CLKREQ Acceleration Interrupt Enable
+  //
+  Ctrl1Register |= B_PCIE_EX_L1SCTL1_L1SSEIE;
+  PciSegmentWrite32 (Base + PcieCapOffset + R_PCIE_EX_L1SCTL1_OFFSET, 0);
+  PciSegmentWrite32 (Base + PcieCapOffset + R_PCIE_EX_L1SCTL2_OFFSET, Ctrl2Register);
+  PciSegmentWrite32 (Base + PcieCapOffset + R_PCIE_EX_L1SCTL1_OFFSET, Ctrl1Register);
+}
+
+/**
+  Converts L1 latency from enumerated register value to microseconds
+
+  @param[in] L1Latency     latency value retrieved from register; see PCIE specification for encoding
+
+  @retval    L1 latency converted to microseconds
+**/
+UINT32
+L1LatencyToUs (
+  UINT32 L1Latency
+  )
+{
+  if (L1Latency < 7) {
+    return 1 * (BIT0 << L1Latency);
+  } else {
+    return ASPM_L1_NO_LIMIT;
+  }
+}
+
+/**
+  Modifies L1 latency by provided value
+
+  @param[in] Aspm     Structure that contains ASPM capabilities of a link, including L1 acceptable latency
+  @param[in] Value    Value, in microseconds, to be added to L1 acceptable latency. Can be negative.
+
+  @retval             Aspm structure with modified L1 acceptable latency
+**/
+STATIC
+ASPM_CAPS
+PatchL1AcceptableLatency (
+  ASPM_CAPS Aspm,
+  INT8      Value
+  )
+{
+  if (Aspm.L1AcceptableLatencyUs != ASPM_L1_NO_LIMIT) {
+    if (Value > 0) {
+      Aspm.L1AcceptableLatencyUs += Value;
+    } else {
+      if (Aspm.L1AcceptableLatencyUs > (UINT32)(-1*Value)) {
+        Aspm.L1AcceptableLatencyUs = Aspm.L1AcceptableLatencyUs + Value;
+      } else {
+        Aspm.L1AcceptableLatencyUs = 0;
+      }
+    }
+  }
+  return Aspm;
+}
+
+/**
+  Reads ASPM capabilities of a device
+
+  @param[in] Sbdf segment:bus:device:function coordinates of a device
+
+  @retval           structure containing device's ASPM capabilities
+**/
+STATIC
+ASPM_CAPS
+GetAspmCaps (
+  SBDF   Sbdf
+  )
+{
+
+  UINT32    LinkCapRegister;
+  UINT32    DevCapRegister;
+  UINT64    Base;
+  ASPM_CAPS Aspm = {0};
+
+  Base = SbdfToBase (Sbdf);
+
+  LinkCapRegister = PciSegmentRead32 (Base + Sbdf.PcieCap + R_PCIE_LCAP_OFFSET);
+  DevCapRegister = PciSegmentRead32 (Base + Sbdf.PcieCap + R_PCIE_DCAP_OFFSET);
+
+  ///
+  /// Check endpoint for pre-1.1 devices based on the Role based Error Reporting Capability bit. Don't report L0s support for old devices
+  ///
+  if (DevCapRegister & B_PCIE_DCAP_RBER) {
+    Aspm.L0sSupported = !!(LinkCapRegister & B_PCIE_LCAP_APMS_L0S);
+  }
+  Aspm.L1Supported = !!(LinkCapRegister & B_PCIE_LCAP_APMS_L1);
+
+  Aspm.LinkL0sExitLatency = (LinkCapRegister & B_PCIE_LCAP_EL0) >> N_PCIE_LCAP_EL0;
+  Aspm.LinkL1ExitLatencyUs = L1LatencyToUs( (LinkCapRegister & B_PCIE_LCAP_EL1) >> N_PCIE_LCAP_EL1);
+
+  if (GetDeviceType (Sbdf) == DevTypePcieEndpoint) {
+    Aspm.L0sAcceptableLatency = (DevCapRegister & B_PCIE_DCAP_E0AL) >> N_PCIE_DCAP_E0AL;
+    Aspm.L1AcceptableLatencyUs = L1LatencyToUs( (DevCapRegister & B_PCIE_DCAP_E1AL) >> N_PCIE_DCAP_E1AL);
+    DEBUG ((DEBUG_INFO, "GetAspmCaps %02x:%02x:%02x L0s%c %d:%d L1%c %d:%d\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func,
+                                                                           Aspm.L0sSupported?'+':'-', Aspm.LinkL0sExitLatency, Aspm.L0sAcceptableLatency,
+                                                                           Aspm.L1Supported?'+':'-', Aspm.LinkL1ExitLatencyUs, Aspm.L1AcceptableLatencyUs));
+  } else {
+    Aspm.L0sAcceptableLatency = ASPM_L0s_NO_LIMIT;
+    Aspm.L1AcceptableLatencyUs = ASPM_L1_NO_LIMIT;
+    DEBUG ((DEBUG_INFO, "GetAspmCaps %02x:%02x:%02x L0s%c %d:x L1%c %d:x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func,
+                                                                           Aspm.L0sSupported?'+':'-', Aspm.LinkL0sExitLatency,
+                                                                           Aspm.L1Supported?'+':'-', Aspm.LinkL1ExitLatencyUs));
+  }
+  return Aspm;
+}
+
+/**
+  Get ASPM L0s and L1 override of given device.
+
+  @param[in] Sbdf                Segment,Bus,Device,Function address of currently visited PCIe device
+  @param[in,out] MyAspm          Current device's ASPM capabilities structure
+  @param[in] Override            Pch Pcie devices OverrideTable
+**/
+STATIC
+VOID
+GetOverrideAspm (
+  SBDF           Sbdf,
+  ASPM_CAPS      *MyAspm,
+  OVERRIDE_TABLE *Override
+  )
+{
+  UINT16      DeviceId;
+  UINT16      VendorId;
+  UINT8       Revision;
+  UINT32      Index;
+  UINT64      Base;
+
+  Base = SbdfToBase (Sbdf);
+
+  VendorId = PciSegmentRead16 (Base + PCI_VENDOR_ID_OFFSET);
+  DeviceId = PciSegmentRead16 (Base + PCI_DEVICE_ID_OFFSET);
+  Revision = PciSegmentRead8  (Base + PCI_REVISION_ID_OFFSET);
+
+  for (Index = 0; Index < Override->Size; Index++) {
+    if (((Override->Table[Index].OverrideConfig & PchPcieL1L2Override) == PchPcieL1L2Override) &&
+        (Override->Table[Index].VendorId == VendorId) &&
+        (Override->Table[Index].DeviceId == DeviceId) &&
+        (Override->Table[Index].RevId == Revision || Override->Table[Index].RevId == 0xFF)) {
+      DEBUG ((DEBUG_INFO, "GetOverrideAspm %02x:%02x:%02x, original L0sSupported = 0x%x, L1Supported = 0x%x\n",
+              Sbdf.Bus, Sbdf.Dev, Sbdf.Func, MyAspm->L0sSupported, MyAspm->L1Supported));
+      if (MyAspm->L0sSupported) {
+        //
+        // If L0s is supported in capability, apply platform override.
+        //
+        MyAspm->L0sSupported = Override->Table[Index].EndPointAspm & BIT0;
+      }
+      if (MyAspm->L1Supported) {
+        //
+        // If L1 is supported in capability, apply platform override.
+        //
+        MyAspm->L1Supported = (Override->Table[Index].EndPointAspm & BIT1) >> 1;
+      }
+      DEBUG ((DEBUG_INFO, "GetOverrideAspm %02x:%02x:%02x, override L0sSupported = 0x%x, L1Supported = 0x%x\n",
+              Sbdf.Bus, Sbdf.Dev, Sbdf.Func, MyAspm->L0sSupported, MyAspm->L1Supported));
+    }
+  }
+}
+
+/**
+  Combines ASPM capabilities of two devices on both ends of a link to determine link's ASPM capabilities
+
+  @param[in] AspmA, AspmB  ASPM capabilities of two devices
+
+  @retval    ASPM_CAPS structure containing combined ASPM capabilities
+**/
+STATIC
+ASPM_CAPS
+CombineAspm (
+  ASPM_CAPS AspmA,
+  ASPM_CAPS AspmB,
+  BOOLEAN   DownstreamPort
+  )
+{
+  ASPM_CAPS Combined;
+
+  if (DownstreamPort) {
+    //
+    // When combining ASPM in downstream ports, combination must reflect state of link just below
+    // and consider all acceptable latencies of all endpoints anywhere down below that port
+    //
+    Combined.L0sSupported = AspmA.L0sSupported & AspmB.L0sSupported;
+    Combined.L1Supported = AspmA.L1Supported & AspmB.L1Supported;
+    Combined.LinkL0sExitLatency = MAX (AspmA.LinkL0sExitLatency, AspmB.LinkL0sExitLatency);
+    Combined.LinkL1ExitLatencyUs = MAX (AspmA.LinkL1ExitLatencyUs, AspmB.LinkL1ExitLatencyUs);
+    Combined.L0sAcceptableLatency = MIN (AspmA.L0sAcceptableLatency, AspmB.L0sAcceptableLatency);
+    Combined.L1AcceptableLatencyUs = MIN (AspmA.L1AcceptableLatencyUs, AspmB.L1AcceptableLatencyUs);
+  } else {
+    //
+    // When combining ASPM in switch upstream ports,
+    // Supported and ExitLatency must only reflect capabilities of upstream port itself
+    // But acceptable latencies must consider all endpoints anywhere below
+    //
+    Combined.L0sSupported = AspmA.L0sSupported;
+    Combined.L1Supported = AspmA.L1Supported;
+    Combined.LinkL0sExitLatency = AspmA.LinkL0sExitLatency;
+    Combined.LinkL1ExitLatencyUs = AspmA.LinkL1ExitLatencyUs;
+    Combined.L0sAcceptableLatency = MIN (AspmA.L0sAcceptableLatency, AspmB.L0sAcceptableLatency);
+    Combined.L1AcceptableLatencyUs = MIN (AspmA.L1AcceptableLatencyUs, AspmB.L1AcceptableLatencyUs);
+  }
+  DEBUG ((DEBUG_INFO, "CombineAspm %x:%x -> %x\n", AspmA.L1AcceptableLatencyUs, AspmB.L1AcceptableLatencyUs, Combined.L1AcceptableLatencyUs));
+  return Combined;
+}
+
+/**
+  Checks if L1 can be enabled on given link, according to ASPM parameters of that link
+
+  @param[in] Aspm            set of parameters describing this link and endpoint devices below it
+
+  @retval    TRUE if L1 can be enabled
+**/
+STATIC
+BOOLEAN
+IsL1Allowed (
+  ASPM_CAPS Aspm
+  )
+{
+  return (Aspm.L1Supported && (Aspm.L1AcceptableLatencyUs >= Aspm.LinkL1ExitLatencyUs));
+}
+
+/**
+  Checks if L0s can be enabled on given link, according to ASPM parameters of that link
+
+  @param[in] Aspm            set of parameters describing this link and endpoint devices below it
+
+  @retval    TRUE if L0s can be enabled
+**/
+STATIC
+BOOLEAN
+IsL0sAllowed (
+  ASPM_CAPS Aspm
+  )
+{
+  return (Aspm.L0sSupported && (Aspm.L0sAcceptableLatency >= Aspm.LinkL0sExitLatency));
+}
+
+/**
+  Enables L0s and L1 for given port, if possible.
+  L0s/L1 can be enabled if it's supported on both sides of a link and if link's latency doesn't exceed
+  acceptable latency of any endpoint below this link
+
+  @param[in] Base            device's base address
+  @param[in] Aspm            set of parameters describing this link and endpoint devices below it
+**/
+STATIC
+VOID
+SetAspm (
+  SBDF      Sbdf,
+  ASPM_CAPS Aspm
+  )
+{
+  UINT16 DataOr;
+
+  DataOr = 0;
+  if (IsL0sAllowed (Aspm)) {
+    DataOr |= V_PCIE_LCTL_ASPM_L0S;
+  }
+  if (IsL1Allowed (Aspm)) {
+    DataOr |= V_PCIE_LCTL_ASPM_L1;
+  }
+  DEBUG ((DEBUG_INFO, "SetAspm on %02x:%02x:%02x to %d\n", Sbdf.Bus,Sbdf.Dev,Sbdf.Func, DataOr));
+  PciSegmentAndThenOr16 (SbdfToBase (Sbdf) + Sbdf.PcieCap + R_PCIE_LCTL_OFFSET, (UINT16)~B_PCIE_LCTL_ASPM, DataOr);
+}
+
+/**
+  Configures Dynamic Link Throttling on the root port
+
+  @param[in] RpSbdf   segment:bus:device:function coordinates of rootport
+**/
+STATIC
+VOID
+DynamicLinkThrottlingEnable (
+  SBDF RpSbdf
+  )
+{
+  UINT16  Data16;
+  BOOLEAN L0sEnabled;
+
+  Data16 = PciSegmentRead16 (SbdfToBase (RpSbdf) + RpSbdf.PcieCap + R_PCIE_LCTL_OFFSET);
+  L0sEnabled = ((Data16 & B_PCIE_LCTL_ASPM ) == V_PCIE_LCTL_ASPM_L0S || (Data16 & B_PCIE_LCTL_ASPM ) == V_PCIE_LCTL_ASPM_L0S_L1);
+  if (L0sEnabled) {
+    DEBUG ((DEBUG_INFO, "Enabling dynamic link throttling \n"));
+    PciSegmentOr32 (SbdfToBase (RpSbdf) + RpSbdf.PcieCap + R_PCH_PCIE_CFG_TNPT, B_PCH_PCIE_CFG_TNPT_DRXLTE | B_PCH_PCIE_CFG_TNPT_DTXLTE);
+  }
+}
+
+/**
+  Adds device entry to a list of devices.
+
+  @param[in,out] Table    array of devices
+  @param[in]     Sbdf     segment:bus:device:function coordinates of device to be added to table
+**/
+STATIC
+VOID
+AddToDeviceTable (
+  SBDF_TABLE *Table,
+  SBDF       Sbdf
+  )
+{
+  if (Table->Count < MAX_SBDF_TABLE_SIZE) {
+    Table->Entry[Table->Count++] = Sbdf;
+  } else {
+    ASSERT (FALSE);
+  }
+}
+
+/**
+  Remove device entry from a list and clear its bus assignment
+
+  @param[in,out] Table    array of devices
+**/
+STATIC
+VOID
+ClearBusFromTable (
+  SBDF_TABLE *Table
+  )
+{
+  while (Table->Count > 0) {
+    PciSegmentWrite32 (SbdfToBase (Table->Entry[Table->Count - 1]) + PCI_BRIDGE_PRIMARY_BUS_REGISTER_OFFSET, 0);
+    Table->Count--;
+  }
+}
+
+/**
+  Attempts to assign secondary and subordinate bus numbers to uninitialized bridges in PCIe tree
+  If the device is a bridge and already has bus numbers assigned, they won't be changed
+  Otherwise new bus number will be assigned below this bridge.
+  This function can be called from SMM, where BIOS must not modify bus numbers to prevent
+  conflict with OS enumerator. To prevent this, this function returns list of bridges whose
+  bus numbers were changed. All devices from that list must have buses cleared afterwards.
+
+  @param[in] Sbdf                segment:bus:device:function coordinates of device to be added to table
+  @param[in] MinBus              minimum Bus number that can be assigned below this port
+  @param[in] MaxBus              maximum Bus number that can be assigned below this port
+  @param[in] BridgeCleanupList   list of bridges where bus numbers were modified
+
+  @retval    maximum bus number assigned anywhere below this device
+**/
+UINT8
+RecursiveBusAssignment (
+  SBDF       Sbdf,
+  UINT8      MinBus,
+  UINT8      MaxBus,
+  SBDF_TABLE *BridgeCleanupList
+  )
+{
+  UINT64  Base;
+  SBDF    ChildSbdf;
+  PCI_DEV_TYPE DevType;
+  UINT32  Data32;
+  UINT8   BelowBus;
+  UINT8   SecondaryBus;
+  UINT8   SubordinateBus;
+  UINT8   PrevSub;
+
+  ChildSbdf.Seg = Sbdf.Seg;
+  InitChildFinder (&ChildSbdf);
+  Base = SbdfToBase (Sbdf);
+
+  //
+  // On way down:
+  //   assign secondary bus, then increase it by one before stepping down; temporarily assign max subordinate bus
+  // On way up:
+  //   fix subordinate bus assignment to equal max bus number assigned anywhere below; return that number
+  //
+  DevType = GetDeviceType (Sbdf);
+  if ((Sbdf.Bus >= MaxBus) || (DevType == DevTypePcieEndpoint) || (DevType == DevTypePci)) {
+    return (UINT8) Sbdf.Bus;
+  } else  {
+    Data32 = PciSegmentRead32 (Base + PCI_BRIDGE_PRIMARY_BUS_REGISTER_OFFSET);
+    SecondaryBus = (UINT8)((Data32 & B_PCI_BRIDGE_BNUM_SCBN) >> 8);
+    SubordinateBus = (UINT8)((Data32 & B_PCI_BRIDGE_BNUM_SBBN) >> 16);
+    if (SecondaryBus != 0) {
+      ChildSbdf.Bus = SecondaryBus;
+      MinBus = SecondaryBus + 1;
+      DEBUG ((DEBUG_INFO, "RecursiveBusAssignmentP %x:%x:%x -> %x,%x,%x \n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func, Sbdf.Bus, MinBus, SubordinateBus));
+      while (FindNextPcieChild (DevType, &ChildSbdf)) {
+        BelowBus = RecursiveBusAssignment (ChildSbdf, MinBus, SubordinateBus, BridgeCleanupList);
+        MinBus   = BelowBus + 1;
+      }
+      return SubordinateBus;
+    } else {
+      Data32 = Sbdf.Bus + (MinBus << 8) + (MaxBus << 16);
+      PciSegmentWrite32(Base + PCI_BRIDGE_PRIMARY_BUS_REGISTER_OFFSET, Data32);
+      AddToDeviceTable (BridgeCleanupList, Sbdf);
+      DEBUG ((DEBUG_INFO, "RecursiveBusAssignmentE %x:%x:%x -> %x,%x,%x \n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func, Sbdf.Bus, MinBus, MaxBus));
+      BelowBus = MinBus;
+      ChildSbdf.Bus = MinBus;
+      MinBus++;
+      PrevSub = BelowBus;
+      while (FindNextPcieChild (DevType, &ChildSbdf)) {
+        BelowBus = RecursiveBusAssignment (ChildSbdf, MinBus, MaxBus, BridgeCleanupList);
+        if (PrevSub > BelowBus) {
+          BelowBus = PrevSub;
+        } else {
+          PrevSub = BelowBus;
+          MinBus = BelowBus + 1;
+        }
+      }
+      Data32  &= ~B_PCI_BRIDGE_BNUM_SBBN;
+      Data32 |= (BelowBus << 16);
+      PciSegmentWrite32 (Base + PCI_BRIDGE_PRIMARY_BUS_REGISTER_OFFSET, Data32);
+      DEBUG ((DEBUG_INFO, "RecursiveBusAssignmentL %x:%x:%x -> %x,%x,%x \n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func, Sbdf.Bus, (Data32&0xFF00)>>8, BelowBus));
+      return BelowBus;
+    }
+  }
+}
+
+/**
+  Enables L0s and/or L1 for PCIE links in the hierarchy below
+  L0s/L1 can be enabled when both sides of a link support it and link latency is smaller than acceptable latency
+  ASPM of a given link is independend from any other link (except 1ms L1 adjustment, read below), so it's possible to
+  have a hierarchy when RP link has no ASPM but links below do.
+
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+  @param[in] Depth                          How many links there are between this port and root complex
+  @param[in] Override                       Pch Pcie devices OverrideTable
+
+  @retval structure that describes acceptable latencies of all endpoints below plus ASPM parameters of last link
+**/
+STATIC
+ASPM_CAPS
+RecursiveAspmConfiguration (
+  SBDF           Sbdf,
+  UINT8          Depth,
+  OVERRIDE_TABLE *Override
+  )
+{
+  SBDF         ChildSbdf;
+  ASPM_CAPS    MyAspm;
+  ASPM_CAPS    ChildAspm;
+  PCI_DEV_TYPE DevType;
+
+  DEBUG ((DEBUG_INFO, "RecursiveAspmConfiguration %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+
+  //
+  // On way down:
+  //   pass number of links traversed; increase it per upstream port visited (not endpoint)
+  // On way up:
+  //   EndPoint: read Acceptable Latencies; subtract Depth From L1AcceptableLat to account for "1us per switch additional delay"
+  //   Downstreamport: AND L0s/L1 caps; calculate LinkLatency; enable L0s/L1 if supported and if acceptable latency is bigger than link latency;
+  //     if L1 not enabled, add back 1us to Acceptable Latency to cancel earlier Depth subtraction
+  //   UpstreamPort: calculate minimum of below Acceptable Latencies; return that, with upper link's Latency and L0s/L1 support
+  //
+  DevType = GetDeviceType(Sbdf);
+  if (DevType == DevTypePcieUpstream) {
+    Depth++;
+  }
+  MyAspm = GetAspmCaps (Sbdf);
+  //
+  // Get ASPM L0s and L1 override
+  //
+  if (Override != NULL) {
+    GetOverrideAspm (Sbdf, &MyAspm, Override);
+  }
+  if (DevType == DevTypePcieEndpoint) {
+    //
+    // Every switch between endpoint and CPU introduces 1us additional latency on L1 exit. This is reflected by
+    // subtracting 1us per switch from endpoint's acceptable L1 latency.
+    // In case L1 doesn't get enabled in one of switches, that 1us will be added back.
+    // This calculation is not precise. It ignores that some switches' added delay may be shadowed by
+    // other links' exit latency. But it guarantees that acceptable latency won't be exceeded and is simple
+    // enough to perform in a single iteration without backtracking.
+    //
+    return PatchL1AcceptableLatency (MyAspm, (-1 * Depth));
+  }
+  if (HasChildBus (Sbdf, &ChildSbdf)) {
+    while (FindNextPcieChild (DevType, &ChildSbdf)) {
+      ChildAspm = RecursiveAspmConfiguration (ChildSbdf, Depth, Override);
+      MyAspm = CombineAspm (MyAspm, ChildAspm, (DevType == DevTypePcieDownstream));
+    }
+    if (DevType == DevTypePcieDownstream) {
+      SetAspm (Sbdf, MyAspm);
+      //
+      // ASPM config must be consistent across all functions of a device. That's why there's while loop.
+      //
+      while (FindNextPcieChild (DevType, &ChildSbdf)) {
+        SetAspm (ChildSbdf, MyAspm);
+      }
+      if (!IsL1Allowed (MyAspm)) {
+        MyAspm = PatchL1AcceptableLatency (MyAspm, 1);
+      }
+    }
+  }
+  return MyAspm;
+}
+
+/**
+  Enables L1 substates for PCIE links in the hierarchy below
+  L1.1 / L1.2 can be enabled if both sides of a link support it.
+
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+
+  @retval  structure that describes L1ss capabilities of the device
+**/
+STATIC
+L1SS_CAPS
+RecursiveL1ssConfiguration (
+  SBDF           Sbdf,
+  OVERRIDE_TABLE *Override
+  )
+{
+  UINT64  Base;
+  SBDF    ChildSbdf;
+  L1SS_CAPS CombinedCaps;
+  L1SS_CAPS ChildCaps;
+  PCI_DEV_TYPE DevType;
+  BOOLEAN   IsCpuPcie;
+
+  IsCpuPcie = FALSE;
+
+  DEBUG ((DEBUG_INFO, "RecursiveL1ssConfiguration %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+
+  Base = SbdfToBase (Sbdf);
+  //
+  // On way down:
+  //   do nothing
+  // On way up:
+  //   In downstream ports, combine L1ss capabilities of that port and device behind it, then enable L1.1 and/or L1.2 if possible
+  //   Return L1ss capabilities
+  //
+  if (HasChildBus (Sbdf, &ChildSbdf)) {
+    DevType = GetDeviceType (Sbdf);
+    while (FindNextPcieChild (DevType, &ChildSbdf)) {
+      ChildCaps = RecursiveL1ssConfiguration (ChildSbdf, Override);
+      if (DevType == DevTypePcieDownstream && ChildSbdf.Func == 0) {
+        CombinedCaps = CombineL1ss (GetL1ssCaps (Base, Override), ChildCaps);
+        SetL1ss (Sbdf, CombinedCaps, Override, IsCpuPcie);
+        SetL1ss (ChildSbdf, CombinedCaps, Override, IsCpuPcie);
+      }
+    }
+  }
+  return GetL1ssCaps (Base, Override);
+}
+
+/**
+  Checks if there is an IoAPIC device in the PCIe hierarchy.
+  If one is found, this function doesn't check for more and returns
+
+  @param[in] BusLimit                       maximum Bus number that can be assigned below this port
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+
+  @retval  TRUE if IoAPIC device was found
+**/
+STATIC
+BOOLEAN
+RecursiveIoApicCheck (
+  SBDF       Sbdf
+  )
+{
+  SBDF         ChildSbdf;
+  UINT8        IoApicPresent;
+  PCI_DEV_TYPE DevType;
+
+  DEBUG ((DEBUG_INFO, "RecursiveIoApicCheck %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+
+  IoApicPresent = FALSE;
+
+  if (IsIoApicDevice (SbdfToBase (Sbdf))) {
+    DEBUG ((DEBUG_INFO, "IoApicFound @%x:%x:%x:%x\n", Sbdf.Seg, Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+    return TRUE;
+  }
+  if (HasChildBus (Sbdf, &ChildSbdf)) {
+    DevType = GetDeviceType (Sbdf);
+    while (FindNextPcieChild (DevType, &ChildSbdf)) {
+      IoApicPresent = RecursiveIoApicCheck (ChildSbdf);
+      if (IoApicPresent) {
+        break;
+      }
+    }
+  }
+  DEBUG ((DEBUG_INFO, "IoApic status %d @%x:%x:%x:%x\n", IoApicPresent, Sbdf.Seg, Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+  return IoApicPresent;
+}
+
+/**
+  Calculates Maximum Payload Size supported by PCIe hierarchy.
+  Starting from a device, it finds the minimum MPS supported by devices below it.
+  There are many valid strategies for setting MPS. This implementation chooses
+  one that is safest, but doesn't guarantee maximum performance:
+    Find minimum MPS under given rootport, then program that minimum value everywhere below that rootport
+
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+
+  @retval  MPS supported by PCIe hierarchy, calculated as MIN(MPS of all devices below)
+**/
+STATIC
+UINT8
+RecursiveMpsCheck (
+  SBDF       Sbdf
+  )
+{
+  SBDF         ChildSbdf;
+  UINT8        MyMps;
+  UINT8        SubtreeMps;
+  PCI_DEV_TYPE DevType;
+
+  DEBUG ((DEBUG_INFO, "RecursiveMpsCheck %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+
+  MyMps = GetMps (Sbdf);
+  if (MyMps == 0) {
+    return MyMps;
+  }
+  if (HasChildBus (Sbdf, &ChildSbdf)) {
+    DevType = GetDeviceType (Sbdf);
+    while (FindNextPcieChild (DevType, &ChildSbdf)) {
+      SubtreeMps = RecursiveMpsCheck (ChildSbdf);
+      MyMps = MIN(MyMps, SubtreeMps);
+    }
+  }
+  return MyMps;
+}
+
+/**
+  Sets Maximum Payload Size in PCIe hierarchy.
+  Starting from a device, it programs the same MPS value to it and all devices below it.
+  There are many valid strategies for setting MPS. This implementation chooses
+  one that is safest, but doesn't guarantee maximum performance:
+    Find minimum MPS under given rootport, then program that minimum value everywhere below that rootport
+
+  @param[in] BusLimit                       maximum Bus number that can be assigned below this port
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+  @param[in] Mps                            Maximum Payload Size to be programmed
+**/
+STATIC
+VOID
+RecursiveMpsConfiguration (
+  SBDF       Sbdf,
+  UINT8      Mps
+  )
+{
+  SBDF    ChildSbdf;
+  PCI_DEV_TYPE DevType;
+
+  DEBUG ((DEBUG_INFO, "RecursiveMpsConfiguration %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+
+  if (HasChildBus (Sbdf, &ChildSbdf)) {
+    DevType = GetDeviceType (Sbdf);
+    while (FindNextPcieChild (DevType, &ChildSbdf)) {
+      RecursiveMpsConfiguration (ChildSbdf, Mps);
+    }
+  }
+  DEBUG ((DEBUG_INFO, "Set MPS on %x:%x:%x to %d\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func, Mps));
+  SetMps (Sbdf, Mps);
+}
+
+/**
+  Sets Maximum Read Resource Size for Endpoint.
+  It programs MRRS value to endpoint device.
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+**/
+STATIC
+VOID
+RecursiveMrrsConfiguration (
+  SBDF       Sbdf
+  )
+{
+  SBDF    ChildSbdf;
+  PCI_DEV_TYPE DevType;
+
+  DEBUG ((DEBUG_INFO, "RecursiveMrrsConfiguration %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+
+  if (HasChildBus (Sbdf, &ChildSbdf)) {
+    DevType = GetDeviceType (Sbdf);
+    while (FindNextPcieChild (DevType, &ChildSbdf)) {
+      RecursiveMrrsConfiguration (ChildSbdf);
+    }
+  }
+  DevType = GetDeviceType (Sbdf);
+  if (DevType == DevTypePcieEndpoint) {
+    SetMrrs (Sbdf);
+  }
+}
+
+/**
+  Sets Enable Clock Power Management bit for devices that support it.
+  A device supports CPM only if all function of this device report CPM support.
+  Downstream ports never report CPM capability, so it's only relevant for upstream ports.
+  When this function executes on upstream component, it will check CPM & set ECPM of downstream component
+  When this function executes on downstream component, all devices below it are guaranteed to
+  return CPM=0 so it will do nothing
+
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+
+  @retval TRUE = this device supports CPM, FALSE = it doesn't
+**/
+STATIC
+BOOLEAN
+RecursiveCpmConfiguration (
+  SBDF       Sbdf
+  )
+{
+  SBDF         ChildSbdf;
+  BOOLEAN      ChildCpm;
+  PCI_DEV_TYPE DevType;
+
+  DEBUG ((DEBUG_INFO, "RecursiveCpmConfiguration %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+
+  ChildCpm = FALSE;
+
+  if (HasChildBus (Sbdf, &ChildSbdf)) {
+    ChildCpm = TRUE;
+    DevType = GetDeviceType (Sbdf);
+    while (FindNextPcieChild (DevType, &ChildSbdf)) {
+      ChildCpm &= RecursiveCpmConfiguration (ChildSbdf);
+    }
+    if (ChildCpm) {
+      while (FindNextPcieChild (DevType, &ChildSbdf)) {
+        EnableCpm (ChildSbdf);
+      }
+    }
+  }
+  return IsCpmSupported (Sbdf);
+}
+
+/**
+  Sets Common Clock Configuration bit for devices that share common clock across link
+  Devices on both sides of a PCIE link share common clock if both upstream component
+  and function 0 of downstream component report Slot Clock Configuration bit = 1.
+  When this function executes on upstream component, it checks SCC of both sides of the link
+  If they both support it, sets CCC for both sides (this means all functions of downstream component)
+  When this function executes on downstream component, it only returns SCC capability
+
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+  @param[in] WaitForRetrain                 decides if this function should busy-wait for link retrain
+
+  @retval TRUE = this device supports SCC, FALSE = it doesn't
+**/
+STATIC
+BOOLEAN
+RecursiveCccConfiguration (
+  SBDF       Sbdf,
+  BOOLEAN    WaitForRetrain
+  )
+{
+  UINT64       Base;
+  SBDF         ChildSbdf;
+  BOOLEAN      MyScc;
+  BOOLEAN      ChildScc;
+  BOOLEAN      LinkScc;
+  PCI_DEV_TYPE DevType;
+
+  DEBUG ((DEBUG_INFO, "RecursiveCccConfiguration %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+
+  ChildScc = 0;
+  Base = SbdfToBase(Sbdf);
+  MyScc = GetScc (SbdfToBase(Sbdf), (UINT8)Sbdf.PcieCap);
+  if (HasChildBus (Sbdf, &ChildSbdf)) {
+    DevType = GetDeviceType (Sbdf);
+    while (FindNextPcieChild (DevType, &ChildSbdf)) {
+      ChildScc |= RecursiveCccConfiguration (ChildSbdf, WaitForRetrain);
+    }
+    if (DevType == DevTypePcieDownstream) {
+      LinkScc = MyScc & ChildScc;
+      if (LinkScc) {
+        EnableCcc (SbdfToBase(Sbdf), (UINT8)Sbdf.PcieCap);
+        while (FindNextPcieChild (DevType, &ChildSbdf)) {
+          EnableCcc (SbdfToBase(ChildSbdf), (UINT8)ChildSbdf.PcieCap);
+        }
+        RetrainLink(Base, (UINT8)Sbdf.PcieCap, WaitForRetrain);
+      }
+    }
+  }
+  return MyScc;
+}
+
+/**
+  Configures Latency Tolerance Reporting in given device and in PCIe tree below it.
+  This function configures Maximum LTR and enables LTR mechanism. It visits devices using depth-first search
+  and skips branches behind devices which do not support LTR.
+  Maximum LTR:
+    This function will set LTR's upper bound for every visited device. Max LTR value is provided as a parameter
+  Enable LTR:
+    LTR should be enabled top-to-bottom in every visited device that supports LTR. This function does not
+    iterate down behind devices with no LTR support. In effect, LTR will be enabled in given device if that device
+    and all devices above it on the way to RootComplex do support LTR.
+
+  This function expects that bridges have bus numbers already configured
+
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+  @param[in] LtrLimit                       Ltr to be programmed to every endpoint
+
+  @retval MaxLTR programmed in this device
+**/
+STATIC
+VOID
+RecursiveLtrConfiguration (
+  SBDF       Sbdf,
+  LTR_LIMIT  LtrLimit
+  )
+{
+  UINT64  Base;
+  SBDF    ChildSbdf;
+  PCI_DEV_TYPE DevType;
+
+  DEBUG ((DEBUG_INFO, "RecursiveLtrConfiguration %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+
+  Base = SbdfToBase(Sbdf);
+
+  if (!IsLtrCapable (Sbdf)) {
+    DEBUG ((DEBUG_INFO, "Not LtrCapable %02x:%02x:%02x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+    return;
+  }
+  EnableLtr (Sbdf);
+  if (HasChildBus (Sbdf, &ChildSbdf)) {
+    DevType = GetDeviceType (Sbdf);
+    while (FindNextPcieChild (DevType, &ChildSbdf)) {
+      RecursiveLtrConfiguration (ChildSbdf, LtrLimit);
+    }
+  }
+  SetLtrLimit (Base, LtrLimit);
+}
+
+/**
+  Check Latency Tolerance Reporting in given device and in PCIe tree below supports or not
+
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+
+  @retval TRUE = this device supports LTR, FALSE = it doesn't
+**/
+BOOLEAN
+RecursiveIsLtrCapable (
+  SBDF       Sbdf
+  )
+{
+  SBDF            ChildSbdf;
+  PCI_DEV_TYPE    DevType;
+  BOOLEAN         LtrCapable;
+  BOOLEAN         TreeLtrCapable;
+
+  DEBUG ((DEBUG_INFO, "RecursiveIsLtrCapable %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+
+  LtrCapable = IsLtrCapable (Sbdf);
+  if (LtrCapable == 0) {
+    DEBUG ((DEBUG_INFO, "Not LtrCapable %02x:%02x:%02x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+    return LtrCapable;
+  }
+  if (HasChildBus (Sbdf, &ChildSbdf)) {
+    DevType = GetDeviceType (Sbdf);
+    while (FindNextPcieChild (DevType, &ChildSbdf)) {
+      TreeLtrCapable = RecursiveIsLtrCapable (ChildSbdf);
+      LtrCapable &= TreeLtrCapable;
+    }
+  }
+  return LtrCapable;
+}
+
+
+/**
+  Checks to see device is PTM Capable
+
+  @param[in] Sbdf    device's segment:bus:device:function coordinates
+
+  @retval TRUE = PTM Capability found, FALSE = Not PTM capable
+**/
+STATIC
+BOOLEAN
+IsPtmCapable (
+  SBDF       Sbdf
+  )
+{
+  UINT16     CapHeaderOffset;
+
+  CapHeaderOffset = PcieFindExtendedCapId ((UINT8) Sbdf.Seg, (UINT8) Sbdf.Bus, (UINT8) Sbdf.Dev, (UINT8) Sbdf.Func, V_PCIE_EX_PTM_CID);
+
+  return (CapHeaderOffset != 0);
+}
+
+/**
+  Get PTM Capability register from PCIe Extended Capability Space.
+
+  @param[in] Sbdf                device's segment:bus:device:function coordinates
+  @param[in] PtmCapHeaderOffset  PTM Capability Header Offset
+
+  @retval LocalPtm       Returns PTM Capability.
+                         If Device is not PTM capable then PTM Capability is zeroed out.
+**/
+STATIC
+PTM_CAPS
+GetPtmCapability (
+  SBDF      Sbdf,
+  UINT16    PtmCapHeaderOffset
+  )
+{
+  PTM_CAPS PtmCaps;
+
+  PtmCaps.Uint32 = 0;
+
+  if (PtmCapHeaderOffset != 0) {
+    PtmCaps.Uint32 = PciSegmentRead32 (SbdfToBase (Sbdf) + PtmCapHeaderOffset + R_PCIE_EX_PTMCAP_OFFSET);
+  }
+
+  return PtmCaps;
+}
+
+/**
+  Get PTM Control register from PCIe Extended Capability Space.
+
+  @param[in] Sbdf                device's segment:bus:device:function coordinates
+  @param[in] PtmCapHeaderOffset  PTM Capability Header Offset
+
+  @retval LocalPtm       Returns PTM Control.
+                         If Device is not PTM capable then PTM Control is zeroed out.
+**/
+STATIC
+PTM_CTRL
+GetPtmControl (
+  SBDF      Sbdf,
+  UINT16    PtmCapHeaderOffset
+  )
+{
+  PTM_CTRL PtmCtrl;
+
+  PtmCtrl.Uint32 = 0;
+
+  if (PtmCapHeaderOffset != 0) {
+    PtmCtrl.Uint32 = PciSegmentRead32 (SbdfToBase (Sbdf) + PtmCapHeaderOffset + R_PCIE_EX_PTMCTL_OFFSET);
+  }
+
+  return PtmCtrl;
+}
+
+/**
+  Set PTM Control register in the PCIe Extended Capability Space.
+
+  @param[in] Sbdf                device's segment:bus:device:function coordinates
+  @param[in] PtmCapHeaderOffset  PTM Capability Header Offset
+  @param[in] PtmCtrl             PTM Control Register
+**/
+STATIC
+VOID
+SetPtmControl (
+  SBDF      Sbdf,
+  UINT16    PtmCapHeaderOffset,
+  PTM_CTRL  PtmCtrl
+  )
+{
+  if (PtmCapHeaderOffset != 0) {
+    PciSegmentWrite32 (SbdfToBase (Sbdf) + PtmCapHeaderOffset + R_PCIE_EX_PTMCTL_OFFSET, PtmCtrl.Uint32);
+  }
+}
+
+/**
+  Enable PTM on device's control register. Set the Effective Clock Granularity.
+
+  @param[in]     Sbdf                 device's segment:bus:device:function coordinates
+  @param[in out] EffectiveGranularity Effective Clock Granularity of the PTM hierarchy
+  @param[in out] PtmHierarchy         Indicates if the current device is within a PTM hierarchy
+**/
+STATIC
+VOID
+SetPtm (
+  IN     SBDF       Sbdf,
+  IN OUT UINT8      *EffectiveGranularity,
+  IN OUT BOOLEAN    *PtmHierarchy
+  )
+{
+  PTM_CTRL CurrentPtmCtrl;
+  PTM_CAPS CurrentPtmCaps;
+  PTM_CTRL OrigPtmCtrl;
+  UINT16   PtmCapHeaderOffset;
+
+  PtmCapHeaderOffset = PcieFindExtendedCapId ((UINT8) Sbdf.Seg, (UINT8) Sbdf.Bus, (UINT8) Sbdf.Dev, (UINT8) Sbdf.Func, V_PCIE_EX_PTM_CID);
+  CurrentPtmCtrl = GetPtmControl (Sbdf, PtmCapHeaderOffset);
+  CurrentPtmCaps = GetPtmCapability (Sbdf, PtmCapHeaderOffset);
+
+  OrigPtmCtrl.Uint32 = CurrentPtmCtrl.Uint32;
+
+  if ( (*PtmHierarchy == FALSE) && CurrentPtmCaps.Bits.RootCapable) {
+    // Select device as PTM Root if PTM Root is not selected.
+    CurrentPtmCtrl.Bits.RootSelect = TRUE;
+    *EffectiveGranularity = (UINT8) CurrentPtmCaps.Bits.LocalClockGranularity;
+    *PtmHierarchy = TRUE;
+  }
+
+  if (*PtmHierarchy == TRUE) {
+    // Enable PTM if device is part of a ptm hierarchy
+    CurrentPtmCtrl.Bits.Enable = TRUE;
+
+    if (CurrentPtmCaps.Bits.RequesterCapable) {
+      // Set Effective Granularity if PTM device is Requester roles.
+      CurrentPtmCtrl.Bits.EffectiveGranularity = *EffectiveGranularity;
+    }
+  }
+
+  if (OrigPtmCtrl.Uint32 != CurrentPtmCtrl.Uint32) {
+    SetPtmControl (Sbdf, PtmCapHeaderOffset, CurrentPtmCtrl);
+  }
+
+  // Update EffectiveGranularity.
+  // Set to zero if 1 or more switches between the root and endpoint report local granularity = 0.
+  // Otherwise set to the max local granularity of the hierarchy.
+  if ( ((CurrentPtmCaps.Bits.LocalClockGranularity == 0) && CurrentPtmCaps.Bits.RequesterCapable) ||
+       (*EffectiveGranularity  == 0) ) {
+    *EffectiveGranularity = 0;
+  } else {
+    *EffectiveGranularity = MAX (*EffectiveGranularity, (UINT8) CurrentPtmCaps.Bits.LocalClockGranularity);
+  }
+}
+
+/**
+  Configures PTM hierarchies by searching for Endpoints and Upstream Switches
+  that are PTM capable. Each PTM device role is identified and configured accordingly.
+  PTM root capable devices are selected as PTM root if the device is not already in a
+  PTM hierarchy.
+  PTM capable Root Ports must be configured before calling this function.
+  @note: This function has not been tested with switches.
+
+  @param[in] Sbdf                 Address of curretly visited Pcie device
+  @param[in] EffectiveGranularity The largest Clock Granularity from Upstream Devices
+  @param[in] PtmHierarchy         TRUE = Device in a PTM Hierarchy, FALSE = Not in PTM Hierarchy
+**/
+STATIC
+VOID
+RecursivePtmConfiguration (
+  SBDF          Sbdf,
+  UINT8         EffectiveGranularity,
+  BOOLEAN       PtmHierarchy
+  )
+{
+  SBDF         ChildSbdf;
+  PCI_DEV_TYPE DevType;
+
+  DEBUG ((DEBUG_INFO, "RecursivePtmConfiguration %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+
+  DevType = GetDeviceType (Sbdf);
+
+  if (IsPtmCapable (Sbdf)) {
+    //
+    // Enable PTM for PTM Capable devices (Endpoints, Upstream Switch, and Root Ports).
+    // @Note: Switches have not been tested.
+    //
+    SetPtm (Sbdf, &EffectiveGranularity, &PtmHierarchy);
+  } else if (!IsPtmCapable (Sbdf) && (DevType == DevTypePcieUpstream) ) {
+    //
+    // Non-PTM UpStream Switch Ports breaks the PTM Hierarchy.
+    // No other downstream PTM devices should be PTM enabled until a PTM Root capable device is selected.
+    //
+    PtmHierarchy = FALSE;
+    EffectiveGranularity = 0;
+  }
+
+  if (HasChildBus (Sbdf, &ChildSbdf)) {
+    while (FindNextPcieChild (DevType, &ChildSbdf)) {
+      RecursivePtmConfiguration (ChildSbdf, EffectiveGranularity, PtmHierarchy);
+    }
+  }
+}
+
+/**
+  Check RequesterSupported & CompleterSupported for Downstream & Upstream device
+  and set ReuqesterEnable and CompleterEnable accordingly
+
+  @param[in] TenBitTagA Downstream device Capability for RequesterSupported/CompleterSupported
+  @param[in] TenBitTagB Upstream device Capability for RequesterSupported/CompleterSupported
+
+  @retval TENBITTAG_CAPS returns local RequesterEnable/CompleterEnable flags.
+**/
+STATIC
+TENBITTAG_CAPS
+Combine10BitTag (
+  TENBITTAG_CAPS TenBitTagA,
+  TENBITTAG_CAPS TenBitTagB
+  )
+{
+  TENBITTAG_CAPS Combined;
+
+  Combined.Bits.RequesterSupported   = TenBitTagA.Bits.CompleterSupported && TenBitTagB.Bits.RequesterSupported;
+  Combined.Bits.CompleterSupported   = TenBitTagA.Bits.RequesterSupported && TenBitTagB.Bits.CompleterSupported;
+  return Combined;
+}
+
+/**
+  Get 10-Bit Tag capability of a device by reading its DCAP/DCAP2
+
+  @param[in] Sbdf     segment:bus:device:function coordinates of a device
+
+  @retval TENBITTAG_CAPS returns local RequesterEnable/CompleterEnable flags
+**/
+STATIC
+TENBITTAG_CAPS
+Get10BitTagCaps (
+  SBDF           Sbdf
+  )
+{
+  TENBITTAG_CAPS Capabilities = {0};
+  UINT32         CapsRegister;
+
+  if (Sbdf.PcieCap == 0) {
+    return Capabilities;
+  }
+
+  CapsRegister = PciSegmentRead32 (SbdfToBase (Sbdf) + Sbdf.PcieCap + R_PCIE_DCAP2_OFFSET);
+
+  Capabilities.Bits.RequesterSupported = !!(CapsRegister & B_PCIE_DCAP2_PX10BTRS);
+  Capabilities.Bits.CompleterSupported = !!(CapsRegister & B_PCIE_DCAP2_PX10BTCS);
+  return Capabilities;
+}
+
+/**
+  Set RequesterEnable bit and ExtendedTagEnable bits of the device
+
+  @param[in] Sbdf       segment:bus:device:function coordinates of a device
+  @param[in] TenBitTag  local ten bit tag struct with RequesterEnable flag
+**/
+STATIC
+VOID
+Set10BitTag (
+  SBDF           Sbdf,
+  TENBITTAG_CAPS TenBitTag
+  )
+{
+  UINT16    CtrlRegister;
+  UINT16    Ctrl2Register;
+  UINT32    CapRegister;
+
+  CtrlRegister = 0;
+  Ctrl2Register = 0;
+  CapRegister = 0;
+
+  if (Sbdf.PcieCap == 0) {
+    return;
+  }
+
+  CapRegister =   PciSegmentRead32 (SbdfToBase (Sbdf) + Sbdf.PcieCap + R_PCIE_DCAP_OFFSET);
+
+  if (CapRegister & B_PCIE_DCAP_ETFS) {
+  CtrlRegister |= B_PCIE_DCTL_ETFE;
+  PciSegmentWrite16 (SbdfToBase (Sbdf) + Sbdf.PcieCap + R_PCIE_DCTL_OFFSET, CtrlRegister);
+  }
+
+  Ctrl2Register |= B_PCIE_DCTL2_PX10BTRE;
+  PciSegmentWrite16 (SbdfToBase (Sbdf) + Sbdf.PcieCap + R_PCIE_DCTL2_OFFSET, Ctrl2Register);
+}
+
+/**
+  Search for Upstream and downstream devices that Support RequesterSupport and CompleterSupport
+  along with Extended Tag Support and set RequesterEnable bit the device accordingly.
+
+  @param[in] Sbdf     segment:bus:device:function coordinates of a device
+
+   @retval TENBITTAG_CAPS returns local RequesterEnable/CompleterEnable flags.
+**/
+STATIC
+TENBITTAG_CAPS
+Recursive10BitTagConfiguration (
+  SBDF           Sbdf
+  )
+{
+  SBDF           ChildSbdf;
+  TENBITTAG_CAPS CombinedCaps;
+  TENBITTAG_CAPS ChildCaps;
+  PCI_DEV_TYPE   DevType;
+
+  DEBUG ((DEBUG_INFO, "Recursive10BitTagConfiguration %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+
+  //
+  // On way down:
+  //   do nothing
+  // On way up:
+  //
+  //
+  if (HasChildBus (Sbdf, &ChildSbdf)) {
+    DevType = GetDeviceType (Sbdf);
+    while (FindNextPcieChild (DevType, &ChildSbdf)) {
+      ChildCaps = Recursive10BitTagConfiguration (ChildSbdf);
+      if (DevType == DevTypePcieDownstream) {
+        CombinedCaps = Combine10BitTag (Get10BitTagCaps (Sbdf), ChildCaps);
+        if (CombinedCaps.Bits.RequesterSupported) {
+          Set10BitTag (ChildSbdf, CombinedCaps);
+        }
+      }
+    }
+  }
+
+  return Get10BitTagCaps (Sbdf);
+}
+
+/**
+  Initializes the following features in rootport and devices behind it:
+  Maximum Payload Size (generic)
+  Rootport packet split (proprietary)
+  EonOfInterrupt forwarding (proprietary)
+  Common Clock Configuration (generic)
+
+  Generic: any code written according to PCIE Express base specification can do that.
+  Proprietary: code uses registers and features that are specific to Intel silicon
+  and probably only this Reference Code knows how to handle that.
+
+  If OEM implemented generic feature enabling in his platform code or trusts Operating System
+  to do it, then those features can be deleted from here.
+
+  CCC requires link retrain, which takes a while. CCC must happen before L0s/L1 programming.
+  If there was guarantee no code would access PCI while links retrain, it would be possible to skip this waiting
+
+  @param[in] RpSegment               address of rootport on PCIe
+  @param[in] RpBus                   address of rootport on PCIe
+  @param[in] RpDevice                address of rootport on PCIe
+  @param[in] RpFunction              address of rootport on PCIe
+  @param[in] BusMin                  minimum Bus number that can be assigned below this rootport
+  @param[in] BusMax                  maximum Bus number that can be assigned below this rootport
+  @param[in] PciSku                  PCIe controller type
+  @param[in] FeatureConfiguration    pointer to status of PCIe features configuration
+**/
+// VOID
+// RootportDownstreamConfiguration (
+//   UINT8                        RpSegment,
+//   UINT8                        RpBus,
+//   UINT8                        RpDevice,
+//   UINT8                        RpFunction,
+//   UINT8                        BusMin,
+//   UINT8                        BusMax,
+//   PCI_SKU                      PciSku,
+//   PCIE_FEATURE_CONFIGURATION   *FeatureConfiguration
+//   )
+// {
+//   UINT8           Mps;
+//   BOOLEAN         IoApicPresent;
+//   UINT64          RpBase;
+//   SBDF            RpSbdf;
+//   SBDF_TABLE      BridgeCleanupList;
+//   SBDF            ChildSbdf;
+//   PCI_DEV_TYPE    DevType;
+
+//   Mps = 0;
+//   IoApicPresent = FALSE;
+//   RpBase = PCI_SEGMENT_LIB_ADDRESS (RpSegment, RpBus, RpDevice, RpFunction, 0);
+//   if (!(IsDevicePresent (RpBase))) {
+//     return;
+//   }
+//   RpSbdf.Seg = RpSegment;
+//   RpSbdf.Bus = RpBus;
+//   RpSbdf.Dev = RpDevice;
+//   RpSbdf.Func = RpFunction;
+//   RpSbdf.PcieCap = PcieBaseFindCapId (RpBase, EFI_PCI_CAPABILITY_ID_PCIEXP);
+
+//   DEBUG ((DEBUG_INFO, "RootportDownstreamConfiguration %x:%x\n", RpDevice, RpFunction));
+//   BridgeCleanupList.Count = 0;
+//   RecursiveBusAssignment (RpSbdf, BusMin, BusMax, &BridgeCleanupList);
+
+//   Mps = RecursiveMpsCheck (RpSbdf);
+//   RecursiveMpsConfiguration (RpSbdf, Mps);
+//   if (PciSku == EnumPchPcie) {
+//     RpBase = SbdfToBase (RpSbdf);
+//     IoApicPresent = RecursiveIoApicCheck(RpSbdf);
+//   }
+//   if ((PciSku == EnumPchPcie) || (PciSku == EnumCpuPcie)) {
+//     ConfigureEoiForwarding (RpBase, IoApicPresent);
+//     if (IoApicPresent && FeatureConfiguration->Callback.EnableRpEoiTarget != NULL) {
+//       FeatureConfiguration->Callback.EnableRpEoiTarget (RpBase);
+//     }
+//   }
+//   RecursiveCccConfiguration (RpSbdf, TRUE);
+
+//   if (IsPtmCapable (RpSbdf)) {
+//     DevType = GetDeviceType (RpSbdf);
+//     if (HasChildBus (RpSbdf, &ChildSbdf)) {
+//       if (FindNextPcieChild (DevType, &ChildSbdf) && IsPtmCapable (ChildSbdf)) {
+//         DEBUG ((DEBUG_INFO, "Child supports PTM proceeding with PTM configuration\n"));
+//         RecursivePtmConfiguration (RpSbdf, 0, FALSE);
+//       }
+//     }
+//   }
+
+//   Recursive10BitTagConfiguration (RpSbdf);
+
+//   ClearBusFromTable (&BridgeCleanupList);
+// }
+
+/**
+  Checks if given PCI device is capable of Latency Tolerance Reporting
+
+  @param[in] Sbdf            device's segment:bus:device:function coordinates
+
+  @retval TRUE if yes
+**/
+BOOLEAN
+IsLtrCapable (
+  SBDF Sbdf
+  )
+{
+  if (Sbdf.PcieCap == 0) {
+    return FALSE;
+  }
+  return !!(PciSegmentRead32 (SbdfToBase (Sbdf) + Sbdf.PcieCap + R_PCIE_DCAP2_OFFSET) & B_PCIE_DCAP2_LTRMS);
+}
+
+/**
+  Returns combination of two LTR override values
+  The resulting LTR override separately chooses stricter limits for snoop and nosnoop
+
+  @param[in] LtrA      LTR override values to be combined
+  @param[in] LtrB      LTR override values to be combined
+
+  @retval LTR override value
+**/
+LTR_OVERRIDE
+CombineLtr (
+  LTR_OVERRIDE LtrA,
+  LTR_OVERRIDE LtrB
+  )
+{
+  UINT64        DecodedLatencyA;
+  UINT64        DecodedLatencyB;
+  LTR_OVERRIDE  Result;
+  static UINT32 ScaleEncoding [8] = {1, 32, 1024, 32768, 1048576, 33554432, 0, 0};
+
+  ZeroMem (&Result, sizeof (LTR_OVERRIDE));
+  DecodedLatencyA = ScaleEncoding[LtrA.MaxSnoopLatencyScale] * LtrA.MaxSnoopLatencyValue;
+  DecodedLatencyB = ScaleEncoding[LtrB.MaxSnoopLatencyScale] * LtrB.MaxSnoopLatencyValue;
+  if ((!LtrB.MaxSnoopLatencyRequirement) || ((DecodedLatencyA < DecodedLatencyB) && LtrA.MaxSnoopLatencyRequirement)) {
+    Result.MaxSnoopLatencyValue       = LtrA.MaxSnoopLatencyValue;
+    Result.MaxSnoopLatencyScale       = LtrA.MaxSnoopLatencyScale;
+    Result.MaxSnoopLatencyRequirement = LtrA.MaxSnoopLatencyRequirement;
+  } else {
+    Result.MaxSnoopLatencyValue       = LtrB.MaxSnoopLatencyValue;
+    Result.MaxSnoopLatencyScale       = LtrB.MaxSnoopLatencyScale;
+    Result.MaxSnoopLatencyRequirement = LtrB.MaxSnoopLatencyRequirement;
+  }
+  DecodedLatencyA = ScaleEncoding[LtrA.MaxNoSnoopLatencyScale] * LtrA.MaxNoSnoopLatencyValue;
+  DecodedLatencyB = ScaleEncoding[LtrB.MaxNoSnoopLatencyScale] * LtrB.MaxNoSnoopLatencyValue;
+  if ((!LtrB.MaxNoSnoopLatencyRequirement) || ((DecodedLatencyA < DecodedLatencyB) && LtrA.MaxNoSnoopLatencyRequirement)) {
+    Result.MaxNoSnoopLatencyValue       = LtrA.MaxNoSnoopLatencyValue;
+    Result.MaxNoSnoopLatencyScale       = LtrA.MaxNoSnoopLatencyScale;
+    Result.MaxNoSnoopLatencyRequirement = LtrA.MaxNoSnoopLatencyRequirement;
+  } else {
+    Result.MaxNoSnoopLatencyValue       = LtrB.MaxNoSnoopLatencyValue;
+    Result.MaxNoSnoopLatencyScale       = LtrB.MaxNoSnoopLatencyScale;
+    Result.MaxNoSnoopLatencyRequirement = LtrB.MaxNoSnoopLatencyRequirement;
+  }
+  if (LtrA.ForceOverride || LtrB.ForceOverride) {
+    Result.ForceOverride = TRUE;
+  }
+  DEBUG ((DEBUG_INFO, "CombineLtr: A(V%d S%d E%d : V%d S%d E%d, F%d)\n",
+    LtrA.MaxSnoopLatencyValue, LtrA.MaxSnoopLatencyScale, LtrA.MaxSnoopLatencyRequirement,
+    LtrA.MaxNoSnoopLatencyValue, LtrA.MaxNoSnoopLatencyScale, LtrA.MaxNoSnoopLatencyRequirement,
+    LtrA.ForceOverride
+    ));
+  DEBUG ((DEBUG_INFO, "          : B(V%d S%d E%d : V%d S%d E%d, F%d)\n",
+    LtrB.MaxSnoopLatencyValue, LtrB.MaxSnoopLatencyScale, LtrB.MaxSnoopLatencyRequirement,
+    LtrB.MaxNoSnoopLatencyValue, LtrB.MaxNoSnoopLatencyScale, LtrB.MaxNoSnoopLatencyRequirement,
+    LtrB.ForceOverride
+    ));
+  DEBUG ((DEBUG_INFO, "          : R(V%d S%d E%d : V%d S%d E%d, F%d)\n",
+    Result.MaxSnoopLatencyValue, Result.MaxSnoopLatencyScale, Result.MaxSnoopLatencyRequirement,
+    Result.MaxNoSnoopLatencyValue, Result.MaxNoSnoopLatencyScale, Result.MaxNoSnoopLatencyRequirement,
+    Result.ForceOverride
+    ));
+  return Result;
+}
+
+/**
+  Returns LTR override value for given device
+  The value is extracted from Device Override table. If the device is not found,
+  the returned value will have Requirement bits clear
+
+  @param[in] Base            device's base address
+  @param[in] Override        device override table
+
+  @retval LTR override value
+**/
+LTR_OVERRIDE
+GetOverrideLtr (
+  UINT64         Base,
+  OVERRIDE_TABLE *Override
+  )
+{
+  UINT16       DevId;
+  UINT16       VenId;
+  UINT16       RevId;
+  UINT32       Index;
+  LTR_OVERRIDE ReturnValue = {0};
+
+  VenId = PciSegmentRead16 (Base + PCI_VENDOR_ID_OFFSET);
+  DevId = PciSegmentRead16 (Base + PCI_DEVICE_ID_OFFSET);
+  RevId = PciSegmentRead16 (Base + PCI_REVISION_ID_OFFSET);
+
+  for (Index = 0; Index < Override->Size; Index++) {
+    if (((Override->Table[Index].OverrideConfig & PchPcieLtrOverride) == PchPcieLtrOverride) &&
+        (Override->Table[Index].VendorId == VenId) &&
+        ((Override->Table[Index].DeviceId == DevId) || (Override->Table[Index].DeviceId == 0xFFFF)) &&
+        ((Override->Table[Index].RevId == RevId) || (Override->Table[Index].RevId == 0xFF))) {
+      if (Override->Table[Index].SnoopLatency & 0x8000) {
+        ReturnValue.MaxSnoopLatencyRequirement = 1;
+        ReturnValue.MaxSnoopLatencyValue = Override->Table[Index].SnoopLatency & 0x3FF;
+        ReturnValue.MaxSnoopLatencyScale = (Override->Table[Index].SnoopLatency & 0x1C00) >> 10;
+      }
+      if (Override->Table[Index].NonSnoopLatency & 0x8000) {
+        ReturnValue.MaxNoSnoopLatencyRequirement = 1;
+        ReturnValue.MaxNoSnoopLatencyValue = Override->Table[Index].NonSnoopLatency & 0x3FF;
+        ReturnValue.MaxNoSnoopLatencyScale = (Override->Table[Index].NonSnoopLatency & 0x1C00) >> 10;
+      }
+      ReturnValue.ForceOverride = Override->Table[Index].ForceLtrOverride;
+      break;
+    }
+  }
+  return ReturnValue;
+}
+
+/**
+  In accordance with PCIe spec, devices with no LTR support are considered to have no LTR requirements
+  which means infinite latency tolerance. This was found to cause problems with HID and Audio devices without LTR
+  support placed behind PCIe switches with LTR support, as Switch's upstream link would be allowed to enter L1.2
+  and cause large latency downstream. To work around such issues and to fix some devices with broken
+  LTR reporting, Device Override table was introduced.
+  This function scans PCIe tree for devices mentioned in override table and calculates the strictest
+  LTR requirement between them. That value will be programmed into rootport's LTR override register
+
+  This function expects that bridges have bus numbers already configured
+
+  @param[in] BusLimit                       maximum Bus number that can be assigned below this port
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+  @param[in] AspmOverride                   Device specific ASPM policy override items
+
+  @retval MaxLTR programmed in this device
+**/
+LTR_OVERRIDE
+RecursiveLtrOverrideCheck (
+  SBDF           Sbdf,
+  OVERRIDE_TABLE *AspmOverride
+  )
+{
+  UINT64       Base;
+  SBDF         ChildSbdf;
+  LTR_OVERRIDE MyLtrOverride;
+  LTR_OVERRIDE ChildLtr;
+  PCI_DEV_TYPE DevType;
+
+  DEBUG ((DEBUG_INFO, "RecursiveLtrOverrideCheck %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+
+  Base = SbdfToBase(Sbdf);
+
+  MyLtrOverride = GetOverrideLtr (Base, AspmOverride);
+  if (HasChildBus (Sbdf, &ChildSbdf)) {
+    DevType = GetDeviceType (Sbdf);
+    while (FindNextPcieChild (DevType, &ChildSbdf)) {
+      ChildLtr = RecursiveLtrOverrideCheck (ChildSbdf, AspmOverride);
+      MyLtrOverride = CombineLtr (MyLtrOverride, ChildLtr);
+    }
+  }
+  return MyLtrOverride;
+}
+
+/**
+  Configures the following power-management related features in rootport and devices behind it:
+  LTR limit (generic)
+  LTR override (proprietary)
+  Clock Power Management (generic)
+  L1 substates (generic except for the override table)
+  L1.LOW substate (proprietary)
+  L0s and L1 (generic)
+
+  Generic: any code written according to PCIE Express base specification can do that.
+  Proprietary: code uses registers and features that are specific to Intel silicon
+  and probably only this Reference Code knows how to handle that.
+
+  If OEM implemented generic feature enabling in his platform code or trusts Operating System
+  to do it, then those features can be deleted from here.
+
+  @param[in] RpSegment                address of rootport on PCIe
+  @param[in] RpBus                    address of rootport on PCIe
+  @param[in] RpDevice                 address of rootport on PCIe
+  @param[in] RpFunction               address of rootport on PCIe
+  @param[in] BusLimit                 maximum Bus number that can be assigned below this rootport
+  @param[in] PcieRpLtrConfig          address of LTR Policy struct
+  @param[in] PcieRpCommonConfig       address of Common PCIe Policy struct
+  @param[in] AspmOverrideTableSize    size of override array
+  @param[in] AspmOverrideTable        array of device that need exceptions in configuration
+  @param[in] FeatureConfiguration     pointer to status of PCIe features configuration
+**/
+VOID
+RootportDownstreamPmConfiguration (
+  UINT8                               RpSegment,
+  UINT8                               RpBus,
+  UINT8                               RpDevice,
+  UINT8                               RpFunction,
+  UINT8                               BusMin,
+  UINT8                               BusMax,
+  PCIE_ROOT_PORT_COMMON_CONFIG        *PcieRpCommonConfig,
+  UINT32                              AspmOverrideTableSize,
+  PCH_PCIE_DEVICE_OVERRIDE            *AspmOverrideTable
+  )
+{
+  LTR_LIMIT      PolicyLtr;
+  LTR_OVERRIDE   TreeLtr;
+  OVERRIDE_TABLE PmOverrideTable;
+  UINT64         RpBase;
+  SBDF           RpSbdf;
+  SBDF_TABLE     BridgeCleanupList;
+
+  RpBase = PCI_SEGMENT_LIB_ADDRESS (RpSegment, RpBus, RpDevice, RpFunction, 0);
+  if (!(IsDevicePresent (RpBase))) {
+    return;
+  }
+  PmOverrideTable.Size = AspmOverrideTableSize;
+  PmOverrideTable.Table = AspmOverrideTable;
+
+  DEBUG ((DEBUG_INFO, "RootportDownstreamPmConfiguration %x:%x\n", RpDevice, RpFunction));
+
+  PolicyLtr.MaxNoSnoopLatencyScale = (PcieRpCommonConfig->PcieRpLtrConfig.LtrMaxNoSnoopLatency & 0x1c00) >> 10;
+  PolicyLtr.MaxNoSnoopLatencyValue = PcieRpCommonConfig->PcieRpLtrConfig.LtrMaxNoSnoopLatency & 0x3FF;
+  PolicyLtr.MaxSnoopLatencyScale   = (PcieRpCommonConfig->PcieRpLtrConfig.LtrMaxSnoopLatency & 0x1c00) >> 10;
+  PolicyLtr.MaxSnoopLatencyValue   = PcieRpCommonConfig->PcieRpLtrConfig.LtrMaxSnoopLatency & 0x3FF;
+
+  RpSbdf.Seg = RpSegment;
+  RpSbdf.Bus = RpBus;
+  RpSbdf.Dev = RpDevice;
+  RpSbdf.Func = RpFunction;
+  RpSbdf.PcieCap = PcieBaseFindCapId (RpBase, EFI_PCI_CAPABILITY_ID_PCIEXP);
+  //
+  // This code could execute either before or after enumeration. If before, then buses would not yet be assigned to bridges,
+  // making devices deeper in the hierarchy inaccessible.
+  // RecursiveBusAssignment will scan whole PCie tree and assign bus numbers to uninitialized bridges, if there are any
+  // List of such bridges will be kept in CleanupList, so that after PM programming is done, bus numbers can brought to original state
+  //
+  BridgeCleanupList.Count = 0;
+  RecursiveBusAssignment(RpSbdf, BusMin, BusMax, &BridgeCleanupList);
+  //
+  // The 'Recursive...' functions below expect bus numbers to be already assigned
+  //
+  RecursiveLtrConfiguration (RpSbdf, PolicyLtr);
+  TreeLtr = RecursiveLtrOverrideCheck (RpSbdf, &PmOverrideTable);
+  ConfigureRpLtrOverride (RpBase, RpSbdf.Dev, &TreeLtr, &(PcieRpCommonConfig->PcieRpLtrConfig));
+  DEBUG ((DEBUG_INFO, "ConfigureRpLtrOverride %x:%x\n", RpSbdf.Dev, RpSbdf.Func));
+  if (PcieRpCommonConfig->EnableCpm) {
+    RecursiveCpmConfiguration (RpSbdf);
+  }
+  //
+  // L1 substates can be modified only when L1 is disabled, so this function must execute
+  // before Aspm configuration which enables L1
+  //
+  RecursiveL1ssConfiguration (RpSbdf, &PmOverrideTable);
+  L1ssProprietaryConfiguration (RpBase, IsLtrCapable (RpSbdf), PcieRpCommonConfig->L1Low);
+  RecursiveAspmConfiguration (RpSbdf, 0, &PmOverrideTable);
+  DynamicLinkThrottlingEnable (RpSbdf);
+  ClearBusFromTable (&BridgeCleanupList);
+}
+
+/**
+  Configures the following power-management related features in rootport and devices behind it:
+  LTR limit (generic)
+  L0s and L1 (generic)
+
+  Generic: any code written according to PCIE Express base specification can do that.
+
+  @param[in] RpSegment                address of rootport on PCIe
+  @param[in] RpBus                    address of rootport on PCIe
+  @param[in] RpDevice                 address of rootport on PCIe
+  @param[in] RpFunction               address of rootport on PCIe
+**/
+VOID
+TcssRootportDownstreamPmConfiguration(
+  UINT8                     RpSegment,
+  UINT8                     RpBus,
+  UINT8                     RpDevice,
+  UINT8                     RpFunction,
+  LTR_LIMIT                 PolicyLtr
+)
+{
+  UINT64         RpBase;
+  SBDF           RpSbdf;
+
+  RpBase = PCI_SEGMENT_LIB_ADDRESS(RpSegment, RpBus, RpDevice, RpFunction, 0);
+  if (!(IsDevicePresent(RpBase))) {
+    return;
+  }
+
+  DEBUG((DEBUG_INFO, "TcssRootportDownstreamPmConfiguration %x:%x\n", RpDevice, RpFunction));
+
+  RpSbdf.Seg = RpSegment;
+  RpSbdf.Bus = RpBus;
+  RpSbdf.Dev = RpDevice;
+  RpSbdf.Func = RpFunction;
+  RpSbdf.PcieCap = PcieBaseFindCapId(RpBase, EFI_PCI_CAPABILITY_ID_PCIEXP);
+
+  //
+  // The 'Recursive...' functions below expect bus numbers to be already assigned
+  //
+  RecursiveLtrConfiguration(RpSbdf, PolicyLtr);
+
+  //
+  // ASPM Enabling
+  //
+  RecursiveAspmConfiguration(RpSbdf, 0,NULL);
+}
+
+/**
+  Checks if Root Port and tree below given root port supports 10BitTag Completer/Requester supported
+
+  @param[in] Segment,Bus,Device,Function  address of currently visited PCIe device
+
+  @retval  TRUE   if DACP2.PX10BTCS or DACP2.PX10BTRS set to 1
+           FALSE  Otherwise
+**/
+BOOLEAN
+Recursive10BitTagCheck (
+  SBDF  Sbdf
+  )
+{
+  UINT64        PcieBase;
+  BOOLEAN       Rp10BitTag;
+  BOOLEAN       SubTree10BitTag;
+  UINT8         EpPcieCapPtr;
+  UINT32        Data32;
+  SBDF          ChildSbdf;
+  PCI_DEV_TYPE  DevType;
+
+  DEBUG ((DEBUG_INFO, "B|D|F %d|%d|%d\t", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
+
+  PcieBase         = PCI_SEGMENT_LIB_ADDRESS (SA_SEG_NUM, (UINT8) Sbdf.Bus, (UINT8) Sbdf.Dev, (UINT8) Sbdf.Func, 0);
+  Data32           = PciSegmentRead32 (PcieBase + PCI_VENDOR_ID_OFFSET);
+  EpPcieCapPtr     = 0;
+  Rp10BitTag       = 0;
+  SubTree10BitTag  = 0;
+
+  if (Data32 != 0xFFFFFFFF) {
+    EpPcieCapPtr = PcieFindCapId (SA_SEG_NUM, (UINT8) Sbdf.Bus, (UINT8) Sbdf.Dev, (UINT8) Sbdf.Func, EFI_PCI_CAPABILITY_ID_PCIEXP);
+    if (EpPcieCapPtr != 0) {
+      Rp10BitTag = !!(PciSegmentRead32 (PcieBase + EpPcieCapPtr + R_PCIE_DCAP2_OFFSET) & (B_PCIE_DCAP2_PX10BTCS | B_PCIE_DCAP2_PX10BTRS));
+      DEBUG ((DEBUG_INFO, "10BitTag Support : %d\n", Rp10BitTag));
+    }
+  }
+  if (Rp10BitTag == 0) {
+    return Rp10BitTag;
+  }
+  if (HasChildBus (Sbdf, &ChildSbdf)) {
+    DevType = GetDeviceType (Sbdf);
+    while (FindNextPcieChild (DevType, &ChildSbdf)) {
+      SubTree10BitTag = Recursive10BitTagCheck (ChildSbdf);
+      Rp10BitTag &= SubTree10BitTag;
+    }
+  }
+  return Rp10BitTag;
+}
+
+/**
+  Program registers to Support 10-bit Tag
+  Only if given Root Port and tree below it supports 10BitTag Completer/Requester
+
+  @param[in] Segment,Bus,Device,Function  address of currently visited PCIe device
+**/
+VOID
+Rootport10BitTagConfiguration (
+  SBDF  RpSbdf
+  )
+{
+  UINT64        RpBase;
+  SBDF_TABLE    BridgeCleanupList;
+  UINT8         TempPciBusMin;
+  UINT8         TempPciBusMax;
+  BOOLEAN       TenBitTag;
+
+  RpBase       = SbdfToBase (RpSbdf);
+  //
+  // Check for device presence
+  //
+  if ((!!(PciSegmentRead16 (RpBase + R_PCIE_CFG_SLSTS) & B_PCIE_SLSTS_PDS)) == FALSE) {
+    DEBUG ((DEBUG_INFO, "Endpoint is not connected\n"));
+    return;
+  }
+
+  TempPciBusMin           = 2;
+  TempPciBusMax           = 10;
+  BridgeCleanupList.Count = 0;
+  RecursiveBusAssignment (RpSbdf, TempPciBusMin, TempPciBusMax, &BridgeCleanupList);
+
+  TenBitTag = Recursive10BitTagCheck (RpSbdf);
+
+  if (TenBitTag) {
+    DEBUG ((DEBUG_INFO, "Program registers to Support 10-bit Tag\n"));
+    //
+    // Program 10-Bit Tag Requester Enable (PX10BTRE) 0x68[12] = 0x1
+    //
+    PciSegmentOr32 (RpBase + R_PCIE_DCTL2_OFFSET, B_PCIE_DCTL2_PX10BTRE);
+    DEBUG ((DEBUG_INFO, "R_PCIE_DCTL2_OFFSET = %x\n", PciSegmentRead32 (RpBase + R_PCIE_DCTL2_OFFSET)));
+    //
+    // Program Fabric 10-bit Tag Support Enable (F10BTSE) 0x5BC[24] = 0x0
+    //
+    PciSegmentAnd32 (RpBase + R_PCIE_CFG_ADVMCTRL, (UINT32)~B_PCIE_CFG_ADVMCTRL_F10BTSE);
+    DEBUG ((DEBUG_INFO, "R_PCIE_ADVMCTRL = %x\n", PciSegmentRead32 (RpBase + R_PCIE_CFG_ADVMCTRL)));
+  }
+
+  ClearBusFromTable (&BridgeCleanupList);
+  return;
+}
+
+/**
+  Returns TRUE and Dev:Func numbers where a PCIe/PCI device could legally be located, or FALSE if there
+  no such coordinates left.
+
+  Segment and Bus fields of SBDF structure are input only and determine which bus will be scanned.
+  This function should be called in a while() loop. It replaces the less efficient method of
+  using nested FOR loops that iterate over all device and function numbers. It is optimized for
+  the amount of bus access. If function0 doesn't exist or doesn't have Multifunction bit set,
+  then higher function numbers are skipped. If parent of this bus is a downstream port, then
+  Device numbers 1-31 get skipped too (there can be only Dev0 behind downstream ports)
+  If device/function number == 0x1F/0x7, this function returns first possible address, that is 0:0
+  Any other device number means Dev:Func contain address of last found child device
+  and this function should search for next one
+
+  @param[in]     ParentDevType  type of bridge who's partent of this bus
+  @param[in,out] Sbdf           On entry: location returned previously from this function
+                                          Dev:Func value of 1F:07 means search should start from the beginning
+                                On exit:  if legal Dev:Func combination was found, that Dev:Func is returned
+                                          otherwise, Dev:Func are initialized to 1F:07 for convenience
+
+  @retval TRUE when next legal Dev:Func address was found; FALSE otherwise
+**/

--- a/Silicon/ArrowlakePkg/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.h
+++ b/Silicon/ArrowlakePkg/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.h
@@ -1,0 +1,44 @@
+/** @file
+  Header file for Pci Express helps library implementation.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#ifndef _PCI_EXPRESS_HELPERS_LIBRARY_H_
+#define _PCI_EXPRESS_HELPERS_LIBRARY_H_
+
+#include <Uefi/UefiBaseType.h>
+#include <Library/BaseLib.h>
+#include <Library/IoLib.h>
+#include <Library/DebugLib.h>
+#include <IndustryStandard/Pci.h>
+#include <Library/PchPcieRpConfig.h>
+#include <Library/PchPcieRpLib.h>
+#include <Library/PchPcrLib.h>
+#include <Library/PchInfoLib.h>
+#include <Library/PciSegmentLib.h>
+#include <Library/TimerLib.h>
+#include <Library/PciExpressHelpersLib.h>
+#include <Library/PcieRpLib.h>
+#include <PcieRegs.h>
+#include <Register/PchPcieRpRegs.h>
+
+
+#define LTR_VALUE_MASK (BIT0 + BIT1 + BIT2 + BIT3 + BIT4 + BIT5 + BIT6 + BIT7 + BIT8 + BIT9)
+#define LTR_SCALE_MASK (BIT10 + BIT11 + BIT12)
+
+#ifndef SLE_FLAG
+  #define CONFIG_WRITE_LOOP_COUNT   100000
+#else // SLE_FLAG
+  #define CONFIG_WRITE_LOOP_COUNT   10
+#endif // SLE_FLAG
+
+//
+// LTR related macros
+//
+#define LTR_LATENCY_VALUE(x)           ((x) & LTR_VALUE_MASK)
+#define LTR_SCALE_VALUE(x)             (((x) & LTR_SCALE_MASK) >> 10)
+#define LTR_LATENCY_NS(x)              (LTR_LATENCY_VALUE(x) * (1 << (5 * LTR_SCALE_VALUE(x))))
+
+
+#endif

--- a/Silicon/ArrowlakePkg/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.inf
+++ b/Silicon/ArrowlakePkg/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.inf
@@ -1,0 +1,43 @@
+## @file
+# Component description file for the PeiDxeSmmPciExpressHelpersLib
+#
+#  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+
+[Defines]
+  INF_VERSION = 0x00010017
+  BASE_NAME = PciExpressHelpersLib
+  FILE_GUID = 07E3F76D-6D26-419d-9053-58696A15B519
+  VERSION_STRING = 1.0
+  MODULE_TYPE = BASE
+  LIBRARY_CLASS = PciExpressHelpersLib
+#
+# The following information is for reference only and not required by the build tools.
+#
+# VALID_ARCHITECTURES = IA32 X64 IPF EBC
+#
+
+
+[LibraryClasses]
+  IoLib
+  DebugLib
+  PchPcrLib
+  PchInfoLib
+  GpioLib
+  TimerLib
+  BasePchPciBdfLib
+  BasePcieHelperLib
+  PcieClientRpLib
+
+[Packages]
+  Silicon/ArrowlakePkg/ArrowlakePkg.dec
+  Silicon/CommonSocPkg/CommonSocPkg.dec
+  MdePkg/MdePkg.dec
+  BootloaderCorePkg/BootloaderCorePkg.dec
+
+[Sources]
+  PciExpressHelpersLibrary.c
+  PciExpressHelpersLibrary.h

--- a/Silicon/ArrowlakePkg/Library/PcieClientRpLib/PcieClientRpLib.c
+++ b/Silicon/ArrowlakePkg/Library/PcieClientRpLib/PcieClientRpLib.c
@@ -1,0 +1,219 @@
+/** @file
+  This file contains routines that support PCI Express initialization
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#include <Uefi/UefiBaseType.h>
+#include <IndustryStandard/Pci.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/PcieHelperLib.h>
+#include <Library/PchSbiAccessLib.h>
+#include <Library/PchPciBdfLib.h>
+#include <Library/PcieRpLib.h>
+#include <Library/PchInfoLib.h>
+#include <Library/PchPcieRpLib.h>
+#include <Register/PchPcieRpRegs.h>
+#include <Register/PcieSipRegs.h>
+#include <PcieRegs.h>
+#include <PchPcieRpInfo.h>
+#include <CpuPcieInfo.h>
+
+/**
+  Get PCIe port number for enabled port.
+  @param[in] RpBase    Root Port pci segment base address
+
+  @retval Root Port number (1 based)
+**/
+UINT32
+PciePortNum (
+  IN     UINT64  RpBase
+  )
+{
+  return PciSegmentRead32 (RpBase + R_PCIE_CFG_LCAP) >> N_PCIE_CFG_LCAP_PN;
+}
+
+/**
+  Get PCIe root port index
+
+  @param[in] RpBase    Root Port pci segment base address
+
+  @retval Root Port index (0 based)
+**/
+UINT32
+PciePortIndex (
+  IN     UINT64  RpBase
+  )
+{
+  return PciePortNum (RpBase) - 1;
+}
+
+/**
+  This function checks whether PHY lane power gating is enabled on the port.
+
+  @param[in] RpBase                 Root Port base address
+
+  @retval TRUE                      PHY power gating is enabled
+  @retval FALSE                     PHY power gating disabled
+**/
+BOOLEAN
+PcieIsPhyLanePgEnabled (
+  IN     UINT64  RpBase
+  )
+{
+  UINT32 Data32;
+
+  Data32 = PciSegmentRead32 (RpBase + R_PCH_PCIE_CFG_PCIEPMECTL);
+  return (Data32 & B_PCH_PCIE_CFG_PCIEPMECTL_DLSULPPGE) != 0;
+}
+
+/**
+  Configures Root Port packet split.
+
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+  @param[in] Mps                            maximum packet size
+**/
+VOID
+ConfigureRpPacketSplit (
+  UINT64 RpBase,
+  UINT8  Mps
+  )
+{
+  PciSegmentAndThenOr32 (RpBase + R_PCIE_CFG_CCFG, (UINT32) ~(B_PCIE_CFG_CCFG_UNRS), Mps << N_PCIE_CFG_CCFG_UNRS);
+}
+
+/**
+  Configures LTR override in Root Port's proprietary registers.
+
+  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+  @param[in] DevNum                         currently visited device number
+  @param[in] RpConfig                       Root Port LTR configuration
+  @param[in] AspmOverride                   combination of LTR override values from all devices under this Root Port
+**/
+VOID
+ConfigureRpLtrOverride (
+  UINT64           RpBase,
+  UINT32           DevNum,
+  LTR_OVERRIDE     *TreeLtr,
+  PCIE_LTR_CONFIG  *LtrConfig
+  )
+{
+  UINT32       OvrEn;
+  UINT32       OvrVal;
+  BOOLEAN      IsCpuPcie;
+  UINT32       LtrCfgLock;
+
+  IsCpuPcie = FALSE;
+  OvrEn = 0;
+  OvrVal = 0;
+  LtrCfgLock = 0;
+
+  if (DevNum == SA_PEG0_DEV_NUM || DevNum == SA_PEG3_DEV_NUM) {
+    IsCpuPcie = TRUE;
+  }
+
+  //
+  // LTR settings from LTROVR register only get acknowledged on rising edge of LTROVR2[1:0]
+  // If those bits were already set (that can happen on a plug-hotUnplug-hotPlug scenario),
+  // they need to be toggled
+  //
+  if (PciSegmentRead32 (RpBase + R_PCH_PCIE_CFG_LTROVR2) != 0) {
+    PciSegmentWrite32 (RpBase + R_PCH_PCIE_CFG_LTROVR2, 0);
+  }
+  //
+  // (*)LatencyOverrideMode = 0 -> no override
+  //                          1 -> override with RP policy values
+  //                          2 -> override with endpoint's override values
+  //
+
+  if (LtrConfig->ForceLtrOverride || TreeLtr->ForceOverride) {
+    OvrEn |= (UINT32) B_PCH_PCIE_CFG_LTROVR2_FORCE_OVERRIDE;
+  }
+  if (LtrConfig->LtrConfigLock == TRUE) {
+    OvrEn |= (UINT32) B_PCH_PCIE_CFG_LTROVR2_LOCK;
+    if (IsCpuPcie) {
+      LtrCfgLock |= (UINT32) B_PCIE_CFG_LPCR_LTRCFGLOCK;
+    }
+  }
+
+  if (LtrConfig->SnoopLatencyOverrideMode == 1) {
+    OvrEn |= (UINT32) B_PCH_PCIE_CFG_LTROVR2_LTRSOVREN;
+    OvrVal |= LtrConfig->SnoopLatencyOverrideValue;
+    OvrVal |= LtrConfig->SnoopLatencyOverrideMultiplier << 10;
+    OvrVal |= (UINT32) B_PCH_PCIE_CFG_LTROVR_LTRSROVR;
+  } else if (LtrConfig->SnoopLatencyOverrideMode == 2) {
+    if (TreeLtr->MaxSnoopLatencyRequirement) {
+      OvrEn |= (UINT32) B_PCH_PCIE_CFG_LTROVR2_LTRSOVREN;
+      OvrVal |= TreeLtr->MaxSnoopLatencyValue;
+      OvrVal |= TreeLtr->MaxSnoopLatencyScale << 10;
+      OvrVal |= (UINT32) B_PCH_PCIE_CFG_LTROVR_LTRSROVR;
+    }
+  }
+  if (LtrConfig->NonSnoopLatencyOverrideMode == 1) {
+    OvrEn |= (UINT32) B_PCH_PCIE_CFG_LTROVR2_LTRNSOVREN;
+    OvrVal |= LtrConfig->NonSnoopLatencyOverrideValue << 16;
+    OvrVal |= LtrConfig->NonSnoopLatencyOverrideMultiplier << 26;
+    OvrVal |= (UINT32) B_PCH_PCIE_CFG_LTROVR_LTRNSROVR;
+  } else if (LtrConfig->NonSnoopLatencyOverrideMode == 2) {
+    if (TreeLtr->MaxNoSnoopLatencyRequirement) {
+      OvrEn |= (UINT32) B_PCH_PCIE_CFG_LTROVR2_LTRNSOVREN;
+      OvrVal |= TreeLtr->MaxNoSnoopLatencyValue << 16;
+      OvrVal |= TreeLtr->MaxNoSnoopLatencyScale << 26;
+      OvrVal |= (UINT32) B_PCH_PCIE_CFG_LTROVR_LTRNSROVR;
+    }
+  }
+  PciSegmentWrite32 (RpBase + R_PCH_PCIE_CFG_LTROVR, OvrVal);
+  PciSegmentWrite32 (RpBase + R_PCH_PCIE_CFG_LTROVR2, OvrEn);
+  if (IsCpuPcie) {
+    PciSegmentOr32(RpBase + R_PCIE_CFG_LPCR, LtrCfgLock);
+  }
+  DEBUG ((DEBUG_INFO, "ConfigureRpLtrOverride %x Val %x En %x\n", RpBase, OvrVal, OvrEn));
+}
+
+/**
+  Configures proprietary parts of L1 substates configuration in Root Port
+
+  @param[in] RpSbdf       segment:bus:device:function coordinates of Root Port
+  @param[in] LtrCapable   TRUE if Root Port is LTR capable
+**/
+VOID
+L1ssProprietaryConfiguration (
+  UINT64  RpBase,
+  BOOLEAN LtrCapable,
+  BOOLEAN L1LowCapable
+  )
+{
+  BOOLEAN ClkreqSupported;
+  BOOLEAN L1ssEnabled;
+  UINT16  PcieCapOffset;
+  UINT32  Data32;
+  BOOLEAN L1LowSupported;
+
+  ClkreqSupported = PcieIsPhyLanePgEnabled (RpBase);
+
+  PcieCapOffset = PcieBaseFindExtendedCapId (RpBase, V_PCIE_EX_L1S_CID);
+  if (PcieCapOffset == 0) {
+    L1ssEnabled = FALSE;
+  } else {
+    Data32 = PciSegmentRead32 (RpBase + PcieCapOffset + R_PCIE_EX_L1SCTL1_OFFSET);
+    L1ssEnabled = Data32 & (B_PCIE_EX_L1SCAP_AL1SS | B_PCIE_EX_L1SCAP_AL12S | B_PCIE_EX_L1SCAP_PPL11S |B_PCIE_EX_L1SCAP_PPL12S);
+  }
+  L1LowSupported = ClkreqSupported && LtrCapable && !L1ssEnabled && L1LowCapable;
+
+  ///
+  /// If L1.SNOOZ and L1.OFF (L1 Sub-States) are not supported and per-port CLKREQ# is supported, and LTR is supported:
+  /// Enable L1.LOW by setting Dxx:Fn:420[17] = 1b
+  ///
+  if (L1LowSupported) {
+    PciSegmentOr32 (RpBase + R_PCH_PCIE_CFG_PCIEPMECTL, (UINT32) B_PCH_PCIE_CFG_PCIEPMECTL_L1LE);
+  } else {
+    PciSegmentAnd32 (RpBase + R_PCH_PCIE_CFG_PCIEPMECTL, (UINT32) ~B_PCH_PCIE_CFG_PCIEPMECTL_L1LE);
+  }
+
+  if (L1LowSupported || L1ssEnabled) {
+    ///
+    /// f.  Set Dxx:Fn:420h[0] to 1b prior to L1 enabling if any L1substate is enabled (including L1.LOW)
+    ///
+    PciSegmentOr32 (RpBase + R_PCH_PCIE_CFG_PCIEPMECTL, B_PCH_PCIE_CFG_PCIEPMECTL_L1FSOE);
+  }
+}

--- a/Silicon/ArrowlakePkg/Library/PcieClientRpLib/PcieClientRpLib.inf
+++ b/Silicon/ArrowlakePkg/Library/PcieClientRpLib/PcieClientRpLib.inf
@@ -1,0 +1,42 @@
+## @file
+# Component description file for the PcieClientRpLib
+#
+#  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+
+[Defines]
+  INF_VERSION = 0x00010017
+  BASE_NAME = PcieClientRpLib
+  FILE_GUID = 77EB467D-674C-4C20-A13E-381600E182C4
+  VERSION_STRING = 1.0
+  MODULE_TYPE = BASE
+  LIBRARY_CLASS = PcieRpLib
+#
+# The following information is for reference only and not required by the build tools.
+#
+# VALID_ARCHITECTURES = IA32 X64 IPF EBC
+#
+
+
+
+[LibraryClasses]
+  IoLib
+  DebugLib
+  #PchPcieRpLib
+  PchPcrLib
+  PchInfoLib
+  GpioLib
+  TimerLib
+  BasePcieHelperLib
+  PchPciBdfLib
+
+[Packages]
+  MdePkg/MdePkg.dec
+  Silicon/CommonSocPkg/CommonSocPkg.dec
+  Silicon/ArrowlakePkg/ArrowlakePkg.dec
+
+[Sources]
+  PcieClientRpLib.c

--- a/Silicon/ArrowlakePkg/Library/PciePm/PciePm.c
+++ b/Silicon/ArrowlakePkg/Library/PciePm/PciePm.c
@@ -1,0 +1,348 @@
+/** @file
+  This file enables PCIe PM configuration
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#include <FspsUpd.h>
+#include <Library/DebugLib.h>
+#include <Library/PciePm.h>
+#include <PcieRegs.h>
+#include <Register/PchPcieRpRegs.h>
+#include <Library/PciSegmentLib.h>
+#include <Library/PcieHelperLib.h>
+#include <Library/PchPciBdfLib.h>
+#include <Library/PchPcieRpConfig.h>
+#include <Library/PciExpressHelpersLib.h>
+#include <Library/CpuPcieHsPhyInitLib.h>
+#include <Library/PchInfoLib.h>
+#include <PcieRegs.h>
+#include <PchAccess.h>
+#include <CpuDataStruct.h>
+#include <CpuRegs.h>
+#include <Register/Cpuid.h>
+#include <Register/SaRegsHostBridge.h>
+#include <Library/PciLib.h>
+#include <Library/PlatformInfo.h>
+
+#define SA_SEG_NUM         0x00
+#define SA_MC_BUS          0x00
+
+#define PCI_CLASS_NETWORK             0x02
+#define PCI_CLASS_NETWORK_ETHERNET    0x00
+#define PCI_CLASS_NETWORK_OTHER       0x80
+
+#define CPU_PCIE_MAX_ROOT_PORTS       4
+#define PCIE_HWEQ_COEFFS_MAX          5
+
+#define CPU_PCIE_ULT_MAX_ROOT_PORT         3
+#define CPU_PCIE_ULX_MAX_ROOT_PORT         1
+#define CPU_PCIE_DT_HALO_MAX_ROOT_PORT     3
+#define CPU_PCIE_ULT_MAX_CONTROLLER        3
+#define CPU_PCIE_ULX_MAX_CONTROLLER        1
+#define CPU_PCIE_DT_HALO_MAX_CONTROLLER    2
+
+GLOBAL_REMOVE_IF_UNREFERENCED PCH_PCIE_DEVICE_OVERRIDE mPcieDeviceTable[] = {
+  //
+  // Intel PRO/Wireless
+  //
+  { 0x8086, 0x422b, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x422c, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x4238, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x4239, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel WiMAX/WiFi Link
+  //
+  { 0x8086, 0x0082, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0085, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0083, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0084, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0086, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0087, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0088, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0089, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x008F, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0090, 0xff, 0xff, 0xff, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel Crane Peak WLAN NIC
+  //
+  { 0x8086, 0x08AE, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x08AF, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel Crane Peak w/BT WLAN NIC
+  //
+  { 0x8086, 0x0896, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0897, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel Kelsey Peak WiFi, WiMax
+  //
+  { 0x8086, 0x0885, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0886, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel Centrino Wireless-N 105
+  //
+  { 0x8086, 0x0894, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0895, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel Centrino Wireless-N 135
+  //
+  { 0x8086, 0x0892, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0893, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel Centrino Wireless-N 2200
+  //
+  { 0x8086, 0x0890, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0891, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel Centrino Wireless-N 2230
+  //
+  { 0x8086, 0x0887, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x0888, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel Centrino Wireless-N 6235
+  //
+  { 0x8086, 0x088E, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x088F, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel CampPeak 2 Wifi
+  //
+  { 0x8086, 0x08B5, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x08B6, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Intel WilkinsPeak 1 Wifi
+  //
+  { 0x8086, 0x08B3, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2AndL1SubstatesOverride, 0x0158, 0x0000000F, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x08B4, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2AndL1SubstatesOverride, 0x0158, 0x0000000F, 0, 0, 0, 0, 0 },
+  //
+  // Intel Wilkins Peak 2 Wifi
+  //
+  { 0x8086, 0x08B1, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2AndL1SubstatesOverride, 0x0158, 0x0000000F, 0, 0, 0, 0, 0 },
+  { 0x8086, 0x08B2, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2AndL1SubstatesOverride, 0x0158, 0x0000000F, 0, 0, 0, 0, 0 },
+  //
+  // Intel Wilkins Peak PF Wifi
+  //
+  { 0x8086, 0x08B0, 0xff, PCI_CLASS_NETWORK, PCI_CLASS_NETWORK_OTHER, PchPcieAspmL1, PchPcieL1L2Override, 0, 0, 0, 0, 0, 0, 0 },
+  //
+  // Teton Glacier Endpoint
+  //
+  { 0x8086, 0x0975, 0xff, 0, 0, 0, PchPcieL1SubstatesOverride, 0, 0xff, 0x3C, 0, 5, 0, 0 },
+  //
+  // Pyramid Glacier Endpoint
+  //
+  { 0x8086, 0x09AD, 0xff, 0, 0, 0, PchPcieL1SubstatesOverride, 0, 0xff, 0x3C, 0, 5, 0, 0 },
+
+  //
+  // End of Table
+  //
+  { 0 }
+};
+
+GLOBAL_REMOVE_IF_UNREFERENCED PCH_PCIE_ROOT_PORT_CONFIG     mPcieRootPortConfig[PCH_MAX_PCIE_ROOT_PORTS];
+GLOBAL_REMOVE_IF_UNREFERENCED PCH_PCIE_ROOT_PORT_CONFIG     mCpuPcieRootPortConfig[CPU_PCIE_MAX_ROOT_PORTS];
+
+/**
+  Store Root Port Config based on FSP-s UPDs
+
+  @param[in]  FspsConfig       The pointer to FSP-S Config
+
+**/
+VOID
+EFIAPI
+StoreRpConfig (
+  VOID *FspsConfig
+)
+{
+  FSP_S_CONFIG  *Config;
+  UINT8         MaxPchPcieRootPorts;
+  UINT8         MaxCpuPciePorts;
+  UINT8         Index;
+
+  Config = (FSP_S_CONFIG *)FspsConfig;
+  if (Config == NULL) {
+    return;
+  }
+
+  MaxPchPcieRootPorts = GetPchMaxPciePortNum ();
+  for (Index = 0; Index < MaxPchPcieRootPorts; Index++) {
+    mPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.LtrMaxNoSnoopLatency = Config->PcieRpLtrMaxNoSnoopLatency[Index];
+    mPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.LtrMaxSnoopLatency = Config->PcieRpLtrMaxSnoopLatency[Index];
+    mPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.LtrConfigLock = Config->PcieRpLtrConfigLock[Index];
+    mPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.SnoopLatencyOverrideMode = Config->PcieRpSnoopLatencyOverrideMode[Index];
+    mPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.SnoopLatencyOverrideValue = Config->PcieRpSnoopLatencyOverrideValue[Index];
+    mPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.SnoopLatencyOverrideMultiplier = Config->PcieRpSnoopLatencyOverrideMultiplier[Index];
+    mPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.NonSnoopLatencyOverrideMode = Config->PcieRpNonSnoopLatencyOverrideMode[Index];
+    mPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.NonSnoopLatencyOverrideValue = Config->PcieRpNonSnoopLatencyOverrideValue[Index];
+    mPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.NonSnoopLatencyOverrideMultiplier = Config->PcieRpNonSnoopLatencyOverrideMultiplier[Index];
+
+    mPcieRootPortConfig[Index].PcieRpCommonConfig.EnableCpm = Config->PcieRpEnableCpm[Index];
+  }
+
+  MaxCpuPciePorts = GetMaxCpuPciePortNum();
+  for (Index = 0; Index < MaxCpuPciePorts; Index++) {
+    mCpuPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.LtrMaxNoSnoopLatency = Config->PcieRpLtrMaxNoSnoopLatency[Index];
+    mCpuPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.LtrMaxSnoopLatency = Config->PcieRpLtrMaxSnoopLatency[Index];
+    mCpuPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.LtrConfigLock = Config->PcieRpLtrConfigLock[Index];
+    mCpuPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.SnoopLatencyOverrideMode = Config->PcieRpSnoopLatencyOverrideMode[Index];
+    mCpuPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.SnoopLatencyOverrideValue = Config->PcieRpSnoopLatencyOverrideValue[Index];
+    mCpuPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.SnoopLatencyOverrideMultiplier = Config->PcieRpSnoopLatencyOverrideMultiplier[Index];
+    mCpuPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.NonSnoopLatencyOverrideMode = Config->PcieRpNonSnoopLatencyOverrideMode[Index];
+    mCpuPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.NonSnoopLatencyOverrideValue = Config->PcieRpNonSnoopLatencyOverrideValue[Index];
+    mCpuPcieRootPortConfig[Index].PcieRpCommonConfig.PcieRpLtrConfig.NonSnoopLatencyOverrideMultiplier = Config->PcieRpNonSnoopLatencyOverrideMultiplier[Index];
+
+    mCpuPcieRootPortConfig[Index].PcieRpCommonConfig.EnableCpm = Config->PcieRpEnableCpm[Index];
+  }
+}
+UINT8
+EFIAPI
+GetCpuSku (
+  VOID
+  );
+
+/**
+  Get CPU Pcie Root Port Device and Function Number by Root Port physical Number
+
+  @param[in]  RpNumber              Root port physical number. (0-based)
+  @param[out] RpDev                 Return corresponding root port device number.
+  @param[out] RpFun                 Return corresponding root port function number.
+
+  @retval     EFI_SUCCESS           Root port device and function is retrieved
+  @retval     EFI_INVALID_PARAMETER RpNumber is invalid
+**/
+EFI_STATUS
+EFIAPI
+GetCpuPcieRpDevFun (
+  IN  UINTN   RpNumber,
+  OUT UINTN   *RpDev,
+  OUT UINTN   *RpFun
+  )
+{
+  if (RpNumber > GetMaxCpuPciePortNum ()) {
+    DEBUG ((DEBUG_ERROR, "GetCpuPcieRpDevFun invalid RpNumber %x", RpNumber));
+    ASSERT (FALSE);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  switch (RpNumber) {
+    case 0:
+      *RpDev = 6;
+      *RpFun = 0;
+      break;
+    case 1:
+      *RpDev = 1;
+      *RpFun = 0;
+      break;
+    case 2:
+      if (GetCpuSku () == EnumCpuTrad) {
+        *RpDev = 1;
+        *RpFun = 1;
+      } else {
+        *RpDev = 6;
+        *RpFun = 2;
+      }
+      break;
+    default:
+      *RpDev = 6;
+      *RpFun = 0;
+      break;
+  }
+  return EFI_SUCCESS;
+}
+
+
+/**
+  Config CPU PCIE power management settings
+**/
+VOID
+CpuPciePmConfig (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      PortIndex;
+  UINT64      RpBase;
+  UINT8       MaxPciePortNum;
+  UINTN       RpDevice;
+  UINTN       RpFunction;
+  UINT8       TempRootPortBusNumMin;
+  UINT8       TempRootPortBusNumMax;
+
+  TempRootPortBusNumMin = 2;
+  TempRootPortBusNumMax = 10;
+
+  MaxPciePortNum = GetMaxCpuPciePortNum ();
+
+  for (PortIndex = 0; PortIndex < MaxPciePortNum; PortIndex++) {
+    Status = GetCpuPcieRpDevFun (PortIndex, &RpDevice, &RpFunction);
+    if (EFI_ERROR (Status)) {
+      continue;
+    }
+
+    RpBase = PCI_SEGMENT_LIB_ADDRESS (SA_SEG_NUM, SA_MC_BUS, (UINT32) RpDevice, (UINT32) RpFunction, 0);
+
+    if (PciSegmentRead16 (RpBase) != 0xFFFF) {
+      RootportDownstreamPmConfiguration (
+        SA_SEG_NUM,
+        SA_MC_BUS,
+        (UINT8)RpDevice,
+        (UINT8)RpFunction,
+        TempRootPortBusNumMin,
+        TempRootPortBusNumMax,
+        &mCpuPcieRootPortConfig[PortIndex].PcieRpCommonConfig,
+        0,
+        NULL
+      );
+    }
+  }
+}
+
+/**
+  Config PCH PCIE power management settings
+**/
+VOID
+PchPciePmConfig (
+  VOID
+  )
+{
+  UINT32  PortIndex;
+  UINT64  RpBase;
+  UINT8   MaxPciePortNum;
+  UINT8   TempRootPortBusNumMin;
+  UINT8   TempRootPortBusNumMax;
+
+  TempRootPortBusNumMin = 2;
+  TempRootPortBusNumMax = 10;
+
+  MaxPciePortNum = GetPchMaxPciePortNum ();
+
+  for (PortIndex = 0; PortIndex < MaxPciePortNum; PortIndex++) {
+    RpBase = PchPcieRpPciCfgBase (PortIndex);
+
+    if (PciSegmentRead16 (RpBase) != 0xFFFF) {
+      RootportDownstreamPmConfiguration (
+        DEFAULT_PCI_SEGMENT_NUMBER_PCH,
+        DEFAULT_PCI_BUS_NUMBER_PCH,
+        PchPcieRpDevNumber (PortIndex),
+        PchPcieRpFuncNumber (PortIndex),
+        TempRootPortBusNumMin,
+        TempRootPortBusNumMax,
+        &mPcieRootPortConfig[PortIndex].PcieRpCommonConfig,
+        ARRAY_SIZE (mPcieDeviceTable) - 1,
+        mPcieDeviceTable
+      );
+
+    }
+  }
+}
+
+/**
+  Config PCIE power management settings
+**/
+VOID
+EFIAPI
+PciePmConfig (
+  VOID
+)
+{
+  CpuPciePmConfig ();
+  PchPciePmConfig ();
+}

--- a/Silicon/ArrowlakePkg/Library/PciePm/PciePm.inf
+++ b/Silicon/ArrowlakePkg/Library/PciePm/PciePm.inf
@@ -1,0 +1,36 @@
+## @file
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010017
+  BASE_NAME                      = PciePm
+  FILE_GUID                      = 59779dd7-6be1-4599-9a6a-b7951ee7040a
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = PciePm
+
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[LibraryClasses]
+  SerialPortLib
+  BaseLib
+  DebugLib
+  PciExpressHelpersLib
+
+[Sources]
+  PciePm.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  IntelFsp2Pkg/IntelFsp2Pkg.dec
+  Silicon/CommonSocPkg/CommonSocPkg.dec
+  Silicon/ArrowlakePkg/ArrowlakePkg.dec


### PR DESCRIPTION
S0ix is failing due to incorrect PCI device configuration 
Ported RootPortDownStreamPmConfiguration to resolve incorrect ASPM and L1 settings