### PR TITLE
fix: EPAYLOAD.bin size is too small

### DIFF
--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
@@ -116,7 +116,7 @@ class Board(BaseBoard):
         self.STAGE2_FD_SIZE       = 0x001F0000
 
         self.PAYLOAD_SIZE         = 0x00030000
-        self.EPAYLOAD_SIZE        = 0x00230000
+        self.EPAYLOAD_SIZE        = 0x00240000
 
         self.OS_LOADER_FD_SIZE    = 0x0005B000
         self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlN50.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlN50.py
@@ -76,7 +76,7 @@ class Board(AlderlakeBoardConfig.Board):
         self.STAGE2_FD_SIZE       = 0x001F0000
 
         self.PAYLOAD_SIZE         = 0x00030000
-        self.EPAYLOAD_SIZE        = 0x00230000
+        self.EPAYLOAD_SIZE        = 0x00240000
 
         self.OS_LOADER_FD_SIZE    = 0x0005B000
         self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE

--- a/Platform/MeteorlakeBoardPkg/BoardConfigMtlp.py
+++ b/Platform/MeteorlakeBoardPkg/BoardConfigMtlp.py
@@ -122,7 +122,7 @@ class Board(BaseBoard):
         self.STAGE2_FD_SIZE       = 0x001F0000
 
         self.PAYLOAD_SIZE         = 0x0002E000
-        self.EPAYLOAD_SIZE        = 0x00230000
+        self.EPAYLOAD_SIZE        = 0x00240000
 
         self.ENABLE_FAST_BOOT = 0
         if self.ENABLE_FAST_BOOT:

--- a/Platform/RaptorlakeBoardPkg/BoardConfigRplPs.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRplPs.py
@@ -37,7 +37,7 @@ class Board(AlderlakeBoardConfig.Board):
         self._CFGDATA_EXT_FILE    = ['CfgDataInt_Rplps_Crb_Ddr5.dlt', 'CfgDataInt_Rplps_Rvp_Ddr5.dlt']
         self._MULTI_VBT_FILE      = {1:'VbtRplPsRvp.dat', 2:'VbtRplPsCrb.dat'}
         self._LP_SUPPORT          = True
-        self.EPAYLOAD_SIZE        = 0x230000
+        self.EPAYLOAD_SIZE        = 0x240000
         self.OS_LOADER_FD_SIZE    = 0x00059000
         self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
         # 0 - PCH UART0, 1 - PCH UART1, 2 - PCH UART2, 0xFF - EC UART 0x3F8

--- a/Platform/RaptorlakeBoardPkg/BoardConfigRplp.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRplp.py
@@ -124,7 +124,7 @@ class Board(BaseBoard):
             self.STAGE2_SIZE += 0x4000
 
         self.PAYLOAD_SIZE         = 0x00030000
-        self.EPAYLOAD_SIZE        = 0x00230000
+        self.EPAYLOAD_SIZE        = 0x00240000
 
         self.OS_LOADER_FD_SIZE    = 0x0005C000
         self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE

--- a/Platform/RaptorlakeBoardPkg/BoardConfigRpls.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRpls.py
@@ -116,7 +116,7 @@ class Board(BaseBoard):
         self.STAGE2_FD_SIZE       = 0x001F0000
 
         self.PAYLOAD_SIZE         = 0x00032000
-        self.EPAYLOAD_SIZE        = 0x00230000
+        self.EPAYLOAD_SIZE        = 0x00240000
         self.OS_LOADER_FD_SIZE    = 0x00059000
         self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 


### PR DESCRIPTION
Fix build failure for rebase the UEFI payload to 202411.