### PR TITLE
fix: [RPLP] Stitch fail when missing diag acm binary

### DIFF
--- a/Platform/RaptorlakeBoardPkg/BoardConfigRplp.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRplp.py
@@ -255,7 +255,8 @@ class Board(BaseBoard):
         if self.FUSA_SUPPORT:
             # FuSa validation requires prebuilt images that can boot OS Loader Ubuntu
             self.PLD_HEAP_SIZE    = 0x09000000
-        self.DIAGNOSTICACM_SIZE   = 0x00001000
+            self.DIAGNOSTICACM_SIZE   = 0x00001000
+
         self.KM_SIZE              = 0x00000400
         self.BPM_SIZE             = 0x00000600
         self.ACM_SIZE             = 0x00040000 + self.KM_SIZE + self.BPM_SIZE

--- a/Platform/RaptorlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/RaptorlakeBoardPkg/Script/StitchIfwi.py
@@ -1,7 +1,7 @@
 ## @ StitchIfwi.py
 #  This is a python stitching script for Slim Bootloader RPL build
 #
-# Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved. <BR>
+# Copyright (c) 2020 - 2024, Intel Corporation. All rights reserved. <BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -94,7 +94,7 @@ def patch_xml_file(stitch_dir, ifwi_src_path):
 
 
 def replace_component (ifwi_src_path, flash_path, file_path, comp_alg, pri_key, svn):
-    print ("Replacing components.......")
+    print ("Replacing components.......%s " % file_path)
     work_dir = os.getcwd()
     ifwi_bin = bytearray (get_file_data (ifwi_src_path))
     ifwi = IFWI_PARSER.parse_ifwi_binary (ifwi_bin)

--- a/Platform/RaptorlakeBoardPkg/Script/StitchIfwiConfig_rplp.py
+++ b/Platform/RaptorlakeBoardPkg/Script/StitchIfwiConfig_rplp.py
@@ -79,9 +79,14 @@ def get_component_replace_list(plt_params_list):
        #    Path                   file name              compress    Key                           SVN
       ('IFWI/BIOS/TS0/ACM0',      'Input/acm0.bin',        'dummy',    '',                            ''),
       ('IFWI/BIOS/TS1/ACM0',      'Input/acm0.bin',        'dummy',    '',                            ''),
+       ]
+
+    if 'fusa' in plt_params_list:
+      print("Replace the DACM")
+      replace_list.extend ([
       ('IFWI/BIOS/TS0/DACM',      'Input/DiagnosticAcm.bin', 'dummy',      '',                        ''),
       ('IFWI/BIOS/TS1/DACM',      'Input/DiagnosticAcm.bin', 'dummy',      '',                        ''),
-       ]
+      ])
 
     if 'tsn' in plt_params_list:
         if os.path.exists('IPFW/TsnSubRegion.bin'):
@@ -112,7 +117,8 @@ def check_parameter(para_list):
         'dual'  : {},
         '64MB'  : {},
         'debug' : {},
-        'posc'  : {}
+        'posc'  : {},
+        'fusa'  : {}
         }
 
     para_help = \
@@ -128,6 +134,7 @@ def check_parameter(para_list):
         '64MB' -- Build for 64MB component to allow space for FuSa BIST pattern data
         'debug' -- Enable DAM and DCI
         'posc' -- Stitch POSC binary into BIOS region.
+        'fusa' -- Stitch Fusa DiagnosticAcm binary into BIOS region
         """
     for para in para_list:
         if para == '':


### PR DESCRIPTION
Cause by cefbf78daed2e8609bb248fb740f381427ce07df. 
The default build will include the DACM region and the replace file should be present during stitch step.

Add fusa stitch option for users who want to replace that component in the BIOS.