### PR TITLE
feat: [RPL/BTL/ARL] Disable OS Loader shell in release builds

### DIFF
--- a/Platform/ArrowlakeBoardPkg/CfgData/CfgDataInt_Arlp_Lpddr5_Rvp.dlt
+++ b/Platform/ArrowlakeBoardPkg/CfgData/CfgDataInt_Arlp_Lpddr5_Rvp.dlt
@@ -16,7 +16,7 @@ PLATFORMID_CFG_DATA.PlatformId                  | 0x19
 PLAT_NAME_CFG_DATA.PlatformName                 | 'ArlhLp5'
 GEN_CFG_DATA.PayloadId                          | ''
 GEN_CFG_DATA.VbtImageId                         | 2
-GEN_CFG_DATA.BootToShell                        | 1
+GEN_CFG_DATA.BootToShell                        | 0
 
 # FIPS mode enablement feature
 FEATURES_CFG_DATA.Features.MeFipsMode           | 0

--- a/Platform/ArrowlakeBoardPkg/CfgData/CfgDataInt_Arlp_Sodimm_Crb.dlt
+++ b/Platform/ArrowlakeBoardPkg/CfgData/CfgDataInt_Arlp_Sodimm_Crb.dlt
@@ -16,7 +16,7 @@ PLATFORMID_CFG_DATA.PlatformId           | 0x1A
 PLAT_NAME_CFG_DATA.PlatformName          | 'ArlhCRB'
 GEN_CFG_DATA.PayloadId                   | ''
 GEN_CFG_DATA.VbtImageId                  | 1
-GEN_CFG_DATA.BootToShell                 | 1
+GEN_CFG_DATA.BootToShell                 | 0
 
 # FIPS mode enablement feature
 FEATURES_CFG_DATA.Features.MeFipsMode           | 0

--- a/Platform/ArrowlakeBoardPkg/CfgData/CfgDataInt_Arlp_Sodimm_Island.dlt
+++ b/Platform/ArrowlakeBoardPkg/CfgData/CfgDataInt_Arlp_Sodimm_Island.dlt
@@ -16,7 +16,7 @@ PLATFORMID_CFG_DATA.PlatformId                  | 0x001B
 PLAT_NAME_CFG_DATA.PlatformName                 | 'ArlhIsd'
 GEN_CFG_DATA.PayloadId                          | 'UEFI'
 GEN_CFG_DATA.VbtImageId                         | 3
-GEN_CFG_DATA.BootToShell                        | 1
+GEN_CFG_DATA.BootToShell                        | 0
 SILICON_CFG_DATA.EcAvailable                    | 0x0
 
 # FIPS mode enablement feature

--- a/Platform/ArrowlakeBoardPkg/CfgData/CfgDataInt_Arlp_Sodimm_Rvp.dlt
+++ b/Platform/ArrowlakeBoardPkg/CfgData/CfgDataInt_Arlp_Sodimm_Rvp.dlt
@@ -16,7 +16,7 @@ PLATFORMID_CFG_DATA.PlatformId                  | 0x0018
 PLAT_NAME_CFG_DATA.PlatformName                 | 'ArlhRVP'
 GEN_CFG_DATA.PayloadId                          | ''
 GEN_CFG_DATA.VbtImageId                         | 2
-GEN_CFG_DATA.BootToShell                        | 1
+GEN_CFG_DATA.BootToShell                        | 0
 
 # FIPS mode enablement feature
 FEATURES_CFG_DATA.Features.MeFipsMode           | 0

--- a/Platform/ArrowlakeBoardPkg/CfgData/CfgDataInt_Arls_Sodimm_Rvp_S04.dlt
+++ b/Platform/ArrowlakeBoardPkg/CfgData/CfgDataInt_Arls_Sodimm_Rvp_S04.dlt
@@ -16,7 +16,7 @@ PLATFORMID_CFG_DATA.PlatformId                  | 0x0015
 PLAT_NAME_CFG_DATA.PlatformName                 | 'ArlsRVP'
 GEN_CFG_DATA.PayloadId                          | ''
 GEN_CFG_DATA.VbtImageId                         | 3
