### PR TITLE
fix : [ARL] Added deprecation warning for ia32 Build

### DIFF
--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -1329,6 +1329,9 @@ class Build(object):
         rebuild_basetools ()
 
     def build(self):
+        if (self._board.BOARD_NAME in [ 'arl', 'arls' ]) & (self._board.BUILD_ARCH == 'IA32') :
+            WARNING = '\033[93m'
+            print(f"{WARNING}\n\n!!! DEPRECATED !!! Arrowlake ia32 build is obsolete. !!! DEPRECATED !!!\n\n{WARNING}")
         print("Build [%s] ..." % self._board.BOARD_NAME)
 
         # Run early build init


### PR DESCRIPTION
Deprecation warning added in the build log for
'arls' and 'arl' ia32 build.