### PR TITLE
fix: remove clear FSP hob from Uefi payload boot path

### DIFF
--- a/BootloaderCommonPkg/Include/Guid/LoaderFspInfoGuid.h
+++ b/BootloaderCommonPkg/Include/Guid/LoaderFspInfoGuid.h
@@ -18,7 +18,7 @@ typedef struct {
   UINT8          Revision;
   UINT8          Reserved0[3];
   UINT32         FspsBase;
-  VOID          *FspHobList;
+  UINT32         FspHobList;
 } LOADER_FSP_INFO;
 
 #endif

--- a/BootloaderCommonPkg/Library/LoaderPerformanceLib/LoaderPerformancePrintLib.c
+++ b/BootloaderCommonPkg/Library/LoaderPerformanceLib/LoaderPerformancePrintLib.c
@@ -391,7 +391,7 @@ PrintFspPerfData (
   FspInfo = GET_GUID_HOB_DATA (FspInfo);
 
   FspFirmwarePerformance = NULL;
-  GuidHob = GetNextGuidHob (&gEdkiiFpdtExtendedFirmwarePerformanceGuid, FspInfo->FspHobList);
+  GuidHob = GetNextGuidHob (&gEdkiiFpdtExtendedFirmwarePerformanceGuid, (VOID*)(UINTN)FspInfo->FspHobList);
   while (GuidHob != NULL) {
     FspFirmwarePerformance   = (UINT8*)GET_GUID_HOB_DATA (GuidHob);
     FspPerformanceLogHeader = (FPDT_PEI_EXT_PERF_HEADER *)FspFirmwarePerformance;

--- a/BootloaderCommonPkg/Library/ShellLib/CmdHob.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdHob.c
@@ -162,7 +162,7 @@ ShellCommandHobFunc (
 
   ShellPrint (L"\nFSP HOBs\n");
   ShellPrint (L"========================================\n");
-  ListHobs (FspInfo->FspHobList);
+  ListHobs ((VOID*)(UINTN)FspInfo->FspHobList);
 
   return EFI_SUCCESS;
 }

--- a/BootloaderCorePkg/Stage2/Stage2Hob.c
+++ b/BootloaderCorePkg/Stage2/Stage2Hob.c
@@ -295,7 +295,7 @@ BuildBaseInfoHob (
   LoaderFspInfo = BuildGuidHob (&gLoaderFspInfoGuid, sizeof (LOADER_FSP_INFO));
   if (LoaderFspInfo != NULL) {
     LoaderFspInfo->FspsBase   = PCD_GET32_WITH_ADJUST (PcdFSPSBase);
-    LoaderFspInfo->FspHobList = LdrGlobal->FspHobList;
+    LoaderFspInfo->FspHobList = (UINT32)(UINTN)LdrGlobal->FspHobList;
   }
 
   // Build serial port hob

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -202,8 +202,6 @@ ProgramSecuritySetting (
 
   // Set the BIOS Lock Enable and EISS bits
   MmioOr8 (SpiBaseAddress + R_SPI_CFG_BC, (UINT8) (B_SPI_CFG_BC_LE | B_SPI_CFG_BC_EISS));
-
-  ClearFspHob ();
 }
 
 /**
@@ -675,6 +673,7 @@ BoardInit (
     }
     break;
   case EndOfFirmware:
+    ClearFspHob ();
     break;
   default:
     break;

--- a/Platform/ArrowlakeBoardPkg/Library/ShellExtensionLib/CmdGpio.c
+++ b/Platform/ArrowlakeBoardPkg/Library/ShellExtensionLib/CmdGpio.c
@@ -340,7 +340,7 @@ UpdatePchSbRegBar (
 
   FspInfo = (LOADER_FSP_INFO *)GetGuidHobData (NULL, NULL, &gLoaderFspInfoGuid);
   ASSERT (FspInfo != NULL);
-  PchConfig = (MTL_PCH_CONFIGURATION *) GetGuidHobData (FspInfo->FspHobList, NULL, &gFspPchConfigGuid);
+  PchConfig = (MTL_PCH_CONFIGURATION *) GetGuidHobData ((VOID*)(UINTN)FspInfo->FspHobList, NULL, &gFspPchConfigGuid);
   if (PchConfig != NULL) {
     GpioPad    = GPIOV2_PAD_ID(0, GPIOV2_MTL_PCH_S_CHIPSET_ID, 0, 0, 0, 0);
     Controller = GpioGetController (GpioPad);

--- a/Silicon/ApollolakePkg/Library/BootMediaPayloadLib/BootMediaLib.c
+++ b/Silicon/ApollolakePkg/Library/BootMediaPayloadLib/BootMediaLib.c
@@ -45,7 +45,7 @@ GetBootMediaType (
   ASSERT(FspInfo != NULL);
   FspInfo = GET_GUID_HOB_DATA(FspInfo);
 
-  GuidHob = GetNextGuidHob(&gEfiBootMediaHobGuid, FspInfo->FspHobList);
+  GuidHob = GetNextGuidHob(&gEfiBootMediaHobGuid, (VOID*)(UINTN)FspInfo->FspHobList);
   ASSERT (GuidHob != NULL);
   BootMediaData = (CURRENT_BOOT_MEDIA *)GET_GUID_HOB_DATA (GuidHob);
 
@@ -84,7 +84,7 @@ GetBootPartition (
   ASSERT(FspInfo != NULL);
   FspInfo = GET_GUID_HOB_DATA(FspInfo);
 
-  GuidHob = GetNextGuidHob(&gEfiBootMediaHobGuid, FspInfo->FspHobList);
+  GuidHob = GetNextGuidHob(&gEfiBootMediaHobGuid, (VOID*)(UINTN)FspInfo->FspHobList);
   ASSERT (GuidHob != NULL);
   BootMediaData = (CURRENT_BOOT_MEDIA *)GET_GUID_HOB_DATA (GuidHob);
 


### PR DESCRIPTION
Remove clear FSP hob from Uefi payload boot path because Fsp NotifyPhase needs FSP hob to work. Fixed 32bit address FspHotList in FSP INFO. UEFI payload consumes ths info to clear FSP hob.