### PR TITLE
feat: [ARLUH] Updating merged ingredient list for ARL-U/H

### DIFF
--- a/Platform/ArrowlakeBoardPkg/Script/StitchIfwiConfig_arlh.py
+++ b/Platform/ArrowlakeBoardPkg/Script/StitchIfwiConfig_arlh.py
@@ -78,8 +78,8 @@ def get_platform_sku():
 def get_component_replace_list(plt_params_list):
     replace_list = [
        #    Path                   file name              compress    Key                           SVN
-      ('IFWI/BIOS/TS0/ACM0',      'Input/acm0.bin',        'dummy',    '',                            ''),
-      ('IFWI/BIOS/TS1/ACM0',      'Input/acm0.bin',        'dummy',    '',                            ''),
+      ('IFWI/BIOS/TS0/ACM0',      'Input/acm0_arlh.bin',        'dummy',    '',                            ''),
+      ('IFWI/BIOS/TS1/ACM0',      'Input/acm0_arlh.bin',        'dummy',    '',                            ''),
        ]
 
     return replace_list
@@ -154,8 +154,8 @@ def get_xml_change_list (platform, plt_params_list):
         ('./FlashLayout/BiosRegion/InputFile',                                                      '$SourceDir\BiosRegion.bin'),
         ('./FlashLayout/Ifwi_IntelMePmcRegion/MeRegionFile',                                        '$SourceDir\ME Sub Partition.bin'),
         ('./FlashLayout/Ifwi_IntelMePmcRegion/PmcBinary',                                           '$SourceDir\CsePlugin#PMC.bin'),
-        ('./FlashLayout/EcRegion/EcRegionPointer',                                                  '$SourceDir\DescriptorPlugin#EcRegionPointer.bin'),
-        ('./FlashLayout/EcRegion/InputFile',                                                        '$SourceDir\SystemPlugin#EcRegion.bin'),
+        ('./FlashLayout/EcRegion/EcRegionPointer',                                                  '$SourceDir\DescriptorPlugin#EcRegionPointer_arlh.bin'),
+        ('./FlashLayout/EcRegion/InputFile',                                                        '$SourceDir\SystemPlugin#EcRegion_arlh.bin'),
         ('./FlashLayout/EcRegion/Enabled',                                                          'Enabled'),
         ('./FlashLayout/GbeRegion/InputFile',                                                       '$SourceDir\SystemPlugin#GbeRegion.bin'),
         ('./FlashLayout/GbeRegion/Enabled',                                                         'Enabled'),

--- a/Platform/ArrowlakeBoardPkg/Script/StitchIfwiConfig_arlu.py
+++ b/Platform/ArrowlakeBoardPkg/Script/StitchIfwiConfig_arlu.py
@@ -78,8 +78,8 @@ def get_platform_sku():
 def get_component_replace_list(plt_params_list):
     replace_list = [
        #    Path                   file name              compress    Key                           SVN
-      ('IFWI/BIOS/TS0/ACM0',      'Input/acm0.bin',        'dummy',    '',                            ''),
-      ('IFWI/BIOS/TS1/ACM0',      'Input/acm0.bin',        'dummy',    '',                            ''),
+      ('IFWI/BIOS/TS0/ACM0',      'Input/acm0_arlu.bin',        'dummy',    '',                            ''),
+      ('IFWI/BIOS/TS1/ACM0',      'Input/acm0_arlu.bin',        'dummy',    '',                            ''),
        ]
 
     return replace_list
@@ -154,8 +154,8 @@ def get_xml_change_list (platform, plt_params_list):
         ('./FlashLayout/BiosRegion/InputFile',                                                      '$SourceDir\BiosRegion.bin'),
         ('./FlashLayout/Ifwi_IntelMePmcRegion/MeRegionFile',                                        '$SourceDir\ME Sub Partition.bin'),
         ('./FlashLayout/Ifwi_IntelMePmcRegion/PmcBinary',                                           '$SourceDir\CsePlugin#PMC.bin'),
-        ('./FlashLayout/EcRegion/EcRegionPointer',                                                  '$SourceDir\DescriptorPlugin#EcRegionPointer.bin'),
-        ('./FlashLayout/EcRegion/InputFile',                                                        '$SourceDir\SystemPlugin#EcRegion.bin'),
+        ('./FlashLayout/EcRegion/EcRegionPointer',                                                  '$SourceDir\DescriptorPlugin#EcRegionPointer_arlu.bin'),
+        ('./FlashLayout/EcRegion/InputFile',                                                        '$SourceDir\SystemPlugin#EcRegion_arlu.bin'),
         ('./FlashLayout/EcRegion/Enabled',                                                          'Enabled'),
         ('./FlashLayout/GbeRegion/InputFile',                                                       '$SourceDir\SystemPlugin#GbeRegion.bin'),
         ('./FlashLayout/GbeRegion/Enabled',                                                         'Enabled'),


### PR DESCRIPTION
ARL-U and ARL-H ingredients are the same, except for ACM and EC binaries. Updating ingredient list in StitchIfwiConfig script for ARL-U and ARL-H.