### PR TITLE
fix: [IPPCRYPTO] Fix Coverity issue

### DIFF
--- a/BootloaderCommonPkg/Library/IppCryptoPerfLib/IppCryptoPerfLib.c
+++ b/BootloaderCommonPkg/Library/IppCryptoPerfLib/IppCryptoPerfLib.c
@@ -112,6 +112,7 @@ VOID EFIAPI CryptoPerfTestPrintResult (
     ShellPrint (L" Usecase                          | Delta (µs)      \n");
     ShellPrint (L"----------------------------------+----------------+\n");
 
+    TimeStamp1 = 0;
     for (Index = 0; Index < PerfData->PerfIndex; Index++) {
         Id = ((UINT16 *)&(PerfData->TimeStamp[Index]))[3];
         if ((Id & 0xF000) == CRYPTO_MEASURE_POINT_ID) {


### PR DESCRIPTION
Initialize the TimeStamp1 variable to prevent a Coverity issue (CWE-457).