### PR TITLE
fix: ci build fail on vs2022

### DIFF
--- a/BootloaderCommonPkg/Library/FullMemoryAllocationLib/Page.c
+++ b/BootloaderCommonPkg/Library/FullMemoryAllocationLib/Page.c
@@ -745,7 +745,7 @@ CoreFindFreePagesI (
       DescEnd = MaxAddress;
     }
 
-    DescEnd = ((DescEnd + 1) & (~ (Alignment - 1))) - 1;
+    DescEnd = ((DescEnd + 1) & (~((UINT64)Alignment - 1))) - 1;
 
     // Skip if DescEnd is less than DescStart after alignment clipping
     if (DescEnd < DescStart) {


### PR DESCRIPTION
d:\a\1\s\BootloaderCommonPkg\Library\FullMemoryAllocationLib\Page.c(748): 
  error C2220: the following warning is treated as an error d:\a\1\s\BootloaderCommonPkg\Library\FullMemoryAllocationLib\Page.c(748): 
  warning C4319: '~': zero extending 'UINTN' to 'UINT64' of greater size 
 
Create by Copilot..