### PR TITLE
fix: [ARL] SerialIoUartMode can't set to SerialIoUartCom

### DIFF
--- a/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -52,7 +52,12 @@ STATIC S3_SAVE_REG mS3SaveReg = {
   { { REG_TYPE_IO, WIDE32, { 0, 0}, (ACPI_BASE_ADDRESS + R_ACPI_IO_SMI_EN), 0x00000000 } }
 };
 
-
+GLOBAL_REMOVE_IF_UNREFERENCED SERIAL_IO_CONTROLLER_DESCRIPTOR mMtlPchLpssUartFixedOffset [] = {
+  { 0xC000,   0xD000},
+  { 0xE000,   0xF000},
+  { 0x10000,  0x11000},
+  { 0x12000,  0x13000}
+};
 
 
 
@@ -975,6 +980,24 @@ VOID UpdLpiStat (
 }
 
 /**
+  Gets Fixed Address used for Pci Config Space manipulation
+
+  @param[in] UartNumber              Serial IO device UART number
+
+  @retval                            Pci Config Address
+**/
+UINT32
+MtlPchGetLpssUartFixedPciCfgOffset (
+  IN UINT8       UartNumber
+  )
+{
+  if (UartNumber < ARRAY_SIZE (mMtlPchLpssUartFixedOffset)) {
+    return mMtlPchLpssUartFixedOffset[UartNumber].Bar1;
+  }
+  return 0x0;
+}
+
+/**
   Update PCH NVS and SA NVS area address and size in ACPI table.
 
   @param[in] Current    Pointer to ACPI description header
@@ -1545,6 +1568,9 @@ PlatformUpdateAcpiGnvs (
       if (MtlPchNvs->UM0[Index] == 0x1) {
         MtlPchNvs->UC0[Index] = MtlPchSerialIoUartPciCfgBase (Index);
       }
+      if (MtlPchNvs->UM0[Index] == 0x3) {
+        MtlPchNvs->UC0[Index] = 0xBE000000  /*PchConfig->ReservedMmioBase */ + MTL_PCH_SERIAL_IO_OFFSET + MtlPchGetLpssUartFixedPciCfgOffset(Index);
+      }
       MtlPchNvs->UD0[Index] = FspsConfig->SerialIoUartDmaEnable[Index];
       MtlPchNvs->UP0[Index] = FspsConfig->SerialIoUartPowerGating[Index];
       MtlPchNvs->UI0[Index] = GetUartInterrupt (Index);
@@ -1685,7 +1711,12 @@ PlatformUpdateAcpiGnvs (
     Length = GetPchMaxSerialIoUartControllersNum ();
     for (Index = 0; Index < Length ; Index++) {
       PchNvs->UM0[Index] = FspsConfig->SerialIoUartMode[Index];
-      PchNvs->UC0[Index] = SerialIoUartPciCfgBase(Index);
+      if (FspsConfig->SerialIoUartMode[Index] == 1) {
+        PchNvs->UC0[Index] = SerialIoUartPciCfgBase(Index);
+      }
+      if (FspsConfig->SerialIoUartMode[Index] == 3) {
+        PchNvs->UC0[Index] = PCH_SERIAL_IO_BASE_ADDRESS + MtlPchGetLpssUartFixedPciCfgOffset(Index);
+      }
       PchNvs->UD0[Index] = FspsConfig->SerialIoUartDmaEnable[Index];
       PchNvs->UP0[Index] = FspsConfig->SerialIoUartPowerGating[Index];
       PchNvs->UI0[Index] = mPchSSerialIoUartMode[Index].SerialIoUARTIrq;

--- a/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.h
+++ b/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.h
@@ -131,7 +131,7 @@
 #define CMOS_EXTENDED_OFFSET_20     0x20
 #define CMOS_EXTENDED_OFFSET_21     0x21
 #define CMOS_VALUE_SWITCH_PLD       0x5A
-
+#define PCH_SERIAL_IO_BASE_ADDRESS  0xFE020000
 /**
   Time spent in the Package C-State.  It is given in units compatible to P1 clock frequency (Guaranteed / Maximum Core Non-Turbo Frequency).
   This time will be updated by PCODE only after the C-State exit (the update of this register has lower priority than actually ensuring that the C-State exit occurs).
@@ -309,5 +309,10 @@ BOOLEAN
 IsHeteroCoreSupported (
   VOID
   );
+
+typedef struct {
+  UINT32 Bar0;
+  UINT32 Bar1;
+} SERIAL_IO_CONTROLLER_DESCRIPTOR;
 
 #endif // __STAGE2_BOARD_INIT_LIB_H__


### PR DESCRIPTION
Verified on adl-s rvp, adl-h crb
 *SILICON_CFG_DATA.SerialIoUartMode               | {0x03, 0x03, 0x03, 0x00, 0x00, 0x00, 0x00}
 *self.DEBUG_PORT_NUMBER = 0xff
 ->Win11 can see 3 com ports.