### PR TITLE
fix: Azure CI build fail on windows

### DIFF
--- a/.azurepipelines/azure-pipelines.yml
+++ b/.azurepipelines/azure-pipelines.yml
@@ -421,7 +421,7 @@ jobs:
         Build.Arch:   ""
         Build.Target: "-r"
   pool:
-    vmImage: 'windows-2019'
+    vmImage: 'windows-2022'
 
   steps:
   - checkout: self
@@ -466,5 +466,5 @@ jobs:
     displayName: Environment configuration
 
   - script: |
-      python BuildLoader.py build $(Build.Name) $(Build.Arch) $(Build.Target) -t vs2019 -k
+      python BuildLoader.py build $(Build.Name) $(Build.Arch) $(Build.Target) -t vs2022 -k
     displayName: 'Run $(Build.Name) build'

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/UpdateAcpiGnvs.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/UpdateAcpiGnvs.c
@@ -387,7 +387,7 @@ UpdateCpuNvs (
   CpuConfigData = (CPU_CONFIG_DATA *)(UINTN)CpuInitDataHob->CpuConfigData;
   CpuSku = GetCpuSku();
 
-  CpuNvs->Cpuid = GetCpuFamily() | GetCpuStepping();
+  CpuNvs->Cpuid = (UINT32)GetCpuFamily() | (UINT32)GetCpuStepping();
   CpuNvs->Revision = CPU_NVS_AREA_REVISION;
   ///
   /// Calculate the number of Oc bins supported. Read in MSR 194h FLEX_RATIO bits (19:17)

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -2055,7 +2055,7 @@ UpdateCpuNvs (
   CpuConfigData = (CPU_CONFIG_DATA *)(UINTN)CpuInitDataHob->CpuConfigData;
   CpuSku = GetCpuSku();
 
-  CpuNvs->Cpuid = GetCpuFamily() | GetCpuStepping();
+  CpuNvs->Cpuid = (UINT32)GetCpuFamily() | (UINT32)GetCpuStepping();
   CpuNvs->Revision = CPU_NVS_AREA_REVISION;
   ///
   /// Calculate the number of Oc bins supported. Read in MSR 194h FLEX_RATIO bits (19:17)


### PR DESCRIPTION
fix the Windows Server 2019 has been retired.
The Windows Server 2019 image has been removed as of 2025-06-30.