### PR TITLE
fix: [Common] limit flash map entry to 16MB

### DIFF
--- a/BootloaderCorePkg/Stage2/Stage2Hob.c
+++ b/BootloaderCorePkg/Stage2/Stage2Hob.c
@@ -132,8 +132,14 @@ SplitMemroyMap (
 
   // Add a flash map entry
   if (NewIdx < PcdGet32 (PcdMemoryMapEntryNumber)) {
-    MemoryMapInfo->Entry[NewIdx].Base = PcdGet32(PcdFlashBaseAddress);
-    MemoryMapInfo->Entry[NewIdx].Size = PcdGet32(PcdFlashSize);
+    if (PcdGet32(PcdFlashSize) < SIZE_16MB){
+      MemoryMapInfo->Entry[NewIdx].Base = PcdGet32(PcdFlashBaseAddress);
+      MemoryMapInfo->Entry[NewIdx].Size = PcdGet32(PcdFlashSize);
+    } else {
+      // Limit flash map entry to 16MB
+      MemoryMapInfo->Entry[NewIdx].Base = (UINT32)(~SIZE_16MB + 1);
+      MemoryMapInfo->Entry[NewIdx].Size = SIZE_16MB;
+    }
     MemoryMapInfo->Entry[NewIdx].Type = MEM_MAP_TYPE_RESERVED;
     MemoryMapInfo->Entry[NewIdx].Flag = 0;
     NewIdx++;


### PR DESCRIPTION
When flash map size is greater than 16MB, the memory map info hob may create an entry overlapping other regions HPET memory space initial may fail due to above.