### PR TITLE
[TGL][TXT] Exposing the TXT ACM device in ACPI table

### DIFF
--- a/Silicon/CommonSocPkg/Include/Library/TxtLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/TxtLib.h
@@ -10,6 +10,16 @@
 #define R_IOPORT_CMOS_STANDARD_DATA             0x71
 #define TXT_CMOS_STATUS_REG                     0x2A
 
+/**
+  Determines whether or not the platform requires initialization for TXT use.
+
+  @retval TRUE          - If the the platoform should be configured for TXT.
+  @retval FALSE         - If TXT is not to be used.
+**/
+BOOLEAN
+EFIAPI
+IsTxtEnabled ();
+
 /*
   Initialize Intel TXT
 */

--- a/Silicon/TigerlakePkg/Library/TxtLib/TxtLib.c
+++ b/Silicon/TigerlakePkg/Library/TxtLib/TxtLib.c
@@ -242,15 +242,14 @@ IsTxtResetSet (
   @retval FALSE         - If TXT is not to be used.
 **/
 BOOLEAN
-IsTxtEnabled (
-  IN TXT_LIB_CONTEXT *TxtLibCtx
-  )
+EFIAPI
+IsTxtEnabled ()
 {
 
   UINT64        Ia32FeatureControl;
   TXT_INFO_DATA *TxtInfoData;
 
-  TxtInfoData = TxtLibCtx->TxtInfoData;
+  TxtInfoData = mTxtLibCtx.TxtInfoData;
 
   ///
   /// If TxtInfoHob reported TXT disabled, return FALSE to indicate TXT should not be used


### PR DESCRIPTION
SSDT table will create a TXT device conditionally
based on CPU_NVS TxtEnable value when txt is enabled.