### PR TITLE
feat: [RPL-A] Deny the update of older microcode versions.

### DIFF
--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -201,11 +201,12 @@ VerifyFwVersion (
   }
 
   //
-  // Allow all UCOD Updates
+  // Check revision for UCODE update
   //
   if (((UINT32)ImageHdr->UpdateHardwareInstance) == FLASH_MAP_SIG_UCODE) {
     DEBUG((DEBUG_INFO, "Capsule update is for UCODE region!!\n"));
-    return EFI_SUCCESS;
+    Status = CheckUCodeVersion (ImageHdr);
+    return Status;
   }
 
   if ((UINT32)ImageHdr->UpdateHardwareInstance == FW_UPDATE_COMP_BIOS_REGION) {

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
@@ -287,6 +287,23 @@ CheckAcmSvn (
   );
 
 /**
+  Perform UCODE revision check
+
+  This function will perform revision checks for UCODE in flash and
+  UCODE in capsule.
+
+  @param[in]  ImageHdr       Pointer to fw mgmt capsule Image header
+
+  @retval  EFI_SUCCESS      revision check successful.
+  @retval  other            error occurred during firmware update
+**/
+EFI_STATUS
+EFIAPI
+CheckUCodeVersion (
+  IN   EFI_FW_MGMT_CAP_IMAGE_HEADER  *ImageHdr
+  );
+
+/**
   Read the value of FW_UPDATE_STATUS.CsmeNeedReset
 
   The CsmeNeedReset flag is used to ensure CSME update


### PR DESCRIPTION
 - According to the Intel 64 and IA-32 Architectures Software Developer's Manual, Volume 3A, Section 10.11.1 titled "Microcode Update", the microcode header does not include an SVN (Security Version Number) field. Additionally, the subsequent section does not reference the SVN either, it only mentions the update revision.
 - Added check to ensure UpdateRevision is not lower than the minimum required version.
 - If UpdateRevision is lower, an error is logged and appropriate action is taken.
 - This prevents unauthorized rollback to older, potentially insecure versions of microcode.