### PR TITLE
feat: Added SMBIOS Production Data Override support

### DIFF
--- a/BootloaderCorePkg/Include/Library/SmbiosInitLib.h
+++ b/BootloaderCorePkg/Include/Library/SmbiosInitLib.h
@@ -19,6 +19,34 @@ typedef struct {
   CHAR8     *String;
 } SMBIOS_TYPE_STRINGS;
 
+typedef struct {
+  // System Information (SMBIOS Type 1)
+  CHAR8   SystemManufacturer[64];             // System manufacturer string
+  CHAR8   SystemProductName[64];              // System product name string
+  CHAR8   SystemVersion[32];                  // System version string
+  CHAR8   SystemSerialNumber[32];             // System serial number string
+  CHAR8   SystemUuid[37];                     // System UUID string (RFC 4122 format)
+  CHAR8   SystemSku[32];                      // System SKU string
+  CHAR8   SystemFamily[64];                   // System family string
+
+  // Baseboard Information (SMBIOS Type 2)
+  CHAR8   BaseboardManufacturer[64];          // Baseboard manufacturer string
+  CHAR8   BaseboardProductName[64];           // Baseboard product name string
+  CHAR8   BaseboardVersion[32];               // Baseboard version string
+  CHAR8   BaseboardSerialNumber[32];          // Baseboard serial number string
+  CHAR8   BaseboardAssetTag[32];              // Baseboard asset tag string
+
+  // Chassis Information (SMBIOS Type 3)
+  CHAR8   ChassisManufacturer[64];            // Chassis manufacturer string
+  CHAR8   ChassisVersion[32];                 // Chassis version string
+  CHAR8   ChassisSerialNumber[32];            // Chassis serial number string
+  CHAR8   ChassisAssetTag[32];                // Chassis asset tag string
+
+  // OEM Data (Platform-specific extensions)
+  CHAR8   OemVersion[32];                     // OEM structure version
+  CHAR8   OemCustomField1[64];                // OEM custom field 1
+  CHAR8   OemCustomField2[64];                // OEM custom field 2
+} DEVICE_INFO_DATA;
 #pragma pack()
 
 /**
@@ -91,6 +119,22 @@ InitSmbiosStringPtr (
 EFI_STATUS
 EFIAPI
 SmbiosInit (
+  VOID
+  );
+
+/**
+  Loads device information from the non-volatile region and applies overrides to SMBIOS strings.
+
+  This function attempts to load a device info binary from the firmware image. If found,
+  it updates the SMBIOS string table with values from the device info, overriding default
+  platform strings such as manufacturer, product name, version, and serial number.
+
+  @retval EFI_SUCCESS      Device info override applied successfully.
+  @retval EFI_NOT_FOUND    Device info binary not found or no SMBIOS strings to override.
+**/
+EFI_STATUS
+EFIAPI
+ApplySmbiosDeviceInfoOverride (
   VOID
   );
 

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -522,6 +522,10 @@ SecStartup (
   }
 
   BoardInit (PostSiliconInit);
+
+  if (FixedPcdGetBool (PcdSmbiosEnabled)) {
+    ApplySmbiosDeviceInfoOverride ();
+  }
   AddMeasurePoint (0x3040);
 
 #if FixedPcdGetBool (PcdEnableCryptoPerfTest)

--- a/BootloaderCorePkg/Stage2/Stage2.inf
+++ b/BootloaderCorePkg/Stage2/Stage2.inf
@@ -151,6 +151,8 @@
   gPlatformModuleTokenSpaceGuid.PcdSmbiosTablesBase
   gPlatformModuleTokenSpaceGuid.PcdSmbiosTablesSize
   gPlatformModuleTokenSpaceGuid.PcdSmbiosEnabled
+  gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsPtr
+  gPlatformModuleTokenSpaceGuid.PcdSmbiosStringsCnt
   gPlatformModuleTokenSpaceGuid.PcdLinuxPayloadEnabled
   gPlatformCommonLibTokenSpaceGuid.PcdMeasuredBootHashMask
   gPlatformModuleTokenSpaceGuid.PcdSmmRebaseMode

