### PR TITLE
feat: [AZB] X710 Loss Issue on AZB CPU PCIe x4 Bus

### DIFF
--- a/Platform/AlderlakeBoardPkg/BoardConfigAzb.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAzb.py
@@ -48,6 +48,10 @@ class Board(BaseBoard):
         self._AZB_WWAN_SUPPORT                = True
         self.SUPPORT_SR_IOV                   = 0
 
+        # _AZB_X710X550WA_SUPPORT enable WA needed to fix the link down issue with X710/X550.
+        # By default, this flag is disabled. If WA is needed then change the flag as True.
+        self._AZB_X710X550WA_SUPPORT          = False
+
         self.PCI_EXPRESS_BASE                 = 0xC0000000
         self.PCI_IO_BASE                      = 0x00002000
         self.PCI_MEM32_BASE                   = 0x80000000
@@ -288,6 +292,9 @@ class Board(BaseBoard):
 
         if self._AZB_WWAN_SUPPORT:
             dsc['PcdsFixedAtBuild'].append ('gPlatformAlderLakeTokenSpaceGuid.PcdAzbWwanSupport | TRUE')
+
+        if self._AZB_X710X550WA_SUPPORT:
+            dsc['PcdsFixedAtBuild'].append ('gPlatformAlderLakeTokenSpaceGuid.PcdAzbX710X550WA | TRUE')
 
         return dsc
 

--- a/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
@@ -69,6 +69,7 @@
   TopSwapLib
   CrashLogLib
   SerialIoI2cLib
+  PciSegmentLib
 
 [Guids]
   gFspNonVolatileStorageHobGuid
@@ -99,3 +100,4 @@
 [FixedPcd]
   gPlatformAlderLakeTokenSpaceGuid.PcdAdlLpSupport
   gPlatformAlderLakeTokenSpaceGuid.PcdAzbWwanSupport
+  gPlatformAlderLakeTokenSpaceGuid.PcdAzbX710X550WA

--- a/Silicon/AlderlakePkg/AlderlakePkg.dec
+++ b/Silicon/AlderlakePkg/AlderlakePkg.dec
@@ -26,6 +26,7 @@
   gPlatformAlderLakeTokenSpaceGuid.PcdAdlNSupport     | FALSE      | BOOLEAN | 0x30000101
   gPlatformAlderLakeTokenSpaceGuid.PcdAzbSupport      | FALSE      | BOOLEAN | 0x30000102
   gPlatformAlderLakeTokenSpaceGuid.PcdAzbWwanSupport  | FALSE      | BOOLEAN | 0x30000103
+  gPlatformAlderLakeTokenSpaceGuid.PcdAzbX710X550WA   | FALSE      | BOOLEAN | 0x30000104
 
 [PcdsDynamic]
   gPlatformAlderLakeTokenSpaceGuid.PcdFusaDiagnosticBoot | 0 | BOOLEAN | 0x30000200


### PR DESCRIPTION
Link Width degrade when performing Reset. Expected to be x4, but degrade to x2. The solution to clear the bit DRXTERMDQ for these specific devices.