### PR TITLE
Enhance firmware update to support more flags

### DIFF
--- a/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
+++ b/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
@@ -53,6 +53,19 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define CAPSULE_FLAG_FORCE_BIOS_UPDATE    BIT31
 
+//
+// Capsule flag to skip updating all non-volatile data regions
+// during BIOS region update (normal update path, NOT force BIOS update).
+// When this flag is set, all non-volatile data regions (MRC data, SBL variable,
+// UEFI variable, SMBIOS) in the new capsule image will be replaced with current
+// flash content before writing, effectively preserving the existing data on flash.
+//
+// This flag only applies to UpdateSystemFirmware (non-force BIOS update).
+// When CAPSULE_FLAG_FORCE_BIOS_UPDATE is set, the entire BIOS region is
+// overwritten and this flag is ignored.
+//
+#define CAPSULE_FLAG_SKIP_ALL_NON_VOLATILE_REGION     BIT1
+
 typedef enum {
   TopSwapSet,
   TopSwapClear

--- a/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
+++ b/BootloaderCorePkg/Tools/GenCapsuleFirmware.py
@@ -405,7 +405,8 @@ FIRMWARE_UPDATE_IMAGE_FILE_GUID = uuid.UUID('{1A3EAE58-B580-4fef-ACA3-A16D9E00DF
 
 class FirmwareUpdateHeader(Structure):
 
-  CAPSULE_FLAG_FORCE_BIOS_UPDATE = 0x80000000
+  CAPSULE_FLAG_FORCE_BIOS_UPDATE            = 0x80000000
+  CAPSULE_FLAG_SKIP_ALL_NON_VOLATILE_REGION = 0x00000002
 
   _fields_ = [
     ('FileGuid',           ARRAY(c_uint8, 16)),
@@ -422,7 +423,7 @@ class FirmwareUpdateHeader(Structure):
   ]
 
 
-def SignImage(RawData, OutFile, HashType, SignScheme, PrivKey, ForceBiosUpdate):
+def SignImage(RawData, OutFile, HashType, SignScheme, PrivKey, CapsuleFlags):
 
     #
     # Generate the new image layout
@@ -445,9 +446,7 @@ def SignImage(RawData, OutFile, HashType, SignScheme, PrivKey, ForceBiosUpdate):
     header.FileGuid         = (c_ubyte *16).from_buffer_copy(FIRMWARE_UPDATE_IMAGE_FILE_GUID.bytes_le)
     header.HeaderSize       = sizeof(FirmwareUpdateHeader)
     header.FirmwreVersion   = 1
-    header.CapsuleFlags     = 0
-    if ForceBiosUpdate:
-        header.CapsuleFlags  |= FirmwareUpdateHeader.CAPSULE_FLAG_FORCE_BIOS_UPDATE
+    header.CapsuleFlags     = CapsuleFlags
     header.ImageOffset      = header.HeaderSize
     header.ImageSize        = file_size
     header.SignatureOffset  = header.ImageOffset + header.ImageSize
@@ -503,11 +502,18 @@ def main():
     parser.add_argument('-o',  '--output', dest='NewImage', type=str, required=True, help='Output file for signed image')
     parser.add_argument("-v",  "--verbose", dest='Verbose', action="store_true", help= "Turn on verbose output with informational messages printed, including capsule headers and warning messages.")
     parser.add_argument("-f",  "--force_bios_update", dest='ForceBiosUpdate', action="store_true", help= "Force update whole BIOS region in a single shot.")
+    parser.add_argument("-sa", "--skip-all", dest='SkipAll', action="store_true", help= "Skip updating the following data regions (MRC data, SBL variable, UEFI variable, SMBIOS) during BIOS region update.")
 
     #
     # Parse command line arguments
     #
     args = parser.parse_args()
+
+    #
+    # --skip-all is not compatible with force BIOS update
+    #
+    if args.ForceBiosUpdate and args.SkipAll:
+        raise Exception ("--skip-all cannot be used together with force BIOS update (-f) !")
 
     #
     # Error out if components overlap
@@ -573,9 +579,19 @@ def main():
         FmpCapsuleHeader.DumpInfo()
 
     #
+    # Build CapsuleFlags
+    #
+    CapsuleFlags = 0
+    if args.ForceBiosUpdate:
+        CapsuleFlags |= FirmwareUpdateHeader.CAPSULE_FLAG_FORCE_BIOS_UPDATE
+    if args.SkipAll:
+        CapsuleFlags |= FirmwareUpdateHeader.CAPSULE_FLAG_SKIP_ALL_NON_VOLATILE_REGION
+        print("[INFO] Skipping the following data regions (MRC data, SBL variable, UEFI variable, SMBIOS) during firmware update.")
+
+    #
     # Create final capsule
     #
-    SignImage(Result, args.NewImage, args.HashType, args.SignScheme, args.PrivKey, args.ForceBiosUpdate)
+    SignImage(Result, args.NewImage, args.HashType, args.SignScheme, args.PrivKey, CapsuleFlags)
     print('Success')
 
     #

--- a/BootloaderCorePkg/Tools/SingleSign.py
+++ b/BootloaderCorePkg/Tools/SingleSign.py
@@ -233,7 +233,7 @@ def single_sign_file (priv_key, hash_type, sign_scheme, in_file, out_file):
     hashdata_bytes = bytearray.fromhex(hashdata)
     open (hash_file, 'wb').write(hashdata_bytes)
 
-    print ("Key used for Singing %s !!" % priv_key)
+    print ("Key used for Signing %s !!" % priv_key)
 
     # sign using Openssl pkeyutl
     cmdargs = [get_openssl_path(), 'pkeyutl', '-sign', '-in', '%s' % hash_file, '-inkey', '%s' % priv_key,

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -780,14 +780,15 @@ ValidateCapsuleLayout (
   }
 
   //
-  // Whitelist CapsuleFlags against the two defined flags:
-  //   CAPSULE_FLAGS_CFG_DATA      (BIT0)  - config data update flag
+  // Whitelist CapsuleFlags against the three defined flags:
+  //   CAPSULE_FLAGS_CFG_DATA      (BIT0)  - config data update
+  //   CAPSULE_FLAG_SKIP_ALL_NON_VOLATILE_REGION (BIT1) - skip update non-volatile region
   //   CAPSULE_FLAG_FORCE_BIOS_UPDATE (BIT31) - bypasses FWU state machine
   // Any bit outside this set is unrecognized and could trigger unintended
   // update paths. Rejecting undefined flags here prevents a crafted capsule
   // from reaching later code with an unexpected flags value.
   //
-  if ((Header->CapsuleFlags & ~(CAPSULE_FLAGS_CFG_DATA | CAPSULE_FLAG_FORCE_BIOS_UPDATE)) != 0) {
+  if ((Header->CapsuleFlags & ~(CAPSULE_FLAGS_CFG_DATA | CAPSULE_FLAG_SKIP_ALL_NON_VOLATILE_REGION | CAPSULE_FLAG_FORCE_BIOS_UPDATE)) != 0) {
     DEBUG ((DEBUG_ERROR, "Invalid capsule: unrecognized CapsuleFlags bits set (0x%x)\n",
             Header->CapsuleFlags));
     return EFI_INVALID_PARAMETER;
@@ -1502,7 +1503,7 @@ ApplyFwImage (
     if ((CapHdr->CapsuleFlags & CAPSULE_FLAG_FORCE_BIOS_UPDATE) != 0) {
       Status = UpdateFullBiosRegion (ImageHdr);
     } else {
-      Status = UpdateSystemFirmware (ImageHdr, FwPolicy);
+      Status = UpdateSystemFirmware (ImageHdr, FwPolicy, CapHdr->CapsuleFlags);
     }
     *ResetRequired = TRUE;
     break;

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.c
@@ -718,12 +718,149 @@ UpdateFullBiosRegion (
 }
 
 /**
+  Preserve a specific component inside a container during BIOS region update.
+
+  This function locates a component within a container on flash and overlays
+  only that component's data onto the capsule image buffer, so that after the
+  BIOS region is written, the component data remains unchanged while other
+  components in the same container can still be updated.
+
+  @param[in] ContainerSig    Container signature in the flash map (e.g. 'IPFW').
+  @param[in] ComponentName   Component name inside the container (e.g. 'SMBS').
+  @param[in] ImageHdr        Pointer to fw mgmt capsule Image header.
+
+  @retval  EFI_SUCCESS       Component data preserved successfully.
+  @retval  EFI_NOT_FOUND     Container or component not found.
+  @retval  others            Error reading from boot media.
+**/
+STATIC
+EFI_STATUS
+PreserveContainerComponent (
+  IN  UINT32                          ContainerSig,
+  IN  UINT32                          ComponentName,
+  IN  EFI_FW_MGMT_CAP_IMAGE_HEADER   *ImageHdr
+  )
+{
+  EFI_STATUS              Status;
+  CONTAINER_HDR           *ContainerHdr;
+  CONTAINER_ENTRY         *ContainerEntry;
+  COMPONENT_ENTRY         *CompEntry;
+  FLASH_MAP               *FlashMapPtr;
+  UINT8                   *CapsuleBase;
+  UINT32                  BiosRgnOffset;
+  UINT32                  RomBase;
+  UINT32                  CompRomOffset;
+
+  FlashMapPtr = GetFlashMapPtr ();
+  if (FlashMapPtr == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  Status = LocateComponentEntry (ContainerSig, ComponentName, &ContainerEntry, &CompEntry);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_INFO, "PreserveContainerComponent: %08X:%08X not found (%r)\n", ContainerSig, ComponentName, Status));
+    return Status;
+  }
+
+  ContainerHdr  = (CONTAINER_HDR *)(UINTN)ContainerEntry->HeaderCache;
+  RomBase       = (UINT32)(0x100000000ULL - FlashMapPtr->RomSize);
+  CompRomOffset = (ContainerEntry->Base - RomBase) + ContainerHdr->DataOffset + CompEntry->Offset;
+
+  //
+  // Overlay the component's current flash data onto the capsule buffer.
+  //
+  CapsuleBase   = (UINT8 *)((UINTN)ImageHdr + sizeof (EFI_FW_MGMT_CAP_IMAGE_HEADER));
+  if ((CompRomOffset + CompEntry->Size) > ImageHdr->UpdateImageSize) {
+    DEBUG ((DEBUG_ERROR, "Component at 0x%X size 0x%X exceeds capsule\n", CompRomOffset, CompEntry->Size));
+    return EFI_INVALID_PARAMETER;
+  }
+  DEBUG ((DEBUG_INFO, "Preserving %08X:%08X (Offset=0x%X, Size=0x%X)\n", ContainerSig, ComponentName, CompRomOffset, CompEntry->Size));
+
+  BiosRgnOffset = GetRomImageOffsetInBiosRegion ();
+  Status = BootMediaRead (BiosRgnOffset + CompRomOffset, CompEntry->Size, CapsuleBase + CompRomOffset);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "PreserveContainerComponent: Failed to read component: %r\n", Status));
+  }
+
+  return Status;
+}
+
+/**
+  Preserve a flash component during BIOS region update.
+
+  This function reads the current content of a flash component from boot media
+  and overlays it onto the capsule image buffer at the same offset, so that
+  after the BIOS region is written, the component data remains unchanged.
+
+  @param[in] Signature       Flash map signature of the component to preserve.
+  @param[in] ImageHdr        Pointer to fw mgmt capsule Image header.
+                             The capsule image buffer starts at ImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER).
+
+  @retval  EFI_SUCCESS       Component data preserved successfully.
+  @retval  EFI_NOT_FOUND     Component not found in flash map.
+  @retval  others            Error reading from boot media.
+**/
+EFI_STATUS
+PreserveFlashRegion (
+  IN  UINT32                          Signature,
+  IN  EFI_FW_MGMT_CAP_IMAGE_HEADER   *ImageHdr
+  )
+{
+  EFI_STATUS              Status;
+  FLASH_MAP_ENTRY_DESC    *Entry;
+  FLASH_MAP               *FlashMap;
+  UINT8                   *CapsuleBase;
+  UINT32                  BiosRgnOffset;
+
+  FlashMap = GetFlashMapPtr ();
+  if (FlashMap == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  //
+  // Non-volatile components (MRCD, VARS, UVAR) are in the non-redundant region
+  // Look for the component in the primary partition.
+  //
+  Entry = GetComponentEntryByPartition (Signature, FALSE);
+  if (Entry == NULL) {
+    DEBUG ((DEBUG_INFO, "PreserveFlashRegion: Component %08X not found, skipping\n", Signature));
+    return EFI_NOT_FOUND;
+  }
+
+  //
+  // CapsuleBase points to the start of the BIOS image in the capsule.
+  // Entry->Offset is the component's offset from the start of the ROM image.
+  // Ensure the component falls within the capsule image boundary.
+  //
+  CapsuleBase = (UINT8 *)((UINTN)ImageHdr + sizeof (EFI_FW_MGMT_CAP_IMAGE_HEADER));
+  if ((UINT32)(Entry->Offset + Entry->Size) > ImageHdr->UpdateImageSize) {
+    DEBUG ((DEBUG_ERROR, "Component %08X at offset 0x%X size 0x%X exceeds capsule image\n", Signature, Entry->Offset, Entry->Size));
+    return EFI_INVALID_PARAMETER;
+  }
+  DEBUG ((DEBUG_INFO, "Preserving %08X (Offset=0x%X, Size=0x%X)\n", Signature, Entry->Offset, Entry->Size));
+
+  //
+  // Read current flash content and overlay onto the capsule buffer.
+  // The BIOS region offset accounts for when the SBL ROM image does not
+  // occupy the entire BIOS region.
+  //
+  BiosRgnOffset = GetRomImageOffsetInBiosRegion ();
+  Status = BootMediaRead (BiosRgnOffset + Entry->Offset, Entry->Size, CapsuleBase + Entry->Offset);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "PreserveFlashRegion: Failed to read %08X from flash, Status = %r\n", Signature, Status));
+  }
+
+  return Status;
+}
+
+/**
   Perform system Firmware update.
 
   This function will update SBL or Configuration data alone.
 
   @param[in] ImageHdr       Pointer to fw mgmt capsule Image header
   @param[in] FwPolicy       Fw update policy
+  @param[in] CapsuleFlags   Capsule flags from firmware update header
 
   @retval  EFI_SUCCESS      Update successful.
   @retval  other            error occurred during firmware update
@@ -731,7 +868,8 @@ UpdateFullBiosRegion (
 EFI_STATUS
 UpdateSystemFirmware (
   IN EFI_FW_MGMT_CAP_IMAGE_HEADER  *ImageHdr,
-  IN FIRMWARE_UPDATE_POLICY        FwPolicy
+  IN FIRMWARE_UPDATE_POLICY        FwPolicy,
+  IN UINT32                        CapsuleFlags
   )
 {
   EFI_STATUS                  Status;
@@ -763,6 +901,35 @@ UpdateSystemFirmware (
     DEBUG ((DEBUG_ERROR, " VerifyFwStruct failed with Status = 0x%x\n", Status));
     FreePool(UpdatePartition);
     return Status;
+  }
+
+  //
+  // Preserve all non-volatile data regions when
+  // CAPSULE_FLAG_SKIP_ALL_NON_VOLATILE_REGION is set.
+  // Each region's current flash content is read and overlaid onto the capsule
+  // source buffer so that after the write, the data on flash remains unchanged.
+  // This flag only applies to the normal BIOS update path (not force BIOS update).
+  //
+  if ((CapsuleFlags & CAPSULE_FLAG_SKIP_ALL_NON_VOLATILE_REGION) != 0) {
+    Status = PreserveFlashRegion (FLASH_MAP_SIG_MRCDATA, ImageHdr);
+    if (EFI_ERROR (Status) && Status != EFI_NOT_FOUND) {
+      DEBUG ((DEBUG_ERROR, "Failed to preserve MRC data: %r\n", Status));
+    }
+
+    Status = PreserveFlashRegion (FLASH_MAP_SIG_VARIABLE, ImageHdr);
+    if (EFI_ERROR (Status) && Status != EFI_NOT_FOUND) {
+      DEBUG ((DEBUG_ERROR, "Failed to preserve SBL variable: %r\n", Status));
+    }
+
+    Status = PreserveFlashRegion (FLASH_MAP_SIG_UEFIVARIABLE, ImageHdr);
+    if (EFI_ERROR (Status) && Status != EFI_NOT_FOUND) {
+      DEBUG ((DEBUG_ERROR, "Failed to preserve UEFI variable: %r\n", Status));
+    }
+
+    Status = PreserveContainerComponent (SIGNATURE_32 ('I', 'P', 'F', 'W'), SIGNATURE_32 ('S', 'M', 'B', 'S'), ImageHdr);
+    if (EFI_ERROR (Status) && Status != EFI_NOT_FOUND) {
+      DEBUG ((DEBUG_ERROR, "Failed to preserve SMBIOS: %r\n", Status));
+    }
   }
 
   //
@@ -1458,7 +1625,7 @@ UpdateSblComponent (
   //
   if (IsRedundantComponent(ImageHdr->UpdateHardwareInstance)) {
     DEBUG ((DEBUG_INFO, "Redundant component update requested! \n"));
-    Status = UpdateSystemFirmware(ImageHdr, FwPolicy);
+    Status = UpdateSystemFirmware(ImageHdr, FwPolicy, 0);
   } else {
     DEBUG ((DEBUG_INFO, "Non redundant component update requested! \n"));
     Status = UpdateNonRedundantComp(ImageHdr);

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.h
@@ -206,6 +206,7 @@ UpdateFullBiosRegion (
 
   @param[in] ImageHdr       Pointer to fw mgmt capsule Image header
   @param[in] FwPolicy       Fw update policy
+  @param[in] CapsuleFlags   Capsule flags from firmware update header
 
   @retval  EFI_SUCCESS      Update successful.
   @retval  other            error occurred during firmware update
@@ -213,7 +214,8 @@ UpdateFullBiosRegion (
 EFI_STATUS
 UpdateSystemFirmware (
   IN EFI_FW_MGMT_CAP_IMAGE_HEADER  *ImageHdr,
-  IN FIRMWARE_UPDATE_POLICY        FwPolicy
+  IN FIRMWARE_UPDATE_POLICY        FwPolicy,
+  IN UINT32                        CapsuleFlags
   );
 
 /**


### PR DESCRIPTION
Add build-time flags to GenCapsuleFirmware.py that allow selectively preserving non-volatile data regions when generating firmware update capsule images. This enables BIOS region updates without overwriting MRC training data, SBL variables, UEFI variables, or SMBIOS data.

During BIOS region update, when a skip flag is set, the corresponding region's current flash content is read and overlaid onto the capsule image buffer before writing, effectively preserving existing data.

Skip flags are incompatible with force BIOS update (-f) and the tool will raise an error if both are specified.