### PR TITLE
fix: Fix SPI raw partition read data corruption

### DIFF
--- a/BootloaderCommonPkg/Include/Library/SpiBlockIoLib.h
+++ b/BootloaderCommonPkg/Include/Library/SpiBlockIoLib.h
@@ -15,7 +15,7 @@
 #include <BlockDevice.h>
 #include <Service/SpiFlashService.h>
 
-#define SPI_BLOCK_SIZE 0x100
+#define SPI_BLOCK_SIZE 0x1
 
 /**
   This function reads blocks from the SPI slave device.


### PR DESCRIPTION
SpiBlockIoLib uses Flash Linear Address (byte-based addressing) for SPI
read operations, but SPI_BLOCK_SIZE was defined as 0x100 (256 bytes).
This mismatch caused incorrect address calculations in functions that
use block-count-based arithmetic (e.g., adding AlignedHeaderBlkCnt to
an LBA address), since the block count derived from a 256-byte block
size does not correspond to actual byte offsets for SPI.

Change SPI_BLOCK_SIZE from 0x100 to 0x1 to reflect the byte-addressable
nature of the SPI flash interface, aligning the block I/O abstraction in
SpiBlockIoLib with the underlying SpiFlashLib addressing scheme.

Tested with Linux kernel based container images loaded from SPI raw partition.