### PR TITLE
fix: [xhci] sync edk2 usb subsystem

### DIFF
--- a/BootloaderCommonPkg/Library/XhciLib/XhcPeim.c
+++ b/BootloaderCommonPkg/Library/XhciLib/XhcPeim.c
@@ -2,7 +2,7 @@
 PEIM to produce gPeiUsb2HostControllerPpiGuid based on gPeiUsbControllerPpiGuid
 which is used to enable recovery function from USB Drivers.
 
-Copyright (c) 2014 - 2023, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2014 - 2024, Intel Corporation. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -643,7 +643,12 @@ XhcPeiControlTransfer (
   } else {
     if (*TransferResult == EFI_USB_NOERROR) {
       Status = EFI_SUCCESS;
-    } else if ((*TransferResult == EFI_USB_ERR_STALL) || (*TransferResult == EFI_USB_ERR_BABBLE)) {
+    } else if ((*TransferResult == EFI_USB_ERR_STALL) ||
+               (*TransferResult == EFI_USB_ERR_BABBLE) ||
+               (*TransferResult == EDKII_USB_ERR_TRANSACTION)) {
+      //
+      // Based on XHCI spec 4.8.3, software should do the reset endpoint while USB Transaction occur.
+      //
       RecoveryStatus = XhcPeiRecoverHaltedEndpoint(Xhc, Urb);
       if (EFI_ERROR (RecoveryStatus)) {
         DEBUG ((DEBUG_ERROR, "XhcPeiControlTransfer: XhcPeiRecoverHaltedEndpoint failed\n"));
@@ -979,7 +984,12 @@ XhcPeiBulkTransfer (
   } else {
     if (*TransferResult == EFI_USB_NOERROR) {
       Status = EFI_SUCCESS;
-    } else if ((*TransferResult == EFI_USB_ERR_STALL) || (*TransferResult == EFI_USB_ERR_BABBLE)) {
+    } else if ((*TransferResult == EFI_USB_ERR_STALL) ||
+               (*TransferResult == EFI_USB_ERR_BABBLE) ||
+               (*TransferResult == EDKII_USB_ERR_TRANSACTION)) {
+      //
+      // Based on XHCI spec 4.8.3, software should do the reset endpoint while USB Transaction occur.
+      //
       RecoveryStatus = XhcPeiRecoverHaltedEndpoint(Xhc, Urb);
       if (EFI_ERROR (RecoveryStatus)) {
         DEBUG ((DEBUG_ERROR, "XhcPeiBulkTransfer: XhcPeiRecoverHaltedEndpoint failed\n"));

--- a/BootloaderCommonPkg/Library/XhciLib/XhcPeim.c
+++ b/BootloaderCommonPkg/Library/XhciLib/XhcPeim.c
@@ -1521,7 +1521,13 @@ UsbInitCtrl (
   // This xHC supports a page size of 2^(n+12) if bit n is Set. For example,
   // if bit 0 is Set, the xHC supports 4k byte page sizes.
   //
-  PageSize         = XhcPeiReadOpReg (XhcDev, XHC_PAGESIZE_OFFSET) & XHC_PAGESIZE_MASK;
+  PageSize = XhcPeiReadOpReg (XhcDev, XHC_PAGESIZE_OFFSET);
+  if ((PageSize & (~XHC_PAGESIZE_MASK)) != 0) {
+    DEBUG ((DEBUG_ERROR, "UsbInitCtrl: Reserved bits are not 0 for PageSize\n"));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  PageSize &= XHC_PAGESIZE_MASK;
   XhcDev->PageSize = 1 << (HighBitSet32 (PageSize) + 12);
 
   DEBUG ((DEBUG_INFO, "XhciPei: UsbHostControllerBaseAddress: %x\n", XhcDev->UsbHostControllerBaseAddress));

--- a/BootloaderCommonPkg/Library/XhciLib/XhcPeim.h
+++ b/BootloaderCommonPkg/Library/XhciLib/XhcPeim.h
@@ -1,7 +1,7 @@
 /** @file
 Private Header file for Usb Host Controller PEIM
 
-Copyright (c) 2014 - 2021, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2014 - 2024, Intel Corporation. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -169,6 +169,11 @@ struct _PEI_XHC_DEV {
   VOID                              *ScratchMap;
   UINT64                            *ScratchEntry;
   UINTN                             *ScratchEntryMap;
+  UINT32                            ExtCapRegBase;
+  UINT32                            UsbLegSupOffset;
+  UINT32                            DebugCapSupOffset;
+  UINT32                            Usb2SupOffset;
+  UINT32                            Usb3SupOffset;
   UINT64                            *DCBAA;
   UINT32                            MaxSlotsEn;
   //

--- a/BootloaderCommonPkg/Library/XhciLib/XhciReg.h
+++ b/BootloaderCommonPkg/Library/XhciLib/XhciReg.h
@@ -1,7 +1,7 @@
 /** @file
 Private Header file for Usb Host Controller PEIM
 
-Copyright (c) 2014 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2014 - 2024, Intel Corporation. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -9,6 +9,13 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #ifndef _EFI_PEI_XHCI_REG_H_
 #define _EFI_PEI_XHCI_REG_H_
+
+//
+// xHCI Extended Capability Codes
+//
+#define XHC_CAP_USB_LEGACY              0x01
+#define XHC_CAP_USB_DEBUG               0x0A
+#define XHC_CAP_USB_SUPPORTED_PROTOCOL  0x02
 
 //
 // Capability registers offset
@@ -105,6 +112,17 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define XHC_IMODI_MASK                  0x0000FFFF  // Interrupt Moderation Interval
 #define XHC_IMODC_MASK                  0xFFFF0000  // Interrupt Moderation Counter
 
+//
+// xHCI Supported Protocol Capability
+//
+#define XHC_SUPPORTED_PROTOCOL_DW0_MAJOR_REVISION_USB2  0x02
+#define XHC_SUPPORTED_PROTOCOL_DW0_MAJOR_REVISION_USB3  0x03
+#define XHC_SUPPORTED_PROTOCOL_NAME_STRING_OFFSET       0x04
+#define XHC_SUPPORTED_PROTOCOL_NAME_STRING_VALUE        0x20425355
+#define XHC_SUPPORTED_PROTOCOL_DW2_OFFSET               0x08
+#define XHC_SUPPORTED_PROTOCOL_PSI_OFFSET               0x10
+#define XHC_SUPPORTED_PROTOCOL_USB2_HIGH_SPEED_PSIM     480
+#define XHC_SUPPORTED_PROTOCOL_USB2_LOW_SPEED_PSIM      1500
 
 #pragma pack (1)
 typedef struct {
@@ -161,6 +179,52 @@ typedef union {
   UINT32                Dword;
   HCCPARAMS             Data;
 } XHC_HCCPARAMS;
+
+//
+// xHCI Supported Protocol Cabability
+//
+typedef struct {
+  UINT8    CapId;
+  UINT8    NextExtCapReg;
+  UINT8    RevMinor;
+  UINT8    RevMajor;
+} SUPPORTED_PROTOCOL_DW0;
+
+typedef union {
+  UINT32                    Dword;
+  SUPPORTED_PROTOCOL_DW0    Data;
+} XHC_SUPPORTED_PROTOCOL_DW0;
+
+typedef struct {
+  UINT32    NameString;
+} XHC_SUPPORTED_PROTOCOL_DW1;
+
+typedef struct {
+  UINT8     CompPortOffset;
+  UINT8     CompPortCount;
+  UINT16    ProtocolDef : 12;
+  UINT16    Psic        : 4;
+} SUPPORTED_PROTOCOL_DW2;
+
+typedef union {
+  UINT32                    Dword;
+  SUPPORTED_PROTOCOL_DW2    Data;
+} XHC_SUPPORTED_PROTOCOL_DW2;
+
+typedef struct {
+  UINT16    Psiv  : 4;
+  UINT16    Psie  : 2;
+  UINT16    Plt   : 2;
+  UINT16    Pfd   : 1;
+  UINT16    RsvdP : 5;
+  UINT16    Lp    : 2;
+  UINT16    Psim;
+} SUPPORTED_PROTOCOL_PROTOCOL_SPEED_ID;
+
+typedef union {
+  UINT32                                  Dword;
+  SUPPORTED_PROTOCOL_PROTOCOL_SPEED_ID    Data;
+} XHC_SUPPORTED_PROTOCOL_PROTOCOL_SPEED_ID;
 
 #pragma pack ()
 

--- a/BootloaderCommonPkg/Library/XhciLib/XhciSched.c
+++ b/BootloaderCommonPkg/Library/XhciLib/XhciSched.c
@@ -291,10 +291,15 @@ XhcPeiCreateTransferTrb (
       TrbStart->TrbCtrSetup.IOC           = 1;
       TrbStart->TrbCtrSetup.IDT           = 1;
       TrbStart->TrbCtrSetup.Type          = TRB_TYPE_SETUP_STAGE;
-      if (Urb->Ep.Direction == EfiUsbDataIn) {
-        TrbStart->TrbCtrSetup.TRT = 3;
-      } else if (Urb->Ep.Direction == EfiUsbDataOut) {
-        TrbStart->TrbCtrSetup.TRT = 2;
+      if (Urb->DataLen > 0) {
+        if (Urb->Ep.Direction == EfiUsbDataIn) {
+          TrbStart->TrbCtrSetup.TRT = 3;
+        } else if (Urb->Ep.Direction == EfiUsbDataOut) {
+          TrbStart->TrbCtrSetup.TRT = 2;
+        } else {
+          DEBUG ((DEBUG_ERROR, "XhcPeiCreateTransferTrb: Direction sholud be IN or OUT when Data exists!\n"));
+          ASSERT (FALSE);
+        }
       } else {
         TrbStart->TrbCtrSetup.TRT = 0;
       }

--- a/BootloaderCommonPkg/Library/XhciLib/XhciSched.c
+++ b/BootloaderCommonPkg/Library/XhciLib/XhciSched.c
@@ -1256,6 +1256,9 @@ XhcPeiInitializeDeviceSlot (
     DeviceAddress = (UINT8) OutputContext->Slot.DeviceAddress;
     DEBUG ((DEBUG_INFO, "XhcPeiInitializeDeviceSlot: Address %d assigned successfully\n", DeviceAddress));
     Xhc->UsbDevContext[SlotId].XhciDevAddr = DeviceAddress;
+  } else {
+    DEBUG ((DEBUG_INFO, "    Address %d assigned unsuccessfully\n"));
+    XhcPeiDisableSlotCmd (Xhc, SlotId);
   }
 
   DEBUG ((DEBUG_INFO, "XhcPeiInitializeDeviceSlot: Enable Slot, Status = %r\n", Status));
@@ -1467,6 +1470,9 @@ XhcPeiInitializeDeviceSlot64 (
     DeviceAddress = (UINT8) OutputContext->Slot.DeviceAddress;
     DEBUG ((DEBUG_INFO, "XhcPeiInitializeDeviceSlot64: Address %d assigned successfully\n", DeviceAddress));
     Xhc->UsbDevContext[SlotId].XhciDevAddr = DeviceAddress;
+  } else {
+    DEBUG ((DEBUG_INFO, "    Address %d assigned unsuccessfully\n"));
+    XhcPeiDisableSlotCmd64 (Xhc, SlotId);
   }
 
   DEBUG ((DEBUG_INFO, "XhcPeiInitializeDeviceSlot64: Enable Slot, Status = %r\n", Status));

--- a/BootloaderCommonPkg/Library/XhciLib/XhciSched.c
+++ b/BootloaderCommonPkg/Library/XhciLib/XhciSched.c
@@ -700,7 +700,7 @@ XhcPeiCheckUrbResult (
         goto EXIT;
 
       case TRB_COMPLETION_USB_TRANSACTION_ERROR:
-        CheckedUrb->Result  |= EFI_USB_ERR_TIMEOUT;
+        CheckedUrb->Result  |= EDKII_USB_ERR_TRANSACTION;
         CheckedUrb->Finished = TRUE;
         DEBUG ((DEBUG_ERROR, "XhcPeiCheckUrbResult: TRANSACTION_ERROR! Completecode = %x\n", EvtTrb->Completecode));
         goto EXIT;

--- a/BootloaderCommonPkg/Library/XhciLib/XhciSched.c
+++ b/BootloaderCommonPkg/Library/XhciLib/XhciSched.c
@@ -2151,6 +2151,7 @@ XhcPeiEvaluateContext (
   CMD_TRB_EVALUATE_CONTEXT      CmdTrbEvalu;
   EVT_TRB_COMMAND_COMPLETION    *EvtTrb;
   INPUT_CONTEXT                 *InputContext;
+  DEVICE_CONTEXT                *OutputContext;
   EFI_PHYSICAL_ADDRESS          PhyAddr;
 
   ASSERT (Xhc->UsbDevContext[SlotId].SlotId != 0);
@@ -2159,10 +2160,14 @@ XhcPeiEvaluateContext (
   // 4.6.7 Evaluate Context
   //
   InputContext = Xhc->UsbDevContext[SlotId].InputContext;
+  OutputContext = Xhc->UsbDevContext[SlotId].OutputContext;
   ZeroMem (InputContext, sizeof (INPUT_CONTEXT));
+
+  CopyMem (&InputContext->EP[0], &OutputContext->EP[0], sizeof (ENDPOINT_CONTEXT));
 
   InputContext->InputControlContext.Dword2 |= BIT1;
   InputContext->EP[0].MaxPacketSize         = MaxPacketSize;
+  InputContext->EP[0].EPState               = 0;
 
   ZeroMem (&CmdTrbEvalu, sizeof (CmdTrbEvalu));
   PhyAddr = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, InputContext, sizeof (INPUT_CONTEXT));
@@ -2205,6 +2210,7 @@ XhcPeiEvaluateContext64 (
   CMD_TRB_EVALUATE_CONTEXT      CmdTrbEvalu;
   EVT_TRB_COMMAND_COMPLETION    *EvtTrb;
   INPUT_CONTEXT_64              *InputContext;
+  DEVICE_CONTEXT_64             *OutputContext;
   EFI_PHYSICAL_ADDRESS          PhyAddr;
 
   ASSERT (Xhc->UsbDevContext[SlotId].SlotId != 0);
@@ -2213,10 +2219,14 @@ XhcPeiEvaluateContext64 (
   // 4.6.7 Evaluate Context
   //
   InputContext = Xhc->UsbDevContext[SlotId].InputContext;
+  OutputContext = Xhc->UsbDevContext[SlotId].OutputContext;
   ZeroMem (InputContext, sizeof (INPUT_CONTEXT_64));
+
+  CopyMem (&InputContext->EP[0], &OutputContext->EP[0], sizeof (ENDPOINT_CONTEXT_64));
 
   InputContext->InputControlContext.Dword2 |= BIT1;
   InputContext->EP[0].MaxPacketSize         = MaxPacketSize;
+  InputContext->EP[0].EPState               = 0;
 
   ZeroMem (&CmdTrbEvalu, sizeof (CmdTrbEvalu));
   PhyAddr = UsbHcGetPciAddrForHostAddr (Xhc->MemPool, InputContext, sizeof (INPUT_CONTEXT_64));

--- a/BootloaderCommonPkg/Library/XhciLib/XhciSched.c
+++ b/BootloaderCommonPkg/Library/XhciLib/XhciSched.c
@@ -1052,6 +1052,26 @@ XhcPeiRingDoorBell (
 }
 
 /**
+  Set Command abort
+
+  @param  Xhc           The XHCI Instance.
+  @param  SlotId        The slot id to be disabled.
+
+**/
+VOID
+XhcCmdRingCmdAbort (
+  IN PEI_XHC_DEV        *Xhc,
+  IN UINT8              SlotId
+  )
+{
+  //
+  // Set XHC_CRCR_CA bit in XHC_CRCR_OFFSET to abort command.
+  //
+  DEBUG ((DEBUG_INFO, "Command Ring Control set Command Abort, SlotId: %d\n", SlotId));
+  XhcPeiSetOpRegBit (Xhc, XHC_CRCR_OFFSET, XHC_CRCR_CA);
+}
+
+/**
   Assign and initialize the device slot for a new device.
 
   @param  Xhc                   The XHCI device.
@@ -1258,6 +1278,13 @@ XhcPeiInitializeDeviceSlot (
     Xhc->UsbDevContext[SlotId].XhciDevAddr = DeviceAddress;
   } else {
     DEBUG ((DEBUG_INFO, "    Address %d assigned unsuccessfully\n"));
+    //
+    // Software may abort the execution of Address Device Command when command failed
+    // due to timeout by following XHCI spec. 4.6.1.2.
+    //
+    if (Status == EFI_TIMEOUT) {
+      XhcCmdRingCmdAbort (Xhc, SlotId);
+    }
     XhcPeiDisableSlotCmd (Xhc, SlotId);
   }
 
@@ -1472,6 +1499,13 @@ XhcPeiInitializeDeviceSlot64 (
     Xhc->UsbDevContext[SlotId].XhciDevAddr = DeviceAddress;
   } else {
     DEBUG ((DEBUG_INFO, "    Address %d assigned unsuccessfully\n"));
+    //
+    // Software may abort the execution of Address Device Command when command failed
+    // due to timeout by following XHCI spec. 4.6.1.2.
+    //
+    if (Status == EFI_TIMEOUT) {
+      XhcCmdRingCmdAbort (Xhc, SlotId);
+    }
     XhcPeiDisableSlotCmd64 (Xhc, SlotId);
   }
 

--- a/BootloaderCommonPkg/Library/XhciLib/XhciSched.c
+++ b/BootloaderCommonPkg/Library/XhciLib/XhciSched.c
@@ -1743,6 +1743,9 @@ XhcPeiSetConfigCmd (
     }
 
     NumEp = IfDesc->NumEndpoints;
+    if ((NumEp == 0) && (MaxDci == 0)) {
+      MaxDci = 1;
+    }
 
     EpDesc = (USB_ENDPOINT_DESCRIPTOR *) (IfDesc + 1);
     for (EpIndex = 0; EpIndex < NumEp; EpIndex++) {
@@ -1959,6 +1962,9 @@ XhcPeiSetConfigCmd64 (
     }
 
     NumEp = IfDesc->NumEndpoints;
+    if ((NumEp == 0) && (MaxDci == 0)) {
+      MaxDci = 1;
+    }
 
     EpDesc = (USB_ENDPOINT_DESCRIPTOR *) (IfDesc + 1);
     for (EpIndex = 0; EpIndex < NumEp; EpIndex++) {

--- a/BootloaderCommonPkg/Library/XhciLib/XhciSched.h
+++ b/BootloaderCommonPkg/Library/XhciLib/XhciSched.h
@@ -1,7 +1,7 @@
 /** @file
 Private Header file for Usb Host Controller PEIM
 
-Copyright (c) 2014 - 2015, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2014 - 2024, Intel Corporation. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -70,6 +70,15 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define TRB_COMPLETION_TRB_ERROR                5
 #define TRB_COMPLETION_STALL_ERROR              6
 #define TRB_COMPLETION_SHORT_PACKET             13
+#define TRB_COMPLETION_STOPPED                  26
+#define TRB_COMPLETION_STOPPED_LENGTH_INVALID   27
+
+//
+// USB Transfer Results Internal Definition
+// Based on XHCI spec 4.8.3, software should do the reset endpoint while USB Transaction occur.
+// Add the error code for USB Transaction error since UEFI spec don't have the related definition.
+//
+#define EDKII_USB_ERR_TRANSACTION  0x200
 
 //
 // The topology string used to present usb device location


### PR DESCRIPTION
Prior to this series of patches, the SBL USB subsystem relied on the edk2 codebase, specifically the MdeModulePkg/Bus/Pci/XhciPei module, as of sometime in 2020. Since that time, numerous corrections have been made. Moreover, there were critical fixes implemented in XhciDxe that had not been incorporated. This set of patches brings over most of the stability and reliability improvements from both the XhciPei and XhciDxe modules within edk2:

b97243dea3c95ad923fa4ca190940158209e8384: Check return value of XHC_PAGESIZE register
b5379899b38ed84561db6dc07dc4641a049ae238: Fix TRT when data length is 0
2363c6926098ee5c75c8780d07f88f5c21010683: Retry device slot init on failure
a3212009d95bbcba7d08076aba2eee51eb1f8e7c: Error handle for USB slot initialization failure
8147fe090fb566f9a1ed8fde24098bbe425026be: Initial XHCI DCI slot's Context value
b3dd9cb836e2aed68198aa79a1ca6afdb25adf80: Input context update for Evaluate Context command
992d5451d19b93635d52db293bab680e32142776: Reset port if status change returns an error
d11f0ea045f598e08b414eeba4f8a74ac1b4ca0b: Abort the Address Device cmd when time out
c12bbc14900aa5c70eec8c0576757c2182db3d01: Reset endpoint while USB Transaction error
7f4eca4cc2e01d4160ef265f477f9d098d7d33df: Add access xHCI Extended Capabilities Pointer
01c2fb0d2260d4de898e4e91e48770ffa5510153: Don't check for invalid PSIV
ec25e904c7da70302f2725e2005e3762f1ae891e: Check port is compatible before getting PSIV
 