### PR TITLE
fix: [ARL] DmiAspm value "4" no longer supported by FSP

### DIFF
--- a/Platform/ArrowlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/ArrowlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -446,7 +446,6 @@ UpdateFspConfig (
   Fspmcfg->SaGv                                                 = 0x1;
   Fspmcfg->PchHdaEnable                                         = 0x1;
   Fspmcfg->DmiMaxLinkSpeed                                      = 0x1;
-  Fspmcfg->DmiAspm                                              = 0x4;
   Fspmcfg->CsVrefLow                                            = 0x45;
   Fspmcfg->CsVrefHigh                                           = 0x1d;
   Fspmcfg->CaVrefLow                                            = 0x45;


### PR DESCRIPTION
FSP no longer supports value of 4 (Auto) for DmiAspm. Setting this breaks Package C10 and S0ix. Fallback to YAML config value (currently 2 for "L1").