### PR TITLE
fix: [ADL/RPL/BTL] Add NULL check before TXT feature config dereference

### DIFF
--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -625,7 +625,7 @@ BoardInit (
       /// This will update the correct TXT enabled state in ACPI table.
       ///
       FeaturesCfgData = (FEATURES_CFG_DATA *) FindConfigDataByTag(CDATA_FEATURES_TAG);
-      if (FeaturesCfgData->Features.TxtEnabled == 1) {
+      if ((FeaturesCfgData != NULL) && (FeaturesCfgData->Features.TxtEnabled == 1)) {
         if (GetBootMode() != BOOT_ON_S3_RESUME) {
           DEBUG ((DEBUG_INFO, "TXT: Calling InitTxt\n"));
           InitTxt();

--- a/Platform/RaptorlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
+++ b/Platform/RaptorlakeBoardPkg/Library/FspmUpdUpdateLib/FspmUpdUpdateLib.c
@@ -358,7 +358,7 @@ UpdateFspConfig (
 
   // TXT Configuration
   FeaturesCfgData = (FEATURES_CFG_DATA *) FindConfigDataByTag(CDATA_FEATURES_TAG);
-  if ((FeaturesCfgData->Features.TxtEnabled == 1) &&
+  if ((FeaturesCfgData != NULL) && (FeaturesCfgData->Features.TxtEnabled == 1) &&
       (FeaturePcdGet (PcdTxtEnabled))) {
     DEBUG((DEBUG_INFO, "Enabling TXT in FSP-M UPD's\n"));
     Fspmcfg->Txt                  = 0x1;


### PR DESCRIPTION
Static analysis flagged dereferencing FeaturesCfgData to check for TXT support without checking for NULL pointer.