### PR TITLE
ICXD:Set SMI lock bit at ReadyToBoot for Osloader.

### DIFF
--- a/Platform/IdavilleBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/IdavilleBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -192,6 +192,12 @@ BoardInit (
   case ReadyToBoot:
     if ((GetBootMode() != BOOT_ON_FLASH_UPDATE) && (GetPayloadId() == 0)) {
       ProgramSecuritySetting ();
+      //
+      // set SMI LOCK (SMI_LOCK)
+      // PWRM Offset 1024h Bit 4
+      //
+      DEBUG ((DEBUG_INFO, "Set SMI Lock\n"));
+      MmioOr8 (PCH_PWRM_BASE_ADDRESS + R_PMC_PWRM_GEN_PMCON_B, (UINT8)B_PMC_PWRM_GEN_PMCON_B_SMI_LOCK);
     }
     break;
   case EndOfFirmware:


### PR DESCRIPTION
 Test info: Confirmed SMI_LOCK setting in OSLoader shell