### PR TITLE
Fix: EnableCrashMode missing the Combo attribute.

### DIFF
--- a/Platform/CommonBoardPkg/CfgData/CfgData_Common.yaml
+++ b/Platform/CommonBoardPkg/CfgData/CfgData_Common.yaml
@@ -2,7 +2,7 @@
 #
 #  Slim Bootloader Platform CFGDATA Option File.
 #
-#  Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2025, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -36,6 +36,7 @@
       value        : 0
   - EnableCrashMode :
       name         : Enable Crash Mode
+      type         : Combo
       option       : $EN_DIS
       help         : >
                      Enable/Disable Crash Mode. Boot into Crash OS only when crash mode is enabled.


### PR DESCRIPTION
Insert the attribute "type : Combo" for the parameter "EnableCrashMode", to make it to be displayed in Config Editor.

Verified: GEN_CFG_DATA.EnableCrashMode can be changed.