### PR TITLE
[CryptoLib]Added PEIM binary alignment for AVX2 instructions

### DIFF
--- a/BootloaderCorePkg/BootloaderCorePkg.fdf
+++ b/BootloaderCorePkg/BootloaderCorePkg.fdf
@@ -260,7 +260,7 @@ FV = OsLoader
 ################################################################################
 [Rule.Common.PEIM]
   FILE PEIM = $(NAMED_GUID) {
-    TE  TE  Align=16  $(INF_OUTPUT)/$(MODULE_NAME).efi
+    TE  TE  Align=32  $(INF_OUTPUT)/$(MODULE_NAME).efi
   }
 
 [Rule.Common.SEC.RESET_VECTOR]


### PR DESCRIPTION
L9/AVX2 instructions require 32 byte alignment for optimal performance. This patch adds alignment to the Stage2 binary to ensure that the AVX2 instructions are properly aligned and does not throw alignment-related exceptions.