### PR TITLE
Fix: disable opt build cause error

### DIFF
--- a/MdePkg/Library/BaseFdtLib/libfdt/libfdt/fdt_rw.c
+++ b/MdePkg/Library/BaseFdtLib/libfdt/libfdt/fdt_rw.c
@@ -86,7 +86,7 @@ static int fdt_splice_struct_(void *fdt, void *p,
     int delta = newlen - oldlen;
     int err;
 
-    if ((err = fdt_splice_(fdt, p, oldlen, newlen)))
+    if ((err = fdt_splice_(fdt, p, oldlen, newlen)) != 0)
         return err;
 
     fdt_set_size_dt_struct(fdt, fdt_size_dt_struct(fdt) + delta);
@@ -108,7 +108,7 @@ static int fdt_splice_string_(void *fdt, int newlen)
         + fdt_off_dt_strings(fdt) + fdt_size_dt_strings(fdt);
     int err;
 
-    if ((err = fdt_splice_(fdt, p, 0, newlen)))
+    if ((err = fdt_splice_(fdt, p, 0, newlen)) != 0)
         return err;
 
     fdt_set_size_dt_strings(fdt, fdt_size_dt_strings(fdt) + newlen);
@@ -192,7 +192,7 @@ static int fdt_resize_property_(void *fdt, int nodeoffset, const char *name,
         return oldlen;
 
     if ((err = fdt_splice_struct_(fdt, (*prop)->data, FDT_TAGALIGN(oldlen),
-                      FDT_TAGALIGN(len))))
+                      FDT_TAGALIGN(len))) != 0)
         return err;
 
     (*prop)->len = cpu_to_fdt32(len);


### PR DESCRIPTION
When build with this command python BuildLoader.py build tgl -a x64
Build error found:
MdePkg\Library\BaseFdtLib\libfdt\libfdt\fdt_rw.c(194) : error C2220: the following warning is treated as an error MdePkg\Library\BaseFdtLib\libfdt\libfdt\fdt_rw.c(111) : warning C4706: assignment within conditional expression MdePkg\Library\BaseFdtLib\libfdt\libfdt\fdt_rw.c(194) : warning C4706: assignment within conditional expression MdePkg\Library\BaseFdtLib\libfdt\libfdt\fdt_rw.c(89) : error C2220: the following warning is treated as an error
 
ref: https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4706?view=msvc-170
 
cc flag change to: DEBUG_VS2019_X64_CC_FLAGS     = /nologo /c /WX /GS- /W4 /Gs32768 /D UNICODE /Gy /FIAutoGen.h /EHs-c- /GR- /GF /Z7 /Od