### PR TITLE
Update TopSwap library for Fwupdate

### DIFF
--- a/BootloaderCommonPkg/BootloaderCommonPkg.dec
+++ b/BootloaderCommonPkg/BootloaderCommonPkg.dec
@@ -131,6 +131,9 @@
   # USB command timeout in milliseconds
   gPlatformCommonLibTokenSpaceGuid.PcdUsbCmdTimeout               |     0x1000 | UINT16 | 0x20000441
 
+  # PID number to access RTC PCR registers
+  gPlatformCommonLibTokenSpaceGuid.PcdPidRtcHostNumber            |       0xC3 | UINT8  | 0x20000442
+
   # Options to limit framebuffer console size (it will be centered if smaller than screen resolution)
   gPlatformCommonLibTokenSpaceGuid.PcdFrameBufferMaxConsoleWidth  | 0xFFFFFFFF | UINT32 | 0x20000501
   gPlatformCommonLibTokenSpaceGuid.PcdFrameBufferMaxConsoleHeight | 0xFFFFFFFF | UINT32 | 0x20000502

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -283,6 +283,8 @@
   gPlatformCommonLibTokenSpaceGuid.PcdHandOffFdtEnable          | $(ENABLE_UPL_HANDOFF_FDT)
   gPayloadTokenSpaceGuid.PcdIoeCsmeUpdateEnabled                | $(ENABLE_IOE_CSME_UPDATE)
 
+  gPlatformCommonLibTokenSpaceGuid.PcdPidRtcHostNumber          | $(PID_RTC_HOST_NUM)
+
 [PcdsPatchableInModule]
   gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel   | 0x8000004F
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress  | $(PCI_EXPRESS_BASE)

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -136,6 +136,7 @@ class BaseBoard(object):
         self.ACPI_PROCESSOR_ID_BASE = 1
         self.USB_KB_POLLING_TIMEOUT = 1
         self.USB_CMD_TIMEOUT        = 0x1000
+        self.PID_RTC_HOST_NUM       = 0xC3
 
         self.VERIFIED_BOOT_STAGE_1B   = 0x0
         self.BOOT_MEDIA_SUPPORT_MASK  = 0xFFFFFFFF

--- a/Platform/AlderlakeBoardPkg/BoardConfig.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfig.py
@@ -279,6 +279,7 @@ class Board(BaseBoard):
             'WatchDogTimerLib|Silicon/CommonSocPkg/Library/WatchDogTimerLib/WatchDogTimerLib.inf',
             'TcoTimerLib|Silicon/CommonSocPkg/Library/TcoTimerLib/TcoTimerLib.inf',
             'TopSwapLib|Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.inf',
+            'P2sbLib|Silicon/CommonSocPkg/Library/P2sbLib/P2sbLib.inf',
             'TxtLib|Silicon/CommonSocPkg/Library/TxtLib/TxtLibNull.inf'
         ]
 

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
@@ -299,6 +299,7 @@ class Board(BaseBoard):
             'WatchDogTimerLib|Silicon/CommonSocPkg/Library/WatchDogTimerLib/WatchDogTimerLib.inf',
             'TcoTimerLib|Silicon/CommonSocPkg/Library/TcoTimerLib/TcoTimerLib.inf',
             'TopSwapLib|Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.inf',
+            'P2sbLib|Silicon/CommonSocPkg/Library/P2sbLib/P2sbLib.inf',
             'TxtLib|Silicon/CommonSocPkg/Library/TxtLib/TxtLibNull.inf'
         ]
 

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlS.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlS.py
@@ -278,6 +278,7 @@ class Board(BaseBoard):
             'WatchDogTimerLib|Silicon/CommonSocPkg/Library/WatchDogTimerLib/WatchDogTimerLib.inf',
             'TcoTimerLib|Silicon/CommonSocPkg/Library/TcoTimerLib/TcoTimerLib.inf',
             'TopSwapLib|Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.inf',
+            'P2sbLib|Silicon/CommonSocPkg/Library/P2sbLib/P2sbLib.inf',
             'TxtLib|Silicon/CommonSocPkg/Library/TxtLib/TxtLibNull.inf'
         ]
 

--- a/Platform/AlderlakeBoardPkg/BoardConfigAzb.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAzb.py
@@ -274,6 +274,7 @@ class Board(BaseBoard):
             'WatchDogTimerLib|Silicon/CommonSocPkg/Library/WatchDogTimerLib/WatchDogTimerLib.inf',
             'TcoTimerLib|Silicon/CommonSocPkg/Library/TcoTimerLib/TcoTimerLib.inf',
             'TopSwapLib|Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.inf',
