### PR TITLE
NVL: Add HECI_SERVICE_V2 and multi-CSME support

### DIFF
--- a/BootloaderCommonPkg/Include/Service/HeciService.h
+++ b/BootloaderCommonPkg/Include/Service/HeciService.h
@@ -12,6 +12,7 @@
 
 #define HECI_SERVICE_SIGNATURE  SIGNATURE_32 ('H', 'E', 'C', 'I')
 #define HECI_SERVICE_VERSION    1
+#define HECI_SERVICE_VERSION_2  2
 
 
 #define  SUBCMD_ENTER_DNX_MODE   1
@@ -132,5 +133,78 @@ typedef struct {
   HECI_RESET_INTERFACE               HeciResetInterface;
   DUMMY_FUNCTION                     Reserved[6];
 } HECI_SERVICE;
+
+
+/**
+  Function sends one message (of any length) through the HECI circular buffer.
+
+  @param[in] HeciDevs             The HECI device to be accessed.
+  @param[in] Message              Pointer to the message data to be sent.
+  @param[in] Length               Length of the message in bytes.
+  @param[in] HostAddress          The address of the Host processor.
+  @param[in] MeAddress            Address of the ME subsystem the message is being sent to.
+
+  @retval EFI_SUCCESS             One message packet sent.
+  @retval EFI_DEVICE_ERROR        Failed to initialize HECI
+  @retval EFI_TIMEOUT             HECI is not ready for communication
+  @retval EFI_UNSUPPORTED      Current ME mode doesn't support send this message through this HECI
+**/
+typedef
+EFI_STATUS
+(EFIAPI *HECI_SEND_V2) (
+  IN UINT32       HeciDevs,
+  IN UINT32      *Message,
+  IN UINT32       Length,
+  IN UINT8        HostAddress,
+  IN UINT8        MeAddress
+  );
+
+/**
+  Reads a message from the ME across HECI. This function can only be used after invoking HeciSend() first.
+
+  @param[in] HeciDevs             The HECI device to be accessed.
+  @param[in] Blocking             Used to determine if the read is BLOCKING or NON_BLOCKING.
+  @param[out] MessageBody         Pointer to a buffer used to receive a message.
+  @param[in][out] Length          Pointer to the length of the buffer on input and the length
+                                  of the message on return. (in bytes)
+
+  @retval EFI_SUCCESS             One message packet read.
+  @retval EFI_DEVICE_ERROR        Failed to initialize HECI or zero-length message packet read
+  @retval EFI_TIMEOUT             HECI is not ready for communication
+  @retval EFI_BUFFER_TOO_SMALL    The caller's buffer was not large enough
+  @retval EFI_UNSUPPORTED         Current ME mode doesn't support this message through this HECI
+**/
+typedef
+EFI_STATUS
+(EFIAPI *HECI_RECEIVE_V2) (
+  IN      UINT32       HeciDevs,
+  IN      UINT32       Blocking,
+  OUT     UINT32      *MessageBody,
+  IN OUT  UINT32      *Length
+  );
+
+/**
+  Function forces a reinit of the heci interface by following the reset heci interface via Host algorithm
+
+  @param[in] HeciDevs             The HECI device to be accessed.
+
+  @retval EFI_TIMEOUT             ME is not ready
+  @retval EFI_SUCCESS             Interface reset
+**/
+typedef
+EFI_STATUS
+(EFIAPI *HECI_RESET_INTERFACE_V2) (
+  IN UINT32        HeciDevs
+  );
+
+typedef struct {
+  SERVICE_COMMON_HEADER              Header;
+  SIMPLE_HECI_CMD                    SimpleHeciCommand;
+  HECI_USER_COMMAND                  HeciUserCommand;
+  HECI_SEND_V2                       HeciSend;
+  HECI_RECEIVE_V2                    HeciReceive;
+  HECI_RESET_INTERFACE_V2            HeciResetInterface;
+  DUMMY_FUNCTION                     Reserved[6];
+} HECI_SERVICE_V2;
 
 #endif

--- a/Silicon/CommonSocPkg/Include/MeChipset.h
+++ b/Silicon/CommonSocPkg/Include/MeChipset.h
@@ -20,6 +20,27 @@ typedef enum {
   ISH_HECI     = 8
 } HECI_DEVICE;
 
+typedef enum {
+  CSME     = 0,
+  CSMEIOE  = 3
+} SECURITY_ENGINE;
+
+typedef struct {
+  UINT8    HeciDevice;
+  UINT8    SecurityEngine;
+  UINT16   Reserved;
+} HECI_DEVICES;
+
+#define HECI1_DEVICES ((HECI_DEVICES){ .HeciDevice = HECI1_DEVICE, .SecurityEngine = CSME, .Reserved = 0 })
+#define HECI2_DEVICES ((HECI_DEVICES){ .HeciDevice = HECI2_DEVICE, .SecurityEngine = CSME, .Reserved = 0 })
+#define HECI3_DEVICES ((HECI_DEVICES){ .HeciDevice = HECI3_DEVICE, .SecurityEngine = CSME, .Reserved = 0 })
+#define HECI4_DEVICES ((HECI_DEVICES){ .HeciDevice = HECI4_DEVICE, .SecurityEngine = CSME, .Reserved = 0 })
+
+#define HECI1_CSME2   ((HECI_DEVICES){ .HeciDevice = HECI1_DEVICE, .SecurityEngine = CSMEIOE, .Reserved = 0 })
+#define HECI2_CSME2   ((HECI_DEVICES){ .HeciDevice = HECI2_DEVICE, .SecurityEngine = CSMEIOE, .Reserved = 0 })
+#define HECI3_CSME2   ((HECI_DEVICES){ .HeciDevice = HECI3_DEVICE, .SecurityEngine = CSMEIOE, .Reserved = 0 })
+#define HECI4_CSME2   ((HECI_DEVICES){ .HeciDevice = HECI4_DEVICE, .SecurityEngine = CSMEIOE, .Reserved = 0 })
+
 #define R_ME_GS_SHDW                      0x48
 #define R_ME_HFS                          0x40
 #define R_ME_HFS_2                        0x48


### PR DESCRIPTION
Previously, the HECI service used HECI_DEVICE to support a single CSME instance. To enable support two CSME instances (SoC CSME and IOE CSME), this update introduces a new HECI_DEVICES structure and related macros to specify both the HECI device and the target security engine.
The new HECI_SERVICE_V2 structure and updated service interface leverage these changes, allowing flexible communication with multiple CSME instances while maintaining backward compatibility with existing platforms.

Signed-off-by: Guo Dong guo.dong@intel.com