### PR TITLE
feat: [ADLS] Update IPU2025.2 Release

### DIFF
--- a/Silicon/AlderlakePkg/FspBin/FspBinIpu.inf
+++ b/Silicon/AlderlakePkg/FspBin/FspBinIpu.inf
@@ -11,7 +11,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = a241c38261338ef8feff1eec9fb56355289a3eaf
+  COMMIT  = 39a1dab37cfb030014e80810acad7868e7cb2ab9
 
 [UserExtensions.SBL."CopyList"]
 # For ADL-S

--- a/Silicon/AlderlakePkg/Microcode/Microcode.inf
+++ b/Silicon/AlderlakePkg/Microcode/Microcode.inf
@@ -14,15 +14,15 @@
   VERSION_STRING       = 1.0
 
 [Sources]
-  m_07_90672_00000036.mcb
+  m_07_90672_0000003a.mcb
   m_80_906a3_00000434.mcb
   m_19_b06e0_0000001c.mcb
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
-  COMMIT = 2e2d6f7598a5abadc3196fce95044b4a01effba7
+  COMMIT = 40feee70d6e9407a469ce5731c8b5dd20cad2542
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/AlderLake/m_07_90672_00000036.pdb  : Silicon/AlderlakePkg/Microcode/m_07_90672_00000036.mcb
+  Microcode/AlderLake/m_07_90672_0000003a.pdb  : Silicon/AlderlakePkg/Microcode/m_07_90672_0000003a.mcb
   Microcode/AlderLake/m_80_906a3_00000434.pdb  : Silicon/AlderlakePkg/Microcode/m_80_906a3_00000434.mcb
   Microcode/AlderLake/m_19_b06e0_0000001c.pdb  : Silicon/AlderlakePkg/Microcode/m_19_b06e0_0000001c.mcb


### PR DESCRIPTION
BIOS version is NEX ADL-S IPU 2025.2 (5402_01) FSP
FSP version is 0C.00.F8.21
platform version is 1.7
Microcode Files are: ['m_07_90672_0000003a.pdb]

Signed-off-by: samihahkasim <samihah.kasim@intel.com>