### PR TITLE
[RPLP] Update for MR2 Hotfix release

### DIFF
--- a/Silicon/RaptorlakePkg/Rplp/Fsp/FspBinRplp.inf
+++ b/Silicon/RaptorlakePkg/Rplp/Fsp/FspBinRplp.inf
@@ -11,7 +11,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = 2fbfee291e9283f2ab77f798bec0d074d3772ca8
+  COMMIT  = 02b30da989444aa988ebb00c00c414bb662babd3
 
 [UserExtensions.SBL."CopyList"]
 # For RPL-P

--- a/Silicon/RaptorlakePkg/Rplp/Microcode/MicrocodeRplp.inf
+++ b/Silicon/RaptorlakePkg/Rplp/Microcode/MicrocodeRplp.inf
@@ -14,12 +14,12 @@
   VERSION_STRING       = 1.0
 
 [Sources]
-  m_e0_b06a2_0000411d.mcb  # RPL-P J0
+  m_e0_b06a2_00004123.mcb  # RPL-P J0
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
-  COMMIT = 01e5a97823e8b8587e99f6ccf0c1a70dfa39fd46
+  COMMIT = 66e03f3d21848e7376a1cc08289a1d930aa61c9a
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/RaptorLake/m_e0_b06a2_0000411d.pdb  : Silicon/RaptorlakePkg/Rplp/Microcode/m_e0_b06a2_0000411d.mcb
+  Microcode/RaptorLake/m_e0_b06a2_00004123.pdb  : Silicon/RaptorlakePkg/Rplp/Microcode/m_e0_b06a2_00004123.mcb
 


### PR DESCRIPTION
- FSP version is NEX RPL-P MR2 Hotfix (0C.01.DE.40)
- Microcode version is 4123