### PR TITLE
fix [ARL] Check EC device existence on board

### DIFF
--- a/Platform/ArrowlakeBoardPkg/Library/Stage1BBoardInitLib/EcSupport.c
+++ b/Platform/ArrowlakeBoardPkg/Library/Stage1BBoardInitLib/EcSupport.c
@@ -201,6 +201,9 @@ SendEcCommandTimeout (
   // Wait for EC to be ready (with a timeout)
   //
   ReceiveEcStatus (&EcStatus);
+  if (EcStatus == 0xFF) {
+    return EFI_DEVICE_ERROR;
+  }
   //
   // Check if output buffer bit(OBF) is set.
   // Read and discard the output buffer data so that next BIOS-EC cmd is in sync


### PR DESCRIPTION
Check EC device existence before sending command.
The patch prevents waiting for timeout when reading BoardId.