### PR TITLE
[ARLS] fix: Update FSP UPD to enable S0ix

### DIFF
--- a/Platform/ArrowlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/ArrowlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -454,6 +454,7 @@ UpdateFspConfig (
 
   if (FeaturesCfgData != NULL) {
     if (FeaturesCfgData->Features.S0ix == 1) {
+      Fspmcfg->InternalGfx        = 0;
       Fspmcfg->PchIshEnable       = 0;
       Fspmcfg->TcssXdciEn         = 0;
       Fspmcfg->TcssDma0En         = 0;


### PR DESCRIPTION
Update FSP UPDS to match bios settings to enable S0ix