### PR TITLE
EDK2 Patch to fix QEMU build on new toolchain

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,4 @@
 # since the files that are being patched have a mixture of line
 # endings. This means it must be treated as binary.
 Silicon/QemuSocPkg/FspBin/Patches/0001-Build-QEMU-FSP-2.0-binaries.patch binary
+Silicon/QemuSocPkg/FspBin/Patches/0002-BaseTools-GCC-newer-versions-fix-Synced-with-EDK2.patch binary

--- a/BootloaderCorePkg/Tools/PrepareBuildComponentBin.py
+++ b/BootloaderCorePkg/Tools/PrepareBuildComponentBin.py
@@ -197,6 +197,10 @@ def BuildFspBins (fsp_dir, sbl_dir, fsp_inf, silicon_pkg_name, flag):
     ret = subprocess.call(cmd.split(' '), cwd=fsp_dir)
     if ret:
         Fatal ('Failed to apply QEMU FSP patch !')
+    cmd = 'git am --keep-cr --whitespace=nowarn %s/0002-BaseTools-GCC-newer-versions-fix-Synced-with-EDK2.patch' % patch_dir
+    ret = subprocess.call(cmd.split(' '), cwd=fsp_dir)
+    if ret:
+        Fatal ('Failed to apply QEMU FSP BuildTools patch !')
     print ('Done\n')
 
     print ('Compiling QEMU FSP source ...')

--- a/Silicon/QemuSocPkg/FspBin/Patches/0002-BaseTools-GCC-newer-versions-fix-Synced-with-EDK2.patch
+++ b/Silicon/QemuSocPkg/FspBin/Patches/0002-BaseTools-GCC-newer-versions-fix-Synced-with-EDK2.patch
@@ -1,0 +1,65 @@
+From befe22ff31d542e4baabde46b4d669daf15c7d59 Mon Sep 17 00:00:00 2001
+From: Fernando Silva <eng.fernandosilva@outlook.com>
+Date: Sat, 15 Mar 2025 17:51:02 -0700
+Subject: [PATCH] BaseTools GCC newer versions fix - Synced with EDK2 This
+ patch aims to fix two edk2 issues with newer GCC. It is a partial fix for
+ building QEMU board for SlimBootloader. There is still a second part of the
+ fix yet to be implemented which is around compiler optimizations with unused
+ symbols for FSP-T. At this point the patch contains the two below fixes from
+ EDK2: - https://edk2.groups.io/g/devel/topic/89997410 -
+ https://edk2.groups.io/g/devel/topic/89997412
+
+---
+ BaseTools/Source/C/GenFfs/GenFfs.c              | 2 +-
+ BaseTools/Source/C/GenSec/GenSec.c              | 2 +-
+ BaseTools/Source/C/LzmaCompress/Sdk/C/LzmaEnc.c | 3 ++-
+ 3 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/BaseTools/Source/C/GenFfs/GenFfs.c b/BaseTools/Source/C/GenFfs/GenFfs.c
+index fcb911f4fc..17c407e3cc 100644
+--- a/BaseTools/Source/C/GenFfs/GenFfs.c
++++ b/BaseTools/Source/C/GenFfs/GenFfs.c
+@@ -542,7 +542,7 @@ GetAlignmentFromFile(char *InFile, UINT32 *Alignment)
+   PeFileBuffer = (UINT8 *) malloc (PeFileSize);
+   if (PeFileBuffer == NULL) {
+     fclose (InFileHandle);
+-    Error(NULL, 0, 4001, "Resource", "memory cannot be allocated  of %s", InFileHandle);
++    Error(NULL, 0, 4001, "Resource", "memory cannot be allocated  of %s", InFile);
+     return EFI_OUT_OF_RESOURCES;
+   }
+   fread (PeFileBuffer, sizeof (UINT8), PeFileSize, InFileHandle);
+diff --git a/BaseTools/Source/C/GenSec/GenSec.c b/BaseTools/Source/C/GenSec/GenSec.c
+index d54a4f9e0a..1ad92de1d5 100644
+--- a/BaseTools/Source/C/GenSec/GenSec.c
++++ b/BaseTools/Source/C/GenSec/GenSec.c
+@@ -1062,7 +1062,7 @@ GetAlignmentFromFile(char *InFile, UINT32 *Alignment)
+   PeFileBuffer = (UINT8 *) malloc (PeFileSize);
+   if (PeFileBuffer == NULL) {
+     fclose (InFileHandle);
+-    Error(NULL, 0, 4001, "Resource", "memory cannot be allocated  of %s", InFileHandle);
++    Error(NULL, 0, 4001, "Resource", "memory cannot be allocated  of %s", InFile);
+     return EFI_OUT_OF_RESOURCES;
+   }
+   fread (PeFileBuffer, sizeof (UINT8), PeFileSize, InFileHandle);
+diff --git a/BaseTools/Source/C/LzmaCompress/Sdk/C/LzmaEnc.c b/BaseTools/Source/C/LzmaCompress/Sdk/C/LzmaEnc.c
+index e281716fee..b575c4f888 100644
+--- a/BaseTools/Source/C/LzmaCompress/Sdk/C/LzmaEnc.c
++++ b/BaseTools/Source/C/LzmaCompress/Sdk/C/LzmaEnc.c
+@@ -2638,12 +2638,13 @@ SRes LzmaEnc_CodeOneMemBlock(CLzmaEncHandle pp, Bool reInit,
+ 
+   nowPos64 = p->nowPos64;
+   RangeEnc_Init(&p->rc);
+-  p->rc.outStream = &outStream.vt;
+ 
+   if (desiredPackSize == 0)
+     return SZ_ERROR_OUTPUT_EOF;
+ 
++  p->rc.outStream = &outStream.vt;
+   res = LzmaEnc_CodeOneBlock(p, desiredPackSize, *unpackSize);
++  p->rc.outStream = NULL;
+   
+   *unpackSize = (UInt32)(p->nowPos64 - nowPos64);
+   *destLen -= outStream.rem;
+-- 
+2.48.1
+


### PR DESCRIPTION
When building using newer toolchains, there are a few changes required that were already patched in EDK2.

Those changes are documented in the two links from EDK2 group discussion:

    https://edk2.groups.io/g/devel/topic/89997410
    https://edk2.groups.io/g/devel/topic/89997412

With this small change and fix for QEMU FSP: Unknown symbol FspSecCoreT:_TempRamInitApi !, it is possible now to build successfully on Fedora 41 additionally to Ubuntu 24.04.