### PR TITLE
ARL: Update FSP-T UPD code region

### DIFF
--- a/Platform/ArrowlakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
+++ b/Platform/ArrowlakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
@@ -42,8 +42,8 @@
 
 #define UCODE_REGION_BASE   FixedPcdGet32(PcdUcodeBase)
 #define UCODE_REGION_SIZE   FixedPcdGet32(PcdUcodeSize)
-#define SG1B_REDB_BASE      (UINT32) ((2 * FixedPcdGet32(PcdTopSwapRegionSize)) + FixedPcdGet32(PcdRedundantRegionSize) + FixedPcdGet32(PcdStage1BSize))
-#define CODE_REGION_SIZE    ALIGN_UP (SG1B_REDB_BASE, SIZE_1MB)
+
+#define CODE_REGION_SIZE    FixedPcdGet32(PcdTopSwapRegionSize)
 #define CODE_REGION_BASE    (UINT32) (BASE_4GB - CODE_REGION_SIZE)
 
 #define MTL_MAX_SERIALIO_UART_CONTROLLERS     3


### PR DESCRIPTION
The FSP UPD code region should try to cover SBL Stage1A and Stage1B with a minimum region size. It would impact MTRR settings before memory init and the MTRR settings would be updated after FspTempRamExit().

Reduce the code region size could improve boot performance for some SKUs.