### PR TITLE
fix: Check for invalid container data pointer from raw partition

### DIFF
--- a/PayloadPkg/OsLoader/LoadImage.c
+++ b/PayloadPkg/OsLoader/LoadImage.c
@@ -220,6 +220,12 @@ GetBootImageFromRawPartition (
   //
   Address =  LogicBlkDev.StartBlock + LbaAddr + AlignedHeaderBlkCnt;
 
+  if (AlignedImageSize <= AlignedHeaderSize) {
+    DEBUG((DEBUG_ERROR, "Invalid image size (0x%x) from header, which is smaller than header size (0x%x)\n", AlignedImageSize, AlignedHeaderSize));
+    FreePages (Buffer, EFI_SIZE_TO_PAGES (AlignedImageSize));
+    return EFI_UNSUPPORTED;
+  }
+
   Status = MediaReadBlocks (
              BootOption->HwPart,
              Address,


### PR DESCRIPTION
When reading container from a raw partition, make sure the container image data pointer is valid.