### PR TITLE
feat: [ARLS] enabled POST code for RVP

### DIFF
--- a/Platform/ArrowlakeBoardPkg/CfgData/CfgDataInt_Arls_Sodimm_Rvp_S04.dlt
+++ b/Platform/ArrowlakeBoardPkg/CfgData/CfgDataInt_Arls_Sodimm_Rvp_S04.dlt
@@ -69,7 +69,7 @@ MEMORY_CFG_DATA.PcieClkSrcUsage                 | { 0x80, 0x0, 0x1, 0x2, 0x4, 0x
 MEMORY_CFG_DATA.RMT                             | 0x1
 MEMORY_CFG_DATA.RMC                             | 0x1
 MEMORY_CFG_DATA.UsbTcPortEnPreMem               | 0x3
-MEMORY_CFG_DATA.I2cPostCodeEnable               | 0x1
+MEMORY_CFG_DATA.I2cPostCodeEnable               | 0x0
 MEMORY_CFG_DATA.DqMapCpu2DramMc0Ch0             | { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
 MEMORY_CFG_DATA.DqMapCpu2DramMc0Ch1             | { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
 MEMORY_CFG_DATA.DqMapCpu2DramMc0Ch2             | { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }

--- a/Platform/ArrowlakeBoardPkg/CfgData/CfgDataInt_Arls_UDimm_Rvp_S02.dlt
+++ b/Platform/ArrowlakeBoardPkg/CfgData/CfgDataInt_Arls_UDimm_Rvp_S02.dlt
@@ -70,7 +70,7 @@ MEMORY_CFG_DATA.PchPcieClkSrcUsage              | { 0xFF, 0xFF, 0xFF, 0xFF, 0x0,
 MEMORY_CFG_DATA.RMT                             | 0x1
 MEMORY_CFG_DATA.RMC                             | 0x1
 MEMORY_CFG_DATA.UsbTcPortEnPreMem               | 0x3
-MEMORY_CFG_DATA.I2cPostCodeEnable               | 0x1
+MEMORY_CFG_DATA.I2cPostCodeEnable               | 0x0
 MEMORY_CFG_DATA.DqMapCpu2DramMc0Ch0             | { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
 MEMORY_CFG_DATA.DqMapCpu2DramMc0Ch1             | { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
 MEMORY_CFG_DATA.DqMapCpu2DramMc0Ch2             | { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }

--- a/Platform/ArrowlakeBoardPkg/CfgData/CfgDataInt_Arls_UDimm_Rvp_S03.dlt
+++ b/Platform/ArrowlakeBoardPkg/CfgData/CfgDataInt_Arls_UDimm_Rvp_S03.dlt
@@ -69,7 +69,7 @@ MEMORY_CFG_DATA.PcieClkSrcUsage                 | { 0x80, 0x0, 0x1, 0xFF, 0x4, 0
 MEMORY_CFG_DATA.RMT                             | 0x1
 MEMORY_CFG_DATA.RMC                             | 0x1
 MEMORY_CFG_DATA.UsbTcPortEnPreMem               | 0x3
-MEMORY_CFG_DATA.I2cPostCodeEnable               | 0x1
+MEMORY_CFG_DATA.I2cPostCodeEnable               | 0x0
 MEMORY_CFG_DATA.DqMapCpu2DramMc0Ch0             | { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
 MEMORY_CFG_DATA.DqMapCpu2DramMc0Ch1             | { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
 MEMORY_CFG_DATA.DqMapCpu2DramMc0Ch2             | { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }


### PR DESCRIPTION
The 7-segment LED on ARL-S RVP is controlled by the EC through I/O port 80h (eSPI). This patch corrects the I2cPostCode setting to FSP-M.