### PR TITLE
fix: [BTL-S] Change SmmRebase mode to "Auto NoSmrr" for edk2 202411

### DIFF
--- a/Platform/RaptorlakeBoardPkg/BoardConfigBtls.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigBtls.py
@@ -113,3 +113,7 @@ class Board(RaptorlakeBoardConfig.Board):
             self.ACM_SIZE     = acm_top - acm_btm
 
         self.FSP_M_STACK_TOP      = 0xFEFDFF00
+
+        # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)
+        # 3: Enable NOSMRR (for edk2-stable202411 and newer UEFI payload)  4: Auto NOSMRR
+        self.ENABLE_SMM_REBASE    = 4


### PR DESCRIPTION
edk2-stable202411 based UEFI payload requires Smm Rebase without setting SMRR. Set this new auto mode for compatibility with this and newer uefi payload.