### PR TITLE
fix: [ADLN] Revert reference lib in PchPcrLib

### DIFF
--- a/Silicon/CommonSocPkg/Library/PchPcrLib/PchPcrLib.inf
+++ b/Silicon/CommonSocPkg/Library/PchPcrLib/PchPcrLib.inf
@@ -32,5 +32,6 @@
   IoLib
   DebugLib
   PchInfoLib
+  GpioSiLib
 
 [Pcd]


### PR DESCRIPTION
Resolve the GetPchPcrAddress reference when build with CSME update driver.