### PR TITLE
feat: [ADLN] expose the FSP-S .ScsEmmcEnable UPD option to SBL config…

### DIFF
--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -367,6 +367,13 @@
                      Enable/Disable UFS controllers 1 and 2. 0- Disable; 1- Enable.
       length       : 0x02
       value        : {0x00, 0x00}
+  - PchEmmcEnable :
+      name         : Enable PCH eMMC
+      type         : EditNum, HEX, (0x0, 0x1)
+      help         : >
+                     Enable/Disable eMMC controller. 0- Disable; 1- Enable.
+      length       : 0x01
+      value        : 0x01
   - PchIshI2cEnable :
       condition    : $(COND_S0IX_DIS)
       name         : Enable PCH ISH I2C pins assigned

--- a/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -610,6 +610,9 @@ UpdateFspConfig (
     if (IsPchLp ()) {
       FspsConfig->UfsEnable[0] = SiCfgData->PchUfsEnable[0];
       FspsConfig->UfsEnable[1] = SiCfgData->PchUfsEnable[1];
+#if defined(PLATFORM_ADLN)
+      FspsConfig->ScsEmmcEnabled = SiCfgData->PchEmmcEnable;
+#endif
     }
 
     // When fast boot is enabled, program SLP_A_MIN_ASST_WDTH to 0


### PR DESCRIPTION
…uration

The FSP-S UPD has an option .ScsEmmcEnable that cannot be modified from SBL configuration.  This change adds the SILICON_CFG_DATA.PchEmmcEnable option to set the UPD value. (Default setting is enabled as before).