-GEN_CFG_DATA.BootToShell                        | 1
+GEN_CFG_DATA.BootToShell                        | 0
 
 # FIPS mode enablement feature
 FEATURES_CFG_DATA.Features.MeFipsMode           | 0

--- a/Platform/ArrowlakeBoardPkg/CfgData/CfgDataInt_Arls_UDimm_Rvp_S02.dlt
+++ b/Platform/ArrowlakeBoardPkg/CfgData/CfgDataInt_Arls_UDimm_Rvp_S02.dlt
@@ -16,7 +16,7 @@ PLATFORMID_CFG_DATA.PlatformId                  | 0x0017
 PLAT_NAME_CFG_DATA.PlatformName                 | 'MtlsRvp'
 GEN_CFG_DATA.PayloadId                          | ''
 GEN_CFG_DATA.VbtImageId                         | 1
-GEN_CFG_DATA.BootToShell                        | 1
+GEN_CFG_DATA.BootToShell                        | 0
 
 # FIPS mode enablement feature
 FEATURES_CFG_DATA.Features.MeFipsMode           | 0

--- a/Platform/ArrowlakeBoardPkg/CfgData/CfgDataInt_Arls_UDimm_Rvp_S03.dlt
+++ b/Platform/ArrowlakeBoardPkg/CfgData/CfgDataInt_Arls_UDimm_Rvp_S03.dlt
@@ -16,7 +16,7 @@ PLATFORMID_CFG_DATA.PlatformId                  | 0x0016
 PLAT_NAME_CFG_DATA.PlatformName                 | 'ArlsRVP3'
 GEN_CFG_DATA.PayloadId                          | ''
 GEN_CFG_DATA.VbtImageId                         | 2
-GEN_CFG_DATA.BootToShell                        | 1
+GEN_CFG_DATA.BootToShell                        | 0
 
 # FIPS mode enablement feature
 FEATURES_CFG_DATA.Features.MeFipsMode           | 0

--- a/Platform/RaptorlakeBoardPkg/CfgData/CfgDataExt_Rplp_Rki.dlt
+++ b/Platform/RaptorlakeBoardPkg/CfgData/CfgDataExt_Rplp_Rki.dlt
@@ -16,7 +16,7 @@ PLATFORMID_CFG_DATA.PlatformId           | 0x001F
 PLAT_NAME_CFG_DATA.PlatformName          | 'RPLP RKI'
 GEN_CFG_DATA.PayloadId                   | ''
 FEATURES_CFG_DATA.Features.S0ix          | 0x0
-GEN_CFG_DATA.BootToShell                 | 1
+GEN_CFG_DATA.BootToShell                 | 0
 
 # BIOS workaround for S3 support with VTD enabled
 # Fix is expected in RPL-S client MR1 release, then this can be removed.

--- a/Platform/RaptorlakeBoardPkg/CfgData/CfgDataExt_Rplp_Upx12.dlt
+++ b/Platform/RaptorlakeBoardPkg/CfgData/CfgDataExt_Rplp_Upx12.dlt
@@ -16,7 +16,7 @@ PLATFORMID_CFG_DATA.PlatformId           | 0x014
 PLAT_NAME_CFG_DATA.PlatformName          | 'UPXi12Rp'
 GEN_CFG_DATA.PayloadId                   | ''
 FEATURES_CFG_DATA.Features.S0ix          | 0x0
-GEN_CFG_DATA.BootToShell                 | 1
+GEN_CFG_DATA.BootToShell                 | 0
 
 # BIOS workaround for S3 support with VTD enabled.
 # Fix is expected in RPL-S client MR1 release, then this can be removed.

--- a/Platform/RaptorlakeBoardPkg/CfgData/CfgDataInt_Rplp_Crb_Ddr5.dlt
+++ b/Platform/RaptorlakeBoardPkg/CfgData/CfgDataInt_Rplp_Crb_Ddr5.dlt
@@ -16,7 +16,7 @@ PLATFORMID_CFG_DATA.PlatformId           | 0x0008
 PLAT_NAME_CFG_DATA.PlatformName          | 'RPLP CRB'
 GEN_CFG_DATA.PayloadId                   | ''
 FEATURES_CFG_DATA.Features.S0ix          | 0x0
