### PR TITLE
fix: [COMMON] build KeyHash Hob only when Verified Boot is enabled

### DIFF
--- a/BootloaderCorePkg/Stage2/Stage2Hob.c
+++ b/BootloaderCorePkg/Stage2/Stage2Hob.c
@@ -359,7 +359,7 @@ BuildBaseInfoHob (
   }
 
   // Build key hash Hob for Payload
-  if (LdrGlobal->HashStorePtr != NULL) {
+  if (FeaturePcdGet(PcdVerifiedBootEnabled) && LdrGlobal->HashStorePtr != NULL) {
 
     HashStorePtr = (HASH_STORE_TABLE *)LdrGlobal->HashStorePtr;
     HashHob      = BuildGuidHob (&gPayloadKeyHashGuid, HashStorePtr->UsedLength);


### PR DESCRIPTION
If Verified Boot is disabled, the data pointed by HashStorePtr is not well-defined, so is the content of the KeyHash Hob. In this case, when fwupdate tries to verify the PUBKEY_FWU hash of the FwuImage, the result will be non-deterministic.