### PR TITLE
fix: [Common/GpioLib] Don't let invalid pin stop GPIO initialization

### DIFF
--- a/Silicon/CommonSocPkg/Library/GpioLib/GpioInit.c
+++ b/Silicon/CommonSocPkg/Library/GpioLib/GpioInit.c
@@ -170,7 +170,8 @@ GpioUnlockPadsForAGroup (
     //
     if (PadNumber >= GpioGroupInfo[GroupIndex].PadPerGroup) {
       DEBUG ((GPIO_DEBUG_ERROR, "GPIO ERROR: Pin number (%d) exceeds possible range for group %d\n", PadNumber, GroupIndex));
-      return EFI_INVALID_PARAMETER;
+      Index++;
+      continue;
     }
 
     PadBitPosition = GPIO_GET_PAD_POSITION (PadNumber);
@@ -283,8 +284,9 @@ GpioConfigurePch (
       // Check if legal pin number
       //
       if (PadNumber >= GpioGroupInfo[GroupIndex].PadPerGroup) {
-        DEBUG ((GPIO_DEBUG_ERROR, "GPIO ERROR: Pin number (%d) exceeds possible range for group %d\n", PadNumber, GroupIndex));
-        return EFI_INVALID_PARAMETER;
+        DEBUG ((DEBUG_ERROR, "GPIO ERROR: Pin number (%d) exceeds possible range for group %d\n", PadNumber, GroupIndex));
+        Index++;
+        continue;
       }
 
       //


### PR DESCRIPTION
If the init table passed to GPIO initialization contains an invalid pin number, debug builds of the init library would terminate silently (i.e. no entries after the offending one would be processed at all, and common config registers like HOSTSW_OWN and unlock data might not get updated). Note that release builds would not detect (and thus simply skip) invalid entries.

This change:
- aligns the debug to the release build behavior: handle all valid GPIO pins passed to the initialization routine;
- complain about invalid pins (debug builds only).
Signed-off-by: Bruno Achauer <bruno.achauer@intel.com>