### PR TITLE
fix: [ARL] Fix SBL build issue in Linux

### DIFF
--- a/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -885,6 +885,7 @@ PatchCpuSsdtTable (
 **/
 STATIC
 UINT32
+EFIAPI
 CalculateRelativePower (
   IN  UINT16  BaseRatio,
   IN  UINT16  CurrRatio,


### PR DESCRIPTION
Accidental removal of EFIAPI from CalculateRelativePower function in Stage2BoardInitLib.c caused GCC to issue incompatible-pointer-types error. This patch addresses the build issue.