### PR TITLE
Update shell to support more command parameters

### DIFF
--- a/BootloaderCommonPkg/Library/ShellLib/Shell.c
+++ b/BootloaderCommonPkg/Library/ShellLib/Shell.c
@@ -380,7 +380,7 @@ RunShellCommand (
   UINTN               Index, Count, BufRemaining;
   EFI_STATUS          Status;
   CONST SHELL_COMMAND *Cmd;
-  CHAR16              *Argv[8]; // FIXME: Use allocator once that's available
+  CHAR16              *Argv[15];
 
   // Parse the command line parameters
   BufRemaining = Shell->CommandLineMaxLen * sizeof(CHAR16);


### PR DESCRIPTION
The current shell implementation limits command line parameters to 8, which is insufficient for some commands. Increase the limit to 15 to accommodate more use cases.

Signed-off-by: Guo Dong guo.dong@intel.com