### PR TITLE
fix: [EHL] modify ACPI method name to resolve GbE auto-negotiation issue

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/AcpiTables/Dsdt/PchPse.asl
+++ b/Platform/ElkhartlakeBoardPkg/AcpiTables/Dsdt/PchPse.asl
@@ -1,7 +1,7 @@
 /**@file
   ACPI DSDT table for PSE
 
- Copyright (c) 2019 - 2023 Intel Corporation. All rights reserved.<BR>
+ Copyright (c) 2019 - 2024 Intel Corporation. All rights reserved.<BR>
  SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -96,7 +96,7 @@ Scope(\_SB.PC00) {
       Return(0x00)
     }
 
-    Method (_IPC, 0x7,Serialized) {
+    Method (IPCG, 0x7,Serialized) {
       Return(IPCS(Arg0,Arg1,Arg2,Arg3,Arg4,Arg5,Arg6))
     }
 
@@ -135,7 +135,7 @@ Scope(\_SB.PC00) {
       Return(0x00)
     }
 
-    Method (_IPC, 0x7,Serialized) {
+    Method (IPCG, 0x7,Serialized) {
        Return(IPCS(Arg0,Arg1,Arg2,Arg3,Arg4,Arg5,Arg6))
     }
 

--- a/Platform/ElkhartlakeBoardPkg/AcpiTables/Dsdt/Platform.asl
+++ b/Platform/ElkhartlakeBoardPkg/AcpiTables/Dsdt/Platform.asl
@@ -1,7 +1,7 @@
 /** @file
   ACPI DSDT table
 
-  Copyright (c) 2011 - 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2011 - 2024, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 #include "Register/PmcRegs.h"
@@ -1089,7 +1089,7 @@ Scope (\_SB)
       Return(0x00)
     }
 
-    Method (_IPC, 0x7, Serialized ) {
+    Method (IPCG, 0x7, Serialized ) {
       Return(IPCS(Arg0,Arg1,Arg2,Arg3,Arg4,Arg5,Arg6))
     }
 
@@ -1112,7 +1112,7 @@ Scope (\_SB)
       Return(0x00)
     }
 
-    Method (_IPC, 0x7,Serialized) {
+    Method (IPCG, 0x7,Serialized) {
       Return(IPCS(Arg0,Arg1,Arg2,Arg3,Arg4,Arg5,Arg6))
     }
 
@@ -1135,7 +1135,7 @@ Scope (\_SB)
       Return(0x00)
     }
 
-    Method (_IPC, 0x7,Serialized) {
+    Method (IPCG, 0x7,Serialized) {
       Return(IPCS(Arg0,Arg1,Arg2,Arg3,Arg4,Arg5,Arg6))
     }
 


### PR DESCRIPTION
Ethernet auto-negotiation failed since the ACPI calling method of Windows GbE driver is changed from "_IPC" to "IPCG", starting from version 5.123.23.601. Hence, in INTC1033 ACPI device, change the ACPI method name accordingly.