### PR TITLE
fix: [ARL][MTL] Change SmmRebase mode to Auto NoSmrr for edk2 202411

### DIFF
--- a/Platform/ArrowlakeBoardPkg/BoardConfigArlh.py
+++ b/Platform/ArrowlakeBoardPkg/BoardConfigArlh.py
@@ -70,7 +70,8 @@ class Board(BaseBoard):
         # If ENABLE_SOURCE_DEBUG is disabled, SKIP_STAGE1A_SOURCE_DEBUG will be ignored
         self.SKIP_STAGE1A_SOURCE_DEBUG = 1
         # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)
-        self.ENABLE_SMM_REBASE    = 2
+        # 3: Enable NOSMRR (for edk2-stable202411 and newer UEFI payload)  4: Auto NOSMRR
+        self.ENABLE_SMM_REBASE    = 4
         # 0: Disable 1: Enable IPP Crypto performance mesurement
         self.ENABLE_IPP_CRYPTO_PERF = 0
         self.ENABLE_FIPS_SELFTEST   = 0

--- a/Platform/ArrowlakeBoardPkg/BoardConfigArls.py
+++ b/Platform/ArrowlakeBoardPkg/BoardConfigArls.py
@@ -71,7 +71,8 @@ class Board(BaseBoard):
         # If ENABLE_SOURCE_DEBUG is disabled, SKIP_STAGE1A_SOURCE_DEBUG will be ignored
         self.SKIP_STAGE1A_SOURCE_DEBUG = 1
         # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)
-        self.ENABLE_SMM_REBASE    = 2
+        # 3: Enable NOSMRR (for edk2-stable202411 and newer UEFI payload)  4: Auto NOSMRR
+        self.ENABLE_SMM_REBASE    = 4
         # 0: Disable 1: Enable IPP Crypto performance mesurement
         self.ENABLE_IPP_CRYPTO_PERF = 0
         self.ENABLE_FIPS_SELFTEST   = 0

--- a/Platform/MeteorlakeBoardPkg/BoardConfigMtlp.py
+++ b/Platform/MeteorlakeBoardPkg/BoardConfigMtlp.py
@@ -64,8 +64,8 @@ class Board(BaseBoard):
         self.ENABLE_SOURCE_DEBUG  = 0
         # If ENABLE_SOURCE_DEBUG is disabled, SKIP_STAGE1A_SOURCE_DEBUG will be ignored
         self.SKIP_STAGE1A_SOURCE_DEBUG = 1
-        # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)
-        self.ENABLE_SMM_REBASE    = 2
+        # 3: Enable NOSMRR (for edk2-stable202411 and newer UEFI payload)  4: Auto NOSMRR
+        self.ENABLE_SMM_REBASE    = 4
 
         # 0 - PCH UART0, 1 - PCH UART1, 2 - PCH UART2, 0xFF - EC UART 0x3F8
         self.DEBUG_PORT_NUMBER = 0x0


### PR DESCRIPTION
edk2-stable202411 based UEFI payload requires Smm Rebase without setting SMRR. Set this new auto mode for compatibility with this and newer uefi payload.