### PR TITLE
fix: [ASL] remove deprecated PLATFORM_ASL

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -812,7 +812,7 @@ UpdateFspConfig (
     FspsConfig->CpuPciePowerGating[1] = SiCfgData->CpuPciePowerGating;
     FspsConfig->CpuPciePowerGating[2] = SiCfgData->CpuPciePowerGating;
     FspsConfig->CpuPciePowerGating[3] = SiCfgData->CpuPciePowerGating;
-#if !defined(PLATFORM_ADLN) && !defined(PLATFORM_ADLN50) && !defined(PLATFORM_ASL)
+#if !defined(PLATFORM_ADLN) && !defined(PLATFORM_ADLN50)
     FspsConfig->L2QosEnumerationEn = SiCfgData->L2QosEnumerationEn;
 #endif
   }
@@ -1213,7 +1213,7 @@ UpdateFspConfig (
         FspsConfig->LidStatus = 0x5b;
         FspsConfig->TcssAuxOri = 0x1;
         FspsConfig->Device4Enable = 0x0; //this controls the thermal device (B0,D4,F0)
-#if defined(PLATFORM_ADLN) || defined(PLATFORM_ASL)
+#if defined(PLATFORM_ADLN)
         FspsConfig->PchFivrVccstIccMaxControl = 0x1;
         FspsConfig->CpuFeaturesInitOnS3ResumeOverride = 0x1;
 #endif

--- a/Platform/AlderlakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
@@ -23,6 +23,7 @@
 #include <Library/ConfigDataLib.h>
 #include <Library/PchInfoLib.h>
 #include <Library/TcoTimerLib.h>
+#include <ConfigDataStruct.h>
 
 #define UCODE_REGION_BASE   FixedPcdGet32(PcdUcodeBase)
 #define UCODE_REGION_SIZE   FixedPcdGet32(PcdUcodeSize)
@@ -56,7 +57,7 @@ FSPT_UPD TempRamInitParams = {
     .PcdSerialIoUartNumber      = FixedPcdGet32 (PcdDebugPortNumber) < PCH_MAX_SERIALIO_UART_CONTROLLERS ? \
                                     FixedPcdGet32 (PcdDebugPortNumber) : 2,
     .PcdSerialIoUartMode        = 4, // SerialIoUartSkipInit, let SBL init UART
-#if defined(PLATFORM_ADLN) || defined(PLATFORM_ASL)
+#if defined(PLATFORM_ADLN)
     .PcdSerialIoUartPowerGating = 1,
 #endif
     .PcdSerialIoUartBaudRate    = 115200,

--- a/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/EcSupport.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/EcSupport.c
@@ -348,7 +348,7 @@ GetBoardId (
   //
   *PlatformId = 0xFF;
 
-#if !defined(PLATFORM_ADLN) && !defined(PLATFORM_ASL)
+#if !defined(PLATFORM_ADLN)
   GetBoardIdFromEC(&BoardID);
 #endif
 

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
@@ -271,7 +271,7 @@ PlatformUpdateAcpiTable (
   VOID                        *FspHobList;
   PLATFORM_DATA               *PlatformData;
   FEATURES_CFG_DATA           *FeaturesCfgData;
-#if FixedPcdGet8 (PcdTccEnabled) && !defined(PLATFORM_RPLS) && !defined(PLATFORM_ADLN) && !defined(PLATFORM_ASL) && !defined(PLATFORM_RPLP)
+#if FixedPcdGet8 (PcdTccEnabled) && !defined(PLATFORM_RPLS) && !defined(PLATFORM_ADLN) && !defined(PLATFORM_RPLP)
   TCC_CFG_DATA                *TccCfgData;
 #endif
   EFI_STATUS                   Status;
@@ -349,7 +349,7 @@ PlatformUpdateAcpiTable (
   } else if (Table->Signature == SIGNATURE_32 ('R', 'T', 'C', 'T')) {
     DEBUG ((DEBUG_INFO, "Find RTCT table\n"));
 
-#if FixedPcdGet8 (PcdTccEnabled) && !defined(PLATFORM_RPLS) && !defined(PLATFORM_ADLN) && !defined(PLATFORM_ASL) && !defined(PLATFORM_RPLP)
+#if FixedPcdGet8 (PcdTccEnabled) && !defined(PLATFORM_RPLS) && !defined(PLATFORM_ADLN) && !defined(PLATFORM_RPLP)
       TccCfgData = (TCC_CFG_DATA *) FindConfigDataByTag(CDATA_TCC_TAG);
       if ((TccCfgData != NULL) && (TccCfgData->TccEnable != 0)) {
         Status = UpdateAcpiRtctTable(Table);
@@ -752,7 +752,7 @@ PlatformUpdateAcpiGnvs (
   UINT32                   Data32;
   GPIO_GROUP               GroupToGpeDwX[3];
   UINT32                   GroupDw[3];
-#if FixedPcdGet8 (PcdTccEnabled) && !defined(PLATFORM_RPLS) && !defined(PLATFORM_ADLN) && !defined(PLATFORM_ASL) && !defined(PLATFORM_RPLP)
+#if FixedPcdGet8 (PcdTccEnabled) && !defined(PLATFORM_RPLS) && !defined(PLATFORM_ADLN) && !defined(PLATFORM_RPLP)
   TCC_CFG_DATA            *TccCfgData;
   CPUID_EXTENDED_TIME_STAMP_COUNTER_EDX  Edx;
   CPUID_PROCESSOR_FREQUENCY_EBX          Ebx;
@@ -1290,7 +1290,7 @@ PlatformUpdateAcpiGnvs (
   SocUpdateAcpiGnvs ((VOID *)GnvsIn);
 
   // TCC mode enabling
-#if FixedPcdGet8 (PcdTccEnabled) && !defined(PLATFORM_RPLS) && !defined(PLATFORM_ADLN) && !defined(PLATFORM_ASL) && !defined(PLATFORM_RPLP)
+#if FixedPcdGet8 (PcdTccEnabled) && !defined(PLATFORM_RPLS) && !defined(PLATFORM_ADLN) && !defined(PLATFORM_RPLP)
     TccCfgData = (TCC_CFG_DATA *) FindConfigDataByTag(CDATA_FEATURES_TAG);
     if ((TccCfgData != NULL) && (TccCfgData->TccEnable != 0)) {
       AsmCpuid (CPUID_TIME_STAMP_COUNTER, NULL, &Ebx.Uint32, NULL, NULL);

--- a/Platform/RaptorlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/RaptorlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -667,7 +667,7 @@ UpdateFspConfig (
     FspsConfig->CpuPciePowerGating[1] = SiCfgData->CpuPciePowerGating;
     FspsConfig->CpuPciePowerGating[2] = SiCfgData->CpuPciePowerGating;
     FspsConfig->CpuPciePowerGating[3] = SiCfgData->CpuPciePowerGating;
-#if !defined(PLATFORM_ADLN) && !defined(PLATFORM_ASL)
+#if !defined(PLATFORM_ADLN)
     FspsConfig->L2QosEnumerationEn = SiCfgData->L2QosEnumerationEn;
 #endif
   }


### PR DESCRIPTION
The PLATFORM_{NAME} macro is dynamically defined by BuildUtility.py, which is based on the board file name. Since ASL has been merged into ADL-N, the PLATFORM_ASL macro has become obsolete and is no longer valid. This commit removes all instances of the deprecated PLATFORM_ASL.

Additionally, this commit addresses an issue where PLATFORM_ADLN was not defined in Stage1ABoardInitLib.c during the build process for ADL-N. The cause was that ConfigDataStruct.h was not included.