### PR TITLE
feat: [ARLS] Added SMBIOS Production Data Override

### DIFF
--- a/BootloaderCommonPkg/Include/Library/SmbiosOverride.h
+++ b/BootloaderCommonPkg/Include/Library/SmbiosOverride.h
@@ -1,0 +1,70 @@
+/** @file
+  SMBIOS Device Information Binary Support for SMBIOS Initialization
+
+  This header defines a structure for storing device-specific SMBIOS strings,
+  allowing platforms to override default SMBIOS values during initialization.
+
+  Copyright (c) 2025, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef __SMBIOS_DEVICE_OVERRIDE_H__
+#define __SMBIOS_DEVICE_OVERRIDE_H__
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+
+//
+// Device Info Binary Structure
+// Used to override default SMBIOS strings with device-specific information
+// This structure is standardized across all platforms
+//
+#pragma pack(push, 1)
+typedef struct {
+  // System Information (SMBIOS Type 1)
+  CHAR8   SystemManufacturer[64];             // System manufacturer string
+  CHAR8   SystemProductName[64];              // System product name string
+  CHAR8   SystemVersion[32];                  // System version string
+  CHAR8   SystemSerialNumber[32];             // System serial number string
+  CHAR8   SystemUuid[37];                     // System UUID string (RFC 4122 format)
+  CHAR8   SystemSku[32];                      // System SKU string
+  CHAR8   SystemFamily[64];                   // System family string
+
+  // Baseboard Information (SMBIOS Type 2)
+  CHAR8   BaseboardManufacturer[64];          // Baseboard manufacturer string
+  CHAR8   BaseboardProductName[64];           // Baseboard product name string
+  CHAR8   BaseboardVersion[32];               // Baseboard version string
+  CHAR8   BaseboardSerialNumber[32];          // Baseboard serial number string
+  CHAR8   BaseboardAssetTag[32];              // Baseboard asset tag string
+
+  // Chassis Information (SMBIOS Type 3)
+  CHAR8   ChassisManufacturer[64];            // Chassis manufacturer string
+  CHAR8   ChassisVersion[32];                 // Chassis version string
+  CHAR8   ChassisSerialNumber[32];            // Chassis serial number string
+  CHAR8   ChassisAssetTag[32];                // Chassis asset tag string
+
+  // OEM Data (Platform-specific extensions)
+  CHAR8   OemVersion[32];                     // OEM structure version
+  CHAR8   OemCustomField1[64];                // OEM custom field 1
+  CHAR8   OemCustomField2[64];                // OEM custom field 2
+} DEVICE_INFO_DATA;
+#pragma pack(pop)
+
+
+/**
+  Get SMBIOS string value with fallback logic
+
+  @param[in] DeviceInfoValue    Value from device info binary (null-terminated)
+  @param[in] DefaultValue       Default platform value
+
+  @retval    Device info value if available and non-empty, otherwise default value
+**/
+CHAR8*
+GetSmbiosStringValue (
+  IN CHAR8    *DeviceInfoValue,
+  IN CHAR8    *DefaultValue
+);
+
+
+#endif // __SMBIOS_DEVICE_OVERRIDE_H__

--- a/BootloaderCommonPkg/Library/SmbiosOverrideLib/SmbiosOverride.c
+++ b/BootloaderCommonPkg/Library/SmbiosOverrideLib/SmbiosOverride.c
@@ -1,0 +1,36 @@
+/** @file
+  SMBIOS Device Information Binary Support Implementation
+
+  This library provides common smbios device info binary support that can be
+  used by any platform's SMBIOS initialization.
+
+  Copyright (c) 2025, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+
+#include <Library/SmbiosOverride.h>
+
+/**
+  Get SMBIOS string value with fallback logic
+
+  @param[in] DeviceInfoValue    Value from device info binary (null-terminated)
+  @param[in] DefaultValue       Default platform value
+
+  @retval    Device info value if available and non-empty, otherwise default value
+**/
+CHAR8*
+GetSmbiosStringValue (
+  IN CHAR8    *DeviceInfoValue,
+  IN CHAR8    *DefaultValue
+  )
+{
+  // Use device info value if available and non-empty, otherwise use default
+  if (DeviceInfoValue != NULL && DeviceInfoValue[0] != '\0') {
+    return DeviceInfoValue;
+  }
+  return DefaultValue;
+}
+
+

--- a/BootloaderCommonPkg/Library/SmbiosOverrideLib/SmbiosOverrideLib.inf
+++ b/BootloaderCommonPkg/Library/SmbiosOverrideLib/SmbiosOverrideLib.inf
@@ -1,0 +1,37 @@
+## @file
+#
+#  Copyright (c) 2025, Intel Corporation. All rights reserved.<BR>
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = SmbiosOverrideLib
+  FILE_GUID                      = C8EF4499-4F0D-49AE-8590-853CC4965B70
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = SmbiosOverrideLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 IPF
+#
+[Sources]
+  SmbiosOverride.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCorePkg/BootloaderCorePkg.dec
+
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+
+
+
+
+