+            'P2sbLib|Silicon/CommonSocPkg/Library/P2sbLib/P2sbLib.inf',
             'TxtLib|Silicon/CommonSocPkg/Library/TxtLib/TxtLibNull.inf'
         ]
 

--- a/Platform/AlderlakeBoardPkg/BoardConfigUp2PTWL.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigUp2PTWL.py
@@ -295,7 +295,8 @@ class Board(BaseBoard):
             'CpuPcieHsPhyInitLib|Silicon/$(SILICON_PKG_NAME)/Library/CpuPcieHsPhyInitLib/CpuPcieHsPhyInitLib.inf',
             'WatchDogTimerLib|Silicon/CommonSocPkg/Library/WatchDogTimerLib/WatchDogTimerLib.inf',
             'TcoTimerLib|Silicon/CommonSocPkg/Library/TcoTimerLib/TcoTimerLib.inf',
-            'TopSwapLib|Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.inf'
+            'TopSwapLib|Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.inf',
+            'P2sbLib|Silicon/CommonSocPkg/Library/P2sbLib/P2sbLib.inf'
         ]
 
         if self.BUILD_CSME_UPDATE_DRIVER:

--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -213,6 +213,7 @@ class Board(BaseBoard):
             'BaseIpcLib|Silicon/$(SILICON_PKG_NAME)/Library/BaseIpcLib/BaseIpcLib.inf',
             'TcoTimerLib|Silicon/CommonSocPkg/Library/TcoTimerLib/TcoTimerLib.inf',
             'TopSwapLib|Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.inf',
+            'P2sbLib|Silicon/CommonSocPkg/Library/P2sbLib/P2sbLib.inf',
             'WatchDogTimerLib|Silicon/CommonSocPkg/Library/WatchDogTimerLib/WatchDogTimerLib.inf'
         ]
         dsc['LibraryClasses.%s' % self.BUILD_ARCH] = common_libs

--- a/Platform/CoffeelakeBoardPkg/BoardConfig.py
+++ b/Platform/CoffeelakeBoardPkg/BoardConfig.py
@@ -206,6 +206,7 @@ class Board(BaseBoard):
             'VtdPmrLib|Silicon/CommonSocPkg/Library/VtdPmrLib/VtdPmrLib.inf',
             'TcoTimerLib|Silicon/CommonSocPkg/Library/TcoTimerLib/TcoTimerLib.inf',
             'TopSwapLib|Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.inf',
+            'P2sbLib|Silicon/CommonSocPkg/Library/P2sbLib/P2sbLib.inf',
             'WatchDogTimerLib|Silicon/CommonSocPkg/Library/WatchDogTimerLib/WatchDogTimerLib.inf'
         ]
         if self.BUILD_CSME_UPDATE_DRIVER:

--- a/Platform/CometlakeBoardPkg/BoardConfig.py
+++ b/Platform/CometlakeBoardPkg/BoardConfig.py
@@ -164,6 +164,7 @@ class Board(BaseBoard):
             'ShellExtensionLib|Platform/$(BOARD_PKG_NAME)/Library/ShellExtensionLib/ShellExtensionLib.inf',
             'TcoTimerLib|Silicon/CommonSocPkg/Library/TcoTimerLib/TcoTimerLib.inf',
             'TopSwapLib|Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.inf',
+            'P2sbLib|Silicon/CommonSocPkg/Library/P2sbLib/P2sbLib.inf',
             'WatchDogTimerLib|Silicon/CommonSocPkg/Library/WatchDogTimerLib/WatchDogTimerLib.inf'
         ]
         if self.BUILD_CSME_UPDATE_DRIVER:

--- a/Platform/CometlakevBoardPkg/BoardConfig.py
+++ b/Platform/CometlakevBoardPkg/BoardConfig.py
@@ -171,6 +171,7 @@ class Board(BaseBoard):
             'ShellExtensionLib|Platform/$(BOARD_PKG_NAME)/Library/ShellExtensionLib/ShellExtensionLib.inf',
             'TcoTimerLib|Silicon/CommonSocPkg/Library/TcoTimerLib/TcoTimerLib.inf',
             'TopSwapLib|Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.inf',
