### PR TITLE
workaround: [UART] ACPI _UID Compatibility

### DIFF
--- a/Platform/AlderlakeBoardPkg/AcpiTables/Dsdt/SerialIoUartAdl.asl
+++ b/Platform/AlderlakeBoardPkg/AcpiTables/Dsdt/SerialIoUartAdl.asl
@@ -46,6 +46,8 @@
 #define UART5_PG          UP05
 #define UART6_PG          UP06
 
+#define UART_UID_BASE     0x50
+
 Scope(\_SB.URSC) {
     Method (_CRS, 0x0, Serialized) {
       Store (UARB (UART0_MODE, UART0_PCIE_BASE), Local0)
@@ -72,6 +74,7 @@ Scope(\_SB.URSC) {
 #define UART_DEVICE_DMA       UART0_DMA
 #define UART_DEVICE_HIDDEN    UAH0
 #define UART_DEVICE_DDN       "SerialIoUart0"
+#define UART_DEVICE_UID       UART_UID_BASE
 #define UART_DEVICE_IRQ       UART0_IRQ
 #define UART_DEVICE_PG        UART0_PG
 Scope(\_SB.PC00) {
@@ -86,6 +89,7 @@ Include ("SerialIoUartHiddenController.asl")
 #undef UART_DEVICE_DMA
 #undef UART_DEVICE_HIDDEN
 #undef UART_DEVICE_DDN
+#undef UART_DEVICE_UID
 #undef UART_DEVICE_IRQ
 #undef UART_DEVICE_PG
 #define UART_DEVICE_ADR       SERIAL_IO_UART1_ADR
@@ -94,6 +98,7 @@ Include ("SerialIoUartHiddenController.asl")
 #define UART_DEVICE_DMA       UART1_DMA
 #define UART_DEVICE_HIDDEN    UAH1
 #define UART_DEVICE_DDN       "SerialIoUart1"
+#define UART_DEVICE_UID       UART_UID_BASE + 1
 #define UART_DEVICE_IRQ       UART1_IRQ
 #define UART_DEVICE_PG        UART1_PG
 Scope(\_SB.PC00) {
@@ -108,6 +113,7 @@ Include ("SerialIoUartHiddenController.asl")
 #undef UART_DEVICE_DMA
 #undef UART_DEVICE_HIDDEN
 #undef UART_DEVICE_DDN
+#undef UART_DEVICE_UID
 #undef UART_DEVICE_IRQ
 #undef UART_DEVICE_PG
 #define UART_DEVICE_ADR       SERIAL_IO_UART2_ADR
@@ -116,6 +122,7 @@ Include ("SerialIoUartHiddenController.asl")
 #define UART_DEVICE_DMA       UART2_DMA
 #define UART_DEVICE_HIDDEN    UAH2
 #define UART_DEVICE_DDN       "SerialIoUart2"
+#define UART_DEVICE_UID       UART_UID_BASE + 2
 #define UART_DEVICE_IRQ       UART2_IRQ
 #define UART_DEVICE_PG        UART2_PG
 Scope(\_SB.PC00) {
@@ -130,6 +137,7 @@ Include ("SerialIoUartHiddenController.asl")
 #undef UART_DEVICE_DMA
 #undef UART_DEVICE_HIDDEN
 #undef UART_DEVICE_DDN
+#undef UART_DEVICE_UID
 #undef UART_DEVICE_IRQ
 #undef UART_DEVICE_PG
 #define UART_DEVICE_ADR       SERIAL_IO_UART3_ADR
@@ -138,6 +146,7 @@ Include ("SerialIoUartHiddenController.asl")
 #define UART_DEVICE_DMA       UART3_DMA
 #define UART_DEVICE_HIDDEN    UAH3
 #define UART_DEVICE_DDN       "SerialIoUart3"
+#define UART_DEVICE_UID       UART_UID_BASE + 3
 #define UART_DEVICE_IRQ       UART3_IRQ
 #define UART_DEVICE_PG        UART3_PG
 Scope(\_SB.PC00) {
@@ -152,6 +161,7 @@ Include ("SerialIoUartHiddenController.asl")
 #undef UART_DEVICE_DMA
 #undef UART_DEVICE_HIDDEN
 #undef UART_DEVICE_DDN
+#undef UART_DEVICE_UID
 #undef UART_DEVICE_IRQ
 #undef UART_DEVICE_PG
 #define UART_DEVICE_ADR       SERIAL_IO_UART4_ADR
@@ -160,6 +170,7 @@ Include ("SerialIoUartHiddenController.asl")
 #define UART_DEVICE_DMA       UART4_DMA
 #define UART_DEVICE_HIDDEN    UAH4
 #define UART_DEVICE_DDN       "SerialIoUart4"
+#define UART_DEVICE_UID       UART_UID_BASE + 4
 #define UART_DEVICE_IRQ       UART4_IRQ
 #define UART_DEVICE_PG        UART4_PG
 Scope(\_SB.PC00) {
@@ -174,6 +185,7 @@ Include ("SerialIoUartHiddenController.asl")
 #undef UART_DEVICE_DMA
 #undef UART_DEVICE_HIDDEN
 #undef UART_DEVICE_DDN
+#undef UART_DEVICE_UID
 #undef UART_DEVICE_IRQ
 #undef UART_DEVICE_PG
 #define UART_DEVICE_ADR       SERIAL_IO_UART5_ADR
@@ -182,6 +194,7 @@ Include ("SerialIoUartHiddenController.asl")
 #define UART_DEVICE_DMA       UART5_DMA
 #define UART_DEVICE_HIDDEN    UAH5
 #define UART_DEVICE_DDN       "SerialIoUart5"
+#define UART_DEVICE_UID       UART_UID_BASE + 5
 #define UART_DEVICE_IRQ       UART5_IRQ
 #define UART_DEVICE_PG        UART5_PG
 Scope(\_SB.PC00) {
@@ -196,6 +209,7 @@ Include ("SerialIoUartHiddenController.asl")
 #undef UART_DEVICE_DMA
 #undef UART_DEVICE_HIDDEN
 #undef UART_DEVICE_DDN
+#undef UART_DEVICE_UID
 #undef UART_DEVICE_IRQ
 #undef UART_DEVICE_PG
 #define UART_DEVICE_ADR       SERIAL_IO_UART6_ADR
@@ -204,6 +218,7 @@ Include ("SerialIoUartHiddenController.asl")
 #define UART_DEVICE_DMA       UART6_DMA
 #define UART_DEVICE_HIDDEN    UAH6
 #define UART_DEVICE_DDN       "SerialIoUart6"
+#define UART_DEVICE_UID       UART_UID_BASE + 6
 #define UART_DEVICE_IRQ       UART6_IRQ
 #define UART_DEVICE_PG        UART6_PG
 Scope(\_SB.PC00) {

--- a/Platform/AlderlakeBoardPkg/AcpiTables/Dsdt/SerialIoUartHiddenController.asl
+++ b/Platform/AlderlakeBoardPkg/AcpiTables/Dsdt/SerialIoUartHiddenController.asl
@@ -10,7 +10,7 @@ Scope(\_SB) {
   If (LOr (LEqual(UART_DEVICE_MODE, SERIAL_IO_UART_HIDDEN), LEqual (UART_DEVICE_MODE, SERIAL_IO_UART_COM))) {
     Device (UART_DEVICE_HIDDEN) {
       Name (_DDN, UART_DEVICE_DDN)
-      Name (_UID, UART_DEVICE_DDN)
+      Name (_UID, UART_DEVICE_UID)
       Method (_HID) { Return (UHID (UART_DEVICE_MODE)) }
       Method (_CRS) { Return (UARH (UART_DEVICE_PCI_BASE, UART_DEVICE_IRQ)) }
       Method (_STA) {

--- a/Platform/ArrowlakeBoardPkg/AcpiTables/Dsdt/SerialIoUartHiddenController.asl
+++ b/Platform/ArrowlakeBoardPkg/AcpiTables/Dsdt/SerialIoUartHiddenController.asl
@@ -11,7 +11,7 @@ Scope (\_SB) {
   If (LOr (LEqual (UART_DEVICE_MODE, SERIAL_IO_UART_HIDDEN), LEqual (UART_DEVICE_MODE, SERIAL_IO_UART_COM))) {
     Device (UART_DEVICE_HIDDEN) {
       Name (_DDN, UART_DEVICE_DDN)
-      Name (_UID, UART_DEVICE_DDN)
+      Name (_UID, UART_DEVICE_UID)
       Method (_HID) { Return (UHID (UART_DEVICE_MODE)) }
       Method (_CRS) { Return (UARH (UART_DEVICE_PCI_BASE, UART_DEVICE_IRQ)) }
       Method (_STA) {

--- a/Platform/ArrowlakeBoardPkg/AcpiTables/Dsdt/SerialIoUartMtl.asl
+++ b/Platform/ArrowlakeBoardPkg/AcpiTables/Dsdt/SerialIoUartMtl.asl
@@ -25,6 +25,8 @@
 #define UART1_PG          UP01
 #define UART2_PG          UP02
 
+#define UART_UID_BASE     0x50
+
 Scope (\_SB.URSC) {
     Method (_CRS, 0x0, Serialized) {
       Store (UARB (UART0_MODE, UART0_PCIE_BASE), Local0)
@@ -43,6 +45,7 @@ Scope (\_SB.URSC) {
 #define UART_DEVICE_DMA       UART0_DMA
 #define UART_DEVICE_HIDDEN    UAH0
 #define UART_DEVICE_DDN       "SerialIoUart0"
+#define UART_DEVICE_UID       UART_UID_BASE
 #define UART_DEVICE_IRQ       UART0_IRQ
 #define UART_DEVICE_PG        UART0_PG
 Scope (\_SB.PC00) {
@@ -57,6 +60,7 @@ Include ("SerialIoUartHiddenController.asl")
 #undef UART_DEVICE_DMA
 #undef UART_DEVICE_HIDDEN
 #undef UART_DEVICE_DDN
+#undef UART_DEVICE_UID
 #undef UART_DEVICE_IRQ
 #undef UART_DEVICE_PG
 #define UART_DEVICE_ADR       SERIAL_IO_UART1_ADR
@@ -65,6 +69,7 @@ Include ("SerialIoUartHiddenController.asl")
 #define UART_DEVICE_DMA       UART1_DMA
 #define UART_DEVICE_HIDDEN    UAH1
 #define UART_DEVICE_DDN       "SerialIoUart1"
+#define UART_DEVICE_UID       UART_UID_BASE + 1
 #define UART_DEVICE_IRQ       UART1_IRQ
 #define UART_DEVICE_PG        UART1_PG
 Scope (\_SB.PC00) {
@@ -79,6 +84,7 @@ Include ("SerialIoUartHiddenController.asl")
 #undef UART_DEVICE_DMA
 #undef UART_DEVICE_HIDDEN
 #undef UART_DEVICE_DDN
+#undef UART_DEVICE_UID
 #undef UART_DEVICE_IRQ
 #undef UART_DEVICE_PG
 #define UART_DEVICE_ADR       SERIAL_IO_UART2_ADR
@@ -87,6 +93,7 @@ Include ("SerialIoUartHiddenController.asl")
 #define UART_DEVICE_DMA       UART2_DMA
 #define UART_DEVICE_HIDDEN    UAH2
 #define UART_DEVICE_DDN       "SerialIoUart2"
+#define UART_DEVICE_UID       UART_UID_BASE + 2
 #define UART_DEVICE_IRQ       UART2_IRQ
 #define UART_DEVICE_PG        UART2_PG
 Scope (\_SB.PC00) {
@@ -101,6 +108,7 @@ Include ("SerialIoUartHiddenController.asl")
 #undef UART_DEVICE_DMA
 #undef UART_DEVICE_HIDDEN
 #undef UART_DEVICE_DDN
+#undef UART_DEVICE_UID
 #undef UART_DEVICE_IRQ
 #undef UART_DEVICE_PG
 

--- a/Platform/ArrowlakeBoardPkg/AcpiTables/Dsdt/SerialIoUartMtlPch.asl
+++ b/Platform/ArrowlakeBoardPkg/AcpiTables/Dsdt/SerialIoUartMtlPch.asl
@@ -51,7 +51,7 @@ Scope (\_SB) {
   If (LOr (LEqual (UART_DEVICE_MODE, SERIAL_IO_UART_HIDDEN), LEqual (UART_DEVICE_MODE, SERIAL_IO_UART_COM))) {
     Device (PUA0) {
       Name (_DDN, "MtlPchSerialIoUart0")
-      Name (_UID, "MtlPchSerialIoUart0")
+      Name (_UID, 0x60)
       Include ("SerialIoUartHiddenDevice.asl")
     }
   }
@@ -82,7 +82,7 @@ Scope (\_SB) {
   If (LOr (LEqual (UART_DEVICE_MODE, SERIAL_IO_UART_HIDDEN), LEqual (UART_DEVICE_MODE, SERIAL_IO_UART_COM))) {
     Device (PUA1) {
       Name (_DDN, "MtlPchSerialIoUart1")
-      Name (_UID, "MtlPchSerialIoUart1")
+      Name (_UID, 0x61)
       Include ("SerialIoUartHiddenDevice.asl")
     }
   }
@@ -113,7 +113,7 @@ Scope (\_SB) {
   If (LOr (LEqual (UART_DEVICE_MODE, SERIAL_IO_UART_HIDDEN), LEqual (UART_DEVICE_MODE, SERIAL_IO_UART_COM))) {
     Device (PUA2) {
       Name (_DDN, "MtlPchSerialIoUart2")
-      Name (_UID, "MtlPchSerialIoUart2")
+      Name (_UID, 0x62)
       Include ("SerialIoUartHiddenDevice.asl")
     }
   }
@@ -144,7 +144,7 @@ Scope (\_SB) {
   If (LOr (LEqual (UART_DEVICE_MODE, SERIAL_IO_UART_HIDDEN), LEqual (UART_DEVICE_MODE, SERIAL_IO_UART_COM))) {
     Device (PUA3) {
       Name (_DDN, "MtlPchSerialIoUart3")
-      Name (_UID, "MtlPchSerialIoUart3")
+      Name (_UID, 0x63)
       Include ("SerialIoUartHiddenDevice.asl")
     }
   }

--- a/Platform/CoffeelakeBoardPkg/AcpiTables/Dsdt/PchSerialIo.asl
+++ b/Platform/CoffeelakeBoardPkg/AcpiTables/Dsdt/PchSerialIo.asl
@@ -1,6 +1,6 @@
 /**@file
 
-  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2025, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -486,7 +486,7 @@ Scope(\_SB.PCI0) {
         If(LEqual(SERIAL_IO_UART0_DEVICE_MODE,SERIAL_IO_HIDDEN)) { Return (EISAID("PNP0C02")) }
         Else { Return (SERIAL_IO_UART0_HID) }
       }
-      Name (_UID, "SerialIoUart0")
+      Name (_UID, 0x50)
       Name (_DDN, "SerialIoUart0")
       Method (_HRV) { Return (LHRV(SERIAL_IO_UART0_BAR1)) }
       Method (_CRS) { Return (LCRS(SERIAL_IO_UART0_DEVICE_MODE,SERIAL_IO_UART0_BAR0,SERIAL_IO_UART0_IRQ_NUMBER)) }
@@ -522,7 +522,7 @@ Scope(\_SB.PCI0) {
         If(LEqual(SERIAL_IO_UART1_DEVICE_MODE,SERIAL_IO_HIDDEN)) { Return (EISAID("PNP0C02")) }
         Else { Return (SERIAL_IO_UART1_HID) }
       }
-      Name (_UID, "SerialIoUart1")
+      Name (_UID, 0x51)
       Name (_DDN, "SerialIoUart1")
       Method (_HRV) { Return (LHRV(SERIAL_IO_UART1_BAR1)) }
       Method (_CRS) { Return (LCRS(SERIAL_IO_UART1_DEVICE_MODE,SERIAL_IO_UART1_BAR0,SERIAL_IO_UART1_IRQ_NUMBER)) }
@@ -558,7 +558,7 @@ Scope(\_SB.PCI0) {
         If(LEqual(SERIAL_IO_UART2_DEVICE_MODE,SERIAL_IO_HIDDEN)) { Return (EISAID("PNP0C02")) }
         Else { Return (SERIAL_IO_UART2_HID) }
       }
-      Name (_UID, "SerialIoUart2")
+      Name (_UID, 0x52)
       Name (_DDN, "SerialIoUart2")
       Method (_HRV) { Return (LHRV(SERIAL_IO_UART2_BAR1)) }
       Method (_CRS) { Return (LCRS(SERIAL_IO_UART2_DEVICE_MODE,SERIAL_IO_UART2_BAR0,SERIAL_IO_UART2_IRQ_NUMBER)) }

--- a/Platform/CometlakeBoardPkg/AcpiTables/Dsdt/PchSerialIo.asl
+++ b/Platform/CometlakeBoardPkg/AcpiTables/Dsdt/PchSerialIo.asl
@@ -1,6 +1,6 @@
 /**@file
 
-  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2025, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -486,7 +486,7 @@ Scope(\_SB.PCI0) {
         If(LEqual(SERIAL_IO_UART0_DEVICE_MODE,SERIAL_IO_HIDDEN)) { Return (EISAID("PNP0C02")) }
         Else { Return (SERIAL_IO_UART0_HID) }
       }
-      Name (_UID, "SerialIoUart0")
+      Name (_UID, 0x50)
       Name (_DDN, "SerialIoUart0")
       Method (_HRV) { Return (LHRV(SERIAL_IO_UART0_BAR1)) }
       Method (_CRS) { Return (LCRS(SERIAL_IO_UART0_DEVICE_MODE,SERIAL_IO_UART0_BAR0,SERIAL_IO_UART0_IRQ_NUMBER)) }
@@ -522,7 +522,7 @@ Scope(\_SB.PCI0) {
         If(LEqual(SERIAL_IO_UART1_DEVICE_MODE,SERIAL_IO_HIDDEN)) { Return (EISAID("PNP0C02")) }
         Else { Return (SERIAL_IO_UART1_HID) }
       }
-      Name (_UID, "SerialIoUart1")
+      Name (_UID, 0x51)
       Name (_DDN, "SerialIoUart1")
       Method (_HRV) { Return (LHRV(SERIAL_IO_UART1_BAR1)) }
       Method (_CRS) { Return (LCRS(SERIAL_IO_UART1_DEVICE_MODE,SERIAL_IO_UART1_BAR0,SERIAL_IO_UART1_IRQ_NUMBER)) }
@@ -558,7 +558,7 @@ Scope(\_SB.PCI0) {
         If(LEqual(SERIAL_IO_UART2_DEVICE_MODE,SERIAL_IO_HIDDEN)) { Return (EISAID("PNP0C02")) }
         Else { Return (SERIAL_IO_UART2_HID) }
       }
-      Name (_UID, "SerialIoUart2")
+      Name (_UID, 0x52)
       Name (_DDN, "SerialIoUart2")
       Method (_HRV) { Return (LHRV(SERIAL_IO_UART2_BAR1)) }
       Method (_CRS) { Return (LCRS(SERIAL_IO_UART2_DEVICE_MODE,SERIAL_IO_UART2_BAR0,SERIAL_IO_UART2_IRQ_NUMBER)) }

--- a/Platform/CometlakevBoardPkg/AcpiTables/Dsdt/PchSerialIo.asl
+++ b/Platform/CometlakevBoardPkg/AcpiTables/Dsdt/PchSerialIo.asl
@@ -1,6 +1,6 @@
 /**@file
 
-  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2025, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -486,7 +486,7 @@ Scope(\_SB.PCI0) {
         If(LEqual(SERIAL_IO_UART0_DEVICE_MODE,SERIAL_IO_HIDDEN)) { Return (EISAID("PNP0C02")) }
         Else { Return (SERIAL_IO_UART0_HID) }
       }
-      Name (_UID, "SerialIoUart0")
+      Name (_UID, 0x50)
       Name (_DDN, "SerialIoUart0")
       Method (_HRV) { Return (LHRV(SERIAL_IO_UART0_BAR1)) }
       Method (_CRS) { Return (LCRS(SERIAL_IO_UART0_DEVICE_MODE,SERIAL_IO_UART0_BAR0,SERIAL_IO_UART0_IRQ_NUMBER)) }
@@ -522,7 +522,7 @@ Scope(\_SB.PCI0) {
         If(LEqual(SERIAL_IO_UART1_DEVICE_MODE,SERIAL_IO_HIDDEN)) { Return (EISAID("PNP0C02")) }
         Else { Return (SERIAL_IO_UART1_HID) }
       }
-      Name (_UID, "SerialIoUart1")
+      Name (_UID, 0x51)
       Name (_DDN, "SerialIoUart1")
       Method (_HRV) { Return (LHRV(SERIAL_IO_UART1_BAR1)) }
       Method (_CRS) { Return (LCRS(SERIAL_IO_UART1_DEVICE_MODE,SERIAL_IO_UART1_BAR0,SERIAL_IO_UART1_IRQ_NUMBER)) }
@@ -558,7 +558,7 @@ Scope(\_SB.PCI0) {
         If(LEqual(SERIAL_IO_UART2_DEVICE_MODE,SERIAL_IO_HIDDEN)) { Return (EISAID("PNP0C02")) }
         Else { Return (SERIAL_IO_UART2_HID) }
       }
-      Name (_UID, "SerialIoUart2")
+      Name (_UID, 0x52)
       Name (_DDN, "SerialIoUart2")
       Method (_HRV) { Return (LHRV(SERIAL_IO_UART2_BAR1)) }
       Method (_CRS) { Return (LCRS(SERIAL_IO_UART2_DEVICE_MODE,SERIAL_IO_UART2_BAR0,SERIAL_IO_UART2_IRQ_NUMBER)) }

--- a/Platform/ElkhartlakeBoardPkg/AcpiTables/Dsdt/PchSerialIoUart.asl
+++ b/Platform/ElkhartlakeBoardPkg/AcpiTables/Dsdt/PchSerialIoUart.asl
@@ -2,7 +2,7 @@
 
   Serial IO UART Controllers ACPI definitions
 
-  Copyright (c) 2018 - 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2025, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -292,7 +292,7 @@ Scope(\_SB) {
   If (LOr (LEqual(UART0_MODE, SERIAL_IO_UART_HIDDEN), LEqual (UART0_MODE, SERIAL_IO_UART_COM))) {
     Device (UAH0) {
       Name (_DDN, "SerialIoUart0")
-      Name (_UID, "SerialIoUart0")
+      Name (_UID, 0x50)
       Method (_HID) { Return (UHID (UART0_MODE)) }
       Method (_CRS) { Return (UARH (UART0_PCIE_BASE, UART0_IRQ)) }
       Method (_STA) {
@@ -315,7 +315,7 @@ Scope(\_SB) {
   If (LOr (LEqual(UART1_MODE, SERIAL_IO_UART_HIDDEN), LEqual (UART1_MODE, SERIAL_IO_UART_COM))) {
     Device (UAH1) {
       Name (_DDN, "SerialIoUart1")
-      Name (_UID, "SerialIoUart1")
+      Name (_UID, 0x51)
       Method (_HID) { Return (UHID (UART1_MODE)) }
       Method (_CRS) { Return (UARH (UART1_PCIE_BASE, UART1_IRQ)) }
       Method (_STA) {
@@ -338,7 +338,7 @@ Scope(\_SB) {
   If (LOr (LEqual(UART2_MODE, SERIAL_IO_UART_HIDDEN), LEqual (UART2_MODE, SERIAL_IO_UART_COM))) {
     Device (UAH2) {
       Name (_DDN, "SerialIoUart2")
-      Name (_UID, "SerialIoUart2")
+      Name (_UID, 0x52)
       Method (_HID) { Return (UHID (UART2_MODE)) }
       Method (_CRS) { Return (UARH (UART2_PCIE_BASE, UART2_IRQ)) }
       Method (_STA) {

--- a/Platform/MeteorlakeBoardPkg/AcpiTables/Dsdt/SerialIoUartHiddenController.asl
+++ b/Platform/MeteorlakeBoardPkg/AcpiTables/Dsdt/SerialIoUartHiddenController.asl
@@ -10,7 +10,7 @@ Scope(\_SB) {
   If (LOr (LEqual(UART_DEVICE_MODE, SERIAL_IO_UART_HIDDEN), LEqual (UART_DEVICE_MODE, SERIAL_IO_UART_COM))) {
     Device (UART_DEVICE_HIDDEN) {
       Name (_DDN, UART_DEVICE_DDN)
-      Name (_UID, UART_DEVICE_DDN)
+      Name (_UID, UART_DEVICE_UID)
       Method (_HID) { Return (UHID (UART_DEVICE_MODE)) }
       Method (_CRS) { Return (UARH (UART_DEVICE_PCI_BASE, UART_DEVICE_IRQ)) }
       Method (_STA) {

--- a/Platform/MeteorlakeBoardPkg/AcpiTables/Dsdt/SerialIoUartMtl.asl
+++ b/Platform/MeteorlakeBoardPkg/AcpiTables/Dsdt/SerialIoUartMtl.asl
@@ -25,6 +25,8 @@
 #define UART1_PG          UP01
 #define UART2_PG          UP02
 
+#define UART_UID_BASE     0x50
+
 Scope (\_SB.URSC) {
     Method (_CRS, 0x0, Serialized) {
       Store (UARB (UART0_MODE, UART0_PCIE_BASE), Local0)
@@ -43,6 +45,7 @@ Scope (\_SB.URSC) {
 #define UART_DEVICE_DMA       UART0_DMA
 #define UART_DEVICE_HIDDEN    UAH0
 #define UART_DEVICE_DDN       "SerialIoUart0"
+#define UART_DEVICE_UID       UART_UID_BASE
 #define UART_DEVICE_IRQ       UART0_IRQ
 #define UART_DEVICE_PG        UART0_PG
 Scope (\_SB.PC00) {
@@ -57,6 +60,7 @@ Include ("SerialIoUartHiddenController.asl")
 #undef UART_DEVICE_DMA
 #undef UART_DEVICE_HIDDEN
 #undef UART_DEVICE_DDN
+#undef UART_DEVICE_UID
 #undef UART_DEVICE_IRQ
 #undef UART_DEVICE_PG
 #define UART_DEVICE_ADR       SERIAL_IO_UART1_ADR
@@ -65,6 +69,7 @@ Include ("SerialIoUartHiddenController.asl")
 #define UART_DEVICE_DMA       UART1_DMA
 #define UART_DEVICE_HIDDEN    UAH1
 #define UART_DEVICE_DDN       "SerialIoUart1"
+#define UART_DEVICE_UID       UART_UID_BASE + 1
 #define UART_DEVICE_IRQ       UART1_IRQ
 #define UART_DEVICE_PG        UART1_PG
 Scope (\_SB.PC00) {
@@ -79,6 +84,7 @@ Include ("SerialIoUartHiddenController.asl")
 #undef UART_DEVICE_DMA
 #undef UART_DEVICE_HIDDEN
 #undef UART_DEVICE_DDN
+#undef UART_DEVICE_UID
 #undef UART_DEVICE_IRQ
 #undef UART_DEVICE_PG
 #define UART_DEVICE_ADR       SERIAL_IO_UART2_ADR
@@ -87,6 +93,7 @@ Include ("SerialIoUartHiddenController.asl")
 #define UART_DEVICE_DMA       UART2_DMA
 #define UART_DEVICE_HIDDEN    UAH2
 #define UART_DEVICE_DDN       "SerialIoUart2"
+#define UART_DEVICE_UID       UART_UID_BASE + 2
 #define UART_DEVICE_IRQ       UART2_IRQ
 #define UART_DEVICE_PG        UART2_PG
 Scope (\_SB.PC00) {
@@ -101,5 +108,6 @@ Include ("SerialIoUartHiddenController.asl")
 #undef UART_DEVICE_DMA
 #undef UART_DEVICE_HIDDEN
 #undef UART_DEVICE_DDN
+#undef UART_DEVICE_UID
 #undef UART_DEVICE_IRQ
 #undef UART_DEVICE_PG

--- a/Platform/TigerlakeBoardPkg/AcpiTables/Dsdt/PchSerialIoUart.asl
+++ b/Platform/TigerlakeBoardPkg/AcpiTables/Dsdt/PchSerialIoUart.asl
@@ -2,7 +2,7 @@
 
   Serial IO UART Controllers ACPI definitions
 
-  Copyright (c) 2018 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018 - 2025, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -338,7 +338,7 @@ Scope(\_SB) {
   If (LOr (LEqual(UART0_MODE, SERIAL_IO_UART_HIDDEN), LEqual (UART0_MODE, SERIAL_IO_UART_COM))) {
     Device (UAH0) {
       Name (_DDN, "SerialIoUart0")
-      Name (_UID, "SerialIoUart0")
+      Name (_UID, 0x50)
       Method (_HID) { Return (UHID (UART0_MODE)) }
       Method (_CRS) { Return (UARH (UART0_PCIE_BASE, UART0_IRQ)) }
       Method (_STA) {
@@ -361,7 +361,7 @@ Scope(\_SB) {
   If (LOr (LEqual(UART1_MODE, SERIAL_IO_UART_HIDDEN), LEqual (UART1_MODE, SERIAL_IO_UART_COM))) {
     Device (UAH1) {
       Name (_DDN, "SerialIoUart1")
-      Name (_UID, "SerialIoUart1")
+      Name (_UID, 0x51)
       Method (_HID) { Return (UHID (UART1_MODE)) }
       Method (_CRS) { Return (UARH (UART1_PCIE_BASE, UART1_IRQ)) }
       Method (_STA) {
@@ -384,7 +384,7 @@ Scope(\_SB) {
   If (LOr (LEqual(UART2_MODE, SERIAL_IO_UART_HIDDEN), LEqual (UART2_MODE, SERIAL_IO_UART_COM))) {
     Device (UAH2) {
       Name (_DDN, "SerialIoUart2")
-      Name (_UID, "SerialIoUart2")
+      Name (_UID, 0x52)
       Method (_HID) { Return (UHID (UART2_MODE)) }
       Method (_CRS) { Return (UARH (UART2_PCIE_BASE, UART2_IRQ)) }
       Method (_STA) {
@@ -407,7 +407,7 @@ Scope(\_SB) {
   If (LOr (LEqual(UART3_MODE, SERIAL_IO_UART_HIDDEN), LEqual (UART3_MODE, SERIAL_IO_UART_COM))) {
     Device (UAH3) {
       Name (_DDN, "SerialIoUART3")
-      Name (_UID, "SerialIoUART3")
+      Name (_UID, 0x53)
       Method (_HID) { Return (UHID (UART3_MODE)) }
       Method (_CRS) { Return (UARH (UART3_PCIE_BASE, UART3_IRQ)) }
       Method (_STA) {
@@ -430,7 +430,7 @@ Scope(\_SB) {
   If (LOr (LEqual(UART4_MODE, SERIAL_IO_UART_HIDDEN), LEqual (UART4_MODE, SERIAL_IO_UART_COM))) {
     Device (UAH4) {
       Name (_DDN, "SerialIoUART4")
-      Name (_UID, "SerialIoUART4")
+      Name (_UID, 0x54)
       Method (_HID) { Return (UHID (UART4_MODE)) }
       Method (_CRS) { Return (UARH (UART4_PCIE_BASE, UART4_IRQ)) }
       Method (_STA) {
@@ -453,7 +453,7 @@ Scope(\_SB) {
   If (LOr (LEqual(UART5_MODE, SERIAL_IO_UART_HIDDEN), LEqual (UART5_MODE, SERIAL_IO_UART_COM))) {
     Device (UAH5) {
       Name (_DDN, "SerialIoUART5")
-      Name (_UID, "SerialIoUART5")
+      Name (_UID, 0x55)
       Method (_HID) { Return (UHID (UART5_MODE)) }
       Method (_CRS) { Return (UARH (UART5_PCIE_BASE, UART5_IRQ)) }
       Method (_STA) {
@@ -476,7 +476,7 @@ Scope(\_SB) {
   If (LOr (LEqual(UART6_MODE, SERIAL_IO_UART_HIDDEN), LEqual (UART6_MODE, SERIAL_IO_UART_COM))) {
     Device (UAH6) {
       Name (_DDN, "SerialIoUART6")
-      Name (_UID, "SerialIoUART6")
+      Name (_UID, 0x56)
       Method (_HID) { Return (UHID (UART6_MODE)) }
       Method (_CRS) { Return (UARH (UART6_PCIE_BASE, UART6_IRQ)) }
       Method (_STA) {


### PR DESCRIPTION
The ACPI spec allows the _UID return value to be either numeric or a string when the HID is not ACPI0007. However, some legacy UART drivers may only evaluate it as a numeric value, potentially leading to misinterpretation of the _UID. To ensure compatibility with these legacy UART drivers, this commit modifies the _UID of all UART devices from a string to a numeric value.

Additionally, to prevent conflicts with other predefined ACPI devices using _HID "PNP0501" or "PNP0C02" in SBL, such as H8S2113Sio, the _UID for UART devices is set to start from 0x50 or 0x60.

Reference: https://uefi.org/specs/ACPI/6.6/06_Device_Configuration.html#uid-unique-id

fixes #2566