### PR TITLE
Enable Fedora 42 Build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,4 @@
 # endings. This means it must be treated as binary.
 Silicon/QemuSocPkg/FspBin/Patches/0001-Build-QEMU-FSP-2.0-binaries.patch binary
 Silicon/QemuSocPkg/FspBin/Patches/0002-BaseTools-GCC-newer-versions-fix-Synced-with-EDK2.patch binary
+Silicon/QemuSocPkg/FspBin/Patches/0003-Update-CFLAGS-so-compilation-works-on-Fedora-42.patch binary

--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -1340,13 +1340,13 @@ RELEASE_GCCNOLTO_AARCH64_DLINK_XIPFLAGS = -z common-page-size=0x20
 *_GCC5_IA32_OBJCOPY_FLAGS        =
 *_GCC5_IA32_NASM_FLAGS           = -f elf32
 
-  DEBUG_GCC5_IA32_CC_FLAGS       = DEF(GCC5_IA32_CC_FLAGS) -flto
+  DEBUG_GCC5_IA32_CC_FLAGS       = DEF(GCC5_IA32_CC_FLAGS) -flto -std=c17
   DEBUG_GCC5_IA32_DLINK_FLAGS    = DEF(GCC5_IA32_X64_DLINK_FLAGS) -flto -Os -Wl,-m,elf_i386,--oformat=elf32-i386
 
-RELEASE_GCC5_IA32_CC_FLAGS       = DEF(GCC5_IA32_CC_FLAGS) -flto -Wno-unused-but-set-variable -Wno-unused-const-variable
+RELEASE_GCC5_IA32_CC_FLAGS       = DEF(GCC5_IA32_CC_FLAGS) -flto -Wno-unused-but-set-variable -Wno-unused-const-variable -std=c17
 RELEASE_GCC5_IA32_DLINK_FLAGS    = DEF(GCC5_IA32_X64_DLINK_FLAGS) -flto -Os -Wl,-m,elf_i386,--oformat=elf32-i386
 
-  NOOPT_GCC5_IA32_CC_FLAGS       = DEF(GCC5_IA32_CC_FLAGS) -O0
+  NOOPT_GCC5_IA32_CC_FLAGS       = DEF(GCC5_IA32_CC_FLAGS) -O0 -std=c17
   NOOPT_GCC5_IA32_DLINK_FLAGS    = DEF(GCC5_IA32_X64_DLINK_FLAGS) -Wl,-m,elf_i386,--oformat=elf32-i386 -O0
 
 ##################
@@ -1372,13 +1372,13 @@ RELEASE_GCC5_IA32_DLINK_FLAGS    = DEF(GCC5_IA32_X64_DLINK_FLAGS) -flto -Os -Wl,
 *_GCC5_X64_OBJCOPY_FLAGS         =
 *_GCC5_X64_NASM_FLAGS            = -f elf64
 
-  DEBUG_GCC5_X64_CC_FLAGS        = DEF(GCC5_X64_CC_FLAGS) -flto -DUSING_LTO
+  DEBUG_GCC5_X64_CC_FLAGS        = DEF(GCC5_X64_CC_FLAGS) -flto -DUSING_LTO -std=c17
   DEBUG_GCC5_X64_DLINK_FLAGS     = DEF(GCC5_X64_DLINK_FLAGS) -flto -Os
 
-RELEASE_GCC5_X64_CC_FLAGS        = DEF(GCC5_X64_CC_FLAGS) -flto -DUSING_LTO -Wno-unused-but-set-variable -Wno-unused-const-variable
+RELEASE_GCC5_X64_CC_FLAGS        = DEF(GCC5_X64_CC_FLAGS) -flto -DUSING_LTO -Wno-unused-but-set-variable -Wno-unused-const-variable -std=c17
 RELEASE_GCC5_X64_DLINK_FLAGS     = DEF(GCC5_X64_DLINK_FLAGS) -flto -Os
 
-  NOOPT_GCC5_X64_CC_FLAGS        = DEF(GCC5_X64_CC_FLAGS) -O0
+  NOOPT_GCC5_X64_CC_FLAGS        = DEF(GCC5_X64_CC_FLAGS) -O0 -std=c17
   NOOPT_GCC5_X64_DLINK_FLAGS     = DEF(GCC5_X64_DLINK_FLAGS) -O0
 
 ##################

--- a/BootloaderCorePkg/Tools/PrepareBuildComponentBin.py
+++ b/BootloaderCorePkg/Tools/PrepareBuildComponentBin.py
@@ -201,6 +201,10 @@ def BuildFspBins (fsp_dir, sbl_dir, fsp_inf, silicon_pkg_name, flag):
     ret = subprocess.call(cmd.split(' '), cwd=fsp_dir)
     if ret:
         Fatal ('Failed to apply QEMU FSP BuildTools patch !')
