### PR TITLE
[MTL/ARL] Correct Definitions for GpioV2Config

### DIFF
--- a/Silicon/CommonSocPkg/Include/GpioV2Config.h
+++ b/Silicon/CommonSocPkg/Include/GpioV2Config.h
@@ -21,17 +21,23 @@ typedef UINT32  GPIOV2_PAD_GROUP;
 
 #define GPIO_STATE(Val)  (UINT32) ((Val >> 1) & 0x01)
 
-#define GPIOV2_PAD_MASK_CHIPSETID              (0xFF)
-#define GPIOV2_PAD_POS_CHIPSETID               (16)
-#define GPIOV2_PAD_MASK_COMMUNITY_INDEX        (0xF)
-#define GPIOV2_PAD_POS_COMMUNITY_INDEX         (12)
-#define GPIOV2_PAD_MASK_GROUP_INDEX            (0xF)
-#define GPIOV2_PAD_POS_GROUP_INDEX             (8)
-#define GPIOV2_PAD_MASK_PAD_INDEX              (0xFF)
+#define GPIOV2_PAD_MASK_FUNCTIONALITY          (0x3FF)
+#define GPIOV2_PAD_POS_FUNCTIONALITY           (22)
+#define GPIOV2_PAD_MASK_CHIPSETID              (0x1F)
+#define GPIOV2_PAD_POS_CHIPSETID               (17)
+#define GPIOV2_PAD_MASK_NATIVE_FUNCTION        (0xF)
+#define GPIOV2_PAD_POS_NATIVE_FUNCTION         (13)
+#define GPIOV2_PAD_MASK_COMMUNITY_INDEX        (0x7)
+#define GPIOV2_PAD_POS_COMMUNITY_INDEX         (10)
+#define GPIOV2_PAD_MASK_GROUP_INDEX            (0x7)
+#define GPIOV2_PAD_POS_GROUP_INDEX             (7)
+#define GPIOV2_PAD_MASK_PAD_INDEX              (0x7F)
 #define GPIOV2_PAD_POS_PAD_INDEX               (0)
 
 #define GPIOV2_PAD_ID(Functionality, ChipsetId, NativeFunction, CommunityIndex, GroupIndex, PadIndex) \
-        ( ((ChipsetId & GPIOV2_PAD_MASK_CHIPSETID) << GPIOV2_PAD_POS_CHIPSETID) |\
+        ( ((Functionality & GPIOV2_PAD_MASK_FUNCTIONALITY) << GPIOV2_PAD_POS_FUNCTIONALITY) |\
+          ((ChipsetId & GPIOV2_PAD_MASK_CHIPSETID) << GPIOV2_PAD_POS_CHIPSETID) |\
+          ((NativeFunction & GPIOV2_PAD_MASK_NATIVE_FUNCTION) << GPIOV2_PAD_POS_NATIVE_FUNCTION) |\
           ((CommunityIndex & GPIOV2_PAD_MASK_COMMUNITY_INDEX) << GPIOV2_PAD_POS_COMMUNITY_INDEX) |\
           ((GroupIndex & GPIOV2_PAD_MASK_GROUP_INDEX) << GPIOV2_PAD_POS_GROUP_INDEX) |\
           ((PadIndex & GPIOV2_PAD_MASK_PAD_INDEX) << GPIOV2_PAD_POS_PAD_INDEX) \


### PR DESCRIPTION
This patch rectifies incorrect definitions for GpioV2 introduced in commit 5d51ee9 (for ARL), which were subsequently merged into CommonSocPkg in commit ca0070312 and affected MTL in commit 7e0e5d3.

The correction resolves errors encountered by the Linux kernel, enabling successful entry into s0ix.

The error messages by Linux kernel without the commit are:

[ 132.527837] ACPI BIOS Error (bug): AE_AML_PACKAGE_LIMIT, Index (0x000000008)
              is beyond end of object (length 0x3) (20240827/exoparg2-393)
[ 132.527873] Initialized Local Variables for Method [GINF]: [ 132.527875] Local0: 00000000a26f218d Package 00000000a26f218d [ 132.527883] Initialized Arguments for Method [GINF]: (3 arguments defined for method invocation) [ 132.527884] Arg0: 00000000d9983d2b Integer 0000000000000000 [ 132.527889] Arg1: 00000000609695f6 Integer 0000000000000008 [ 132.527893] Arg2: 000000009b1a979c Integer 0000000000000001