### PR TITLE
fix: [common] Fix Coverity issues in in ElfLib

### DIFF
--- a/BootloaderCommonPkg/Library/ElfLib/ElfLib.c
+++ b/BootloaderCommonPkg/Library/ElfLib/ElfLib.c
@@ -291,6 +291,7 @@ ParseElfImage (
   Base = MAX_UINT32;
   FileOffset = 0;
   ElfCt->ReloadRequired = FALSE;
+  SegAlignment = 0;
 
   ASSERT(ElfCt->PhNum < MAX_ELF_PHNUM);
   for (Index = 0; Index < ElfCt->PhNum; Index++) {


### PR DESCRIPTION
- Uninitialized scalar variable (CWE-457) on SegAlignment