### PR TITLE
[CryptoLib] Update x86intrin.h to support GCC backward compatibility

### DIFF
--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/x86intrin.h
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/x86intrin.h
@@ -12,7 +12,27 @@
 // IppCryptoSupport.h's 'size_t' typedef (UINTN vs system size_t)
 #define _MM_MALLOC_H_INCLUDED
 // Provide LZCNT and other GP-register intrinsics (_lzcnt_u32 etc.)
+// x86gprintrin.h might be missing on some GCC toolchain images.
+#if defined(__has_include) && __has_include(<x86gprintrin.h>)
 #include <x86gprintrin.h>
+#else
+// Fallback: provide only the GP-register intrinsics used by ipp-crypto.
+#ifndef IPP_SBL_LZCNT_INTRINSICS_DEFINED
+#define IPP_SBL_LZCNT_INTRINSICS_DEFINED
+
+static __inline__ unsigned int __attribute__((__always_inline__))
+_lzcnt_u32 (unsigned int __X)
+{
+  return __builtin_ia32_lzcnt_u32 (__X);
+}
+
+static __inline__ unsigned long long __attribute__((__always_inline__))
+_lzcnt_u64 (unsigned long long __X)
+{
+  return __builtin_ia32_lzcnt_u64 (__X);
+}
+#endif /* IPP_SBL_LZCNT_INTRINSICS_DEFINED */
+#endif
 // Provide SSE2 vector types (__m128i etc.) and intrinsics needed by ipp-crypto
 #include <emmintrin.h>
 #endif


### PR DESCRIPTION
•	Added __has_include guard around the <x86gprintrin.h> include — this macro is available in GCC 5+ so it works on all supported toolchains. •	When <x86gprintrin.h> is not available (older GCC, or one with incomplete header packages like the CI's GCC 9.4.0 image), it falls throug to a fallback block that includes <immintrin.h> and manually declares _lzcnt_u32/_lzcnt_u64 using the underlying builtins — exactly what ipp-crypto needs from that header.
•	When <x86gprintrin.h> is available (newer or more complete GCC installs), the original include path is used unchanged.