+    cmd = 'git am --keep-cr --whitespace=nowarn %s/0003-Update-CFLAGS-so-compilation-works-on-Fedora-42.patch' % patch_dir
+    ret = subprocess.call(cmd.split(' '), cwd=fsp_dir)
+    if ret:
+        Fatal ('Failed to apply QEMU FSP Fedora 42 compatibility patch !')
     print ('Done\n')
 
     print ('Compiling QEMU FSP source ...')

--- a/Silicon/QemuSocPkg/FspBin/Patches/0002-BaseTools-GCC-newer-versions-fix-Synced-with-EDK2.patch
+++ b/Silicon/QemuSocPkg/FspBin/Patches/0002-BaseTools-GCC-newer-versions-fix-Synced-with-EDK2.patch
@@ -9,6 +9,7 @@ Subject: [PATCH] BaseTools GCC newer versions fix - Synced with EDK2 This
  EDK2: - https://edk2.groups.io/g/devel/topic/89997410 -
  https://edk2.groups.io/g/devel/topic/89997412
 
+Signed-off-by: Fernando Silva <eng.fernandosilva@outlook.com>
 ---
  BaseTools/Source/C/GenFfs/GenFfs.c              | 2 +-
  BaseTools/Source/C/GenSec/GenSec.c              | 2 +-

