### PR TITLE
fix: Remove unused variables from the code

### DIFF
--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -535,7 +535,6 @@ SecStartup (
     if (Status == EFI_NOT_FOUND) {
       DEBUG ((DEBUG_INFO, "Display splash early setup failed, will retry after PCI enumeration.\n"));
       SplashPostPci = TRUE;
-      Status = EFI_SUCCESS;
     }
   }
 


### PR DESCRIPTION
The variable's value is assigned but never used, making it a dead store.
Signed-off-by: samihahkasim <samihah.kasim@intel.com>