### PR TITLE
fix: [ARL][MTL] Fix Coverity issues

### DIFF
--- a/BootloaderCommonPkg/Library/ThunkLib/X64/DispatchExecute.c
+++ b/BootloaderCommonPkg/Library/ThunkLib/X64/DispatchExecute.c
@@ -3,7 +3,7 @@
   Provide a thunk function to transition from long mode to compatibility mode to execute 32-bit code and then transit
   back to long mode.
 
-  Copyright (c) 2014 - 2020, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2014 - 2025, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -107,6 +107,9 @@ Execute32BitCode (
     // For TempRamInit in XIP, it might be running from temp memory.
     // To be safe, need to copy the thunk code into memory for execution to prevent crash.
     ExecuteCode = (EXECUTE_32BIT_CODE)(UINTN)AllocateTemporaryMemory (0);
+    if (ExecuteCode == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
     CopyMem ((VOID *)(UINTN)ExecuteCode, (VOID *)(UINTN)AsmExecute32BitCode, AsmGetExecute32CodeLength());
   } else {
     ExecuteCode = (EXECUTE_32BIT_CODE)AsmExecute32BitCode;

--- a/Platform/MeteorlakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
+++ b/Platform/MeteorlakeBoardPkg/Library/Stage1ABoardInitLib/Stage1ABoardInitLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020 - 2025, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -108,9 +108,7 @@ EarlyPlatformDataCheck (
     SetDebugPort (PcdGet8 (PcdDebugPortNumber));
   } else {
     SetDebugPort  (StitchData->DebugUart);
-    if ((StitchData->PlatformId > 0) && (StitchData->PlatformId < 32)) {
-      SetPlatformId (StitchData->PlatformId);
-    }
+    SetPlatformId (StitchData->PlatformId);
   }
 }
 

--- a/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/SmbiosInit.c
+++ b/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/SmbiosInit.c
@@ -61,6 +61,9 @@ InitializeSmbiosInfo (
 if (FeaturePcdGet (PcdSmbiosEnabled)) {
     Index         = 0;
     TempSmbiosStrTbl  = (SMBIOS_TYPE_STRINGS *) AllocateTemporaryMemory (0);
+    if (TempSmbiosStrTbl == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
     VerInfoTbl  = GetVerInfoPtr ();
     TempName[8] = 0;
 

--- a/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -29,23 +29,11 @@ CONST PCH_PCIE_CONTROLLER_INFO mPchPcieControllerInfo[] = {
   { 27, PID_SPF, 20 },
 };
 
-CONST PCH_SERIAL_IO_CONFIG_INFO mPchSSerialIoSPIMode[PCH_MAX_SERIALIO_SPI_CONTROLLERS] = {
-  {0,R_VER4_SERIAL_IO_PCR_PCICFGCTRL_SPI0},
-  {1,R_VER4_SERIAL_IO_PCR_PCICFGCTRL_SPI1},
-  {0,R_VER4_SERIAL_IO_PCR_PCICFGCTRL_SPI2}
-};
-
 CONST PCH_SERIAL_IO_CONFIG_INFO mPchMtlSerialIoSpiPciCfgCtrAddr[] = {
   {0,R_SERIAL_IO_PCR_PCICFGCTR11},
   {1,R_SERIAL_IO_PCR_PCICFGCTR12},
   {0,R_SERIAL_IO_PCR_PCICFGCTR13},
   {0,R_SERIAL_IO_PCR_PCICFGCTR14}
-};
-
-CONST PCH_SERIAL_IO_CONFIG_INFO mPchSSerialIoI2CMode[PCH_MAX_SERIALIO_I2C_CONTROLLERS] = {
-  {1,R_VER4_SERIAL_IO_PCR_PCICFGCTRL_I2C0},
-  {1,R_VER4_SERIAL_IO_PCR_PCICFGCTRL_I2C1},
-  {1,R_VER4_SERIAL_IO_PCR_PCICFGCTRL_I2C2}
 };
 
 CONST PCH_SERIAL_IO_UART_CONFIG_INFO mPchSSerialIoUartMode[PCH_MAX_SERIALIO_UART_CONTROLLERS] = {
@@ -1517,32 +1505,16 @@ PlatformUpdateAcpiGnvs (
   //SPI
   Length = GetPchMaxSerialIoSpiControllersNum ();
   for (Index = 0; Index < Length ; Index++) {
-    PchNvs->SC0[Index] = mPchSSerialIoSPIMode[Index].SerialIoPCIeConfig;
+    PchNvs->SC0[Index] = MtlPchSerialIoSpiPciCfgBase (Index);
     PchNvs->SM0[Index] = FspsConfig->SerialIoSpiMode[Index];
   }
-
-  PchNvs->SC0[0] = 991232;
-  PchNvs->SC0[1] = 995328;
-  PchNvs->SC0[2] = 614400;
-  PchNvs->SC0[3] = 622592;
-  PchNvs->SC0[4] = 626688;
-  PchNvs->SC0[5] = 573440;
-  PchNvs->SC0[5] = 577536;
 
   //I2C
   Length = GetPchMaxSerialIoI2cControllersNum ();
   for (Index = 0; Index < Length ; Index++) {
-    PchNvs->IC0[Index] = mPchSSerialIoI2CMode[Index].SerialIoPCIeConfig;
+    PchNvs->IC0[Index] = MtlPchSerialIoI2cPciCfgBase (Index);
     PchNvs->IM0[Index] = FspsConfig->SerialIoI2cMode[Index];
   }
-  PchNvs->IC0[0] = 688128;
-  PchNvs->IC0[1] = 692224;
-  PchNvs->IC0[2] = 696320;
-  PchNvs->IC0[3] = 700416;
-  PchNvs->IC0[4] = 819200;
-  PchNvs->IC0[5] = 823296;
-  PchNvs->IC0[6] = 524288;
-  PchNvs->IC0[7] = 528384;
 
   PchNvs->ClockToRootPortMap[0] = 0x80;
   PchNvs->ClockToRootPortMap[1] = 0x9;

--- a/Silicon/MeteorlakePkg/Include/Library/PchInfoLib.h
+++ b/Silicon/MeteorlakePkg/Include/Library/PchInfoLib.h
@@ -1,7 +1,7 @@
 /** @file
   Header file for PchInfoLib.
 
-  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020 - 2025, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -738,4 +738,83 @@ BOOLEAN
 MtlSocIsPchAttached (
   VOID
 );
+
+/**
+  Get Serial IO SPI controller PCIe Device Number
+
+  @param[in]  SpiNumber       Serial IO SPI controller index
+
+  @retval Serial IO SPI controller PCIe Device Number
+**/
+UINT8
+EFIAPI
+MtlPchSerialIoSpiDevNumber (
+  IN UINT8       SpiNumber
+  );
+
+/**
+  Get Serial IO SPI controller PCIe Function Number
+
+  @param[in]  SpiNumber       Serial IO SPI controller index
+
+  @retval Serial IO SPI controller PCIe Function Number
+**/
+UINT8
+EFIAPI
+MtlPchSerialIoSpiFuncNumber (
+  IN UINT8       SpiNumber
+  );
+
+/**
+  Get Serial IO SPI controller address that can be passed to the PCI Segment Library functions.
+
+  @param[in]  SpiNumber       Serial IO SPI controller index
+
+  @retval Serial IO SPI controller address in PCI Segment Library representation
+**/
+UINT64
+EFIAPI
+MtlPchSerialIoSpiPciCfgBase (
+  IN UINT8        SpiNumber
+  );
+
+/**
+  Get Serial IO I2C controller PCIe Device Number
+
+  @param[in]  I2cNumber       Serial IO I2C controller index
+
+  @retval Serial IO I2C controller PCIe Device Number
+**/
+UINT8
+EFIAPI
+MtlPchSerialIoI2cDevNumber (
+  IN UINT8       I2cNumber
+  );
+
+/**
+  Get Serial IO I2C controller PCIe Function Number
+
+  @param[in]  I2cNumber       Serial IO I2C controller index
+
+  @retval Serial IO I2C controller PCIe Function Number
+**/
+UINT8
+EFIAPI
+MtlPchSerialIoI2cFuncNumber (
+  IN UINT8       I2cNumber
+  );
+
+/**
+  Get Serial IO I2C controller address that can be passed to the PCI Segment Library functions.
+
+  @param[in]  I2cNumber       Serial IO I2C controller index
+
+  @retval Serial IO I2C controller address in PCI Segment Library representation
+**/
+UINT64
+EFIAPI
+MtlPchSerialIoI2cPciCfgBase (
+  IN UINT8        I2cNumber
+  );
+
 #endif // _PCH_INFO_LIB_H_

--- a/Silicon/MeteorlakePkg/Library/PchInfoLib/PchInfoLibMtl.c
+++ b/Silicon/MeteorlakePkg/Library/PchInfoLib/PchInfoLibMtl.c
@@ -1,7 +1,7 @@
 /** @file
-  Pch information library for ADL.
+  Pch information library for MTL.
 
-  Copyright (c) 2020 - 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2020 - 2025, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -939,7 +939,187 @@ MtlSocGetXhciMaxUsb2PortNum (
 }
 
 /**
-  Get Maximum Usb3 Port Number of XHCI Controller
+  Get Serial IO SPI controller PCIe Device Number
+
+  @param[in]  SpiNumber       Serial IO SPI controller index
+
+  @retval Serial IO SPI controller PCIe Device Number
+**/
+UINT8
+EFIAPI
+MtlPchSerialIoSpiDevNumber (
+  IN UINT8       SpiNumber
+  )
+{
+  if (GetPchMaxSerialIoSpiControllersNum () <= SpiNumber) {
+    ASSERT (FALSE);
+    return 0xFF;
+  }
+  switch (SpiNumber) {
+    case 0:
+      return PCI_DEVICE_NUMBER_PCH_SERIAL_IO_SPI0;
+    case 1:
+      return PCI_DEVICE_NUMBER_PCH_SERIAL_IO_SPI1;
+    case 2:
+      return PCI_DEVICE_NUMBER_PCH_SERIAL_IO_SPI2;
+    case 3:
+      return PCI_DEVICE_NUMBER_PCH_SERIAL_IO_SPI3;
+    default:
+      ASSERT (FALSE);
+      return 0xFF;
+  }
+}
+
+/**
+  Get Serial IO SPI controller PCIe Function Number
+
+  @param[in]  SpiNumber       Serial IO SPI controller index
+
+  @retval Serial IO SPI controller PCIe Function Number
+**/
+UINT8
+EFIAPI
+MtlPchSerialIoSpiFuncNumber (
+  IN UINT8       SpiNumber
+  )
+{
+  if (GetPchMaxSerialIoSpiControllersNum () <= SpiNumber) {
+    ASSERT (FALSE);
+    return 0xFF;
+  }
+  switch (SpiNumber) {
+    case 0:
+      return PCI_FUNCTION_NUMBER_PCH_SERIAL_IO_SPI0;
+    case 1:
+      return PCI_FUNCTION_NUMBER_PCH_SERIAL_IO_SPI1;
+    case 2:
+      return PCI_FUNCTION_NUMBER_PCH_SERIAL_IO_SPI2;
+    case 3:
+      return PCI_FUNCTION_NUMBER_PCH_SERIAL_IO_SPI3;
+    default:
+      ASSERT (FALSE);
+      return 0xFF;
+  }
+}
+
+/**
+  Get Serial IO SPI controller address that can be passed to the PCI Segment Library functions.
+
+  @param[in]  SpiNumber       Serial IO SPI controller index
+
+  @retval Serial IO SPI controller address in PCI Segment Library representation
+**/
+UINT64
+EFIAPI
+MtlPchSerialIoSpiPciCfgBase (
+  IN UINT8        SpiNumber
+  )
+{
+  return PCI_SEGMENT_LIB_ADDRESS (
+           DEFAULT_PCI_SEGMENT_NUMBER_PCH,
+           DEFAULT_PCI_BUS_NUMBER_PCH,
+           MtlPchSerialIoSpiDevNumber (SpiNumber),
+           MtlPchSerialIoSpiFuncNumber (SpiNumber),
+           0
+           );
+}
+
+/**
+  Get Serial IO I2C controller PCIe Device Number
+
+  @param[in]  I2cNumber       Serial IO I2C controller index
+
+  @retval Serial IO I2C controller PCIe Device Number
+**/
+UINT8
+EFIAPI
+MtlPchSerialIoI2cDevNumber (
+  IN UINT8       I2cNumber
+  )
+{
+  if (GetPchMaxSerialIoI2cControllersNum () <= I2cNumber) {
+    ASSERT (FALSE);
+    return 0xFF;
+  }
+  switch (I2cNumber) {
+    case 0:
+      return PCI_DEVICE_NUMBER_PCH_SERIAL_IO_I2C0;
+    case 1:
+      return PCI_DEVICE_NUMBER_PCH_SERIAL_IO_I2C1;
+    case 2:
+      return PCI_DEVICE_NUMBER_PCH_SERIAL_IO_I2C2;
+    case 3:
+      return PCI_DEVICE_NUMBER_PCH_SERIAL_IO_I2C3;
+    case 4:
+      return PCI_DEVICE_NUMBER_PCH_SERIAL_IO_I2C4;
+    case 5:
+      return PCI_DEVICE_NUMBER_PCH_SERIAL_IO_I2C5;
+    default:
+      ASSERT (FALSE);
+      return 0xFF;
+  }
+}
+
+/**
+  Get Serial IO I2C controller PCIe Function Number
+
+  @param[in]  I2cNumber       Serial IO I2C controller index
+
+  @retval Serial IO I2C controller PCIe Function Number
+**/
+UINT8
+EFIAPI
+MtlPchSerialIoI2cFuncNumber (
+  IN UINT8       I2cNumber
+  )
+{
+  if (GetPchMaxSerialIoI2cControllersNum () <= I2cNumber) {
+    ASSERT (FALSE);
+    return 0xFF;
+  }
+  switch (I2cNumber) {
+    case 0:
+      return PCI_FUNCTION_NUMBER_PCH_SERIAL_IO_I2C0;
+    case 1:
+      return PCI_FUNCTION_NUMBER_PCH_SERIAL_IO_I2C1;
+    case 2:
+      return PCI_FUNCTION_NUMBER_PCH_SERIAL_IO_I2C2;
+    case 3:
+      return PCI_FUNCTION_NUMBER_PCH_SERIAL_IO_I2C3;
+    case 4:
+      return PCI_FUNCTION_NUMBER_PCH_SERIAL_IO_I2C4;
+    case 5:
+      return PCI_FUNCTION_NUMBER_PCH_SERIAL_IO_I2C5;
+    default:
+      ASSERT (FALSE);
+      return 0xFF;
+  }
+}
+
+/**
+  Get Serial IO I2C controller address that can be passed to the PCI Segment Library functions.
+
+  @param[in]  I2cNumber       Serial IO I2C controller index
+
+  @retval Serial IO I2C controller address in PCI Segment Library representation
+**/
+UINT64
+EFIAPI
+MtlPchSerialIoI2cPciCfgBase (
+  IN UINT8        I2cNumber
+  )
+{
+  return PCI_SEGMENT_LIB_ADDRESS (
+           DEFAULT_PCI_SEGMENT_NUMBER_PCH,
+           DEFAULT_PCI_BUS_NUMBER_PCH,
+           MtlPchSerialIoI2cDevNumber (I2cNumber),
+           MtlPchSerialIoI2cFuncNumber (I2cNumber),
+           0
+           );
+}
+
+/**
+ Get Maximum Usb3 Port Number of XHCI Controller
 
   @retval Maximum Usb3 Port Number of XHCI Controller
 **/


### PR DESCRIPTION
ARL
- Execute32BitCode: CWE-476 Deference null return value

MTL
- PlatformUpdateAcpiGnvs: CWE-563 Unused value
- InitializeSmbiosInfo: CWE-476 Dereference null return value
- EarlyPlatformDataCheck: CWE-569 Operands don't affect result