--- a/Platform/ArrowlakeBoardPkg/BoardConfigArlh.py
+++ b/Platform/ArrowlakeBoardPkg/BoardConfigArlh.py
@@ -115,6 +115,9 @@ class Board(BaseBoard):
         self.ENABLE_FWU           = 1
         self.ENABLE_SMBIOS        = 1
 
+        # Enable SMBIOS value override with user defined value
+        self.ENABLE_SMBIOS_OVERRIDE = 0
+
         self.ENABLE_CSME_UPDATE   = 1
 
         # CSME update library is required to enable this option and will be available as part of CSME kit
@@ -203,6 +206,11 @@ class Board(BaseBoard):
 
         self.NON_REDUNDANT_SIZE   = 0x3BF000 + self.SIIPFW_SIZE
         self.NON_VOLATILE_SIZE    = 0x001000
+
+        if self.ENABLE_SMBIOS_OVERRIDE:
+            self.OEMDATA_SIZE = 0x002000
+            self.NON_VOLATILE_SIZE = 0x003000
+
         self.SLIMBOOTLOADER_SIZE  = (self.TOP_SWAP_SIZE + self.REDUNDANT_SIZE) * 2 + \
                                     self.NON_REDUNDANT_SIZE + self.NON_VOLATILE_SIZE
         self.SLIMBOOTLOADER_SIZE  = ((self.SLIMBOOTLOADER_SIZE + 0xFFFFF) & ~0xFFFFF)
@@ -456,28 +464,36 @@ class Board(BaseBoard):
         container_list.append (
           # Name | Image File             |    CompressAlg  | AuthType                        | Key File                        | Region Align   | Region Size |  Svn Info
           # ========================================================================================================================================================
-          ('IPFW',      'SIIPFW.bin',          '',     container_list_auth_type,   'KEY_ID_CONTAINER'+'_'+self._RSA_SIGN_TYPE,        0,          0     ,        0),   # Container Header
+          [('IPFW',      'SIIPFW.bin',          '',     container_list_auth_type,   'KEY_ID_CONTAINER'+'_'+self._RSA_SIGN_TYPE,        0,          0     ,        0)],   # Container Header
         )
 
         bins = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'Binaries')
 
         if self.ENABLE_TCC:
