### PR TITLE
[ARLs/uh] Fix s0ix no display

### DIFF
--- a/Platform/ArrowlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/ArrowlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -479,7 +479,6 @@ UpdateFspConfig (
       Fspmcfg->TcssItbtPcie2En    = 0;
       Fspmcfg->TcssItbtPcie3En    = 0;
       Fspmcfg->PchHdaDspEnable    = 0;
-       Fspmcfg->InternalGfx       = 0;
       Fspmcfg->PchHdaAudioLinkHdaEnable  = 0;
       ZeroMem (Fspmcfg->PchHdaAudioLinkDmicEnable, sizeof (Fspmcfg->PchHdaAudioLinkDmicEnable));
       DEBUG ((DEBUG_INFO, "Stage 1B S0ix config applied.\n"));


### PR DESCRIPTION
Remove the workaround (WA) to prevent the GuC module hang issue during s0ix transitions. intel kernel 6.11 fixed.

verified on arls s02 rvp/arlp rvp with kernel 6.12