### PR TITLE
fix: [common] Fix Coverity issues

### DIFF
--- a/BootloaderCommonPkg/Library/ElfLib/ElfLib.c
+++ b/BootloaderCommonPkg/Library/ElfLib/ElfLib.c
@@ -326,7 +326,8 @@ ParseElfImage (
   CurrentLoadAddress           = ElfCt->FileBase + FileOffset;
 
   // check if CurrentLoadAddress meets load alignment requirement.
-  if ( ((UINTN)CurrentLoadAddress & ~(SegAlignment - 1)) != (UINTN)CurrentLoadAddress) {
+  // Only when SegAlignment > 1, perform the alignment check
+  if ((SegAlignment > 1) && ((UINTN)CurrentLoadAddress & ~(SegAlignment - 1)) != (UINTN)CurrentLoadAddress) {
     ElfCt->ReloadRequired = TRUE;
   }
   if (!ElfCt->ReloadRequired) {

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/gsmodstuff.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/gsmodstuff.c
@@ -63,7 +63,7 @@ BNU_CHUNK_T gsMontFactor(BNU_CHUNK_T m0)
          y+=x;
       mask += mask + 1;
    }
-   return 0-y;
+   return (BNU_CHUNK_T)(0U - y);
 }
 
 /*

--- a/BootloaderCommonPkg/Library/RpmbLib/RpmbLib.c
+++ b/BootloaderCommonPkg/Library/RpmbLib/RpmbLib.c
@@ -43,7 +43,7 @@ RpmbCalcHmacSha256(
   )
 {
   //TODO: Andriod does HMAC_Update in a loop of BlockCnt. Change this later if we need BlocksCnt > 1
-  return HmacSha256 ((UINT8 *)Frames->Data, HMAC_DATA_LEN, Key, KeySize, Mac, RPMB_MAC_SIZE);
+  return HmacSha256 ((UINT8 *)&Frames->Data, HMAC_DATA_LEN, Key, KeySize, Mac, RPMB_MAC_SIZE);
 }
 
 /**

--- a/BootloaderCommonPkg/Library/ShellLib/CmdBoot.c
+++ b/BootloaderCommonPkg/Library/ShellLib/CmdBoot.c
@@ -136,6 +136,7 @@ GetBootDeviceInfo (
 {
   EFI_STATUS                 Status;
   BOOLEAN                    IsHex;
+  UINTN                      TempDevType;
 
   do {
     ShellPrint (L"Enter ImageType (Default 0x%X, Fastboot 0x%X)\n",
@@ -166,13 +167,17 @@ GetBootDeviceInfo (
     if (EFI_ERROR (Status)) {
       return Status;
     }
-    BootOption->DevType = (OS_BOOT_MEDIUM_TYPE) ((IsHex) ? StrHexToUintn (Buffer) : StrDecimalToUintn (Buffer));
 
     if (StrLen (Buffer) == 0) {
       BootOption->DevType = CurrOption->DevType;
       break;
-    } else if (BootOption->DevType < OsBootDeviceMax) {
-      break;
+    } else {
+      TempDevType = (IsHex) ? StrHexToUintn (Buffer) : StrDecimalToUintn (Buffer);
+      if (TempDevType < OsBootDeviceMax) {
+        // Only perform the cast to OS_BOOT_MEDIUM_TYPE if the value is valid
+        BootOption->DevType = (OS_BOOT_MEDIUM_TYPE) TempDevType;
+        break;
+      }
     }
     ShellPrint (L"Invalid DevType value '%s', please re-enter\n", Buffer);
   } while (1);

--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
@@ -353,7 +353,7 @@ MpInit (
       InitializeSpinLock (&mMpDataStruct.SpinLock);
 
       //
-      // Allocate 1 K * 16 AP Stack, assume to support max 16 CPUs
+      // Allocate 4K * 16 AP Stack, assume to support max 16 CPUs
       //
       ApStackTop = (EFI_PHYSICAL_ADDRESS) (UINTN)AllocatePages ( \
                    EFI_SIZE_TO_PAGES (PcdGet32 (PcdCpuMaxLogicalProcessorNumber) * AP_STACK_SIZE));


### PR DESCRIPTION
Resolved coverity issues
1. Overflowed constant (CWE-190) in ElfLib.c, gsmodstuff.c, CmdBoot.c
2. Out-of-bounds access (CWE-119) in RpmbLib.c