### PR TITLE
fix: [ADL/RPL] Fixing SBL build issue due to payload size

### DIFF
--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
@@ -116,7 +116,7 @@ class Board(BaseBoard):
         self.STAGE2_FD_SIZE       = 0x001F0000
 
         self.PAYLOAD_SIZE         = 0x00030000
-        self.EPAYLOAD_SIZE        = 0x00230000
+        self.EPAYLOAD_SIZE        = 0x00240000
 
         self.OS_LOADER_FD_SIZE    = 0x0005B000
         self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE

--- a/Platform/RaptorlakeBoardPkg/BoardConfigRplPs.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRplPs.py
@@ -37,7 +37,7 @@ class Board(AlderlakeBoardConfig.Board):
         self._CFGDATA_EXT_FILE    = ['CfgDataInt_Rplps_Crb_Ddr5.dlt', 'CfgDataInt_Rplps_Rvp_Ddr5.dlt']
         self._MULTI_VBT_FILE      = {1:'VbtRplPsRvp.dat', 2:'VbtRplPsCrb.dat'}
         self._LP_SUPPORT          = True
-        self.EPAYLOAD_SIZE        = 0x230000
+        self.EPAYLOAD_SIZE        = 0x240000
         self.OS_LOADER_FD_SIZE    = 0x00059000
         self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
         # 0 - PCH UART0, 1 - PCH UART1, 2 - PCH UART2, 0xFF - EC UART 0x3F8

--- a/Platform/RaptorlakeBoardPkg/BoardConfigRplp.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRplp.py
@@ -124,7 +124,7 @@ class Board(BaseBoard):
             self.STAGE2_SIZE += 0x4000
 
         self.PAYLOAD_SIZE         = 0x00030000
-        self.EPAYLOAD_SIZE        = 0x00230000
+        self.EPAYLOAD_SIZE        = 0x00240000
 
         self.OS_LOADER_FD_SIZE    = 0x0005C000
         self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE

--- a/Platform/RaptorlakeBoardPkg/BoardConfigRpls.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRpls.py
@@ -116,7 +116,7 @@ class Board(BaseBoard):
         self.STAGE2_FD_SIZE       = 0x001F0000
 
         self.PAYLOAD_SIZE         = 0x00032000
-        self.EPAYLOAD_SIZE        = 0x00230000
+        self.EPAYLOAD_SIZE        = 0x00240000
         self.OS_LOADER_FD_SIZE    = 0x00059000
         self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 


### PR DESCRIPTION
After migrating UEFI build to edk2-stable202411 branch, SBL build for ADL-N, RPL-P, RPL-PS and RPL-S platforms failed to the insufficient EPAYLOAD size. This commit addressed the build issue.