### PR TITLE
fix: [ADLN] Correct platform id values in ACPI tables update

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
@@ -429,9 +429,9 @@ PlatformUpdateAcpiTable (
     if (GlobalNvs->PlatformNvs.Rtd3Support == 1) {
 
       // return EFI_SUCCESS only when PlatformID matches
-      if (GetPlatformId () == BoardIdAdlNDdr5Crb && Table->OemTableId == SIGNATURE_64('A', 'd', 'l', 'N' ,'_' ,'C' ,'r' ,'b')) {
+      if (GetPlatformId () == PLATFORM_ID_ADL_N_DDR5_CRB && Table->OemTableId == SIGNATURE_64('A', 'd', 'l', 'N' ,'_' ,'C' ,'r' ,'b')) {
         Status = EFI_SUCCESS;
-      } else if (GetPlatformId () == BoardIdAdlNLp5Rvp && Table->OemTableId == SIGNATURE_64('A', 'd', 'l', 'N' ,'_' ,'R' ,'v' ,'p')) {
+      } else if (GetPlatformId () == PLATFORM_ID_ADL_N_LPDDR5_RVP && Table->OemTableId == SIGNATURE_64('A', 'd', 'l', 'N' ,'_' ,'R' ,'v' ,'p')) {
         Status = EFI_SUCCESS;
       }
       DEBUG ((DEBUG_INFO, "Board SsdtRtd3 Table: %x\n", Table->OemTableId));


### PR DESCRIPTION
When checking whether to update the RTD3 SSDT table for ADL RVP/CRB SKUs, the GetPlatformId() return values are compared against the board id that was probed from the hardware (instead of the platform id to which the board id was mapped; cf. EcSupport.c).