### PR TITLE
Fetch ACTM binary from repo using INF file

### DIFF
--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -857,9 +857,50 @@ def gen_smbios_bin(yaml_file, bin_file):
             out.write(string_val.encode('ascii') + b'\0')
             i += 3  # Skip to next entry
 
-def gen_actm_file (brd_pkg_name, actm_bin, actm_file):
-    # Copy ACTM file
-    src_path = os.path.join(os.environ['PLT_SOURCE'], 'Platform', brd_pkg_name, 'Actm', actm_bin)
+def get_actm_bin_path (actm_inf_path, plt_dir):
+    # Locate ACTM binary path from INF.
+    # Checks CopyList destination first, then falls back to [Sources] section.
+    from PrepareBuildComponentBin import GetCopyList
+    actm_inf_dir = os.path.dirname(actm_inf_path)
+
+    # Try CopyList destination first (used when binary is cloned/copied from repo)
+    copy_list = GetCopyList (actm_inf_path)
+    if copy_list:
+        candidate = os.path.join(plt_dir, copy_list[0][1])
+        if os.path.exists(candidate):
+            return candidate
+
+    # Fall back to [Sources] section resolved relative to INF directory
+    in_sources = False
+    with open(actm_inf_path, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if line.startswith('['):
+                if line.startswith('[Sources'):
+                    in_sources = True
+                else:
+                    if in_sources:
+                        break
+                    in_sources = False
+                continue
+            if in_sources and line and not line.startswith('#'):
+                # Try path relative to INF directory
+                candidate = os.path.join(actm_inf_dir, line)
+                if os.path.exists(candidate):
+                    return candidate
+                # Try just the filename in INF directory
+                candidate = os.path.join(actm_inf_dir, os.path.basename(line))
+                if os.path.exists(candidate):
+                    return candidate
+
+    return None
+
+
+def gen_actm_file (actm_inf, plt_dir, actm_file):
+    actm_inf_path = actm_inf if os.path.isabs(actm_inf) else os.path.join(plt_dir, actm_inf)
+    src_path = get_actm_bin_path (actm_inf_path, plt_dir)
+    if not src_path:
+        raise Exception ('ACTM binary not found from INF: %s' % actm_inf_path)
     shutil.copy (src_path, actm_file)
     return
 

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -1606,7 +1606,10 @@ def main():
                     fsp_inf_full_path = os.path.join(sbl_dir, fsp_inf)
                     dest_dir = sbl_dir
 
-                    plt_dir = os.environ['PLT_SOURCE'] if 'PLT_SOURCE' in os.environ else None
+                    if 'PLT_SOURCE' in os.environ:
+                        plt_dir = os.environ['PLT_SOURCE']
+                    else:
+                        plt_dir = os.path.abspath (os.path.join (os.path.dirname (board_cfgs[index]), '../..'))
 
                     if not os.path.exists(fsp_inf_full_path) and plt_dir:
                         fsp_inf_full_path = os.path.join(plt_dir, fsp_inf)

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -147,7 +147,6 @@ class BaseBoard(object):
         self.BOOT_PERFORMANCE_MASK    = 0x00000001
 
         self.HAVE_VBT_BIN          = 0
-        self.HAVE_ACTM_BIN         = 0
         self.HAVE_FIT_TABLE        = 0
         self.HAVE_VERIFIED_BOOT    = 0
         self.HAVE_MEASURED_BOOT    = 0
@@ -274,7 +273,6 @@ class BaseBoard(object):
 
         self._PLATFORM_ID          = None
         self._MULTI_VBT_FILE       = {}
-        self._ACTM_BIN_FILE        = ''
         self._CFGDATA_DEF_FILE     = ''
         self._CFGDATA_INT_FILE     = []
         self._CFGDATA_EXT_FILE     = []
@@ -1317,20 +1315,25 @@ class Build(object):
             else:
                 gen_vbt_file (self._board.BOARD_PKG_NAME, self._board._MULTI_VBT_FILE, os.path.join(self._fv_dir, 'Vbt.bin'))
 
+        # Fetch ACTM binary from repo if ACTM_INF_FILE is defined
+        if hasattr(self._board, 'ACTM_INF_FILE'):
+            actm_repo_dir = os.path.abspath (os.path.join(plt_dir, '../Download', self._board.SILICON_PKG_NAME, '$AUTO'))
+            PreBuild.CopyBins (actm_repo_dir, plt_dir, self._board.ACTM_INF_FILE)
+
         # create ACTM file
-        if self._board.HAVE_ACTM_BIN:
-            if hasattr(self._board, 'BOARD_PKG_NAME_OVERRIDE'):
-                gen_actm_file (self._board.BOARD_PKG_NAME_OVERRIDE, self._board._ACTM_BIN_FILE, os.path.join(self._fv_dir, 'ACTM.bin'))
-            else:
-                gen_actm_file (self._board.BOARD_PKG_NAME, self._board._ACTM_BIN_FILE, os.path.join(self._fv_dir, 'ACTM.bin'))
+        if hasattr(self._board, 'ACTM_INF_FILE'):
+            gen_actm_file (self._board.ACTM_INF_FILE, plt_dir, os.path.join(self._fv_dir, 'ACTM.bin'))
 
         # create platform include dsc file
         platform_dsc_path = os.path.join(sbl_dir, 'BootloaderCorePkg', 'Platform.dsc')
         self.create_dsc_inc_file (platform_dsc_path)
 
         # process INF files having [UserExtensions.SBL."CopyList"]
+        ignore_list = [self._board.FSP_INF_FILE, self._board.MICROCODE_INF_FILE]
+        if hasattr(self._board, 'ACTM_INF_FILE'):
+            ignore_list.append(self._board.ACTM_INF_FILE)
         try:
-            PreBuild.ProcessInfFileCopyList (sbl_dir, [self._board.FSP_INF_FILE, self._board.MICROCODE_INF_FILE])
+            PreBuild.ProcessInfFileCopyList (sbl_dir, ignore_list)
         except Exception as e:
             raise Exception(f'Failed to process other INF files: {str(e)}')
 
@@ -1639,6 +1642,21 @@ def main():
                             if os.path.exists(file_full_path):
                                 print('Removing %s' % file_full_path)
                                 os.remove(file_full_path)
+
+                    if hasattr(board, 'ACTM_INF_FILE'):
+                        actm_inf = board.ACTM_INF_FILE
+                        actm_inf_full_path = os.path.join(sbl_dir, actm_inf)
+                        dest_dir = sbl_dir
+                        if not os.path.exists(actm_inf_full_path) and plt_dir:
+                            actm_inf_full_path = os.path.join(plt_dir, actm_inf)
+                            dest_dir = plt_dir
+
+                        if os.path.exists(actm_inf_full_path):
+                            for _, file in PreBuild.GetCopyList (actm_inf_full_path):
+                                file_full_path = os.path.join(dest_dir, file)
+                                if os.path.exists(file_full_path):
+                                    print('Removing %s' % file_full_path)
+                                    os.remove(file_full_path)
 
                     break
 


### PR DESCRIPTION
Add CopyBins call in pre_build to clone ACTM binary from firmwareblob repo when ACTM_INF_FILE is defined in board config.