### PR TITLE
Fix CI build failure

### DIFF
--- a/.azurepipelines/azure-pipelines.yml
+++ b/.azurepipelines/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
 - job: QEMU
 
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-24.04'
 
   steps:
   - checkout: self
@@ -141,7 +141,7 @@ jobs:
         Build.Target: ""
 
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-24.04'
 
   steps:
   - checkout: self


### PR DESCRIPTION
CI build failed for the case using ubuntu 20.04. It looks the Azure Pipelines agent could not be found in the build job.
This PR just changes the settings to use ubuntu 24.04.