### PR TITLE
fix: Reload segment selectors after GDT Load in Stage1a

### DIFF
--- a/BootloaderCorePkg/Stage1A/Ia32/UpdateSelectors.nasm
+++ b/BootloaderCorePkg/Stage1A/Ia32/UpdateSelectors.nasm
@@ -1,0 +1,38 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;
+; Module Name:
+;
+;  UpdateSelectors.nasm
+;
+; Abstract:
+;
+;  This code reloads the segment selectors after GDT update
+;
+;------------------------------------------------------------------------------
+DEFAULT REL
+SECTION .text
+BITS 32
+
+; LINEAR_CODE_SEL 0x10 for ia32 CS
+FarJmpData:
+    dd ReloadCs
+    dw 10h
+
+global  ASM_PFX(UpdateSelectors)
+ASM_PFX(UpdateSelectors):
+        push    ax
+        ; LINEAR_SEL selector 0x8 for ia32 segments
+        mov     ax, 8
+        mov     ds, ax
+        mov     es, ax
+        mov     fs, ax
+        mov     gs, ax
+        mov     ss, ax
+        jmp far [FarJmpData]
+ReloadCs:
+        pop     ax
+        ret

--- a/BootloaderCorePkg/Stage1A/Stage1A.c
+++ b/BootloaderCorePkg/Stage1A/Stage1A.c
@@ -482,6 +482,7 @@ SecStartup (
   LdrGlobal->CarSize               = Stage1aAsmParam->CarTop - LdrGlobal->CarBase;
 
   LoadGdt (&GdtTable, (IA32_DESCRIPTOR *)&mGdt);
+  UpdateSelectors();
   LoadIdt (&IdtTable, (UINT32)(UINTN)LdrGlobal);
   SetLoaderGlobalDataPointer (LdrGlobal);
 

--- a/BootloaderCorePkg/Stage1A/Stage1A.h
+++ b/BootloaderCorePkg/Stage1A/Stage1A.h
@@ -52,4 +52,13 @@ ContinueFunc (
   IN VOID  *Params
   );
 
+/**
+  Reloads segment selectors based on SBL GDT. This is useful if reset
+  vector GDT is different from Stage1A GDT.
+
+**/
+VOID
+EFIAPI
+UpdateSelectors (VOID);
+
 #endif

--- a/BootloaderCorePkg/Stage1A/Stage1A.inf
+++ b/BootloaderCorePkg/Stage1A/Stage1A.inf
@@ -27,9 +27,11 @@
 
 [Sources.IA32]
   Ia32/SecEntry.nasm
+  Ia32/UpdateSelectors.nasm
 
 [Sources.X64]
   X64/SecEntry.nasm
+  X64/UpdateSelectors.nasm
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/BootloaderCorePkg/Stage1A/X64/UpdateSelectors.nasm
+++ b/BootloaderCorePkg/Stage1A/X64/UpdateSelectors.nasm
@@ -1,0 +1,40 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+;
+; Module Name:
+;
+;  UpdateSelectors.nasm
+;
+; Abstract:
+;
+;  This code reloads the segment selectors after GDT update
+;
+;------------------------------------------------------------------------------
+
+DEFAULT REL
+SECTION .text
+
+BITS 64
+
+; LINEAR_CODE64_SEL 0x20 for x64 CS
+FarJmpData:
+    dq ReloadCs
+    dw 20h
+
+global  ASM_PFX(UpdateSelectors)
+ASM_PFX(UpdateSelectors):
+        push    ax
+        ; LINEAR_SEL 0x8 for x64 segments
+        mov     ax, 8
+        mov     ds, ax
+        mov     es, ax
+        mov     fs, ax
+        mov     gs, ax
+        mov     ss, ax
+        jmp far [FarJmpData]
+ReloadCs:
+        pop     ax
+        ret


### PR DESCRIPTION
If ResetVector GDT is different from that loaded in Stage1A SecStartup() then segment selectors need to be reloaded after GDT is updated.