### PR TITLE
fix: [EHL] Set SMI Lock bit for OsLoader

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -844,6 +844,9 @@ BoardInit (
     }
     if ((GetBootMode() != BOOT_ON_FLASH_UPDATE) && (GetPayloadId() == 0)) {
       ProgramSecuritySetting ();
+      // Set SMI Lock
+      DEBUG ((DEBUG_INFO, "Set SMI Lock\n"));
+      MmioOr8 (PCH_PWRM_BASE_ADDRESS + R_PMC_PWRM_GEN_PMCON_B, (UINT8)B_PMC_PWRM_GEN_PMCON_B_SMI_LOCK);
     }
     break;
   case EndOfFirmware:


### PR DESCRIPTION
Set SMI Lock bit at ReadyToBoot for OsLoader before jumping to OS

verified on EHL CRB.