-            container_list.append (
+            container_list[0].append (
               ('TCCC', 'TccCacheCfg.bin' if os.path.exists(os.path.join(bins,   'TccCacheCfg.bin')) else '',   'Lz4', container_list_auth_type, 'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE, 0, self.TCC_CCFG_SIZE, 0),   # TCC Cache Config
             )
-            container_list.append (
+            container_list[0].append (
               ('TCCM', 'TccCrlBinary.bin' if os.path.exists(os.path.join(bins, 'TccCrlBinary.bin')) else '', 'Lz4', container_list_auth_type, 'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE, 0, self.TCC_CRL_SIZE, 0),   # TCC Crl
             )
-            container_list.append (
+            container_list[0].append (
               ('TCCT', 'TccStreamCfg.bin' if os.path.exists(os.path.join(bins,  'TccStreamCfg.bin')) else '',  'Lz4', container_list_auth_type, 'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE, 0, self.TCC_STREAM_SIZE, 0),   # TCC Stream Config
             )
 
         if self.ENABLE_TSN:
-            container_list.append (
+            container_list[0].append (
               ('TMAC','TsnSubRegion.bin' if os.path.exists(os.path.join(bins,  'TsnSubRegion.bin')) else '',   'Lz4', container_list_auth_type, 'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE, 0, self.TMAC_SIZE, 0),   # TSN MAC Address
             )
 
-        return [container_list]
+        if self.ENABLE_SMBIOS_OVERRIDE:
+            CompFileOemData = os.path.join(bins, 'DeviceInfo.bin')
+            # Add OEM Data container to the main container list
+            container_list.append ([
+                ('DEVI', 'DeviceInfo_signed.bin', '', container_list_auth_type, 'KEY_ID_CONTAINER'+'_'+self._RSA_SIGN_TYPE, 0, 0, 0),   # Container Header
+                ('DINF', CompFileOemData, 'Lz4', container_list_auth_type, 'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE, 0, 0, 0),   # Component
+            ])
+
+        return container_list
 
     def GetOutputImages (self):
         # define extra images that will be copied to output folder
@@ -502,11 +518,13 @@ class Board(BaseBoard):
                 ),
             ])
 
+        non_volatile_img_list = [('SBLRSVD.bin', '' , self.SBLRSVD_SIZE,  STITCH_OPS.MODE_FILE_NOP, STITCH_OPS.MODE_POS_TAIL)]
+
+        if self.ENABLE_SMBIOS_OVERRIDE:
+            non_volatile_img_list.append(('DeviceInfo_signed.bin',   ''     , self.OEMDATA_SIZE,  STITCH_OPS.MODE_FILE_NOP, STITCH_OPS.MODE_POS_TAIL))
+
         img_list.extend ([
-            ('NON_VOLATILE.bin', [
-                ('SBLRSVD.bin',    ''        , self.SBLRSVD_SIZE,  STITCH_OPS.MODE_FILE_NOP, STITCH_OPS.MODE_POS_TAIL),
-                ]
-            ),
+            ('NON_VOLATILE.bin', non_volatile_img_list),
             ('NON_REDUNDANT.bin', [
                 ('SIIPFW.bin'   ,  ''        , self.SIIPFW_SIZE,   STITCH_OPS.MODE_FILE_PAD, STITCH_OPS.MODE_POS_TAIL),
                 ('VARIABLE.bin' ,  ''        , self.VARIABLE_SIZE, STITCH_OPS.MODE_FILE_NOP, STITCH_OPS.MODE_POS_TAIL),

--- a/Platform/ArrowlakeBoardPkg/BoardConfigArls.py
+++ b/Platform/ArrowlakeBoardPkg/BoardConfigArls.py
@@ -116,6 +116,9 @@ class Board(BaseBoard):
         self.ENABLE_FWU           = 1
         self.ENABLE_SMBIOS        = 1
 
+        # Enable SMBIOS value override with user defined value
+        self.ENABLE_SMBIOS_OVERRIDE = 0
+
         self.ENABLE_CSME_UPDATE   = 1
 
         # CSME update library is required to enable this option and will be available as part of CSME kit
@@ -204,6 +207,11 @@ class Board(BaseBoard):
 
         self.NON_REDUNDANT_SIZE   = 0x3BF000 + self.SIIPFW_SIZE
         self.NON_VOLATILE_SIZE    = 0x001000
+
+        if self.ENABLE_SMBIOS_OVERRIDE:
+            self.OEMDATA_SIZE = 0x002000
+            self.NON_VOLATILE_SIZE = 0x003000
+
         self.SLIMBOOTLOADER_SIZE  = (self.TOP_SWAP_SIZE + self.REDUNDANT_SIZE) * 2 + \
                                     self.NON_REDUNDANT_SIZE + self.NON_VOLATILE_SIZE
         self.SLIMBOOTLOADER_SIZE  = ((self.SLIMBOOTLOADER_SIZE + 0xFFFFF) & ~0xFFFFF)
@@ -461,28 +469,35 @@ class Board(BaseBoard):
         container_list.append (
           # Name | Image File             |    CompressAlg  | AuthType                        | Key File                        | Region Align   | Region Size |  Svn Info
           # ========================================================================================================================================================
-          ('IPFW',      'SIIPFW.bin',          '',     container_list_auth_type,   'KEY_ID_CONTAINER'+'_'+self._RSA_SIGN_TYPE,        0,          0     ,        0),   # Container Header
+          [('IPFW',      'SIIPFW.bin',          '',     container_list_auth_type,   'KEY_ID_CONTAINER'+'_'+self._RSA_SIGN_TYPE,        0,          0     ,        0)],   # Container Header
         )
 
         bins = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'Binaries')
 
         if self.ENABLE_TCC:
-            container_list.append (
+            container_list[0].append (
               ('TCCC', 'TccCacheCfg.bin' if os.path.exists(os.path.join(bins,   'TccCacheCfg.bin')) else '',   'Lz4', container_list_auth_type, 'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE, 0, self.TCC_CCFG_SIZE, 0),   # TCC Cache Config
             )
-            container_list.append (
+            container_list[0].append (
               ('TCCM', 'TccCrlBinary.bin' if os.path.exists(os.path.join(bins, 'TccCrlBinary.bin')) else '', 'Lz4', container_list_auth_type, 'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE, 0, self.TCC_CRL_SIZE, 0),   # TCC Crl
             )
-            container_list.append (
+            container_list[0].append (
               ('TCCT', 'TccStreamCfg.bin' if os.path.exists(os.path.join(bins,  'TccStreamCfg.bin')) else '',  'Lz4', container_list_auth_type, 'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE, 0, self.TCC_STREAM_SIZE, 0),   # TCC Stream Config
             )
 
         if self.ENABLE_TSN:
-            container_list.append (
+            container_list[0].append (
               ('TMAC','TsnSubRegion.bin' if os.path.exists(os.path.join(bins,  'TsnSubRegion.bin')) else '',   'Lz4', container_list_auth_type, 'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE, 0, self.TMAC_SIZE, 0),   # TSN MAC Address
             )
 
-        return [container_list]
+        if self.ENABLE_SMBIOS_OVERRIDE:
+            CompFileOemData = os.path.join(bins, 'DeviceInfo.bin')
+            # Add OEM Data container to the main container list
+            container_list.append ([
+                ('DEVI', 'DeviceInfo_signed.bin', '', container_list_auth_type, 'KEY_ID_CONTAINER'+'_'+self._RSA_SIGN_TYPE, 0, 0, 0),   # Container Header
+                ('DINF', CompFileOemData, 'Lz4', container_list_auth_type, 'KEY_ID_CONTAINER_COMP'+'_'+self._RSA_SIGN_TYPE, 0, 0, 0),   # Component
+            ])
+        return container_list
 
     def GetOutputImages (self):
         # define extra images that will be copied to output folder
@@ -507,11 +522,13 @@ class Board(BaseBoard):
                 ),
             ])
 
+        non_volatile_img_list = [('SBLRSVD.bin', '' , self.SBLRSVD_SIZE,  STITCH_OPS.MODE_FILE_NOP, STITCH_OPS.MODE_POS_TAIL)]
+
+        if self.ENABLE_SMBIOS_OVERRIDE:
+            non_volatile_img_list.append(('DeviceInfo_signed.bin',   ''     , self.OEMDATA_SIZE,  STITCH_OPS.MODE_FILE_NOP, STITCH_OPS.MODE_POS_TAIL))
+
         img_list.extend ([
-            ('NON_VOLATILE.bin', [
-                ('SBLRSVD.bin',    ''        , self.SBLRSVD_SIZE,  STITCH_OPS.MODE_FILE_NOP, STITCH_OPS.MODE_POS_TAIL),
-                ]
-            ),
+            ('NON_VOLATILE.bin', non_volatile_img_list),
             ('NON_REDUNDANT.bin', [
                 ('SIIPFW.bin'   ,  ''        , self.SIIPFW_SIZE,   STITCH_OPS.MODE_FILE_PAD, STITCH_OPS.MODE_POS_TAIL),
                 ('VARIABLE.bin' ,  ''        , self.VARIABLE_SIZE, STITCH_OPS.MODE_FILE_NOP, STITCH_OPS.MODE_POS_TAIL),


### PR DESCRIPTION
Added SMBIOS Data Override feature in common library

DeviceInfo binary can be generated using GenSmbiosOverrideBin.py in the Tools folder
DeviceInfo binary will be loaded if exist under <Platform>/<platformBoardPkg>/Binaries
The binary is used to override default SMBIOS value