### PR TITLE
feat: [ARL] Update for ARL MR2

### DIFF
--- a/Platform/ArrowlakeBoardPkg/BoardConfigArlh.py
+++ b/Platform/ArrowlakeBoardPkg/BoardConfigArlh.py
@@ -24,7 +24,7 @@ class Board(BaseBoard):
 
         self.VERINFO_IMAGE_ID     = 'SB_ARLH'
         self.VERINFO_PROJ_MAJOR_VER = 1
-        self.VERINFO_PROJ_MINOR_VER = 1
+        self.VERINFO_PROJ_MINOR_VER = 2
         self.VERINFO_SVN            = 1
         self.VERINFO_BUILD_DATE     = time.strftime("%m/%d/%Y")
 

--- a/Silicon/ArrowlakePkg/Arlh/Fsp/FspBin.inf
+++ b/Silicon/ArrowlakePkg/Arlh/Fsp/FspBin.inf
@@ -11,7 +11,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = a7130986134516b1e41309dd5a529e5f873bd15c
+  COMMIT  = bb073b44232f79bac20af50e76f02269a92c227e
 
 [UserExtensions.SBL."CopyList"]
   ArrowLakeFspBinPkg/IoT/ArrowLakeUH/Fsp.fd                 : Silicon/ArrowlakePkg/Arlh/Fsp/FspRel.bin
@@ -23,4 +23,4 @@
   ArrowLakeFspBinPkg/IoT/ArrowLakeUH/Include/FspsUpd.h      : Silicon/ArrowlakePkg/Arlh/Fsp/FspsUpd.h
   ArrowLakeFspBinPkg/IoT/ArrowLakeUH/Include/MemInfoHob.h   : Silicon/ArrowlakePkg/Arlh/Fsp/MemInfoHob.h
   FSP_License.pdf                                           : Silicon/ArrowlakePkg/Arlh/Fsp/FSP_License.pdf
-  ArrowLakeFspBinPkg/IoT/ArrowLakeUH/Vbt/Vbt.json           : Platform/ArrowlakeBoardPkg/VbtBin/Vbt_arlh.json
+  ArrowLakeFspBinPkg/IoT/ArrowLakeUH/Vbt/Vbt_MTL.json       : Platform/ArrowlakeBoardPkg/VbtBin/VbtArlh.json

--- a/Silicon/ArrowlakePkg/Arlh/Microcode/Microcode.inf
+++ b/Silicon/ArrowlakePkg/Arlh/Microcode/Microcode.inf
@@ -14,11 +14,11 @@
   VERSION_STRING       = 1.0
 
 [Sources]
-  m_82_c0662_00000118.mcb # ARL H A0 PO (CPUID c0662) Version
+  m_82_c0662_00000119.mcb # ARL H A0 PO (CPUID c0662) Version
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
-  COMMIT = 722b0a7363642572578ce25ff6c8fd947ab1ef7b
+  COMMIT = 12e3be7ba1c3e816ba7412341f1ba3ab65180120
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/ArrowLake/m_82_c0662_00000118.pdb  : Silicon/ArrowlakePkg/Arlh/Microcode/m_82_c0662_00000118.mcb
+  Microcode/ArrowLake/m_82_c0662_00000119.pdb  : Silicon/ArrowlakePkg/Arlh/Microcode/m_82_c0662_00000119.mcb


### PR DESCRIPTION
- FSP: ECG ARL-UH MR2 (0D.00.EB.60)
- Microcode: ARLU: m_80_b0650_0000000a / ARLH: m_82_c0662_00000119
- VBT: 261
- platform version: SB_ARLU-1.2 / SB_ARLH-1.2