### PR TITLE
fix: [TGL] Set SMI lock bit for Osloader

### DIFF
--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -957,6 +957,10 @@ BoardInit (
   case ReadyToBoot:
     if ((GetBootMode() != BOOT_ON_FLASH_UPDATE) && (GetPayloadId() == 0)) {
       ProgramSecuritySetting ();
+
+      //Set SMI Lock (SMI_LOCK)
+      DEBUG ((DEBUG_INFO, "Set SMI Lock\n"));
+      MmioOr8 (PCH_PWRM_BASE_ADDRESS + R_PMC_PWRM_GEN_PMCON_B, (UINT8)B_PMC_PWRM_GEN_PMCON_B_SMI_LOCK);
     }
 
     break;


### PR DESCRIPTION
Set SMI lock bit at ReadyToBoot for Osloader