### PR TITLE
fix: [ARL] Set SMI lock bit for Osloader

### DIFF
--- a/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -141,6 +141,10 @@ ProgramSecuritySetting (
 
   // Set the BIOS Lock Enable and EISS bits
   MmioOr8 (SpiBaseAddress + R_SPI_CFG_BC, (UINT8) (B_SPI_CFG_BC_LE | B_SPI_CFG_BC_EISS));
+
+  // Set SMI LOCK (SMI_LOCK)
+  DEBUG ((DEBUG_INFO, "Set SMI Lock\n"));
+  MmioOr8 (PCH_PWRM_BASE_ADDRESS + R_PMC_PWRM_GEN_PMCON_B, (UINT8)B_PMC_PWRM_GEN_PMCON_B_SMI_LOCK);
 }
 
 /**


### PR DESCRIPTION
Set SMI lock bit at ReadyToBoot for Osloader
Uefi payload will set this bit in its driver.