### PR TITLE
fix: [Common] Set LfbSize in Linux framebuffer parameters

### DIFF
--- a/BootloaderCommonPkg/Library/LinuxLib/LinuxLib.c
+++ b/BootloaderCommonPkg/Library/LinuxLib/LinuxLib.c
@@ -301,6 +301,7 @@ UpdateLinuxBootParams (
       Bp->ScreenInfo.Capabilities   |= VIDEO_CAPABILITY_64BIT_BASE;
       Bp->ScreenInfo.LfbWidth        = (UINT16)GfxMode->HorizontalResolution;
       Bp->ScreenInfo.LfbHeight       = (UINT16)GfxMode->VerticalResolution;
+      Bp->ScreenInfo.LfbSize         = (UINT32)(GfxMode->HorizontalResolution * GfxMode->VerticalResolution * 4);
       Bp->ScreenInfo.Pages           = 1;
       Bp->ScreenInfo.RedSize         = 8;
       Bp->ScreenInfo.GreenSize       = 8;


### PR DESCRIPTION
The LfbSize field in the Linux screen_info structure was not being set during framebuffer handoff, causing Linux kernel to reject the framebuffer with "sysfb: VRAM smaller than advertised" error. This resulted in display issues where only the SBL splash screen was visible but the OS failed to display properly.

The fix calculates and sets the framebuffer size based on resolution and color depth: LfbSize = HorizontalResolution × VerticalResolution × 4 bytes.

This ensures proper framebuffer validation in the Linux kernel and enables successful display handoff from SBL to the operating system.

Tested on Ubuntu 24.04 with 1280x1024 display resolution.

Resolves display initialization issues in Linux distributions that depend on proper framebuffer size information for graphics subsystem initialization.