### PR TITLE
SpiBlockIoLib: Fix dead code in SpiGetMediaInfo

### DIFF
--- a/BootloaderCommonPkg/Library/SpiBlockIoLib/SpiBlockIoLib.c
+++ b/BootloaderCommonPkg/Library/SpiBlockIoLib/SpiBlockIoLib.c
@@ -124,8 +124,7 @@ SpiGetMediaInfo (
   }
 
   Status = mSpiService->SpiGetRegion (FlashRegionAll, &FlashBase, &FlashSize);
-  DevBlockInfo->BlockNum  = ((FlashSize % SPI_BLOCK_SIZE) == 0) ? FlashSize / SPI_BLOCK_SIZE :
-                            (FlashSize / SPI_BLOCK_SIZE) + 1;
+  DevBlockInfo->BlockNum  = FlashSize;
   DevBlockInfo->BlockSize = SPI_BLOCK_SIZE;
 
   return Status;


### PR DESCRIPTION
SPI_BLOCK_SIZE is defined as 1, so the modulo check (FlashSize % SPI_BLOCK_SIZE) is always 0, making the else branch of the BlockNum ternary unreachable dead code.

Simplify the assignment to directly set BlockNum to FlashSize, which is equivalent and removes the Coverity dead code finding.