### PR TITLE
fix: [ADL/RPL/BTL] Use AlderlakePkg header files instead of CommonSoC

### DIFF
--- a/Silicon/AlderlakePkg/Library/PciePm/PciePm.inf
+++ b/Silicon/AlderlakePkg/Library/PciePm/PciePm.inf
@@ -32,5 +32,5 @@
 [Packages]
   MdePkg/MdePkg.dec
   IntelFsp2Pkg/IntelFsp2Pkg.dec
-  Silicon/CommonSocPkg/CommonSocPkg.dec
   Silicon/AlderlakePkg/AlderlakePkg.dec
+  Silicon/CommonSocPkg/CommonSocPkg.dec


### PR DESCRIPTION
Newly added CommonSoC header files are overriding differeng platform header files in some cases.