### PR TITLE
fix:[ARL-H] Added BiosRedAssistance setting in stitch config

### DIFF
--- a/Platform/ArrowlakeBoardPkg/Script/StitchIfwiConfig_arlh.py
+++ b/Platform/ArrowlakeBoardPkg/Script/StitchIfwiConfig_arlh.py
@@ -147,6 +147,7 @@ def get_xml_change_list (platform, plt_params_list):
         # Path                                                                      | value |
         # =========================================================================================
         #   Region Order
+        ('./FlashSettings/BiosConfiguration/BiosRedAssistance',                                     'Disabled'),
         ('./FlashLayout/DescriptorRegion/HarnessGlobalData/SelectedRvp',                            'ARL-H DDR5 SBS (MTP-P + ARL-H)'),
         ('./FlashLayout/BiosRegion/InputFile',                                                      '$SourceDir\BiosRegion.bin'),
         ('./FlashLayout/Ifwi_IntelMePmcRegion/MeRegionFile',                                        '$SourceDir\ME Sub Partition.bin'),


### PR DESCRIPTION
BiosRedAssistance setting is added to stitch config. By default it is disabled. Enable for FW resiliancy.