### PR TITLE
fix: [Common] Fix coverity issues for x64 build

### DIFF
--- a/BootloaderCommonPkg/Library/ConfigDataLib/ConfigDataLib.c
+++ b/BootloaderCommonPkg/Library/ConfigDataLib/ConfigDataLib.c
@@ -367,7 +367,7 @@ BuildConfigData (
         // Handle array item specially
         ArrayHdr     = (ARRAY_CFG_HDR *)Cdata;
         ArrayHdrCurr = (ARRAY_CFG_HDR *)CdataCurr;
-        BitMaskLen   = (CdataHdr->Length << 2) - HdrLen - OFFSET_OF(ARRAY_CFG_HDR, BaseTableBitMask) \
+        BitMaskLen   = (CdataHdr->Length << 2) - HdrLen - (UINT32)OFFSET_OF(ARRAY_CFG_HDR, BaseTableBitMask) \
                        - (ArrayHdr->ItemSize * ArrayHdr->ItemCount);
 
         // Update BaseTableBitMask
@@ -375,7 +375,7 @@ BuildConfigData (
         ArrayHdr->BaseTableId = 0x80;
 
         // Update skip bit accordingly in the entry based on BaseTableBitMask
-        GpioTableDataOffset = OFFSET_OF(ARRAY_CFG_HDR, BaseTableBitMask) + BitMaskLen;
+        GpioTableDataOffset = (UINT32)OFFSET_OF(ARRAY_CFG_HDR, BaseTableBitMask) + BitMaskLen;
         for (Index2 = 0; Index2 < ArrayHdr->ItemCount; Index2++) {
           if ((ArrayHdr->BaseTableBitMask[Index2 >> 3] & (1 << (Index2 & 7))) == 0) {
             // Skip one entry

--- a/BootloaderCommonPkg/Library/GraphicsLib/GraphicsLib.c
+++ b/BootloaderCommonPkg/Library/GraphicsLib/GraphicsLib.c
@@ -336,7 +336,7 @@ FrameBufferWrite (
     SetMem (Console->TextDisplayBuf, Console->Rows * Console->Cols, 0);
     // Zero framebuffer
     GfxInfoHob = Console->GfxInfoHob;
-    Length = (GfxInfoHob->GraphicsMode.HorizontalResolution * GfxInfoHob->GraphicsMode.PixelsPerScanLine) * 4;
+    Length = ((UINTN)GfxInfoHob->GraphicsMode.HorizontalResolution * GfxInfoHob->GraphicsMode.PixelsPerScanLine) * 4;
     SetMem64 ((UINT32 *) (UINTN)(GfxInfoHob->FrameBufferBase), Length, 0);
     Console->CursorX = 0;
     Console->CursorY = 0;

--- a/BootloaderCommonPkg/Library/LinuxLib/LinuxLib.c
+++ b/BootloaderCommonPkg/Library/LinuxLib/LinuxLib.c
@@ -233,7 +233,7 @@ LoadBzImage (
   }
 
   KernelBuf  = (VOID *) (UINTN)LINUX_KERNEL_BASE;
-  KernelSize = Bp->Hdr.SysSize * 16;
+  KernelSize = (UINTN)Bp->Hdr.SysSize * 16;
   CopyMem (KernelBuf, (UINT8 *)ImageBase + BootParamSize, KernelSize);
 
   //

--- a/BootloaderCommonPkg/Library/PagingLib/PagingLib.c
+++ b/BootloaderCommonPkg/Library/PagingLib/PagingLib.c
@@ -363,9 +363,9 @@ CreateIdentityMappingPageTables (
   NumOfPdpEntries = (UINT32) LShiftU64 (1, PhysicalAddressBits - 30);
 
   if (!Page1GSupport) {
-    TotalPagesNum = ((NumOfPdpEntries + 1) * NumOfPml4Entries + 1) * NumOfPml5Entries + 1;
+    TotalPagesNum = ((UINTN)(NumOfPdpEntries + 1) * NumOfPml4Entries + 1) * NumOfPml5Entries + 1;
   } else {
-    TotalPagesNum = (NumOfPml4Entries + 1) * NumOfPml5Entries + 1;
+    TotalPagesNum = (UINTN)(NumOfPml4Entries + 1) * NumOfPml5Entries + 1;
   }
 
   if (!Page5LevelSupport) {

--- a/BootloaderCommonPkg/Library/PartitionLib/PartitionLib.c
+++ b/BootloaderCommonPkg/Library/PartitionLib/PartitionLib.c
@@ -385,7 +385,7 @@ FindGptPartitions (
     }
   }
 
-  ReadSize = Gpt->NumberOfPartitionEntries * Gpt->SizeOfPartitionEntry;
+  ReadSize = (UINTN)Gpt->NumberOfPartitionEntries * Gpt->SizeOfPartitionEntry;
   ReadSize = (ReadSize % DevBlockInfo->BlockSize) == 0 ? ReadSize : DevBlockInfo->BlockSize * ((
                ReadSize / DevBlockInfo->BlockSize) + 1);
   GptEntries = (EFI_PARTITION_ENTRY *) AllocatePool (ReadSize);

--- a/BootloaderCommonPkg/Library/ShellLib/CmdMm.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdMm.c
@@ -111,7 +111,7 @@ MmRead (
   IN BOOLEAN IsIoAddr
 )
 {
-  UINTN  Index;
+  UINT32 Index;
   UINT32 Start;
   UINT32 ItemsPerRow;
 


### PR DESCRIPTION
Address following coverity issues
1. Integer Overflow or Wraparound (CWE 190)
2. Unexpected Sign Extension (CWD 194)

Test = boot up Windows and Ubuntu