### PR TITLE
fix: [Common] Assign PCI_MAX_BUS to BusLimit for BusScanTypeList type

### DIFF
--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
@@ -1705,7 +1705,7 @@ PciScanRootBridges (
   // Use PCI_MAX_BUS if the enum policy has no multiple buses.
   //
   BusLimit = PCI_MAX_BUS;
-  if (EnumPolicy->NumOfBus > 1) {
+  if ((EnumPolicy->BusScanType == BusScanTypeRange) && (EnumPolicy->NumOfBus > 1)) {
     if (StartIndex != EndIndex) {
       BusLimit = EnumPolicy->BusScanItems[EnumPolicy->NumOfBus - 1];
     }


### PR DESCRIPTION
When platform chooses BusScanTypeList for PCI enumeration, the BusLimit should be set to PCI_MAX_BUS. The BusScanItems defines primary bus for PCie root port. If there is device attached to root port, which will present on secondary bus, in the meantime the bus number is greater than Buslimit, this device cannot be found from enumeration. Assign PCI_MAX_BUS to BusLimit to prevent this issue.