### PR TITLE
fix: [Tool] BaseTools built with specified VS on Windows

### DIFF
--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -40,7 +40,7 @@ def rebuild_basetools ():
 
         if not check_files_exist (exe_list, os.path.join(sblsource, 'BaseTools', 'Bin', 'Win32'), '.exe'):
             print ("Could not find pre-built BaseTools binaries, try to rebuild BaseTools ...")
-            ret = run_process (['BaseTools\\toolsetup.bat', 'forcerebuild'])
+            ret = run_process (['BaseTools\\toolsetup.bat', 'forcerebuild', os.environ['TOOL_CHAIN']])
 
     if ret:
         print ("Build BaseTools failed, please check required build environment and utilities !")


### PR DESCRIPTION
When multiple versions of Visual Studio (VS) were installed, the BaseTools would be built with the latest version, regardless of user preference (i.e., specified by the "-t" option). This behavior was incorrect for users needing to build with a specific VS. This commit addresses the issue by aligning the BaseTools to build with the user-specified version of VS.

Test steps:

1.   Two versions of VS are installed: VS2017 and VS2022
2.   Default build: python BuildLoader.py build tgl   # also verified with "mtl"
3.   Build with specific version: python BuildLoader.py build tgl -t vs2022