### PR TITLE
[ASL/TWL] Update for ASL MR4, TWL MR1

### DIFF
--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
@@ -22,9 +22,9 @@ class Board(BaseBoard):
 
         super(Board, self).__init__(*args, **kwargs)
 
-        self.VERINFO_IMAGE_ID     = 'SB_ADLN'
+        self.VERINFO_IMAGE_ID     = 'SB_ASL'
         self.VERINFO_PROJ_MAJOR_VER = 1
-        self.VERINFO_PROJ_MINOR_VER = 7
+        self.VERINFO_PROJ_MINOR_VER = 4
         self.VERINFO_SVN            = 1
         self.VERINFO_BUILD_DATE     = time.strftime("%m/%d/%Y")
 

--- a/Silicon/AlderlakePkg/FspBin/FspBin.inf
+++ b/Silicon/AlderlakePkg/FspBin/FspBin.inf
@@ -11,7 +11,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = 15848ee4934acbd94069454f369e9869bb0f1295
+  COMMIT  = 5d0424c89ddd4903cdd31eb36bc1c921c15422e3
 
 [UserExtensions.SBL."CopyList"]
 # For ADL-PS


### PR DESCRIPTION
- FSP: IoT TWL MR1/ASL MR4 (0C.02.89.40)
- Microcode: m_19_b06e0_0000001d
- VBT: 256
- platform version: SB_ASL-1.4