### PR TITLE
fix: [ADL] rework the UpdateResetReason #2442

### DIFF
--- a/PayloadPkg/OsLoader/BootOption.c
+++ b/PayloadPkg/OsLoader/BootOption.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2025, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -147,7 +147,7 @@ GetCurrentBootOption (
   }
 
   // Give another chance like crashmode if ResetReason has non-cold boot reason
-  Data8 = (UINT8)~(ResetCold | ResetPowerOn | ResetGlobal | ResetWakeS3);
+  Data8 = (UINT8)~(ResetCold | ResetPowerOn | ResetGlobal | ResetWakeS3 | ResetWakeS4);
   if ((OsBootOptionList->ResetReason & Data8) == 0) {
     return OsBootOptionList->CurrentBoot;
   }

--- a/Silicon/AlderlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.inf
+++ b/Silicon/AlderlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2025, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -34,6 +34,7 @@
   PcdLib
   IoLib
   SpiFlashLib
+  TcoTimerLib
 
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress

--- a/Silicon/ElkhartlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/ElkhartlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -1,7 +1,7 @@
 /** @file
   The platform hook library.
 
-  Copyright (c) 2013 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2013 - 2025, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -31,106 +31,6 @@ EnableCodeExecution (
 )
 {
 
-}
-
-/**
-  Check if boot is caused by watch dog timer
-
-  @RETVAL   TRUE     It is caused by watch dog timer timeout.
-  @RETVAL   FALSE    It is not caused by watch dog timer timeout.
-**/
-BOOLEAN
-IsRebootByWdt (
-  VOID
-)
-{
-  UINT32   TcoBase;
-  UINT32   SbRegBase;
-  UINT32   GeneralControlReg;
-  UINT16   TcoSts2Reg;
-  BOOLEAN  RebootByWdt;
-
-  RebootByWdt = FALSE;
-
-  // Get No_Reboot from SmBus PCR register via P2SB base address
-  SbRegBase  = PciRead32 (PCI_LIB_ADDRESS(0, 31, 1, 0x10)) & 0xFF000000;
-  GeneralControlReg = MmioRead32  (SbRegBase + ((SMBUS_PORT_ID) << 16) + GENERAL_CONTROL_REG);
-
-  // Get Tco Status2 from from SmBus config space
-  TcoBase     = PciRead32 (PCI_LIB_ADDRESS(0, 31, 4, 0x50)) & 0x0000FFE0;
-  TcoSts2Reg  = IoRead16 (TcoBase + 0x6);
-
-  DEBUG ((DEBUG_INFO, "TcoSts2Reg= 0x%x, GeneralControlReg = 0x%x\n", TcoSts2Reg, GeneralControlReg));
-  if (((GeneralControlReg & TCO_STS_NO_REBOOT) == 0) && !(TcoSts2Reg & TCO_STS_2ND_TIMEOUT)) {
-    RebootByWdt = TRUE;
-  }
-
-  return RebootByWdt;
-}
-
-/**
-  Check if this boot is caused by warm reset.
-
-  @RETVAL   TRUE     It is caused by warm reset.
-  @RETVAL   FALSE    It is not caused by warm reset.
-**/
-BOOLEAN
-IsWarmReset (
-  VOID
-  )
-{
-  VOID                  *FspHobList;
-  MEMORY_PLATFORM_DATA  *MemPlatformData;
-  UINT8                 ResetType;
-  BOOLEAN               IsWarmReset;
-
-  IsWarmReset     = FALSE;
-  MemPlatformData = NULL;
-  FspHobList = GetFspHobListPtr ();
-  if (FspHobList != NULL) {
-    MemPlatformData = GetGuidHobData (
-                        FspHobList,
-                        NULL,
-                        &gSiMemoryPlatformDataGuid
-                        );
-  }
-  if (MemPlatformData != NULL) {
-    if (MemPlatformData->BootMode == 1) {
-      IsWarmReset = TRUE;
-    }
-  } else {
-    //
-    // Read reset type from reset control register 0xCF9, writing 0x04/0x06
-    // to 0xCF9 also cause warm reset.
-    //
-    ResetType = IoRead8 (0xCF9);
-    if ((ResetType == 0x4) || (ResetType == 0x6)) {
-      IsWarmReset = TRUE;
-    }
-  }
-
-  return IsWarmReset;
-}
-
-/**
-  Update reset reason.
-**/
-VOID
-EFIAPI
-UpdateResetReason (
-  VOID
-)
-{
-  UINT8    ResetReason;
-
-  ResetReason  = 0;
-  if (IsRebootByWdt ()) {
-    ResetReason |= ResetTcoWdt;
-  }
-  if (IsWarmReset ()) {
-    ResetReason |= ResetWarm;
-  }
-  SetResetReason (ResetReason);
 }
 
 /**

--- a/Silicon/TigerlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/TigerlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -1,7 +1,7 @@
 /** @file
   The platform hook library.
 
-  Copyright (c) 2013 - 2017, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2013 - 2025, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -32,106 +32,6 @@ EnableCodeExecution (
 )
 {
 
-}
-
-/**
-  Check if boot is caused by watch dog timer
-
-  @RETVAL   TRUE     It is caused by watch dog timer timeout.
-  @RETVAL   FALSE    It is not caused by watch dog timer timeout.
-**/
-BOOLEAN
-IsRebootByWdt (
-  VOID
-)
-{
-  UINT32   TcoBase;
-  UINT32   SbRegBase;
-  UINT32   GeneralControlReg;
-  UINT16   TcoSts2Reg;
-  BOOLEAN  RebootByWdt;
-
-  RebootByWdt = FALSE;
-
-  // Get No_Reboot from SmBus PCR register via P2SB base address
-  SbRegBase  = PciRead32 (PCI_LIB_ADDRESS(0, 31, 1, 0x10)) & 0xFF000000;
-  GeneralControlReg = MmioRead32  (SbRegBase + ((SMBUS_PORT_ID) << 16) + GENERAL_CONTROL_REG);
-
-  // Get Tco Status2 from from SmBus config space
-  TcoBase     = PciRead32 (PCI_LIB_ADDRESS(0, 31, 4, 0x50)) & 0x0000FFE0;
-  TcoSts2Reg  = IoRead16 (TcoBase + 0x6);
-
-  DEBUG ((DEBUG_INFO, "TcoSts2Reg= 0x%x, GeneralControlReg = 0x%x\n", TcoSts2Reg, GeneralControlReg));
-  if (((GeneralControlReg & TCO_STS_NO_REBOOT) == 0) && !(TcoSts2Reg & TCO_STS_2ND_TIMEOUT)) {
-    RebootByWdt = TRUE;
-  }
-
-  return RebootByWdt;
-}
-
-/**
-  Check if this boot is caused by warm reset.
-
-  @RETVAL   TRUE     It is caused by warm reset.
-  @RETVAL   FALSE    It is not caused by warm reset.
-**/
-BOOLEAN
-IsWarmReset (
-  VOID
-  )
-{
-  VOID                  *FspHobList;
-  MEMORY_PLATFORM_DATA  *MemPlatformData;
-  UINT8                 ResetType;
-  BOOLEAN               IsWarmReset;
-
-  IsWarmReset     = FALSE;
-  MemPlatformData = NULL;
-  FspHobList = GetFspHobListPtr ();
-  if (FspHobList != NULL) {
-    MemPlatformData = GetGuidHobData (
-                        FspHobList,
-                        NULL,
-                        &gSiMemoryPlatformDataGuid
-                        );
-  }
-  if (MemPlatformData != NULL) {
-    if (MemPlatformData->BootMode == 1) {
-      IsWarmReset = TRUE;
-    }
-  } else {
-    //
-    // Read reset type from reset control register 0xCF9, writing 0x04/0x06
-    // to 0xCF9 also cause warm reset.
-    //
-    ResetType = IoRead8 (0xCF9);
-    if ((ResetType == 0x4) || (ResetType == 0x6)) {
-      IsWarmReset = TRUE;
-    }
-  }
-
-  return IsWarmReset;
-}
-
-/**
-  Update reset reason.
-**/
-VOID
-EFIAPI
-UpdateResetReason (
-  VOID
-)
-{
-  UINT8    ResetReason;
-
-  ResetReason  = 0;
-  if (IsRebootByWdt ()) {
-    ResetReason |= ResetTcoWdt;
-  }
-  if (IsWarmReset ()) {
-    ResetReason |= ResetWarm;
-  }
-  SetResetReason (ResetReason);
 }
 
 /**


### PR DESCRIPTION
This commit refines the UpdateResetReason for ADL with the following improvements:

1. Replacing IsRebootByWdt with WasBootCausedByTcoTimeout. Previously, ADL utilized IsRebootByWdt, which was incorrect and redundant. The incorrect aspect involved checking a non-existent bit field (TCO_STS_NO_REBOOT), while the redundancy lay in its functionality being identical to WasBootCausedByTcoTimeout(). Consequently, this commit removes IsRebootByWdt and substitutes IsRebootByWdt with WasBootCausedByTcoTimeout.

2. Prioritizing S3/S4 for RstCause assignment in UpdateResetReason. The original code assigned ResetWakeS3 or ResetWakeS4 or S3/S4 resume at the end of the check logic. However, ResetWakeS3 and ResetWakeS4 already imply a successful resume, allowing us to move these checks to the beginning of the function.

3. Setting ResetUnknown for MMIO failure.

4. Setting ResetUnknown for B_PMC_PWRM_GEN_PMCON_A_PWR_FLR. This should be an independent check, rather than an "else-if" check as in the original code.

5. Simplifying the check for ResetWarm and ResetCold, as both are held when B_PMC_PWRM_GEN_PMCON_A_HOST_RST_STS is set.

Additionally, the commit skips ResetWakeS4 for crash mode in GetCurrentBootOption.

Finally, it removes the UpdateResetReason from TGL and EHL as it is unused.
