### PR TITLE
fix: Preserve ET_EXEC ELF load address for fixed-address executables

### DIFF
--- a/BootloaderCommonPkg/Include/Library/ElfLib.h
+++ b/BootloaderCommonPkg/Include/Library/ElfLib.h
@@ -17,6 +17,9 @@
 
 #define  ELF_PT_LOAD   1
 
+#define  ELF_ET_EXEC   2
+#define  ELF_ET_DYN    3
+
 /*
  * Define Max value for Coverity check
  */
@@ -34,6 +37,7 @@ typedef struct {
   UINT8         *ImageAddress;           ///< The destination memory address set by caller.
   UINTN         ImageSize;               ///< The memory size for loading and execution.
   UINT32        EiClass;
+  UINT16        EiType;                  ///< ELF type: ET_EXEC (2) or ET_DYN (3).
   UINT32        ShNum;
   UINT32        PhNum;
   UINTN         ShStrOff;

--- a/BootloaderCommonPkg/Library/ElfLib/ElfLib.c
+++ b/BootloaderCommonPkg/Library/ElfLib/ElfLib.c
@@ -340,6 +340,7 @@ ParseElfImage (
     }
 
     ElfCt->EntryPoint = (UINTN)Elf32Hdr->e_entry;
+    ElfCt->EiType     = Elf32Hdr->e_type;
     ElfCt->ShNum      = Elf32Hdr->e_shnum;
     ElfCt->PhNum      = Elf32Hdr->e_phnum;
     ElfCt->ShStrLen   = Elf32Shdr->sh_size;
@@ -406,6 +407,7 @@ ParseElfImage (
     }
 
     ElfCt->EntryPoint = (UINTN)Elf64Hdr->e_entry;
+    ElfCt->EiType     = Elf64Hdr->e_type;
     ElfCt->ShNum      = Elf64Hdr->e_shnum;
     ElfCt->PhNum      = Elf64Hdr->e_phnum;
     ElfCt->ShStrLen   = (UINTN)Elf64Shdr->sh_size;

--- a/BootloaderCommonPkg/Library/UniversalPayloadLib/UniversalPayloadLib.c
+++ b/BootloaderCommonPkg/Library/UniversalPayloadLib/UniversalPayloadLib.c
@@ -81,7 +81,13 @@ LoadElfPayload (
   }
 
   if (Context.ReloadRequired) {
-    Context.ImageAddress = AllocatePages (EFI_SIZE_TO_PAGES (Context.ImageSize));
+    if ((Context.EiType == ELF_ET_EXEC) && (Context.PreferredImageAddress != NULL)) {
+      // ET_EXEC is a fixed-address executable.
+      // It must be loaded to its preferred address since it has no relocation support.
+      Context.ImageAddress = Context.PreferredImageAddress;
+    } else {
+      Context.ImageAddress = AllocatePages (EFI_SIZE_TO_PAGES (Context.ImageSize));
+    }
   }
 
   // Load ELF into the required base


### PR DESCRIPTION
Commit 8d32ccb changed ELF reload to always allocate new memory via AllocatePages(), which breaks fixed-address ET_EXEC images that have no relocation support and must run at their linked address.

Add EiType field to ELF_IMAGE_CONTEXT and populate it from e_type during ParseElfImage(). In LoadElfPayload(), use PreferredImageAddress for ET_EXEC images instead of allocating new memory. ET_DYN images continue to use AllocatePages() with relocation as before.