### PR TITLE
fix: [MTL] Set SMI Lock bit for OsLoader

### DIFF
--- a/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -447,6 +447,9 @@ BoardInit (
   case ReadyToBoot:
     if ((GetBootMode() != BOOT_ON_FLASH_UPDATE) && (GetPayloadId() == 0)) {
       ProgramSecuritySetting ();
+
+      // Set SMI Lock
+      MmioOr8 (PCH_PWRM_BASE_ADDRESS + R_PMC_PWRM_GEN_PMCON_B, (UINT8)B_PMC_PWRM_GEN_PMCON_B_SMI_LOCK);
     }
     break;
   case EndOfFirmware:


### PR DESCRIPTION
Set SMI Lock bit at ReadyToBoot for OsLoader before jumping to OS