### PR TITLE
fix:[AZB] Fix USB drive detection issue on CRB

### DIFF
--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_BootOption_Azb.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_BootOption_Azb.yaml
@@ -11,10 +11,9 @@
 - $ACTION      :
     page         : OS
 # usb
-- !expand { BOOT_OPTION_TMPL : [ 0 ,   0       ,  0 ,    5   ,   0   ,    0xFF  ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 1 ,   0       ,  0 ,    5   ,   1   ,    0xFF  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 0 ,   0       ,  0 ,    5   ,   1   ,    0xFF  ,     1 ,     1 , '/boot/sbl_os' ] }
 # nvme
-- !expand { BOOT_OPTION_TMPL : [ 2 ,   0       ,  0 ,    6   ,   0   ,    0x0   ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 3 ,   0       ,  0 ,    6   ,   1   ,    0x0   ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 1 ,   0       ,  0 ,    6   ,   0   ,    0x0   ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 2 ,   0       ,  0 ,    6   ,   1   ,    0x0   ,     1 ,     1 , '/boot/sbl_os' ] }
 # ufs
-- !expand { BOOT_OPTION_TMPL : [ 4 ,   0       ,  0 ,    3   ,   1   ,    0x0   ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 3 ,   0       ,  0 ,    3   ,   1   ,    0x0   ,     1 ,     1 , '/boot/sbl_os' ] }

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -78,6 +78,7 @@
   CrashLogLib
   FusaConfigLib
   PciSegmentLib
+  MediaAccessLib
 
 [Guids]
   gOsConfigDataGuid


### PR DESCRIPTION
Resolved hardware issue where USB instance 0, mapped to eMMC, needs initialization and deinitialization to detect a USB flash drive.