### PR TITLE
fix: Set Lid state open

### DIFF
--- a/Silicon/CommonSocPkg/Library/IgdOpRegionLib/IgdOpRegionLib30/IgdOpRegionLib30.c
+++ b/Silicon/CommonSocPkg/Library/IgdOpRegionLib/IgdOpRegionLib30/IgdOpRegionLib30.c
@@ -208,6 +208,9 @@ IgdOpRegionInit (
     CopyMem (mIgdOpRegion.OpRegion->MBox4.RVBT, VbtFileBuffer, VbtFileBuffer->HeaderVbtSize);
   }
 
+  // Set LID state to open
+  mIgdOpRegion.OpRegion->MBox1.CLID = 0x01;
+
   // Initialize hardware state:
   // Set ASLS Register to the OpRegion physical memory address.
   // Set SWSCI register bit 15 to a "1" to activate SCI interrupts.


### PR DESCRIPTION
Set Lid state open as default in Igd OpRegion 30 library