### PR TITLE
feat:[AZB]Update Boardconfig to support UEFI pyld

### DIFF
--- a/Platform/AlderlakeBoardPkg/BoardConfigAzb.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAzb.py
@@ -78,7 +78,7 @@ class Board(BaseBoard):
         self.ENABLE_PCIE_PM                   = 1
         # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)
         # 3: Enable NOSMRR (for edk2-stable202411 and newer UEFI payload)  4: Auto NOSMRR
-        self.ENABLE_SMM_REBASE                = 4
+        self.ENABLE_SMM_REBASE                = 2
 
         # 0 - PCH UART0, 1 - PCH UART1, 2 - PCH UART2, 0xFF - EC UART 0x3F8
         self.DEBUG_PORT_NUMBER                = 0x0


### PR DESCRIPTION
    Updated Boardconfig to support boot with UEFI payload . AZB still uses
    old payload edk2-stable202008.