### PR TITLE
fix: [MTL] correct ACPI DMAR table

### DIFF
--- a/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -1029,15 +1029,15 @@ DmarTableUpdate (
     return ;
   }
 
-  BaseAddress = ReadVtdBaseAddress(0);
+  BaseAddress = ReadVtdBaseAddress(IGD_VTD);
   Flags   = 0;
-  DmarHdr = AddDrhdHdr (AcpiHeader, Flags, SIZE_64KB, 0, BaseAddress);
+  DmarHdr = AddDrhdHdr (AcpiHeader, Flags, SIZE_4KB, 0, BaseAddress);
   ASSERT (DmarHdr != NULL);
 
   AddScopeData (AcpiHeader, DmarHdr, EFI_ACPI_DEVICE_SCOPE_ENTRY_TYPE_PCI_ENDPOINT, 0, 0, 0, IGD_DEV_NUM, IGD_FUN_NUM);
 
-  BaseAddress = ReadVtdBaseAddress(2);
-  DmarHdr = AddDrhdHdr (AcpiHeader, EFI_ACPI_DMAR_DRHD_FLAGS_INCLUDE_PCI_ALL, SIZE_64KB, 0, BaseAddress);
+  BaseAddress = ReadVtdBaseAddress(IOP_VTD);
+  DmarHdr = AddDrhdHdr (AcpiHeader, EFI_ACPI_DMAR_DRHD_FLAGS_INCLUDE_PCI_ALL, SIZE_4KB, 0, BaseAddress);
   ASSERT (DmarHdr != NULL);
   AddScopeData (AcpiHeader, DmarHdr, EFI_ACPI_DEVICE_SCOPE_ENTRY_TYPE_IOAPIC, 0, 2, V_P2SB_CFG_IBDF_BUS, V_P2SB_CFG_IBDF_DEV, V_P2SB_CFG_IBDF_FUNC);
   AddScopeData (AcpiHeader, DmarHdr, EFI_ACPI_DEVICE_SCOPE_ENTRY_TYPE_MSI_CAPABLE_HPET, 0, 0, V_P2SB_CFG_HBDF_BUS, V_P2SB_CFG_HBDF_DEV, V_P2SB_CFG_HBDF_FUNC);

--- a/Silicon/MeteorlakePkg/Include/Register/VtdRegs.h
+++ b/Silicon/MeteorlakePkg/Include/Register/VtdRegs.h
@@ -12,9 +12,7 @@
 ///
 /// Vt-d Engine base address.
 ///
-#define R_MCHBAR_VTD1_OFFSET                 0x5400  ///< HW UNIT1 for IGD
-#define R_MCHBAR_VTD2_LOW_OFFSET             0x7880  ///< HW UNIT2 for IPU
-#define R_MCHBAR_VTD3_OFFSET                 0x5410  ///< HW UNIT3 for all other - PEG, USB, SATA etc
+#define R_MCHBAR_VTD1_OFFSET                 0x5410  // VT IOMMU VC0
 
 
 #endif

--- a/Silicon/MeteorlakePkg/Library/VTdLib/VTdLib.c
+++ b/Silicon/MeteorlakePkg/Library/VTdLib/VTdLib.c
@@ -39,9 +39,6 @@ GetVtdBarSize (
   Read VTD Engine Base Address from VTD BAR Offsets.
 
   @param[in]  VtdEngineNumber        - Engine number for which VTD Base Adderess is required.
-                                        0 = IGD VT-d (VTD1_OFFSET)
-                                        1 = IPU VT-d (VTD2_LOW_OFFSET) - may not exist on all SKUs
-                                        2 = IOP VT-d (VTD3_OFFSET)
 
   @retval   VTD Engine Base Address
 **/
@@ -57,14 +54,11 @@ ReadVtdBaseAddress (
   MchBar          = PciRead32 ((UINTN)McD0BaseAddress + R_SA_MCHBAR) & (~BIT0);
 
   switch (VtdEngineNumber) {
-    case 0:
-      return (MmioRead32 (MchBar + 0x5400) & (~BIT0));
+    case IGD_VTD:
+      return (MmioRead32 (MchBar + R_MCHBAR_VTD1_OFFSET) & (~BIT0));
       break;
-    case 1:
-      return (MmioRead32 (MchBar + R_MCHBAR_VTD2_LOW_OFFSET) & (~BIT0));
-      break;
-    case 2:
-      return (MmioRead32 (MchBar + 0x5410) & (~BIT0));
+    case IOP_VTD:
+      return ((MmioRead32 (MchBar + R_MCHBAR_VTD1_OFFSET) & (~BIT0)) + GetVtdBarSize());
       break;
     default:
       return 0x0;


### PR DESCRIPTION
SBL failed to boot into Windows when ENABLE_VTD = 1. This resulted from incorrect ACPI DMAR configurations. This patch corrected the VTD BAR and the size of remapping hardware register set.