--- a/Silicon/QemuSocPkg/FspBin/Patches/0003-Update-CFLAGS-so-compilation-works-on-Fedora-42.patch
+++ b/Silicon/QemuSocPkg/FspBin/Patches/0003-Update-CFLAGS-so-compilation-works-on-Fedora-42.patch
@@ -1,0 +1,79 @@
+From 9f74ad12d869f80a61be570cd3095a4f406eec56 Mon Sep 17 00:00:00 2001
+From: Fernando Silva <eng.fernandosilva@outlook.com>
+Date: Tue, 17 Jun 2025 22:59:15 -0700
+Subject: [PATCH] Update CFLAGS so compilation works on Fedora 42
+
+Signed-off-by: Fernando Silva <eng.fernandosilva@outlook.com>
+---
+ BaseTools/Conf/tools_def.template                  | 12 ++++++------
+ BaseTools/Source/C/VfrCompile/Pccts/antlr/makefile |  2 +-
+ BaseTools/Source/C/VfrCompile/Pccts/dlg/makefile   |  2 +-
+ 3 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/BaseTools/Conf/tools_def.template b/BaseTools/Conf/tools_def.template
+index 933b3160fd..c91e5fece0 100755
+--- a/BaseTools/Conf/tools_def.template
++++ b/BaseTools/Conf/tools_def.template
+@@ -2370,13 +2370,13 @@ RELEASE_GCC49_AARCH64_DLINK_XIPFLAGS = -z common-page-size=0x20
+ *_GCC5_IA32_OBJCOPY_FLAGS        =
+ *_GCC5_IA32_NASM_FLAGS           = -f elf32
+ 
+-  DEBUG_GCC5_IA32_CC_FLAGS       = DEF(GCC5_IA32_CC_FLAGS) -flto -Os
++  DEBUG_GCC5_IA32_CC_FLAGS       = DEF(GCC5_IA32_CC_FLAGS) -flto -Os -std=c17
+   DEBUG_GCC5_IA32_DLINK_FLAGS    = DEF(GCC5_IA32_X64_DLINK_FLAGS) -flto -Os -Wl,-m,elf_i386,--oformat=elf32-i386
+ 
+-RELEASE_GCC5_IA32_CC_FLAGS       = DEF(GCC5_IA32_CC_FLAGS) -flto -Os -Wno-unused-but-set-variable -Wno-unused-const-variable
++RELEASE_GCC5_IA32_CC_FLAGS       = DEF(GCC5_IA32_CC_FLAGS) -flto -Os -Wno-unused-but-set-variable -Wno-unused-const-variable -std=c17
+ RELEASE_GCC5_IA32_DLINK_FLAGS    = DEF(GCC5_IA32_X64_DLINK_FLAGS) -flto -Os -Wl,-m,elf_i386,--oformat=elf32-i386
+ 
+-  NOOPT_GCC5_IA32_CC_FLAGS       = DEF(GCC5_IA32_CC_FLAGS) -O0
++  NOOPT_GCC5_IA32_CC_FLAGS       = DEF(GCC5_IA32_CC_FLAGS) -O0 -std=c17
+   NOOPT_GCC5_IA32_DLINK_FLAGS    = DEF(GCC5_IA32_X64_DLINK_FLAGS) -Wl,-m,elf_i386,--oformat=elf32-i386 -O0
+ 
+ ##################
+@@ -2402,13 +2402,13 @@ RELEASE_GCC5_IA32_DLINK_FLAGS    = DEF(GCC5_IA32_X64_DLINK_FLAGS) -flto -Os -Wl,
+ *_GCC5_X64_OBJCOPY_FLAGS         =
+ *_GCC5_X64_NASM_FLAGS            = -f elf64
+ 
+-  DEBUG_GCC5_X64_CC_FLAGS        = DEF(GCC5_X64_CC_FLAGS) -flto -DUSING_LTO -Os
++  DEBUG_GCC5_X64_CC_FLAGS        = DEF(GCC5_X64_CC_FLAGS) -flto -DUSING_LTO -Os -std=c17
+   DEBUG_GCC5_X64_DLINK_FLAGS     = DEF(GCC5_X64_DLINK_FLAGS) -flto -Os
+ 
+-RELEASE_GCC5_X64_CC_FLAGS        = DEF(GCC5_X64_CC_FLAGS) -flto -DUSING_LTO -Os -Wno-unused-but-set-variable -Wno-unused-const-variable
++RELEASE_GCC5_X64_CC_FLAGS        = DEF(GCC5_X64_CC_FLAGS) -flto -DUSING_LTO -Os -Wno-unused-but-set-variable -Wno-unused-const-variable -std=c17
+ RELEASE_GCC5_X64_DLINK_FLAGS     = DEF(GCC5_X64_DLINK_FLAGS) -flto -Os
+ 
+-  NOOPT_GCC5_X64_CC_FLAGS        = DEF(GCC5_X64_CC_FLAGS) -O0
++  NOOPT_GCC5_X64_CC_FLAGS        = DEF(GCC5_X64_CC_FLAGS) -O0 -std=c17
+   NOOPT_GCC5_X64_DLINK_FLAGS     = DEF(GCC5_X64_DLINK_FLAGS) -O0
+ 
+ ##################
+diff --git a/BaseTools/Source/C/VfrCompile/Pccts/antlr/makefile b/BaseTools/Source/C/VfrCompile/Pccts/antlr/makefile
+index 559b1c99f1..3d6b31417b 100644
+--- a/BaseTools/Source/C/VfrCompile/Pccts/antlr/makefile
++++ b/BaseTools/Source/C/VfrCompile/Pccts/antlr/makefile
+@@ -174,7 +174,7 @@ ANTLR=${BIN_DIR}/antlr
+ DLG=${BIN_DIR}/dlg
+ OBJ_EXT=o
+ OUT_OBJ = -o
+-BUILD_CFLAGS= $(COPT) -I. -I$(SET) -I$(PCCTS_H) -DUSER_ZZSYN $(COTHER) -DZZLEXBUFSIZE=65536
++BUILD_CFLAGS= $(COPT) -I. -I$(SET) -I$(PCCTS_H) -DUSER_ZZSYN $(COTHER) -DZZLEXBUFSIZE=65536 -std=gnu11
+ BUILD_CPPFLAGS=
+ #
+ # SGI Users, use this CFLAGS
+diff --git a/BaseTools/Source/C/VfrCompile/Pccts/dlg/makefile b/BaseTools/Source/C/VfrCompile/Pccts/dlg/makefile
+index 5a3561edec..379aaaf717 100644
+--- a/BaseTools/Source/C/VfrCompile/Pccts/dlg/makefile
++++ b/BaseTools/Source/C/VfrCompile/Pccts/dlg/makefile
+@@ -122,7 +122,7 @@ endif
+ COPT=-O
+ ANTLR=${BIN_DIR}/antlr
+ DLG=${BIN_DIR}/dlg
+-BUILD_CFLAGS= $(COPT) -I. -I$(SET) -I$(PCCTS_H) -DUSER_ZZSYN -DZZLEXBUFSIZE=65536
++BUILD_CFLAGS= $(COPT) -I. -I$(SET) -I$(PCCTS_H) -DUSER_ZZSYN -DZZLEXBUFSIZE=65536 -std=gnu11
+ BUILD_CPPFLAGS=
+ OBJ_EXT=o
+ OUT_OBJ = -o
+-- 
+2.49.0
+


### PR DESCRIPTION
Fedora 42 updates GCC toolchain to version 15 which now defaults to higher versions of C standard with stricter rules that prevent SBL from building successful. Given official supported OS/Toolchains are not yet moved to later C standard, it should be no harm to pin to C17 which makes SBL build successfully.
With that this PR adds -std=c17 for GCC5 templates to solve the compatibility issue.

Additionally it was not possible to build QEMU FSP due to incompatibilities in the toolchain of older EDK2 tag used. This PR also fixes the QEMU build by applying later changes from EDK2 BaseTools. The change consists in using -std=gnu11 in the Makefile for https://github.com/tianocore/edk2/blob/master/BaseTools/Source/C/VfrCompile/Pccts/dlg/makefile and https://github.com/tianocore/edk2/blob/master/BaseTools/Source/C/VfrCompile/Pccts/antlr/makefile

Even though Fedora is not officially supported, the code changes in this PR will allow for Fedora users to get familiar with SBL without the need of resorting to container builds or dual boot. 