+            'P2sbLib|Silicon/CommonSocPkg/Library/P2sbLib/P2sbLib.inf',
             'WatchDogTimerLib|Silicon/CommonSocPkg/Library/WatchDogTimerLib/WatchDogTimerLib.inf'
         ]
         if self.BUILD_CSME_UPDATE_DRIVER:

--- a/Platform/ElkhartlakeBoardPkg/BoardConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/BoardConfig.py
@@ -253,6 +253,7 @@ class Board(BaseBoard):
             'MeExtMeasurementLib|Silicon/$(SILICON_PKG_NAME)/Library/MeExtMeasurementLib/MeExtMeasurementLib.inf',
             'TcoTimerLib|Silicon/CommonSocPkg/Library/TcoTimerLib/TcoTimerLib.inf',
             'TopSwapLib|Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.inf',
+            'P2sbLib|Silicon/CommonSocPkg/Library/P2sbLib/P2sbLib.inf',
             'WatchDogTimerLib|Silicon/CommonSocPkg/Library/WatchDogTimerLib/WatchDogTimerLib.inf'
         ]
 

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -218,6 +218,7 @@ class Board(BaseBoard):
             'BootGuardLib|Silicon/CommonSocPkg/Library/BootGuardLibCBnT/BootGuardLibCBnT.inf',
             'TcoTimerLib|Silicon/CommonSocPkg/Library/TcoTimerLib/TcoTimerLib.inf',
             'TopSwapLib|Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.inf',
+            'P2sbLib|Silicon/CommonSocPkg/Library/P2sbLib/P2sbLib.inf',
             'WatchDogTimerLib|Silicon/CommonSocPkg/Library/WatchDogTimerLib/WatchDogTimerLib.inf'
         ]
         dsc['PcdsFeatureFlag.%s' % self.BUILD_ARCH] = [

--- a/Platform/RaptorlakeBoardPkg/BoardConfigRplp.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRplp.py
@@ -380,7 +380,8 @@ class Board(BaseBoard):
             'CpuPcieHsPhyInitLib|Silicon/$(SILICON_PKG_NAME)/Library/CpuPcieHsPhyInitLib/CpuPcieHsPhyInitLib.inf',
             'WatchDogTimerLib|Silicon/CommonSocPkg/Library/WatchDogTimerLib/WatchDogTimerLib.inf',
             'TcoTimerLib|Silicon/CommonSocPkg/Library/TcoTimerLib/TcoTimerLib.inf',
-            'TopSwapLib|Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.inf'
+            'TopSwapLib|Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.inf',
+            'P2sbLib|Silicon/CommonSocPkg/Library/P2sbLib/P2sbLib.inf'
         ]
 
         # TXT Library: Use real implementation if TXT_ENABLED, else use NULL stub

--- a/Platform/RaptorlakeBoardPkg/BoardConfigRpls.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRpls.py
@@ -305,7 +305,8 @@ class Board(BaseBoard):
             'CpuPcieHsPhyInitLib|Silicon/$(SILICON_PKG_NAME)/Library/CpuPcieHsPhyInitLib/CpuPcieHsPhyInitLib.inf',
             'WatchDogTimerLib|Silicon/CommonSocPkg/Library/WatchDogTimerLib/WatchDogTimerLib.inf',
             'TcoTimerLib|Silicon/CommonSocPkg/Library/TcoTimerLib/TcoTimerLib.inf',
-            'TopSwapLib|Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.inf'
+            'TopSwapLib|Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.inf',
+            'P2sbLib|Silicon/CommonSocPkg/Library/P2sbLib/P2sbLib.inf'
         ]
 
         # TXT Library: Use real implementation if TXT_ENABLED, else use NULL stub

--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -293,6 +293,7 @@ class Board(BaseBoard):
             'WatchDogTimerLib|Silicon/CommonSocPkg/Library/WatchDogTimerLib/WatchDogTimerLib.inf',
             'TcoTimerLib|Silicon/CommonSocPkg/Library/TcoTimerLib/TcoTimerLib.inf',
             'TopSwapLib|Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.inf',
+            'P2sbLib|Silicon/CommonSocPkg/Library/P2sbLib/P2sbLib.inf',
             'TxtLib|Silicon/$(SILICON_PKG_NAME)/Library/TxtLib/TxtLib.inf'
         ]
 

--- a/Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.c
+++ b/Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.c
@@ -11,83 +11,38 @@
 #include <Library/IoLib.h>
 #include <Library/PcdLib.h>
 #include <Library/BaseLib.h>