--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -255,6 +255,7 @@
   gPlatformModuleTokenSpaceGuid.PcdResizableBarSupport    | FALSE      | BOOLEAN | 0x20000216
   gPlatformModuleTokenSpaceGuid.PcdEnablePciePm           | FALSE      | BOOLEAN | 0x20000222
   gPlatformModuleTokenSpaceGuid.PcdEnableFwuNotify        | FALSE      | BOOLEAN | 0x20000225
+  gPlatformModuleTokenSpaceGuid.PcdSmbiosOverride         | FALSE      | BOOLEAN | 0x20000227
 
 [PcdsDynamic]
   gPlatformModuleTokenSpaceGuid.PcdFspResetStatus         | 0          | UINT64 | 0x20000224

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -125,6 +125,7 @@
   FitLib|BootloaderCommonPkg/Library/FitLib/FitLib.inf
   FdtLib|MdePkg/Library/BaseFdtLib/BaseFdtLib.inf
   BuildFdtLib|BootloaderCommonPkg/Library/BuildFdtLib/BuildFdtLib.inf
+  SmbiosOverrideLib|BootloaderCommonPkg/Library/SmbiosOverrideLib/SmbiosOverrideLib.inf
 
 !if $(ENABLE_SOURCE_DEBUG)
   DebugAgentLib|BootloaderCommonPkg/Library/DebugAgentLib/DebugAgentLib.inf
@@ -361,6 +362,8 @@
   gPlatformModuleTokenSpaceGuid.PcdEnablePciePm           | $(ENABLE_PCIE_PM)
   gPlatformCommonLibTokenSpaceGuid.PcdFspNoEop            | $(HAVE_NO_FSP_EOP)
   gPlatformModuleTokenSpaceGuid.PcdEnableFwuNotify        | $(ENABLE_FWU_NOTIFY)
+  gPlatformModuleTokenSpaceGuid.PcdSmbiosOverride         | $(ENABLE_SMBIOS_OVERRIDE)
+
 
 !ifdef $(S3_DEBUG)
   gPlatformModuleTokenSpaceGuid.PcdS3DebugEnabled         | $(S3_DEBUG)

--- a/Platform/ArrowlakeBoardPkg/BoardConfigArls.py
+++ b/Platform/ArrowlakeBoardPkg/BoardConfigArls.py
@@ -116,6 +116,9 @@ class Board(BaseBoard):
         self.ENABLE_FWU           = 1
         self.ENABLE_SMBIOS        = 1
 
+        # Enable SMBIOS value override with user defined value
+        self.ENABLE_SMBIOS_OVERRIDE = 0
+
         self.ENABLE_CSME_UPDATE   = 1
 
         # CSME update library is required to enable this option and will be available as part of CSME kit
@@ -204,6 +207,11 @@ class Board(BaseBoard):
 
         self.NON_REDUNDANT_SIZE   = 0x3BF000 + self.SIIPFW_SIZE
         self.NON_VOLATILE_SIZE    = 0x001000
+
+        if self.ENABLE_SMBIOS_OVERRIDE:
+            self.OEMDATA_SIZE = 0x002000
+            self.NON_VOLATILE_SIZE = 0x003000
+
         self.SLIMBOOTLOADER_SIZE  = (self.TOP_SWAP_SIZE + self.REDUNDANT_SIZE) * 2 + \
                                     self.NON_REDUNDANT_SIZE + self.NON_VOLATILE_SIZE
         self.SLIMBOOTLOADER_SIZE  = ((self.SLIMBOOTLOADER_SIZE + 0xFFFFF) & ~0xFFFFF)
@@ -395,6 +403,9 @@ class Board(BaseBoard):
             'CryptoLib|%s' % self.GetIppCryptoInf()
         ]
 
+        if self.ENABLE_SMBIOS_OVERRIDE:
+            dsc['LibraryClasses.%s' % self.BUILD_ARCH].append ('SmbiosOverrideLib|BootloaderCommonPkg/Library/SmbiosOverrideLib/SmbiosOverrideLib.inf')
+
         if self.ENABLE_PCIE_PM:
             lib = [
             'PciePm|Silicon/$(SILICON_PKG_NAME)/Library/PciePm/PciePm.inf',
@@ -461,28 +472,36 @@ class Board(BaseBoard):
         container_list.append (
           # Name | Image File             |    CompressAlg  | AuthType                        | Key File                        | Region Align   | Region Size |  Svn Info
           # ========================================================================================================================================================
-          ('IPFW',      'SIIPFW.bin',          '',     container_list_auth_type,   'KEY_ID_CONTAINER'+'_'+self._RSA_SIGN_TYPE,        0,          0     ,        0),   # Container Header
+          [('IPFW',      'SIIPFW.bin',          '',     container_list_auth_type,   'KEY_ID_CONTAINER'+'_'+self._RSA_SIGN_TYPE,        0,          0     ,        0)],   # Container Header
         )
 
         bins = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'Binaries')
 
         if self.ENABLE_TCC:
