### PR TITLE
fix: [ARLS] Workaround for Windows boot and shutdown

### DIFF
--- a/Platform/ArrowlakeBoardPkg/AcpiTables/EcSsdt/EcBaseMethod.asl
+++ b/Platform/ArrowlakeBoardPkg/AcpiTables/EcSsdt/EcBaseMethod.asl
@@ -37,12 +37,13 @@ Method (ECRD, 1, Serialized, 0, IntObj, FieldUnitObj)
     }
     Store (Zero, ECTK)   // Clear flag for checking once only
   }
-  Sleep(3) // WA - for slow windows boot
+
   Store (Acquire (ECMT, 1000), Local0)  // save Acquire result so we can check for Mutex acquired
   If (LEqual (Local0, Zero))  // check for Mutex acquired
   {
     If (ECAV) {
       Store (DerefOf (Arg0), Local1) // Execute Read from EC
+      Sleep(3) // WA - for slow windows boot
       Release (ECMT)
       Return (Local1)
     }
@@ -83,8 +84,10 @@ Method (ECWT, 2, Serialized,,, {IntObj, FieldUnitObj})
   {
     If (ECAV) {
       Store (Arg0, Arg1) // Execute Write to EC
+      Sleep(5)
     } // If (ECAV)
     Else {
+      Release (ECMT)
       Return (0xFFFFFFFF)
     }
     Release (ECMT)


### PR DESCRIPTION
Updated the 3ms delay after EC Read and 5ms after EC Write. Give EC time to complete RAM access. Added missing EC mutex release