### PR TITLE
fix: Some firmware updates fail when sbl size exceeds 16MB

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.c
@@ -248,13 +248,24 @@ FwuTopSwapSetting (
   EFI_STATUS        Status;
   UINT32            RsvdBase;
   UINT32            RsvdSize;
-  FW_UPDATE_STATUS  *FwUpdStatus;
+  FW_UPDATE_STATUS  FwUpdStatus;
 
   Status = GetComponentInfoByPartition (FLASH_MAP_SIG_BLRESERVED, FALSE, &RsvdBase, &RsvdSize);
   if (EFI_ERROR (Status)) {
     DEBUG((DEBUG_ERROR, "Could not get component information for bootloader reserved region\n"));
   }
-  FwUpdStatus = (FW_UPDATE_STATUS *)(UINTN)RsvdBase;
+
+  RsvdBase -= PcdGet32(PcdFlashBaseAddress);
+  Status = SpiFlashRead(
+             FlashRegionBios,
+             RsvdBase,
+             sizeof(FW_UPDATE_STATUS),
+             (UINT8*)&FwUpdStatus
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG((DEBUG_ERROR, "Could not get FW Update status from flash\n"));
+    return;
+  }
 
 
   // If in a recovery path, stay on current partition
@@ -262,7 +273,7 @@ FwuTopSwapSetting (
     return;
   }
 
-  switch (FwUpdStatus->StateMachine) {
+  switch (FwUpdStatus.StateMachine) {
     case FW_UPDATE_SM_RECOVERY:
       // This indicates that recovery is in progress
       ASSERT (PcdGetBool (PcdSblResiliencyEnabled));

--- a/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
+++ b/Platform/AlderlakeBoardPkg/Library/Stage1BBoardInitLib/Stage1BBoardInitLib.inf
@@ -95,7 +95,7 @@
   gPlatformAlderLakeTokenSpaceGuid.PcdDisplayId
   gPlatformAlderLakeTokenSpaceGuid.PcdBoardRev
   gPlatformAlderLakeTokenSpaceGuid.PcdMemConfigId
-
+  gPlatformModuleTokenSpaceGuid.PcdFlashBaseAddress
 
 [FixedPcd]
   gPlatformAlderLakeTokenSpaceGuid.PcdAdlLpSupport

--- a/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.c
+++ b/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.c
@@ -275,6 +275,7 @@ CheckStateMachine (
   EFI_STATUS          Status;
   UINT32              RsvdBase;
   UINT32              RsvdSize;
+  FW_UPDATE_STATUS    TempFwUpdStatus;
 
   if (pFwUpdStatus == NULL) {
     Status = GetComponentInfoByPartition (FLASH_MAP_SIG_BLRESERVED, FALSE, &RsvdBase, &RsvdSize);
@@ -282,7 +283,18 @@ CheckStateMachine (
       DEBUG((DEBUG_ERROR, "Could not get component information for bootloader reserved region\n"));
       return Status;
     }
-    pFwUpdStatus = (FW_UPDATE_STATUS *)(UINTN)RsvdBase;
+    RsvdBase -= PcdGet32(PcdFlashBaseAddress);
+    Status = SpiFlashRead(
+              FlashRegionBios,
+              RsvdBase,
+              sizeof(FW_UPDATE_STATUS),
+              (UINT8*)&TempFwUpdStatus
+              );
+    if (EFI_ERROR (Status)) {
+      DEBUG((DEBUG_ERROR, "Could not get FW Update status from flash\n"));
+      return EFI_UNSUPPORTED;
+    }
+    pFwUpdStatus = &TempFwUpdStatus;
   }
 
   //

--- a/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.inf
+++ b/Platform/CommonBoardPkg/Library/BoardSupportLib/BoardSupportLib.inf
@@ -38,3 +38,4 @@
   gPlatformModuleTokenSpaceGuid.PcdCfgDatabaseSize
   gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled
   gPlatformModuleTokenSpaceGuid.PcdGraphicsVbtAddress
+  gPlatformModuleTokenSpaceGuid.PcdFlashBaseAddress


### PR DESCRIPTION
With certain flash layouts when sbl size exceeds 16MB, the FW update status in the SBL reserved region can overflow the memory mapped portion of SPI flash and needs to be read through SPI controller access.