### PR TITLE
feat: Enable POSC to Boot ELF

### DIFF
--- a/PayloadPkg/OsLoader/PreOsSupport.c
+++ b/PayloadPkg/OsLoader/PreOsSupport.c
@@ -1,6 +1,6 @@
 /** @file
 
-  Copyright (c) 2019 - 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2019 - 2025, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -52,7 +52,8 @@ GetNormalOsInfo (
     UpdateLinuxBootParams (OsBootParam);
     PreOsParams->OsBootState.Esi     = (UINT32)(UINTN)OsBootParam;
     PreOsParams->OsBootState.Eip     = OsBootParam->Hdr.Code32Start;
-  } else if ((LoadedImage->Flags & LOADED_IMAGE_MULTIBOOT) != 0) {
+  } else if ((LoadedImage->Flags & (LOADED_IMAGE_ELF | LOADED_IMAGE_MULTIBOOT)) != 0) {
+    DEBUG((DEBUG_INFO, "POSC to boot %a\n", (LoadedImage->Flags & LOADED_IMAGE_ELF)?"elf":"mb"));
     BootState = &LoadedImage->Image.MultiBoot.BootState;
     PreOsParams->OsBootState.Eax     = BootState->Eax;
     PreOsParams->OsBootState.Ebx     = BootState->Ebx;


### PR DESCRIPTION
This commit introduces the following changes:
1. Enables POSC to boot ELF files.
2. Corrects typos in the multiboot information dump.
3. Adds cases to handle unsupported yet bootable multiboot tags.

Tests has been conducted with (1) non-multiboot2 ELF, and (2) multiboot2 ELF images on TGL and EHL.