### PR TITLE
fix: OSLoader shell boot command doesn't set Valid status of RAW LBA

### DIFF
--- a/BootloaderCommonPkg/Library/ShellLib/CmdBoot.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdBoot.c
@@ -394,6 +394,7 @@ GetBootLbaInfo (
   } else {
     BootOption->Image[0].LbaImage.LbaAddr = (UINT32) ((IsHex) ? StrHexToUintn (Buffer) : StrDecimalToUintn (Buffer));
   }
+  BootOption->Image[0].LbaImage.Valid = 1;
 
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
When changing a boot option from a non-RAW type to RAW, the boot command does not set the valid field of the LbaImage.