### PR TITLE
feat: [ADLN] Expose FSP-M .PchHdaAudioLinkSspEnable UPD to SBL config

### DIFF
--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_Memory.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_Memory.yaml
@@ -437,6 +437,13 @@
                      Determines DMIC<N> Clock Source. 0- Both, 1- ClkA, 2- ClkB
       length       : 0x0002
       value        : {0x01, 0x01}
+  - PchHdaAudioLinkSspEnable :
+      name         : Enable HD Audio SSP0 Link
+      type         : EditNum, HEX, (0x00, 0xFFFFFFFFFFFF)
+      help         : >
+                     Enable/disable HD Audio SSP_N/I2S link. Muxed with HDA. N-number 0-5
+      length       : 0x06
+      value        : { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }
   - PchHdaAudioLinkSndwEnable :
       name         : Enable HD Audio SoundWire#N Link
       type         : EditNum, HEX, (0x0, 0xFFFFFFFF)

--- a/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -317,6 +317,9 @@ UpdateFspConfig (
   CopyMem (Fspmcfg->PchHdaAudioLinkDmicEnable, MemCfgData->PchHdaAudioLinkDmicEnable, sizeof(MemCfgData->PchHdaAudioLinkDmicEnable));
   Fspmcfg->PchHdaAudioLinkDmicClockSelect[0] = MemCfgData->PchHdaAudioLinkDmicClockSelect[0];
   Fspmcfg->PchHdaAudioLinkDmicClockSelect[1] = MemCfgData->PchHdaAudioLinkDmicClockSelect[1];
+#if defined(PLATFORM_ADLN)
+  CopyMem (Fspmcfg->PchHdaAudioLinkSspEnable,  MemCfgData->PchHdaAudioLinkSspEnable,  sizeof(MemCfgData->PchHdaAudioLinkSspEnable));
+#endif
   CopyMem (Fspmcfg->PchHdaAudioLinkSndwEnable, MemCfgData->PchHdaAudioLinkSndwEnable, sizeof(MemCfgData->PchHdaAudioLinkSndwEnable));
   Fspmcfg->PchHdaIDispLinkTmode              = MemCfgData->PchHdaIDispLinkTmode;
   Fspmcfg->PchHdaIDispLinkFrequency   = MemCfgData->PchHdaIDispLinkFrequency;


### PR DESCRIPTION
The FSP-M UPD has an option .PchHdaAudioLinkSspEnable to enable HD Audio SSP_N/I2S links; however, this cannot be modified from SBL configuration. This change adds the MEMORY_CFG_DATA.PchHdaAudioLinkSspEnable option to set the UPD value. (Default setting is all channel disabled as before).