### PR TITLE
fix: correct offset and value for disabling SPI prefetching and caching

### DIFF
--- a/Silicon/CommonSocPkg/Include/Register/RegsSpi.h
+++ b/Silicon/CommonSocPkg/Include/Register/RegsSpi.h
@@ -45,9 +45,8 @@
 #define V_SPI_BC_BBS_LPC                1              ///< Boot BIOS strapped to LPC
 #define B_SPI_BCR_SMM_BWP               BIT5           ///< Enable InSMM.STS
 #define B_SPI_BCR_SRC                    (BIT3 | BIT2) ///< SPI Read Configuration (SRC)
-#define V_SPI_BCR_SRC_PREF_EN_CACHE_EN   0x08          ///< Prefetch Enable, Cache Enable
-#define V_SPI_BCR_SRC_PREF_DIS_CACHE_DIS 0x04          ///< Prefetch Disable, Cache Disable
-#define V_SPI_BCR_SRC_PREF_DIS_CACHE_EN  0x00          ///< Prefetch Disable, Cache Enable
+#define N_SPI_CFG_BC_SRC                2
+#define V_SPI_BCR_SRC_PREF_DIS_CACHE_DIS 0x01          ///< Prefetch Disable, Cache Disable
 #define N_SPI_BCR_SYNC_SS                8
 #define B_SPI_BCR_SYNC_SS                BIT8
 #define B_SPI_BCR_BILD                   BIT7

--- a/Silicon/CommonSocPkg/Library/PchSpiLib/PchSpiLib.c
+++ b/Silicon/CommonSocPkg/Library/PchSpiLib/PchSpiLib.c
@@ -126,9 +126,9 @@ SaveAndDisableSpiPrefetchCache (
 
   BiosCtlSave = MmioRead8 (PchSpiBase + R_SPI_BCR) & B_SPI_BCR_SRC;
 
-  MmioAndThenOr32 (PchSpiBase + R_SPI_BCR, \
-    (UINT32) (~B_SPI_BCR_SRC), \
-    (UINT32) (V_SPI_BCR_SRC_PREF_DIS_CACHE_DIS <<  B_SPI_BCR_SRC));
+  MmioAndThenOr8 (PchSpiBase + R_SPI_BCR, \
+    (UINT8) (~B_SPI_BCR_SRC), \
+    (UINT8) (V_SPI_BCR_SRC_PREF_DIS_CACHE_DIS <<  N_SPI_CFG_BC_SRC));
 
   return BiosCtlSave;
 }


### PR DESCRIPTION
This commit corrects the SaveAndDisableSpiPrefetchCache by applying the correct offset (3:2) and value (b'01) to disable Prefetching and Caching.

Additionally, the following improvements were made:

1. Aligned V_SPI_BCR_SRC_PREF_DIS_CACHE_DIS with EDS.

2. Introduced N_SPI_CFG_BC_SRC for enhanced functionality in SaveAndDisableSpiPrefetchCache.

3. Enhanced performance and reliability by switching from MmioAndThenOr32 to MmioAndThenOr8.

4. Removed unused constants: V_SPI_BCR_SRC_PREF_EN_CACHE_EN and V_SPI_BCR_SRC_PREF_DIS_CACHE_EN.

Verified with TGL RVP and EHL CRB

Discussion: https://groups.io/g/slimbootloader/topic/spi_write_and_read_cycle/113260279