### PR TITLE
fix: [ADL][RPL] Change SmmRebase mode to Auto NoSmrr for edk2 202411

### DIFF
--- a/Platform/AlderlakeBoardPkg/BoardConfig.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfig.py
@@ -1,7 +1,7 @@
 ## @file
 # This file is used to provide board specific image information.
 #
-#  Copyright (c) 2020 - 2024, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2025, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -65,7 +65,8 @@ class Board(BaseBoard):
         self.SKIP_STAGE1A_SOURCE_DEBUG = 1
         self.ENABLE_PCIE_PM       = 1
         # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)
-        self.ENABLE_SMM_REBASE    = 2
+        # 3: Enable NOSMRR (for edk2-stable202411 and newer UEFI payload)  4: Auto NOSMRR
+        self.ENABLE_SMM_REBASE    = 4
 
         # 0 - PCH UART0, 1 - PCH UART1, 2 - PCH UART2, 0xFF - EC UART 0x3F8
         self.DEBUG_PORT_NUMBER = 0x2

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
@@ -64,7 +64,8 @@ class Board(BaseBoard):
         self.SKIP_STAGE1A_SOURCE_DEBUG = 1
         self.ENABLE_PCIE_PM       = 1
         # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)
-        self.ENABLE_SMM_REBASE    = 2
+        # 3: Enable NOSMRR (for edk2-stable202411 and newer UEFI payload)  4: Auto NOSMRR
+        self.ENABLE_SMM_REBASE    = 4
 
         # 0 - PCH UART0, 1 - PCH UART1, 2 - PCH UART2, 0xFF - EC UART 0x3F8
         self.DEBUG_PORT_NUMBER = 0x0

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlN50.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlN50.py
@@ -55,7 +55,8 @@ class Board(AlderlakeBoardConfig.Board):
         self.SKIP_STAGE1A_SOURCE_DEBUG = 1
         self.ENABLE_PCIE_PM       = 1
         # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)
-        self.ENABLE_SMM_REBASE    = 2
+        # 3: Enable NOSMRR (for edk2-stable202411 and newer UEFI payload)  4: Auto NOSMRR
+        self.ENABLE_SMM_REBASE    = 4
 
         # 0 - PCH UART0, 1 - PCH UART1, 2 - PCH UART2, 0xFF - EC UART 0x3F8
         self.DEBUG_PORT_NUMBER = 0x1

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlS.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlS.py
@@ -1,7 +1,7 @@
 ## @file
 # This file is used to provide board specific image information.
 #
-#  Copyright (c) 2020 - 2024, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2025, Intel Corporation. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -66,7 +66,8 @@ class Board(BaseBoard):
         self.SKIP_STAGE1A_SOURCE_DEBUG = 1
         self.ENABLE_PCIE_PM       = 1
         # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)
-        self.ENABLE_SMM_REBASE    = 2
+        # 3: Enable NOSMRR (for edk2-stable202411 and newer UEFI payload)  4: Auto NOSMRR
+        self.ENABLE_SMM_REBASE    = 4
 
         # 0 - PCH UART0, 1 - PCH UART1, 2 - PCH UART2, 0xFF - EC UART 0x3F8
         self.DEBUG_PORT_NUMBER = 0x2

--- a/Platform/AlderlakeBoardPkg/BoardConfigAzb.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAzb.py
@@ -77,7 +77,8 @@ class Board(BaseBoard):
         self.SKIP_STAGE1A_SOURCE_DEBUG        = 1
         self.ENABLE_PCIE_PM                   = 1
         # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)
-        self.ENABLE_SMM_REBASE                = 2
+        # 3: Enable NOSMRR (for edk2-stable202411 and newer UEFI payload)  4: Auto NOSMRR
+        self.ENABLE_SMM_REBASE                = 4
 
         # 0 - PCH UART0, 1 - PCH UART1, 2 - PCH UART2, 0xFF - EC UART 0x3F8
         self.DEBUG_PORT_NUMBER                = 0x0

--- a/Platform/RaptorlakeBoardPkg/BoardConfigRplp.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRplp.py
@@ -69,7 +69,8 @@ class Board(BaseBoard):
         self.SKIP_STAGE1A_SOURCE_DEBUG = 1
         self.ENABLE_PCIE_PM       = 1
         # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)
-        self.ENABLE_SMM_REBASE    = 2
+        # 3: Enable NOSMRR (for edk2-stable202411 and newer UEFI payload)  4: Auto NOSMRR
+        self.ENABLE_SMM_REBASE    = 4
 
         # 0 - PCH UART0, 1 - PCH UART1, 2 - PCH UART2, 0xFF - EC UART 0x3F8
         self.DEBUG_PORT_NUMBER =0

--- a/Platform/RaptorlakeBoardPkg/BoardConfigRpls.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRpls.py
@@ -64,7 +64,8 @@ class Board(BaseBoard):
         self.SKIP_STAGE1A_SOURCE_DEBUG = 1
         self.ENABLE_PCIE_PM       = 1
         # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)
-        self.ENABLE_SMM_REBASE    = 2
+        # 3: Enable NOSMRR (for edk2-stable202411 and newer UEFI payload)  4: Auto NOSMRR
+        self.ENABLE_SMM_REBASE    = 4
 
         # 0 - PCH UART0, 1 - PCH UART1, 2 - PCH UART2, 0xFF - EC UART 0x3F8
         self.DEBUG_PORT_NUMBER = 0xFF


### PR DESCRIPTION
edk2-stable202411 based UEFI payload requires Smm Rebase without setting SMRR. Set this new auto mode for compatibility with this and newer uefi payload.