### PR TITLE
fix: [AZB] X710 Loss Issue on AZB CPU PCIe x4 Bus

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
@@ -66,6 +66,7 @@
   SmbusLib
   TopSwapLib
   CrashLogLib
+  PciSegmentLib
 
 [Guids]
   gFspNonVolatileStorageHobGuid
@@ -88,3 +89,4 @@
 [FixedPcd]
   gPlatformAlderLakeTokenSpaceGuid.PcdAdlLpSupport
   gPlatformAlderLakeTokenSpaceGuid.PcdAzbWwanSupport
+  gPlatformAlderLakeTokenSpaceGuid.PcdAzbSupport


### PR DESCRIPTION
Link Width degrade when performing Reset. Expected to be x4, but degrade to x2. The solution to clear the bit DRXTERMDQ for these specific devices.