### PR TITLE
BootloaderCorePkg/Tools: Add sbl_dir fallback for driver_inf path lookup

### DIFF
--- a/BootloaderCorePkg/Tools/PrepareBuildComponentBin.py
+++ b/BootloaderCorePkg/Tools/PrepareBuildComponentBin.py
@@ -193,6 +193,10 @@ def GetRepoAndCommit (driver_inf):
 
 def CopyBins (repo_dir, sbl_dir, driver_inf):
     if not os.path.exists(driver_inf):
+        driver_inf = os.path.join(sbl_dir, driver_inf)
+    if not os.path.exists(driver_inf):
+        if driver_inf:
+            print ('WARNING: driver_inf not found: %s' % driver_inf)
         return
 
     sys.stdout.flush()


### PR DESCRIPTION
In CopyBins(), when driver_inf is not found relative to the current working directory, fall back to resolving it relative to sbl_dir before giving up.