### PR TITLE
fix: [MTL] correct platform flavor

### DIFF
--- a/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1825,7 +1825,15 @@ PlatformUpdateAcpiGnvs (
   PlatformNvs->ApicEnable = 1;
   PlatformNvs->PlatformId = (UINT8) GetPlatformId ();
   PlatformNvs->GenerationId = 0;
-  PlatformNvs->PlatformFlavor = FlavorDesktop;
+  switch (GetPlatformId ()) {
+  case PLATFORM_ID_ARL_H_DDR5_RVP:
+  case PLATFORM_ID_ARL_H_LP5x_Rvp:
+    PlatformNvs->PlatformFlavor = FlavorMobile;
+    break;
+  default:
+    PlatformNvs->PlatformFlavor = FlavorDesktop;
+    break;
+  }
   PlatformNvs->BoardRev = 1;
   PlatformNvs->BoardType = 0;
   PlatformNvs->PlatformCpuId = 0xC0660;

--- a/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1610,7 +1610,7 @@ PlatformUpdateAcpiGnvs (
   PlatformNvs->UsbTypeCSupport = 1;
 
   PlatformNvs->GenerationId = 0;
-  PlatformNvs->PlatformFlavor = FlavorDesktop;
+  PlatformNvs->PlatformFlavor = FlavorMobile;
   PlatformNvs->BoardRev = 1;
   PlatformNvs->BoardType = 0;
   FeaturesCfgData = (FEATURES_CFG_DATA *) FindConfigDataByTag (CDATA_FEATURES_TAG);


### PR DESCRIPTION
The MTL boards currently supported by SBL are FlavorMobile.