### PR TITLE
fix: [common] Fix Coverity issue

### DIFF
--- a/MdePkg/Library/BaseFdtLib/libfdt/libfdt/fdt_overlay.c
+++ b/MdePkg/Library/BaseFdtLib/libfdt/libfdt/fdt_overlay.c
@@ -557,6 +557,8 @@ static int overlay_apply_node(void *fdt, int target,
             return -FDT_ERR_INTERNAL;
         if (prop_len < 0)
             return prop_len;
+        if (!prop)
+            return -FDT_ERR_INTERNAL;
 
         ret = fdt_setprop(fdt, target, name, prop, prop_len);
         if (ret)


### PR DESCRIPTION
Check fdt_getprop_by_offset() return value for NULL pointer (like all other callers) to prevent a Coverity issue (CWE-476).