### PR TITLE
feat: Add Board flag for AP Init Wait time

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -153,6 +153,8 @@
   # 1: Sort the CPU based on CPU APIC ID in ascending order
   # 2: Sort the CPU based on CPU APIC ID in descending order
   gPlatformModuleTokenSpaceGuid.PcdCpuSortMethod          |     0      | UINT32 | 0x200000E4
+  # Time to wait for AP Wakeup in MicroSeconds. Usually only needed for high core count SoCs
+  gPlatformModuleTokenSpaceGuid.PcdCpuApInitWaitInMicroSeconds | 0     | UINT32 | 0x200001A4
 
   # Size of the Hash store allocated in bootloader
   gPlatformModuleTokenSpaceGuid.PcdHashStoreSize          | 0x00000200 | UINT32 | 0x200000F1
@@ -220,8 +222,6 @@
   gPlatformModuleTokenSpaceGuid.PcdPciResourceIoBase      | 0x00000000 | UINT32 | 0x200001A1
   gPlatformModuleTokenSpaceGuid.PcdPciResourceMem32Base   | 0x00000000 | UINT32 | 0x200001A2
   gPlatformModuleTokenSpaceGuid.PcdPciResourceMem64Base   | 0x0000000000000000  | UINT64     | 0x200001A3
-
-
 
 [PcdsFeatureFlag]
   # Determine if the Intel GFX device should be enabled or not in system

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -239,6 +239,7 @@
   gPlatformModuleTokenSpaceGuid.PcdAcpiProcessorIdBase    | $(ACPI_PROCESSOR_ID_BASE)
   gPlatformModuleTokenSpaceGuid.PcdCpuMaxLogicalProcessorNumber | $(CPU_MAX_LOGICAL_PROCESSOR_NUMBER)
   gPlatformModuleTokenSpaceGuid.PcdCpuSortMethod          | $(CPU_SORT_METHOD)
+  gPlatformModuleTokenSpaceGuid.PcdCpuApInitWaitInMicroSeconds | $(CPU_AP_WAIT_TIME_US)
 
   gPlatformCommonLibTokenSpaceGuid.PcdConsoleInDeviceMask  | $(CONSOLE_IN_DEVICE_MASK)
   gPlatformCommonLibTokenSpaceGuid.PcdConsoleOutDeviceMask | $(CONSOLE_OUT_DEVICE_MASK)

--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.inf
@@ -55,6 +55,7 @@
 [FixedPcd]
   gPlatformModuleTokenSpaceGuid.PcdCpuMaxLogicalProcessorNumber
   gPlatformModuleTokenSpaceGuid.PcdCpuSortMethod
+  gPlatformModuleTokenSpaceGuid.PcdCpuApInitWaitInMicroSeconds
 
 [Pcd]
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegBase

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -190,6 +190,7 @@ class BaseBoard(object):
 
         self.CPU_MAX_LOGICAL_PROCESSOR_NUMBER = 16
         self.CPU_SORT_METHOD       = 0
+        self.CPU_AP_WAIT_TIME_US   = 0
 
         self.ACM_SIZE              = 0
         self.ACM_FIT_VERISON       = 0x100


### PR DESCRIPTION
Some silicon requires longer than provided for all APs to enter the wakeup routine. This change makes this platform configurable. The default wait time is none and can be increased for platforms with higher core count Si.