### PR TITLE
fix: Setup Payload incorrectly handles config data with the refer flag

### DIFF
--- a/BootloaderCommonPkg/Library/ConfigDataLib/ConfigDataLib.c
+++ b/BootloaderCommonPkg/Library/ConfigDataLib/ConfigDataLib.c
@@ -363,46 +363,49 @@ BuildConfigData (
       CdataCurr = ((UINT8 *)CdataHdrCurr + sizeof (CDATA_HEADER) + sizeof (CDATA_COND) * CdataHdrCurr->ConditionNum);
       HdrLen = sizeof (CDATA_HEADER) + sizeof (CDATA_COND) * CdataHdr->ConditionNum;
       Cdata  = (UINT8 *)CdataHdr + HdrLen;
-      if ((CdataHdr->Flags & CDATA_FLAG_TYPE_ARRAY) != 0) {
-        // Handle array item specially
-        ArrayHdr     = (ARRAY_CFG_HDR *)Cdata;
-        ArrayHdrCurr = (ARRAY_CFG_HDR *)CdataCurr;
-        BitMaskLen   = (CdataHdr->Length << 2) - HdrLen - (UINT32)OFFSET_OF(ARRAY_CFG_HDR, BaseTableBitMask) \
-                       - (ArrayHdr->ItemSize * ArrayHdr->ItemCount);
+      // Don't copy reference data
+      if ((CdataHdr->Flags & CDATA_FLAG_TYPE_REFER) == 0) {
+        if ((CdataHdr->Flags & CDATA_FLAG_TYPE_ARRAY) != 0) {
+          // Handle array item specially
+          ArrayHdr     = (ARRAY_CFG_HDR *)Cdata;
+          ArrayHdrCurr = (ARRAY_CFG_HDR *)CdataCurr;
+          BitMaskLen   = (CdataHdr->Length << 2) - HdrLen - (UINT32)OFFSET_OF(ARRAY_CFG_HDR, BaseTableBitMask) \
+                        - (ArrayHdr->ItemSize * ArrayHdr->ItemCount);
 
-        // Update BaseTableBitMask
-        CopyMem (ArrayHdr->BaseTableBitMask, ArrayHdrCurr->BaseTableBitMask, BitMaskLen);
-        ArrayHdr->BaseTableId = 0x80;
+          // Update BaseTableBitMask
+          CopyMem (ArrayHdr->BaseTableBitMask, ArrayHdrCurr->BaseTableBitMask, BitMaskLen);
+          ArrayHdr->BaseTableId = 0x80;
 
-        // Update skip bit accordingly in the entry based on BaseTableBitMask
-        GpioTableDataOffset = (UINT32)OFFSET_OF(ARRAY_CFG_HDR, BaseTableBitMask) + BitMaskLen;
-        for (Index2 = 0; Index2 < ArrayHdr->ItemCount; Index2++) {
-          if ((ArrayHdr->BaseTableBitMask[Index2 >> 3] & (1 << (Index2 & 7))) == 0) {
-            // Skip one entry
-            Offset2 = Index2 * ArrayHdr->ItemSize;
-            Ptr   = Cdata + GpioTableDataOffset + Offset2;
-            Index = ArrayHdr->ItemValidBitOff;
-            Ptr[Index >> 3] |= (1 << (Index & 7));
-          }
-        }
-
-        // Update extra entries
-        for (Index = 0; Index  < ArrayHdrCurr->ItemCount; Index++) {
-          Offset1 = Index * ArrayHdrCurr->ItemSize;
-          ItemId  = GetArrayItemId (ArrayHdrCurr, CdataCurr + GpioTableDataOffset + Offset1);
+          // Update skip bit accordingly in the entry based on BaseTableBitMask
+          GpioTableDataOffset = (UINT32)OFFSET_OF(ARRAY_CFG_HDR, BaseTableBitMask) + BitMaskLen;
           for (Index2 = 0; Index2 < ArrayHdr->ItemCount; Index2++) {
-            Offset2 = Index2 * ArrayHdr->ItemSize;
-            if (GetArrayItemId (ArrayHdr, Cdata + GpioTableDataOffset + Offset2) == ItemId) {
-              // Set item as valid in BaseTableBitMask
-              ArrayHdr->BaseTableBitMask[Index >> 3] |= (1 << (Index & 7));
-              CopyMem (Cdata + GpioTableDataOffset + Offset2, CdataCurr + GpioTableDataOffset + Offset1,  ArrayHdr->ItemSize);
-              break;
+            if ((ArrayHdr->BaseTableBitMask[Index2 >> 3] & (1 << (Index2 & 7))) == 0) {
+              // Skip one entry
+              Offset2 = Index2 * ArrayHdr->ItemSize;
+              Ptr   = Cdata + GpioTableDataOffset + Offset2;
+              Index = ArrayHdr->ItemValidBitOff;
+              Ptr[Index >> 3] |= (1 << (Index & 7));
             }
           }
+
+          // Update extra entries
+          for (Index = 0; Index  < ArrayHdrCurr->ItemCount; Index++) {
+            Offset1 = Index * ArrayHdrCurr->ItemSize;
+            ItemId  = GetArrayItemId (ArrayHdrCurr, CdataCurr + GpioTableDataOffset + Offset1);
+            for (Index2 = 0; Index2 < ArrayHdr->ItemCount; Index2++) {
+              Offset2 = Index2 * ArrayHdr->ItemSize;
+              if (GetArrayItemId (ArrayHdr, Cdata + GpioTableDataOffset + Offset2) == ItemId) {
+                // Set item as valid in BaseTableBitMask
+                ArrayHdr->BaseTableBitMask[Index >> 3] |= (1 << (Index & 7));
+                CopyMem (Cdata + GpioTableDataOffset + Offset2, CdataCurr + GpioTableDataOffset + Offset1,  ArrayHdr->ItemSize);
+                break;
+              }
+            }
+          }
+        } else {
+          // Copy full CFGDATA tag data
+          CopyMem (Cdata, CdataCurr, (CdataHdr->Length << 2) - HdrLen);
         }
-      } else {
-        // Copy full CFGDATA tag data
-        CopyMem (Cdata, CdataCurr, (CdataHdr->Length << 2) - HdrLen);
       }
     } else {
       // Set platform mask


### PR DESCRIPTION
CfgDataTool de-dupes config data in some circumstances when using the "merge" command. In such a case, the CDATA_FLAG_TYPE_REFER flag is set in the header, and a special REFERENCE_CFG_DATA struct is added after the conditions that points to the reference Config Data. ConfigDataLib's BuildConfigData() triggers a config data corruption when handling these that needed to be fixed. Instead, the setup payload will expand these de-duped configs using the reference data so they can be modified independently. This will cause an increase in Config Data size when saving data from setup in these cases.