+#include <Library/P2sbLib.h>
+#include <Register/P2sbRegs.h>
+#include <Library/PciLib.h>
+#include <Library/BootloaderCommonLib.h>
+#include <Guid/OsBootOptionGuid.h>
 
-#define PCI_DEVICE_NUMBER_PCH_LPC       31
-#define PID_RTC_HOST                    0xC3
 #define R_RTC_PCR_BUC                   0x3414
 
 /**
-  Get the address of P2sb register.
+  Get P2SB device address
 
-  This function get the address of the P2sb register.
+  @retval     Device address for P2SB device. If the device could not be
+              found in the device table, a default P2SB device address is
+              returned.
 
-  @retval  UINTN  The base address of the P2sb register.
 **/
 UINTN
-GetP2sbBase (
+GetP2sbDeviceAddr (
   VOID
   )
 {
-  return MM_PCI_ADDRESS (0, PCI_DEVICE_NUMBER_PCH_LPC, 1, 0);
-}
+  UINTN               P2sbBase;
 
-/**
-  Get the address of the top swap register.
-
-  This function get the address of the top swap register and reports
-  if P2sbBar was unhidden in the process.
-
-  @param[out] TopSwapBase   The base address of the top swap register.
-  @param[out] P2sbWasHidden If P2sbBar needed to be unhidden to get
-                            the address.
-  @retval  EFI_SUCCESS      Address successfully found.
-  @retval  others           Error occurred.
-**/
-EFI_STATUS
-GetTopSwapBase (
-  OUT UINT32    *TopSwapBase,
-  OUT BOOLEAN   *P2sbWasHidden
-  )
-{
-  UINTN   P2sbBase;
-  UINT32  P2sbBar;
-  BOOLEAN P2sbIsHidden;
-
-  if (TopSwapBase == NULL || P2sbWasHidden == NULL) {
-    return EFI_INVALID_PARAMETER;
+  P2sbBase = GetDeviceAddr (PlatformDeviceP2sb, 0);
+  if ((P2sbBase & 0x0FFFFFFF) != 0) {
+    P2sbBase = TO_PCI_LIB_ADDRESS(P2sbBase);
+  } else {
+    DEBUG ((DEBUG_WARN, "P2SB device not found in device table. Use default P2SB device address.\n"));
+    P2sbBase = PCI_LIB_ADDRESS(0, PCI_DEVICE_NUMBER_PCH_P2SB, PCI_FUNCTION_NUMBER_PCH_P2SB, 0);
   }
 
-  P2sbBase = GetP2sbBase ();
-  P2sbIsHidden = FALSE;
-  if (MmioRead16 (P2sbBase) == 0xFFFF) {
-    MmioWrite8 (P2sbBase + 0xE1, 0);
-    DEBUG ((DEBUG_INFO, "P2sbBar is hidden, unhide it\n"));
-    P2sbIsHidden = TRUE;
-  }
-
-
-  P2sbBar = MmioRead32 (P2sbBase + 0x10);
-  P2sbBar  &= 0xFFFFFFF0;
-  if (P2sbBar == 0xFFFFFFF0) {
-    DEBUG ((DEBUG_ERROR, "P2sbBar could not be unhidden!\n"));
-    return EFI_ACCESS_DENIED;
-  }
-
-  *TopSwapBase    = P2sbBar | ((PID_RTC_HOST) << 16) | (UINT16)(R_RTC_PCR_BUC);
-  *P2sbWasHidden  = P2sbIsHidden;
-
-  return EFI_SUCCESS;
-}
-
-/**
-  Hide P2sbBar.
-**/
-VOID
-HideP2sbBar (
-  VOID
-  )
-{
-  MmioWrite8 (GetP2sbBase () + 0xE1, BIT0);
+  return P2sbBase;
 }
 
 /**
@@ -106,23 +61,30 @@ SetBootPartition (
   IN BOOT_PARTITION  Partition
   )
 {
-  EFI_STATUS  Status;
-  UINT32      TopSwapBase;
-  BOOLEAN     P2sbIsHidden;
+  BOOLEAN             P2sbIsHidden;
+  UINT32              AndData;
+  UINT32              OrData;
+  UINTN               P2sbBase;
 
-  Status = GetTopSwapBase (&TopSwapBase, &P2sbIsHidden);
-  if (EFI_ERROR (Status)) {
-    return Status;
+  P2sbBase = GetP2sbDeviceAddr ();
+  P2sbIsHidden = FALSE;
+  if (PciRead16 (P2sbBase) == 0xFFFF) {
+    PciWrite8 (P2sbBase + R_P2SB_CFG_P2SBC + 1, 0);
+    DEBUG ((DEBUG_INFO, "P2SB is hidden, Read VID_DID(0x%x) after unhiding.\n", PciRead32 (P2sbBase)));
+    P2sbIsHidden = TRUE;
   }
 
+  AndData = (UINT32)~BIT0;
   if (Partition == BackupPartition) {
-    MmioOr32 (TopSwapBase, BIT0);
+    OrData = BIT0;
   } else {
-    MmioAnd32 (TopSwapBase, (UINT32)~BIT0);
+    OrData = 0;
   }
+
+  P2SbAndThenOr32 (P2sbBase, PcdGet8 (PcdPidRtcHostNumber), 0, R_RTC_PCR_BUC, AndData, OrData);
 
   if (P2sbIsHidden) {
-    HideP2sbBar ();
+    PciWrite8 (P2sbBase + R_P2SB_CFG_P2SBC + 1, B_P2SB_CFG_P2SBC_HIDE >> 8);
   }
 
   return EFI_SUCCESS;
@@ -144,28 +106,30 @@ GetBootPartition (
   OUT BOOT_PARTITION *Partition
   )
 {
-  EFI_STATUS  Status;
-  UINT32      TopSwapBase;
-  BOOLEAN     P2sbIsHidden;
+  BOOLEAN             P2sbIsHidden;
+  UINT32              RegValue;
+  UINTN               P2sbBase;
 
   if (Partition == NULL) {
     DEBUG ((DEBUG_ERROR, "Partition not initialized!\n"));
     return EFI_INVALID_PARAMETER;
   }
 
-  Status = GetTopSwapBase (&TopSwapBase, &P2sbIsHidden);
-  if (EFI_ERROR (Status)) {
-    return Status;
+  P2sbBase = GetP2sbDeviceAddr ();
+  P2sbIsHidden = FALSE;
+  if (PciRead16 (P2sbBase) == 0xFFFF) {
+    PciWrite8 (P2sbBase + R_P2SB_CFG_P2SBC + 1, 0);
+    DEBUG ((DEBUG_INFO, "P2SB is hidden, Read VID_DID(0x%x) after unhide.\n", PciRead32 (P2sbBase)));
+    P2sbIsHidden = TRUE;
   }
 
-  if (MmioRead32 (TopSwapBase) & BIT0) {
-    *Partition = BackupPartition;
-  } else {
-    *Partition = PrimaryPartition;
-  }
+  RegValue = P2sbRead32 (P2sbBase, PcdGet8 (PcdPidRtcHostNumber), 0, R_RTC_PCR_BUC);
+  *Partition = (BOOT_PARTITION)(RegValue & BIT0);
+
+  DEBUG ((DEBUG_INFO, "*Partition = 0x%x\n", *Partition));
 
   if (P2sbIsHidden) {
-    HideP2sbBar ();
+    PciWrite8(P2sbBase + R_P2SB_CFG_P2SBC + 1, B_P2SB_CFG_P2SBC_HIDE >> 8);
   }
 
   return EFI_SUCCESS;

--- a/Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.inf
+++ b/Silicon/CommonSocPkg/Library/TopSwapLib/TopSwapLib.inf
@@ -28,6 +28,10 @@
   IoLib
   BootloaderCommonLib
   PcdLib
+  P2sbLib
 
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
+
+[FixedPcd]
+  gPlatformCommonLibTokenSpaceGuid.PcdPidRtcHostNumber


### PR DESCRIPTION
Replace direct MMIO-based P2SB bar manipulation in TopSwapLib with P2sbLib API calls. Use GetDeviceAddr() to look up the P2SB device from the platform device table instead of hardcoding PCI BDF, and use P2SB PCI config space to hide/unhide the P2SB bar instead of MMIO writes.

Add PcdPidRtcHostNumber to BootloaderCommonPkg.dec to allow per-platform configuration of the RTC host port ID used to access the RTC PCR BUC register for top swap control.

Update Alderlake, Raptorlake board configs to link P2sbLib with TopSwapLib. Add P2sbLib dependency to TopSwapLib.inf.