### PR TITLE
Enhance ELF loading

### DIFF
--- a/BootloaderCommonPkg/Library/UniversalPayloadLib/UniversalPayloadLib.c
+++ b/BootloaderCommonPkg/Library/UniversalPayloadLib/UniversalPayloadLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020 - 2025, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -78,9 +78,8 @@ LoadElfPayload (
     }
   }
 
-  // Always try to run at preferred address
   if (Context.ReloadRequired) {
-    Context.ImageAddress = Context.PreferredImageAddress;
+    Context.ImageAddress = AllocatePages (EFI_SIZE_TO_PAGES (Context.ImageSize));
   }
 
   // Load ELF into the required base


### PR DESCRIPTION
Current implementation only supports the case that ELF file doesn't reload. If the ELF file has to be reload (e.g.: to meet alignment requirement), SBL need copy it to a different location and run.
Recently EDKII updated universal payload ELF image link script, and the new ELF text alignment was changed to 0x1000 from 0x40. Mostly the default file load location could not meet this requirement. So enhancement SBL to copy it to a new location for this case.