### PR TITLE
fix: Source Level Debug breaks in X64.

### DIFF
--- a/BootloaderCommonPkg/Library/DebugAgentLib/DebugAgent.h
+++ b/BootloaderCommonPkg/Library/DebugAgentLib/DebugAgent.h
@@ -131,21 +131,6 @@ typedef struct {
 } DEBUG_AGENT_MAILBOX;
 #pragma pack()
 
-///
-/// Byte packed structure for an IA-32 Interrupt Gate Descriptor.
-///
-typedef union {
-  struct {
-    UINT32  OffsetLow:16;   ///< Offset bits 15..0.
-    UINT32  Selector:16;    ///< Selector.
-    UINT32  Reserved_0:8;   ///< Reserved.
-    UINT32  GateType:8;     ///< Gate Type.  See #defines above.
-    UINT32  OffsetHigh:16;  ///< Offset bits 31..16.
-  } Bits;
-  UINT64  Uint64;
-} IA32_IDT_ENTRY;
-
-
 typedef union {
   struct {
     UINT32  LimitLow    : 16;

--- a/BootloaderCommonPkg/Library/DebugAgentLib/DebugAgentLib.c
+++ b/BootloaderCommonPkg/Library/DebugAgentLib/DebugAgentLib.c
@@ -253,7 +253,7 @@ UpdateDebugAgentIdt (
   )
 {
   IA32_DESCRIPTOR              Idtr;
-  IA32_IDT_ENTRY              *IdtEntry;
+  IA32_IDT_GATE_DESCRIPTOR    *IdtEntry;
   UINT64                      *MailboxLocationPointer;
   DEBUG_AGENT_MAILBOX         *Mailbox;
 
@@ -285,7 +285,7 @@ UpdateDebugAgentIdt (
 
   IdtDescriptor = &Idtr;
 
-  IdtEntry = (IA32_IDT_ENTRY *)(IdtDescriptor->Base);
+  IdtEntry = (IA32_IDT_GATE_DESCRIPTOR *)(IdtDescriptor->Base);
   MailboxLocationPointer = (UINT64 *) ((UINTN) IdtEntry[DEBUG_MAILBOX_VECTOR].Bits.OffsetLow +
                                       ((UINTN) IdtEntry[DEBUG_MAILBOX_VECTOR].Bits.OffsetHigh << 16));
   Mailbox = (DEBUG_AGENT_MAILBOX *) (UINTN)(*MailboxLocationPointer);


### PR DESCRIPTION
DebugAgentLib was using its own IDT Entry structure definition that didn't adjust for x64. Removed this definition and switched to built in definition from ProcessorBind.h which does adjust for architecture correctly.