### PR TITLE
[EHL] Skip ACPI _PSS when EIST is disabled

### DIFF
--- a/Platform/ElkhartlakeBoardPkg/AcpiTables/CpuSsdt/Cpu0Ist.asl
+++ b/Platform/ElkhartlakeBoardPkg/AcpiTables/CpuSsdt/Cpu0Ist.asl
@@ -18,6 +18,7 @@ DefinitionBlock (
 {
   External(\_SB.OSCP, IntObj)
   External(\TCNT, FieldUnitObj)
+  External(\_SB.CFGD, IntObj)
   External(\_SB.CPPC, FieldUnitObj)
   External(\_SB.PR00, DeviceObj)
 
@@ -49,6 +50,14 @@ DefinitionBlock (
     //
     Method(_PSS,0)
     {
+      //
+      // If EIST is disabled, do not expose placeholder P-state data.
+      //
+      If (LNot(And(\_SB.CFGD, PPM_EIST)))
+      {
+        Return (Package(0) {})
+      }
+
       If(And(\_SB.OSCP,0x0400))
       {
         Return (TPSS)

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/UpdateAcpiTable.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/UpdateAcpiTable.c
@@ -463,7 +463,11 @@ PlatformUpdateAcpiTable (
     PatchCpuSsdtTable (Table, GlobalNvs);
   } else if (Table->OemTableId == SIGNATURE_64 ('C', 'p', 'u', '0', 'I', 's', 't', 0)) {
     if (GetBootMode () != BOOT_ON_FLASH_UPDATE) {
-      AcpiPatchPss (Table, GlobalNvs);
+      if ((GlobalNvs->CpuNvs.PpmFlags & PPM_EIST) != 0) {
+        AcpiPatchPss (Table, GlobalNvs);
+      } else {
+        DEBUG ((DEBUG_INFO, "Skip Cpu0Ist _PSS patch because EIST is disabled\n"));
+      }
     }
   } else if (Table->Signature == EFI_BDAT_TABLE_SIGNATURE) {
     FspHobList = GetFspHobListPtr ();


### PR DESCRIPTION
Prevent invalid CPU performance-state ACPI data from being exposed when EIST is disabled.

This change:

-skips _PSS ACPI patching when EIST is disabled
-makes _PSS return no performance states when EIST is disabled

Signed-off-by: samihahkasim [samihah.kasim@intel.com](mailto:samihah.kasim@intel.com)