### PR TITLE
fix: [ARL] Remove dependency on SblOpen folder for stitching

### DIFF
--- a/Platform/ArrowlakeBoardPkg/Script/StitchIfwi.py
+++ b/Platform/ArrowlakeBoardPkg/Script/StitchIfwi.py
@@ -29,11 +29,11 @@ sys.dont_write_bytecode = True
 # sign_bin_flag can be set to false to avoid signing process. Applicable for Btg profile 0
 sign_bin_flag = True
 
-sblopen_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../../../../', 'SblOpen')
+sblopen_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../'))
 if not os.path.exists (sblopen_dir):
     sblopen_dir = os.getenv('SBL_SOURCE', '')
-
-sys.path.append (os.path.join(sblopen_dir, "BootloaderCorePkg" , "Tools"))
+if not os.path.exists (sblopen_dir):
+    raise  Exception("Please set env 'SBL_SOURCE' to SBL open source root folder")
 
 try:
     from   IfwiUtility import *
@@ -147,12 +147,6 @@ def replace_component (ifwi_src_path, flash_path, file_path, comp_alg, pri_key, 
         container_file = os.path.join(work_dir, 'CTN_%s.bin') % comp_name
         gen_file_from_object (container_file, ifwi_bin[replace_comp.offset:replace_comp.offset + replace_comp.length])
         comp_file     = os.path.join(work_dir, file_path)
-        sblopen_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../../../../', 'SblOpen')
-        if not os.path.exists (sblopen_dir):
-            sblopen_dir = os.getenv('SBL_SOURCE', '')
-
-        if not os.path.exists (sblopen_dir):
-           raise  Exception("Please set env 'SBL_SOURCE' to SBL open source root folder")
 
         if os.name == 'nt':
             tool_bin_dir  = os.path.join(sblopen_dir, "BaseTools", "Bin", "Win32")

--- a/Platform/ArrowlakeBoardPkg/Script/StitchLoader.py
+++ b/Platform/ArrowlakeBoardPkg/Script/StitchLoader.py
@@ -12,7 +12,7 @@ from   ctypes import *
 from   functools import reduce
 
 sys.dont_write_bytecode = True
-sblopen_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../../../../', 'SblOpen')
+sblopen_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../'))
 if not os.path.exists (sblopen_dir):
     sblopen_dir = os.getenv('SBL_SOURCE', '')
 sys.path.append (os.path.join(sblopen_dir, "BootloaderCorePkg" , "Tools"))


### PR DESCRIPTION
This commit addresses the issue of hard dependency on the SblOpen folder, allowing stitching to proceed without it.