### PR TITLE
fix: [ADL/RPL/BTL] Build error with VS2022

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
@@ -561,7 +561,7 @@ UpdateCpuNvs (
   ///
   /// Update NVS ASL items.
   ///
-  CpuNvs->Cpuid = GetCpuFamily() | GetCpuStepping();
+  CpuNvs->Cpuid = (UINT32)GetCpuFamily() | (UINT32)GetCpuStepping();
   CpuNvs->Revision = 1;
 
   ///


### PR DESCRIPTION
Explicit cast added to resolve a build error with VS2022 caused by bitwise ORing different enum types.