-GEN_CFG_DATA.BootToShell                 | 1
+GEN_CFG_DATA.BootToShell                 | 0
 
 # BIOS workaround for S3 support with VTD enabled
 # Fix is expected in RPL-S client MR1 release, then this can be removed.

--- a/Platform/RaptorlakeBoardPkg/CfgData/CfgDataInt_Rplp_Rvp_Ddr5.dlt
+++ b/Platform/RaptorlakeBoardPkg/CfgData/CfgDataInt_Rplp_Rvp_Ddr5.dlt
@@ -16,7 +16,7 @@ PLATFORMID_CFG_DATA.PlatformId           | 0x0012
 PLAT_NAME_CFG_DATA.PlatformName          | 'RPLPDDR5'
 GEN_CFG_DATA.PayloadId                   | ''
 FEATURES_CFG_DATA.Features.S0ix          | 0x0
-GEN_CFG_DATA.BootToShell                 | 1
+GEN_CFG_DATA.BootToShell                 | 0
 
 # BIOS workaround for S3 support with VTD enabled
 # Fix is expected in RPL-S client MR1 release, then this can be removed.

--- a/Platform/RaptorlakeBoardPkg/CfgData/CfgDataInt_Rplp_Rvp_Lpddr5.dlt
+++ b/Platform/RaptorlakeBoardPkg/CfgData/CfgDataInt_Rplp_Rvp_Lpddr5.dlt
@@ -426,7 +426,7 @@ GPIO_CFG_DATA.GpioPinConfig1_GPD09.GPIOSkip_GPD09 | 1
 GPIO_CFG_DATA.GpioPinConfig1_GPD10.GPIOSkip_GPD10 | 1
 GPIO_CFG_DATA.GpioPinConfig1_GPD11.GPIOSkip_GPD11 | 1
 GPIO_CFG_DATA.GpioPinConfig1_GPD12.GPIOSkip_GPD12 | 1
-GEN_CFG_DATA.BootToShell  |1
+GEN_CFG_DATA.BootToShell  |0
 
 # Set 'TxtEnabled' to '1' for TXT Feature enablement
 FEATURES_CFG_DATA.Features.TxtEnabled                       | 0

--- a/Platform/RaptorlakeBoardPkg/CfgData/CfgDataInt_Rpls_Rvp_Ddr5.dlt
+++ b/Platform/RaptorlakeBoardPkg/CfgData/CfgDataInt_Rpls_Rvp_Ddr5.dlt
@@ -17,7 +17,7 @@ PLATFORMID_CFG_DATA.PlatformId           | 0x0019
 PLAT_NAME_CFG_DATA.PlatformName          | 'RPLS S14'
 GEN_CFG_DATA.PayloadId                   | ''
 FEATURES_CFG_DATA.Features.S0ix          | 0x0
-GEN_CFG_DATA.BootToShell                 | 1
+GEN_CFG_DATA.BootToShell                 | 0
 
 #
 # This GPIO maps to the SW7C1 4-block DIP switch's 3rd switch.

--- a/Platform/RaptorlakeBoardPkg/CfgData/CfgDataInt_Rpls_Rvp_SODdr5.dlt
+++ b/Platform/RaptorlakeBoardPkg/CfgData/CfgDataInt_Rpls_Rvp_SODdr5.dlt
@@ -17,7 +17,7 @@ PLATFORMID_CFG_DATA.PlatformId           | 0x0011
 PLAT_NAME_CFG_DATA.PlatformName          | 'RPLS S17'
 GEN_CFG_DATA.PayloadId                   | ''
 FEATURES_CFG_DATA.Features.S0ix          | 0x0
-GEN_CFG_DATA.BootToShell                 | 1
+GEN_CFG_DATA.BootToShell                 | 0
 
 #
 # This GPIO maps to the SW7C1 4-block DIP switch's 3rd switch.


### PR DESCRIPTION
OS Loader shell is enabled on release builds on the supported boards for these platforms but should be disabled.