### PR TITLE
fix: [ARL] Fixing 64-bit build with ENABLE_SOURCE_DEBUG

### DIFF
--- a/BootloaderCommonPkg/Include/Library/DebugAgentLib.h
+++ b/BootloaderCommonPkg/Include/Library/DebugAgentLib.h
@@ -86,7 +86,7 @@ PeCoffLoaderUnloadImageExtraAction (
 **/
 VOID
 PeCoffFindAndReportImageInfo (
-  IN UINT32   ImageBase
+  IN UINTN   ImageBase
   );
 
 /**

--- a/BootloaderCommonPkg/Library/DebugAgentLib/DebugAgentLib.inf
+++ b/BootloaderCommonPkg/Library/DebugAgentLib/DebugAgentLib.inf
@@ -37,6 +37,12 @@
   Ia32/ArchDebugSupport.c
   Ia32/IntHandlerFuncs.c
 
+[Sources.X64]
+  X64/AsmFuncs.nasm
+  X64/IntHandler.nasm
+  X64/ArchDebugSupport.c
+  X64/IntHandlerFuncs.c
+
 [Packages]
   MdePkg/MdePkg.dec
   BootloaderCommonPkg/BootloaderCommonPkg.dec

--- a/BootloaderCommonPkg/Library/DebugAgentLib/PeCoffExtraActionLib.c
+++ b/BootloaderCommonPkg/Library/DebugAgentLib/PeCoffExtraActionLib.c
@@ -464,7 +464,7 @@ PeCoffLoaderGetPdbPointer (
 **/
 VOID
 PeCoffFindAndReportImageInfo (
-  IN UINT32   ImageBase
+  IN UINTN   ImageBase
   )
 {
   UINTN                           Pe32Data;

--- a/BootloaderCommonPkg/Library/DebugAgentLib/PeCoffExtraActionLibNull.c
+++ b/BootloaderCommonPkg/Library/DebugAgentLib/PeCoffExtraActionLibNull.c
@@ -49,7 +49,7 @@ PeCoffLoaderUnloadImageExtraAction (
 **/
 VOID
 PeCoffFindAndReportImageInfo (
-  IN UINT32   ImageBase
+  IN UINTN   ImageBase
   )
 {
   return;

--- a/BootloaderCommonPkg/Library/DebugAgentLib/X64/ArchDebugSupport.c
+++ b/BootloaderCommonPkg/Library/DebugAgentLib/X64/ArchDebugSupport.c
@@ -1,0 +1,114 @@
+/** @file
+  Supporting functions for X64 architecture.
+
+  Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "DebugAgent.h"
+
+/**
+  Initialize IDT entries to support source level debug.
+
+**/
+VOID
+InitializeDebugIdt (
+  VOID
+  )
+{
+  IA32_IDT_GATE_DESCRIPTOR   *IdtEntry;
+  UINTN                      InterruptHandler;
+  IA32_DESCRIPTOR            IdtDescriptor;
+  UINTN                      Index;
+  UINT16                     CodeSegment;
+  UINT32                     RegEdx;
+
+  AsmReadIdtr (&IdtDescriptor);
+
+  //
+  // Use current CS as the segment selector of interrupt gate in IDT
+  //
+  CodeSegment = AsmReadCs ();
+
+  IdtEntry = (IA32_IDT_GATE_DESCRIPTOR *) IdtDescriptor.Base;
+
+  for (Index = 0; Index < 20; Index ++) {
+    if (((PcdGet32 (PcdExceptionsIgnoredByDebugger) & ~(BIT1 | BIT3)) & (1 << Index)) != 0) {
+      //
+      // If the exception is masked to be reserved except for INT1 and INT3, skip it
+      //
+      continue;
+    }
+    InterruptHandler = (UINTN)&Exception0Handle + Index * ExceptionStubHeaderSize;
+    IdtEntry[Index].Bits.OffsetLow       = (UINT16)(UINTN)InterruptHandler;
+    IdtEntry[Index].Bits.OffsetHigh      = (UINT16)((UINTN)InterruptHandler >> 16);
+    IdtEntry[Index].Bits.OffsetUpper     = (UINT32)((UINTN)InterruptHandler >> 32);
+    IdtEntry[Index].Bits.Selector        = CodeSegment;
+    IdtEntry[Index].Bits.GateType        = IA32_IDT_GATE_TYPE_INTERRUPT_32;
+  }
+
+  InterruptHandler = (UINTN) &TimerInterruptHandle;
+  IdtEntry[DEBUG_TIMER_VECTOR].Bits.OffsetLow       = (UINT16)(UINTN)InterruptHandler;
+  IdtEntry[DEBUG_TIMER_VECTOR].Bits.OffsetHigh      = (UINT16)((UINTN)InterruptHandler >> 16);
+  IdtEntry[DEBUG_TIMER_VECTOR].Bits.OffsetUpper     = (UINT32)((UINTN)InterruptHandler >> 32);
+  IdtEntry[DEBUG_TIMER_VECTOR].Bits.Selector        = CodeSegment;
+  IdtEntry[DEBUG_TIMER_VECTOR].Bits.GateType        = IA32_IDT_GATE_TYPE_INTERRUPT_32;
+
+  //
+  // If the CPU supports Debug Extensions(CPUID:01 EDX:BIT2), then
+  // Set DE flag in CR4 to enable IO breakpoint
+  //
+  AsmCpuid (1, NULL, NULL, NULL, &RegEdx);
+  if ((RegEdx & BIT2) != 0) {
+    AsmWriteCr4 (AsmReadCr4 () | BIT3);
+  }
+}
+
+/**
+  Retrieve exception handler from IDT table by ExceptionNum.
+
+  @param[in]  ExceptionNum    Exception number
+
+  @return Exception handler
+
+**/
+VOID *
+GetExceptionHandlerInIdtEntry (
+  IN UINTN             ExceptionNum
+  )
+{
+  IA32_IDT_GATE_DESCRIPTOR   *IdtEntry;
+  IA32_DESCRIPTOR            IdtDescriptor;
+
+  AsmReadIdtr (&IdtDescriptor);
+  IdtEntry = (IA32_IDT_GATE_DESCRIPTOR *) IdtDescriptor.Base;
+
+  return (VOID *) (IdtEntry[ExceptionNum].Bits.OffsetLow |
+                  (((UINTN)IdtEntry[ExceptionNum].Bits.OffsetHigh) << 16) |
+                  (((UINTN)IdtEntry[ExceptionNum].Bits.OffsetUpper) << 32));
+}
+
+/**
+  Set exception handler in IDT table by ExceptionNum.
+
+  @param[in]  ExceptionNum      Exception number
+  @param[in]  ExceptionHandler  Exception Handler to be set
+
+**/
+VOID
+SetExceptionHandlerInIdtEntry (
+  IN UINTN             ExceptionNum,
+  IN VOID              *ExceptionHandler
+  )
+{
+  IA32_IDT_GATE_DESCRIPTOR   *IdtEntry;
+  IA32_DESCRIPTOR            IdtDescriptor;
+
+  AsmReadIdtr (&IdtDescriptor);
+  IdtEntry = (IA32_IDT_GATE_DESCRIPTOR *) IdtDescriptor.Base;
+
+  IdtEntry[ExceptionNum].Bits.OffsetLow   = (UINT16)(UINTN)ExceptionHandler;
+  IdtEntry[ExceptionNum].Bits.OffsetHigh  = (UINT16)((UINTN)ExceptionHandler >> 16);
+  IdtEntry[ExceptionNum].Bits.OffsetUpper = (UINT32)((UINTN)ExceptionHandler >> 32);
+}

--- a/BootloaderCommonPkg/Library/DebugAgentLib/X64/ArchDebugSupport.h
+++ b/BootloaderCommonPkg/Library/DebugAgentLib/X64/ArchDebugSupport.h
@@ -1,0 +1,21 @@
+/** @file
+  X64 specific defintions for debug agent library instance.
+
+  Copyright (c) 2010 - 2012, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _ARCH_DEBUG_SUPPORT_H_
+#define _ARCH_DEBUG_SUPPORT_H_
+
+#include "ProcessorContext.h"
+#include "TransferProtocol.h"
+
+#define DEBUG_SW_BREAKPOINT_SYMBOL       0xcc
+#define DEBUG_ARCH_SYMBOL                DEBUG_DATA_BREAK_CPU_ARCH_X64
+
+typedef DEBUG_DATA_X64_FX_SAVE_STATE     DEBUG_DATA_FX_SAVE_STATE;
+typedef DEBUG_DATA_X64_SYSTEM_CONTEXT    DEBUG_CPU_CONTEXT;
+
+#endif

--- a/BootloaderCommonPkg/Library/DebugAgentLib/X64/AsmFuncs.nasm
+++ b/BootloaderCommonPkg/Library/DebugAgentLib/X64/AsmFuncs.nasm
@@ -1,0 +1,399 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2016, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Module Name:
+;
+;   AsmFuncs.nasm
+;
+; Abstract:
+;
+;   Debug interrupt handle functions.
+;
+;------------------------------------------------------------------------------
+
+#include "DebugException.h"
+
+SECTION .data
+
+extern ASM_PFX(InterruptProcess)
+global ASM_PFX(Exception0Handle)
+global ASM_PFX(TimerInterruptHandle)
+global ASM_PFX(ExceptionStubHeaderSize)
+
+%macro AGENT_HANDLER_SIGNATURE 0
+  db   0x41, 0x47, 0x54, 0x48       ; SIGNATURE_32('A','G','T','H')
+%endmacro
+
+ASM_PFX(ExceptionStubHeaderSize): dd Exception1Handle - ASM_PFX(Exception0Handle) ;
+CommonEntryAddr: dq CommonEntry ;
+
+DEFAULT REL
+SECTION .text
+
+AGENT_HANDLER_SIGNATURE
+ASM_PFX(Exception0Handle):
+    cli
+    push    rcx
+    mov     rcx, dword 0
+    jmp     qword [CommonEntryAddr]
+AGENT_HANDLER_SIGNATURE
+Exception1Handle:
+    cli
+    push    rcx
+    mov     rcx, dword 1
+    jmp     qword [CommonEntryAddr]
+AGENT_HANDLER_SIGNATURE
+Exception2Handle:
+    cli
+    push    rcx
+    mov     rcx, dword 2
+    jmp     qword [CommonEntryAddr]
+AGENT_HANDLER_SIGNATURE
+Exception3Handle:
+    cli
+    push    rcx
+    mov     rcx, dword 3
+    jmp     qword [CommonEntryAddr]
+AGENT_HANDLER_SIGNATURE
+Exception4Handle:
+    cli
+    push    rcx
+    mov     rcx, dword 4
+    jmp     qword [CommonEntryAddr]
+AGENT_HANDLER_SIGNATURE
+Exception5Handle:
+    cli
+    push    rcx
+    mov     rcx, dword 5
+    jmp     qword [CommonEntryAddr]
+AGENT_HANDLER_SIGNATURE
+Exception6Handle:
+    cli
+    push    rcx
+    mov     rcx, dword 6
+    jmp     qword [CommonEntryAddr]
+AGENT_HANDLER_SIGNATURE
+Exception7Handle:
+    cli
+    push    rcx
+    mov     rcx, dword 7
+    jmp     qword [CommonEntryAddr]
+AGENT_HANDLER_SIGNATURE
+Exception8Handle:
+    cli
+    push    rcx
+    mov     rcx, dword 8
+    jmp     qword [CommonEntryAddr]
+AGENT_HANDLER_SIGNATURE
+Exception9Handle:
+    cli
+    push    rcx
+    mov     rcx, dword 9
+    jmp     qword [CommonEntryAddr]
+AGENT_HANDLER_SIGNATURE
+Exception10Handle:
+    cli
+    push    rcx
+    mov     rcx, dword 10
+    jmp     qword [CommonEntryAddr]
+AGENT_HANDLER_SIGNATURE
+Exception11Handle:
+    cli
+    push    rcx
+    mov     rcx, dword 11
+    jmp     qword [CommonEntryAddr]
+AGENT_HANDLER_SIGNATURE
+Exception12Handle:
+    cli
+    push    rcx
+    mov     rcx, dword 12
+    jmp     qword [CommonEntryAddr]
+AGENT_HANDLER_SIGNATURE
+Exception13Handle:
+    cli
+    push    rcx
+    mov     rcx, dword 13
+    jmp     qword [CommonEntryAddr]
+AGENT_HANDLER_SIGNATURE
+Exception14Handle:
+    cli
+    push    rcx
+    mov     rcx, dword 14
+    jmp     qword [CommonEntryAddr]
+AGENT_HANDLER_SIGNATURE
+Exception15Handle:
+    cli
+    push    rcx
+    mov     rcx, dword 15
+    jmp     qword [CommonEntryAddr]
+AGENT_HANDLER_SIGNATURE
+Exception16Handle:
+    cli
+    push    rcx
+    mov     rcx, dword 16
+    jmp     qword [CommonEntryAddr]
+AGENT_HANDLER_SIGNATURE
+Exception17Handle:
+    cli
+    push    rcx
+    mov     rcx, dword 17
+    jmp     qword [CommonEntryAddr]
+AGENT_HANDLER_SIGNATURE
+Exception18Handle:
+    cli
+    push    rcx
+    mov     rcx, dword 18
+    jmp     qword [CommonEntryAddr]
+AGENT_HANDLER_SIGNATURE
+Exception19Handle:
+    cli
+    push    rcx
+    mov     rcx, dword 19
+    jmp     qword [CommonEntryAddr]
+AGENT_HANDLER_SIGNATURE
+ASM_PFX(TimerInterruptHandle):
+    cli
+    push    rcx
+    mov     rcx, dword 32
+    jmp     qword [CommonEntryAddr]
+
+CommonEntry:
+    ; We need to determine if any extra data was pushed by the exception
+    cmp     rcx, DEBUG_EXCEPT_DOUBLE_FAULT
+    je      NoExtrPush
+    cmp     rcx, DEBUG_EXCEPT_INVALID_TSS
+    je      NoExtrPush
+    cmp     rcx, DEBUG_EXCEPT_SEG_NOT_PRESENT
+    je      NoExtrPush
+    cmp     rcx, DEBUG_EXCEPT_STACK_FAULT
+    je      NoExtrPush
+    cmp     rcx, DEBUG_EXCEPT_GP_FAULT
+    je      NoExtrPush
+    cmp     rcx, DEBUG_EXCEPT_PAGE_FAULT
+    je      NoExtrPush
+    cmp     rcx, DEBUG_EXCEPT_ALIGNMENT_CHECK
+    je      NoExtrPush
+
+    push    qword [rsp]
+    mov     qword [rsp + 8], 0
+
+NoExtrPush:
+    push    rbp
+    mov     rbp, rsp
+
+    ; store UINT64  r8, r9, r10, r11, r12, r13, r14, r15;
+    push    r15
+    push    r14
+    push    r13
+    push    r12
+    push    r11
+    push    r10
+    push    r9
+    push    r8
+
+    mov     r8, cr8
+    push    r8
+
+    ; store UINT64  Rdi, Rsi, Rbp, Rsp, Rdx, Rcx, Rbx, Rax;
+    push    rax
+    push    rbx
+    push    qword [rbp + 8]       ; original rcx
+    push    rdx
+    push    qword [rbp + 6 * 8]   ; original rsp
+    push    qword [rbp]           ; original rbp
+    push    rsi
+    push    rdi
+
+    ;; UINT32  Cr0, Cr1, Cr2, Cr3, Cr4;
+    ;; insure FXSAVE/FXRSTOR is enabled in CR4...
+    ;; ... while we're at it, make sure DE is also enabled...
+    mov     rax, cr4
+    or      rax, 0x208
+    mov     cr4, rax
+    push    rax
+    mov     rax, cr3
+    push    rax
+    mov     rax, cr2
+    push    rax
+    push    0
+    mov     rax, cr0
+    push    rax
+
+    xor     rax, rax
+    mov     rax, Ss
+    push    rax
+    mov     rax, Cs
+    push    rax
+    mov     rax, Ds
+    push    rax
+    mov     rax, Es
+    push    rax
+    mov     rax, Fs
+    push    rax
+    mov     rax, Gs
+    push    rax
+
+    ;; EIP
+    mov     rax, [rbp + 8 * 3] ; EIP
+    push    rax
+
+    ;; UINT64  Gdtr[2], Idtr[2];
+    sub  rsp, 16
+    sidt [rsp]
+    sub  rsp, 16
+    sgdt [rsp]
+
+    ;; UINT64  Ldtr, Tr;
+    xor  rax, rax
+    str  ax
+    push rax
+    sldt ax
+    push rax
+
+    ;; EFlags
+    mov     rax, [rbp + 8 * 5]
+    push    rax
+
+    ;; UINT64  Dr0, Dr1, Dr2, Dr3, Dr6, Dr7;
+    mov     rax, dr7
+    push    rax
+
+    ;; clear Dr7 while executing debugger itself
+    xor     rax, rax
+    mov     dr7, rax
+
+    ;; Dr6
+    mov     rax, dr6
+    push    rax
+
+    ;; insure all status bits in dr6 are clear...
+    xor     rax, rax
+    mov     dr6, rax
+
+    mov     rax, dr3
+    push    rax
+    mov     rax, dr2
+    push    rax
+    mov     rax, dr1
+    push    rax
+    mov     rax, dr0
+    push    rax
+
+    ;; Clear Direction Flag
+    cld
+
+    sub     rsp, 512
+    mov     rdi, rsp
+    ;; Clear the buffer
+    xor     rax, rax
+    push    rcx
+    mov     rcx, dword 64 ;= 512 / 8
+    rep     stosq
+    pop     rcx
+    mov     rdi, rsp
+    db 0xf, 0xae, 00000111y ;fxsave [rdi]
+
+    ;; save the exception data
+    push    qword [rbp + 16]
+
+    ; call the C interrupt process function
+    mov     rdx, rsp      ; Structure
+    mov     r15, rcx      ; save vector in r15
+
+    ;
+    ; Per X64 calling convention, allocate maximum parameter stack space
+    ; and make sure RSP is 16-byte aligned
+    ;
+    sub     rsp, 32 + 8
+    call    ASM_PFX(InterruptProcess)
+    add     rsp, 32 + 8
+
+    ;; skip the exception data
+    add     rsp, 8
+
+    mov     rsi, rsp
+    db 0xf, 0xae, 00001110y ; fxrstor [rsi]
+    add     rsp, 512
+
+    ;; UINT64  Dr0, Dr1, Dr2, Dr3, Dr6, Dr7;
+    pop     rax
+    mov     dr0, rax
+    pop     rax
+    mov     dr1, rax
+    pop     rax
+    mov     dr2, rax
+    pop     rax
+    mov     dr3, rax
+    ;; skip restore of dr6.  We cleared dr6 during the context save.
+    add     rsp, 8
+    pop     rax
+    mov     dr7, rax
+
+    ;; set EFlags
+    pop     qword [rbp + 8 * 5]
+
+    ;; UINT64  Ldtr, Tr;
+    ;; UINT64  Gdtr[2], Idtr[2];
+    ;; Best not let anyone mess with these particular registers...
+    add     rsp, 24 * 2
+
+    ;; UINT64  Eip;
+    pop     qword [rbp + 8 * 3]   ; set EIP in stack
+
+    ;; UINT64  Gs, Fs, Es, Ds, Cs, Ss;
+    ;; NOTE - modified segment registers could hang the debugger...  We
+    ;;        could attempt to insulate ourselves against this possibility,
+    ;;        but that poses risks as well.
+    ;;
+    pop     rax
+    pop     rax
+    pop     rax
+    mov     es, rax
+    pop     rax
+    mov     ds, rax
+    pop     qword [rbp + 8 * 4]    ; Set CS in stack
+    pop     rax
+    mov     ss, rax
+
+    ;; UINT64  Cr0, Cr1, Cr2, Cr3, Cr4;
+    pop     rax
+    mov     cr0, rax
+    add     rsp, 8    ; skip for Cr1
+    pop     rax
+    mov     cr2, rax
+    pop     rax
+    mov     cr3, rax
+    pop     rax
+    mov     cr4, rax
+
+    ;; restore general register
+    pop    rdi
+    pop    rsi
+    add    rsp, 8  ; skip rbp
+    add    rsp, 8  ; skip rsp
+    pop    rdx
+    pop    rcx
+    pop    rbx
+    pop    rax
+
+    pop    r8
+    mov    cr8, r8
+
+    ; store UINT64  r8, r9, r10, r11, r12, r13, r14, r15;
+    pop     r8
+    pop     r9
+    pop     r10
+    pop     r11
+    pop     r12
+    pop     r13
+    pop     r14
+    pop     r15
+
+    mov     rsp, rbp
+    pop     rbp
+    add     rsp, 16      ; skip rcx and error code
+
+    iretq
+

--- a/BootloaderCommonPkg/Library/DebugAgentLib/X64/DebugException.h
+++ b/BootloaderCommonPkg/Library/DebugAgentLib/X64/DebugException.h
@@ -1,0 +1,30 @@
+/** @file
+  Exception defintions.
+
+  Copyright (c) 2010, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _DEBUG_EXCEPTION_H_
+#define _DEBUG_EXCEPTION_H_
+
+#define DEBUG_EXCEPT_DIVIDE_ERROR             0
+#define DEBUG_EXCEPT_DEBUG                    1
+#define DEBUG_EXCEPT_NMI                      2
+#define DEBUG_EXCEPT_BREAKPOINT               3
+#define DEBUG_EXCEPT_OVERFLOW                 4
+#define DEBUG_EXCEPT_BOUND                    5
+#define DEBUG_EXCEPT_INVALID_OPCODE           6
+#define DEBUG_EXCEPT_DOUBLE_FAULT             8
+#define DEBUG_EXCEPT_INVALID_TSS             10
+#define DEBUG_EXCEPT_SEG_NOT_PRESENT         11
+#define DEBUG_EXCEPT_STACK_FAULT             12
+#define DEBUG_EXCEPT_GP_FAULT                13
+#define DEBUG_EXCEPT_PAGE_FAULT              14
+#define DEBUG_EXCEPT_FP_ERROR                16
+#define DEBUG_EXCEPT_ALIGNMENT_CHECK         17
+#define DEBUG_EXCEPT_MACHINE_CHECK           18
+#define DEBUG_EXCEPT_SIMD                    19
+
+#endif

--- a/BootloaderCommonPkg/Library/DebugAgentLib/X64/IntHandler.nasm
+++ b/BootloaderCommonPkg/Library/DebugAgentLib/X64/IntHandler.nasm
@@ -1,0 +1,23 @@
+;------------------------------------------------------------------------------
+;
+; Copyright (c) 2016, Intel Corporation. All rights reserved.<BR>
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;
+; Module Name:
+;
+;   IntHandler.nasm
+;
+; Abstract:
+;
+;   Assembly interrupt handler function.
+;
+;------------------------------------------------------------------------------
+
+global ASM_PFX(AsmInterruptHandle)
+
+DEFAULT REL
+SECTION .text
+ASM_PFX(AsmInterruptHandle):
+    cli
+    mov   al, 1
+    iretq

--- a/BootloaderCommonPkg/Library/DebugAgentLib/X64/IntHandlerFuncs.c
+++ b/BootloaderCommonPkg/Library/DebugAgentLib/X64/IntHandlerFuncs.c
@@ -1,0 +1,95 @@
+/** @file
+  X64 arch function to access IDT vector.
+
+  Copyright (c) 2013 - 2018, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PeCoffExtraActionLib.h>
+
+/**
+  Read IDT entry to check if IDT entries are setup by Debug Agent.
+
+  @param[in]  IdtDescriptor      Pointer to IDT Descriptor.
+  @param[in]  InterruptType      Interrupt type.
+
+  @retval  TRUE     IDT entries were setup by Debug Agent.
+  @retval  FALSE    IDT entries were not setuo by Debug Agent.
+
+**/
+BOOLEAN
+CheckDebugAgentHandler (
+  IN  IA32_DESCRIPTOR            *IdtDescriptor,
+  IN  UINTN                      InterruptType
+  )
+{
+  IA32_IDT_GATE_DESCRIPTOR   *IdtEntry;
+  UINTN                      InterruptHandler;
+
+  IdtEntry = (IA32_IDT_GATE_DESCRIPTOR *) IdtDescriptor->Base;
+  if (IdtEntry == NULL) {
+    return FALSE;
+  }
+
+  InterruptHandler = IdtEntry[InterruptType].Bits.OffsetLow +
+                    (((UINTN)IdtEntry[InterruptType].Bits.OffsetHigh) << 16) +
+                    (((UINTN)IdtEntry[InterruptType].Bits.OffsetUpper) << 32);
+  if (InterruptHandler >= sizeof (UINT32) &&  *(UINT32 *)(InterruptHandler - sizeof (UINT32)) == AGENT_HANDLER_SIGNATURE) {
+    return TRUE;
+  } else {
+    return FALSE;
+  }
+}
+
+/**
+  Save IDT entry for INT1 and update it.
+
+  @param[in]  IdtDescriptor      Pointer to IDT Descriptor.
+  @param[out] SavedIdtEntry      Original IDT entry returned.
+
+**/
+VOID
+SaveAndUpdateIdtEntry1 (
+  IN  IA32_DESCRIPTOR            *IdtDescriptor,
+  OUT IA32_IDT_GATE_DESCRIPTOR   *SavedIdtEntry
+  )
+{
+  IA32_IDT_GATE_DESCRIPTOR   *IdtEntry;
+  UINT16                     CodeSegment;
+  UINTN                      InterruptHandler;
+
+  IdtEntry = (IA32_IDT_GATE_DESCRIPTOR *) IdtDescriptor->Base;
+  CopyMem (SavedIdtEntry, &IdtEntry[1], sizeof (IA32_IDT_GATE_DESCRIPTOR));
+
+    //
+  // Use current CS as the segment selector of interrupt gate in IDT
+  //
+  CodeSegment = AsmReadCs ();
+
+  InterruptHandler = (UINTN) &AsmInterruptHandle;
+  IdtEntry[1].Bits.OffsetLow       = (UINT16)(UINTN)InterruptHandler;
+  IdtEntry[1].Bits.OffsetHigh      = (UINT16)((UINTN)InterruptHandler >> 16);
+  IdtEntry[1].Bits.OffsetUpper     = (UINT32)((UINTN)InterruptHandler >> 32);
+  IdtEntry[1].Bits.Selector        = CodeSegment;
+  IdtEntry[1].Bits.GateType        = IA32_IDT_GATE_TYPE_INTERRUPT_32;
+}
+
+/**
+  Restore IDT entry for INT1.
+
+  @param[in]  IdtDescriptor      Pointer to IDT Descriptor.
+  @param[in]  RestoredIdtEntry   IDT entry to be restored.
+
+**/
+VOID
+RestoreIdtEntry1 (
+  IN  IA32_DESCRIPTOR            *IdtDescriptor,
+  IN  IA32_IDT_GATE_DESCRIPTOR   *RestoredIdtEntry
+  )
+{
+  IA32_IDT_GATE_DESCRIPTOR   *IdtEntry;
+
+  IdtEntry = (IA32_IDT_GATE_DESCRIPTOR *) IdtDescriptor->Base;
+  CopyMem (&IdtEntry[1], RestoredIdtEntry, sizeof (IA32_IDT_GATE_DESCRIPTOR));
+}

--- a/BootloaderCommonPkg/Library/DebugAgentLib/X64/ProcessorContext.h
+++ b/BootloaderCommonPkg/Library/DebugAgentLib/X64/ProcessorContext.h
@@ -1,0 +1,304 @@
+/** @file
+  IA32/x64 architecture specific defintions needed by debug transfer protocol.It is only
+  intended to be used by Debug related module implementation.
+
+  Copyright (c) 2010 - 2012, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __PROCESSOR_CONTEXT_H__
+#define __PROCESSOR_CONTEXT_H__
+
+//
+//  IA-32/x64 processor register index table
+//
+#define SOFT_DEBUGGER_REGISTER_DR0     0x00
+#define SOFT_DEBUGGER_REGISTER_DR1     0x01
+#define SOFT_DEBUGGER_REGISTER_DR2     0x02
+#define SOFT_DEBUGGER_REGISTER_DR3     0x03
+#define SOFT_DEBUGGER_REGISTER_DR6     0x04
+#define SOFT_DEBUGGER_REGISTER_DR7     0x05
+#define SOFT_DEBUGGER_REGISTER_EFLAGS  0x06
+#define SOFT_DEBUGGER_REGISTER_LDTR    0x07
+#define SOFT_DEBUGGER_REGISTER_TR      0x08
+#define SOFT_DEBUGGER_REGISTER_GDTR0   0x09 // the low 32bit of GDTR
+#define SOFT_DEBUGGER_REGISTER_GDTR1   0x0A // the high 32bit of GDTR
+#define SOFT_DEBUGGER_REGISTER_IDTR0   0x0B // the low 32bit of IDTR
+#define SOFT_DEBUGGER_REGISTER_IDTR1   0x0C // the high 32bot of IDTR
+#define SOFT_DEBUGGER_REGISTER_EIP     0x0D
+#define SOFT_DEBUGGER_REGISTER_GS      0x0E
+#define SOFT_DEBUGGER_REGISTER_FS      0x0F
+#define SOFT_DEBUGGER_REGISTER_ES      0x10
+#define SOFT_DEBUGGER_REGISTER_DS      0x11
+#define SOFT_DEBUGGER_REGISTER_CS      0x12
+#define SOFT_DEBUGGER_REGISTER_SS      0x13
+#define SOFT_DEBUGGER_REGISTER_CR0     0x14
+#define SOFT_DEBUGGER_REGISTER_CR1     0x15
+#define SOFT_DEBUGGER_REGISTER_CR2     0x16
+#define SOFT_DEBUGGER_REGISTER_CR3     0x17
+#define SOFT_DEBUGGER_REGISTER_CR4     0x18
+
+#define SOFT_DEBUGGER_REGISTER_DI      0x19
+#define SOFT_DEBUGGER_REGISTER_SI      0x1A
+#define SOFT_DEBUGGER_REGISTER_BP      0x1B
+#define SOFT_DEBUGGER_REGISTER_SP      0x1C
+#define SOFT_DEBUGGER_REGISTER_DX      0x1D
+#define SOFT_DEBUGGER_REGISTER_CX      0x1E
+#define SOFT_DEBUGGER_REGISTER_BX      0x1F
+#define SOFT_DEBUGGER_REGISTER_AX      0x20
+
+//
+// This below registers are only available for x64 (not valid for Ia32 mode)
+//
+#define SOFT_DEBUGGER_REGISTER_CR8     0x21
+#define SOFT_DEBUGGER_REGISTER_R8      0x22
+#define SOFT_DEBUGGER_REGISTER_R9      0x23
+#define SOFT_DEBUGGER_REGISTER_R10     0x24
+#define SOFT_DEBUGGER_REGISTER_R11     0x25
+#define SOFT_DEBUGGER_REGISTER_R12     0x26
+#define SOFT_DEBUGGER_REGISTER_R13     0x27
+#define SOFT_DEBUGGER_REGISTER_R14     0x28
+#define SOFT_DEBUGGER_REGISTER_R15     0x29
+
+//
+// This below registers are FP / MMX / XMM registers
+//
+#define SOFT_DEBUGGER_REGISTER_FP_BASE            0x30
+
+#define SOFT_DEBUGGER_REGISTER_FP_FCW          (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x00)
+#define SOFT_DEBUGGER_REGISTER_FP_FSW          (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x01)
+#define SOFT_DEBUGGER_REGISTER_FP_FTW          (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x02)
+#define SOFT_DEBUGGER_REGISTER_FP_OPCODE       (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x03)
+#define SOFT_DEBUGGER_REGISTER_FP_EIP          (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x04)
+#define SOFT_DEBUGGER_REGISTER_FP_CS           (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x05)
+#define SOFT_DEBUGGER_REGISTER_FP_DATAOFFSET   (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x06)
+#define SOFT_DEBUGGER_REGISTER_FP_DS           (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x07)
+#define SOFT_DEBUGGER_REGISTER_FP_MXCSR        (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x08)
+#define SOFT_DEBUGGER_REGISTER_FP_MXCSR_MASK   (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x09)
+#define SOFT_DEBUGGER_REGISTER_ST0             (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x0A)
+#define SOFT_DEBUGGER_REGISTER_ST1             (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x0B)
+#define SOFT_DEBUGGER_REGISTER_ST2             (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x0C)
+#define SOFT_DEBUGGER_REGISTER_ST3             (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x0D)
+#define SOFT_DEBUGGER_REGISTER_ST4             (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x0E)
+#define SOFT_DEBUGGER_REGISTER_ST5             (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x0F)
+#define SOFT_DEBUGGER_REGISTER_ST6             (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x10)
+#define SOFT_DEBUGGER_REGISTER_ST7             (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x11)
+#define SOFT_DEBUGGER_REGISTER_XMM0            (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x12)
+#define SOFT_DEBUGGER_REGISTER_XMM1            (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x13)
+#define SOFT_DEBUGGER_REGISTER_XMM2            (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x14)
+#define SOFT_DEBUGGER_REGISTER_XMM3            (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x15)
+#define SOFT_DEBUGGER_REGISTER_XMM4            (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x16)
+#define SOFT_DEBUGGER_REGISTER_XMM5            (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x17)
+#define SOFT_DEBUGGER_REGISTER_XMM6            (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x18)
+#define SOFT_DEBUGGER_REGISTER_XMM7            (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x19)
+#define SOFT_DEBUGGER_REGISTER_XMM8            (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x1A)
+#define SOFT_DEBUGGER_REGISTER_XMM9            (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x1B)
+#define SOFT_DEBUGGER_REGISTER_XMM10           (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x1C)
+#define SOFT_DEBUGGER_REGISTER_XMM11           (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x1D)
+#define SOFT_DEBUGGER_REGISTER_XMM12           (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x1E)
+#define SOFT_DEBUGGER_REGISTER_XMM13           (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x1F)
+#define SOFT_DEBUGGER_REGISTER_XMM14           (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x20)
+#define SOFT_DEBUGGER_REGISTER_XMM15           (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x21)
+#define SOFT_DEBUGGER_REGISTER_MM0             (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x22)
+#define SOFT_DEBUGGER_REGISTER_MM1             (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x23)
+#define SOFT_DEBUGGER_REGISTER_MM2             (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x24)
+#define SOFT_DEBUGGER_REGISTER_MM3             (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x25)
+#define SOFT_DEBUGGER_REGISTER_MM4             (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x26)
+#define SOFT_DEBUGGER_REGISTER_MM5             (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x27)
+#define SOFT_DEBUGGER_REGISTER_MM6             (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x28)
+#define SOFT_DEBUGGER_REGISTER_MM7             (SOFT_DEBUGGER_REGISTER_FP_BASE + 0x29)
+
+#define SOFT_DEBUGGER_REGISTER_MAX             SOFT_DEBUGGER_REGISTER_MM7
+
+#define SOFT_DEBUGGER_MSR_EFER                 (0xC0000080)
+
+#pragma pack(1)
+
+///
+/// FXSAVE_STATE
+/// FP / MMX / XMM registers (see fxrstor instruction definition)
+///
+typedef struct {
+  UINT16  Fcw;
+  UINT16  Fsw;
+  UINT16  Ftw;
+  UINT16  Opcode;
+  UINT32  Eip;
+  UINT16  Cs;
+  UINT16  Reserved1;
+  UINT32  DataOffset;
+  UINT16  Ds;
+  UINT8   Reserved2[2];
+  UINT32  Mxcsr;
+  UINT32  Mxcsr_Mask;
+  UINT8   St0Mm0[10];
+  UINT8   Reserved3[6];
+  UINT8   St1Mm1[10];
+  UINT8   Reserved4[6];
+  UINT8   St2Mm2[10];
+  UINT8   Reserved5[6];
+  UINT8   St3Mm3[10];
+  UINT8   Reserved6[6];
+  UINT8   St4Mm4[10];
+  UINT8   Reserved7[6];
+  UINT8   St5Mm5[10];
+  UINT8   Reserved8[6];
+  UINT8   St6Mm6[10];
+  UINT8   Reserved9[6];
+  UINT8   St7Mm7[10];
+  UINT8   Reserved10[6];
+  UINT8   Xmm0[16];
+  UINT8   Xmm1[16];
+  UINT8   Xmm2[16];
+  UINT8   Xmm3[16];
+  UINT8   Xmm4[16];
+  UINT8   Xmm5[16];
+  UINT8   Xmm6[16];
+  UINT8   Xmm7[16];
+  UINT8   Reserved11[14 * 16];
+} DEBUG_DATA_IA32_FX_SAVE_STATE;
+
+///
+///  IA-32 processor context definition
+///
+typedef struct {
+  UINT32                         ExceptionData;
+  DEBUG_DATA_IA32_FX_SAVE_STATE  FxSaveState;
+  UINT32                         Dr0;
+  UINT32                         Dr1;
+  UINT32                         Dr2;
+  UINT32                         Dr3;
+  UINT32                         Dr6;
+  UINT32                         Dr7;
+  UINT32                         Eflags;
+  UINT32                         Ldtr;
+  UINT32                         Tr;
+  UINT32                         Gdtr[2];
+  UINT32                         Idtr[2];
+  UINT32                         Eip;
+  UINT32                         Gs;
+  UINT32                         Fs;
+  UINT32                         Es;
+  UINT32                         Ds;
+  UINT32                         Cs;
+  UINT32                         Ss;
+  UINT32                         Cr0;
+  UINT32                         Cr1;  ///< Reserved
+  UINT32                         Cr2;
+  UINT32                         Cr3;
+  UINT32                         Cr4;
+  UINT32                         Edi;
+  UINT32                         Esi;
+  UINT32                         Ebp;
+  UINT32                         Esp;
+  UINT32                         Edx;
+  UINT32                         Ecx;
+  UINT32                         Ebx;
+  UINT32                         Eax;
+} DEBUG_DATA_IA32_SYSTEM_CONTEXT;
+
+///
+/// FXSAVE_STATE
+/// FP / MMX / XMM registers (see fxrstor instruction definition)
+///
+typedef struct {
+  UINT16  Fcw;
+  UINT16  Fsw;
+  UINT16  Ftw;
+  UINT16  Opcode;
+  UINT32  Eip;
+  UINT16  Cs;
+  UINT16  Reserved1;
+  UINT32  DataOffset;
+  UINT16  Ds;
+  UINT8   Reserved2[2];
+  UINT32  Mxcsr;
+  UINT32  Mxcsr_Mask;
+  UINT8   St0Mm0[10];
+  UINT8   Reserved3[6];
+  UINT8   St1Mm1[10];
+  UINT8   Reserved4[6];
+  UINT8   St2Mm2[10];
+  UINT8   Reserved5[6];
+  UINT8   St3Mm3[10];
+  UINT8   Reserved6[6];
+  UINT8   St4Mm4[10];
+  UINT8   Reserved7[6];
+  UINT8   St5Mm5[10];
+  UINT8   Reserved8[6];
+  UINT8   St6Mm6[10];
+  UINT8   Reserved9[6];
+  UINT8   St7Mm7[10];
+  UINT8   Reserved10[6];
+  UINT8   Xmm0[16];
+  UINT8   Xmm1[16];
+  UINT8   Xmm2[16];
+  UINT8   Xmm3[16];
+  UINT8   Xmm4[16];
+  UINT8   Xmm5[16];
+  UINT8   Xmm6[16];
+  UINT8   Xmm7[16];
+  UINT8   Xmm8[16];
+  UINT8   Xmm9[16];
+  UINT8   Xmm10[16];
+  UINT8   Xmm11[16];
+  UINT8   Xmm12[16];
+  UINT8   Xmm13[16];
+  UINT8   Xmm14[16];
+  UINT8   Xmm15[16];
+  UINT8   Reserved11[6 * 16];
+} DEBUG_DATA_X64_FX_SAVE_STATE;
+
+///
+///  x64 processor context definition
+///
+typedef struct {
+  UINT64                         ExceptionData;
+  DEBUG_DATA_X64_FX_SAVE_STATE   FxSaveState;
+  UINT64                         Dr0;
+  UINT64                         Dr1;
+  UINT64                         Dr2;
+  UINT64                         Dr3;
+  UINT64                         Dr6;
+  UINT64                         Dr7;
+  UINT64                         Eflags;
+  UINT64                         Ldtr;
+  UINT64                         Tr;
+  UINT64                         Gdtr[2];
+  UINT64                         Idtr[2];
+  UINT64                         Eip;
+  UINT64                         Gs;
+  UINT64                         Fs;
+  UINT64                         Es;
+  UINT64                         Ds;
+  UINT64                         Cs;
+  UINT64                         Ss;
+  UINT64                         Cr0;
+  UINT64                         Cr1;  ///< Reserved
+  UINT64                         Cr2;
+  UINT64                         Cr3;
+  UINT64                         Cr4;
+  UINT64                         Rdi;
+  UINT64                         Rsi;
+  UINT64                         Rbp;
+  UINT64                         Rsp;
+  UINT64                         Rdx;
+  UINT64                         Rcx;
+  UINT64                         Rbx;
+  UINT64                         Rax;
+  UINT64                         Cr8;
+  UINT64                         R8;
+  UINT64                         R9;
+  UINT64                         R10;
+  UINT64                         R11;
+  UINT64                         R12;
+  UINT64                         R13;
+  UINT64                         R14;
+  UINT64                         R15;
+} DEBUG_DATA_X64_SYSTEM_CONTEXT;
+
+#pragma pack()
+
+#endif
+


### PR DESCRIPTION
Adding 64-bit DebugAgentLib source files, header files and nasm files to build SBL image with ENABLE_SOURCE_DEBUG=1