-            container_list.append (
+            container_list[0].append (
               ('TCCC', 'TccCacheCfg.bin' if os.path.exists(os.path.join(bins,   'TccCacheCfg.bin')) else '',   'Lz4', container_list_auth_type, 'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE, 0, self.TCC_CCFG_SIZE, 0),   # TCC Cache Config
             )
-            container_list.append (
+            container_list[0].append (
               ('TCCM', 'TccCrlBinary.bin' if os.path.exists(os.path.join(bins, 'TccCrlBinary.bin')) else '', 'Lz4', container_list_auth_type, 'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE, 0, self.TCC_CRL_SIZE, 0),   # TCC Crl
             )
-            container_list.append (
+            container_list[0].append (
               ('TCCT', 'TccStreamCfg.bin' if os.path.exists(os.path.join(bins,  'TccStreamCfg.bin')) else '',  'Lz4', container_list_auth_type, 'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE, 0, self.TCC_STREAM_SIZE, 0),   # TCC Stream Config
             )
 
         if self.ENABLE_TSN:
-            container_list.append (
+            container_list[0].append (
               ('TMAC','TsnSubRegion.bin' if os.path.exists(os.path.join(bins,  'TsnSubRegion.bin')) else '',   'Lz4', container_list_auth_type, 'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE, 0, self.TMAC_SIZE, 0),   # TSN MAC Address
             )
 
-        return [container_list]
+        if self.ENABLE_SMBIOS_OVERRIDE:
+            CompFileOemData = os.path.join(bins, 'DeviceInfo.bin')
+            # Add OEM Data container to the main container list
+            container_list.append ([
+                ('DEVI', 'DeviceInfo_signed.bin', '', container_list_auth_type, 'KEY_ID_CONTAINER'+'_'+self._RSA_SIGN_TYPE, 0, 0, 0),   # Container Header
+                ('DINF', CompFileOemData, 'Lz4', container_list_auth_type, 'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE, 0, 0, 0),   # Component
+            ])
+
+        return container_list
 
     def GetOutputImages (self):
         # define extra images that will be copied to output folder
@@ -507,11 +526,13 @@ class Board(BaseBoard):
                 ),
             ])
 
+        non_volatile_img_list = [('SBLRSVD.bin', '' , self.SBLRSVD_SIZE,  STITCH_OPS.MODE_FILE_NOP, STITCH_OPS.MODE_POS_TAIL)]
+
+        if self.ENABLE_SMBIOS_OVERRIDE:
+            non_volatile_img_list.append(('DeviceInfo_signed.bin',   ''     , self.OEMDATA_SIZE,  STITCH_OPS.MODE_FILE_NOP, STITCH_OPS.MODE_POS_TAIL))
+
         img_list.extend ([
-            ('NON_VOLATILE.bin', [
-                ('SBLRSVD.bin',    ''        , self.SBLRSVD_SIZE,  STITCH_OPS.MODE_FILE_NOP, STITCH_OPS.MODE_POS_TAIL),
-                ]
-            ),
+            ('NON_VOLATILE.bin', non_volatile_img_list),
             ('NON_REDUNDANT.bin', [
                 ('SIIPFW.bin'   ,  ''        , self.SIIPFW_SIZE,   STITCH_OPS.MODE_FILE_PAD, STITCH_OPS.MODE_POS_TAIL),
                 ('VARIABLE.bin' ,  ''        , self.VARIABLE_SIZE, STITCH_OPS.MODE_FILE_NOP, STITCH_OPS.MODE_POS_TAIL),

--- a/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.h
+++ b/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.h
@@ -94,6 +94,7 @@
 #include <Library/MtlPchPcieRpLib.h>
 #include <Library/MtlSocInfoLib.h>
 #include <Guid/PciRootBridgeInfoGuid.h>
+#include <Library/ContainerLib.h>
 
 #define V_EPOC_XTAL_38_4_MHZ  0x38400000
 //

--- a/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -70,6 +70,8 @@
   MtlPchPcieRpLib
   PciePm
   P2sbLib
+  ContainerLib
+  SmbiosOverrideLib
 
 [Guids]
   gOsConfigDataGuid
@@ -117,3 +119,4 @@
   gPlatformModuleTokenSpaceGuid.PcdIgdOpRegionAddress
   gPlatformModuleTokenSpaceGuid.PcdPciResAllocTableBase
   gPlatformModuleTokenSpaceGuid.PcdEnablePciePm
+  gPlatformModuleTokenSpaceGuid.PcdSmbiosOverride


### PR DESCRIPTION
Added SMBIOS Data Override feature in common library for SBL2.0 DeviceInfo binary will be loaded and used to override default SMBIOS value DeviceInfo binary can be generated using GenSmbiosOverrideBin.py in the Tools folder Feature can be enabled/disabled via ENABLE_SMBIOS_OVERRIDE in boardconfig