### PR TITLE
fix: [KSV] Fix build failure

### DIFF
--- a/Platform/KaseyvilleBoardPkg/BoardConfigKsv.py
+++ b/Platform/KaseyvilleBoardPkg/BoardConfigKsv.py
@@ -167,8 +167,7 @@ class Board(BaseBoard):
 
         self.NON_REDUNDANT_SIZE   = 0x01000000
 
-        # Need a little bit more for full paging table
-        self.OS_LOADER_FD_SIZE    = 0x0005E000
+        self.OS_LOADER_FD_SIZE    = 0x00060000
         self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.SLIMBOOTLOADER_SIZE  = 0x01000000 # 16 MB

--- a/Platform/KaseyvilleBoardPkg/Library/Stage2BoardInitLib/AcpiTablesInit.c
+++ b/Platform/KaseyvilleBoardPkg/Library/Stage2BoardInitLib/AcpiTablesInit.c
@@ -488,6 +488,7 @@ PatchCpuPmSsdtTable (
 **/
 STATIC
 UINT32
+EFIAPI
 CalculateRelativePower (
   IN  UINT16  BaseRatio,
   IN  UINT16  CurrRatio,


### PR DESCRIPTION
Fixed build failure due to missing EFIAPI in CalculateRelativePower function and insufficient osloader size.