### PR TITLE
feat: [MTL] expose fsp-m .OcLock UPD option to SBL config data

### DIFF
--- a/Platform/MeteorlakeBoardPkg/CfgData/CfgData_Int_Mtlp_DDR5_CRB.dlt
+++ b/Platform/MeteorlakeBoardPkg/CfgData/CfgData_Int_Mtlp_DDR5_CRB.dlt
@@ -2,7 +2,7 @@
 #
 #  Platform Configuration Delta File.
 #
-#  Copyright (c) 2021 - 2024, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2021 - 2025, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 #
@@ -81,8 +81,6 @@ SILICON_CFG_DATA.Usb2PhyPredeemp                | {0x03, 0x03, 0x03, 0x03, 0x03,
 SILICON_CFG_DATA.PchSerialIoI2cPadsTermination  | {0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01}
 SILICON_CFG_DATA.SataLedEnable                  | 0
 SILICON_CFG_DATA.EcAvailable                    | 0
-SILICON_CFG_DATA.TurboRatioLimitRatio           | {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
-SILICON_CFG_DATA.AtomTurboRatioLimitRatio       | {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 SILICON_CFG_DATA.PchPmSlpSusMinAssert           | 0x0
 SILICON_CFG_DATA.PchPmSlpS3MinAssert            | 0x0
 SILICON_CFG_DATA.PchIshI3cEnable                | 1

--- a/Platform/MeteorlakeBoardPkg/CfgData/CfgData_Int_Mtlp_DDR5_MCL.dlt
+++ b/Platform/MeteorlakeBoardPkg/CfgData/CfgData_Int_Mtlp_DDR5_MCL.dlt
@@ -2,7 +2,7 @@
 #
 #  Platform Configuration Delta File.
 #
-#  Copyright (c) 2021 - 2024, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2021 - 2025, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 #
@@ -82,8 +82,6 @@ SILICON_CFG_DATA.Usb2PhyPredeemp                | {0x03, 0x03, 0x03, 0x03, 0x03,
 SILICON_CFG_DATA.PchSerialIoI2cPadsTermination  | {0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01}
 SILICON_CFG_DATA.SataLedEnable                  | 0
 SILICON_CFG_DATA.EcAvailable                    | 0
-SILICON_CFG_DATA.TurboRatioLimitRatio           | {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
-SILICON_CFG_DATA.AtomTurboRatioLimitRatio       | {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 SILICON_CFG_DATA.PchPmSlpSusMinAssert           | 0x0
 SILICON_CFG_DATA.PchPmSlpS3MinAssert            | 0x0
 SILICON_CFG_DATA.PchIshI3cEnable                | 1

--- a/Platform/MeteorlakeBoardPkg/CfgData/CfgData_Int_Mtlp_DDR5_Rvp.dlt
+++ b/Platform/MeteorlakeBoardPkg/CfgData/CfgData_Int_Mtlp_DDR5_Rvp.dlt
@@ -2,7 +2,7 @@
 #
 #  Platform Configuration Delta File.
 #
-#  Copyright (c) 2021 - 2024, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2021 - 2025, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 #
@@ -89,8 +89,6 @@ SILICON_CFG_DATA.Usb2PhyPetxiset                | {0x06, 0x06, 0x06, 0x06, 0x06,
 SILICON_CFG_DATA.Usb2PhyPredeemp                | {0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 SILICON_CFG_DATA.PchSerialIoI2cPadsTermination  | {0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01}
 SILICON_CFG_DATA.SataLedEnable                  | 0
-SILICON_CFG_DATA.TurboRatioLimitRatio           | {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
-SILICON_CFG_DATA.AtomTurboRatioLimitRatio       | {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 SILICON_CFG_DATA.PchPmSlpSusMinAssert           | 0x0
 SILICON_CFG_DATA.PchPmSlpS3MinAssert            | 0x0
 SILICON_CFG_DATA.PchIshI3cEnable                | 1

--- a/Platform/MeteorlakeBoardPkg/CfgData/CfgData_Int_Mtlp_LPDDR5_Rvp.dlt
+++ b/Platform/MeteorlakeBoardPkg/CfgData/CfgData_Int_Mtlp_LPDDR5_Rvp.dlt
@@ -2,7 +2,7 @@
 #
 #  Platform Configuration Delta File.
 #
-#  Copyright (c) 2023 - 2024, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2023 - 2025, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 #
@@ -75,8 +75,6 @@ SILICON_CFG_DATA.Usb2PhyPetxiset                | {0x06, 0x06, 0x06, 0x06, 0x06,
 SILICON_CFG_DATA.Usb2PhyPredeemp                | {0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 SILICON_CFG_DATA.PchSerialIoI2cPadsTermination  | {0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01}
 SILICON_CFG_DATA.SataLedEnable                  | 0
-SILICON_CFG_DATA.TurboRatioLimitRatio           | {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
-SILICON_CFG_DATA.AtomTurboRatioLimitRatio       | {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 SILICON_CFG_DATA.PchPmSlpSusMinAssert           | 0x0
 SILICON_CFG_DATA.PchPmSlpS3MinAssert            | 0x0
 SILICON_CFG_DATA.PchIshI3cEnable                | 1

--- a/Platform/MeteorlakeBoardPkg/CfgData/CfgData_Int_Mtlps_DDR5_CRB.dlt
+++ b/Platform/MeteorlakeBoardPkg/CfgData/CfgData_Int_Mtlps_DDR5_CRB.dlt
@@ -2,7 +2,7 @@
 #
 #  Platform Configuration Delta File.
 #
-#  Copyright (c) 2021 - 2024, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2021 - 2025, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 #
@@ -96,9 +96,6 @@ SILICON_CFG_DATA.PchSerialIoI2cPadsTermination  | {0x01, 0x01, 0x01, 0x01, 0x01,
 SILICON_CFG_DATA.SataLedEnable                  | 0
 SILICON_CFG_DATA.EcAvailable                    | 0
 SILICON_CFG_DATA.EnableTcssCovTypeA             | {0x0, 0x82, 0x0, 0x0}
-
-SILICON_CFG_DATA.TurboRatioLimitRatio           | {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
-SILICON_CFG_DATA.AtomTurboRatioLimitRatio       | {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 SILICON_CFG_DATA.PchPmSlpSusMinAssert           | 0x4
 SILICON_CFG_DATA.PchPmSlpS3MinAssert            | 0x3
 SILICON_CFG_DATA.PchIshI3cEnable                | 0

--- a/Platform/MeteorlakeBoardPkg/CfgData/CfgData_Int_Mtlps_DDR5_RVP.dlt
+++ b/Platform/MeteorlakeBoardPkg/CfgData/CfgData_Int_Mtlps_DDR5_RVP.dlt
@@ -2,7 +2,7 @@
 #
 #  Platform Configuration Delta File.
 #
-#  Copyright (c) 2021 - 2024, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2021 - 2025, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 #
@@ -81,8 +81,6 @@ SILICON_CFG_DATA.Usb2PhyPredeemp                | {0x03, 0x03, 0x03, 0x03, 0x03,
 SILICON_CFG_DATA.PchSerialIoI2cPadsTermination  | {0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01}
 SILICON_CFG_DATA.SataLedEnable                  | 0
 SILICON_CFG_DATA.EcAvailable                    | 0
-SILICON_CFG_DATA.TurboRatioLimitRatio           | {0x2A, 0x2A, 0x28, 0x28, 0x26, 0x26, 0x26, 0x26}
-SILICON_CFG_DATA.AtomTurboRatioLimitRatio       | {0x1F, 0x1F, 0x1F, 0x1F, 0x1C, 0x1C, 0x1C, 0x1C}
 SILICON_CFG_DATA.PchPmSlpSusMinAssert           | 0x4
 SILICON_CFG_DATA.PchPmSlpS3MinAssert            | 0x3
 SILICON_CFG_DATA.PchIshI3cEnable                | 0

--- a/Platform/MeteorlakeBoardPkg/CfgData/CfgData_Power.yaml
+++ b/Platform/MeteorlakeBoardPkg/CfgData/CfgData_Power.yaml
@@ -1071,6 +1071,42 @@
                      Reserved for CPU Post-Mem Production
       length       : 0x8
       value        : {0x00}
+  - OcLock :
+      name         : Over clocking Lock
+      type         : Combo
+      option       : $EN_DIS
+      help         : >
+                     Lock Overclocking. 0: Disable; <b>1: Enable
+      length       : 0x01
+      value        : 0x01
+  - TurboRatioLimitRatio :
+      name         : Turbo Ratio Limit Ratio array
+      type         : EditNum, HEX, (0x00,0xFFFFFFFFFFFFFFFF)
+      help         : >
+                     TurboRatioLimitRatio[7-0] will pair with TurboRatioLimitNumCore[7-0] to determine the active core ranges for each frequency point.
+      length       : 0x08
+      value        : {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+  - TurboRatioLimitNumCore :
+      name         : Turbo Ratio Limit Num Core array
+      type         : EditNum, HEX, (0x00, 0xFFFFFFFF)
+      help         : >
+                     TurboRatioLimitNumCore[7-0] will pair with TurboRatioLimitRatio[7-0] to determine the active core ranges for each frequency point.
+      length       : 0x08
+      value        : {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+  - AtomTurboRatioLimitRatio :
+      name         : Turbo Ratio Limit Ratio array
+      type         : EditNum, HEX, (0x00,0xFFFFFFFFFFFFFFFF)
+      help         : >
+                     AtomTurboRatioLimitRatio[7-0] will pair with AtomTurboRatioLimitNumCore[7-0] to determine the active core ranges for each frequency point.
+      length       : 0x08
+      value        : {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+  - AtomTurboRatioLimitNumCore :
+      name         : Turbo Ratio Limit Ratio array
+      type         : EditNum, HEX, (0x00,0xFFFFFFFFFFFFFFFF)
+      help         : >
+                     AtomTurboRatioLimitNumCore[7-0] will pair with AtomTurboRatioLimitRatio[7-0] to determine the active core ranges for each frequency point.
+      length       : 0x08
+      value        : {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
   - Dummy        :
-      length       : 0x2
+      length       : 0x1
       value        : 0x0

--- a/Platform/MeteorlakeBoardPkg/CfgData/CfgData_Silicon.yaml
+++ b/Platform/MeteorlakeBoardPkg/CfgData/CfgData_Silicon.yaml
@@ -2,7 +2,7 @@
 #
 #  Slim Bootloader CFGDATA Option File.
 #
-#  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2025, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -436,20 +436,6 @@
                      Determines ISH GP GPIO Pin muxing. See GPIO_*_MUXING_ISH_GP_x_GPIO_*. 'x' are GP_NUMBER
       length       : 0x0C
       value        : {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00}
-  - TurboRatioLimitRatio :
-      name         : Turbo Ratio Limit Num Core array
-      type         : EditNum, HEX, (0x00,0xFFFFFFFFFFFFFFFFFFFF)
-      help         : >
-                     Performance-core Turbo Ratio Limit Ratio0-7 (TRLR) defines the turbo ratio (max is 85 in normal mode and 120 in core extension mode). Ratio[0]: This Turbo Ratio Limit Ratio0 must be greater than or equal all other ratio values. If this value is invalid, thn set all other active cores to minimum. Otherwise, align the Ratio Limit to 0. Please check each active cores. Ratio[1~7]: This Turbo Ratio Limit Ratio1 must be <= to Turbo Ratio Limit Ratio0~6."
-      length       : 0x08
-      value        : {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00}
-  - AtomTurboRatioLimitRatio :
-      name         : ATOM Turbo Ratio Limit Ratio array
-      type         : EditNum, HEX, (0x00,0xFFFFFFFFFFFFFFFFFFFF)
-      help         : >
-                     Efficient-core Turbo Ratio Limit Ratio0-7 defines the turbo ratio (max is 85 irrespective of the core extension mode), the core range is defined in E-core Turbo Ratio Limit CoreCount0-7.
-      length       : 0x08
-      value        : {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00}
   - IomTypeCPortPadCfg :
       name         : TypeC port GPIO setting
       type         : Table

--- a/Platform/MeteorlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/MeteorlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2020 - 2024, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020 - 2025, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -233,7 +233,6 @@ UpdateFspConfig (
   CopyMem (Fspmcfg->PchHdaAudioLinkDmicClockSelect, MemCfgData->PchHdaAudioLinkDmicClockSelect, sizeof(MemCfgData->PchHdaAudioLinkDmicClockSelect));
 
   Fspmcfg->SkipMbpHob = 0;
-
   // Gfx
   GfxCfgData = (GRAPHICS_CFG_DATA *)FindConfigDataByTag (CDATA_GRAPHICS_TAG);
   if (GfxCfgData != NULL) {
@@ -406,6 +405,7 @@ UpdateFspConfig (
     Fspmcfg->TdcTimeWindow[0]                                     = 0x3e8;
     Fspmcfg->TdcTimeWindow[1]                                     = 0x3e8;
     Fspmcfg->TdcTimeWindow[2]                                     = 0x3e8;
+    Fspmcfg->OcLock                                               = PowerCfgData->OcLock;
   }
 
   Fspmcfg->ActiveCoreCount                                      = MemCfgData->ActiveCoreCount;//0x4;

--- a/Platform/MeteorlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/MeteorlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2020 - 2024, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020 - 2025, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -586,17 +586,11 @@ UpdateFspConfig (
     FspsConfig->PcieGen3EqPh3Preset4List[11]               = 0x9;
     FspsConfig->PcieGen4EqPh3NoOfPresetOrCoeff[11]         = 0x5;
 
-    for (Index = 0; Index < 8; Index++) {
-      FspsConfig->TurboRatioLimitRatio[Index]                = SiCfgData->TurboRatioLimitRatio[Index];
-      FspsConfig->AtomTurboRatioLimitRatio[Index]            = SiCfgData->AtomTurboRatioLimitRatio[Index];
-    }
   } //End of SiCfgData Ptr
 
   for (Index = 0; Index < 8; Index++) {
     FspsConfig->PcieRpSnoopLatencyOverrideMode[Index]      = 0x2;
     FspsConfig->PcieRpNonSnoopLatencyOverrideMode[Index]   = 0x2;
-    FspsConfig->TurboRatioLimitNumCore[Index]              = 0x0;
-    FspsConfig->AtomTurboRatioLimitNumCore[Index]          = 0x0;
   }
 
   // Set VerbTable is disabled by default. Enable it only when specified by config data.
@@ -757,6 +751,13 @@ UpdateFspConfig (
     FspsConfig->ConfigTdpLevel                = PowerCfgData->ConfigTdpLevel;
     FspsConfig->RaceToHalt                    = PowerCfgData->RaceToHalt;
     FspsConfig->PkgCStateLimit                = PowerCfgData->PkgCStateLimit;
+
+    for (Index = 0; Index < 8; Index++) {
+      FspsConfig->TurboRatioLimitRatio[Index]                = PowerCfgData->TurboRatioLimitRatio[Index];
+      FspsConfig->TurboRatioLimitNumCore[Index]              = PowerCfgData->TurboRatioLimitNumCore[Index];
+      FspsConfig->AtomTurboRatioLimitRatio[Index]            = PowerCfgData->AtomTurboRatioLimitRatio[Index];
+      FspsConfig->AtomTurboRatioLimitNumCore[Index]          = PowerCfgData->AtomTurboRatioLimitNumCore[Index];
+    }
   }
 
   //Misc Fsps Upd


### PR DESCRIPTION
The FSP-S UPD has an option .OcLock that cannot be modified from SBL configuration. Need this for controlling the max turbo frequency.

Tested on mtl-ps crb with those config changed.
  SILICON_CFG_DATA.TurboRatioLimitRatio           | {0x2A, 0x2A, 0x28, 0x28, 0x26, 0x26, 0x26, 0x26}
  SILICON_CFG_DATA.AtomTurboRatioLimitRatio       | {0x1F, 0x1F, 0x1F, 0x1F, 0x1C, 0x1C, 0x1C, 0x1C}
  POWER_CFG_DATA.OcLock                         | 0