### PR TITLE
fix: [toolchain] zero extension warning from 'UINTN' to 'UINT64'

### DIFF
--- a/BootloaderCommonPkg/Library/FullMemoryAllocationLib/Page.c
+++ b/BootloaderCommonPkg/Library/FullMemoryAllocationLib/Page.c
@@ -1,7 +1,7 @@
 /** @file
   Memory page management functions.
 
-Copyright (c) 2007 - 2017, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2007 - 2025, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -745,7 +745,7 @@ CoreFindFreePagesI (
       DescEnd = MaxAddress;
     }
 
-    DescEnd = ((DescEnd + 1) & (~ (Alignment - 1))) - 1;
+    DescEnd = ((DescEnd + 1) & (~((UINT64)Alignment - 1))) - 1;
 
     // Skip if DescEnd is less than DescStart after alignment clipping
     if (DescEnd < DescStart) {


### PR DESCRIPTION
This commit addresses the build error encountered in the Azure CI build pipeline. The build process was halted due to a fatal error (NMAKE : fatal error U1077).

  (skip)
  d:\a\1\s\BootloaderCommonPkg\Library\FullMemoryAllocationLib\Page.c(748): error C2220: the following warning is treated as an error
  d:\a\1\s\BootloaderCommonPkg\Library\FullMemoryAllocationLib\Page.c(748): warning C4319: '~': zero extending 'UINTN' to 'UINT64' of greater size
  PayloadLib.c
  NMAKE : fatal error U1077: (skip)