### PR TITLE
feat: Add debug messages for PCIe BAR Size calculation

### DIFF
--- a/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
+++ b/BootloaderCorePkg/Library/PciEnumerationLib/PciEnumerationLib.c
@@ -367,6 +367,13 @@ PciParseBar (
     }
   }
 
+#if DEBUG_PCI_ENUM
+  DEBUG((DEBUG_INFO, "    Bar: %d BarType: %d Size: 0x%llx\n",
+    BarIndex,
+    PciIoDevice->PciBar[BarIndex].BarType,
+    PciIoDevice->PciBar[BarIndex].Length));
+#endif
+
   //
   // Check the length again so as to keep compatible with some special bars
   //
@@ -532,6 +539,11 @@ GatherDeviceInfo (
       }
     }
   }
+
+#if DEBUG_PCI_ENUM
+  DEBUG((DEBUG_INFO, "    VID|DID: %4X|%4X\n",
+    PciExpressRead16(PciIoDevice->Address), PciExpressRead16(PciIoDevice->Address + 2)));
+#endif
 
   //
   // Start to parse the bars


### PR DESCRIPTION
This update addresses issues related to high/low MMIO, which are common in x86 builds, particularly for legacy platforms where x86 is the default build for SBL.

The commit introduces a straightforward debug log to assist in quickly identifying devices that require larger MMIO space in the low MMIO region.

To enable this feature, please set DEBUG_PCI_ENUM to 1 in PciEnumerationLib.c.

The output log would like:

  PciBus: Discovered PCI @ [00|0A|00]
      VID|DID: 8086|A77D
      Bar: 0 BarType: 3 Size: 0x8000