### PR TITLE
[TGL][TXT][S3 Resume]Updated TXT initialization for S3 sleep

### DIFF
--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -908,7 +908,10 @@ BoardInit (
     if (FeaturePcdGet (PcdTxtEnabled)) {
       FeaturesCfgData = (FEATURES_CFG_DATA *) FindConfigDataByTag(CDATA_FEATURES_TAG);
       if (FeaturesCfgData->Features.TxtEnabled == 1) {
+        if (GetBootMode() != BOOT_ON_S3_RESUME)
           InitTxt();
+        else
+          TxtS3Restore();
       }
     }
     break;
@@ -967,6 +970,13 @@ BoardInit (
     break;
 
   case ReadyToBoot:
+    if (FeaturePcdGet (PcdTxtEnabled) && GetBootMode() == BOOT_ON_S3_RESUME) {
+      FeaturesCfgData = (FEATURES_CFG_DATA *) FindConfigDataByTag(CDATA_FEATURES_TAG);
+      if (FeaturesCfgData->Features.TxtEnabled == 1) {
+          TxtS3Resume();
+      }
+    }
+
     if ((GetBootMode() != BOOT_ON_FLASH_UPDATE) && (GetPayloadId() == 0)) {
       ProgramSecuritySetting ();
 

--- a/Silicon/CommonSocPkg/Include/Library/TxtLib.h
+++ b/Silicon/CommonSocPkg/Include/Library/TxtLib.h
@@ -27,4 +27,28 @@ EFI_STATUS
 EFIAPI
 InitTxt();
 
+/**
+  Initializes Intel TXT for S3 resume by launching BIOS ACM.
+  This function finds the BIOS ACM and launches it with SCHECK function
+  to complete TXT initialization after S3 resume.
+
+  @retval EFI_SUCCESS   - BIOS ACM launched successfully for S3 resume
+**/
+EFI_STATUS
+EFIAPI
+TxtS3Resume();
+
+/**
+  Restores Intel TXT device memory registers (HEAP and SINIT) for S3 resume.
+  This function restores the TXT register state without touching actual memory
+  content, which must be preserved across S3 for TBOOT/MLE operation.
+
+  @retval EFI_SUCCESS     - TXT registers restored successfully
+  @retval EFI_UNSUPPORTED - Required TXT information not available
+  @retval Other           - Error during initialization
+**/
+EFI_STATUS
+EFIAPI
+TxtS3Restore();
+
 #endif


### PR DESCRIPTION
- On S3 Resume TXT HEAP and TXT SINIT base and size registers are restored to previous value using TXT info hob. TXT DPR registers are updated by ACM on running SCHECK. This is done using s3 boot script in BIOS.
- SCHECK is run just before control is transferred to TBOOT in ready to boot stage (done in BIOS as well) for the TPM Locality 0 and 2 to be available for TBOOT to read.