### PR TITLE
feat: Add FIPS compliant IppCryptoLib instance.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "BootloaderCommonPkg/Library/IppCrypto2Lib/ipp-crypto"]
+	path = BootloaderCommonPkg/Library/IppCrypto2Lib/ipp-crypto
+	url = https://github.com/intel/ipp-crypto.git

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCrypto2Lib.inf
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCrypto2Lib.inf
@@ -1,0 +1,115 @@
+## @file
+#
+#  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = IppCryptoLib
+  FILE_GUID                      = C2C87C18-7282-479F-A7E6-BF297C94CC54
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = CryptoLib
+  DEFINE IPP_PATH                = ipp-crypto
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  IppCryptoSupport.c
+  hmac.c
+  rsa_verify.c
+  sha256.c
+  sha384.c
+  sm3.c
+  $(IPP_PATH)/include/ippcpdefs.h
+  $(IPP_PATH)/sources/include/owndefs.h
+  $(IPP_PATH)/sources/ippcp/owncp.h
+  $(IPP_PATH)/sources/ippcp/pcpbn.h
+  $(IPP_PATH)/sources/ippcp/pcptool.h
+
+  # Misc source files
+  $(IPP_PATH)/sources/ippcp/pcpmgf1ca_rmf.c
+  $(IPP_PATH)/sources/ippcp/gsmod_engineinit.c
+  $(IPP_PATH)/sources/ippcp/gsmod_enginegetsize.c
+  $(IPP_PATH)/sources/ippcp/gsmod_montfactor.c
+  $(IPP_PATH)/sources/ippcp/pcpngmontexpstuff_bin.c
+  $(IPP_PATH)/sources/ippcp/pcpmontred.c
+
+  # BigNum source files
+  $(IPP_PATH)/sources/ippcp/pcpbngetsize.c
+  $(IPP_PATH)/sources/ippcp/pcpbninit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnsetoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbngetoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_setoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_getoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_mul_adc.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_sqr_adc.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_add.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_add.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_addmuldigit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_sub.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_sub.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_submuldigit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_nlz.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_nlz.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_div.c
+
+  # RSA Source files
+  $(IPP_PATH)/sources/ippcp/pcprsa_getsizepublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_getbuffersizepublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_initpublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_setpublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_sizeof_pubkey.h
+  $(IPP_PATH)/sources/ippcp/pcprsaverifyhash_pkcs1v15_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcprsaverify_pss_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gspub_cipher.c
+  $(IPP_PATH)/sources/ippcp/gsmodmethod_rsa.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_montexpgetsize.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsmethod__gpr_public.c
+
+  # Hash source files
+  $(IPP_PATH)/sources/ippcp/pcphashmethod_sha256.c
+  $(IPP_PATH)/sources/ippcp/pcphashsha256px.c
+  $(IPP_PATH)/sources/ippcp/pcphashmethod_sha384.c
+  $(IPP_PATH)/sources/ippcp/pcphashsha512px.c
+  $(IPP_PATH)/sources/ippcp/sm3/pcphashmethod_sm3.c
+  $(IPP_PATH)/sources/ippcp/sm3/pcphashsm3px.c
+  $(IPP_PATH)/sources/ippcp/pcphashmessage_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashinit_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashupdate_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashfinal_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashca_rmf.c
+
+  # HMAC source files
+  $(IPP_PATH)/sources/ippcp/pcphmacmessage_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacgetsize_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacca_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacupdate_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacfinal_rmf.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  MemoryAllocationLib
+
+[FixedPcd]
+  gPlatformCommonLibTokenSpaceGuid.PcdCryptoShaOptMask
+  gPlatformCommonLibTokenSpaceGuid.PcdIppHashLibSupportedMask
+  gPlatformCommonLibTokenSpaceGuid.PcdCompSignSchemeSupportedMask
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = -D_ABL_ /GL-
+  GCC:*_*_*_CC_FLAGS  = -D_ABL_ -w -Wformat -Wformat-security
+

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCrypto2LibE9.inf
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCrypto2LibE9.inf
@@ -1,0 +1,148 @@
+## @file
+#
+#  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = IppCryptoLib
+  FILE_GUID                      = A734DB8A-4273-4A0A-A6A2-C973DC4EB5F3
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = CryptoLib
+  DEFINE IPP_PATH                = ipp-crypto
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = X64
+#
+
+[Sources]
+  IppCryptoSupport.c
+  hmac.c
+  rsa_verify.c
+  sha256.c
+  sha384.c
+  sm3.c
+  intrin.h
+  $(IPP_PATH)/include/ippcpdefs.h
+  $(IPP_PATH)/sources/include/owndefs.h
+  $(IPP_PATH)/sources/ippcp/owncp.h
+  $(IPP_PATH)/sources/ippcp/pcpbn.h
+  $(IPP_PATH)/sources/ippcp/pcptool.h
+  $(IPP_PATH)/sources/include/asmdefs.inc
+  $(IPP_PATH)/sources/include/ia_32e.inc
+  $(IPP_PATH)/sources/include/ia_common.inc
+  $(IPP_PATH)/sources/include/utils.inc
+
+  # Misc source files
+  $(IPP_PATH)/sources/ippcp/pcpmgf1ca_rmf.c
+  $(IPP_PATH)/sources/ippcp/gsmod_engineinit.c
+  $(IPP_PATH)/sources/ippcp/gsmod_enginegetsize.c
+  $(IPP_PATH)/sources/ippcp/gsmod_montfactor.c
+  $(IPP_PATH)/sources/ippcp/pcpngmontexpstuff_bin.c
+  $(IPP_PATH)/sources/ippcp/pcpmontred.c
+
+  # BigNum source files
+  $(IPP_PATH)/sources/ippcp/pcpbngetsize.c
+  $(IPP_PATH)/sources/ippcp/pcpbninit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnsetoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbngetoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_setoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_getoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_mul_adc.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_sqr_adc.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_add.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_add.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_addmuldigit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_sub.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_sub.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_submuldigit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_nlz.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_nlz.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_div.c
+
+  # RSA Source files
+  $(IPP_PATH)/sources/ippcp/pcprsa_getsizepublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_getbuffersizepublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_initpublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_setpublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_sizeof_pubkey.h
+  $(IPP_PATH)/sources/ippcp/pcprsaverifyhash_pkcs1v15_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcprsaverify_pss_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gspub_cipher.c
+  $(IPP_PATH)/sources/ippcp/gsmodmethod_rsa.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_montexpgetsize.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsmethod__gpr_public.c
+
+  # Hash source files
+  $(IPP_PATH)/sources/ippcp/pcphashmessage_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashinit_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashupdate_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashfinal_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashca_rmf.c
+  $(IPP_PATH)/sources/ippcp/sm3/pcpsm3stuff.h
+
+  # HMAC source files
+  $(IPP_PATH)/sources/ippcp/pcphmacmessage_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacgetsize_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacca_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacupdate_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacfinal_rmf.c
+
+[Sources.X64]
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpvariant_xmm7560.inc
+  # E9 files
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha256e9as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsm3e9as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha512e9as.nasm
+  # M7 files
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuaddm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnudivm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuincm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusubm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnumulschoolm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusqrschoolm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpmontreductionm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcppurgeblkm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnum7.inc
+
+[UserExtensions.SBL."CopyList"]
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha256e9as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha256e9as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsm3e9as.asm            : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsm3e9as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha512e9as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha512e9as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuaddm7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuaddm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnudivm7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnudivm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuincm7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuincm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusubm7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusubm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnumulschoolm7as.asm   : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnumulschoolm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusqrschoolm7as.asm   : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusqrschoolm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpmontreductionm7as.asm  : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpmontreductionm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcppurgeblkm7as.asm       : $(IPP_PATH)/sources/ippcp/asm_intel64/pcppurgeblkm7as.nasm
+
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  MemoryAllocationLib
+
+[FixedPcd]
+  gPlatformCommonLibTokenSpaceGuid.PcdCryptoShaOptMask
+  gPlatformCommonLibTokenSpaceGuid.PcdIppHashLibSupportedMask
+  gPlatformCommonLibTokenSpaceGuid.PcdCompSignSchemeSupportedMask
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = -D_ABL_ -D_E9 /GL- /arch:AVX
+  MSFT:*_*_X64_NASM_FLAGS = -D_ABL_ -D_E9 -DWIN32E
+  GCC:*_*_X64_NASM_FLAGS = -D_ABL_ -D_E9 -DLINUX32E
+  GCC:*_*_*_CC_FLAGS  = -D_ABL_ -D_E9 -w -Wformat -Wformat-security -march=sandybridge -mavx -maes -mpclmul -msha -mrdrnd -mrdseed
+

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCrypto2LibL9.inf
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCrypto2LibL9.inf
@@ -1,0 +1,150 @@
+## @file
+#
+#  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = IppCryptoLib
+  FILE_GUID                      = 56D08B33-9663-4D74-9D8A-DBA2F38B62B2
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = CryptoLib
+  DEFINE IPP_PATH                = ipp-crypto
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = X64
+#
+
+[Sources]
+  IppCryptoSupport.c
+  hmac.c
+  rsa_verify.c
+  sha256.c
+  sha384.c
+  sm3.c
+  intrin.h
+  $(IPP_PATH)/include/ippcpdefs.h
+  $(IPP_PATH)/sources/include/owndefs.h
+  $(IPP_PATH)/sources/ippcp/owncp.h
+  $(IPP_PATH)/sources/ippcp/pcpbn.h
+  $(IPP_PATH)/sources/ippcp/pcptool.h
+  $(IPP_PATH)/sources/include/asmdefs.inc
+  $(IPP_PATH)/sources/include/ia_32e.inc
+  $(IPP_PATH)/sources/include/ia_common.inc
+  $(IPP_PATH)/sources/include/utils.inc
+
+  # Misc source files
+  $(IPP_PATH)/sources/ippcp/pcpmgf1ca_rmf.c
+  $(IPP_PATH)/sources/ippcp/gsmod_engineinit.c
+  $(IPP_PATH)/sources/ippcp/gsmod_enginegetsize.c
+  $(IPP_PATH)/sources/ippcp/gsmod_montfactor.c
+  $(IPP_PATH)/sources/ippcp/pcpngmontexpstuff_bin.c
+  $(IPP_PATH)/sources/ippcp/pcpmontred.c
+  $(IPP_PATH)/sources/ippcp/cpinit.c
+
+  # BigNum source files
+  $(IPP_PATH)/sources/ippcp/pcpbngetsize.c
+  $(IPP_PATH)/sources/ippcp/pcpbninit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnsetoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbngetoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_setoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_getoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_mul_adc.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_sqr_adc.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_add.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_add.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_addmuldigit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_sub.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_sub.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_submuldigit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_nlz.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_nlz.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_div.c
+
+  # RSA Source files
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsmethod__avx2_public.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_getsizepublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_getbuffersizepublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_initpublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_setpublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_sizeof_pubkey.h
+  $(IPP_PATH)/sources/ippcp/pcprsaverifyhash_pkcs1v15_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcprsaverify_pss_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gspub_cipher.c
+  $(IPP_PATH)/sources/ippcp/gsmodmethod_rsa.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_montexpgetsize.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsmethod__gpr_public.c
+
+  # Hash source files
+  $(IPP_PATH)/sources/ippcp/pcphashmessage_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashinit_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashupdate_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashfinal_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashca_rmf.c
+  $(IPP_PATH)/sources/ippcp/sm3/pcpsm3stuff.h
+
+  # HMAC source files
+  $(IPP_PATH)/sources/ippcp/pcphmacmessage_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacgetsize_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacca_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacupdate_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacfinal_rmf.c
+
+[Sources.X64]
+  #L9 files
+  $(IPP_PATH)/sources/ippcp/asm_intel64/cpinitas.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha256l9as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha512l9as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsm3l9_ni_as.nasm
+  #M7 FIles
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuaddm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnudivm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuincm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusubm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnumulschoolsrvl9as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnumulschoolsrvl9pp.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcppurgeblkm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnum7.inc
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpvariant_xmm7560.inc
+
+[UserExtensions.SBL."CopyList"]
+  $(IPP_PATH)/sources/ippcp/asm_intel64/cpinitas.asm              : $(IPP_PATH)/sources/ippcp/asm_intel64/cpinitas.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha256l9as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha256l9as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha512l9as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha512l9as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsm3l9_ni_as.asm        : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsm3l9_ni_as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuaddm7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuaddm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnudivm7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnudivm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuincm7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuincm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusubm7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusubm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnumulschoolsrvl9.asm  : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnumulschoolsrvl9as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnumulschoolsrvl9pp.asm  : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnumulschoolsrvl9pp.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcppurgeblkm7as.asm       : $(IPP_PATH)/sources/ippcp/asm_intel64/pcppurgeblkm7as.nasm
+
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  MemoryAllocationLib
+
+[FixedPcd]
+  gPlatformCommonLibTokenSpaceGuid.PcdCryptoShaOptMask
+  gPlatformCommonLibTokenSpaceGuid.PcdIppHashLibSupportedMask
+  gPlatformCommonLibTokenSpaceGuid.PcdCompSignSchemeSupportedMask
+
+[BuildOptions]
+  MSFT:*_*_X64_CC_FLAGS = -D_ABL_ -D_L9 -D_ARCH_EM64T /GL- /arch:AVX2
+  MSFT:*_*_X64_NASM_FLAGS = -D_ABL_ -D_L9 -DWIN32E
+  GCC:*_*_X64_NASM_FLAGS = -D_ABL_ -D_L9 -DLINUX32E
+  GCC:*_*_*_CC_FLAGS  = -D_ABL_ -D_L9 -w -Wformat -Wformat-security -march=haswell -mavx2 -maes -mvaes -mpclmul -mvpclmulqdq -msha -mrdrnd -mrdseed
+

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCrypto2LibM7.inf
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCrypto2LibM7.inf
@@ -1,0 +1,147 @@
+## @file
+#
+#  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = IppCryptoLib
+  FILE_GUID                      = 9A5D5637-B1C3-4480-A403-61AF27F81995
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = CryptoLib
+  DEFINE IPP_PATH                = ipp-crypto
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = X64
+#
+
+[Sources]
+  IppCryptoSupport.c
+  hmac.c
+  rsa_verify.c
+  sha256.c
+  sha384.c
+  sm3.c
+  intrin.h
+  $(IPP_PATH)/include/ippcpdefs.h
+  $(IPP_PATH)/sources/include/owndefs.h
+  $(IPP_PATH)/sources/ippcp/owncp.h
+  $(IPP_PATH)/sources/ippcp/pcpbn.h
+  $(IPP_PATH)/sources/ippcp/pcptool.h
+  $(IPP_PATH)/sources/include/asmdefs.inc
+  $(IPP_PATH)/sources/include/ia_32e.inc
+  $(IPP_PATH)/sources/include/ia_common.inc
+  $(IPP_PATH)/sources/include/utils.inc
+
+  # Misc source files
+  $(IPP_PATH)/sources/ippcp/pcpmgf1ca_rmf.c
+  $(IPP_PATH)/sources/ippcp/gsmod_engineinit.c
+  $(IPP_PATH)/sources/ippcp/gsmod_enginegetsize.c
+  $(IPP_PATH)/sources/ippcp/gsmod_montfactor.c
+  $(IPP_PATH)/sources/ippcp/pcpngmontexpstuff_bin.c
+  $(IPP_PATH)/sources/ippcp/pcpmontred.c
+
+  # BigNum source files
+  $(IPP_PATH)/sources/ippcp/pcpbngetsize.c
+  $(IPP_PATH)/sources/ippcp/pcpbninit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnsetoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbngetoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_setoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_getoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_mul_adc.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_sqr_adc.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_add.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_add.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_addmuldigit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_sub.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_sub.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_submuldigit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_nlz.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_nlz.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_div.c
+
+  # RSA Source files
+  $(IPP_PATH)/sources/ippcp/pcprsa_getsizepublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_getbuffersizepublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_initpublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_setpublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_sizeof_pubkey.h
+  $(IPP_PATH)/sources/ippcp/pcprsaverifyhash_pkcs1v15_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcprsaverify_pss_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gspub_cipher.c
+  $(IPP_PATH)/sources/ippcp/gsmodmethod_rsa.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_montexpgetsize.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsmethod__gpr_public.c
+
+  # Hash source files
+  $(IPP_PATH)/sources/ippcp/sm3/pcphashmethod_sm3.c
+  $(IPP_PATH)/sources/ippcp/sm3/pcphashsm3px.c
+  $(IPP_PATH)/sources/ippcp/pcphashmessage_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashinit_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashupdate_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashfinal_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashca_rmf.c
+  $(IPP_PATH)/sources/ippcp/sm3/pcpsm3stuff.h
+
+  # HMAC source files
+  $(IPP_PATH)/sources/ippcp/pcphmacmessage_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacgetsize_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacca_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacupdate_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacfinal_rmf.c
+
+[Sources.X64]
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpvariant_xmm7560.inc
+  # m7 files
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha256m7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha512m7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuaddm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnudivm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuincm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusubm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnumulschoolm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusqrschoolm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpmontreductionm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcppurgeblkm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnum7.inc
+
+[UserExtensions.SBL."CopyList"]
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha256m7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha256m7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha512m7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha512m7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuaddm7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuaddm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnudivm7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnudivm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuincm7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuincm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusubm7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusubm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnumulschoolm7as.asm   : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnumulschoolm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusqrschoolm7as.asm   : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusqrschoolm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpmontreductionm7as.asm  : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpmontreductionm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcppurgeblkm7as.asm       : $(IPP_PATH)/sources/ippcp/asm_intel64/pcppurgeblkm7as.nasm
+
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  MemoryAllocationLib
+
+[FixedPcd]
+  gPlatformCommonLibTokenSpaceGuid.PcdCryptoShaOptMask
+  gPlatformCommonLibTokenSpaceGuid.PcdIppHashLibSupportedMask
+  gPlatformCommonLibTokenSpaceGuid.PcdCompSignSchemeSupportedMask
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = -D_ABL_ -D_M7 /GL-
+  MSFT:*_*_X64_NASM_FLAGS = -D_ABL_ -D_M7 -DWIN32E
+  GCC:*_*_X64_NASM_FLAGS = -D_ABL_ -D_M7 -DLINUX32E
+  GCC:*_*_*_CC_FLAGS  = -D_ABL_ -D_M7 -w -Wformat -Wformat-security -march=nocona -msse3
+

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCrypto2LibU8.inf
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCrypto2LibU8.inf
@@ -1,0 +1,148 @@
+## @file
+#
+#  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = IppCryptoLib
+  FILE_GUID                      = 26965FAA-AB4D-4F8F-8AF0-37C26BC051B0
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = CryptoLib
+  DEFINE IPP_PATH                = ipp-crypto
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = X64
+#
+
+[Sources]
+  IppCryptoSupport.c
+  hmac.c
+  rsa_verify.c
+  sha256.c
+  sha384.c
+  sm3.c
+  intrin.h
+  $(IPP_PATH)/include/ippcpdefs.h
+  $(IPP_PATH)/sources/include/owndefs.h
+  $(IPP_PATH)/sources/ippcp/owncp.h
+  $(IPP_PATH)/sources/ippcp/pcpbn.h
+  $(IPP_PATH)/sources/ippcp/pcptool.h
+  $(IPP_PATH)/sources/include/asmdefs.inc
+  $(IPP_PATH)/sources/include/ia_32e.inc
+  $(IPP_PATH)/sources/include/ia_common.inc
+  $(IPP_PATH)/sources/include/utils.inc
+
+  # Misc source files
+  $(IPP_PATH)/sources/ippcp/pcpmgf1ca_rmf.c
+  $(IPP_PATH)/sources/ippcp/gsmod_engineinit.c
+  $(IPP_PATH)/sources/ippcp/gsmod_enginegetsize.c
+  $(IPP_PATH)/sources/ippcp/gsmod_montfactor.c
+  $(IPP_PATH)/sources/ippcp/pcpngmontexpstuff_bin.c
+  $(IPP_PATH)/sources/ippcp/pcpmontred.c
+
+  # BigNum source files
+  $(IPP_PATH)/sources/ippcp/pcpbngetsize.c
+  $(IPP_PATH)/sources/ippcp/pcpbninit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnsetoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbngetoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_setoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_getoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_mul_adc.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_sqr_adc.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_add.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_add.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_addmuldigit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_sub.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_sub.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_submuldigit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_nlz.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_nlz.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_div.c
+
+  # RSA Source files
+  $(IPP_PATH)/sources/ippcp/pcprsa_getsizepublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_getbuffersizepublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_initpublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_setpublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_sizeof_pubkey.h
+  $(IPP_PATH)/sources/ippcp/pcprsaverifyhash_pkcs1v15_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcprsaverify_pss_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gspub_cipher.c
+  $(IPP_PATH)/sources/ippcp/gsmodmethod_rsa.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_montexpgetsize.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsmethod__gpr_public.c
+
+  # Hash source files
+  $(IPP_PATH)/sources/ippcp/pcphashmessage_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashinit_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashupdate_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashfinal_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashca_rmf.c
+  $(IPP_PATH)/sources/ippcp/sm3/pcpsm3stuff.h
+
+  # HMAC source files
+  $(IPP_PATH)/sources/ippcp/pcphmacmessage_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacgetsize_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacca_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacupdate_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacfinal_rmf.c
+
+[Sources.X64]
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpvariant_xmm7560.inc
+  # U8 files
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha256u8as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsm3u8as.nasm
+  # m7 files
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha512m7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuaddm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnudivm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuincm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusubm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnumulschoolm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusqrschoolm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpmontreductionm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcppurgeblkm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnum7.inc
+
+[UserExtensions.SBL."CopyList"]
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha256u8as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha256u8as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsm3u8as.asm            : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsm3u8as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha512m7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha512m7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuaddm7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuaddm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnudivm7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnudivm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuincm7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuincm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusubm7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusubm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnumulschoolm7as.asm   : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnumulschoolm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusqrschoolm7as.asm   : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusqrschoolm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpmontreductionm7as.asm  : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpmontreductionm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcppurgeblkm7as.asm       : $(IPP_PATH)/sources/ippcp/asm_intel64/pcppurgeblkm7as.nasm
+
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  MemoryAllocationLib
+
+[FixedPcd]
+  gPlatformCommonLibTokenSpaceGuid.PcdCryptoShaOptMask
+  gPlatformCommonLibTokenSpaceGuid.PcdIppHashLibSupportedMask
+  gPlatformCommonLibTokenSpaceGuid.PcdCompSignSchemeSupportedMask
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = -D_ABL_ -D_U8 /GL-
+  MSFT:*_*_X64_NASM_FLAGS = -D_ABL_ -D_U8 -DWIN32E
+  GCC:*_*_X64_NASM_FLAGS = -D_ABL_ -D_U8 -DLINUX32E
+  GCC:*_*_*_CC_FLAGS  = -D_ABL_ -D_U8 -w -Wformat -Wformat-security
+

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCrypto2LibY8.inf
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCrypto2LibY8.inf
@@ -1,0 +1,149 @@
+## @file
+#
+#  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = IppCryptoLib
+  FILE_GUID                      = 26965FAA-AB4D-4F8F-8AF0-37C26BC051B0
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = CryptoLib
+  DEFINE IPP_PATH                = ipp-crypto
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = X64
+#
+
+[Sources]
+  IppCryptoSupport.c
+  hmac.c
+  rsa_verify.c
+  sha256.c
+  sha384.c
+  sm3.c
+  intrin.h
+  $(IPP_PATH)/include/ippcpdefs.h
+  $(IPP_PATH)/sources/include/owndefs.h
+  $(IPP_PATH)/sources/ippcp/owncp.h
+  $(IPP_PATH)/sources/ippcp/pcpbn.h
+  $(IPP_PATH)/sources/ippcp/pcptool.h
+  $(IPP_PATH)/sources/include/asmdefs.inc
+  $(IPP_PATH)/sources/include/ia_32e.inc
+  $(IPP_PATH)/sources/include/ia_common.inc
+  $(IPP_PATH)/sources/include/utils.inc
+
+  # Misc source files
+  $(IPP_PATH)/sources/ippcp/pcpmgf1ca_rmf.c
+  $(IPP_PATH)/sources/ippcp/gsmod_engineinit.c
+  $(IPP_PATH)/sources/ippcp/gsmod_enginegetsize.c
+  $(IPP_PATH)/sources/ippcp/gsmod_montfactor.c
+  $(IPP_PATH)/sources/ippcp/pcpngmontexpstuff_bin.c
+  $(IPP_PATH)/sources/ippcp/pcpmontred.c
+
+  # BigNum source files
+  $(IPP_PATH)/sources/ippcp/pcpbngetsize.c
+  $(IPP_PATH)/sources/ippcp/pcpbninit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnsetoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbngetoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_setoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_getoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_mul_adc.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_sqr_adc.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_add.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_add.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_addmuldigit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_sub.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_sub.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_submuldigit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_nlz.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_nlz.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_div.c
+
+  # RSA Source files
+  $(IPP_PATH)/sources/ippcp/pcprsa_getsizepublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_getbuffersizepublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_initpublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_setpublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_sizeof_pubkey.h
+  $(IPP_PATH)/sources/ippcp/pcprsaverifyhash_pkcs1v15_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcprsaverify_pss_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gspub_cipher.c
+  $(IPP_PATH)/sources/ippcp/gsmodmethod_rsa.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_montexpgetsize.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsmethod__gpr_public.c
+
+  # Hash source files
+  $(IPP_PATH)/sources/ippcp/pcphashmessage_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashinit_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashupdate_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashfinal_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphashca_rmf.c
+  $(IPP_PATH)/sources/ippcp/sm3/pcpsm3stuff.h
+
+  # HMAC source files
+  $(IPP_PATH)/sources/ippcp/pcphmacmessage_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacgetsize_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacca_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacupdate_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacfinal_rmf.c
+
+[Sources.X64]
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpvariant_xmm7560.inc
+  # NI files
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha256nias.nasm
+  # U8 files
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsm3u8as.nasm
+  # m7 files
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha512m7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuaddm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnudivm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuincm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusubm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnumulschoolm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusqrschoolm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpmontreductionm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcppurgeblkm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnum7.inc
+
+[UserExtensions.SBL."CopyList"]
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha256nias.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha256nias.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsm3u8as.asm            : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsm3u8as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha512m7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpsha512m7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuaddm7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuaddm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnudivm7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnudivm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuincm7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnuincm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusubm7as.asm         : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusubm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnumulschoolm7as.asm   : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnumulschoolm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusqrschoolm7as.asm   : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpbnusqrschoolm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcpmontreductionm7as.asm  : $(IPP_PATH)/sources/ippcp/asm_intel64/pcpmontreductionm7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_intel64/pcppurgeblkm7as.asm       : $(IPP_PATH)/sources/ippcp/asm_intel64/pcppurgeblkm7as.nasm
+
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  MemoryAllocationLib
+
+[FixedPcd]
+  gPlatformCommonLibTokenSpaceGuid.PcdCryptoShaOptMask
+  gPlatformCommonLibTokenSpaceGuid.PcdIppHashLibSupportedMask
+  gPlatformCommonLibTokenSpaceGuid.PcdCompSignSchemeSupportedMask
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = -D_ABL_ -D_Y8 /GL-
+  MSFT:*_*_X64_NASM_FLAGS = -D_ABL_ -D_Y8 -DWIN32E
+  GCC:*_*_X64_NASM_FLAGS = -D_ABL_ -D_Y8 -DLINUX32E
+  GCC:*_*_*_CC_FLAGS  = -D_ABL_ -D_Y8 -w -Wformat -Wformat-security -march=nehalem -msse4.2 -maes -mpclmul -msha -U__INTEL_COMPILER
+

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCryptoSupport.c
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCryptoSupport.c
@@ -1,0 +1,32 @@
+/** @file
+  Helper functions for IppCryptoLib
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include "IppCryptoSupport.h"
+
+void *
+memset (
+  void *dest,
+  int ch,
+  size_t count
+  )
+{
+  return SetMem(dest, (UINTN)(count),(UINT8)(ch));
+}
+
+
+void *
+memcpy (
+  void *dest_str,
+  const void * src_str,
+  size_t n
+  )
+{
+  return CopyMem(dest_str,src_str, (UINTN)(n));
+}

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCryptoSupport.h
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCryptoSupport.h
@@ -1,0 +1,64 @@
+/** @file
+  Root include file of C runtime library to support building the Intel
+  IPPCrypto library.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef IPP_CRYPTO_LIB_SUPPORT_H_
+#define IPP_CRYPTO_LIB_SUPPORT_H_
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+
+typedef UINT8    uint8_t;
+typedef UINT16   uint16_t;
+typedef INT32    int32_t;
+typedef UINT32   uint32_t;
+typedef UINT64   uint64_t;
+typedef UINTN    uintptr_t;
+typedef UINTN    size_t;
+typedef BOOLEAN  bool;
+
+#define true   (1 == 1)
+#define false  (1 == 0)
+
+//
+// Definitions for global constants used by library routines
+//
+#define INT_MAX     0x7FFFFFFF           /* Maximum (signed) int value */
+#define INT32_MAX   0x7FFFFFFF           /* Maximum (signed) int32 value */
+#define UINT32_MAX  0xFFFFFFFF           /* Maximum unsigned int32 value */
+
+//
+// Function prototypes of Library routines
+//
+void *
+memset     (
+  void *,
+  int,
+  size_t
+  );
+
+void *
+memcpy    (
+  void *,
+  const void *,
+  size_t
+  );
+
+
+//
+// Macros that directly map functions to BaseLib functions
+//
+
+#define _byteswap_ushort(x)                 SwapBytes16(x)
+#define _byteswap_ulong(x)                  SwapBytes32(x)
+#define _byteswap_uint64(x)                 SwapBytes64(x)
+#define _lrotl(x, nBits)                    LRotU32((x), (nBits))
+#define _lrotr(x, nBits)                    RRotU32((x), (nBits))
+
+#endif /* IPP_CRYPTO_LIB_SUPPORT_H_ */

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/README.md
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/README.md
@@ -1,0 +1,25 @@
+
+# FIPS compliant IppCryptoLib
+This version of IppCryptoLib utilizes a newer version of the ipp-crypto project that is certified to comply with the Federal Information Processing Standards. This version only supports build for the X64 architecture. A FIPS certified implementation is not available for the IA32 architecture in Slim Bootloader.
+
+## Git Submodule
+The ipp-crypto project is now included unmodified as a git submodule. This means that git submodules will need to be initialized as part of clone/fetch of the Slim Bootloader code.
+
+
+## x86 Extended Instruction Set  Optimizations
+The ipp-crypto project includes enhanced implementations of many crypto primitives using enhancements to the x86 ISA that are not present in every CPU. The optimization levels are represented internally by a letter/number combination. There are many more combinations than these supported by ipp-crypto, but these are the ones which have an effect on the primatives used by Slim Bootloader. The below table shows the optimized instruction sets used for each optimization level (row headings) for each algorithm (column headings). You should expect some performance increase from each lower row in the table.
+
+|        | **SHA256** | **SHA384** | **SM3** | **RSA**   |
+|--------|------------|------------|---------|-----------|
+| **M7** | SSE3       | SSE3       | _None_  | SSE3      |
+| **U8** | SSSE3      | SSE3       | SSSE3   | SSE3      |
+| **Y8** | SSE4.2     | SSE3       | SSSE3   | SSE3      |
+| **E9** | AVX        | AVX        | AVX     | SSE3      |
+| **L9** | AVX2       | AVX2       | AVX2    | AVX2/SSE3 |
+
+## ipp-crypto Project
+The [Intel® Integrated Performance Primitives Cryptography Project](https://github.com/intel/cryptography-primitives) is a secure, fast and lightweight library of building blocks for cryptography, highly-optimized for various Intel® CPUs. ipp-crypto is validated for FIPS-140-3
+You can find more information on the ipp-crypto github page.
+
+### License
+Intel® Cryptography Primitives Library is licensed under Apache License, Version 2.0.

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/hmac.c
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/hmac.c
@@ -1,0 +1,194 @@
+/** @file
+
+  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "owndefs.h"
+#include "owncp.h"
+#include "pcphash.h"
+#include "pcptool.h"
+#include <Library/MemoryAllocationLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Uefi/UefiBaseType.h>
+
+IPPAPI( const IppsHashMethod*, ippsHashMethod_SHA256Sbl, (void) )
+
+#define  DEBUG_IPP    0
+
+EFI_STATUS
+EFIAPI
+HmacSha256 (const Ipp8u* pMsg, Ipp32u msgLen, const Ipp8u* pKey, Ipp32u keyLen, Ipp8u* pMD, Ipp32u mdLen)
+{
+  IppStatus Result;
+  Result = ippsHMACMessage_rmf(pMsg, msgLen, pKey, keyLen, pMD, mdLen, ippsHashMethod_SHA256Sbl ());
+  if (Result != ippStsNoErr) {
+    return EFI_PROTOCOL_ERROR;
+  }
+  return EFI_SUCCESS;
+}
+
+#if DEBUG_IPP
+static void DumpStr(const char* note, const Ipp8u* inp, int inpLen, int lineLen)
+{
+  int n;
+  int m;
+  int printNum;
+
+  if(note) {
+    DEBUG ((DEBUG_INFO, "%s\n", note));
+  }
+  for(n=0; n<inpLen; n+=lineLen) {
+    printNum = ((n+lineLen)<=inpLen)? lineLen : inpLen-n;
+    for(m=0; m<printNum; m++) {
+      DEBUG ((DEBUG_INFO, "%02x", inp[n+m]));
+    }
+    DEBUG ((DEBUG_INFO, "\n"));
+  }
+}
+#endif
+
+IppStatus HKDFExtract( Ipp8u* prk, int prkLen,
+                       const Ipp8u* salt, int saltLen,
+                       const Ipp8u* ikm, int ikmLen,
+                       const IppsHashMethod* pMethod
+                     )
+{
+  return ippsHMACMessage_rmf(ikm, ikmLen, salt, saltLen, prk, prkLen, pMethod);
+}
+
+IppStatus HKDFExpand( Ipp8u* okm, int okmLen,
+                      const Ipp8u* prk, int prkLen,
+                      const Ipp8u* info,int infoLen,
+                      const IppsHashMethod* pMethod)
+{
+  int ctxSize = 0;
+  IppsHMACState_rmf* pHMAC;
+  Ipp8u tmp[IPP_SHA512_DIGEST_BITSIZE/8];
+  int tmpLen;
+  int hashLen;
+  Ipp8u cnt;
+  int outLen;
+  int copyLen;
+  IppStatus Sts;
+
+  Sts = ippsHMACGetSize_rmf(&ctxSize);
+  if(Sts !=ippStsNoErr) {
+    return Sts;
+  }
+
+  pHMAC = AllocatePool (ctxSize);
+  if (pHMAC == NULL) {
+    Sts = ippStsNoMemErr;
+    return Sts;
+  }
+
+  Sts = ippsHMACInit_rmf(prk, prkLen, pHMAC, pMethod);
+  if(Sts !=ippStsNoErr) {
+    goto Exit;
+  }
+
+  tmpLen = 0;
+  hashLen = prkLen;
+  cnt = 1;
+
+  for(outLen=0; outLen<okmLen; outLen+=hashLen) {
+    Sts = ippsHMACUpdate_rmf(tmp,  tmpLen, pHMAC);
+    if(Sts !=ippStsNoErr) {
+      goto Exit;
+    }
+    Sts = ippsHMACUpdate_rmf(info, infoLen, pHMAC);
+    if(Sts !=ippStsNoErr) {
+      goto Exit;
+    }
+    Sts = ippsHMACUpdate_rmf(&cnt, sizeof(cnt), pHMAC);
+    if(Sts !=ippStsNoErr) {
+      goto Exit;
+    }
+    cnt++;
+    Sts = ippsHMACFinal_rmf(tmp,  hashLen, pHMAC);
+    if(Sts !=ippStsNoErr) {
+      goto Exit;
+    }
+    tmpLen = hashLen;
+
+    copyLen = ((outLen+hashLen)<=okmLen)? hashLen : okmLen-outLen;
+
+    CopyMem(okm+outLen, tmp, copyLen);
+  }
+
+Exit:
+  FreePool(pHMAC);
+  return Sts;
+}
+
+EFI_STATUS
+HKDF ( const IppsHashMethod* pMethod,
+       const Ipp8u* salt, int saltLen,
+       const Ipp8u* ikm, int ikmLen,
+       const Ipp8u* info,int infoLen,
+       Ipp8u* okm, int okmLen
+     )
+{
+  Ipp8u tprk[IPP_SHA256_DIGEST_BITSIZE/8];
+  IppStatus Sts;
+
+  // TODO: Check to see if Expand returns correct OKM  or not if ikmLen > 64
+  if ((saltLen > 64) ||  (infoLen > 64) || (ikmLen > 64)){
+    DEBUG ((DEBUG_ERROR, "HKDF: Invalid Parameter\n"));
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  // step 1 (extract)
+  Sts = HKDFExtract(tprk,sizeof(tprk), salt,saltLen, ikm,ikmLen, pMethod);
+  if(Sts !=ippStsNoErr) {
+    DEBUG ((DEBUG_ERROR, "HKDF Extract failed:%d\n", Sts));
+    return EFI_PROTOCOL_ERROR;
+  }
+#if DEBUG_IPP
+  DumpStr("prk:\n", tprk, sizeof(tprk), 32);
+#endif
+
+  // step 2 (expand)
+  Sts = HKDFExpand(okm,okmLen, tprk,sizeof(tprk), info,infoLen, pMethod);
+  if(Sts !=ippStsNoErr) {
+    DEBUG ((DEBUG_ERROR, "HKDF Expand failed:%d\n", Sts));
+    return EFI_PROTOCOL_ERROR;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/* Wrapper function for HMAC HKDF logic
+ * Returns non-zero on failure, 0 on success.
+ */
+EFI_STATUS
+HkdfExtractExpand( const Ipp8u* salt, int saltLen,
+                   const Ipp8u* ikm, int ikmLen,
+                   const Ipp8u* info, int infoLen,
+                   Ipp8u* okm, int okmLen
+                 )
+{
+  EFI_STATUS Status;
+
+#if DEBUG_IPP
+  DEBUG ((DEBUG_INFO, "SaltLen = %x, IKMLen = 0x%x, OKMLen = 0x%x, Info = 0x%x\n", saltLen, ikmLen, okmLen, infoLen));
+  DumpStr("salt:", salt, saltLen, 32);
+  DumpStr("ikm:", ikm, ikmLen, 32);
+  DumpStr("info:", info, 10, 32);
+#endif
+
+  Status = HKDF( ippsHashMethod_SHA256Sbl(),
+                    salt, saltLen,
+                    ikm, ikmLen,
+                    info, infoLen,
+                    okm, okmLen
+               );
+#if DEBUG_IPP
+  DumpStr("okm:\n", okm, okmLen, 32);
+#endif
+
+  return Status;
+}

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/immintrin.h
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/immintrin.h
@@ -1,0 +1,9 @@
+/** @file
+  Include file to support building the Intel IPPCrypto library.
+
+Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+// Dummy include file needed to resolve Visual Studio build errors

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/intrin.h
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/intrin.h
@@ -1,0 +1,9 @@
+/** @file
+  Include file to support building the Intel IPPCrypto library.
+
+Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+// Dummy include file needed to resolve Visual Studio build errors

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/rsa_verify.c
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/rsa_verify.c
@@ -1,0 +1,330 @@
+/** @file
+
+  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "owndefs.h"
+#include "owncp.h"
+
+#include "pcpngrsa.h"
+#include "pcphash.h"
+#include "pcptool.h"
+
+#include <Library/CryptoLib.h>
+#include <Library/BlMemoryAllocationLib.h>
+
+IPPAPI(IppStatus, ippsRSAVerifyHash_PKCS1v15_rmf,(const Ipp8u* md,
+                                                  const Ipp8u* pSign, int* pIsValid,
+                                                  const IppsRSAPublicKeyState* pKey,
+                                                  const IppsHashMethod* pMethod,
+                                                        Ipp8u* pBuffer))
+
+IPPAPI( const IppsHashMethod*, ippsHashMethod_SHA384Sbl, (void) )
+IPPAPI( const IppsHashMethod*, ippsHashMethod_SHA256Sbl, (void) )
+
+
+/* Wrapper function for RSA PKCS_1.5 Verify to make the inferface consistent.
+ * Returns non-zero on failure, 0 on success.
+ */
+int VerifyRsaPkcs1Signature (CONST PUB_KEY_HDR *PubKeyHdr, CONST SIGNATURE_HDR *SignatureHdr,  CONST UINT8  *Hash)
+{
+  int    sz_n;
+  int    sz_e;
+  int    sz_rsa;
+  int    sz_scratch;
+  int    signature_verified;
+
+  Ipp8u  *rsa_n;
+  Ipp8u  *rsa_e;
+  Ipp16u  mod_len;
+  Ipp8u  *bn_buf;
+  IppsBigNumState *bn_rsa_n;
+  IppsBigNumState *bn_rsa_e;
+  Ipp8u *scratch_buf;
+  IppStatus err;
+  IppsRSAPublicKeyState *rsa_key_s;
+  Ipp8u *bn_buf_ptr;
+  const IppsHashMethod  *pHashMethod = NULL;
+
+  signature_verified = 0;
+
+  rsa_n = (Ipp8u *) PubKeyHdr->KeyData;
+  rsa_e = (Ipp8u *) PubKeyHdr->KeyData + PubKeyHdr->KeySize - RSA_E_SIZE;
+  mod_len = PubKeyHdr->KeySize - RSA_E_SIZE;
+
+  err = ippsRSA_GetSizePublicKey(mod_len * 8, RSA_E_SIZE * 8, &sz_rsa);
+  if (err != ippStsNoErr) {
+    return err;
+  }
+
+  err = ippsBigNumGetSize(mod_len / sizeof(Ipp32u), &sz_n);
+  if (err != ippStsNoErr) {
+    return err;
+  }
+  err = ippsBigNumGetSize(RSA_E_SIZE / sizeof(Ipp32u), &sz_e);
+  if (err != ippStsNoErr) {
+    return err;
+  }
+
+  // Allign sz
+  sz_rsa = IPP_ALIGNED_SIZE (sz_rsa, sizeof(Ipp32u));
+  sz_n   = IPP_ALIGNED_SIZE (sz_n, sizeof(Ipp32u));
+  sz_e   = IPP_ALIGNED_SIZE (sz_e, sizeof(Ipp32u));
+
+  // Allocate BN Buf
+  bn_buf = AllocateTemporaryMemory (sz_rsa + sz_n + sz_e);
+  if (bn_buf ==  NULL) {
+    return ippStsNoMemErr;
+  }
+
+  scratch_buf  = NULL;
+  bn_buf_ptr   = bn_buf;
+  rsa_key_s    = (IppsRSAPublicKeyState*) bn_buf_ptr;
+  bn_buf_ptr   = bn_buf_ptr + sz_rsa;
+  bn_rsa_n     = (IppsBigNumState *) bn_buf_ptr;
+  bn_buf_ptr   = bn_buf_ptr + sz_n;
+  bn_rsa_e     = (IppsBigNumState *) bn_buf_ptr;
+
+  err = ippsBigNumInit(mod_len / sizeof(Ipp32u), bn_rsa_n);
+  if (err != ippStsNoErr) {
+    goto Done;
+  }
+
+  err = ippsSetOctString_BN(rsa_n, mod_len, bn_rsa_n);
+  if (err != ippStsNoErr) {
+    goto Done;
+  }
+
+  err = ippsBigNumInit(RSA_E_SIZE / sizeof(Ipp32u), bn_rsa_e);
+  if (err != ippStsNoErr) {
+    goto Done;
+  }
+
+  err = ippsSetOctString_BN(rsa_e, RSA_E_SIZE, bn_rsa_e);
+  if (err != ippStsNoErr) {
+    goto Done;
+  }
+
+  err = ippsRSA_InitPublicKey(mod_len * 8, RSA_E_SIZE * 8, rsa_key_s, sz_rsa);
+  if (err != ippStsNoErr) {
+    goto Done;
+  }
+
+  err = ippsRSA_SetPublicKey(bn_rsa_n, bn_rsa_e, rsa_key_s);
+  if (err != ippStsNoErr) {
+    goto Done;
+  }
+
+  err =ippsRSA_GetBufferSizePublicKey (&sz_scratch, rsa_key_s);
+  if (err != ippStsNoErr) {
+    goto Done;
+  }
+
+  scratch_buf = AllocateTemporaryMemory (sz_scratch);
+  if (scratch_buf ==  NULL) {
+    goto Done;
+  }
+
+  if ((SignatureHdr->HashAlg == HASH_TYPE_SHA256) &&
+      ((FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_256) != 0)) {
+    pHashMethod = ippsHashMethod_SHA256Sbl();
+  } else if ((SignatureHdr->HashAlg == HASH_TYPE_SHA384) &&
+             ((FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_384) != 0)) {
+    pHashMethod = ippsHashMethod_SHA384Sbl();
+  }
+
+  if (pHashMethod != NULL) {
+    err = ippsRSAVerifyHash_PKCS1v15_rmf((const Ipp8u *)Hash, (Ipp8u *)SignatureHdr->Signature, &signature_verified, rsa_key_s, pHashMethod, scratch_buf);
+  } else {
+    err = ippStsNoOperation;
+  }
+
+  Done:
+    if (scratch_buf) {
+      FreeTemporaryMemory (scratch_buf);
+    }
+    if (bn_buf) {
+      FreeTemporaryMemory (bn_buf);
+    }
+    if (err != ippStsNoErr) {
+      return err;
+    }
+
+  return !signature_verified;
+}
+
+
+/* Wrapper function for RSA PSS verify to make the inferface consistent.
+ * Returns non-zero on failure, 0 on success.
+ */
+int VerifyRsaPssSignature (CONST PUB_KEY_HDR *PubKeyHdr, CONST SIGNATURE_HDR *SignatureHdr,  CONST UINT8  *Src, CONST UINT32  Size)
+{
+  int    sz_n;
+  int    sz_e;
+  int    sz_rsa;
+  int    sz_scratch;
+  int    signature_verified;
+
+  Ipp8u  *rsa_n;
+  Ipp8u  *rsa_e;
+  Ipp16u  mod_len;
+  Ipp8u  *bn_buf;
+  IppsBigNumState *bn_rsa_n;
+  IppsBigNumState *bn_rsa_e;
+  Ipp8u *scratch_buf;
+  IppStatus err;
+  IppsRSAPublicKeyState *rsa_key_s;
+  Ipp8u *bn_buf_ptr;
+  const IppsHashMethod  *pHashMethod = NULL;
+
+  scratch_buf = NULL;
+
+  signature_verified = 0;
+
+  rsa_n = (Ipp8u *) PubKeyHdr->KeyData;
+  rsa_e = (Ipp8u *) PubKeyHdr->KeyData + PubKeyHdr->KeySize - RSA_E_SIZE;
+  mod_len = PubKeyHdr->KeySize - RSA_E_SIZE;
+
+  err = ippsRSA_GetSizePublicKey(mod_len * 8, RSA_E_SIZE * 8, &sz_rsa);
+  if (err != ippStsNoErr) {
+    return err;
+  }
+
+  err = ippsBigNumGetSize(mod_len / sizeof(Ipp32u), &sz_n);
+  if (err != ippStsNoErr) {
+    return err;
+  }
+  err = ippsBigNumGetSize(RSA_E_SIZE / sizeof(Ipp32u), &sz_e);
+  if (err != ippStsNoErr) {
+    return err;
+  }
+
+  // Allign sz
+  sz_rsa = IPP_ALIGNED_SIZE (sz_rsa, sizeof(Ipp32u));
+  sz_n   = IPP_ALIGNED_SIZE (sz_n, sizeof(Ipp32u));
+  sz_e   = IPP_ALIGNED_SIZE (sz_e, sizeof(Ipp32u));
+
+  // Allocate BN Buf
+  bn_buf = AllocateTemporaryMemory (sz_rsa + sz_n + sz_e);
+  if (bn_buf ==  NULL) {
+    return ippStsNoMemErr;
+  }
+
+  bn_buf_ptr   = bn_buf;
+  rsa_key_s    = (IppsRSAPublicKeyState*) bn_buf_ptr;
+  bn_buf_ptr   = bn_buf_ptr + sz_rsa;
+  bn_rsa_n     = (IppsBigNumState *) bn_buf_ptr;
+  bn_buf_ptr   = bn_buf_ptr + sz_n;
+  bn_rsa_e     = (IppsBigNumState *) bn_buf_ptr;
+
+  err = ippsBigNumInit(mod_len / sizeof(Ipp32u), bn_rsa_n);
+  if (err != ippStsNoErr) {
+    goto Done;
+  }
+
+  err = ippsSetOctString_BN(rsa_n, mod_len, bn_rsa_n);
+  if (err != ippStsNoErr) {
+    goto Done;
+  }
+
+  err = ippsBigNumInit(RSA_E_SIZE / sizeof(Ipp32u), bn_rsa_e);
+  if (err != ippStsNoErr) {
+    goto Done;
+  }
+
+  err = ippsSetOctString_BN(rsa_e, RSA_E_SIZE, bn_rsa_e);
+  if (err != ippStsNoErr) {
+    goto Done;
+  }
+
+  err = ippsRSA_InitPublicKey(mod_len * 8, RSA_E_SIZE * 8, rsa_key_s, sz_rsa);
+  if (err != ippStsNoErr) {
+    goto Done;
+  }
+
+  err = ippsRSA_SetPublicKey(bn_rsa_n, bn_rsa_e, rsa_key_s);
+  if (err != ippStsNoErr) {
+    goto Done;
+  }
+
+  err =ippsRSA_GetBufferSizePublicKey (&sz_scratch, rsa_key_s);
+  if (err != ippStsNoErr) {
+    goto Done;
+  }
+
+  scratch_buf = AllocateTemporaryMemory (sz_scratch);
+  if (scratch_buf ==  NULL) {
+    goto Done;
+  }
+
+  if ((SignatureHdr->HashAlg == HASH_TYPE_SHA256)
+          && ((FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_256) != 0)){
+    pHashMethod = ippsHashMethod_SHA256Sbl();
+  } else if ((SignatureHdr->HashAlg == HASH_TYPE_SHA384)
+          && ((FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_384) != 0)){
+     pHashMethod = ippsHashMethod_SHA384Sbl();
+  }
+
+  if (pHashMethod != NULL) {
+    err = ippsRSAVerify_PSS_rmf((const Ipp8u *)Src, Size, (Ipp8u *)SignatureHdr->Signature, &signature_verified, rsa_key_s, pHashMethod, scratch_buf);
+  } else {
+    err = ippStsNoOperation;
+  }
+
+  Done:
+    if (scratch_buf != NULL) {
+      FreeTemporaryMemory (scratch_buf);
+    }
+    if (bn_buf) {
+      FreeTemporaryMemory (bn_buf);
+    }
+    if (err != ippStsNoErr) {
+      return err;
+    }
+
+  return !signature_verified;
+}
+
+/* Wrapper function for RSA PKCS_1.5 Verify to make the inferface consistent.
+ * Returns RETURN_SUCCESS on success, others on failure.
+ */
+RETURN_STATUS
+EFIAPI
+RsaVerify_Pkcs_1_5 (CONST PUB_KEY_HDR *PubKeyHdr, CONST SIGNATURE_HDR *SignatureHdr,  CONST UINT8  *Hash)
+{
+
+  if (FixedPcdGet8(PcdCompSignSchemeSupportedMask) & IPP_RSALIB_PKCS_1_5) {
+    if ((SignatureHdr->SigType != SIGNING_TYPE_RSA_PKCS_1_5) ||
+                    ((SignatureHdr->SigSize != RSA2048_MOD_SIZE) && (SignatureHdr->SigSize != RSA3072_MOD_SIZE))) {
+      return RETURN_INVALID_PARAMETER;
+    } else {
+      return VerifyRsaPkcs1Signature (PubKeyHdr, SignatureHdr, Hash) ? RETURN_SECURITY_VIOLATION : RETURN_SUCCESS ;
+    }
+  } else {
+      return RETURN_UNSUPPORTED;
+  }
+}
+
+
+/* Wrapper function for RSA-PSS verify to make the inferface consistent.
+ * Returns RETURN_SUCCESS on success, others on failure.
+ */
+RETURN_STATUS
+EFIAPI
+RsaVerify_PSS (CONST PUB_KEY_HDR *PubKeyHdr, CONST SIGNATURE_HDR *SignatureHdr,  CONST UINT8  *Src, CONST UINT32 SrcSize)
+{
+
+  if (FixedPcdGet8(PcdCompSignSchemeSupportedMask) & IPP_RSALIB_PSS) {
+    if ((SignatureHdr->SigType != SIGNING_TYPE_RSA_PSS) ||
+                    ((SignatureHdr->SigSize != RSA2048_MOD_SIZE) && (SignatureHdr->SigSize != RSA3072_MOD_SIZE))) {
+      return RETURN_INVALID_PARAMETER;
+    } else {
+      return VerifyRsaPssSignature (PubKeyHdr, SignatureHdr, Src, SrcSize) ? RETURN_SECURITY_VIOLATION : RETURN_SUCCESS ;
+    }
+  } else {
+      return RETURN_UNSUPPORTED;
+  }
+}
+

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/sha256.c
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/sha256.c
@@ -1,0 +1,162 @@
+/** @file
+
+  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+
+#include "owndefs.h"
+#include "owncp.h"
+#include "pcphash.h"
+#include "pcptool.h"
+#include "pcphash_rmf.h"
+#include "pcpsha256stuff.h"
+
+#include <Library/CryptoLib.h>
+#include <Library/DebugLib.h>
+
+/**
+  Initializes user context for hash computation. Compaitable with XIP.
+
+  @retval                  Pointer to SHA256 hash-method.
+**/
+IPPFUN( const IppsHashMethod*, ippsHashMethod_SHA256Sbl, (void) )
+{
+   static IppsHashMethod method = {
+      ippHashAlg_SHA256,
+      IPP_SHA256_DIGEST_BITSIZE/8,
+      MBS_SHA256,
+      MLR_SHA256,
+      sha256_hashInit,
+#if (_IPP32E >= _IPP32E_Y8) && (_IPP32E < _IPP32E_E9)
+      sha256_ni_hashUpdate,
+#else
+      sha256_hashUpdate,
+#endif
+      sha256_hashOctString,
+      sha256_msgRep
+   };
+   return &method;
+}
+
+/**
+  Computes the SHA-256 message digest of a input data buffer.
+
+  This function performs the SHA-256 message digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  @param[in]   pMsg        Pointer to the buffer containing the data to be hashed.
+  @param[in]   msgLen      Length of Data buffer in bytes.
+  @param[out]  pMD         Pointer to a buffer that receives the SHA-256 digest
+                           value (32 bytes).
+
+  @retval                  A pointer to SHA-256 digest value
+**/
+Ipp8u*
+EFIAPI
+Sha256 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
+{
+  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_256) {
+
+    ippsHashMessage_rmf(pMsg, msgLen, pMD, ippsHashMethod_SHA256Sbl ());
+    return pMD;
+
+  } else {
+    pMD = NULL;
+    return pMD;
+  }
+}
+
+/**
+  Initializes the hash context for SHA256 hashing.
+
+  @param[in]   HashCtx       Pointer to the hash context buffer.
+  @param[in]   HashCtxSize   Length of the hash context.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_BUFFER_TOO_SMALL    Hash context buffer size is not large enough.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+EFIAPI
+Sha256Init (
+  IN      HASH_CTX   *HashCtx,
+  IN      Ipp32u      HashCtxSize
+  )
+{
+  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_256) {
+    if (HashCtxSize < sizeof(IppsHashState_rmf)) {
+      return RETURN_BUFFER_TOO_SMALL;
+    }
+
+    if (ippsHashInit_rmf((IppsHashState_rmf*)HashCtx, ippsHashMethod_SHA256Sbl ()) == ippStsNoErr) {
+      return RETURN_SUCCESS;
+    }
+
+    return RETURN_SECURITY_VIOLATION;
+
+  } else {
+    return RETURN_UNSUPPORTED;
+  }
+}
+
+/**
+  Consumes the data for SHA256 hashing.
+  This method can be called multiple times to hash separate pieces of data.
+
+  @param[in]   HashCtx     Pointer to the hash context buffer.
+  @param[in]   Msg         Data to be hashed.
+  @param[in]   MsgLen      Length of data to be hashed.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+EFIAPI
+Sha256Update (
+  IN        HASH_CTX   *HashCtx,
+  IN CONST  Ipp8u      *Msg,
+  IN        Ipp32u      MsgLen
+  )
+{
+  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_256) {
+    if (ippsHashUpdate_rmf(Msg, MsgLen, (IppsHashState_rmf*)HashCtx) == ippStsNoErr) {
+      return RETURN_SUCCESS;
+    }
+
+    return RETURN_SECURITY_VIOLATION;
+
+  }  else {
+    return RETURN_UNSUPPORTED;
+  }
+}
+
+
+/**
+  Finalizes the SHA256 hashing and returns the hash.
+
+  @param[in]   HashCtx     Pointer to the hash context buffer.
+  @param[out]  Hash        Sha256 hash of the data.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+EFIAPI
+Sha256Final (
+  IN       HASH_CTX   *HashCtx,
+  OUT      Ipp8u      *Hash
+  )
+{
+  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_256) {
+    if (ippsHashFinal_rmf(Hash, (IppsHashState_rmf*)HashCtx) == ippStsNoErr) {
+      return RETURN_SUCCESS;
+    }
+
+    return RETURN_SECURITY_VIOLATION;
+
+  } else {
+    return RETURN_UNSUPPORTED;
+  }
+}

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/sha384.c
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/sha384.c
@@ -1,0 +1,157 @@
+/** @file
+
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+
+#include "owndefs.h"
+#include "owncp.h"
+#include "pcphash.h"
+#include "pcptool.h"
+#include "pcphash_rmf.h"
+#include "pcpsha512stuff.h"
+
+#include <Library/CryptoLib.h>
+#include <Library/DebugLib.h>
+
+/**
+  Initializes user context for hash computation. Compaitable with XIP.
+
+  @retval                  Pointer to SHA384 hash-method.
+**/
+IPPFUN( const IppsHashMethod*, ippsHashMethod_SHA384Sbl, (void) )
+{
+   static IppsHashMethod method = {
+      ippHashAlg_SHA384,
+      IPP_SHA384_DIGEST_BITSIZE/8,
+      MBS_SHA512,
+      MLR_SHA512,
+      sha512_384_hashInit,
+      sha512_hashUpdate,
+      sha512_384_hashOctString,
+      sha512_msgRep
+   };
+   return &method;
+}
+
+/**
+  Computes the SHA-384 message digest of a input data buffer.
+
+  This function performs the SHA-384 message digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  @param[in]   pMsg        Pointer to the buffer containing the data to be hashed.
+  @param[in]   msgLen      Length of Data buffer in bytes.
+  @param[out]  pMD         Pointer to a buffer that receives the SHA-384 digest
+                           value (48 bytes).
+
+  @retval                  A pointer to SHA-384 digest value
+**/
+Ipp8u*
+EFIAPI
+Sha384 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
+{
+  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_384) {
+    ippsHashMessage_rmf(pMsg, msgLen, pMD, ippsHashMethod_SHA384Sbl ());
+    return pMD;
+
+  } else {
+    pMD = NULL;
+    return pMD;
+  }
+}
+
+/**
+  Initializes the hash context for SHA384 hashing.
+
+  @param[in]   HashCtx       Pointer to the hash context buffer.
+  @param[in]   HashCtxSize   Length of the hash context.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_BUFFER_TOO_SMALL    Hash context buffer size is not large enough.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+EFIAPI
+Sha384Init (
+  IN      HASH_CTX   *HashCtx,
+  IN      Ipp32u      HashCtxSize
+  )
+{
+  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_384) {
+    if (HashCtxSize < sizeof(IppsHashState_rmf)) {
+      return RETURN_BUFFER_TOO_SMALL;
+    }
+
+    if (ippsHashInit_rmf((IppsHashState_rmf*)HashCtx, ippsHashMethod_SHA384Sbl ()) == ippStsNoErr) {
+      return RETURN_SUCCESS;
+    }
+
+    return RETURN_SECURITY_VIOLATION;
+
+  } else {
+    return RETURN_UNSUPPORTED;
+  }
+}
+
+/**
+  Consumes the data for SHA384 hashing.
+  This method can be called multiple times to hash separate pieces of data.
+
+  @param[in]   HashCtx     Pointer to the hash context buffer.
+  @param[in]   Msg         Data to be hashed.
+  @param[in]   MsgLen      Length of data to be hashed.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+EFIAPI
+Sha384Update (
+  IN        HASH_CTX   *HashCtx,
+  IN CONST  Ipp8u      *Msg,
+  IN        Ipp32u      MsgLen
+  )
+{
+  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_384) {
+    if (ippsHashUpdate_rmf(Msg, MsgLen, (IppsHashState_rmf*)HashCtx) == ippStsNoErr) {
+      return RETURN_SUCCESS;
+    }
+
+    return RETURN_SECURITY_VIOLATION;
+
+  } else {
+      return RETURN_UNSUPPORTED;
+  }
+}
+
+
+/**
+  Finalizes the SHA384 hashing and returns the hash.
+
+  @param[in]   HashCtx     Pointer to the hash context buffer.
+  @param[out]  Hash        Sha384 hash of the data.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+EFIAPI
+Sha384Final (
+  IN       HASH_CTX   *HashCtx,
+  OUT      Ipp8u      *Hash
+  )
+{
+  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SHA2_384) {
+    if (ippsHashFinal_rmf(Hash, (IppsHashState_rmf*)HashCtx) == ippStsNoErr) {
+      return RETURN_SUCCESS;
+    }
+
+    return RETURN_SECURITY_VIOLATION;
+
+  } else {
+    return RETURN_UNSUPPORTED;
+  }
+}

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/sm3.c
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/sm3.c
@@ -1,0 +1,160 @@
+/** @file
+
+  Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+
+#include "owndefs.h"
+#include "owncp.h"
+#include "pcphash.h"
+#include "pcptool.h"
+#include "pcphash_rmf.h"
+#include "pcpsm3stuff.h"
+
+#include <Library/CryptoLib.h>
+
+/**
+  Initializes user context for hash computation. Compaitable with XIP.
+
+  @retval                  Pointer to SM3 hash-method.
+**/
+IPPFUN( const IppsHashMethod*, ippsHashMethod_SM3Sbl, (void) )
+{
+   static IppsHashMethod method = {
+      ippHashAlg_SM3,
+      IPP_SM3_DIGEST_BITSIZE/8,
+      MBS_SM3,
+      MLR_SM3,
+      sm3_hashInit,
+#if (_IPP32E >= _IPP32E_L9)
+      sm3_hashUpdate_ni,
+#else
+      sm3_hashUpdate,
+#endif
+      sm3_hashOctString,
+      sm3_msgRep
+   };
+   return &method;
+}
+
+/**
+  Computes the SM3 message digest of a input data buffer.
+
+  This function performs the SM3 message digest of a given data buffer, and places
+  the digest value into the specified memory.
+
+  @param[in]   pMsg        Pointer to the buffer containing the data to be hashed.
+  @param[in]   msgLen      Length of Data buffer in bytes.
+  @param[out]  pMD         Pointer to a buffer that receives the SM3 digest
+                           value (32 bytes).
+
+  @retval                  A pointer to SM3 digest value
+**/
+Ipp8u*
+EFIAPI
+Sm3 (const Ipp8u* pMsg, Ipp32u msgLen, Ipp8u* pMD)
+{
+  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SM3_256) {
+    ippsHashMessage_rmf(pMsg, msgLen, pMD, ippsHashMethod_SM3Sbl ());
+    return pMD;
+
+  } else {
+    pMD = NULL;
+    return pMD;
+  }
+
+}
+
+/**
+  Initializes the hash context for Sm3 hashing.
+
+  @param[in]   HashCtx       Pointer to the hash context buffer.
+  @param[in]   HashCtxSize   Length of the hash context.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_BUFFER_TOO_SMALL    Hash context buffer size is not large enough.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+EFIAPI
+Sm3Init (
+  IN      HASH_CTX   *HashCtx,
+  IN      Ipp32u      HashCtxSize
+  )
+{
+  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SM3_256) {
+    if (HashCtxSize < sizeof(IppsHashState_rmf)) {
+      return RETURN_BUFFER_TOO_SMALL;
+    }
+
+    if (ippsHashInit_rmf((IppsHashState_rmf*)HashCtx, ippsHashMethod_SM3Sbl ()) == ippStsNoErr) {
+      return RETURN_SUCCESS;
+    }
+
+    return RETURN_SECURITY_VIOLATION;
+
+  } else {
+    return RETURN_UNSUPPORTED;
+  }
+}
+
+/**
+  Consumes the data for Sm3 hashing.
+  This method can be called multiple times to hash separate pieces of data.
+
+  @param[in]   HashCtx     Pointer to the hash context buffer.
+  @param[in]   Msg         Data to be hashed.
+  @param[in]   MsgLen      Length of data to be hashed.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+EFIAPI
+Sm3Update (
+  IN        HASH_CTX   *HashCtx,
+  IN CONST  Ipp8u      *Msg,
+  IN        Ipp32u      MsgLen
+  )
+{
+
+  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SM3_256) {
+    if (ippsHashUpdate_rmf(Msg, MsgLen, (IppsHashState_rmf*)HashCtx) == ippStsNoErr) {
+      return RETURN_SUCCESS;
+    }
+
+    return RETURN_SECURITY_VIOLATION;
+  } else {
+    return RETURN_UNSUPPORTED;
+  }
+}
+
+
+/**
+  Finalizes the Sm3 hashing and returns the hash.
+
+  @param[in]   HashCtx     Pointer to the hash context buffer.
+  @param[out]  Hash        Sm3 hash of the data.
+
+  @retval  RETURN_SUCCESS             Success.
+  @retval  RETURN_SECURITY_VIOLATION  All other errors.
+**/
+RETURN_STATUS
+EFIAPI
+Sm3Final (
+  IN       HASH_CTX   *HashCtx,
+  OUT      Ipp8u      *Hash
+  )
+{
+  if (FixedPcdGet8(PcdIppHashLibSupportedMask) & IPP_HASHLIB_SM3_256) {
+    if (ippsHashFinal_rmf(Hash, (IppsHashState_rmf*)HashCtx) == ippStsNoErr) {
+      return RETURN_SUCCESS;
+    }
+
+    return RETURN_SECURITY_VIOLATION;
+  } else {
+    return RETURN_UNSUPPORTED;
+  }
+}

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/stdlib.h
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/stdlib.h
@@ -1,0 +1,11 @@
+/** @file
+  Include file to support building the Intel IPPCrypto library.
+
+Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+// Dummy include file needed to use Slim Bootloader definitions for any code looking for stdlib.h
+
+#include <IppCryptoSupport.h>

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/x86intrin.h
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/x86intrin.h
@@ -1,0 +1,8 @@
+/** @file
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+// Dummy include file needed to resolve GCC build errors

--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -84,6 +84,11 @@ IPP_CRYPTO_OPTIMIZATION_MASK = {
     "SHA256_NI"       : 0x0002,
     "SHA384_W7"       : 0x0004,
     "SHA384_G9"       : 0x0008,
+    "X64_M7"          : 0x0020, # SSE3
+    "X64_U8"          : 0x0040, # SSSE3
+    "X64_Y8"          : 0x0080, # SSE4.2
+    "X64_E9"          : 0x0100, # AVX
+    "X64_L9"          : 0x0200, # AVX2
     }
 
 IPP_CRYPTO_ALG_MASK = {


### PR DESCRIPTION
Latest ipp-crytpo code is FIPS compliant. Need to add it as a submodule to maintain FIPS compliance. This requires adding each ASM optimized implementation as a separate .inf file and selecting at the platform level. Old IppCryptoLib instance needs to be kept for backwards compatibility.