### PR TITLE
fix: Setup payload yaml processing and x64 fixes

### DIFF
--- a/BootloaderCorePkg/Tools/SblSetup.py
+++ b/BootloaderCorePkg/Tools/SblSetup.py
@@ -2075,7 +2075,11 @@ def rebuild_cfgs (cfg_win, pages, page_id):
                 combo = ComboBox(cfg_win, rc)
                 combo.set_text(cfg['name'])
                 ops_list = get_cfg_item_options (cfg)
-                value = int(cfg['value'], 0)
+                try:
+                    value = int(cfg['value'], 0)
+                except:
+                    print('Conversion error: %s - %s' % (cfg['path'], cfg['value']))
+                    value = 0
                 combo.add ([i[1] for i in ops_list])
                 combo.set_select_by_value (value)
                 combo.set_help (cfg['help'])

--- a/PayloadPkg/OsLoader/OsLoader.c
+++ b/PayloadPkg/OsLoader/OsLoader.c
@@ -805,7 +805,7 @@ StartBooting (
       (SWITCH_STACK_ENTRY_POINT)(UINTN)MultiBoot->BootState.EntryPoint,
       (VOID *)(UINTN)PcdGet32 (PcdPayloadHobList),
       FeaturePcdGet (PcdPayloadModuleEnabled) ? &PldModParam : NULL,
-      (VOID *)((UINT8 *)mEntryStack + 8)
+      (VOID *)ALIGN_DOWN(((UINTN)mEntryStack + 8), CPU_STACK_ALIGNMENT)
       );
     Status = EFI_DEVICE_ERROR;
 


### PR DESCRIPTION
Mismatch between YAML config type and value was causing setup to crash. Handle it gracefully and print an error instead.

Stack alignment issues in x64.