### PR TITLE
feat: [Common] Add support to load payload from PDR

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -255,6 +255,7 @@
   gPlatformModuleTokenSpaceGuid.PcdResizableBarSupport    | FALSE      | BOOLEAN | 0x20000216
   gPlatformModuleTokenSpaceGuid.PcdEnablePciePm           | FALSE      | BOOLEAN | 0x20000222
   gPlatformModuleTokenSpaceGuid.PcdEnableFwuNotify        | FALSE      | BOOLEAN | 0x20000225
+  gPlatformModuleTokenSpaceGuid.PcdPayloadLoadFromPDR     | FALSE      | BOOLEAN | 0x20000230
 
 [PcdsDynamic]
   gPlatformModuleTokenSpaceGuid.PcdFspResetStatus         | 0          | UINT64 | 0x20000224

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -365,6 +365,7 @@
   gPlatformModuleTokenSpaceGuid.PcdEnablePciePm           | $(ENABLE_PCIE_PM)
   gPlatformCommonLibTokenSpaceGuid.PcdFspNoEop            | $(HAVE_NO_FSP_EOP)
   gPlatformModuleTokenSpaceGuid.PcdEnableFwuNotify        | $(ENABLE_FWU_NOTIFY)
+  gPlatformModuleTokenSpaceGuid.PcdPayloadLoadFromPDR     | $(ENABLE_EPLD_FROM_PDR)
   gPlatformCommonLibTokenSpaceGuid.PcdTxtEnabled          | $(TXT_ENABLED)
 
 

--- a/BootloaderCorePkg/Stage2/Stage2.inf
+++ b/BootloaderCorePkg/Stage2/Stage2.inf
@@ -157,6 +157,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdBootPerformanceMask
   gPlatformModuleTokenSpaceGuid.PcdSblResiliencyEnabled
   gPlatformModuleTokenSpaceGuid.PcdEnableFwuNotify
+  gPlatformModuleTokenSpaceGuid.PcdPayloadLoadFromPDR
   gPlatformCommonLibTokenSpaceGuid.PcdEnableCryptoPerfTest
   gPlatformCommonLibTokenSpaceGuid.PcdHandOffFdtEnable
   gPlatformModuleTokenSpaceGuid.PcdSmramTsegBase

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -177,6 +177,7 @@ class BaseBoard(object):
         self.ENABLE_MULTI_USB_BOOT_DEV = 1
         self.ENABLE_SBL_SETUP      = 0
         self.ENABLE_PAYLOD_MODULE  = 0
+        self.ENABLE_EPLD_FROM_PDR  = 0
         self.ENABLE_FAST_BOOT      = 0
         self.ENABLE_LEGACY_EF_SEG  = 1
         # 0: Disable  1: Enable  2: Auto (disable for UEFI payload, enable for others)


### PR DESCRIPTION
Added support to load EPayload from PDR as an alternate loading method. This is useful if the overall bootloader binary cannot fit inside the BIOS region or there is a need to load multiple payloads or load an OS as a payload. To enable this feature, user should set self.ENABLE_PDR_LOAD to 1 in the corresponding BoardConfig file.