### PR TITLE
fix: [MTL-P] EC timeout issues/ACPI error on RVP.

### DIFF
--- a/Platform/MeteorlakeBoardPkg/AcpiTables/EcSsdt/Devices/Bat0Virt.asl
+++ b/Platform/MeteorlakeBoardPkg/AcpiTables/EcSsdt/Devices/Bat0Virt.asl
@@ -18,15 +18,6 @@ Device (BAT0)
 
   Method (_STA, 0)
   {
-    If (And (BATP, BIT1))   // Virtual Battery is supported.
-    {
-      If (And (BNUM, 3))   // Real Battery 1 or 2 present?
-      {
-        Return (0x000B)  // Yes.  Hide Virtual.
-      } Else {
-        Return (0x001F)    // No.  Show Virtual.
-      }
-    }
     Return (0)
   }
 

--- a/Platform/MeteorlakeBoardPkg/AcpiTables/EcSsdt/Devices/Bat1Real.asl
+++ b/Platform/MeteorlakeBoardPkg/AcpiTables/EcSsdt/Devices/Bat1Real.asl
@@ -7,7 +7,6 @@
 
 External (\_SB.PC00.LPCB.H_EC.B1FC, FieldUnitObj)
 External (\_SB.PC00.LPCB.H_EC.B1RC, FieldUnitObj)
-External (\BATP, IntObj)
 
 //
 // Define the Real Battery 1 Control Method.
