### PR TITLE
fix: Remove OS page to fix ConfigEditor display issues

### DIFF
--- a/Platform/CommonBoardPkg/CfgData/CfgData_Common.yaml
+++ b/Platform/CommonBoardPkg/CfgData/CfgData_Common.yaml
@@ -58,8 +58,6 @@
                      Specify image ID for desired VBT binary
       length       : 0x04
       value        : 1
-  - $ACTION      :
-      page         : OS
   - CurrentBoot  :
       name         : Current Boot Option
       type         : Combo
@@ -78,6 +76,3 @@
                      have same behavior with debug build in the release build.
       length       : 0x01
       value        : 0
-  - Dummy        :
-      length       : 0x3
-      value        : 0x0


### PR DESCRIPTION
Remove the OS configuration page from CfgData_Common.yaml to address
ConfigEditor display problems with BootToShell and CurrentBoot options.
All platforms currently set GEN_CFG_DATA.BootToShell, making a separate
OS page unnecessary and incompatible with the existing configuration.