### PR TITLE
fix: [Common] Handle invalid shell command gracefully

### DIFF
--- a/BootloaderCommonPkg/Library/ShellLib/Shell.c
+++ b/BootloaderCommonPkg/Library/ShellLib/Shell.c
@@ -400,7 +400,11 @@ RunShellCommand (
     return EFI_SUCCESS;
   }
 
-  ASSERT (Count <= (sizeof (Argv) / sizeof (Argv[0])));
+  if (Count > (sizeof (Argv) / sizeof (Argv[0]))) {
+    ShellPrint (L"Invalid command (try help)\n");
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   for (Index = 0, Ptr = Buf; Index < Count; Index++) {
     Argv[Index]  = Ptr;
     Ptr     += StrLen (Ptr) + 1;


### PR DESCRIPTION
Currently an ASSERT is triggered halting the system if the command length is greater than the argv buffer size. Handle this error gracefully to avoid system halt.