### PR TITLE
fix: [Common] fix some TCC codes didn't take effect

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -71,7 +71,7 @@ GetCpuStepping(
   return ((CPU_STEPPING) (Eax.Uint32 & CPUID_FULL_STEPPING));
 }
 
-#if FeaturePcdGet(PcdTccEnabled)
+#if FixedPcdGetBool(PcdTccEnabled)
 /**
   Update FSP-M UPD config data for TCC mode and tuning
 
@@ -636,7 +636,7 @@ UpdateFspConfig (
   }
 
   // Tcc enabling
-#if FeaturePcdGet(PcdTccEnabled)
+#if FixedPcdGetBool(PcdTccEnabled)
   TccModePreMemConfig (FspmUpd);
 #endif
 

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -152,7 +152,7 @@ GetBoardIdFromSmbus (
   }
 }
 
-#if FeaturePcdGet(PcdTccEnabled)
+#if FixedPcdGetBool(PcdTccEnabled)
 /**
   Update FSP-M UPD config data for TCC mode and tuning
 
@@ -498,7 +498,7 @@ UpdateFspConfig (
 
     //Vtd Config
     Fspmcfg->VtdDisable                 = !FeaturePcdGet (PcdVtdEnabled);
-#if FeaturePcdGet(PcdTccEnabled)
+#if FixedPcdGetBool(PcdTccEnabled)
     DEBUG ((DEBUG_INFO, "Enable VTd since TCC is enabled\n"));
     Fspmcfg->VtdDisable = 0;
 #endif
@@ -701,7 +701,7 @@ UpdateFspConfig (
   // Enable s0ix by default
   PLAT_FEAT.S0ixEnable = 1;
 
-#if FeaturePcdGet(PcdTccEnabled)
+#if FixedPcdGetBool(PcdTccEnabled)
   TccModePreMemConfig (FspmUpd);
 #endif
 

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -853,7 +853,7 @@ BoardInit (
   }
 }
 
-#if FeaturePcdGet(PcdTccEnabled)
+#if FixedPcdGetBool(PcdTccEnabled)
 /**
   Update FSP-S UPD config data for TCC mode and tuning
 
@@ -868,6 +868,9 @@ TccModePostMemConfig (
   FSPS_UPD  *FspsUpd
 )
 {
+  UINT8  Index;
+  UINT8  MaxPchPcieRootPorts;
+
   DEBUG ((DEBUG_INFO, "Set TCC silicon:\n"));
 
   // Set default values for TCC related Silicon settings
@@ -915,7 +918,6 @@ TccModePostMemConfig (
   DEBUG ((DEBUG_INFO, "TccErrorLogEn         = %x\n", FspsUpd->FspsConfig.TccErrorLogEn          ));
   DEBUG ((DEBUG_INFO, "PcieRpAspm            = %x\n", FspsUpd->FspsConfig.PcieRpAspm[0]          ));
   DEBUG ((DEBUG_INFO, "PcieRpL1Substates     = %x\n", FspsUpd->FspsConfig.PcieRpL1Substates[0]   ));
-  DEBUG ((DEBUG_INFO, "Rtd3Support           = %x\n", mTccRtd3Support                            ));
 
   return EFI_SUCCESS;
 }

--- a/Platform/MeteorlakeBoardPkg/AcpiTables/Dsdt/PcieAdl.asl
+++ b/Platform/MeteorlakeBoardPkg/AcpiTables/Dsdt/PcieAdl.asl
@@ -74,9 +74,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -133,9 +130,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -192,9 +186,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -251,9 +242,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -366,9 +354,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -425,9 +410,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -484,9 +466,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -599,9 +578,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -658,9 +634,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -717,9 +690,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -776,9 +746,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -835,9 +802,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -894,9 +858,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -953,9 +914,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -1012,9 +970,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -1071,9 +1026,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -1130,9 +1082,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -1189,9 +1138,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -1304,9 +1250,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -1363,9 +1306,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -1422,9 +1362,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -1481,9 +1418,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -1540,9 +1474,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -1599,9 +1530,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {
@@ -1658,9 +1586,6 @@ Scope(\_SB.PC00) {
     }
     Store (GSIP (), SIPV)
     Include ("PchPcieCommon.asl")
-#if FeaturePcdGet (PcdTccEnabled) == 1
-    Include ("PchPcieAtscCommon.asl")
-#endif
     Method (_PRT, 0) {
       If (CondRefOf (PICM)) {
         If (PICM) {

--- a/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -63,7 +63,7 @@ InitEcCpuFanControl (
   VOID
 );
 
-#if FeaturePcdGet(PcdTccEnabled)
+#if FixedPcdGetBool(PcdTccEnabled)
 /**
   Update FSP-M UPD config data for TCC mode and tuning
 
@@ -181,7 +181,7 @@ UpdateFspConfig (
   }
   PlatformData->PlatformFeatures.VtdEnable = (!MemCfgData->VtdDisable) & FeaturePcdGet (PcdVtdEnabled);
 
-#if FeaturePcdGet(PcdTccEnabled)
+#if FixedPcdGetBool(PcdTccEnabled)
   // Need enable VTD if TCC is enalbed.
   DEBUG ((DEBUG_INFO, "Enable VTd since TCC is enabled\n"));
   PlatformData->PlatformFeatures.VtdEnable = 1;
@@ -469,7 +469,7 @@ UpdateFspConfig (
     }
   }
 
-#if FeaturePcdGet(PcdTccEnabled)
+#if FixedPcdGetBool(PcdTccEnabled)
   // Update TCC related UPDs if TCC is enabled
   TccModePreMemConfig (FspmUpd);
 #endif

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1055,7 +1055,7 @@ FspUpdatePcieRpPolicy (
   FspsUpd->FspsConfig.PcieRpFunctionSwap = 0x1;
 }
 
-#if FeaturePcdGet(PcdTccEnabled)
+#if FixedPcdGetBool(PcdTccEnabled)
 /**
   Update FSP-S UPD config data for TCC mode and tuning
 
@@ -1070,6 +1070,10 @@ TccModePostMemConfig (
   FSPS_UPD  *FspsUpd
 )
 {
+  UINT8  Index;
+  UINT8  MaxPchPcieRootPorts;
+  UINT8  MaxCpuPciePorts;
+
   DEBUG ((DEBUG_INFO, "Set TCC silicon:\n"));
 
   // TCC related Silicon settings
@@ -1453,7 +1457,7 @@ UpdateFspConfig (
     CopyMem (FspsConfig->PtmEnabled, SiCfgData->TcssPcieRootPortPtmEn, sizeof(SiCfgData->TcssPcieRootPortPtmEn));
   }
 
-#if FeaturePcdGet(PcdTccEnabled)
+#if FixedPcdGetBool(PcdTccEnabled)
     Status = TccModePostMemConfig (FspsUpd);
 #endif
 


### PR DESCRIPTION
Some TCC codes are separated with the directive #if FeaturePcdGet(PcdTccEnabled), which might be evaluated as False especially during C preprocessing.
Besides, the PcdTccEnabled is declared as FixedPcd. So changed the directive to #if FixedPcdGetBool.