### PR TITLE
fix: [common] Fix Coverity issues in RpmbLib.

### DIFF
--- a/BootloaderCommonPkg/Library/RpmbLib/RpmbLib.c
+++ b/BootloaderCommonPkg/Library/RpmbLib/RpmbLib.c
@@ -42,8 +42,7 @@ RpmbCalcHmacSha256(
   OUT UINT8               Mac[]
   )
 {
-  //TODO: Andriod does HMAC_Update in a loop of BlockCnt. Change this later if we need BlocksCnt > 1
-  return HmacSha256 ((UINT8 *)Frames->Data, HMAC_DATA_LEN, Key, KeySize, Mac, RPMB_MAC_SIZE);
+  return HmacSha256 ((UINT8 *)Frames->Data, sizeof(Frames->Data), Key, KeySize, Mac, RPMB_MAC_SIZE);
 }
 
 /**


### PR DESCRIPTION
Out-of-bounds access (OVERRUN)
overrun-buffer-arg: Overrunning array Frames->Data of 256 bytes by passing it to a function which accesses it at byte offset 283 using argument 284U