### PR TITLE
fix: [Common] correct the free memory function for fs load command

### DIFF
--- a/BootloaderCommonPkg/Library/ShellLib/CmdFs.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdFs.c
@@ -298,8 +298,8 @@ CmdFsLoad (
 
   Status = ReadFile (FileHandle, Image, &ImageSize);
   if (EFI_ERROR (Status)) {
-    if (Image != NULL) {
-      FreePool (Image);
+    if ((Image != NULL) && (LoadAddr == 0)) {
+      FreePages (Image, EFI_SIZE_TO_PAGES (ImageSize));
     }
     goto FileLoadErrOut;
   }


### PR DESCRIPTION
When OsLoader shell "fs load" failed to read file, the assertion happened with the error log "CR has Bad Signature". It's caused when FreePool() tried to free the memory allocated by AllocatePages(). So modify the free memory function to FreePages()