### PR TITLE
feat: [ASL] Update for ASL MR6/TWL MR3

### DIFF
--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
@@ -23,8 +23,8 @@ class Board(BaseBoard):
         super(Board, self).__init__(*args, **kwargs)
 
         self.VERINFO_IMAGE_ID     = 'SB_ASL'
-        self.VERINFO_PROJ_MAJOR_VER = 2
-        self.VERINFO_PROJ_MINOR_VER = 5
+        self.VERINFO_PROJ_MAJOR_VER = 1
+        self.VERINFO_PROJ_MINOR_VER = 6
         self.VERINFO_SVN            = 1
         self.VERINFO_BUILD_DATE     = time.strftime("%m/%d/%Y")
 

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlPs.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlPs.py
@@ -24,6 +24,7 @@ class Board(AlderlakeBoardConfig.Board):
         self.BOARD_NAME           = 'adlps'
         self.VERINFO_PROJ_MAJOR_VER = 1
         self.VERINFO_PROJ_MINOR_VER = 6
+        self.FSP_IMAGE_ID         = '$RPLFSPE'
         self._EXTRA_INC_PATH      = ['Silicon/AlderlakePkg/Adlps/Include']
         self._FSP_PATH_NAME       = 'Silicon/AlderlakePkg/Adlps/FspBin'
         self.MICROCODE_INF_FILE   = 'Silicon/AlderlakePkg/Microcode/Microcode.inf'

--- a/Silicon/AlderlakePkg/FspBin/FspBin.inf
+++ b/Silicon/AlderlakePkg/FspBin/FspBin.inf
@@ -11,7 +11,7 @@
 
 [UserExtensions.SBL."CloneRepo"]
   REPO    = https://github.com/intel/FSP.git
-  COMMIT  = 45e148caeda52100d63dabe46b20e259ad0e4dd2
+  COMMIT  = 2baff97c11a4777aab0cd8992ea29ce528b4fcfb
 
 
 [UserExtensions.SBL."CopyList"]


### PR DESCRIPTION
- FSP: ADL-N IPU 2026.3 v7113_51 (0C.E2.8A.40)
- Microcode: m_19_b06e0_00000021
- platform version: SB_ASL-1.6
- 
Signed-off-by: samihahkasim <samihah.kasim@intel.com>