### PR TITLE
fix: [Common] Update script to identify FSP-I

### DIFF
--- a/IntelFsp2Pkg/Tools/SplitFspBin.py
+++ b/IntelFsp2Pkg/Tools/SplitFspBin.py
@@ -493,7 +493,7 @@ class FspImage:
         self.FihOffset = fihoff
         self.Offset    = offset
         self.FvIdxList = []
-        self.Type      = "XTMSXXXXOXXXXXXX"[(fih.ComponentAttribute >> 12) & 0x0F]
+        self.Type      = "XTMSIXXXOXXXXXXX"[(fih.ComponentAttribute >> 12) & 0x0F]
         self.PatchList = patch
         self.PatchList.append(fihoff + 0x1C)
 


### PR DESCRIPTION
Current script identifies FSP-I as FSP-X. Update the component attribute parsing logic to represent 'I' component correctly (as defined in FSP 2.4 spec onwards).