### PR TITLE
ARL: Fix PCH SBREG_BAR update logic

### DIFF
--- a/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -265,7 +265,6 @@ UpdatePchSbRegBar (
   VOID
   )
 {
-
   MTL_PCH_CONFIGURATION     *PchConfig;
   GPIOV2_CONTROLLER         *Controller;
   GPIOV2_PAD                GpioPad;
@@ -279,7 +278,7 @@ UpdatePchSbRegBar (
     GpioPad    = GPIOV2_PAD_ID(0, GPIOV2_MTL_PCH_S_CHIPSET_ID, 0, 0, 0, 0);
     Controller = GpioGetController (GpioPad);
     Controller->SbRegBar = PchConfig->ReservedMmio64Base;
-    DEBUG ((DEBUG_INFO, "Get Pch SBREG = 0x%llX\n", PchConfig->ReservedMmio64Base));
+    DEBUG ((DEBUG_INFO, "FSP PCH SBREG_BAR = 0x%llX\n", PchConfig->ReservedMmio64Base));
   }
 }
 
@@ -311,7 +310,6 @@ BoardInit (
 
   switch (InitPhase) {
   case PreSiliconInit:
-    UpdatePchSbRegBar ();
     EnableLegacyRegions ();
     ConfigureGpioV2 (CDATA_GPIO_TAG, NULL, 0);
 
@@ -327,6 +325,7 @@ BoardInit (
 
     break;
   case PostSiliconInit:
+    UpdatePchSbRegBar ();
     if (IsWdtFlagsSet(WDT_FLAG_TCC_DSO_IN_PROGRESS)) {
       WdtDisable (WDT_FLAG_TCC_DSO_IN_PROGRESS);
     }

--- a/Silicon/ArrowlakePkg/Library/GpioV2Lib/GpioV2Init.c
+++ b/Silicon/ArrowlakePkg/Library/GpioV2Lib/GpioV2Init.c
@@ -1183,15 +1183,11 @@ ConfigurePad (
   DEBUG_CODE_BEGIN ();
   RegOffset     = GetRegisterOffset (GpioPad, GpioV2Dw0Reg);
   RegisterValue = GpioRead32 (GpioPad, RegOffset);
-  DEBUG ((DEBUG_INFO, "DW0 Offset= 0x%x, Value= 0x%x\n", RegOffset, RegisterValue));
+  DEBUG ((DEBUG_INFO, "Pad:0x%x, DW0(0x%x)=0x%x  ", GpioPad, RegOffset, RegisterValue));
 
   RegOffset     = GetRegisterOffset (GpioPad, GpioV2Dw1Reg);
   RegisterValue = GpioRead32 (GpioPad, RegOffset);
-  DEBUG ((DEBUG_INFO, "DW1 Offset= 0x%x, Value= 0x%x\n", RegOffset, RegisterValue));
-
-  RegOffset     = GetRegisterOffset (GpioPad, GpioV2Dw2Reg);
-  RegisterValue = GpioRead32 (GpioPad, RegOffset);
-  DEBUG ((DEBUG_INFO, "DW2 Offset= 0x%x, Value= 0x%x\n", RegOffset, RegisterValue));
+  DEBUG ((DEBUG_INFO, "DW1(0x%x)=0x%x\n", RegOffset, RegisterValue));
   DEBUG_CODE_END ();
 
   return EFI_SUCCESS;

--- a/Silicon/ArrowlakePkg/Library/MtlPchPcieRpLib/MtlPchPcieRpLib.c
+++ b/Silicon/ArrowlakePkg/Library/MtlPchPcieRpLib/MtlPchPcieRpLib.c
@@ -130,8 +130,6 @@ MtlPchGetPcieRpDevFun (
     *RpFun = RpNumber % 8;
   }
 
-  DEBUG ((DEBUG_INFO, "\n-%d, P2sbBase 0x%llx, PID=0x%x, Fid = 0x%x, PciePcd = 0x%x\n", Index, P2sbBase, PcieInfo[Index].Pid, Fid, PciePcd));
-
   return EFI_SUCCESS;
 }
 

--- a/Silicon/ArrowlakePkg/Library/PcieRpSocLib/PcieRpSocLib.c
+++ b/Silicon/ArrowlakePkg/Library/PcieRpSocLib/PcieRpSocLib.c
@@ -203,7 +203,6 @@ MtlSocGetPcieRpDevFun (
   } else {
     P2sbBase = GetP2sbDeviceAddr2 (DEVICE_TABLE_P2SB_INSTANCE_SOC);
   }
-  DEBUG ((DEBUG_INFO, "P2sbBase 0x%llx\n",P2sbBase));
 
   if ((P2sbBase & 0x0FFFFFFF) != 0) {
     P2sbBase = TO_PCI_LIB_ADDRESS (P2sbBase);
@@ -217,7 +216,6 @@ MtlSocGetPcieRpDevFun (
   if (PciePcd != 0xFFFFFFFF) {
     *RpFun = (PciePcd >> (FuncIndex * S_SPX_PCR_PCD_RP_FIELD)) & B_SPX_PCR_PCD_RP1FN;
   }
-  DEBUG ((DEBUG_INFO, "%d, P2sbBase 0x%llx, PID=0x%x, Fid = 0x%x, PciePcd = 0x%x\n", Index, P2sbBase, PcieInfo[Index].Pid, Fid, PciePcd));
 
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
FSP might produce a HOB to report PCH P2SB SBREG_BAR, but FSP doesn't program it to P2SB PCI device yet. So need update the logic on how to use it.
This PR also clean up the debug message.