### PR TITLE
IppCrypto2Lib: Fix x86intrin.h header chain with -nostdlib

### DIFF
--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/x86intrin.h
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/x86intrin.h
@@ -34,5 +34,14 @@ _lzcnt_u64 (unsigned long long __X)
 #endif /* IPP_SBL_LZCNT_INTRINSICS_DEFINED */
 #endif
 // Provide SSE2 vector types (__m128i etc.) and intrinsics needed by ipp-crypto
+// Only include emmintrin.h when x86gprintrin.h is available to avoid
+// header chain issues with -nostdlib on some toolchains
+#if defined(__has_include)
+#if __has_include(<x86gprintrin.h>)
 #include <emmintrin.h>
+#endif
+#else
+#include <emmintrin.h>
+#endif
+
 #endif


### PR DESCRIPTION
Conditionally include emmintrin.h only when x86gprintrin.h is available. This prevents system header chain failures with -nostdlib flag while maintaining ipp-crypto compatibility.