### PR TITLE
Firmware Update: Add defensive bounds-checking hardening

### DIFF
--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -854,14 +854,14 @@ ValidateCapsuleLayout (
     return EFI_INVALID_PARAMETER;
   }
 
-  *FwUpdHeader = Header;
-
   if (CapHeader != NULL) {
     if (Header->ImageSize < sizeof (EFI_FW_MGMT_CAP_HEADER)) {
       return EFI_INVALID_PARAMETER;
     }
     *CapHeader = (EFI_FW_MGMT_CAP_HEADER *)((UINTN)Header + Header->ImageOffset);
   }
+
+  *FwUpdHeader = Header;
 
   return EFI_SUCCESS;
 }

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -1,7 +1,7 @@
 /** @file
 This driver is to update firmware in boot media.
 
-Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2017 - 2026, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -115,6 +115,17 @@ VerifySblVersion (
     // EFI_UNSUPPORTED from PlatformGetStage1AOffset and getting stage1Abase
     // will be handled in common way using the below implementation.
     if (Status == EFI_UNSUPPORTED) {
+      //
+      // The last 4 bytes of the BIOS region payload hold the Stage 1A FV base
+      // address. Guard against integer underflow: UpdateImageSize comes from the
+      // untrusted capsule image and if it were less than 4 the subtraction below
+      // would wrap to a very large address and pass an arbitrary pointer to GetSvn.
+      //
+      if (ImageHdr->UpdateImageSize < 4) {
+        DEBUG((DEBUG_ERROR, "VerifySblVersion: UpdateImageSize (%d) too small to contain FV base\n",
+               ImageHdr->UpdateImageSize));
+        return EFI_INVALID_PARAMETER;
+      }
       // Last 4 bytes of the BIOS region contain Stage 1A FV base.
       Stage1AFvBase = (UINT32)((UINTN)ImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER) + ImageHdr->UpdateImageSize - 4);
       Status = GetSvn (Stage1AFvBase, &CapsuleBlVersion);
@@ -299,6 +310,16 @@ ValidThenDecFwuRetryCount (
 
   FwUpdStatusOffset = PcdGet32(PcdFwUpdStatusBase);
 
+  //
+  // Guard against UINT32 overflow before adding the field offset, for the same
+  // reason as SetStateMachineFlag and UpdateStatus: a wrapped offset would
+  // direct a flash write to an unintended address.
+  //
+  if (((UINT64)FwUpdStatusOffset + OFFSET_OF(FW_UPDATE_STATUS, RetryCount)) > MAX_UINT32) {
+    DEBUG((DEBUG_ERROR, "ValidThenDecFwuRetryCount: FwUpdStatusOffset (0x%x) causes overflow\n", FwUpdStatusOffset));
+    return FALSE;
+  }
+
   FwUpdStatusOffset += OFFSET_OF(FW_UPDATE_STATUS, RetryCount);
   Status = BootMediaWrite (FwUpdStatusOffset, sizeof(UINT8), (UINT8 *)&(RetryCount));
   if (EFI_ERROR (Status)) {
@@ -372,6 +393,17 @@ SetStateMachineFlag (
   DEBUG((DEBUG_INIT, "Set next FWU state: 0x%02X\n", StateMachine));
 
   FwUpdStatusOffset = PcdGet32(PcdFwUpdStatusBase);
+
+  //
+  // Guard against UINT32 overflow before adding the field offset. An unchecked
+  // addition when PcdFwUpdStatusBase is misconfigured near MAX_UINT32 would
+  // silently wrap and direct the BootMediaWrite to an unintended flash address,
+  // mirroring the same class of bug fixed in UpdateStatus.
+  //
+  if (((UINT64)FwUpdStatusOffset + OFFSET_OF(FW_UPDATE_STATUS, StateMachine)) > MAX_UINT32) {
+    DEBUG((DEBUG_ERROR, "SetStateMachineFlag: FwUpdStatusOffset (0x%x) causes overflow\n", FwUpdStatusOffset));
+    return EFI_INVALID_PARAMETER;
+  }
 
   FwUpdStatusOffset += OFFSET_OF(FW_UPDATE_STATUS, StateMachine);
   Status = BootMediaWrite (FwUpdStatusOffset, sizeof(UINT8), (UINT8 *)&(StateMachine));
@@ -619,6 +651,20 @@ UpdateStatus (
   FwUpdStatusOffset = PcdGet32(PcdFwUpdStatusBase);
 
   //
+  // Verify the full status region (FW_UPDATE_STATUS header + all component
+  // entries) fits within the 32-bit address space. If PcdFwUpdStatusBase is
+  // misconfigured near the top of the UINT32 range, the COMP_STATUS_OFFSET
+  // arithmetic used later would silently wrap and direct flash writes to
+  // unintended addresses, potentially corrupting unrelated flash regions.
+  //
+  if (((UINT64)FwUpdStatusOffset + sizeof(FW_UPDATE_STATUS) +
+       ((UINT64)MAX_FW_COMPONENTS * sizeof(FW_UPDATE_COMP_STATUS))) > MAX_UINT32) {
+    DEBUG((DEBUG_ERROR, "UpdateStatus: FwUpdStatusOffset (0x%x) causes status region overflow\n",
+           FwUpdStatusOffset));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
   // Read all the component structures
   //
   Status = BootMediaRead ((FwUpdStatusOffset + sizeof(FW_UPDATE_STATUS)), \
@@ -699,6 +745,128 @@ UpdateStatus (
 }
 
 /**
+  Validate capsule header layout and optional capsule body header.
+
+  @param[in]  FwImage       Capsule buffer.
+  @param[in]  FwSize        Capsule buffer size.
+  @param[out] FwUpdHeader   Validated firmware update header.
+  @param[out] CapHeader     Validated capsule body header.
+
+  @retval EFI_SUCCESS            Capsule layout is valid.
+  @retval EFI_INVALID_PARAMETER  Capsule layout is invalid.
+**/
+STATIC
+EFI_STATUS
+ValidateCapsuleLayout (
+  IN  UINT8                    *FwImage,
+  IN  UINT32                   FwSize,
+  OUT FIRMWARE_UPDATE_HEADER   **FwUpdHeader,
+  OUT EFI_FW_MGMT_CAP_HEADER   **CapHeader OPTIONAL
+  )
+{
+  UINT32                  SignatureEnd;
+  UINT32                  PubKeyEnd;
+  UINT32                  ImageEnd;
+  FIRMWARE_UPDATE_HEADER  *Header;
+
+  if ((FwUpdHeader == NULL) || (FwImage == NULL) || (FwSize < sizeof (FIRMWARE_UPDATE_HEADER))) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Header = (FIRMWARE_UPDATE_HEADER *)FwImage;
+
+  if (!CompareGuid (&Header->FileGuid, &gFirmwareUpdateImageFileGuid)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Whitelist CapsuleFlags against the two defined flags:
+  //   CAPSULE_FLAGS_CFG_DATA      (BIT0)  - config data update flag
+  //   CAPSULE_FLAG_FORCE_BIOS_UPDATE (BIT31) - bypasses FWU state machine
+  // Any bit outside this set is unrecognized and could trigger unintended
+  // update paths. Rejecting undefined flags here prevents a crafted capsule
+  // from reaching later code with an unexpected flags value.
+  //
+  if ((Header->CapsuleFlags & ~(CAPSULE_FLAGS_CFG_DATA | CAPSULE_FLAG_FORCE_BIOS_UPDATE)) != 0) {
+    DEBUG ((DEBUG_ERROR, "Invalid capsule: unrecognized CapsuleFlags bits set (0x%x)\n",
+            Header->CapsuleFlags));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Every region offset must lie strictly outside the fixed-size header.
+  // A SignatureOffset less than sizeof(FIRMWARE_UPDATE_HEADER) would shrink the
+  // RSA-signed data window [0, SignatureOffset) so that it no longer covers
+  // the header fields PubKeyOffset, ImageOffset, and CapsuleFlags — allowing
+  // an attacker to construct a capsule where only the FileGUID is signed while
+  // the critical offset and flag fields are left unsigned.  ImageOffset and
+  // PubKeyOffset smaller than the header would also create unexpected overlaps
+  // between the header and the data regions.
+  //
+  if ((Header->SignatureOffset < sizeof (FIRMWARE_UPDATE_HEADER)) ||
+      (Header->PubKeyOffset    < sizeof (FIRMWARE_UPDATE_HEADER)) ||
+      (Header->ImageOffset     < sizeof (FIRMWARE_UPDATE_HEADER))) {
+    DEBUG ((DEBUG_ERROR, "Invalid capsule: region offsets (Sig=0x%x Pk=0x%x Img=0x%x) below header size (0x%x)\n",
+            Header->SignatureOffset, Header->PubKeyOffset, Header->ImageOffset,
+            (UINT32)sizeof (FIRMWARE_UPDATE_HEADER)));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((Header->SignatureOffset >= FwSize) || (Header->SignatureSize > (FwSize - Header->SignatureOffset))) {
+    return EFI_INVALID_PARAMETER;
+  }
+  SignatureEnd = Header->SignatureOffset + Header->SignatureSize;
+
+  if ((Header->PubKeyOffset >= FwSize) || (Header->PubKeySize > (FwSize - Header->PubKeyOffset))) {
+    return EFI_INVALID_PARAMETER;
+  }
+  PubKeyEnd = Header->PubKeyOffset + Header->PubKeySize;
+
+  if (PubKeyEnd != FwSize) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Verify each region is large enough to hold its fixed-size struct header.
+  // ValidateCapsuleLayout is the single authoritative gate for all callers
+  // (AuthenticateCapsule, ProcessCapsule, CheckCapsuleForRedundant, FindImage).
+  // Placing the checks here ensures no caller can cast a region pointer and
+  // read struct fields beyond the validated boundary.
+  //
+  if (Header->SignatureSize < sizeof (SIGNATURE_HDR)) {
+    DEBUG ((DEBUG_ERROR, "Invalid capsule: SignatureSize (0x%x) too small for SIGNATURE_HDR\n",
+            Header->SignatureSize));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (Header->PubKeySize < sizeof (PUB_KEY_HDR)) {
+    DEBUG ((DEBUG_ERROR, "Invalid capsule: PubKeySize (0x%x) too small for PUB_KEY_HDR\n",
+            Header->PubKeySize));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if ((Header->ImageOffset >= FwSize) || (Header->ImageSize > (FwSize - Header->ImageOffset))) {
+    return EFI_INVALID_PARAMETER;
+  }
+  ImageEnd = Header->ImageOffset + Header->ImageSize;
+
+  if ((ImageEnd > Header->SignatureOffset) || (SignatureEnd > Header->PubKeyOffset)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *FwUpdHeader = Header;
+
+  if (CapHeader != NULL) {
+    if (Header->ImageSize < sizeof (EFI_FW_MGMT_CAP_HEADER)) {
+      return EFI_INVALID_PARAMETER;
+    }
+    *CapHeader = (EFI_FW_MGMT_CAP_HEADER *)((UINTN)Header + Header->ImageOffset);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
   Verify the capsule image against its signature.
 
   This function first gets the hash of the processed public key, then compare it
@@ -720,36 +888,14 @@ AuthenticateCapsule (
   )
 {
   EFI_STATUS                Status;
-
   FIRMWARE_UPDATE_HEADER    *Header;
   PUB_KEY_HDR               *PubKeyHdr;
   SIGNATURE_HDR             *SignatureHdr;
 
-  Header = (FIRMWARE_UPDATE_HEADER *)FwImage;
-  if (FwSize < sizeof (FIRMWARE_UPDATE_HEADER)) {
-    DEBUG ((DEBUG_ERROR, "Invalid capsule: file is too small. file size=%d\n", FwSize));
-    return EFI_INVALID_PARAMETER;
-  }
-
-  if (!CompareGuid (&Header->FileGuid, &gFirmwareUpdateImageFileGuid)) {
-    DEBUG ((DEBUG_ERROR, "Invalid capsule: Image file guid is not expected. guid=%g\n", &Header->FileGuid));
-    return EFI_INVALID_PARAMETER;
-  }
-
-  if (Header->SignatureOffset >= FwSize || Header->SignatureOffset + Header->SignatureSize >= FwSize) {
-    DEBUG ((DEBUG_ERROR, "Invalid capsule: SignatureOffset=0x%x, SignatureSize=0x%x\n", Header->SignatureOffset,
-            Header->SignatureSize));
-    return EFI_INVALID_PARAMETER;
-  }
-
-  if (Header->PubKeyOffset >= FwSize || Header->PubKeyOffset + Header->PubKeySize != FwSize) {
-    DEBUG ((DEBUG_ERROR, "Invalid capsule: PubKeyOffset=0x%x, PubKeySize=0x%x\n", Header->PubKeyOffset, Header->PubKeySize));
-    return EFI_INVALID_PARAMETER;
-  }
-
-  if (Header->ImageOffset >= FwSize || Header->ImageOffset + Header->ImageSize >= FwSize) {
-    DEBUG ((DEBUG_ERROR, "Invalid capsule: ImageOffset=0x%x, ImageSize=0x%x\n", Header->ImageOffset, Header->ImageSize));
-    return EFI_INVALID_PARAMETER;
+  Status = ValidateCapsuleLayout (FwImage, FwSize, &Header, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Invalid capsule layout in AuthenticateCapsule: Status=%r\n", Status));
+    return Status;
   }
 
   PubKeyHdr       = (PUB_KEY_HDR *) (FwImage + Header->PubKeyOffset);
@@ -810,25 +956,45 @@ IsValidPayloadBoundary (
   )
 {
   UINT16                        TotalPayloadCount;
+  UINT32                        TotalCount32;
   EFI_FW_MGMT_CAP_IMAGE_HEADER  *ImgHeader;
+  UINT64                        MinPayloadOffset;
+  UINT64                        RemainingSize;
+  UINT64                        ImageSize;
 
   if ((FwUpdHeader == NULL) || (CapHeader == NULL)) {
     return FALSE;
   }
 
-  TotalPayloadCount = (UINT16)(CapHeader->EmbeddedDriverCount + CapHeader->PayloadItemCount);
+  ImageSize = FwUpdHeader->ImageSize;
+
+  //
+  // Use a UINT32 intermediate to detect overflow before narrowing to UINT16.
+  // EmbeddedDriverCount and PayloadItemCount are each UINT16 (up to 65535);
+  // adding them directly as UINT16 would silently wrap to a smaller value,
+  // causing MinPayloadOffset to be under-estimated and defeating the boundary
+  // check entirely.
+  //
+  TotalCount32 = (UINT32)CapHeader->EmbeddedDriverCount + (UINT32)CapHeader->PayloadItemCount;
+  if (TotalCount32 > MAX_UINT16) {
+    DEBUG((DEBUG_ERROR, "Invalid capsule body: total payload count overflow (0x%x)\n", TotalCount32));
+    return FALSE;
+  }
+  TotalPayloadCount = (UINT16)TotalCount32;
 
   if (TotalPayloadCount == 0) {
     DEBUG((DEBUG_ERROR, "Invalid capsule body: no payload\n"));
     return FALSE;
   }
 
-  if (Offset < (sizeof(EFI_FW_MGMT_CAP_HEADER) + TotalPayloadCount * sizeof (UINT64))) {
+  MinPayloadOffset = sizeof (EFI_FW_MGMT_CAP_HEADER) + (UINT64)TotalPayloadCount * sizeof (UINT64);
+  if (Offset < MinPayloadOffset) {
     DEBUG((DEBUG_ERROR, "Invalid offset (0x%x): not in payload regions\n", Offset));
     return FALSE;
   }
 
-  if (Offset > (FwUpdHeader->ImageSize - sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER))) {
+  if ((ImageSize < sizeof (EFI_FW_MGMT_CAP_IMAGE_HEADER)) ||
+      (Offset > (ImageSize - sizeof (EFI_FW_MGMT_CAP_IMAGE_HEADER)))) {
     DEBUG((DEBUG_ERROR, "Invalid offset (0x%x): no room for payload header\n", Offset));
     return FALSE;
   }
@@ -840,8 +1006,20 @@ IsValidPayloadBoundary (
     return FALSE;
   }
 
-  if (FwUpdHeader->ImageSize < (Offset + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER) + \
-                               ImgHeader->UpdateImageSize + ImgHeader->UpdateVendorCodeSize)) {
+  RemainingSize = ImageSize - Offset;
+  if (RemainingSize < sizeof (EFI_FW_MGMT_CAP_IMAGE_HEADER)) {
+    DEBUG((DEBUG_ERROR, "Invalid payload header: no room for image header\n"));
+    return FALSE;
+  }
+
+  RemainingSize -= sizeof (EFI_FW_MGMT_CAP_IMAGE_HEADER);
+  if (ImgHeader->UpdateImageSize > RemainingSize) {
+    DEBUG((DEBUG_ERROR, "Invalid payload size: exceed capsue body size\n"));
+    return FALSE;
+  }
+
+  RemainingSize -= ImgHeader->UpdateImageSize;
+  if (ImgHeader->UpdateVendorCodeSize > RemainingSize) {
     DEBUG((DEBUG_ERROR, "Invalid payload size: exceed capsue body size\n"));
     return FALSE;
   }
@@ -871,12 +1049,24 @@ GetPayloadHeaderByIndex (
   )
 {
   UINT64                  Offset;
+  UINT64                  OffsetTableEntryOffset;
 
   if ((FwUpdHeader == NULL) || (CapHeader == NULL) || (OutImgHeader == NULL)) {
     return EFI_NOT_FOUND;
   }
 
-  if (Index > CapHeader->PayloadItemCount) {
+  if (Index >= CapHeader->PayloadItemCount) {
+    return EFI_NOT_FOUND;
+  }
+
+  if (FwUpdHeader->ImageSize < sizeof (EFI_FW_MGMT_CAP_HEADER)) {
+    return EFI_NOT_FOUND;
+  }
+
+  OffsetTableEntryOffset = sizeof (EFI_FW_MGMT_CAP_HEADER) +
+                           ((UINT64)CapHeader->EmbeddedDriverCount + Index) * sizeof (UINT64);
+  if (OffsetTableEntryOffset > ((UINT64)FwUpdHeader->ImageSize - sizeof (UINT64))) {
+    DEBUG((DEBUG_ERROR, "Invalid capsule payload offset table entry: Index=%d TableOffset=0x%llx\n", Index, OffsetTableEntryOffset));
     return EFI_NOT_FOUND;
   }
 
@@ -885,6 +1075,18 @@ GetPayloadHeaderByIndex (
 
   if (!IsValidPayloadBoundary (FwUpdHeader, CapHeader, Offset)) {
     DEBUG((DEBUG_ERROR, "Invalid capsule payload boundary: Index=%d Offset=0x%x\n", Index, Offset));
+    return EFI_NOT_FOUND;
+  }
+
+  //
+  // IsValidPayloadBoundary already confirmed Offset <= FwUpdHeader->ImageSize
+  // (a UINT32), so the value is bounded within 32 bits. This explicit guard
+  // is defense-in-depth for 32-bit (IA32) builds where casting a UINT64 to
+  // UINTN silently truncates any stray high-order bits, which could produce
+  // a pointer that lands outside the capsule buffer.
+  //
+  if (Offset > (UINT64)FwUpdHeader->ImageSize) {
+    DEBUG((DEBUG_ERROR, "Invalid payload offset (0x%llx) exceeds image size\n", Offset));
     return EFI_NOT_FOUND;
   }
 
@@ -953,6 +1155,12 @@ ProcessCapsule (
   SIGNATURE_HDR                 *SignatureHdr;
   UINT32                        SigLen;
 
+  Status = ValidateCapsuleLayout (FwImage, FwSize, &FwUpdHeader, &CapHeader);
+  if (EFI_ERROR (Status)) {
+    DEBUG((DEBUG_ERROR, "Invalid capsule layout in ProcessCapsule: Status=%r\n", Status));
+    return EFI_INVALID_PARAMETER;
+  }
+
   FwUpdStatusOffset = PcdGet32(PcdFwUpdStatusBase);
 
   //
@@ -991,7 +1199,23 @@ ProcessCapsule (
   // set SM to capsule processing stage, this will reset back to
   // init at the end of firmware update
   //
-  SignatureHdr = (SIGNATURE_HDR *) (FwImage + ((FIRMWARE_UPDATE_HEADER *)FwImage)->SignatureOffset);
+  //
+  // ValidateCapsuleLayout already confirmed SignatureSize >= sizeof(SIGNATURE_HDR),
+  // so the cast below is safe. Verify the inner SigSize field does not claim more
+  // bytes than the signature region can hold; MIN() limits the copy length but an
+  // oversized SigSize still indicates a malformed capsule and must be rejected.
+  //
+  SignatureHdr = (SIGNATURE_HDR *) (FwImage + FwUpdHeader->SignatureOffset);
+  //
+  // Verify SigSize does not extend beyond the signature region boundary.
+  // Although MIN() below limits the copy length, an oversized SigSize field
+  // would indicate a malformed capsule and must be rejected.
+  //
+  if (SignatureHdr->SigSize > (FwUpdHeader->SignatureSize - (UINT32)sizeof (SIGNATURE_HDR))) {
+    DEBUG((DEBUG_ERROR, "Invalid capsule: SigSize (0x%x) extends beyond signature region\n",
+           SignatureHdr->SigSize));
+    return EFI_INVALID_PARAMETER;
+  }
   SigLen       = MIN (SignatureHdr->SigSize, sizeof(FwUpdStatus.CapsuleSig));
   if (FwUpdStatus.StateMachine == FW_UPDATE_SM_INIT) {
     //
@@ -1035,14 +1259,11 @@ ProcessCapsule (
     return EFI_SUCCESS;
   }
 
-  FwUpdHeader = (FIRMWARE_UPDATE_HEADER *)FwImage;
-  CapHeader = (EFI_FW_MGMT_CAP_HEADER *)((UINTN)FwUpdHeader + FwUpdHeader->ImageOffset);
-
   //
   // If capsule header is NULL or no payloads found in the capsule
   // return EFI_NOT_FOUND;
   //
-  if ((CapHeader == NULL) || (CapHeader->PayloadItemCount == 0)) {
+  if (CapHeader->PayloadItemCount == 0) {
     ImgHeader = NULL;
     return EFI_NOT_FOUND;
   }
@@ -1137,17 +1358,12 @@ CheckCapsuleForRedundant (
   *ContainsRedundant = FALSE;
   CapImageHdr = NULL;
 
-  FwUpdHeader = (FIRMWARE_UPDATE_HEADER *)CapImage;
-  if (FwUpdHeader == NULL) {
+  Status = ValidateCapsuleLayout (CapImage, CapImageSize, &FwUpdHeader, &CapHeader);
+  if (EFI_ERROR (Status)) {
     return EFI_NOT_FOUND;
   }
 
-  //
-  // If capsule header is NULL or no payloads found in the capsule
-  // return EFI_NOT_FOUND
-  //
-  CapHeader = (EFI_FW_MGMT_CAP_HEADER *)((UINTN)FwUpdHeader + FwUpdHeader->ImageOffset);
-  if ((CapHeader == NULL) || (CapHeader->PayloadItemCount == 0)) {
+  if (CapHeader->PayloadItemCount == 0) {
     return EFI_NOT_FOUND;
   }
 
@@ -1208,17 +1424,12 @@ FindImage (
   *ImageHdr = NULL;
   CapImageHdr = NULL;
 
-  FwUpdHeader = (FIRMWARE_UPDATE_HEADER *)CapImage;
-  if (FwUpdHeader == NULL) {
+  Status = ValidateCapsuleLayout (CapImage, CapImageSize, &FwUpdHeader, &CapHeader);
+  if (EFI_ERROR (Status)) {
     return EFI_NOT_FOUND;
   }
 
-  //
-  // If capsule header is NULL or no payloads found in the capsule
-  // return EFI_NOT_FOUND;
-  //
-  CapHeader = (EFI_FW_MGMT_CAP_HEADER *)((UINTN)FwUpdHeader + FwUpdHeader->ImageOffset);
-  if ((CapHeader == NULL) || (CapHeader->PayloadItemCount == 0)) {
+  if (CapHeader->PayloadItemCount == 0) {
     return EFI_NOT_FOUND;
   }
 
@@ -1457,7 +1668,8 @@ InitFirmwareUpdate (
     //
     // Error condition
     if (CapsuleImage != NULL) {
-      FreePool(CapsuleImage);
+      FreePool (CapsuleImage);
+      CapsuleImage = NULL;
     }
     return Status;
   }
@@ -1702,6 +1914,24 @@ InitFirmwareRecovery (
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "GetRegionInfo, Status = 0x%x\n", Status));
     return Status;
+  }
+
+  //
+  // Guard the four sequential UINT32 subtractions below against underflow.
+  // During recovery the flash map entries may themselves be partially corrupted;
+  // an unchecked subtraction that wraps to a large value would direct
+  // UpdateBootPartition to copy from or write to an unintended flash region —
+  // the opposite of what recovery is meant to do. Use UINT64 arithmetic to
+  // validate all four subtractions in one combined check before narrowing.
+  //
+  // Reject zero-sized regions and validate space capacity for primary and backup
+  // regions in 64-bit arithmetic to prevent overflow, even though the actual sizes are 32-bit.
+  if ((TopSwapRegionSize == 0) || (RedundantRegionSize == 0) ||
+      ((UINT64)FlashMap->RomSize <
+       ((UINT64)TopSwapRegionSize * 2 + (UINT64)RedundantRegionSize * 2))) {
+    DEBUG ((DEBUG_ERROR, "InitFirmwareRecovery: region sizes (TS=0x%x Rdnt=0x%x) exceed ROM size (0x%x)\n",
+            TopSwapRegionSize, RedundantRegionSize, FlashMap->RomSize));
+    return EFI_INVALID_PARAMETER;
   }
 
   // Top swap source address is already mapped to primary or backup by

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
@@ -71,6 +71,7 @@
   gPayloadTokenSpaceGuid.PcdPayloadHobList
   gPlatformCommonLibTokenSpaceGuid.PcdAcpiPmTimerBase
   gPayloadTokenSpaceGuid.PcdFwUpdStatusBase
+  gPayloadTokenSpaceGuid.PcdMaxCapsuleSize
   gPlatformCommonLibTokenSpaceGuid.PcdLowestSupportedFwVer
   gPayloadTokenSpaceGuid.PcdCsmeUpdateEnabled
   gPayloadTokenSpaceGuid.PcdIoeCsmeUpdateEnabled

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.c
@@ -69,6 +69,11 @@ BootMediaGetRegion (
   OUT    UINT32             *RegionSize OPTIONAL
   )
 {
+  if (mFwuSpiService == NULL) {
+    DEBUG ((DEBUG_ERROR, "BootMediaGetRegion service not initialized\n"));
+    return EFI_NOT_READY;
+  }
+
   return mFwuSpiService->SpiGetRegion (FlashRegionType, BaseAddress, RegionSize);
 }
 
@@ -91,6 +96,31 @@ BootMediaRead (
   OUT    UINT8    *Buffer
   )
 {
+  UINT64  EndAddress;
+
+  if (mFwuSpiService == NULL) {
+    DEBUG ((DEBUG_ERROR, "BootMediaRead service not initialized\n"));
+    return EFI_NOT_READY;
+  }
+
+  if ((ByteCount != 0) && (Buffer == NULL)) {
+    DEBUG ((DEBUG_ERROR, "BootMediaRead invalid buffer for non-zero ByteCount\n"));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (Address > MAX_UINT32) {
+    DEBUG ((DEBUG_ERROR, "BootMediaRead address out of range: 0x%llx\n", Address));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (ByteCount != 0) {
+    EndAddress = Address + (UINT64)ByteCount - 1;
+    if ((EndAddress < Address) || (EndAddress > MAX_UINT32)) {
+      DEBUG ((DEBUG_ERROR, "BootMediaRead range out of bounds: 0x%llx + 0x%x\n", Address, ByteCount));
+      return EFI_INVALID_PARAMETER;
+    }
+  }
+
   return mFwuSpiService->SpiRead (FlashRegionBios, (UINT32)Address, ByteCount, Buffer);
 }
 
@@ -115,6 +145,31 @@ BootMediaReadByType (
   OUT    UINT8              *Buffer
   )
 {
+  UINT64  EndAddress;
+
+  if (mFwuSpiService == NULL) {
+    DEBUG ((DEBUG_ERROR, "BootMediaReadByType service not initialized\n"));
+    return EFI_NOT_READY;
+  }
+
+  if ((ByteCount != 0) && (Buffer == NULL)) {
+    DEBUG ((DEBUG_ERROR, "BootMediaReadByType invalid buffer for non-zero ByteCount\n"));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (Address > MAX_UINT32) {
+    DEBUG ((DEBUG_ERROR, "BootMediaReadByType address out of range: 0x%llx\n", Address));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (ByteCount != 0) {
+    EndAddress = Address + (UINT64)ByteCount - 1;
+    if ((EndAddress < Address) || (EndAddress > MAX_UINT32)) {
+      DEBUG ((DEBUG_ERROR, "BootMediaReadByType range out of bounds: 0x%llx + 0x%x\n", Address, ByteCount));
+      return EFI_INVALID_PARAMETER;
+    }
+  }
+
   return mFwuSpiService->SpiRead (FlashRegionType, (UINT32)Address, ByteCount, Buffer);
 }
 
@@ -137,6 +192,31 @@ BootMediaWrite (
   OUT    UINT8    *Buffer
   )
 {
+  UINT64  EndAddress;
+
+  if (mFwuSpiService == NULL) {
+    DEBUG ((DEBUG_ERROR, "BootMediaWrite service not initialized\n"));
+    return EFI_NOT_READY;
+  }
+
+  if ((ByteCount != 0) && (Buffer == NULL)) {
+    DEBUG ((DEBUG_ERROR, "BootMediaWrite invalid buffer for non-zero ByteCount\n"));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (Address > MAX_UINT32) {
+    DEBUG ((DEBUG_ERROR, "BootMediaWrite address out of range: 0x%llx\n", Address));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (ByteCount != 0) {
+    EndAddress = Address + (UINT64)ByteCount - 1;
+    if ((EndAddress < Address) || (EndAddress > MAX_UINT32)) {
+      DEBUG ((DEBUG_ERROR, "BootMediaWrite range out of bounds: 0x%llx + 0x%x\n", Address, ByteCount));
+      return EFI_INVALID_PARAMETER;
+    }
+  }
+
   return mFwuSpiService->SpiWrite (FlashRegionBios, (UINT32)Address, ByteCount, Buffer);
 }
 
@@ -161,6 +241,31 @@ BootMediaWriteByType (
   OUT    UINT8              *Buffer
   )
 {
+  UINT64  EndAddress;
+
+  if (mFwuSpiService == NULL) {
+    DEBUG ((DEBUG_ERROR, "BootMediaWriteByType service not initialized\n"));
+    return EFI_NOT_READY;
+  }
+
+  if ((ByteCount != 0) && (Buffer == NULL)) {
+    DEBUG ((DEBUG_ERROR, "BootMediaWriteByType invalid buffer for non-zero ByteCount\n"));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (Address > MAX_UINT32) {
+    DEBUG ((DEBUG_ERROR, "BootMediaWriteByType address out of range: 0x%llx\n", Address));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (ByteCount != 0) {
+    EndAddress = Address + (UINT64)ByteCount - 1;
+    if ((EndAddress < Address) || (EndAddress > MAX_UINT32)) {
+      DEBUG ((DEBUG_ERROR, "BootMediaWriteByType range out of bounds: 0x%llx + 0x%x\n", Address, ByteCount));
+      return EFI_INVALID_PARAMETER;
+    }
+  }
+
   return mFwuSpiService->SpiWrite (FlashRegionType, (UINT32)Address, ByteCount, Buffer);
 }
 
@@ -182,6 +287,26 @@ BootMediaErase (
   IN     UINT32   ByteCount
   )
 {
+  UINT64  EndAddress;
+
+  if (mFwuSpiService == NULL) {
+    DEBUG ((DEBUG_ERROR, "BootMediaErase service not initialized\n"));
+    return EFI_NOT_READY;
+  }
+
+  if (Address > MAX_UINT32) {
+    DEBUG ((DEBUG_ERROR, "BootMediaErase address out of range: 0x%llx\n", Address));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (ByteCount != 0) {
+    EndAddress = Address + (UINT64)ByteCount - 1;
+    if ((EndAddress < Address) || (EndAddress > MAX_UINT32)) {
+      DEBUG ((DEBUG_ERROR, "BootMediaErase range out of bounds: 0x%llx + 0x%x\n", Address, ByteCount));
+      return EFI_INVALID_PARAMETER;
+    }
+  }
+
   return mFwuSpiService->SpiErase (FlashRegionBios, (UINT32)Address, ByteCount);
 }
 
@@ -206,6 +331,7 @@ GetSvn (
   )
 {
   UINT32                Stage1AFvBase;
+  UINT32                FvBaseOffset;
   UINT32                TopSwapRegionSize;
   EFI_STATUS            Status;
 
@@ -222,10 +348,21 @@ GetSvn (
     DEBUG((DEBUG_ERROR, "Error getting top swap region size, failed with status: %r\n", Status));
     return Status;
   }
+
+  if (Stage1AFvPointer < TopSwapRegionSize) {
+    DEBUG((DEBUG_ERROR, "Invalid Stage1A FV pointer 0x%08x below top swap region size 0x%08x\n",
+          Stage1AFvPointer, TopSwapRegionSize));
+    return EFI_COMPROMISED_DATA;
+  }
   Stage1AFvPointer = Stage1AFvPointer - TopSwapRegionSize;
 
-  Stage1AFvBase = (UINT32)(*(UINT32 *)(UINTN)Stage1AFvPointer);
-  Stage1AFvBase = Stage1AFvPointer - (~Stage1AFvBase + 1) + sizeof(UINT32);
+  FvBaseOffset = (UINT32)(*(UINT32 *)(UINTN)Stage1AFvPointer);
+  if (((UINT64)Stage1AFvPointer + (UINT64)FvBaseOffset + sizeof (UINT32)) > MAX_UINT32) {
+    DEBUG((DEBUG_ERROR, "Stage1A FV base computation overflow: Ptr=0x%08x Offset=0x%08x\n",
+          Stage1AFvPointer, FvBaseOffset));
+    return EFI_COMPROMISED_DATA;
+  }
+  Stage1AFvBase = Stage1AFvPointer + FvBaseOffset + sizeof (UINT32);
 
   Status = GetVersionfromFv (Stage1AFvBase, FALSE, BlVersion);
   if (EFI_ERROR (Status)) {
@@ -311,18 +448,33 @@ UpdateRegionBlock (
 {
   EFI_STATUS    Status;
   UINT8         *ReadBuffer;
+  UINT8         *VerifyBuffer;
   UINT32        Count;
   UINT32        BlockLen;
+  UINT32        WriteSize;
+  UINT8         *WriteBuffer;
   UINT8         *Src;
 
   ReadBuffer = NULL;
+  VerifyBuffer = NULL;
 
   if (Length == 0) {
     return EFI_SUCCESS;
   }
 
+  if ((Address & (SIZE_4KB - 1)) != 0) {
+    DEBUG ((DEBUG_ERROR, "UpdateRegionBlock requires 4KB-aligned address: 0x%llx\n", Address));
+    return EFI_INVALID_PARAMETER;
+  }
+
   ReadBuffer = AllocatePages (EFI_SIZE_TO_PAGES (SIZE_4KB));
   if (ReadBuffer == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  VerifyBuffer = AllocatePages (EFI_SIZE_TO_PAGES (SIZE_4KB));
+  if (VerifyBuffer == NULL) {
+    FreePages (ReadBuffer, EFI_SIZE_TO_PAGES (SIZE_4KB));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -340,7 +492,15 @@ UpdateRegionBlock (
     if (Count + BlockLen > Length) {
       BlockLen = Length - Count;
     }
-    Status = BootMediaRead(Address + Count, BlockLen, ReadBuffer);
+
+    // Partial tail update still needs full 4KB erase granularity.
+    // Preserve trailing bytes in the same erase block to avoid corrupting
+    // adjacent data outside the requested update range.
+    if (BlockLen < SIZE_4KB) {
+      Status = BootMediaRead(Address + Count, SIZE_4KB, ReadBuffer);
+    } else {
+      Status = BootMediaRead(Address + Count, BlockLen, ReadBuffer);
+    }
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "BootMediaRead.  readaddr: 0x%llx, Status = 0x%x\n", Address + Count, Status));
       goto End;
@@ -351,12 +511,21 @@ UpdateRegionBlock (
       continue;
     }
 
+    if (BlockLen < SIZE_4KB) {
+      CopyMem (ReadBuffer, Src + Count, BlockLen);
+      WriteBuffer = ReadBuffer;
+      WriteSize   = SIZE_4KB;
+    } else {
+      WriteBuffer = Src + Count;
+      WriteSize   = BlockLen;
+    }
+
     //
     // Erase the boot media
     // Block length for erase is always 4K bytes
     //
     DEBUG ((DEBUG_INIT, "x"));
-    Status = BootMediaErase ((UINT32) (Address + Count),  SIZE_4KB);
+    Status = BootMediaErase (Address + Count,  SIZE_4KB);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "ERROR: in BootMediaErase. Status = 0x%x\n", Status));
       goto End;
@@ -365,7 +534,7 @@ UpdateRegionBlock (
     //
     // Write to the boot media
     //
-    Status = BootMediaWrite ((UINT32) (Address + Count),  BlockLen, Src + Count);
+    Status = BootMediaWrite (Address + Count, WriteSize, WriteBuffer);
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "ERROR: in BootDeviceWrite. Status = 0x%x\n", Status));
       goto End;
@@ -374,8 +543,13 @@ UpdateRegionBlock (
     //
     // Verify the written data
     //
-    Status = BootMediaRead (Address + Count, BlockLen, ReadBuffer);
-    if (CompareMem (Src + Count, ReadBuffer, BlockLen) != 0) {
+    Status = BootMediaRead (Address + Count, WriteSize, VerifyBuffer);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "Verify BootMediaRead failed.  readaddr: 0x%llx, Status = 0x%x\n", Address + Count, Status));
+      goto End;
+    }
+
+    if (CompareMem (WriteBuffer, VerifyBuffer, WriteSize) != 0) {
       DEBUG ((DEBUG_ERROR, "Verify Error !\n"));
       Status = EFI_DEVICE_ERROR;
       goto End;
@@ -383,6 +557,10 @@ UpdateRegionBlock (
   }
 
 End:
+  if (VerifyBuffer != NULL) {
+    FreePages (VerifyBuffer, EFI_SIZE_TO_PAGES (SIZE_4KB));
+  }
+
   if (ReadBuffer != NULL) {
     FreePages (ReadBuffer, EFI_SIZE_TO_PAGES (SIZE_4KB));
   }
@@ -644,10 +822,23 @@ UpdateSingleComponent (
 
   AllocateSize    = sizeof (FIRMWARE_UPDATE_PARTITION) + sizeof (FIRMWARE_UPDATE_REGION);
   UpdatePartition = (FIRMWARE_UPDATE_PARTITION *) AllocatePool (AllocateSize);
-  ASSERT (UpdatePartition != NULL);
+  if (UpdatePartition == NULL) {
+    DEBUG ((DEBUG_ERROR, "AllocatePool failed for update partition\n"));
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   UpdateRegion                  = &UpdatePartition->FwRegion[0];
-  UpdateRegion->ToUpdateAddress = FlashMap->RomSize + CompBase;
+
+  //
+  // Guard against UINT32 overflow: RomSize + CompBase may exceed MAX_UINT32
+  //
+  if (((UINT64)FlashMap->RomSize + (UINT64)CompBase) > MAX_UINT32) {
+    DEBUG((DEBUG_ERROR, "UpdateSingleComponent: address computation overflow: RomSize=0x%x CompBase=0x%x\n",
+          FlashMap->RomSize, CompBase));
+    FreePool(UpdatePartition);
+    return EFI_UNSUPPORTED;
+  }
+  UpdateRegion->ToUpdateAddress = (UINT32)(FlashMap->RomSize + CompBase);
   UpdateRegion->UpdateSize      = ImageHdr->UpdateImageSize;
   UpdateRegion->SourceAddress   = (UINT8 *)((UINTN)ImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER));
   UpdatePartition->RegionCount  = 1;
@@ -725,6 +916,7 @@ UpdateContainerComp (
   UINT8                    CompInMem[sizeof(LOADER_COMPRESSED_HEADER)];
   FLASH_MAP                *FlashMapPtr;
   UINT32                   RomBase;
+  UINT64                   CompAddr;
 
   ComponentName = (UINT32)RShiftU64 (ImageHdr->UpdateHardwareInstance, 32);
   ContainerName = (UINT32)ImageHdr->UpdateHardwareInstance;
@@ -748,7 +940,12 @@ UpdateContainerComp (
     //
     // Component base = Container base + data offset from container base + offset of component inside container
     //
-    ComponentBase     = ContainerEntryPtr->Base + ContainerHdr->DataOffset + ComponentEntryPtr->Offset;
+    CompAddr = (UINT64)ContainerEntryPtr->Base + (UINT64)ContainerHdr->DataOffset + (UINT64)ComponentEntryPtr->Offset;
+    if (CompAddr > MAX_UINT32) {
+      DEBUG((DEBUG_ERROR, "Container component address overflow: 0x%llx\n", CompAddr));
+      return EFI_UNSUPPORTED;
+    }
+    ComponentBase     = (UINT32)CompAddr;
     FlashCompLzHeader = (LOADER_COMPRESSED_HEADER *) (UINTN)ComponentBase;
   } else {
     // Container base is NOT the flash address, need get its flash address
@@ -757,12 +954,24 @@ UpdateContainerComp (
       DEBUG((DEBUG_INFO, "Component with the matching signature not found."));
       return Status;
     }
-    ComponentBase += ContainerHdr->DataOffset + ComponentEntryPtr->Offset;
+    CompAddr = (UINT64)ComponentBase + (UINT64)ContainerHdr->DataOffset + (UINT64)ComponentEntryPtr->Offset;
+    if (CompAddr > MAX_UINT32) {
+      DEBUG((DEBUG_ERROR, "Container component address overflow: 0x%llx\n", CompAddr));
+      return EFI_UNSUPPORTED;
+    }
+    ComponentBase = (UINT32)CompAddr;
 
     // Read compressed header since container might not be MMIO mapped.
     FlashMapPtr = GetFlashMapPtr ();
-    ASSERT (FlashMapPtr != NULL);
+    if (FlashMapPtr == NULL) {
+      DEBUG((DEBUG_ERROR, "Failed to get flash map pointer for container component update\n"));
+      return EFI_NOT_FOUND;
+    }
     RomBase = (UINT32) (0x100000000ULL - FlashMapPtr->RomSize);
+    if (ComponentBase < RomBase) {
+      DEBUG((DEBUG_ERROR, "Container component address underflow: CompBase=0x%x RomBase=0x%x\n", ComponentBase, RomBase));
+      return EFI_UNSUPPORTED;
+    }
     Status  = BootMediaRead(ComponentBase - RomBase, sizeof(LOADER_COMPRESSED_HEADER), CompInMem);
     if (EFI_ERROR(Status)) {
       DEBUG((DEBUG_INFO, "Boot Media device error, read command aborts."));
@@ -815,6 +1024,8 @@ CheckSblContainerSvn (
   COMPONENT_ENTRY           *CapCompEntry;
   LOADER_COMPRESSED_HEADER  *CapLzHdr;
   UINT64                    FlashComponentName;
+  UINT64                    CapDataEnd;
+  UINT64                    CapCompOffset;
   UINT8                     ContainerSvnCheck;
   UINT8                     ComponentSvnCheck;
   EFI_STATUS                Status;
@@ -834,6 +1045,24 @@ CheckSblContainerSvn (
 
   // Locate the container header info from capsule image.
   CapContainerAddr   = (CONTAINER_HDR *)((UINTN)ImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER));
+
+  if (ImageHdr->UpdateImageSize < sizeof (CONTAINER_HDR)) {
+    DEBUG((DEBUG_ERROR, "Container payload too small for container header: 0x%x\n", ImageHdr->UpdateImageSize));
+    return EFI_COMPROMISED_DATA;
+  }
+
+  if ((CapContainerAddr->DataOffset < sizeof (CONTAINER_HDR)) ||
+      (CapContainerAddr->DataOffset > ImageHdr->UpdateImageSize)) {
+    DEBUG((DEBUG_ERROR, "Container data offset out of bounds: 0x%x\n", CapContainerAddr->DataOffset));
+    return EFI_COMPROMISED_DATA;
+  }
+
+  CapDataEnd = (UINT64)CapContainerAddr->DataOffset + (UINT64)CapContainerAddr->DataSize;
+  if ((CapDataEnd < CapContainerAddr->DataOffset) || (CapDataEnd > ImageHdr->UpdateImageSize)) {
+    DEBUG((DEBUG_ERROR, "Container data region out of bounds: Offset=0x%x Size=0x%x Payload=0x%x\n",
+          CapContainerAddr->DataOffset, CapContainerAddr->DataSize, ImageHdr->UpdateImageSize));
+    return EFI_COMPROMISED_DATA;
+  }
 
   //Check capsule container SVN with container avaiable in flash
   if (CapContainerAddr->Svn >= FlashContainerHdr->Svn) {
@@ -865,6 +1094,25 @@ CheckSblContainerSvn (
     CapCompEntry = NULL;
     CapCompEntry = LocateComponentEntryFromContainer ((CONTAINER_HDR *) CapContainerAddr, (UINT32 ) FlashComponentName);
     if (CapCompEntry != NULL) {
+      if (((UINT64)CapCompEntry->Offset > CapContainerAddr->DataSize) ||
+          ((UINT64)CapCompEntry->Size > ((UINT64)CapContainerAddr->DataSize - CapCompEntry->Offset))) {
+        DEBUG ((DEBUG_ERROR, "Component entry out of bounds in capsule container: Offset=0x%x Size=0x%x DataSize=0x%x\n",
+                CapCompEntry->Offset, CapCompEntry->Size, CapContainerAddr->DataSize));
+        return EFI_COMPROMISED_DATA;
+      }
+
+      CapCompOffset = (UINT64)CapContainerAddr->DataOffset + (UINT64)CapCompEntry->Offset;
+      //
+      // Defense-in-depth: reject offsets that don't fit in 32 bits or exceed payload bounds
+      //
+      if ((CapCompOffset < CapContainerAddr->DataOffset) ||
+          (CapCompOffset > MAX_UINT32) ||
+          (CapCompOffset > ((UINT64)ImageHdr->UpdateImageSize - sizeof (LOADER_COMPRESSED_HEADER)))) {
+        DEBUG ((DEBUG_ERROR, "Component header out of capsule bounds: Offset=0x%llx Payload=0x%x\n",
+                CapCompOffset, ImageHdr->UpdateImageSize));
+        return EFI_COMPROMISED_DATA;
+      }
+
       CapLzHdr = (LOADER_COMPRESSED_HEADER *)((UINT8 *)CapContainerAddr + CapContainerAddr->DataOffset + CapCompEntry->Offset);
 
       if ((IS_COMPRESSED (CapLzHdr) == FALSE) || (IS_COMPRESSED (FlashLzHdr) == FALSE)) {
@@ -959,7 +1207,6 @@ CheckSblConfigDataSvn (
   //
   // Get base address of CFGDATA from  firmware block to update
   //
-
   if (FwPolicy.Fields.UpdatePartitionB == 0x1) {
     Status = GetComponentInfoByPartition(FLASH_MAP_SIG_CFGDATA, TRUE, (UINT32 *) &CfgBlobFlashAddr, &CfgBlobSize);
   } else if (FwPolicy.Fields.UpdatePartitionA == 0x1) {
@@ -972,6 +1219,12 @@ CheckSblConfigDataSvn (
   }
 
   CfgBlobFlashDataPtr = (CDATA_BLOB *) (UINTN) CfgBlobFlashAddr;
+
+  if (ImageHdr->UpdateImageSize < sizeof (CDATA_BLOB)) {
+    DEBUG((DEBUG_ERROR, "Config data payload too small for CDATA_BLOB header: 0x%x\n",
+          ImageHdr->UpdateImageSize));
+    return EFI_COMPROMISED_DATA;
+  }
 
   // Locate config data blob header info from capsule image
   CfgBlobCapAddr = (CDATA_BLOB *)((UINTN)ImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER));
@@ -1080,9 +1333,11 @@ CheckUCodeVersion (
   UINT32                NewUCodeRev;
   UINTN                 ImageBase;
   UINTN                 Offset;
+  UINTN                 RemainingSize;
   CPU_MICROCODE_HEADER  *UCodeHdr;
   UINT8                 *ImageByte;
   UINT32                uCodeVer;
+  UINT32                SlotSize;
 
   if (ImageHdr == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -1092,8 +1347,14 @@ CheckUCodeVersion (
   DEBUG((DEBUG_INFO, "Existing UCODE revision: %x\n", ExistingUCodeRev));
 
   // Update is only supported for platforms that slot their uCode
-  if (PcdGet32 (PcdUcodeSlotSize) == 0) {
+  SlotSize = PcdGet32 (PcdUcodeSlotSize);
+  if (SlotSize == 0) {
     DEBUG((DEBUG_ERROR, "Existing image does not contain uCode slots!!\n"));
+    return EFI_UNSUPPORTED;
+  }
+
+  if (SlotSize < sizeof (CPU_MICROCODE_HEADER)) {
+    DEBUG((DEBUG_ERROR, "uCode slot size is too small for header: 0x%x\n", SlotSize));
     return EFI_UNSUPPORTED;
   }
 
@@ -1102,11 +1363,17 @@ CheckUCodeVersion (
   ImageBase = (UINTN)ImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER);
   ImageByte = (UINT8*)(ImageBase + Offset);
 
-  while (*ImageByte != PAD_BYTE && Offset < ImageHdr->UpdateImageSize) {
+  while ((Offset < ImageHdr->UpdateImageSize) && (*ImageByte != PAD_BYTE)) {
+    RemainingSize = (UINTN)ImageHdr->UpdateImageSize - Offset;
+    if (RemainingSize < sizeof (CPU_MICROCODE_HEADER)) {
+      DEBUG((DEBUG_ERROR, "uCode header exceeds update payload bounds\n"));
+      return EFI_COMPROMISED_DATA;
+    }
+
     UCodeHdr = (CPU_MICROCODE_HEADER *)ImageByte;
 
     // Ensure uCode size from header does not exceed slot size
-    if (UCodeHdr->TotalSize > PcdGet32 (PcdUcodeSlotSize)) {
+    if (UCodeHdr->TotalSize > SlotSize) {
       uCodeVer = 0;
       break;
     }
@@ -1115,7 +1382,12 @@ CheckUCodeVersion (
       uCodeVer = UCodeHdr->UpdateRevision;
     }
 
-    Offset   += PcdGet32(PcdUcodeSlotSize);
+    if (((UINTN)ImageHdr->UpdateImageSize - Offset) < SlotSize) {
+      Offset = (UINTN)ImageHdr->UpdateImageSize;
+      break;
+    }
+
+    Offset   += SlotSize;
     ImageByte = (UINT8*)(ImageBase + Offset);
   }
 
@@ -1213,6 +1485,13 @@ ReadCsmeNeedResetFlag (
   UINT8       Value;
 
   FwUpdStatusOffset = PcdGet32(PcdFwUpdStatusBase);
+  //
+  // Guard against UINT32 overflow before adding the field offset
+  //
+  if (((UINT64)FwUpdStatusOffset + OFFSET_OF(FW_UPDATE_STATUS, CsmeNeedReset)) > MAX_UINT32) {
+    DEBUG((DEBUG_ERROR, "ReadCsmeNeedResetFlag: FwUpdStatusOffset (0x%x) causes overflow\n", FwUpdStatusOffset));
+    return CSME_NEED_RESET_INVALID;
+  }
   FwUpdStatusOffset += OFFSET_OF(FW_UPDATE_STATUS, CsmeNeedReset);
 
   Value = CSME_NEED_RESET_INIT;
@@ -1252,6 +1531,13 @@ WriteCsmeNeedResetFlag (
   }
 
   FwUpdStatusOffset = PcdGet32(PcdFwUpdStatusBase);
+  //
+  // Guard against UINT32 overflow before adding the field offset
+  //
+  if (((UINT64)FwUpdStatusOffset + OFFSET_OF(FW_UPDATE_STATUS, CsmeNeedReset)) > MAX_UINT32) {
+    DEBUG((DEBUG_ERROR, "WriteCsmeNeedResetFlag: FwUpdStatusOffset (0x%x) causes overflow\n", FwUpdStatusOffset));
+    return EFI_DEVICE_ERROR;
+  }
   FwUpdStatusOffset += OFFSET_OF(FW_UPDATE_STATUS, CsmeNeedReset);
 
   Status = BootMediaWrite (FwUpdStatusOffset, sizeof(UINT8), (UINT8 *)&Value);
@@ -1301,12 +1587,20 @@ VerifyUcodeStruct (
 {
   UINTN                 ImageBase;
   UINTN                 ImageOffset;
+  UINTN                 RemainingSize;
   CPU_MICROCODE_HEADER  *UCodeHdr;
   UINT8                 *ImageByte;
+  UINT32                SlotSize;
 
   // Update is only supported for platforms that slot their uCode
-  if (PcdGet32 (PcdUcodeSlotSize) == 0) {
+  SlotSize = PcdGet32 (PcdUcodeSlotSize);
+  if (SlotSize == 0) {
     DEBUG((DEBUG_ERROR, "Existing image does not contain uCode slots!!\n"));
+    return EFI_UNSUPPORTED;
+  }
+
+  if (SlotSize < sizeof (CPU_MICROCODE_HEADER)) {
+    DEBUG((DEBUG_ERROR, "uCode slot size is too small for header: 0x%x\n", SlotSize));
     return EFI_UNSUPPORTED;
   }
 
@@ -1314,7 +1608,13 @@ VerifyUcodeStruct (
   ImageOffset = 0;
 
   ImageByte = (UINT8*)(ImageBase + ImageOffset);
-  while (*ImageByte != PAD_BYTE && ImageOffset < ImageHdr->UpdateImageSize) {
+  while ((ImageOffset < ImageHdr->UpdateImageSize) && (*ImageByte != PAD_BYTE)) {
+    RemainingSize = (UINTN)ImageHdr->UpdateImageSize - ImageOffset;
+    if (RemainingSize < sizeof (CPU_MICROCODE_HEADER)) {
+      DEBUG((DEBUG_ERROR, "uCode header exceeds update payload bounds\n"));
+      return EFI_NO_MAPPING;
+    }
+
     UCodeHdr = (CPU_MICROCODE_HEADER *)ImageByte;
 
     // Ensure patches in update image start at slot boundaries
@@ -1324,11 +1624,17 @@ VerifyUcodeStruct (
     }
 
     // Ensure total size from header does not exceed slot size
-    if (UCodeHdr->TotalSize > PcdGet32 (PcdUcodeSlotSize)) {
+    if (UCodeHdr->TotalSize > SlotSize) {
       DEBUG((DEBUG_ERROR, "Total uCode size from header exceeds uCode slot size!!\n"));
       return EFI_NO_MAPPING;
     }
-    ImageOffset += PcdGet32(PcdUcodeSlotSize);
+
+    if (((UINTN)ImageHdr->UpdateImageSize - ImageOffset) < SlotSize) {
+      DEBUG((DEBUG_ERROR, "uCode slot exceeds update payload bounds\n"));
+      return EFI_NO_MAPPING;
+    }
+
+    ImageOffset += SlotSize;
     ImageByte = (UINT8*)(ImageBase + ImageOffset);
   }
 

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdateHelper.c
@@ -331,7 +331,8 @@ GetSvn (
   )
 {
   UINT32                Stage1AFvBase;
-  UINT32                FvBaseOffset;
+  INT32                 FvBaseOffset;
+  INT64                 Stage1AFvBase64;
   UINT32                TopSwapRegionSize;
   EFI_STATUS            Status;
 
@@ -356,13 +357,14 @@ GetSvn (
   }
   Stage1AFvPointer = Stage1AFvPointer - TopSwapRegionSize;
 
-  FvBaseOffset = (UINT32)(*(UINT32 *)(UINTN)Stage1AFvPointer);
-  if (((UINT64)Stage1AFvPointer + (UINT64)FvBaseOffset + sizeof (UINT32)) > MAX_UINT32) {
-    DEBUG((DEBUG_ERROR, "Stage1A FV base computation overflow: Ptr=0x%08x Offset=0x%08x\n",
-          Stage1AFvPointer, FvBaseOffset));
+  FvBaseOffset = (INT32)(*(UINT32 *)(UINTN)Stage1AFvPointer);
+  Stage1AFvBase64 = (INT64)(UINT64)Stage1AFvPointer + (INT64)FvBaseOffset + (INT64)sizeof (UINT32);
+  if ((Stage1AFvBase64 < 0) || (Stage1AFvBase64 > MAX_UINT32)) {
+    DEBUG((DEBUG_ERROR, "Stage1A FV base computation out of range: Ptr=0x%08x Offset=0x%08x\n",
+          Stage1AFvPointer, (UINT32)FvBaseOffset));
     return EFI_COMPROMISED_DATA;
   }
-  Stage1AFvBase = Stage1AFvPointer + FvBaseOffset + sizeof (UINT32);
+  Stage1AFvBase = (UINT32)Stage1AFvBase64;
 
   Status = GetVersionfromFv (Stage1AFvBase, FALSE, BlVersion);
   if (EFI_ERROR (Status)) {

--- a/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
+++ b/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
@@ -21,6 +21,7 @@
 #include <Library/FirmwareUpdateLib.h>
 #include <Library/ConfigDataLib.h>
 #include <Library/BootOptionLib.h>
+#include <Library/PcdLib.h>
 #include <ConfigDataCommonStruct.h>
 
 /**
@@ -135,11 +136,18 @@ GetCapsuleFromRawPartition (
   VOID                      *Buffer;
   UINTN                     ImageSize;
   LOGICAL_BLOCK_DEVICE      LogicBlkDev;
-  UINTN                     AlginedHeaderSize;
-  UINTN                     AlginedImageSize;
+  UINTN                     AlignedHeaderSize;
+  UINTN                     AlignedImageSize;
   UINT32                    BlockSize;
+  UINT32                    MaxCapsuleSize;
   UINT8                     BlockData[4096];
   FIRMWARE_UPDATE_HEADER    *FwUpdHeader;
+  UINT64                    StartBlock;
+  UINT64                    LastBlock;
+  UINT64                    BlockCount;
+
+  Buffer = NULL;
+  MaxCapsuleSize = PcdGet32 (PcdMaxCapsuleSize);
 
   DEBUG ((DEBUG_INFO, "Load image from SwPart (0x%x), LbaAddr(0x%x)\n", 0, 0));
   Status = GetLogicalPartitionInfo (CapsuleInfo->SwPart, HwPartHandle, &LogicBlkDev);
@@ -159,13 +167,43 @@ GetCapsuleFromRawPartition (
   // Make sure to round the Header size to be block aligned in bytes.
   //
   BlockSize = BlockInfo.BlockSize;
-  AlginedHeaderSize = ((sizeof (FIRMWARE_UPDATE_HEADER) % BlockSize) == 0) ? \
+  if ((BlockSize == 0) || (BlockSize > sizeof (BlockData))) {
+    DEBUG ((DEBUG_INFO, "Invalid block size %u for capsule header read\n", BlockSize));
+    return EFI_UNSUPPORTED;
+  }
+
+  AlignedHeaderSize = ((sizeof (FIRMWARE_UPDATE_HEADER) % BlockSize) == 0) ? \
                       sizeof (FIRMWARE_UPDATE_HEADER) : \
                       ((sizeof (FIRMWARE_UPDATE_HEADER) / BlockSize) + 1) * BlockSize;
+  if (AlignedHeaderSize > sizeof (BlockData)) {
+    DEBUG ((DEBUG_INFO, "Aligned header size 0x%x exceeds local buffer size 0x%x\n",
+            AlignedHeaderSize, sizeof (BlockData)));
+    return EFI_UNSUPPORTED;
+  }
+
+  StartBlock = (UINT64)LogicBlkDev.StartBlock + (UINT64)CapsuleInfo->LbaAddr;
+  if (StartBlock > MAX_UINT32) {
+    DEBUG ((DEBUG_INFO, "Capsule start LBA overflow: Start=0x%llx\n", StartBlock));
+    return EFI_UNSUPPORTED;
+  }
+
+  BlockCount = (AlignedHeaderSize + BlockSize - 1) / BlockSize;
+  if (BlockCount == 0) {
+    DEBUG ((DEBUG_INFO, "Invalid block count for capsule header read\n"));
+    return EFI_UNSUPPORTED;
+  }
+
+  LastBlock = StartBlock + BlockCount - 1;
+  if ((LastBlock < StartBlock) || (LastBlock > LogicBlkDev.LastBlock)) {
+    DEBUG ((DEBUG_INFO, "Capsule header read exceeds partition: Start=0x%llx Last=0x%llx PartLast=0x%llx\n",
+            StartBlock, LastBlock, (UINT64)LogicBlkDev.LastBlock));
+    return EFI_UNSUPPORTED;
+  }
+
   Status = MediaReadBlocks (
              CapsuleInfo->HwPart,
-             LogicBlkDev.StartBlock + CapsuleInfo->LbaAddr,
-             AlginedHeaderSize,
+             (EFI_LBA)StartBlock,
+             AlignedHeaderSize,
              BlockData
              );
   if (EFI_ERROR (Status)) {
@@ -195,13 +233,48 @@ GetCapsuleFromRawPartition (
   // Make sure to round the image size to be block aligned in bytes.
   //
   ImageSize        = CAPSULE_IMAGE_SIZE ((FIRMWARE_UPDATE_HEADER *) BlockData);
-  AlginedImageSize = ((ImageSize % BlockSize) == 0) ? \
+  if (ImageSize == 0) {
+    DEBUG ((DEBUG_INFO, "Invalid capsule image size: 0\n"));
+    return EFI_LOAD_ERROR;
+  }
+
+  if ((MaxCapsuleSize != 0) && (ImageSize > MaxCapsuleSize)) {
+    DEBUG ((DEBUG_INFO, "Capsule image size 0x%x exceeds policy cap 0x%x\n",
+            ImageSize, MaxCapsuleSize));
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  if (ImageSize > ((UINTN)~0ULL - (BlockSize - 1))) {
+    DEBUG ((DEBUG_INFO, "Capsule image size overflow during alignment, ImageSize=0x%x BlockSize=0x%x\n",
+            ImageSize, BlockSize));
+    return EFI_UNSUPPORTED;
+  }
+
+  AlignedImageSize = ((ImageSize % BlockSize) == 0) ? \
                      ImageSize : \
                      ((ImageSize / BlockSize) + 1) * BlockSize;
 
-  Buffer = (UINT8 *) AllocatePages (EFI_SIZE_TO_PAGES (AlginedImageSize));
+  if (AlignedImageSize < ImageSize) {
+    DEBUG ((DEBUG_INFO, "Invalid aligned capsule image size: 0x%x < 0x%x\n", AlignedImageSize, ImageSize));
+    return EFI_UNSUPPORTED;
+  }
+
+  BlockCount = (AlignedImageSize + BlockSize - 1) / BlockSize;
+  if (BlockCount == 0) {
+    DEBUG ((DEBUG_INFO, "Invalid block count for capsule image read\n"));
+    return EFI_UNSUPPORTED;
+  }
+
+  LastBlock = StartBlock + BlockCount - 1;
+  if ((LastBlock < StartBlock) || (LastBlock > LogicBlkDev.LastBlock)) {
+    DEBUG ((DEBUG_INFO, "Capsule image read exceeds partition: Start=0x%llx Last=0x%llx PartLast=0x%llx\n",
+            StartBlock, LastBlock, (UINT64)LogicBlkDev.LastBlock));
+    return EFI_UNSUPPORTED;
+  }
+
+  Buffer = (UINT8 *) AllocatePool (AlignedImageSize);
   if (Buffer == NULL) {
-    DEBUG ((DEBUG_INFO, "Allocate memory (size:0x%x) fail.\n", AlginedImageSize));
+    DEBUG ((DEBUG_INFO, "Allocate memory (size:0x%x) fail.\n", AlignedImageSize));
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -210,16 +283,18 @@ GetCapsuleFromRawPartition (
   //
   Status = MediaReadBlocks (
              CapsuleInfo->HwPart,
-             LogicBlkDev.StartBlock + CapsuleInfo->LbaAddr,
-             AlginedImageSize,
+             (EFI_LBA)StartBlock,
+             AlignedImageSize,
              Buffer
              );
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_INFO, "Read capsule image error, Status = %r\n", Status));
+    FreePool (Buffer);
     return  Status;
   }
 
-  if ((Buffer == NULL) || (ImageSize == 0)) {
+  if (ImageSize == 0) {
+    FreePool (Buffer);
     return EFI_LOAD_ERROR;
   }
 
@@ -251,6 +326,8 @@ LoadCapsuleImage (
   )
 {
   EFI_STATUS          Status;
+  UINTN               CapsuleImageSizeN;
+  UINT32              MaxCapsuleSize;
   UINTN               HardwareDeviceBlockIndex;
   DEVICE_BLOCK_INFO   BlockInfo;
   EFI_HANDLE          FsHandle;
@@ -265,6 +342,8 @@ LoadCapsuleImage (
   }
 
   *CapsuleImageSize = 0;
+  CapsuleImageSizeN  = 0;
+  MaxCapsuleSize     = PcdGet32 (PcdMaxCapsuleSize);
   *CapsuleImage     = NULL;
   FileHandle        = NULL;
   HwPartHandle      = NULL;
@@ -279,7 +358,15 @@ LoadCapsuleImage (
   // If we do not have file system, try reading capsule from raw partition
   //
   if (CapsuleInfo->FsType >= EnumFileSystemMax) {
-    Status = GetCapsuleFromRawPartition (CapsuleInfo, HwPartHandle, CapsuleImage, (UINTN *)CapsuleImageSize);
+    Status = GetCapsuleFromRawPartition (CapsuleInfo, HwPartHandle, CapsuleImage, &CapsuleImageSizeN);
+    if (!EFI_ERROR (Status)) {
+      if (CapsuleImageSizeN > MAX_UINT32) {
+        DEBUG((DEBUG_ERROR, " Capsule image size 0x%llx exceeds UINT32 range\n", (UINT64)CapsuleImageSizeN));
+        Status = EFI_UNSUPPORTED;
+      } else {
+        *CapsuleImageSize = (UINT32)CapsuleImageSizeN;
+      }
+    }
     goto Done;
   }
 
@@ -313,23 +400,44 @@ LoadCapsuleImage (
       goto Done;
     }
 
-    Status = GetFileSize (FileHandle, (UINTN *)CapsuleImageSize);
+    Status = GetFileSize (FileHandle, &CapsuleImageSizeN);
     if (EFI_ERROR(Status)) {
       DEBUG((DEBUG_ERROR, " Get Capsule File '%s' size Status : %r\n", FileName, Status));
       goto Done;
     }
 
-    *CapsuleImage = AllocatePool (*CapsuleImageSize);
+    if (CapsuleImageSizeN > MAX_UINT32) {
+      DEBUG((DEBUG_ERROR, " Capsule file size 0x%llx exceeds UINT32 range\n", (UINT64)CapsuleImageSizeN));
+      Status = EFI_UNSUPPORTED;
+      goto Done;
+    }
+
+    if ((MaxCapsuleSize != 0) && (CapsuleImageSizeN > MaxCapsuleSize)) {
+      DEBUG((DEBUG_ERROR, " Capsule file size 0x%llx exceeds policy cap 0x%x\n",
+             (UINT64)CapsuleImageSizeN, MaxCapsuleSize));
+      Status = EFI_BAD_BUFFER_SIZE;
+      goto Done;
+    }
+
+    *CapsuleImage = AllocatePool (CapsuleImageSizeN);
     if (*CapsuleImage == NULL) {
       Status = EFI_OUT_OF_RESOURCES;
       goto Done;
     }
 
-    Status = ReadFile (FileHandle, *CapsuleImage, (UINTN *)CapsuleImageSize);
+    Status = ReadFile (FileHandle, *CapsuleImage, &CapsuleImageSizeN);
     if (EFI_ERROR(Status)) {
       DEBUG((DEBUG_ERROR, " Read Capsule File '%s' Status : %r\n", FileName, Status));
       goto Done;
     }
+
+    if (CapsuleImageSizeN > MAX_UINT32) {
+      DEBUG((DEBUG_ERROR, " Capsule file read size 0x%llx exceeds UINT32 range\n", (UINT64)CapsuleImageSizeN));
+      Status = EFI_UNSUPPORTED;
+      goto Done;
+    }
+
+    *CapsuleImageSize = (UINT32)CapsuleImageSizeN;
   } else {
     Status = EFI_NOT_FOUND;
   }
@@ -339,16 +447,18 @@ Done:
     CloseFile (FileHandle);
   }
 
+  if (FsHandle != NULL) {
+    CloseFileSystem (FsHandle);
+  }
+
+  if (HwPartHandle != NULL) {
+    FreePool (HwPartHandle);
+  }
+
   if (EFI_ERROR (Status)) {
     if (*CapsuleImage != NULL) {
       FreePool (*CapsuleImage);
       *CapsuleImage = NULL;
-    }
-    if (FsHandle != NULL) {
-      CloseFileSystem (FsHandle);
-    }
-    if (HwPartHandle != NULL) {
-      FreePool (HwPartHandle);
     }
   }
 
@@ -374,7 +484,7 @@ GetOsImageList (
 
   GuidHob = GetNextGuidHob (&gOsBootOptionGuid, GetHobListPtr());
   if (GuidHob == NULL) {
-    ASSERT (GuidHob);
+    DEBUG((DEBUG_ERROR, "OS boot option HOB not found\\n"));
     return NULL;
   }
   return (OS_BOOT_OPTION_LIST *)GET_GUID_HOB_DATA (GuidHob);
@@ -455,9 +565,11 @@ GetCapsuleImage (
 
     Status = LoadCapsuleImage (CapsuleInfo, CapsuleImage, CapsuleImageSize);
     if (!EFI_ERROR(Status)) {
+      // Clamp dump length to actual capsule size to prevent OOB read
+      UINT32 DumpLen = (*CapsuleImageSize < 256) ? *CapsuleImageSize : 256;
       DEBUG ((DEBUG_INFO, "Capsule Image found, ImageSize=0x%x\n", *CapsuleImageSize));
-      DEBUG ((DEBUG_INFO, "First 256Bytes of capsule image\n"));
-      DumpHex (2, 0, 256, (VOID *)*CapsuleImage);
+      DEBUG ((DEBUG_INFO, "Dumping first %u bytes of capsule image\n", DumpLen));
+      DumpHex (2, 0, DumpLen, (VOID *)*CapsuleImage);
       break;
     }
   }

--- a/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
+++ b/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
@@ -232,7 +232,7 @@ GetCapsuleFromRawPartition (
   //
   // Make sure to round the image size to be block aligned in bytes.
   //
-  ImageSize        = CAPSULE_IMAGE_SIZE ((FIRMWARE_UPDATE_HEADER *) BlockData);
+  ImageSize = CAPSULE_IMAGE_SIZE ((FIRMWARE_UPDATE_HEADER *) BlockData);
   if (ImageSize == 0) {
     DEBUG ((DEBUG_INFO, "Invalid capsule image size: 0\n"));
     return EFI_LOAD_ERROR;
@@ -244,7 +244,7 @@ GetCapsuleFromRawPartition (
     return EFI_BAD_BUFFER_SIZE;
   }
 
-  if (ImageSize > ((UINTN)~0ULL - (BlockSize - 1))) {
+  if (ImageSize > (MAX_UINTN - ((UINTN)BlockSize - 1))) {
     DEBUG ((DEBUG_INFO, "Capsule image size overflow during alignment, ImageSize=0x%x BlockSize=0x%x\n",
             ImageSize, BlockSize));
     return EFI_UNSUPPORTED;
@@ -291,11 +291,6 @@ GetCapsuleFromRawPartition (
     DEBUG ((DEBUG_INFO, "Read capsule image error, Status = %r\n", Status));
     FreePool (Buffer);
     return  Status;
-  }
-
-  if (ImageSize == 0) {
-    FreePool (Buffer);
-    return EFI_LOAD_ERROR;
   }
 
   *CapsuleImage = Buffer;

--- a/PayloadPkg/PayloadPkg.dec
+++ b/PayloadPkg/PayloadPkg.dec
@@ -49,3 +49,4 @@
   gPayloadTokenSpaceGuid.PcdIoeCsmeUpdateEnabled     | 0x00000000 | UINT32 | 0x30001001
   gPayloadTokenSpaceGuid.PcdExtraImageSupportEnabled | 0x01       | UINT8  | 0x30001002
   gPayloadTokenSpaceGuid.PcdShellEnabled             | 0x01       | UINT8  | 0x30001003
+  gPayloadTokenSpaceGuid.PcdMaxCapsuleSize           | 0x10000000 | UINT32 | 0x30001004

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -115,7 +115,7 @@ class Board(BaseBoard):
         if self._SMBIOS_YAML_FILE:
             self.SIIPFW_SIZE += 0x1000
         self.EPAYLOAD_SIZE        = 0x0020D000
-        self.PAYLOAD_SIZE         = 0x00021000
+        self.PAYLOAD_SIZE         = 0x00022000
         self.CFGDATA_SIZE         = 0x00001000
         self.KEYHASH_SIZE         = 0x00001000
         self.VARIABLE_SIZE        = 0x00002000

--- a/Silicon/QemuSocPkg/Library/SpiFlashLib/SpiFlashLib.c
+++ b/Silicon/QemuSocPkg/Library/SpiFlashLib/SpiFlashLib.c
@@ -272,8 +272,11 @@ SpiFlashRead (
   }
 
   Address = Address - SpiInstance->TotalFlashSize - SpiInstance->StoreBase;
+
+  // Treat the upper bound as exclusive: [Address, Address + ByteCount).
+  // This allows reading the last valid page where Address + ByteCount == TotalFlashSize.
   if ((Address >= SpiInstance->TotalFlashSize) ||
-      (Address + ByteCount >= SpiInstance->TotalFlashSize)) {
+      (ByteCount > (SpiInstance->TotalFlashSize - Address))) {
     return EFI_INVALID_PARAMETER;
   }
 
@@ -325,8 +328,11 @@ SpiFlashWrite (
   }
 
   Address = Address - SpiInstance->TotalFlashSize - SpiInstance->StoreBase;
+
+  // Treat the upper bound as exclusive: [Address, Address + ByteCount).
+  // This allows writing the last valid page where Address + ByteCount == TotalFlashSize.
   if ((Address >= SpiInstance->TotalFlashSize) ||
-      (Address + ByteCount >= SpiInstance->TotalFlashSize)) {
+      (ByteCount > (SpiInstance->TotalFlashSize - Address))) {
     return EFI_INVALID_PARAMETER;
   }
 
@@ -389,8 +395,11 @@ SpiFlashErase (
   }
 
   Address = Address - SpiInstance->TotalFlashSize - SpiInstance->StoreBase;
+
+  // Treat the upper bound as exclusive: [Address, Address + ByteCount).
+  // This allows erasing up to the last valid page where Address + ByteCount == TotalFlashSize.
   if ((Address >= SpiInstance->TotalFlashSize) ||
-      (Address + ByteCount >= SpiInstance->TotalFlashSize)) {
+      (ByteCount > (SpiInstance->TotalFlashSize - Address))) {
     return EFI_INVALID_PARAMETER;
   }
 


### PR DESCRIPTION
- Enforce exclusive-upper-bound semantics in QEMU SPI flash operations to prevent off-by-one boundary violations during firmware reads and writes

- Add capsule image size validation for debug output to prevent reading beyond allocated buffer boundaries

- Add various verification and checking of capsule metadata

These changes improve the robustness and security of firmware update operations and ensure safer debug output handling during capsule image ingestion.