### PR TITLE
fix: Prevent creation or authentication of containers with no comp auth

### DIFF
--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
@@ -382,6 +382,7 @@ AutheticateContainerInternal (
   LOADER_COMPRESSED_HEADER *CompressHdr;
   EFI_STATUS                Status;
   COMPONENT_CALLBACK_INFO   CbInfo;
+  UINT64                    SignatureBuf;
 
   // Find authentication data offset and authenticate the container header
   Status = EFI_UNSUPPORTED;
@@ -393,6 +394,7 @@ AutheticateContainerInternal (
       AuthType = ContainerHdr->AuthType;
       AuthData = (UINT8 *)ContainerHdr + ALIGN_UP(ContainerHdrSize, AUTH_DATA_ALIGN);
       if ((AuthType == AUTH_TYPE_NONE) && FeaturePcdGet (PcdVerifiedBootEnabled)) {
+        // Enforce header authentication if verified boot is enabled.
         Status = EFI_SECURITY_VIOLATION;
       } else {
         Status = AuthenticateComponent ((UINT8 *)ContainerHdr, ContainerHdrSize,
@@ -412,37 +414,56 @@ AutheticateContainerInternal (
     }
   }
 
-  if (!EFI_ERROR (Status) && \
-      ((ContainerHdr->Flags & CONTAINER_HDR_FLAG_MONO_SIGNING) != 0)) {
-    // Additional verification if the container is signed monolithically.
-    // It is required for the container to be loaded in memory before registeration.
-    Status = EFI_UNSUPPORTED;
-    if ((ContainerHdr->Count > 1) && !IS_FLASH_ADDRESS (ContainerHeader)) {
-      // Use the last entry to verify all other combined components
-      CompEntry = (COMPONENT_ENTRY *)&ContainerHdr[1];
-      for (Index = 0; Index < (UINT32)(ContainerHdr->Count - 1); Index++) {
-        CompEntry = (COMPONENT_ENTRY *)((UINT8 *)(CompEntry + 1) + CompEntry->HashSize);
-      }
-      CompData    = (UINT8 *)(UINTN)(ContainerEntry->Base + ContainerHdr->DataOffset + CompEntry->Offset);
-      CompressHdr = (LOADER_COMPRESSED_HEADER *)CompData;
-      if (CompressHdr->Signature == LZDM_SIGNATURE) {
-        SignedDataLen = sizeof (LOADER_COMPRESSED_HEADER) + CompressHdr->CompressedSize;
-        AuthData = CompData + ALIGN_UP(SignedDataLen, AUTH_DATA_ALIGN);
-        DataBuf  = (UINT8 *)(UINTN)(ContainerEntry->Base + ContainerHdr->DataOffset);
-        DataLen  = CompEntry->Offset;
-        Status   = AuthenticateComponent (DataBuf, DataLen, CompEntry->AuthType,
-                                          AuthData, CompEntry->HashData, 0);
-
-        if ((!EFI_ERROR(Status)) && (ContainerCallback != NULL)) {
-          // Update component Call back info after authenticaton is done
-          // This info will used by firmware stage to extend to TPM
-          CbInfo.ComponentType    = ContainerHeader->Signature;
-          CbInfo.CompBuf          = DataBuf;
-          CbInfo.CompLen          = DataLen;
-          CbInfo.HashAlg          = GetHashAlg(CompEntry->AuthType);
-          CbInfo.HashData         = CompEntry->HashData;
-          ContainerCallback (PROGESS_ID_AUTHENTICATE, &CbInfo);
+  if (!EFI_ERROR (Status)) {
+    if ((ContainerHdr->Flags & CONTAINER_HDR_FLAG_MONO_SIGNING) != 0) {
+      // Additional verification if the container is signed monolithically.
+      // It is required for the container to be loaded in memory before registeration.
+      Status = EFI_UNSUPPORTED;
+      if ((ContainerHdr->Count > 1) && !IS_FLASH_ADDRESS (ContainerHeader)) {
+        // Use the last entry to verify all other combined components
+        CompEntry = (COMPONENT_ENTRY *)&ContainerHdr[1];
+        for (Index = 0; Index < (UINT32)(ContainerHdr->Count - 1); Index++) {
+          CompEntry = (COMPONENT_ENTRY *)((UINT8 *)(CompEntry + 1) + CompEntry->HashSize);
         }
+        CompData    = (UINT8 *)(UINTN)(ContainerEntry->Base + ContainerHdr->DataOffset + CompEntry->Offset);
+        CompressHdr = (LOADER_COMPRESSED_HEADER *)CompData;
+        if (CompressHdr->Signature == LZDM_SIGNATURE) {
+          if ((CompEntry->AuthType == AUTH_TYPE_NONE) && FeaturePcdGet (PcdVerifiedBootEnabled)) {
+            // Enforce component authentication if verified boot is enabled.
+            Status =  EFI_SECURITY_VIOLATION;
+          } else {
+            SignedDataLen = sizeof (LOADER_COMPRESSED_HEADER) + CompressHdr->CompressedSize;
+            AuthData = CompData + ALIGN_UP(SignedDataLen, AUTH_DATA_ALIGN);
+            DataBuf  = (UINT8 *)(UINTN)(ContainerEntry->Base + ContainerHdr->DataOffset);
+            DataLen  = CompEntry->Offset;
+            Status   = AuthenticateComponent (DataBuf, DataLen, CompEntry->AuthType,
+                                              AuthData, CompEntry->HashData, 0);
+
+            if ((!EFI_ERROR(Status)) && (ContainerCallback != NULL)) {
+              // Update component Call back info after authenticaton is done
+              // This info will used by firmware stage to extend to TPM
+              CbInfo.ComponentType    = ContainerHeader->Signature;
+              CbInfo.CompBuf          = DataBuf;
+              CbInfo.CompLen          = DataLen;
+              CbInfo.HashAlg          = GetHashAlg(CompEntry->AuthType);
+              CbInfo.HashData         = CompEntry->HashData;
+              ContainerCallback (PROGESS_ID_AUTHENTICATE, &CbInfo);
+            }
+          }
+        }
+      }
+    } else if (FeaturePcdGet (PcdVerifiedBootEnabled)) {
+      // For non-Mono signing all components must have auth data when verified boot is enabled
+      DEBUG((DEBUG_INFO, "Verify Container %4a AuthTypes\n", (CHAR8 *)&ContainerHdr->Signature));
+      for (Index = 0 , CompEntry = (COMPONENT_ENTRY *)(ContainerHdr+1); Index < ContainerHdr->Count; Index++) {
+        SignatureBuf = CompEntry->Name;
+        DEBUG((DEBUG_INFO, "Component %4a AuthType %X\n", (CHAR8 *)&SignatureBuf, CompEntry->AuthType));
+        if (CompEntry->AuthType == AUTH_TYPE_NONE) {
+          DEBUG((DEBUG_INFO, "All container content must be authenticated in verified boot flow.\n"));
+          Status =  EFI_SECURITY_VIOLATION;
+          break;
+        }
+        CompEntry = (COMPONENT_ENTRY *)((UINT8 *)(CompEntry + 1) + CompEntry->HashSize);
       }
     }
   }

--- a/BootloaderCorePkg/Tools/GenContainer.py
+++ b/BootloaderCorePkg/Tools/GenContainer.py
@@ -485,6 +485,8 @@ class CONTAINER ():
                     component.attribute = COMPONENT_ENTRY._attr['RESERVED']
                     compress_alg        = 'Dummy'
                     is_last_entry       = True
+                    if auth_type == 'NONE':
+                        raise Exception ("Monolithic signing component with auth type '%s' not valid !" % auth_type)
 
             # compress the component
             lz_file = compress (in_file, compress_alg, svn, self.out_dir, self.tool_dir)

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlPs.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlPs.py
@@ -36,5 +36,5 @@ class Board(AlderlakeBoardConfig.Board):
         # 0 - PCH UART0, 1 - PCH UART1, 2 - PCH UART2, 0xFF - EC UART 0x3F8
         self.DEBUG_PORT_NUMBER = 0x0
 
-        self.OS_LOADER_FD_SIZE = 0x0005A000
+        self.OS_LOADER_FD_SIZE = 0x0005B000
         self.OS_LOADER_FD_NUMBLK = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE

--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -116,7 +116,7 @@ class Board(BaseBoard):
         if self.ENABLE_SOURCE_DEBUG:
             self.STAGE1B_SIZE += 0x2000
         self.STAGE2_SIZE          = 0x00034000
-        self.PAYLOAD_SIZE         = 0x00022000
+        self.PAYLOAD_SIZE         = 0x00023000
 
         if len(self._PAYLOAD_NAME.split(';')) > 1:
             # EPAYLOAD is specified


### PR DESCRIPTION
Prevent GenContainer.py from creating monolithic signed containers with no component authorization data. Prevent ContainerLib from authenticating such containers when verified boot is enabled.