### PR TITLE
fixes: Guard checks and robustness fixes across storage, partition, U…

### DIFF
--- a/BootloaderCommonPkg/Library/FatLib/FatLiteLib.c
+++ b/BootloaderCommonPkg/Library/FatLib/FatLiteLib.c
@@ -212,6 +212,10 @@ FatGetCacheBlock (
   CacheBuffer->Lba            = Lba;
   CacheBuffer->Size           = PrivateData->BlockDevice[BlockDeviceNo].BlockSize;
 
+  if ((CacheBuffer->Size == 0) || (CacheBuffer->Size > PEI_FAT_MAX_BLOCK_SIZE)) {
+     return EFI_DEVICE_ERROR;
+  }
+
   //
   // Read in the data
   //

--- a/BootloaderCommonPkg/Library/FitLib/FitLib.c
+++ b/BootloaderCommonPkg/Library/FitLib/FitLib.c
@@ -54,14 +54,20 @@ FitParseFirmwarePropertyData (
   }
 
   for (Index = 0; Index < sizeof (PropertyData32List) / sizeof (PROPERTY_DATA); Index++) {
-    PropertyPtr      = FdtGetProperty (Fdt, TianoNode, PropertyData32List[Index].Name, &TempLen);
+    PropertyPtr = FdtGetProperty (Fdt, TianoNode, PropertyData32List[Index].Name, &TempLen);
+    if ((PropertyPtr == NULL) || (TempLen < (INT32)sizeof (UINT32))) {
+      return EFI_NOT_FOUND;
+    }
     Data32           = (UINT32 *)(PropertyPtr->Data);
     ContextOffset32  = (UINT32 *)((UINTN)Context + PropertyData32List[Index].Offset);
     *ContextOffset32 = Fdt32ToCpu (*Data32);
   }
 
-  for (Index = 0; Index < sizeof (PropertyData64List)/sizeof (PROPERTY_DATA); Index++) {
-    PropertyPtr      = FdtGetProperty (Fdt, TianoNode, PropertyData64List[Index].Name, &TempLen);
+  for (Index = 0; Index < sizeof (PropertyData64List) / sizeof (PROPERTY_DATA); Index++) {
+    PropertyPtr = FdtGetProperty (Fdt, TianoNode, PropertyData64List[Index].Name, &TempLen);
+    if ((PropertyPtr == NULL) || (TempLen < (INT32)sizeof (UINT64))) {
+      return EFI_NOT_FOUND;
+    }
     Data64           = (UINT64 *)(PropertyPtr->Data);
     ContextOffset64  = (UINT64 *)((UINTN)Context + PropertyData64List[Index].Offset);
     *ContextOffset64 = Fdt64ToCpu (*Data64);
@@ -103,8 +109,11 @@ IsFitImage (
 
   Fdt         = ImageBase;
   PropertyPtr = FdtGetProperty (Fdt, 0, "size", &TempLen);
-  Data32      = (UINT32 *)(PropertyPtr->Data);
-  UplSize     = Fdt32ToCpu (*Data32);
+  if ((PropertyPtr == NULL) || (TempLen < (INT32)sizeof (UINT32))) {
+    return FALSE;
+  }
+  Data32  = (UINT32 *)(PropertyPtr->Data);
+  UplSize = Fdt32ToCpu (*Data32);
   ConfigNode  = FdtSubnodeOffsetNameLen (Fdt, 0, "configurations", (INT32)AsciiStrLen ("configurations"));
   if (ConfigNode <= 0) {
     return FALSE;
@@ -116,12 +125,34 @@ IsFitImage (
   }
 
   PropertyPtr = FdtGetProperty (Fdt, Config1Node, "firmware", &TempLen);
-  Firmware    = (CHAR8 *)(PropertyPtr->Data);
+  if ((PropertyPtr == NULL) || (TempLen <= 0)) {
+    return FALSE;
+  }
+  Firmware = (CHAR8 *)(PropertyPtr->Data);
 
-  FitParseFirmwarePropertyData (Fdt, Firmware, Context);
+  if (EFI_ERROR (FitParseFirmwarePropertyData (Fdt, Firmware, Context))) {
+    return FALSE;
+  }
 
-  Context->ImageBase          = (EFI_PHYSICAL_ADDRESS)(UINTN)ImageBase;
-  Context->PayloadSize        = UplSize;
+  Context->ImageBase   = (EFI_PHYSICAL_ADDRESS)(UINTN)ImageBase;
+  Context->PayloadSize = UplSize;
+
+  // Validate entry-start is within the loaded image bounds to prevent a crafted
+  // FIT payload from redirecting Stage2 execution to an arbitrary address.
+  {
+    EFI_PHYSICAL_ADDRESS  ImageEnd;
+
+    if (Context->PayloadSize > MAX_UINT64 - Context->ImageBase) {
+      return FALSE;
+    }
+
+    ImageEnd = Context->ImageBase + Context->PayloadSize;
+    if ((Context->PayloadEntryPoint < Context->ImageBase) ||
+        (Context->PayloadEntryPoint >= ImageEnd)) {
+      return FALSE;
+    }
+  }
+
   Context->RelocateTableCount = (Context->PayloadEntrySize - (Context->RelocateTableOffset - Context->PayloadEntryOffset)) / sizeof (FIT_RELOCATE_ITEM);
 
   return TRUE;

--- a/BootloaderCommonPkg/Library/LitePeCoffLib/LitePeCoffLib.c
+++ b/BootloaderCommonPkg/Library/LitePeCoffLib/LitePeCoffLib.c
@@ -216,8 +216,11 @@ PeCoffRelocateImage (
     BlockSize = * (UINT32 *) (RelocDataPtr + 2);
     RelocDataPtr += 4;
 
-    if (BlockSize == 0) {
-      break;
+    // BlockSize must be >= 8 (4-byte PageRva + 4-byte BlockSize fields) to avoid
+    // unsigned underflow in (BlockSize - 8) used by the inner loop iteration count.
+    // Also reject blocks that exceed the remaining reloc section to prevent OOB reads.
+    if ((BlockSize == 0) || (BlockSize < sizeof (EFI_IMAGE_BASE_RELOCATION)) || (BlockSize > RelocSectionSize)) {
+      return RETURN_UNSUPPORTED;
     }
 
     RelocSectionSize -= sizeof (UINT32) * 2;

--- a/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpress.c
+++ b/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpress.c
@@ -117,9 +117,34 @@ EnumerateNvmeDevNamespace (
     Flbas     = NamespaceData->Flbas;
     LbaFmtIdx = Flbas & 0xF;
     Lbads     = NamespaceData->LbaFormat[LbaFmtIdx].Lbads;
+
+    //
+    // Lbads is device-controlled (UINT8, 0–255).
+    // NVMe spec defines valid sector sizes as 512B–64KB (Lbads 9–16).
+    // Lbads < 9 produces unreasonably small block sizes (1–256 bytes),
+    // causing extreme loop counts and UINT32 Bytes overflows in ReadSectors.
+    // Lbads > 31 would shift a UINT32 by >= 32 bits (undefined behaviour).
+    // Lbads 17–31 produces block sizes (128KB–2GB) that overflow DMA math.
+    //
+    if ((Lbads < 9) || (Lbads > 16)) {
+      DEBUG ((DEBUG_ERROR, "EnumerateNvmeDevNamespace: Invalid Lbads %d for namespace %d\n",
+              Lbads, NamespaceId));
+      Status = EFI_DEVICE_ERROR;
+      goto Exit;
+    }
     Device->Media.BlockSize = (UINT32)1 << Lbads;
 
-    Device->Media.LastBlock                     = NamespaceData->Nsze - 1;
+    //
+    // Nsze = 0 causes LastBlock = UINT64_MAX (wraps),
+    // bypassing the LBA out-of-bounds check in NvmeBlockIoReadBlocks and
+    // allowing reads from arbitrary LBA addresses.
+    //
+    if (NamespaceData->Nsze == 0) {
+      DEBUG ((DEBUG_ERROR, "EnumerateNvmeDevNamespace: Nsze is 0 for namespace %d\n", NamespaceId));
+      Status = EFI_DEVICE_ERROR;
+      goto Exit;
+    }
+    Device->Media.LastBlock = NamespaceData->Nsze - 1;
     Device->Media.LogicalBlocksPerPhysicalBlock = 1;
     Device->Media.LowestAlignedLba              = 1;
 
@@ -142,10 +167,25 @@ EnumerateNvmeDevNamespace (
     Device->StorageSecurity.SendData    = NvmeStorageSecuritySendData;
 
     //
+    // NamespaceId is 1-based and device-controlled via
+    // NvmeIdentifyController Nn field.  Guard the array index to prevent an
+    // out-of-bounds write into adjacent globals when a malicious or buggy
+    // device reports more namespaces than the fixed array can hold.
+    //
+    if (NamespaceId > ARRAY_SIZE (mMultiNvmeDrive)) {
+      DEBUG ((DEBUG_ERROR, "EnumerateNvmeDevNamespace: NamespaceId %d exceeds mMultiNvmeDrive capacity\n",
+              NamespaceId));
+      FreePool (Device);
+      Status = EFI_UNSUPPORTED;
+      goto Exit;
+    }
+
+    //
     // Create DiskInfo Protocol instance
     //
     CopyMem (&Device->NamespaceData, NamespaceData, sizeof (NVME_ADMIN_NAMESPACE_DATA));
     InitializeDiskInfo (Device);
+
     mMultiNvmeDrive[NamespaceId - 1] = Device; //NamespaceId is 1 based
 
     if ((Private->ControllerData->Oacs & SECURITY_SEND_RECEIVE_SUPPORTED) == 0) {
@@ -302,9 +342,13 @@ NvmeInitialize (
 
   if (NvmeInitMode == DevDeinit) {
     if (mNvmeCtrlPrivate != NULL) {
+      //
+      // Save PciBaseAddr before NvmeDeInitialize frees the Private structure.
+      //
+      UINTN SavedPciBase = mNvmeCtrlPrivate->PciBaseAddr;
       NvmeDeInitialize (mNvmeCtrlPrivate);
       // Disable Bus Master
-      MmioAnd16 (mNvmeCtrlPrivate->PciBaseAddr + PCI_COMMAND_OFFSET,
+      MmioAnd16 (SavedPciBase + PCI_COMMAND_OFFSET,
                  (UINT16)~(EFI_PCI_COMMAND_IO_SPACE | EFI_PCI_COMMAND_MEMORY_SPACE | EFI_PCI_COMMAND_BUS_MASTER));
       mNvmeCtrlPrivate = NULL;
     }

--- a/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressBlockIo.c
+++ b/BootloaderCommonPkg/Library/NvmExpressLib/NvmExpressBlockIo.c
@@ -72,6 +72,15 @@ ReadSectors (
 
   Private    = Device->Controller;
   BlockSize  = Device->Media.BlockSize;
+
+  //
+  // Guard against UINT32 overflow in Blocks * BlockSize.
+  // BlockSize >= 512 is guaranteed by the NVME-B Lbads validation, so the
+  // maximum safe Blocks value is 0xFFFFFFFF / BlockSize.
+  //
+  if (BlockSize == 0 || Blocks > (MAX_UINT32 / BlockSize)) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
   Bytes      = Blocks * BlockSize;
 
   ZeroMem (&CommandPacket, sizeof (EFI_NVM_EXPRESS_PASS_THRU_COMMAND_PACKET));
@@ -135,6 +144,13 @@ WriteSectors (
 
   Private    = Device->Controller;
   BlockSize  = Device->Media.BlockSize;
+
+  //
+  // Guard against UINT32 overflow in Blocks * BlockSize.
+  //
+  if (BlockSize == 0 || Blocks > (MAX_UINT32 / BlockSize)) {
+    return EFI_BAD_BUFFER_SIZE;
+  }
   Bytes      = Blocks * BlockSize;
 
   ZeroMem (&CommandPacket, sizeof (EFI_NVM_EXPRESS_PASS_THRU_COMMAND_PACKET));

--- a/BootloaderCommonPkg/Library/PartitionLib/PartitionLib.c
+++ b/BootloaderCommonPkg/Library/PartitionLib/PartitionLib.c
@@ -184,7 +184,7 @@ FindMbrPartitions (
   // We have a valid mbr - add each partition
   //
   for (Index = 0; Index < MAX_MBR_PARTITIONS; Index++) {
-    if (Mbr->Partition[Index].OSIndicator == 0x00 || UNPACK_INT32 (Mbr->Partition[Index].SizeInLBA) == 0) {
+    if (Mbr->Partition[Index].OSIndicator == 0x00 || UNPACK_UINT32 (Mbr->Partition[Index].SizeInLBA) == 0) {
       //
       // Don't use null MBR entries
       //
@@ -192,12 +192,15 @@ FindMbrPartitions (
     }
     //
     // Register this partition
+    // Use UNPACK_UINT32 (not UNPACK_INT32) for SizeInLBA to prevent
+    // sign-extension. A malicious MBR with SizeInLBA set to a large negative
+    // value via UNPACK_INT32 would wrap LastBlock to near UINT64_MAX.
     //
     if (PartBlockDev->BlockDeviceCount < PART_MAX_BLOCK_DEVICE) {
       Status                      = EFI_SUCCESS;
       BlockDev                    = & (PartBlockDev->BlockDevice[PartBlockDev->BlockDeviceCount]);
       BlockDev->StartBlock        = UNPACK_UINT32 (Mbr->Partition[Index].StartingLBA);
-      BlockDev->LastBlock         = BlockDev->StartBlock + UNPACK_INT32 (Mbr->Partition[Index].SizeInLBA) - 1;
+      BlockDev->LastBlock         = BlockDev->StartBlock + UNPACK_UINT32 (Mbr->Partition[Index].SizeInLBA) - 1;
       PartBlockDev->BlockDeviceCount++;
     }
   }
@@ -385,9 +388,67 @@ FindGptPartitions (
     }
   }
 
+  //
+  // Guard all device-controlled GPT header fields
+  // before using them in allocations or loops.
+  //
+  // SizeOfPartitionEntry must be >= sizeof(EFI_PARTITION_ENTRY) (128)
+  // per UEFI spec ("shall be set to 128 x 2^n, n >= 0").
+  //
+  if (Gpt->SizeOfPartitionEntry < sizeof (EFI_PARTITION_ENTRY)) {
+    DEBUG ((DEBUG_ERROR, "FindGptPartitions: SizeOfPartitionEntry %d < %d (invalid)\n",
+            Gpt->SizeOfPartitionEntry, (UINT32)sizeof (EFI_PARTITION_ENTRY)));
+    Status = EFI_UNSUPPORTED;
+    goto Done;
+  }
+
+  // Previously there was a guard for rejecting NumberOfPartitionEntries > 128,
+  // but the UEFI spec allows for more than 128 entries, so we need to allow for that but
+  // still guard against unreasonably large values. So we add back guard to reject unreasonably
+  // large NumberOfPartitionEntries.
+  // The UEFI spec (§5.3.2) requires at least 128 entries but potentially larger value,
+  // so a hard cap at 128 would reject legitimate disks (e.g. some ISO images like Ubuntu
+  // distro or tools that create larger tables).  We use 8192 as a practical upper
+  // bound: with SizeOfPartitionEntry >= 128 this caps the allocation at
+  // around 1 MB, which is still sane for a sbl memory pool, while covering all
+  // potential real-world partition tables.
+  //
+  if (Gpt->NumberOfPartitionEntries > 8192) {
+    DEBUG ((DEBUG_ERROR, "FindGptPartitions: NumberOfPartitionEntries %d > 8192 (unreasonable)\n",
+            Gpt->NumberOfPartitionEntries));
+    Status = EFI_UNSUPPORTED;
+    goto Done;
+  }
+
+  //
+  // Detect UINTN overflow in NumberOfPartitionEntries * SizeOfPartitionEntry.
+  // Both fields are attacker-controlled; a crafted product can wrap to a small
+  // value, causing AllocatePool to succeed for a tiny buffer that
+  // MediaReadBlocks then overflows.
+  //
+  if (Gpt->NumberOfPartitionEntries != 0 &&
+      Gpt->SizeOfPartitionEntry > (MAX_UINTN / Gpt->NumberOfPartitionEntries)) {
+    DEBUG ((DEBUG_ERROR, "FindGptPartitions: ReadSize overflow (Entries=%d Size=%d)\n",
+            Gpt->NumberOfPartitionEntries, Gpt->SizeOfPartitionEntry));
+    Status = EFI_UNSUPPORTED;
+    goto Done;
+  }
+
   ReadSize = (UINTN)Gpt->NumberOfPartitionEntries * Gpt->SizeOfPartitionEntry;
-  ReadSize = (ReadSize % DevBlockInfo->BlockSize) == 0 ? ReadSize : DevBlockInfo->BlockSize * ((
-               ReadSize / DevBlockInfo->BlockSize) + 1);
+
+  //
+  // Detect overflow in the block-size rounding-up step.
+  //
+  if (DevBlockInfo->BlockSize != 0 && (ReadSize % DevBlockInfo->BlockSize) != 0) {
+    UINTN RoundedBlocks = ReadSize / DevBlockInfo->BlockSize + 1;
+    if (RoundedBlocks > (MAX_UINTN / DevBlockInfo->BlockSize)) {
+      DEBUG ((DEBUG_ERROR, "FindGptPartitions: ReadSize rounding overflow\n"));
+      Status = EFI_UNSUPPORTED;
+      goto Done;
+    }
+    ReadSize = DevBlockInfo->BlockSize * RoundedBlocks;
+  }
+
   GptEntries = (EFI_PARTITION_ENTRY *) AllocatePool (ReadSize);
   if (GptEntries == NULL) {
     Status = EFI_OUT_OF_RESOURCES;
@@ -528,6 +589,10 @@ FindPartitions (
     return Status;
   }
 
+  if ((DevBlockInfo.BlockSize == 0) || (DevBlockInfo.BlockSize > PART_MAX_BLOCK_SIZE)) {
+    DEBUG ((DEBUG_ERROR, "Invalid/Unsupported block size: 0x%x\n", DevBlockInfo.BlockSize));
+    return EFI_INVALID_PARAMETER;
+  }
 
   PartBlockDev = (PART_BLOCK_DEVICE *) AllocateZeroPool (sizeof (PART_BLOCK_DEVICE));
   if (PartBlockDev == NULL) {

--- a/BootloaderCommonPkg/Library/UsbBusLib/HubPeim.c
+++ b/BootloaderCommonPkg/Library/UsbBusLib/HubPeim.c
@@ -317,6 +317,17 @@ PeiUsbHubReadDesc (
   }
 
   //
+  // Reject descriptors shorter than the fixed header portion
+  // (7 bytes: Length, DescriptorType, NbrPorts, HubCharacteristics[2],
+  // PwrOn2PwrGood, HubContrCurrent).
+  //
+  if (HubDescriptor->Length < 7) {
+    DEBUG ((DEBUG_ERROR, "PeiUsbHubReadDesc: descriptor Length %d too small (min 7)\n",
+            HubDescriptor->Length));
+    return EFI_DEVICE_ERROR;
+  }
+
+  //
   // Get the whole hub descriptor
   //
   return PeiGetHubDescriptor (PeiServices, PeiUsbDevice, UsbIoPpi, HubDescriptor->Length, HubDescriptor);
@@ -390,7 +401,10 @@ PeiDoHubConfig (
   //
   // The length field of descriptor is UINT8 type, so the buffer
   // with 256 bytes is enough to hold the descriptor data.
+  // Zero-initialize so that uninitialized fields are not used if the device
+  // returns a shorter descriptor than expected.
   //
+  ZeroMem (HubDescBuffer, sizeof (HubDescBuffer));
   HubDescriptor = (EFI_USB_HUB_DESCRIPTOR *) HubDescBuffer;
 
   //
@@ -406,7 +420,15 @@ PeiDoHubConfig (
     return EFI_DEVICE_ERROR;
   }
 
+  //
+  // Cap hub port count to USB spec maximum (15 for HS, 15 for SS)
+  //
   PeiUsbDevice->DownStreamPortNo = HubDescriptor->NbrPorts;
+  if (PeiUsbDevice->DownStreamPortNo > USB_MAX_HUB_PORTS_SUPPORTED) {
+    DEBUG ((DEBUG_ERROR, "PeiDoHubConfig: NbrPorts %d exceeds limit, clamping to %d\n",
+            PeiUsbDevice->DownStreamPortNo, USB_MAX_HUB_PORTS_SUPPORTED));
+    PeiUsbDevice->DownStreamPortNo = USB_MAX_HUB_PORTS_SUPPORTED;
+  }
 
   if (PeiUsbDevice->DeviceSpeed == EFI_USB_SPEED_SUPER) {
     DEBUG ((DEBUG_VERBOSE, "PeiDoHubConfig: Set Hub Depth as 0x%x\n", PeiUsbDevice->Tier));

--- a/BootloaderCommonPkg/Library/UsbBusLib/HubPeim.h
+++ b/BootloaderCommonPkg/Library/UsbBusLib/HubPeim.h
@@ -75,6 +75,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define USB_HUB_REQ_SET_DEPTH               12
 
+#define USB_MAX_HUB_PORTS_SUPPORTED         15
+
 #define MAXBYTES  8
 #pragma pack(1)
 //

--- a/BootloaderCommonPkg/Library/UsbBusLib/UsbPeim.c
+++ b/BootloaderCommonPkg/Library/UsbBusLib/UsbPeim.c
@@ -13,6 +13,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 USB_IO_CALLBACK        mUsbIoCb;
 
+#define USB_MAX_DEVICE_ADDRESS   127
+#define USB_MAX_ENUM_TIER        5
+
 //
 // UsbIo PPI interface function
 //
@@ -207,6 +210,14 @@ PeiHubEnumeration (
         NewPeiUsbDevice->Port             = (UINT8)Index;
         NewPeiUsbDevice->Parent           = &PeiUsbDevice->UsbIoPpi;
 
+        if (NewPeiUsbDevice->Tier > USB_MAX_ENUM_TIER) {
+          DEBUG ((DEBUG_ERROR, "PeiHubEnumeration: Tier %d exceeds max tier %d\n",
+            NewPeiUsbDevice->Tier,
+            USB_MAX_ENUM_TIER));
+          FreePages (NewPeiUsbDevice, MemPages);
+          continue;
+        }
+
         if (((PortStatus.PortChangeStatus & USB_PORT_STAT_C_RESET) == 0) ||
             ((PortStatus.PortStatus & (USB_PORT_STAT_CONNECTION | USB_PORT_STAT_ENABLE)) == 0)) {
           //
@@ -214,12 +225,16 @@ PeiHubEnumeration (
           //
           PeiResetHubPort (PeiServices, UsbIoPpi, (UINT8) (Index + 1));
 
-          PeiHubGetPortStatus (
-            PeiServices,
-            UsbIoPpi,
-            (UINT8) (Index + 1),
-            (UINT32 *) &PortStatus
-            );
+          Status = PeiHubGetPortStatus (
+                     PeiServices,
+                     UsbIoPpi,
+                     (UINT8) (Index + 1),
+                     (UINT32 *) &PortStatus
+                     );
+          if (EFI_ERROR (Status)) {
+            FreePages (NewPeiUsbDevice, MemPages);
+            continue;
+          }
         } else {
           PeiHubClearPortFeature (
             PeiServices,
@@ -262,56 +277,111 @@ PeiHubEnumeration (
                    );
 
         if (EFI_ERROR (Status)) {
+          FreePages (NewPeiUsbDevice, MemPages);
           continue;
         }
         DEBUG ((DEBUG_VERBOSE, "PeiHubEnumeration: PeiConfigureUsbDevice Success\n"));
-
-        Status = PeiServicesInstallPpi (&NewPeiUsbDevice->UsbIoPpiList);
 
         if (NewPeiUsbDevice->InterfaceDesc->InterfaceClass == 0x09) {
           NewPeiUsbDevice->IsHub  = 0x1;
 
           Status = PeiDoHubConfig (PeiServices, NewPeiUsbDevice);
           if (EFI_ERROR (Status)) {
+            FreePages (NewPeiUsbDevice, MemPages);
             return Status;
           }
 
-          PeiHubEnumeration (PeiServices, NewPeiUsbDevice, CurrentAddress);
+          Status = PeiHubEnumeration (PeiServices, NewPeiUsbDevice, CurrentAddress);
+          if (EFI_ERROR (Status)) {
+            FreePages (NewPeiUsbDevice, MemPages);
+            return Status;
+          }
         }
 
-        for (InterfaceIndex = 1; InterfaceIndex < NewPeiUsbDevice->ConfigDesc->NumInterfaces; InterfaceIndex++) {
-          //
-          // Begin to deal with the new device
-          //
-          MemPages = sizeof (PEI_USB_DEVICE) / EFI_PAGE_SIZE + 1;
-          Status = PeiServicesAllocatePages (
-                     EfiBootServicesCode,
-                     MemPages,
-                     &AllocateAddress
-                     );
-          if (EFI_ERROR (Status)) {
-            return EFI_OUT_OF_RESOURCES;
-          }
-          CopyMem ((VOID *) (UINTN)AllocateAddress, NewPeiUsbDevice, sizeof (PEI_USB_DEVICE));
-          NewPeiUsbDevice = (PEI_USB_DEVICE *) ((UINTN) AllocateAddress);
-          NewPeiUsbDevice->AllocateAddress  = (UINTN) AllocateAddress;
-          NewPeiUsbDevice->UsbIoPpiList.Ppi = &NewPeiUsbDevice->UsbIoPpi;
-          NewPeiUsbDevice->InterfaceDesc = NewPeiUsbDevice->InterfaceDescList[InterfaceIndex];
-          for (EndpointIndex = 0; EndpointIndex < NewPeiUsbDevice->InterfaceDesc->NumEndpoints; EndpointIndex++) {
-            NewPeiUsbDevice->EndpointDesc[EndpointIndex] = NewPeiUsbDevice->EndpointDescList[InterfaceIndex][EndpointIndex];
-          }
+        Status = PeiServicesInstallPpi (&NewPeiUsbDevice->UsbIoPpiList);
+        if (EFI_ERROR (Status)) {
+          FreePages (NewPeiUsbDevice, MemPages);
+          continue;
+        }
 
-          Status = PeiServicesInstallPpi (&NewPeiUsbDevice->UsbIoPpiList);
+        {
+          // Keep the original (first-interface) device pointer stable so that
+          // (a) the loop condition is never evaluated against freed memory, and
+          // (b) every clone is always made from the same source, giving a
+          //     constant DataDelta and avoiding chained-delta fragility.
+          PEI_USB_DEVICE  *BaseDevice    = NewPeiUsbDevice;
+          PEI_USB_DEVICE  *ClonedDevice;
+          UINTN            NumInterfaces = BaseDevice->ConfigDesc->NumInterfaces;
+          UINTN            IfIdx;
+          UINTN            EpIdx;
+          INTN             DataDelta;
 
-          if (NewPeiUsbDevice->InterfaceDesc->InterfaceClass == 0x09) {
-            NewPeiUsbDevice->IsHub  = 0x1;
-
-            Status = PeiDoHubConfig (PeiServices, NewPeiUsbDevice);
+          for (InterfaceIndex = 1; InterfaceIndex < NumInterfaces; InterfaceIndex++) {
+            //
+            // Clone the base (first-interface) device for each additional interface.
+            //
+            MemPages = sizeof (PEI_USB_DEVICE) / EFI_PAGE_SIZE + 1;
+            Status = PeiServicesAllocatePages (
+                       EfiBootServicesCode,
+                       MemPages,
+                       &AllocateAddress
+                       );
             if (EFI_ERROR (Status)) {
-              return Status;
+              return EFI_OUT_OF_RESOURCES;
             }
 
-            PeiHubEnumeration (PeiServices, NewPeiUsbDevice, CurrentAddress);
+            CopyMem ((VOID *) (UINTN)AllocateAddress, BaseDevice, sizeof (PEI_USB_DEVICE));
+            ClonedDevice = (PEI_USB_DEVICE *) ((UINTN) AllocateAddress);
+            ClonedDevice->AllocateAddress  = (UINTN) AllocateAddress;
+            ClonedDevice->UsbIoPpiList.Ppi = &ClonedDevice->UsbIoPpi;
+
+            // Relocate all ConfigurationData-relative pointers from the base
+            // allocation to the equivalent offset in the new copy.
+            DataDelta = (INTN)ClonedDevice->ConfigurationData -
+                        (INTN)BaseDevice->ConfigurationData;
+            if (ClonedDevice->ConfigDesc != NULL) {
+              ClonedDevice->ConfigDesc = (EFI_USB_CONFIG_DESCRIPTOR *)((UINT8 *)ClonedDevice->ConfigDesc + DataDelta);
+            }
+
+            for (IfIdx = 0; IfIdx < MAX_INTERFACE; IfIdx++) {
+              if (ClonedDevice->InterfaceDescList[IfIdx] != NULL) {
+                ClonedDevice->InterfaceDescList[IfIdx] =
+                  (EFI_USB_INTERFACE_DESCRIPTOR *)((UINT8 *)ClonedDevice->InterfaceDescList[IfIdx] + DataDelta);
+              }
+              for (EpIdx = 0; EpIdx < MAX_ENDPOINT; EpIdx++) {
+                if (ClonedDevice->EndpointDescList[IfIdx][EpIdx] != NULL) {
+                  ClonedDevice->EndpointDescList[IfIdx][EpIdx] =
+                    (EFI_USB_ENDPOINT_DESCRIPTOR *)((UINT8 *)ClonedDevice->EndpointDescList[IfIdx][EpIdx] + DataDelta);
+                }
+              }
+            }
+
+            ClonedDevice->InterfaceDesc = ClonedDevice->InterfaceDescList[InterfaceIndex];
+            for (EndpointIndex = 0; EndpointIndex < ClonedDevice->InterfaceDesc->NumEndpoints; EndpointIndex++) {
+              ClonedDevice->EndpointDesc[EndpointIndex] = ClonedDevice->EndpointDescList[InterfaceIndex][EndpointIndex];
+            }
+
+            if (ClonedDevice->InterfaceDesc->InterfaceClass == 0x09) {
+              ClonedDevice->IsHub  = 0x1;
+
+              Status = PeiDoHubConfig (PeiServices, ClonedDevice);
+              if (EFI_ERROR (Status)) {
+                FreePages (ClonedDevice, MemPages);
+                return Status;
+              }
+
+              Status = PeiHubEnumeration (PeiServices, ClonedDevice, CurrentAddress);
+              if (EFI_ERROR (Status)) {
+                FreePages (ClonedDevice, MemPages);
+                return Status;
+              }
+            }
+
+            Status = PeiServicesInstallPpi (&ClonedDevice->UsbIoPpiList);
+            if (EFI_ERROR (Status)) {
+              FreePages (ClonedDevice, MemPages);
+              continue;  // safe: BaseDevice is untouched; NumInterfaces is a local
+            }
           }
         }
       }
@@ -354,13 +424,13 @@ PeiUsbEnumeration (
 
   CurrentAddress = 0;
   if (Usb2HcPpi != NULL) {
-    Usb2HcPpi->GetRootHubPortNumber (
+    Status = Usb2HcPpi->GetRootHubPortNumber (
       PeiServices,
       Usb2HcPpi,
       (UINT8 *) &NumOfRootPort
       );
   } else if (UsbHcPpi != NULL) {
-    UsbHcPpi->GetRootHubPortNumber (
+    Status = UsbHcPpi->GetRootHubPortNumber (
       PeiServices,
       UsbHcPpi,
       (UINT8 *) &NumOfRootPort
@@ -370,6 +440,11 @@ PeiUsbEnumeration (
     return EFI_INVALID_PARAMETER;
   }
 
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "PeiUsbEnumeration: GetRootHubPortNumber failed: %r\n", Status));
+    return Status;
+  }
+
   DEBUG ((DEBUG_VERBOSE, "PeiUsbEnumeration: NumOfRootPort: %x\n", NumOfRootPort));
 
   for (Index = 0; Index < NumOfRootPort; Index++) {
@@ -377,20 +452,26 @@ PeiUsbEnumeration (
     // First get root port status to detect changes happen
     //
     if (Usb2HcPpi != NULL) {
-      Usb2HcPpi->GetRootHubPortStatus (
+      Status = Usb2HcPpi->GetRootHubPortStatus (
         PeiServices,
         Usb2HcPpi,
         (UINT8) Index,
         &PortStatus
         );
     } else {
-      UsbHcPpi->GetRootHubPortStatus (
+      Status = UsbHcPpi->GetRootHubPortStatus (
         PeiServices,
         UsbHcPpi,
         (UINT8) Index,
         &PortStatus
         );
     }
+
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "PeiUsbEnumeration: GetRootHubPortStatus failed on port %d: %r\n", Index, Status));
+      continue;
+    }
+
     DEBUG ((DEBUG_VERBOSE, "USB Status --- Port: %x ConnectChange[%04x] Status[%04x]\n", Index, PortStatus.PortChangeStatus,
             PortStatus.PortStatus));
     //
@@ -451,19 +532,24 @@ PeiUsbEnumeration (
             );
 
           if (Usb2HcPpi != NULL) {
-            Usb2HcPpi->GetRootHubPortStatus (
-              PeiServices,
-              Usb2HcPpi,
-              (UINT8) Index,
-              &PortStatus
-              );
+            Status = Usb2HcPpi->GetRootHubPortStatus (
+                       PeiServices,
+                       Usb2HcPpi,
+                       (UINT8) Index,
+                       &PortStatus
+                       );
           } else {
-            UsbHcPpi->GetRootHubPortStatus (
-              PeiServices,
-              UsbHcPpi,
-              (UINT8) Index,
-              &PortStatus
-              );
+            Status = UsbHcPpi->GetRootHubPortStatus (
+                       PeiServices,
+                       UsbHcPpi,
+                       (UINT8) Index,
+                       &PortStatus
+                       );
+          }
+
+          if (EFI_ERROR (Status)) {
+            FreePages (PeiUsbDevice, MemPages);
+            continue;
           }
         } else {
           if (Usb2HcPpi != NULL) {
@@ -507,56 +593,117 @@ PeiUsbEnumeration (
                    );
 
         if (EFI_ERROR (Status)) {
+          FreePages (PeiUsbDevice, MemPages);
           continue;
         }
         DEBUG ((DEBUG_VERBOSE, "PeiUsbEnumeration: PeiConfigureUsbDevice Success\n"));
-
-        Status = PeiServicesInstallPpi (&PeiUsbDevice->UsbIoPpiList);
 
         if (PeiUsbDevice->InterfaceDesc->InterfaceClass == 0x09) {
           PeiUsbDevice->IsHub = 0x1;
 
           Status = PeiDoHubConfig (PeiServices, PeiUsbDevice);
           if (EFI_ERROR (Status)) {
+            FreePages (PeiUsbDevice, MemPages);
             return Status;
           }
 
-          PeiHubEnumeration (PeiServices, PeiUsbDevice, &CurrentAddress);
+          Status = PeiHubEnumeration (PeiServices, PeiUsbDevice, &CurrentAddress);
+          if (EFI_ERROR (Status)) {
+            FreePages (PeiUsbDevice, MemPages);
+            return Status;
+          }
         }
 
-        for (InterfaceIndex = 1; InterfaceIndex < PeiUsbDevice->ConfigDesc->NumInterfaces; InterfaceIndex++) {
-          //
-          // Begin to deal with the new device
-          //
-          MemPages = sizeof (PEI_USB_DEVICE) / EFI_PAGE_SIZE + 1;
-          Status = PeiServicesAllocatePages (
-                     EfiBootServicesCode,
-                     MemPages,
-                     &AllocateAddress
-                     );
-          if (EFI_ERROR (Status)) {
-            return EFI_OUT_OF_RESOURCES;
-          }
-          CopyMem ((VOID *) (UINTN)AllocateAddress, PeiUsbDevice, sizeof (PEI_USB_DEVICE));
-          PeiUsbDevice = (PEI_USB_DEVICE *) ((UINTN) AllocateAddress);
-          PeiUsbDevice->AllocateAddress  = (UINTN) AllocateAddress;
-          PeiUsbDevice->UsbIoPpiList.Ppi = &PeiUsbDevice->UsbIoPpi;
-          PeiUsbDevice->InterfaceDesc = PeiUsbDevice->InterfaceDescList[InterfaceIndex];
-          for (EndpointIndex = 0; EndpointIndex < PeiUsbDevice->InterfaceDesc->NumEndpoints; EndpointIndex++) {
-            PeiUsbDevice->EndpointDesc[EndpointIndex] = PeiUsbDevice->EndpointDescList[InterfaceIndex][EndpointIndex];
-          }
+        //
+        // Install UsbIo PPI for the new device only after successful configuration and hub enumeration
+        //
+        Status = PeiServicesInstallPpi (&PeiUsbDevice->UsbIoPpiList);
+        if (EFI_ERROR (Status)) {
+          FreePages (PeiUsbDevice, MemPages);
+          continue;
+        }
 
-          Status = PeiServicesInstallPpi (&PeiUsbDevice->UsbIoPpiList);
+        {
+          // Keep the original (first-interface) device pointer stable so that
+          // (a) the loop condition is never evaluated against freed memory, and
+          // (b) every clone is always made from the same source, giving a
+          //     constant DataDelta and avoiding chained-delta fragility.
+          PEI_USB_DEVICE  *BaseDevice    = PeiUsbDevice;
+          PEI_USB_DEVICE  *ClonedDevice;
+          UINTN            NumInterfaces = BaseDevice->ConfigDesc->NumInterfaces;
+          UINTN            IfIdx;
+          UINTN            EpIdx;
+          INTN             DataDelta;
 
-          if (PeiUsbDevice->InterfaceDesc->InterfaceClass == 0x09) {
-            PeiUsbDevice->IsHub = 0x1;
-
-            Status = PeiDoHubConfig (PeiServices, PeiUsbDevice);
+          for (InterfaceIndex = 1; InterfaceIndex < NumInterfaces; InterfaceIndex++) {
+            //
+            // Clone the base (first-interface) device for each additional interface.
+            //
+            MemPages = sizeof (PEI_USB_DEVICE) / EFI_PAGE_SIZE + 1;
+            Status = PeiServicesAllocatePages (
+                       EfiBootServicesCode,
+                       MemPages,
+                       &AllocateAddress
+                       );
             if (EFI_ERROR (Status)) {
-              return Status;
+              return EFI_OUT_OF_RESOURCES;
             }
 
-            PeiHubEnumeration (PeiServices, PeiUsbDevice, &CurrentAddress);
+            CopyMem ((VOID *) (UINTN)AllocateAddress, BaseDevice, sizeof (PEI_USB_DEVICE));
+            ClonedDevice = (PEI_USB_DEVICE *) ((UINTN) AllocateAddress);
+            ClonedDevice->AllocateAddress  = (UINTN) AllocateAddress;
+            ClonedDevice->UsbIoPpiList.Ppi = &ClonedDevice->UsbIoPpi;
+
+            // Relocate all ConfigurationData-relative pointers from the base
+            // allocation to the equivalent offset in the new copy.
+            DataDelta = (INTN)ClonedDevice->ConfigurationData -
+                        (INTN)BaseDevice->ConfigurationData;
+            if (ClonedDevice->ConfigDesc != NULL) {
+              ClonedDevice->ConfigDesc = (EFI_USB_CONFIG_DESCRIPTOR *)((UINT8 *)ClonedDevice->ConfigDesc + DataDelta);
+            }
+
+            for (IfIdx = 0; IfIdx < MAX_INTERFACE; IfIdx++) {
+              if (ClonedDevice->InterfaceDescList[IfIdx] != NULL) {
+                ClonedDevice->InterfaceDescList[IfIdx] =
+                  (EFI_USB_INTERFACE_DESCRIPTOR *)((UINT8 *)ClonedDevice->InterfaceDescList[IfIdx] + DataDelta);
+              }
+              for (EpIdx = 0; EpIdx < MAX_ENDPOINT; EpIdx++) {
+                if (ClonedDevice->EndpointDescList[IfIdx][EpIdx] != NULL) {
+                  ClonedDevice->EndpointDescList[IfIdx][EpIdx] =
+                    (EFI_USB_ENDPOINT_DESCRIPTOR *)((UINT8 *)ClonedDevice->EndpointDescList[IfIdx][EpIdx] + DataDelta);
+                }
+              }
+            }
+
+            ClonedDevice->InterfaceDesc = ClonedDevice->InterfaceDescList[InterfaceIndex];
+            for (EndpointIndex = 0; EndpointIndex < ClonedDevice->InterfaceDesc->NumEndpoints; EndpointIndex++) {
+              ClonedDevice->EndpointDesc[EndpointIndex] = ClonedDevice->EndpointDescList[InterfaceIndex][EndpointIndex];
+            }
+
+            if (ClonedDevice->InterfaceDesc->InterfaceClass == 0x09) {
+              ClonedDevice->IsHub = 0x1;
+
+              Status = PeiDoHubConfig (PeiServices, ClonedDevice);
+              if (EFI_ERROR (Status)) {
+                FreePages (ClonedDevice, MemPages);
+                return Status;
+              }
+
+              Status = PeiHubEnumeration (PeiServices, ClonedDevice, &CurrentAddress);
+              if (EFI_ERROR (Status)) {
+                FreePages (ClonedDevice, MemPages);
+                return Status;
+              }
+            }
+
+            //
+            // Install UsbIo PPI for the new device only after successful configuration and hub enumeration
+            //
+            Status = PeiServicesInstallPpi (&ClonedDevice->UsbIoPpiList);
+            if (EFI_ERROR (Status)) {
+              FreePages (ClonedDevice, MemPages);
+              continue;  // safe: BaseDevice is untouched; NumInterfaces is a local
+            }
           }
         }
       } else {
@@ -594,6 +741,7 @@ PeiConfigureUsbDevice (
   EFI_USB_DEVICE_DESCRIPTOR   DeviceDescriptor;
   EFI_STATUS                  Status;
   PEI_USB_IO_PPI              *UsbIoPpi;
+  UINT8                       AssignedAddress;
   UINT8                       Retry;
   UINT8                       StrLoop;
   UINT32                      StrOffset;
@@ -634,12 +782,26 @@ PeiConfigureUsbDevice (
     PeiUsbDevice->MaxPacketSize0 = DeviceDescriptor.MaxPacketSize0;
   }
 
-  (*DeviceAddress) ++;
+  //
+  // MaxPacketSize0 = 0 is never valid per USB 2.0 §9.6.1
+  // (valid: 8, 16, 32, 64) and USB 3.0 §9.6.1 (valid: 512).
+  //
+  if (PeiUsbDevice->MaxPacketSize0 == 0) {
+    DEBUG ((DEBUG_ERROR, "PeiConfigureUsbDevice: MaxPacketSize0 is 0, rejecting device\n"));
+    return EFI_DEVICE_ERROR;
+  }
+
+  if (*DeviceAddress >= USB_MAX_DEVICE_ADDRESS) {
+    DEBUG ((DEBUG_ERROR, "PeiConfigureUsbDevice: USB device address exhausted\n"));
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  AssignedAddress = (UINT8) (*DeviceAddress + 1);
 
   Status = PeiUsbSetDeviceAddress (
              PeiServices,
              UsbIoPpi,
-             *DeviceAddress
+             AssignedAddress
              );
 
   if (EFI_ERROR (Status)) {
@@ -648,7 +810,8 @@ PeiConfigureUsbDevice (
   }
   MicroSecondDelay (USB_SET_DEVICE_ADDRESS_STALL);
 
-  PeiUsbDevice->DeviceAddress = *DeviceAddress;
+  *DeviceAddress = AssignedAddress;
+  PeiUsbDevice->DeviceAddress = AssignedAddress;
 
   //
   // Get whole USB device descriptor
@@ -685,7 +848,10 @@ PeiConfigureUsbDevice (
       StringDescriptor = (EFI_USB_STRING_DESCRIPTOR *)PeiUsbDevice->ConfigurationData;
       StrOffset = OFFSET_OF(EFI_USB_STRING_DESCRIPTOR, String);
       if (StringDescriptor->Length > StrOffset) {
-        WcharCnt = ARRAY_SIZE(PeiUsbDevice->ProductName) - 1;
+        //
+        // Pass the full buffer size (including null terminator slot) to StrnCatS/StrCatS.
+        //
+        WcharCnt = ARRAY_SIZE(PeiUsbDevice->ProductName);
         StrnCatS (PeiUsbDevice->ProductName, WcharCnt,
                   StringDescriptor->String,  (StringDescriptor->Length - StrOffset) / sizeof(CHAR16));
         StrCatS  (PeiUsbDevice->ProductName, WcharCnt, L" ");
@@ -769,6 +935,14 @@ PeiUsbGetAllConfiguration (
   ConfigDescLength  = ConfigDesc->TotalLength;
 
   //
+  // Reject TotalLength values that exceed the fixed ConfigurationData buffer (1024 bytes)
+  //
+  if (ConfigDescLength > sizeof (PeiUsbDevice->ConfigurationData)) {
+    DEBUG ((DEBUG_ERROR, "PeiUsbGetAllConfiguration: ConfigDescLength %d exceeds buffer size\n", ConfigDescLength));
+    return EFI_DEVICE_ERROR;
+  }
+
+  //
   // Then we get the total descriptors for this configuration
   //
   Status = PeiUsbGetDescriptor (
@@ -806,6 +980,20 @@ PeiUsbGetAllConfiguration (
   Ptr += sizeof (EFI_USB_CONFIG_DESCRIPTOR);
   LengthLeft = ConfigDescLength - SkipBytes - sizeof (EFI_USB_CONFIG_DESCRIPTOR);
 
+  //
+  // Reject NumInterfaces values that exceed MAX_INTERFACE or are zero
+  //
+  if (PeiUsbDevice->ConfigDesc->NumInterfaces == 0) {
+    DEBUG ((DEBUG_ERROR, "PeiUsbGetAllConfiguration: NumInterfaces is zero\n"));
+    return EFI_DEVICE_ERROR;
+  }
+
+  if (PeiUsbDevice->ConfigDesc->NumInterfaces > MAX_INTERFACE) {
+    DEBUG ((DEBUG_ERROR, "PeiUsbGetAllConfiguration: NumInterfaces %d exceeds MAX_INTERFACE\n",
+            PeiUsbDevice->ConfigDesc->NumInterfaces));
+    return EFI_DEVICE_ERROR;
+  }
+
   for (InterfaceIndex = 0; InterfaceIndex < PeiUsbDevice->ConfigDesc->NumInterfaces; InterfaceIndex++) {
 
     //
@@ -823,6 +1011,14 @@ PeiUsbGetAllConfiguration (
       return Status;
     }
 
+    //
+    // Guard against LengthLeft underflow before subtracting the skipped bytes and interface descriptor size.
+    //
+    if (LengthLeft < SkipBytes + sizeof (EFI_USB_INTERFACE_DESCRIPTOR)) {
+      DEBUG ((DEBUG_ERROR, "PeiUsbGetAllConfiguration: LengthLeft underflow at interface %d\n", InterfaceIndex));
+      return EFI_DEVICE_ERROR;
+    }
+
     Ptr += SkipBytes;
     if (InterfaceIndex == 0) {
       PeiUsbDevice->InterfaceDesc = (EFI_USB_INTERFACE_DESCRIPTOR *) Ptr;
@@ -837,7 +1033,10 @@ PeiUsbGetAllConfiguration (
     // Parse all the endpoint descriptor within this interface
     //
     NumOfEndpoint = PeiUsbDevice->InterfaceDescList[InterfaceIndex]->NumEndpoints;
-    ASSERT (NumOfEndpoint <= MAX_ENDPOINT);
+    if (NumOfEndpoint > MAX_ENDPOINT) {
+      DEBUG ((DEBUG_ERROR, "PeiUsbGetAllConfiguration: NumEndpoints %d exceeds MAX_ENDPOINT\n", NumOfEndpoint));
+      return EFI_DEVICE_ERROR;
+    }
 
     for (Index = 0; Index < NumOfEndpoint; Index++) {
       //
@@ -855,11 +1054,29 @@ PeiUsbGetAllConfiguration (
         return Status;
       }
 
+      //
+      // Guard against LengthLeft underflow before subtracting
+      // the skipped bytes and endpoint descriptor size.
+      //
+      if (LengthLeft < SkipBytes + sizeof (EFI_USB_ENDPOINT_DESCRIPTOR)) {
+        DEBUG ((DEBUG_ERROR, "PeiUsbGetAllConfiguration: LengthLeft underflow at endpoint %d\n", Index));
+        return EFI_DEVICE_ERROR;
+      }
+
       Ptr += SkipBytes;
       if (InterfaceIndex == 0) {
         PeiUsbDevice->EndpointDesc[Index] = (EFI_USB_ENDPOINT_DESCRIPTOR *) Ptr;
       }
       PeiUsbDevice->EndpointDescList[InterfaceIndex][Index] = (EFI_USB_ENDPOINT_DESCRIPTOR *) Ptr;
+
+      //
+      // MaxPacketSize = 0 is never valid for any endpoint type.
+      //
+      if (PeiUsbDevice->EndpointDescList[InterfaceIndex][Index]->MaxPacketSize == 0) {
+        DEBUG ((DEBUG_ERROR, "PeiUsbGetAllConfiguration: MaxPacketSize 0 at if %d ep %d\n",
+                InterfaceIndex, Index));
+        return EFI_DEVICE_ERROR;
+      }
 
       Ptr += sizeof (EFI_USB_ENDPOINT_DESCRIPTOR);
       LengthLeft -= SkipBytes;

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlN50.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlN50.py
@@ -79,7 +79,7 @@ class Board(AlderlakeBoardConfig.Board):
         self.PAYLOAD_SIZE         = 0x00030000
         self.EPAYLOAD_SIZE        = 0x00240000
 
-        self.OS_LOADER_FD_SIZE    = 0x0005D000
+        self.OS_LOADER_FD_SIZE    = 0x0005E000
         self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.ENABLE_FAST_BOOT = 0

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlPs.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlPs.py
@@ -36,5 +36,5 @@ class Board(AlderlakeBoardConfig.Board):
         # 0 - PCH UART0, 1 - PCH UART1, 2 - PCH UART2, 0xFF - EC UART 0x3F8
         self.DEBUG_PORT_NUMBER = 0x0
 
-        self.OS_LOADER_FD_SIZE = 0x0005D000
+        self.OS_LOADER_FD_SIZE = 0x0005E000
         self.OS_LOADER_FD_NUMBLK = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE

--- a/Platform/ElkhartlakeBoardPkg/BoardConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/BoardConfig.py
@@ -149,7 +149,7 @@ class Board(BaseBoard):
         self.PAYLOAD_EXE_BASE     = 0x00B00000
         self.PAYLOAD_SIZE         = 0x00030000
         self.EPAYLOAD_SIZE        = 0x00162000
-        self.OS_LOADER_FD_SIZE    = 0x0005B000
+        self.OS_LOADER_FD_SIZE    = 0x0005C000
         self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
         self.UCODE_SIZE           = 0x00010000 if self.HAVE_FSP_BIN != 0 else 0
         self.MRCDATA_SIZE         = 0x00008000

--- a/Platform/MeteorlakeBoardPkg/BoardConfigMtlp.py
+++ b/Platform/MeteorlakeBoardPkg/BoardConfigMtlp.py
@@ -124,7 +124,7 @@ class Board(BaseBoard):
         self.STAGE2_FD_BASE       = 0x01000000
         self.STAGE2_FD_SIZE       = 0x001F0000
 
-        self.PAYLOAD_SIZE         = 0x00030000
+        self.PAYLOAD_SIZE         = 0x00031000
         self.EPAYLOAD_SIZE        = 0x00240000
 
         self.ENABLE_FAST_BOOT = 0
@@ -161,7 +161,7 @@ class Board(BaseBoard):
         self.SBLRSVD_SIZE         = 0x00001000
         self.FWUPDATE_SIZE        = 0x00020000 if self.ENABLE_FWU else 0
         # Need a little bit more for full paging table
-        self.OS_LOADER_FD_SIZE    = 0x0005E000
+        self.OS_LOADER_FD_SIZE    = 0x0005F000
         self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         # If BUILD_IDENTICAL_TS is 0, the flash map sizings and layout

--- a/Platform/RaptorlakeBoardPkg/BoardConfigRplPs.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRplPs.py
@@ -38,7 +38,7 @@ class Board(AlderlakeBoardConfig.Board):
         self._MULTI_VBT_FILE      = {1:'VbtRplPsRvp.dat', 2:'VbtRplPsCrb.dat'}
         self._LP_SUPPORT          = True
         self.EPAYLOAD_SIZE        = 0x240000
-        self.OS_LOADER_FD_SIZE    = 0x0005D000
+        self.OS_LOADER_FD_SIZE    = 0x0005E000
         self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         # TXT (Trusted Execution Technology) support

--- a/Platform/RaptorlakeBoardPkg/BoardConfigRplp.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRplp.py
@@ -131,7 +131,7 @@ class Board(BaseBoard):
         self.PAYLOAD_SIZE         = 0x00030000
         self.EPAYLOAD_SIZE        = 0x00240000
 
-        self.OS_LOADER_FD_SIZE    = 0x0005D000
+        self.OS_LOADER_FD_SIZE    = 0x0005E000
         self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.ENABLE_FAST_BOOT = 0

--- a/Platform/RaptorlakeBoardPkg/BoardConfigRpls.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRpls.py
@@ -125,7 +125,7 @@ class Board(BaseBoard):
 
         self.PAYLOAD_SIZE         = 0x00032000
         self.EPAYLOAD_SIZE        = 0x00240000
-        self.OS_LOADER_FD_SIZE    = 0x0005E000
+        self.OS_LOADER_FD_SIZE    = 0x0005F000
         self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.ENABLE_FAST_BOOT = 0

--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -128,7 +128,7 @@ class Board(BaseBoard):
             self.STAGE1B_SIZE         = 0x00180000
             self.STAGE2_SIZE          = 0x00110000
             self.STAGE2_FD_SIZE       = 0x00200000
-            self.OS_LOADER_FD_SIZE    = 0x0005B000
+            self.OS_LOADER_FD_SIZE    = 0x0005C000
             self.PAYLOAD_SIZE         = 0x00080000
 
         if self.ENABLE_SOURCE_DEBUG:

--- a/Silicon/ApollolakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
+++ b/Silicon/ApollolakePkg/Library/FirmwareUpdateLib/FirmwareUpdateLib.c
@@ -93,7 +93,7 @@ MarkBootParitionBpdt (
   }
 
   BpdtHeader->Signature = HeaderState;
-  if (HeaderSize != 0) {
+  if (HeaderSize != NULL) {
     *HeaderSize           = BPDT_SIZE;
   }
   return EFI_SUCCESS;
@@ -126,6 +126,9 @@ PlatformGetStage1AOffset (
 {
   EFI_STATUS                   Status;
   UINT32                       Offset;
+  UINT32                       FlashMapOffset;
+  UINT32                       FlashMapLimit;
+  UINT32                       EntryEnd;
   UINT8                       *Ptr;
   UINT32                       Index;
   UINT32                       RgnBase;
@@ -145,29 +148,67 @@ PlatformGetStage1AOffset (
   }
 
   // Search for Flash Map signature in image
+  Status      = EFI_NOT_FOUND;
   FlashMapPtr = NULL;
   Ptr         = (UINT8 *)((UINTN)ImageHdr + sizeof(EFI_FW_MGMT_CAP_IMAGE_HEADER));
   BpOffset    = IsBackupPartition ? (RgnSize >> 1) : 0;
+  if (ImageHdr->UpdateImageSize < (FLASH_MAP_IN_FV_OFFSET + sizeof (UINT32))) {
+    DEBUG((DEBUG_ERROR, "Capsule image too small to contain flash map signature\n"));
+    return EFI_COMPROMISED_DATA;
+  }
+
+  FlashMapLimit = ImageHdr->UpdateImageSize - (FLASH_MAP_IN_FV_OFFSET + sizeof (UINT32));
   for (Offset = BpOffset; Offset < ImageHdr->UpdateImageSize; Offset += SIZE_4KB) {
-     if (*(UINT32 *)(Ptr + Offset + FLASH_MAP_IN_FV_OFFSET) == FLASH_MAP_SIG_HEADER) {
+     if (Offset > FlashMapLimit) {
+       break;
+     }
+
+     FlashMapOffset = Offset + FLASH_MAP_IN_FV_OFFSET;
+     if (*(UINT32 *)(Ptr + FlashMapOffset) == FLASH_MAP_SIG_HEADER) {
         // This is flash map
-        FlashMapPtr = (FLASH_MAP *)(Ptr + Offset + FLASH_MAP_IN_FV_OFFSET);
+        FlashMapPtr = (FLASH_MAP *)(Ptr + FlashMapOffset);
         break;
      }
   }
 
   if (FlashMapPtr != NULL) {
+    FlashMapOffset = (UINT32)((UINTN)FlashMapPtr - (UINTN)Ptr);
+    if ((ImageHdr->UpdateImageSize - FlashMapOffset) < FLASH_MAP_HEADER_SIZE) {
+      DEBUG((DEBUG_ERROR, "Flash map header exceeds capsule image bounds\n"));
+      return EFI_COMPROMISED_DATA;
+    }
+
+    if ((FlashMapPtr->Length < FLASH_MAP_HEADER_SIZE) ||
+        (FlashMapPtr->Length > (ImageHdr->UpdateImageSize - FlashMapOffset))) {
+      DEBUG((DEBUG_ERROR, "Flash map length out of capsule bounds: 0x%x\n", FlashMapPtr->Length));
+      return EFI_COMPROMISED_DATA;
+    }
+
     // Search for Stage1A in flash map
     MaxEntries = ((FlashMapPtr->Length - FLASH_MAP_HEADER_SIZE) / sizeof (FLASH_MAP_ENTRY_DESC));
     for (Index = 0; Index < MaxEntries; Index++) {
       EntryDesc = FlashMapPtr->EntryDesc[Index];
       if (EntryDesc.Signature == FLASH_MAP_SIG_STAGE1A) {
+        if ((EntryDesc.Size > 0) && (EntryDesc.Offset > (MAX_UINT32 - EntryDesc.Size))) {
+          DEBUG((DEBUG_ERROR, "Stage1A entry size causes overflow\n"));
+          return EFI_COMPROMISED_DATA;
+        }
+        EntryEnd = EntryDesc.Offset + EntryDesc.Size;
+        if ((EntryEnd < EntryDesc.Offset) || (EntryEnd > ImageHdr->UpdateImageSize)) {
+          DEBUG((DEBUG_ERROR, "Stage1A entry out of capsule bounds: Offset=0x%x Size=0x%x Payload=0x%x\n",
+                EntryDesc.Offset, EntryDesc.Size, ImageHdr->UpdateImageSize));
+          return EFI_COMPROMISED_DATA;
+        }
+
         *Base  = (UINT32)(UINTN)(Ptr + EntryDesc.Offset);
         *Size  = EntryDesc.Size;
         Status = EFI_SUCCESS;
         break;
       }
     }
+  } else {
+    DEBUG((DEBUG_ERROR, "Could not find flash map in capsule image\n"));
+    Status = EFI_NOT_FOUND;
   }
 
   if (EFI_ERROR(Status)) {


### PR DESCRIPTION
…SB, and firmware-update libs

Add defensive guard checks and fix edge-case handling in multiple libraries to improve stability and prevent null/overflow errors. Updates touch NvmExpress (NvmExpress.c, NvmExpressBlockIo.c), PartitionLib (PartitionLib.c), USB PEIMs (HubPeim.c, UsbPeim.c), and FirmwareUpdateLib, consolidating misc hardening and validation improvements across the bootloader.