### PR TITLE
fix: [ARL-S] Workaround for windows boot delay

### DIFF
--- a/Platform/ArrowlakeBoardPkg/AcpiTables/EcSsdt/EcBaseMethod.asl
+++ b/Platform/ArrowlakeBoardPkg/AcpiTables/EcSsdt/EcBaseMethod.asl
@@ -37,7 +37,7 @@ Method (ECRD, 1, Serialized, 0, IntObj, FieldUnitObj)
     }
     Store (Zero, ECTK)   // Clear flag for checking once only
   }
-
+  Sleep(3) // WA - for slow windows boot
   Store (Acquire (ECMT, 1000), Local0)  // save Acquire result so we can check for Mutex acquired
   If (LEqual (Local0, Zero))  // check for Mutex acquired
   {


### PR DESCRIPTION
Adding a 3ms delay before any EC Read from ACPI resolves the windows boot delay. Still following up on root cause.