### PR TITLE
Fix source level debug in X64

### DIFF
--- a/BootloaderCommonPkg/Library/DebugAgentLib/DebugTimer.c
+++ b/BootloaderCommonPkg/Library/DebugAgentLib/DebugTimer.c
@@ -80,6 +80,12 @@ SaveAndSetDebugTimerInterrupt (
 {
   BOOLEAN     OldDebugTimerInterruptState;
 
+  // Disable timer interrupt to avoid #SS exception in 64bit mode.
+  // This would not impact source level debug feature.
+  if (sizeof(UINTN) == 8) {
+    EnableStatus = FALSE;
+  }
+
   OldDebugTimerInterruptState = GetApicTimerInterruptState ();
 
   if (OldDebugTimerInterruptState != EnableStatus) {


### PR DESCRIPTION
In X64 build, an stack segment exception was seen when debug timer interrupt is enabled.
Just disable interrupt to WA this issue.