@@ -17,13 +16,6 @@ Device (BAT1) {
   Name (_UID, 1)
 
   Method (_STA, 0) {
-    If (And (BATP, BIT0)) {  // Battery is supported.
-      If (And (BNUM, BIT0)) { // Real Battery 1 present?
-        Return (0x001F)  // Yes.  Show it.
-      } Else {
-        Return (0x000B)    // No.  Hide it.
-      }
-    }
     Return (0)
   }
 

--- a/Platform/MeteorlakeBoardPkg/AcpiTables/EcSsdt/EcDevice.asl
+++ b/Platform/MeteorlakeBoardPkg/AcpiTables/EcSsdt/EcDevice.asl
@@ -20,7 +20,7 @@ Device (H_EC) {
   //
   // Devices under H_EC scope
   //
-  //Include ("Devices/Als.asl")
+  Include ("Devices/Als.asl")
   Include ("Devices/Bat0Virt.asl")
   Include ("Devices/Bat1Real.asl")
   Include ("Devices/Lid0.asl")
@@ -29,4 +29,3 @@ Device (H_EC) {
   Include ("Devices/ConvertibleIndicator.asl")
   Include ("Devices/DockingIndicator.asl")
 }
-

--- a/Platform/MeteorlakeBoardPkg/AcpiTables/EcSsdt/EcNvs.asl
+++ b/Platform/MeteorlakeBoardPkg/AcpiTables/EcSsdt/EcNvs.asl
@@ -1,0 +1,37 @@
+/**@file
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+  // Define a Global region of ACPI NVS Region that may be used for any
+  // type of implementation.  The starting offset and size will be fixed
+  // up by the System BIOS during POST.  Note that the Size must be a word
+  // in size to be fixed up correctly.
+
+  OperationRegion (ENVS, SystemMemory, 0xFFFF0000, 0xAA55)
+  Field (ENVS, AnyAcc, Lock, Preserve)
+  {  Offset(0),      IUBE, 8,  // Offset(0),     IUER Button Enable
+  Offset(1),      IUCE, 8,  // Offset(1),     IUER Convertible Enable
+  Offset(2),      IUDE, 8,  // Offset(2),     IUER Dock Enable
+  Offset(3),      ECNO, 8,  // Offset(3),     EC Notification of Low Power S0 Idle State
+  Offset(4),      ECLP, 8,  // Offset(4),     EC Low Power Mode: 1 - Enabled, 0 - Disabled
+  Offset(5),      BATS, 8,  // Offset(5),     Battery Support - Bit0: Real Battery is supported on this platform. Bit1: Virtual Battery is supported on this platform.
+  Offset(6),      EHK3, 8,  // Offset(6),     Ec Hotkey F3 Support
+  Offset(7),      EHK4, 8,  // Offset(7),     Ec Hotkey F4 Support
+  Offset(8),      EHK5, 8,  // Offset(8),     Ec Hotkey F5 Support
+  Offset(9),      EHK6, 8,  // Offset(9),     Ec Hotkey F6 Support
+  Offset(10),     EHK7, 8,  // Offset(10),    Ec Hotkey F7 Support
+  Offset(11),     EHK8, 8,  // Offset(11),    Ec Hotkey F8 Support
+  Offset(12),     VBVP, 8,  // Offset(12),    Virtual Button Volume Up Support
+  Offset(13),     VBVD, 8,  // Offset(13),    Virtual Button Volume Down Support
+  Offset(14),     VBHB, 8,  // Offset(14),    Virtual Button Home Button Support
+  Offset(15),     VBRL, 8,  // Offset(15),    Virtual Button Rotation Lock Support
+  Offset(16),     SMSS, 8,  // Offset(16),    Slate Mode Switch Support
+  Offset(17),     ADAS, 8,  // Offset(17),    Ac Dc Auto Switch Support
+  Offset(18),     PPBG, 32, // Offset(18),    Pm Power Button Gpio Pin
+  Offset(22),     EGPE, 32, // Offset(22),    Ecdt GPE bit value
+  Offset(26),     LSWP, 32, // Offset(26),    Lid Switch Wake Gpio
+  Offset(30),     PGED, 8,  // Offset(30),    Pseudo G3 counter Enable/Disable
+  Offset(31),     EBTP, 8,  // Offset(31),    Enable battery _BTP support
+  }

--- a/Platform/MeteorlakeBoardPkg/AcpiTables/EcSsdt/EcSsdt.asl
+++ b/Platform/MeteorlakeBoardPkg/AcpiTables/EcSsdt/EcSsdt.asl
@@ -18,7 +18,7 @@ DefinitionBlock (
   If (LEqual(\ECON,1)){
     External (\_SB.PC00.LPCB, DeviceObj)
     External (\_SB.HIDD, DeviceObj)
-
+    Include ("EcNvs.asl")
     Scope (\_SB.PC00.LPCB) {
       Include ("EcDevice.asl")
     }

--- a/Platform/MeteorlakeBoardPkg/AcpiTables/Ecdt/Ecdt.act
+++ b/Platform/MeteorlakeBoardPkg/AcpiTables/Ecdt/Ecdt.act
@@ -73,7 +73,7 @@ EFI_ACPI_EMBEDDED_CONTROLLER_BOOT_RESOURCES_ENTIRE_TABLE Ecdt = {
     },
 
     1, // UID
-    0  // GPE_BIT
+    0x6E  // GPE_BIT
   },
   "\\_SB.PC00.LPCB.H_EC" //EC_ID
 };

--- a/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1140,6 +1140,26 @@ PlatformUpdateAcpiTable (
     }
   }
 
+  //
+  // EC SSDT
+  //
+  if (Table->Signature == EFI_ACPI_6_4_SECONDARY_SYSTEM_DESCRIPTION_TABLE_SIGNATURE &&
+      Table->OemTableId == SIGNATURE_64 ('E', 'c', 'S', 's', 'd', 't', ' ', 0)) {
+    DEBUG((DEBUG_INFO, "Found EcSsdt\n"));
+    for (; Ptr < End; Ptr++) {
+      if (*(UINT32 *)Ptr == SIGNATURE_32 ('E','N','V','S')) {
+        Base = (UINT32) (UINTN) &GlobalNvs->EcNvs;
+        DEBUG ((DEBUG_INFO, "ENVS Base Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 6), Base));
+        *(UINT32 *)(Ptr + 6) = Base;
+
+        Size = sizeof (EC_NVS_AREA);
+        DEBUG ((DEBUG_INFO, "ENVS Size Old=0x%04X New=0x%04X\n", *(UINT16 *)(Ptr + 11), Size));
+        *(UINT16 *)(Ptr + 11) = Size;
+        break;
+      }
+    }
+  }
+
   return EFI_SUCCESS;
 }
 
@@ -1371,7 +1391,6 @@ PlatformUpdateAcpiGnvs (
   CPU_NVS_AREA            *CpuNvs;
   SYSTEM_AGENT_NVS_AREA   *SaNvs;
   SYS_CPU_INFO            *SysCpuInfo;
-  EC_NVS_AREA             *EcNvs;
   DPTF_NVS_AREA           *DptfNvs;
   FSPS_UPD                *FspsUpd;
   FSP_S_CONFIG            *FspsConfig;
@@ -1390,7 +1409,6 @@ PlatformUpdateAcpiGnvs (
   PlatformNvs = (PLATFORM_NVS_AREA *) &GlobalNvs->PlatformNvs;
   PchNvs      = (PCH_NVS_AREA *) &GlobalNvs->PchNvs;
   CpuNvs      = (CPU_NVS_AREA *) &GlobalNvs->CpuNvs;
-  EcNvs       = (EC_NVS_AREA  *) &GlobalNvs->EcNvs;
   DptfNvs     = (DPTF_NVS_AREA*) &GlobalNvs->DptfNvs;
   SaNvs       = (SYSTEM_AGENT_NVS_AREA *) &GlobalNvs->SaNvs;
   FspsUpd     = (FSPS_UPD *)(UINTN)PcdGet32 (PcdFspsUpdPtr);
@@ -1787,7 +1805,7 @@ PlatformUpdateAcpiGnvs (
   PlatformNvs->WwanFwFlashDevice = 0;
   PlatformNvs->XdciFnEnable = 1;
 
-  EcNvs->LidSwitchWakeGpio = GPIOV2_MTL_SOC_M_GPP_V2;
+  //EcNvs->LidSwitchWakeGpio = GPIOV2_MTL_SOC_M_GPP_V2;
   PlatformNvs->HidEventFilterEnable         = 0x01;
   PlatformNvs->Rtd3Support = 0x1;
   PlatformNvs->Rtd3P0dl = 0x64;

--- a/Silicon/MeteorlakePkg/Include/EcNvsAreaDef.h
+++ b/Silicon/MeteorlakePkg/Include/EcNvsAreaDef.h
@@ -33,6 +33,7 @@ typedef struct {
   UINT32   EcdtGpeNumber;                           ///< Offset 22      Ecdt GPE bit value
   UINT32   LidSwitchWakeGpio;                       ///< Offset 26      Lid Switch Wake Gpio
   UINT8    PseudoG3StateCounter;                    ///< Offset 30      Pseudo G3 counter Enable/Disable
+  UINT8    EnableBTP;                               ///< Offset 31      Enable battery _BTP support
 } EC_NVS_AREA;
 
 #pragma pack(pop)


### PR DESCRIPTION
Windows system log will report Event 13, ACPI error several times and cause windows slow booting issue.

This patch contains:
1. EC data can't be read/updated.
2. fixed ACPI error in Linux system
3. Include NVS def and sync NVS definition. Without this, the EC ACPI device is disappear in windows.