### PR TITLE
[CryptoLib] Added IA32 support to IppCrypto2Lib v2.0.0

### DIFF
--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCrypto2LibG9.inf
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCrypto2LibG9.inf
@@ -1,0 +1,212 @@
+## @file
+#
+#  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = IppCryptoLib
+  FILE_GUID                      = F39C67D5-153F-4A02-9874-8C089F8D0D7E
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = CryptoLib
+  DEFINE IPP_PATH                = ipp-crypto
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32
+#
+
+[Sources]
+  IppCryptoSupportIA32.c
+  hmac.c
+  rsa_verify.c
+  sha256.c
+  sha384.c
+  sm3.c
+  assert.h
+  $(IPP_PATH)/include/ippcpdefs.h
+  $(IPP_PATH)/sources/include/owndefs.h
+  $(IPP_PATH)/sources/ippcp/owncp.h
+  $(IPP_PATH)/sources/ippcp/hash/pcphash.h
+  $(IPP_PATH)/sources/ippcp/hash/sha512/pcpsha512stuff.h
+  $(IPP_PATH)/sources/ippcp/hash/sha256/pcpsha256stuff.h
+  $(IPP_PATH)/sources/ippcp/hash/sm3/pcpsm3stuff.h
+
+  # Misc source files
+  $(IPP_PATH)/sources/ippcp/pcpmgf1ca_rmf.c
+  $(IPP_PATH)/sources/ippcp/gsmod_engineinit.c
+  $(IPP_PATH)/sources/ippcp/gsmod_enginegetsize.c
+  $(IPP_PATH)/sources/ippcp/gsmod_montfactor.c
+  $(IPP_PATH)/sources/ippcp/pcpngmontexpstuff_bin.c
+  # pcpmontred.c replaced by pcpmontreductionv8as.nasm in [Sources.IA32]
+
+  # BigNum source files
+  $(IPP_PATH)/sources/ippcp/pcpbngetsize.c
+  $(IPP_PATH)/sources/ippcp/pcpbninit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnsetoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbngetoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_setoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_getoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_mul_adc.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_sqr_adc.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_add.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_add.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_addmuldigit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_sub.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_sub.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_nlz.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_nlz.c
+
+  # RSA Source files
+  $(IPP_PATH)/sources/ippcp/pcprsa_getsizepublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_getbuffersizepublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_initpublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_setpublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsaverify_pss_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gspub_cipher.c
+  $(IPP_PATH)/sources/ippcp/gsmodmethod_rsa.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_montexpgetsize.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsmethod__gpr_public.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsmethod__sse2_public.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsmethod__sse2_private.c
+  $(IPP_PATH)/sources/ippcp/pcpngmontexpstuff_sse2.c
+  $(IPP_PATH)/sources/ippcp/cpinit.c
+
+  # Hash source files
+  $(IPP_PATH)/sources/ippcp/hash/sha256/pcphashmethod_sha256.c
+  # pcphashsha256px.c replaced by pcpsha256g9as.nasm in [Sources.IA32]
+  $(IPP_PATH)/sources/ippcp/hash/sha384/pcphashmethod_sha384.c
+  # pcphashsha512px.c replaced by pcpsha512g9as.nasm in [Sources.IA32]
+  $(IPP_PATH)/sources/ippcp/hash/sm3/pcphashmethod_sm3.c
+  $(IPP_PATH)/sources/ippcp/hash/sm3/pcphashsm3px.c
+  $(IPP_PATH)/sources/ippcp/hash/sha3/pcpsha3ca.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashmessage_rmf.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashinit_rmf.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashupdate_rmf.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashfinal_rmf.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashca_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcprsaverify_pkcs1v15_rmf.c
+
+  # HMAC source files
+  $(IPP_PATH)/sources/ippcp/pcphmacmessage_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacgetsize_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacca_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacupdate_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacfinal_rmf.c
+
+  # FIPS source files
+  fips.c
+  $(IPP_PATH)/include/ippcp/fips_cert.h
+  $(IPP_PATH)/sources/ippcp/fips_cert/common.c
+  $(IPP_PATH)/sources/ippcp/fips_cert/selftest_rsa_sign_verify_pkcs_v15.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_getbuffersizeprivatekey.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_inc.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_dec.c
+  $(IPP_PATH)/sources/ippcp/hash/sha1/pcphashsha1px.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_setprivatekeytype1.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_initprivatekeytype1.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_getsizeprivatekeytype1.c
+  $(IPP_PATH)/sources/ippcp/pcpbnsetwords.c
+  $(IPP_PATH)/sources/ippcp/pcprsasign_pkcs1v15_rmf.c
+  $(IPP_PATH)/sources/ippcp/hash/sha256/pcphashmethodset_sha256_tt.c
+  $(IPP_PATH)/sources/ippcp/hash/sha224/pcphashmethodset_sha224_tt.c
+  $(IPP_PATH)/sources/ippcp/hash/sha384/pcphashmethodset_sha384_tt.c
+  $(IPP_PATH)/sources/ippcp/hash/sha512/pcphashmethodset_sha512_tt.c
+  $(IPP_PATH)/sources/ippcp/hash/sha512/pcphashmethodset_sha512_224_tt.c
+  $(IPP_PATH)/sources/ippcp/hash/sha512/pcphashmethodset_sha512_256_tt.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsmethod__gpr_private.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsprv_cipher_crt.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsprv_cipher.c
+  $(IPP_PATH)/sources/ippcp/pcpngmontexpstuff_win_sscm.c
+  $(IPP_PATH)/sources/ippcp/pcpngmontexpstuff_win.c
+  $(IPP_PATH)/sources/ippcp/gsscramble.c
+  $(IPP_PATH)/sources/ippcp/gsscramble_sscm.c
+  $(IPP_PATH)/sources/ippcp/fips_cert/selftest_hash_msg_upd_sha.c
+  $(IPP_PATH)/sources/ippcp/hash/sha512/pcphashmethodset_sha512.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashgetsize_rmf.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashgettag_rmf.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashcnt.c
+  $(IPP_PATH)/sources/ippcp/fips_cert/selftest_rsa_sign_verify_pss.c
+  $(IPP_PATH)/sources/ippcp/pcprsasign_pss_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_generatekeys.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_initprivatekeytype2.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_getsizeprivatekeytype2.c
+  $(IPP_PATH)/sources/ippcp/pcpprimeginitca.c
+  $(IPP_PATH)/sources/ippcp/pcpprimegetsize.c
+  $(IPP_PATH)/sources/ippcp/pcpprngenca.c
+  $(IPP_PATH)/sources/ippcp/pcpprnginitca.c
+  $(IPP_PATH)/sources/ippcp/pcpprnggetsize.c
+  $(IPP_PATH)/sources/ippcp/pcpprngen_range.c
+  $(IPP_PATH)/sources/ippcp/pcpprngen_pattern.c
+  $(IPP_PATH)/sources/ippcp/pcpprime_mimimaltest.c
+  $(IPP_PATH)/sources/ippcp/pcpbn_val3.c
+  $(IPP_PATH)/sources/ippcp/pcpbn_val1.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_lsr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_ntz.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_minv.c
+  $(IPP_PATH)/sources/ippcp/pcpbnarithgcd.c
+  $(IPP_PATH)/sources/ippcp/gsmodmethod_mont.c
+  $(IPP_PATH)/sources/ippcp/pcpprng_gen.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_gcd.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashmethodgetsize.c
+
+[Sources.IA32]
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha1nias.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha256nias.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha256g9as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha512g9as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpmontreductionv8as.nasm
+  # W7 asm: BNU arithmetic, SHA1, PurgeBlock (guard >= _IPP_W7=8, fires with H9=256)
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnuaddw7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnusubw7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnumuldgtw7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnusqrw7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcppurgeblkw7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha1w7as.nasm
+  # V8 asm: cpMulAdc_BNU_school (guard >= _IPP_V8=32, fires with H9=256)
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnumulschoolv8as.nasm
+  # H9-NI: UpdateSHA512ni
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha512h9ni.nasm
+
+[UserExtensions.SBL."CopyList"]
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha1nias.asm            : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha1nias.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha256nias.asm          : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha256nias.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha256g9as.asm          : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha256g9as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha512g9as.asm          : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha512g9as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpmontreductionv8as.asm   : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpmontreductionv8as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnuaddw7as.asm          : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnuaddw7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnusubw7as.asm          : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnusubw7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnumuldgtw7as.asm       : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnumuldgtw7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnusqrw7as.asm          : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnusqrw7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcppurgeblkw7as.asm        : $(IPP_PATH)/sources/ippcp/asm_ia32/pcppurgeblkw7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha1w7as.asm            : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha1w7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnumulschoolv8as.asm    : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnumulschoolv8as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha512h9ni.asm          : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha512h9ni.nasm
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  MemoryAllocationLib
+
+[FixedPcd]
+  gPlatformCommonLibTokenSpaceGuid.PcdCryptoShaOptMask
+  gPlatformCommonLibTokenSpaceGuid.PcdIppHashLibSupportedMask
+  gPlatformCommonLibTokenSpaceGuid.PcdCompSignSchemeSupportedMask
+  gPlatformCommonLibTokenSpaceGuid.PcdCompSignHashAlg
+  gPlatformCommonLibTokenSpaceGuid.PcdCompSignType
+
+[BuildOptions.IA32]
+  MSFT:*_*_*_CC_FLAGS = -D_ABL_ -D_V8 -D_P8 -D_G9 -D_H9 -D_ARCH_IA32 -DIPPCP_FIPS_MODE -D_NO_IPP_DEPRECATED -D__ALIGN64= -D_USE_C_cpInc_BNU_ /arch:SSE2 /GL- /wd4616 /wd1418 /wd1419 /wd4996
+  MSFT:*_*_IA32_NASM_FLAGS == -Ox -f win32 -D_ABL_ -D_G9 -D_H9
+  GCC:*_*_IA32_NASM_FLAGS = -D_ABL_ -D_G9 -D_H9
+  GCC:*_*_*_CC_FLAGS  = -D_ABL_ -D_V8 -D_P8 -D_G9 -D_H9 -D_ARCH_IA32 -D__INTEL_LLVM_COMPILER -DIPPCP_FIPS_MODE -D_NO_IPP_DEPRECATED -D__ALIGN64= -D_USE_C_cpInc_BNU_ -w -Wformat -Wformat-security

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCrypto2LibNI.inf
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCrypto2LibNI.inf
@@ -1,0 +1,209 @@
+## @file
+#
+#  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = IppCryptoLib
+  FILE_GUID                      = 8F4C6E1D-5B92-4A37-B5C0-9E2D7F8A3C5B
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = CryptoLib
+  DEFINE IPP_PATH                = ipp-crypto
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32
+#
+
+[Sources]
+  IppCryptoSupportIA32.c
+  hmac.c
+  rsa_verify.c
+  sha256.c
+  sha384.c
+  sm3.c
+  assert.h
+  $(IPP_PATH)/include/ippcpdefs.h
+  $(IPP_PATH)/sources/include/owndefs.h
+  $(IPP_PATH)/sources/ippcp/owncp.h
+  $(IPP_PATH)/sources/ippcp/hash/pcphash.h
+  $(IPP_PATH)/sources/ippcp/hash/sha512/pcpsha512stuff.h
+  $(IPP_PATH)/sources/ippcp/hash/sha256/pcpsha256stuff.h
+  $(IPP_PATH)/sources/ippcp/hash/sm3/pcpsm3stuff.h
+
+  # Misc source files
+  $(IPP_PATH)/sources/ippcp/pcpmgf1ca_rmf.c
+  $(IPP_PATH)/sources/ippcp/gsmod_engineinit.c
+  $(IPP_PATH)/sources/ippcp/gsmod_enginegetsize.c
+  $(IPP_PATH)/sources/ippcp/gsmod_montfactor.c
+  $(IPP_PATH)/sources/ippcp/pcpngmontexpstuff_bin.c
+  # pcpmontred.c replaced by pcpmontreductionv8as.nasm in [Sources.IA32]
+
+  # BigNum source files
+  $(IPP_PATH)/sources/ippcp/pcpbngetsize.c
+  $(IPP_PATH)/sources/ippcp/pcpbninit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnsetoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbngetoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_setoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_getoctstr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_mul_adc.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_sqr_adc.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_add.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_add.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_addmuldigit.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_sub.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_sub.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_nlz.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu32_nlz.c
+
+  # RSA Source files
+  $(IPP_PATH)/sources/ippcp/pcprsa_getsizepublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_getbuffersizepublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_initpublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_setpublickey.c
+  $(IPP_PATH)/sources/ippcp/pcprsaverify_pss_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gspub_cipher.c
+  $(IPP_PATH)/sources/ippcp/gsmodmethod_rsa.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_montexpgetsize.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsmethod__gpr_public.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsmethod__sse2_public.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsmethod__sse2_private.c
+  $(IPP_PATH)/sources/ippcp/pcpngmontexpstuff_sse2.c
+  $(IPP_PATH)/sources/ippcp/cpinit.c
+
+  # Hash source files
+  $(IPP_PATH)/sources/ippcp/hash/sha256/pcphashmethod_sha256.c
+  # pcphashsha256px.c replaced by pcpsha256g9as.nasm in [Sources.IA32]
+  $(IPP_PATH)/sources/ippcp/hash/sha384/pcphashmethod_sha384.c
+  # pcphashsha512px.c replaced by pcpsha512g9as.nasm in [Sources.IA32]
+  $(IPP_PATH)/sources/ippcp/hash/sm3/pcphashmethod_sm3.c
+  $(IPP_PATH)/sources/ippcp/hash/sm3/pcphashsm3px.c
+  $(IPP_PATH)/sources/ippcp/hash/sha3/pcpsha3ca.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashmessage_rmf.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashinit_rmf.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashupdate_rmf.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashfinal_rmf.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashca_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcprsaverify_pkcs1v15_rmf.c
+
+  # HMAC source files
+  $(IPP_PATH)/sources/ippcp/pcphmacmessage_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacgetsize_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacca_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacupdate_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcphmacfinal_rmf.c
+
+  # FIPS source files
+  fips.c
+  $(IPP_PATH)/include/ippcp/fips_cert.h
+  $(IPP_PATH)/sources/ippcp/fips_cert/common.c
+  $(IPP_PATH)/sources/ippcp/fips_cert/selftest_rsa_sign_verify_pkcs_v15.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_getbuffersizeprivatekey.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_inc.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_dec.c
+  $(IPP_PATH)/sources/ippcp/hash/sha1/pcphashsha1px.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_setprivatekeytype1.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_initprivatekeytype1.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_getsizeprivatekeytype1.c
+  $(IPP_PATH)/sources/ippcp/pcpbnsetwords.c
+  $(IPP_PATH)/sources/ippcp/pcprsasign_pkcs1v15_rmf.c
+  $(IPP_PATH)/sources/ippcp/hash/sha256/pcphashmethodset_sha256_tt.c
+  $(IPP_PATH)/sources/ippcp/hash/sha224/pcphashmethodset_sha224_tt.c
+  $(IPP_PATH)/sources/ippcp/hash/sha384/pcphashmethodset_sha384_tt.c
+  $(IPP_PATH)/sources/ippcp/hash/sha512/pcphashmethodset_sha512_tt.c
+  $(IPP_PATH)/sources/ippcp/hash/sha512/pcphashmethodset_sha512_224_tt.c
+  $(IPP_PATH)/sources/ippcp/hash/sha512/pcphashmethodset_sha512_256_tt.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsmethod__gpr_private.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsprv_cipher_crt.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsprv_cipher.c
+  $(IPP_PATH)/sources/ippcp/pcpngmontexpstuff_win_sscm.c
+  $(IPP_PATH)/sources/ippcp/pcpngmontexpstuff_win.c
+  $(IPP_PATH)/sources/ippcp/gsscramble.c
+  $(IPP_PATH)/sources/ippcp/gsscramble_sscm.c
+  $(IPP_PATH)/sources/ippcp/fips_cert/selftest_hash_msg_upd_sha.c
+  $(IPP_PATH)/sources/ippcp/hash/sha512/pcphashmethodset_sha512.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashgetsize_rmf.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashgettag_rmf.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashcnt.c
+  $(IPP_PATH)/sources/ippcp/fips_cert/selftest_rsa_sign_verify_pss.c
+  $(IPP_PATH)/sources/ippcp/pcprsasign_pss_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_generatekeys.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_initprivatekeytype2.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_getsizeprivatekeytype2.c
+  $(IPP_PATH)/sources/ippcp/pcpprimeginitca.c
+  $(IPP_PATH)/sources/ippcp/pcpprimegetsize.c
+  $(IPP_PATH)/sources/ippcp/pcpprngenca.c
+  $(IPP_PATH)/sources/ippcp/pcpprnginitca.c
+  $(IPP_PATH)/sources/ippcp/pcpprnggetsize.c
+  $(IPP_PATH)/sources/ippcp/pcpprngen_range.c
+  $(IPP_PATH)/sources/ippcp/pcpprngen_pattern.c
+  $(IPP_PATH)/sources/ippcp/pcpprime_mimimaltest.c
+  $(IPP_PATH)/sources/ippcp/pcpbn_val3.c
+  $(IPP_PATH)/sources/ippcp/pcpbn_val1.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_lsr.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_ntz.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_minv.c
+  $(IPP_PATH)/sources/ippcp/pcpbnarithgcd.c
+  $(IPP_PATH)/sources/ippcp/gsmodmethod_mont.c
+  $(IPP_PATH)/sources/ippcp/pcpprng_gen.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_gcd.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashmethodgetsize.c
+
+[Sources.IA32]
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha1nias.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha256nias.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha256g9as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha512g9as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpmontreductionv8as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnuaddw7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnusubw7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnumuldgtw7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnusqrw7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcppurgeblkw7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha1w7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnumulschoolv8as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha512h9ni.nasm
+
+[UserExtensions.SBL."CopyList"]
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha1nias.asm            : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha1nias.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha256nias.asm          : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha256nias.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha256g9as.asm          : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha256g9as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha512g9as.asm          : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha512g9as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpmontreductionv8as.asm   : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpmontreductionv8as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnuaddw7as.asm          : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnuaddw7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnusubw7as.asm          : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnusubw7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnumuldgtw7as.asm       : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnumuldgtw7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnusqrw7as.asm          : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnusqrw7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcppurgeblkw7as.asm        : $(IPP_PATH)/sources/ippcp/asm_ia32/pcppurgeblkw7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha1w7as.asm            : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha1w7as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnumulschoolv8as.asm    : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpbnumulschoolv8as.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha512h9ni.asm          : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha512h9ni.nasm
+
+[Packages]
+  MdePkg/MdePkg.dec
+  BootloaderCommonPkg/BootloaderCommonPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  MemoryAllocationLib
+
+[FixedPcd]
+  gPlatformCommonLibTokenSpaceGuid.PcdCryptoShaOptMask
+  gPlatformCommonLibTokenSpaceGuid.PcdIppHashLibSupportedMask
+  gPlatformCommonLibTokenSpaceGuid.PcdCompSignSchemeSupportedMask
+  gPlatformCommonLibTokenSpaceGuid.PcdCompSignHashAlg
+  gPlatformCommonLibTokenSpaceGuid.PcdCompSignType
+
+[BuildOptions.IA32]
+  MSFT:*_*_*_CC_FLAGS = -D_ABL_ -D_V8 -D_P8 -D_H9 -D_ARCH_IA32 -DIPPCP_FIPS_MODE -D_NO_IPP_DEPRECATED -D__ALIGN64= -D_USE_C_cpInc_BNU_ /arch:SSE2 /GL- /wd4616 /wd4996
+  MSFT:*_*_IA32_NASM_FLAGS == -Ox -f win32 -D_ABL_ -D_H9
+  GCC:*_*_IA32_NASM_FLAGS = -D_ABL_ -D_H9
+  GCC:*_*_*_CC_FLAGS  = -D_ABL_ -D_V8 -D_P8 -D_H9 -D_ARCH_IA32 -D__INTEL_LLVM_COMPILER -DIPPCP_FIPS_MODE -D_NO_IPP_DEPRECATED -D__ALIGN64= -D_USE_C_cpInc_BNU_ -w -Wformat -Wformat-security

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCrypto2LibW7.inf
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCrypto2LibW7.inf
@@ -10,7 +10,7 @@
 [Defines]
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = IppCryptoLib
-  FILE_GUID                      = C2C87C18-7282-479F-A7E6-BF297C94CC54
+  FILE_GUID                      = 2C55826A-4637-45FD-A9E8-6D73AB2C11E1
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = CryptoLib
@@ -19,22 +19,24 @@
 #
 # The following information is for reference only and not required by the build tools.
 #
-#  VALID_ARCHITECTURES           = X64 IA32
+#  VALID_ARCHITECTURES           = IA32
 #
 
 [Sources]
+  IppCryptoSupportIA32.c
   hmac.c
   rsa_verify.c
   sha256.c
   sha384.c
   sm3.c
-  intrin.h
   assert.h
   $(IPP_PATH)/include/ippcpdefs.h
   $(IPP_PATH)/sources/include/owndefs.h
   $(IPP_PATH)/sources/ippcp/owncp.h
-  $(IPP_PATH)/sources/ippcp/pcpbn.h
-  $(IPP_PATH)/sources/ippcp/pcptool.h
+  $(IPP_PATH)/sources/ippcp/hash/pcphash.h
+  $(IPP_PATH)/sources/ippcp/hash/sha512/pcpsha512stuff.h
+  $(IPP_PATH)/sources/ippcp/hash/sha256/pcpsha256stuff.h
+  $(IPP_PATH)/sources/ippcp/hash/sm3/pcpsm3stuff.h
 
   # Misc source files
   $(IPP_PATH)/sources/ippcp/pcpmgf1ca_rmf.c
@@ -53,7 +55,6 @@
   $(IPP_PATH)/sources/ippcp/pcpbnu_getoctstr.c
   $(IPP_PATH)/sources/ippcp/pcpbnu_arith_mul_adc.c
   $(IPP_PATH)/sources/ippcp/pcpbnu_arith_sqr_adc.c
-  $(IPP_PATH)/sources/ippcp/pcpprng_gen.c
   $(IPP_PATH)/sources/ippcp/pcpbnu_arith_add.c
   $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_add.c
   $(IPP_PATH)/sources/ippcp/pcpbnu_arith_addmuldigit.c
@@ -67,7 +68,6 @@
   $(IPP_PATH)/sources/ippcp/pcprsa_getbuffersizepublickey.c
   $(IPP_PATH)/sources/ippcp/pcprsa_initpublickey.c
   $(IPP_PATH)/sources/ippcp/pcprsa_setpublickey.c
-  $(IPP_PATH)/sources/ippcp/pcprsa_sizeof_pubkey.h
   $(IPP_PATH)/sources/ippcp/pcprsaverify_pss_rmf.c
   $(IPP_PATH)/sources/ippcp/pcprsa_gspub_cipher.c
   $(IPP_PATH)/sources/ippcp/gsmodmethod_rsa.c
@@ -75,31 +75,18 @@
   $(IPP_PATH)/sources/ippcp/pcprsa_gsmethod__gpr_public.c
 
   # Hash source files
+  $(IPP_PATH)/sources/ippcp/hash/sha256/pcphashmethod_sha256.c
+  $(IPP_PATH)/sources/ippcp/hash/sha256/pcphashsha256px.c
+  $(IPP_PATH)/sources/ippcp/hash/sha384/pcphashmethod_sha384.c
+  $(IPP_PATH)/sources/ippcp/hash/sha512/pcphashsha512px.c
+  $(IPP_PATH)/sources/ippcp/hash/sm3/pcphashmethod_sm3.c
+  $(IPP_PATH)/sources/ippcp/hash/sm3/pcphashsm3px.c
   $(IPP_PATH)/sources/ippcp/hash/sha3/pcpsha3ca.c
   $(IPP_PATH)/sources/ippcp/hash/pcphashmessage_rmf.c
   $(IPP_PATH)/sources/ippcp/hash/pcphashinit_rmf.c
   $(IPP_PATH)/sources/ippcp/hash/pcphashupdate_rmf.c
   $(IPP_PATH)/sources/ippcp/hash/pcphashfinal_rmf.c
   $(IPP_PATH)/sources/ippcp/hash/pcphashca_rmf.c
-  $(IPP_PATH)/sources/ippcp/hash/pcphashcnt.c
-  $(IPP_PATH)/sources/ippcp/hash/pcphashgetsize_rmf.c
-  $(IPP_PATH)/sources/ippcp/hash/pcphashgettag_rmf.c
-  $(IPP_PATH)/sources/ippcp/hash/pcphashmethodgetsize.c
-  $(IPP_PATH)/sources/ippcp/hash/sha256/pcphashmethod_sha256.c
-  $(IPP_PATH)/sources/ippcp/hash/sha256/pcphashsha256px.c
-  $(IPP_PATH)/sources/ippcp/hash/sha256/pcphashmethodset_sha256_tt.c
-  $(IPP_PATH)/sources/ippcp/hash/sha224/pcphashmethodset_sha224_tt.c
-  $(IPP_PATH)/sources/ippcp/hash/sha384/pcphashmethod_sha384.c
-  $(IPP_PATH)/sources/ippcp/hash/sha384/pcphashmethodset_sha384_tt.c
-  $(IPP_PATH)/sources/ippcp/hash/sha512/pcphashmethodset_sha512_tt.c
-  $(IPP_PATH)/sources/ippcp/hash/sha512/pcphashmethodset_sha512_224_tt.c
-  $(IPP_PATH)/sources/ippcp/hash/sha512/pcphashmethodset_sha512_256_tt.c
-  $(IPP_PATH)/sources/ippcp/hash/sha512/pcphashsha512px.c
-  $(IPP_PATH)/sources/ippcp/hash/sha1/pcpsha1ca.c
-  $(IPP_PATH)/sources/ippcp/hash/sha1/pcphashsha1px.c
-  $(IPP_PATH)/sources/ippcp/hash/sha512/pcphashmethodset_sha512.c
-  $(IPP_PATH)/sources/ippcp/hash/sm3/pcphashmethod_sm3.c
-  $(IPP_PATH)/sources/ippcp/hash/sm3/pcphashsm3px.c
   $(IPP_PATH)/sources/ippcp/pcprsaverify_pkcs1v15_rmf.c
 
   # HMAC source files
@@ -108,72 +95,70 @@
   $(IPP_PATH)/sources/ippcp/pcphmacca_rmf.c
   $(IPP_PATH)/sources/ippcp/pcphmacupdate_rmf.c
   $(IPP_PATH)/sources/ippcp/pcphmacfinal_rmf.c
-  $(IPP_PATH)/sources/ippcp/pcphmacgettag_rmf.c
-  $(IPP_PATH)/sources/ippcp/pcphmacduplicate_rmf.c
 
   # FIPS source files
   fips.c
   $(IPP_PATH)/include/ippcp/fips_cert.h
   $(IPP_PATH)/sources/ippcp/fips_cert/common.c
-  $(IPP_PATH)/sources/ippcp/fips_cert/selftest_hash_msg_upd_sha.c
   $(IPP_PATH)/sources/ippcp/fips_cert/selftest_rsa_sign_verify_pkcs_v15.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_getbuffersizeprivatekey.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_inc.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_dec.c
+  $(IPP_PATH)/sources/ippcp/hash/sha1/pcphashsha1px.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_setprivatekeytype1.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_initprivatekeytype1.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_getsizeprivatekeytype1.c
+  $(IPP_PATH)/sources/ippcp/pcpbnsetwords.c
+  $(IPP_PATH)/sources/ippcp/pcprsasign_pkcs1v15_rmf.c
+  $(IPP_PATH)/sources/ippcp/hash/sha256/pcphashmethodset_sha256_tt.c
+  $(IPP_PATH)/sources/ippcp/hash/sha224/pcphashmethodset_sha224_tt.c
+  $(IPP_PATH)/sources/ippcp/hash/sha384/pcphashmethodset_sha384_tt.c
+  $(IPP_PATH)/sources/ippcp/hash/sha512/pcphashmethodset_sha512_tt.c
+  $(IPP_PATH)/sources/ippcp/hash/sha512/pcphashmethodset_sha512_224_tt.c
+  $(IPP_PATH)/sources/ippcp/hash/sha512/pcphashmethodset_sha512_256_tt.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsmethod__gpr_private.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsprv_cipher_crt.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_gsprv_cipher.c
+  $(IPP_PATH)/sources/ippcp/pcpngmontexpstuff_win_sscm.c
+  $(IPP_PATH)/sources/ippcp/pcpngmontexpstuff_win.c
+  $(IPP_PATH)/sources/ippcp/gsscramble.c
+  $(IPP_PATH)/sources/ippcp/gsscramble_sscm.c
+  $(IPP_PATH)/sources/ippcp/fips_cert/selftest_hash_msg_upd_sha.c
+  $(IPP_PATH)/sources/ippcp/hash/sha512/pcphashmethodset_sha512.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashgetsize_rmf.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashgettag_rmf.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashcnt.c
   $(IPP_PATH)/sources/ippcp/fips_cert/selftest_rsa_sign_verify_pss.c
-  $(IPP_PATH)/sources/ippcp/fips_cert/selftest_aes_upd_hmac.c
-
-  # Additional source files
-  $(IPP_PATH)/sources/ippcp/cpinit.c
+  $(IPP_PATH)/sources/ippcp/pcprsasign_pss_rmf.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_generatekeys.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_initprivatekeytype2.c
+  $(IPP_PATH)/sources/ippcp/pcprsa_getsizeprivatekeytype2.c
   $(IPP_PATH)/sources/ippcp/pcpprimeginitca.c
   $(IPP_PATH)/sources/ippcp/pcpprimegetsize.c
-  $(IPP_PATH)/sources/ippcp/pcpprime_mimimaltest.c
   $(IPP_PATH)/sources/ippcp/pcpprngenca.c
   $(IPP_PATH)/sources/ippcp/pcpprnginitca.c
   $(IPP_PATH)/sources/ippcp/pcpprnggetsize.c
   $(IPP_PATH)/sources/ippcp/pcpprngen_range.c
   $(IPP_PATH)/sources/ippcp/pcpprngen_pattern.c
-  $(IPP_PATH)/sources/ippcp/pcpbn_val1.c
+  $(IPP_PATH)/sources/ippcp/pcpprime_mimimaltest.c
   $(IPP_PATH)/sources/ippcp/pcpbn_val3.c
+  $(IPP_PATH)/sources/ippcp/pcpbn_val1.c
   $(IPP_PATH)/sources/ippcp/pcpbnu_lsr.c
-  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_gcd.c
-  $(IPP_PATH)/sources/ippcp/pcpbnarithgcd.c
-  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_inc.c
-  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_dec.c
-  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_minv.c
   $(IPP_PATH)/sources/ippcp/pcpbnu_ntz.c
-  $(IPP_PATH)/sources/ippcp/pcpbnu32_nlz.c
-  $(IPP_PATH)/sources/ippcp/pcprsa_getbuffersizeprivatekey.c
-  $(IPP_PATH)/sources/ippcp/pcprsa_setprivatekeytype1.c
-  $(IPP_PATH)/sources/ippcp/pcprsa_initprivatekeytype1.c
-  $(IPP_PATH)/sources/ippcp/pcprsa_getsizeprivatekeytype1.c
-  $(IPP_PATH)/sources/ippcp/pcprsa_initprivatekeytype2.c
-  $(IPP_PATH)/sources/ippcp/pcprsa_getsizeprivatekeytype2.c
-  $(IPP_PATH)/sources/ippcp/pcpbnsetwords.c
-  $(IPP_PATH)/sources/ippcp/pcprsasign_pkcs1v15_rmf.c
-  $(IPP_PATH)/sources/ippcp/pcprsasign_pss_rmf.c
-  $(IPP_PATH)/sources/ippcp/pcprsa_generatekeys.c
-  $(IPP_PATH)/sources/ippcp/pcprsa_gsmethod__gpr_private.c
-  $(IPP_PATH)/sources/ippcp/pcprsa_gsprv_cipher.c
-  $(IPP_PATH)/sources/ippcp/pcprsa_gsprv_cipher_crt.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_minv.c
+  $(IPP_PATH)/sources/ippcp/pcpbnarithgcd.c
   $(IPP_PATH)/sources/ippcp/gsmodmethod_mont.c
-  $(IPP_PATH)/sources/ippcp/pcpngmontexpstuff_win.c
-  $(IPP_PATH)/sources/ippcp/pcpngmontexpstuff_win_sscm.c
-  $(IPP_PATH)/sources/ippcp/gsscramble.c
-  $(IPP_PATH)/sources/ippcp/gsscramble_sscm.c
-  $(IPP_PATH)/sources/ippcp/hash/pcphashduplicate_rmf.c
-  $(IPP_PATH)/sources/include/asmdefs.inc
-  $(IPP_PATH)/sources/include/ia_32e.inc
-  $(IPP_PATH)/sources/include/ia_common.inc
-  $(IPP_PATH)/sources/include/utils.inc
-  $(IPP_PATH)/sources/ippcp/hash/sha512/pcpsha512stuff.h
-  $(IPP_PATH)/sources/ippcp/hash/sm3/pcpsm3stuff.h
-
-[Sources.X64]
-  IppCryptoSupportX64.c
-  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_muldigit.c
-  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_submuldigit.c
-  $(IPP_PATH)/sources/ippcp/pcpbnu32_arith_div.c
+  $(IPP_PATH)/sources/ippcp/pcpprng_gen.c
+  $(IPP_PATH)/sources/ippcp/pcpbnu_arith_gcd.c
+  $(IPP_PATH)/sources/ippcp/hash/pcphashmethodgetsize.c
 
 [Sources.IA32]
-  IppCryptoSupportIA32.c
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha1nias.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha256nias.nasm
+
+[UserExtensions.SBL."CopyList"]
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha1nias.asm            : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha1nias.nasm
+  $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha256nias.asm          : $(IPP_PATH)/sources/ippcp/asm_ia32/pcpsha256nias.nasm
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -191,11 +176,8 @@
   gPlatformCommonLibTokenSpaceGuid.PcdCompSignHashAlg
   gPlatformCommonLibTokenSpaceGuid.PcdCompSignType
 
-[BuildOptions.X64]
-  # /wd4996: Upstream ipp-crypto uses APIs MSVC labels as deprecated.
-  MSFT:*_*_*_CC_FLAGS = -D_ABL_ -D_ARCH_EM64T -DIPPCP_FIPS_MODE /GL- /wd4996
-  GCC:*_*_*_CC_FLAGS  = -D_ABL_ -D_ARCH_EM64T -DIPPCP_FIPS_MODE -w -Wformat -Wformat-security
-
 [BuildOptions.IA32]
-  MSFT:*_*_*_CC_FLAGS = -D_ABL_ -D_ARCH_IA32 -DIPPCP_FIPS_MODE -D__ALIGN64= /GL- /wd4616 /wd4996
-  GCC:*_*_*_CC_FLAGS  = -D_ABL_ -D_ARCH_IA32 -DIPPCP_FIPS_MODE -w -Wformat -Wformat-security
+  MSFT:*_*_*_CC_FLAGS = -D_ABL_ -D_ARCH_IA32 -DIPPCP_FIPS_MODE -D_NO_IPP_DEPRECATED -D__ALIGN64= -D_USE_C_cpInc_BNU_ /GL- /wd4616 /wd1418 /wd1419 /wd4996
+  MSFT:*_*_IA32_NASM_FLAGS == -Ox -f win32 -D_ABL_ -D_W7
+  GCC:*_*_IA32_NASM_FLAGS = -D_ABL_ -D_W7
+  GCC:*_*_*_CC_FLAGS  = -D_ABL_ -D_ARCH_IA32 -D__INTEL_LLVM_COMPILER -DIPPCP_FIPS_MODE -D_NO_IPP_DEPRECATED -D__ALIGN64= -D_USE_C_cpInc_BNU_ -w -Wformat -Wformat-security

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCryptoSupportIA32.c
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/IppCryptoSupportIA32.c
@@ -1,0 +1,445 @@
+/** @file
+  IppCrypto support functions for IA32 architecture.
+
+  CPU feature detection, shift helpers, and BNU32 arithmetic optimized for
+  IA32. These functions support ipp-crypto v2.0.0 on 32-bit systems.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Base.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+
+#define IPP_CRYPTO_SUPPORT_IMPLEMENTATION
+#include "IppCryptoSupport.h"
+
+// Tell MSVC not to treat memset/memcpy as intrinsics in this file so that
+// the definitions below are accepted. Without this, MSVC emits C2169.
+#ifdef _MSC_VER
+#pragma function(memset, memcpy)
+// In ipp-crypto v2.0.0 the C interface was split: PurgeBlock() became an inline
+// volatile-pointer wrapper that calls PurgeBlockInternal() (the real symbol).
+// The NASM file (pcppurgeblkw7as.nasm) still exports the old name 'PurgeBlock'.
+// In SBL non-merged builds OWNAPI() is the identity macro, so the linker
+// needs bare 'PurgeBlockInternal'.  Map it to the existing NASM export.
+#pragma comment(linker, "/alternatename:PurgeBlockInternal=PurgeBlock")
+#endif
+
+void *
+memset (
+  void   *dest,
+  int    ch,
+  size_t count
+  )
+{
+  return SetMem(dest, (UINTN)(count),(UINT8)(ch));
+}
+
+//
+// CPU feature detection functions required by cpinit.c.
+// Real CPUID/XCR0 implementations; cp_issue_avx512_instruction
+// returns 0 (requires inline asm, conservative for boot firmware).
+// Functions match IPP_OWN_DECL convention: __cdecl, no mangling.
+//
+void
+__cdecl
+cpGetReg (
+  int  *buf,
+  int  valEAX,
+  int  valECX
+  )
+{
+  UINT32  Eax;
+  UINT32  Ebx;
+  UINT32  Ecx;
+  UINT32  Edx;
+
+  AsmCpuidEx ((UINT32)valEAX, (UINT32)valECX, &Eax, &Ebx, &Ecx, &Edx);
+  buf[0] = (int)Eax;
+  buf[1] = (int)Ebx;
+  buf[2] = (int)Ecx;
+  buf[3] = (int)Edx;
+}
+
+int
+__cdecl
+cp_is_avx_extension (
+  void
+  )
+{
+  UINT32  Eax;
+  UINT32  Ebx;
+  UINT32  Ecx;
+  UINT32  Edx;
+  UINT64  Xcr0;
+
+  AsmCpuid (1, &Eax, &Ebx, &Ecx, &Edx);
+  if ((Ecx & BIT27) == 0 || (Ecx & BIT28) == 0) {
+    return 0;
+  }
+
+  Xcr0 = AsmXGetBv (0);
+  return ((Xcr0 & 0x6) == 0x6) ? 1 : 0;
+}
+
+int
+__cdecl
+cp_is_avx512_extension (
+  void
+  )
+{
+  UINT64  Xcr0;
+
+  if (cp_is_avx_extension () == 0) {
+    return 0;
+  }
+
+  Xcr0 = AsmXGetBv (0);
+  return ((Xcr0 & 0xE6) == 0xE6) ? 1 : 0;
+}
+
+int
+__cdecl
+cp_issue_avx512_instruction (
+  void
+  )
+{
+  return 0;
+}
+
+UINT64
+__cdecl
+cp_get_pentium_counter (
+  void
+  )
+{
+  return AsmReadTsc ();
+}
+
+#ifdef _MSC_VER
+//
+// MSVC IA32 64-bit shift helpers.
+//
+// IMPORTANT: _allshl, _aullshl, _allshr, _aullshr use a NON-STANDARD calling
+// convention on IA32: the 64-bit operand is passed in EDX:EAX (NOT on the stack)
+// and the shift count is in CL (NOT on the stack).  A normal __cdecl C function
+// would read garbage from the stack instead.  These MUST be __declspec(naked)
+// with inline asm so the compiler does not generate a standard prologue and the
+// register values are used as-is.  For _aullshr specifically, keep this aligned
+// with Download/QemuSocPkg/QemuFsp/CryptoPkg/Library/IntrinsicLib/Ia32/MathRShiftU64.c.
+//
+__declspec(naked)
+void
+__cdecl
+_allshl (void)
+{
+  __asm {
+    cmp   cl, 64
+    jae   allshl_exit
+    cmp   cl, 32
+    jae   allshl_more32
+    shld  edx, eax, cl
+    shl   eax, cl
+    ret
+allshl_more32:
+    mov   edx, eax
+    xor   eax, eax
+    and   cl, 31
+    shl   edx, cl
+    ret
+allshl_exit:
+    xor   eax, eax
+    xor   edx, edx
+    ret
+  }
+}
+
+__declspec(naked)
+void
+__cdecl
+_aullshl (void)
+{
+  __asm {
+    cmp   cl, 64
+    jae   aullshl_exit
+    cmp   cl, 32
+    jae   aullshl_more32
+    shld  edx, eax, cl
+    shl   eax, cl
+    ret
+aullshl_more32:
+    mov   edx, eax
+    xor   eax, eax
+    and   cl, 31
+    shl   edx, cl
+    ret
+aullshl_exit:
+    xor   eax, eax
+    xor   edx, edx
+    ret
+  }
+}
+
+__declspec(naked)
+void
+__cdecl
+_allshr (void)
+{
+  __asm {
+    cmp   cl, 64
+    jae   allshr_exit
+    cmp   cl, 32
+    jae   allshr_more32
+    shrd  eax, edx, cl
+    sar   edx, cl
+    ret
+allshr_more32:
+    mov   eax, edx
+    sar   edx, 31
+    and   cl, 31
+    sar   eax, cl
+    ret
+allshr_exit:
+    sar   edx, 31
+    mov   eax, edx
+    ret
+  }
+}
+
+__declspec(naked)
+void
+__cdecl
+_aullshr (void)
+{
+  __asm {
+    cmp   cl, 64
+    jae   aullshr_exit
+    cmp   cl, 32
+    jae   aullshr_more32
+    shrd  eax, edx, cl
+    shr   edx, cl
+    ret
+aullshr_more32:
+    mov   eax, edx
+    xor   edx, edx
+    and   cl, 31
+    shr   eax, cl
+    ret
+aullshr_exit:
+    xor   eax, eax
+    xor   edx, edx
+    ret
+  }
+}
+#endif /* _MSC_VER */
+
+void *
+memcpy (
+  void        *dest_str,
+  const void  *src_str,
+  size_t      n
+  )
+{
+  return CopyMem(dest_str,src_str, (UINTN)(n));
+}
+
+#if defined (MDE_CPU_IA32)
+
+//
+// IA32 SBL-safe replacements for BNU32 64-bit arithmetic functions.
+// Replaces pcpbnu32_arith_muldigit.c, pcpbnu32_arith_submuldigit.c,
+// pcpbnu32_arith_div.c from ipp-crypto.  Those files use native C 64-bit
+// operators which generate __allmul/__aulldiv calls not present in Stage1.
+// Uses MultU64x32 / DivU64x32 (EDK2 BaseLib inline asm) instead.
+//
+#include "owncp.h"
+#include "pcpbnumisc.h"
+#include "pcpbnu32misc.h"
+#include "pcpbnu32arith.h"
+
+IPP_OWN_DEFN (Ipp32u, cpMulDgt_BNU32, (Ipp32u* pR, const Ipp32u* pA, cpSize nsA, Ipp32u val))
+{
+   Ipp32u carry = 0;
+   cpSize i;
+   for (i = 0; i < nsA; i++) {
+      Ipp64u t = MultU64x32 ((UINT64)pA[i], (UINT32)val) + carry;
+      pR[i] = IPP_LODWORD (t);
+      carry  = IPP_HIDWORD (t);
+   }
+   return carry;
+}
+
+#if !((_IPP32E==_IPP32E_M7) || (_IPP32E==_IPP32E_U8) || \
+      (_IPP32E==_IPP32E_Y8) || (_IPP32E>=_IPP32E_E9) || (_IPP32E==_IPP32E_N8))
+IPP_OWN_DEFN (Ipp32u, cpSubMulDgt_BNU32, (Ipp32u* pR, const Ipp32u* pA, cpSize nsA, Ipp32u val))
+{
+   Ipp32u carry = 0;
+   for (; nsA > 0; nsA--) {
+      Ipp64u r = (Ipp64u)*pR - MultU64x32 ((UINT64)*pA++, (UINT32)val) - carry;
+      *pR++ = IPP_LODWORD (r);
+      carry  = 0 - IPP_HIDWORD (r);
+   }
+   return carry;
+}
+
+IPP_OWN_DEFN (int, cpDiv_BNU32, (Ipp32u* pQ, cpSize* sizeQ, Ipp32u* pX, cpSize sizeX, Ipp32u* pY, cpSize sizeY))
+{
+   FIX_BNU32 (pY, sizeY);
+   FIX_BNU32 (pX, sizeX);
+
+   if (sizeX < sizeY) {
+      if (pQ) { pQ[0] = 0; *sizeQ = 1; }
+      return sizeX;
+   }
+
+   if (1 == sizeY) {
+      int i;
+      Ipp32u r = 0;
+      for (i = (int)sizeX - 1; i >= 0; i--) {
+         Ipp64u tmp = IPP_MAKEDWORD (pX[i], r);
+         Ipp32u q   = IPP_LODWORD (DivU64x32 (tmp, (UINT32)pY[0]));
+         r          = IPP_LODWORD (tmp - MultU64x32 ((UINT64)pY[0], (UINT32)q));
+         if (pQ) pQ[i] = q;
+      }
+      pX[0] = r;
+      if (pQ) { FIX_BNU32 (pQ, sizeX); *sizeQ = sizeX; }
+      return 1;
+   }
+
+   {
+      cpSize qs  = sizeX - sizeY + 1;
+      cpSize nlz = cpNLZ_BNU32 (pY[sizeY - 1]);
+      pX[sizeX] = 0;
+      if (nlz) {
+         cpSize ni;
+         pX[sizeX] = pX[sizeX - 1] >> (32 - nlz);
+         for (ni = sizeX - 1; ni > 0; ni--)
+            pX[ni] = (pX[ni] << nlz) | (pX[ni - 1] >> (32 - nlz));
+         pX[0] <<= nlz;
+         for (ni = sizeY - 1; ni > 0; ni--)
+            pY[ni] = (pY[ni] << nlz) | (pY[ni - 1] >> (32 - nlz));
+         pY[0] <<= nlz;
+      }
+      {
+         Ipp32u yHi = pY[sizeY - 1];
+         int i;
+         for (i = (int)qs - 1; i >= 0; i--) {
+            Ipp32u extend;
+            Ipp64u tmp = IPP_MAKEDWORD (pX[i + sizeY - 1], pX[i + sizeY]);
+            Ipp64u q   = DivU64x32 (tmp, (UINT32)yHi);
+            Ipp64u r   = tmp - MultU64x32 (q, (UINT32)yHi);
+            for (; IPP_HIDWORD (q) ||
+                   (Ipp64u)MultU64x32 (q, (UINT32)pY[sizeY - 2]) > IPP_MAKEDWORD (pX[i + sizeY - 2], r); ) {
+               q -= 1; r += yHi;
+               if (IPP_HIDWORD (r)) break;
+            }
+            extend = cpSubMulDgt_BNU32 (pX + i, pY, sizeY, (Ipp32u)q);
+            extend = (pX[i + sizeY] -= extend);
+            if (extend) {
+               q -= 1;
+               extend = cpAdd_BNU32 (pX + i, pY, pX + i, sizeY);
+               pX[i + sizeY] += extend;
+            }
+            if (pQ) pQ[i] = IPP_LODWORD (q);
+         }
+      }
+      if (nlz) {
+         cpSize ni;
+         for (ni = 0; ni < sizeX; ni++)
+            pX[ni] = (pX[ni] >> nlz) | (pX[ni + 1] << (32 - nlz));
+         for (ni = 0; ni < sizeY - 1; ni++)
+            pY[ni] = (pY[ni] >> nlz) | (pY[ni + 1] << (32 - nlz));
+         pY[sizeY - 1] >>= nlz;
+      }
+      FIX_BNU32 (pX, sizeX);
+      if (pQ) { FIX_BNU32 (pQ, qs); *sizeQ = qs; }
+      return sizeX;
+   }
+}
+#endif /* !X64 levels */
+
+//
+// MSVC IA32 emits __aulldiv / __aullrem / __allmul for 64-bit arithmetic.
+// These wrappers MUST NOT call DivU64x64Remainder: on MSVC IA32, Math64.c
+// implements that with C's '/' and '%' operators, which re-emit __aulldiv,
+// causing infinite recursion and a triple-fault.
+//
+// Fast path uses DivU64x32 (inline asm DIV instruction — divisor is always
+// 32-bit in cpDiv_BNU32). General fallback uses a shift loop with only
+// LShiftU64/RShiftU64 (inline asm) so no CRT helpers are ever called.
+//
+
+INT64
+__cdecl
+_allmul (
+  IN INT64  Multiplicand,
+  IN INT64  Multiplier
+  )
+{
+  return (INT64)MultU64x64 ((UINT64)Multiplicand, (UINT64)Multiplier);
+}
+
+UINT64
+__cdecl
+_aulldiv (
+  IN UINT64  Dividend,
+  IN UINT64  Divisor
+  )
+{
+  if (((UINT32 *)&Divisor)[1] == 0) {
+    return DivU64x32 (Dividend, ((UINT32 *)&Divisor)[0]);
+  }
+
+  {
+    UINT64  Quotient  = 0;
+    UINT64  Remainder = 0;
+    INTN    i;
+
+    for (i = 63; i >= 0; i--) {
+      Remainder = LShiftU64 (Remainder, 1);
+      if (RShiftU64 (Dividend, (UINTN)i) & 1) {
+        ((UINT32 *)&Remainder)[0] |= 1;
+      }
+      if (Remainder >= Divisor) {
+        Remainder -= Divisor;
+        Quotient  |= LShiftU64 (1ULL, (UINTN)i);
+      }
+    }
+    return Quotient;
+  }
+}
+
+UINT64
+__cdecl
+_aullrem (
+  IN UINT64  Dividend,
+  IN UINT64  Divisor
+  )
+{
+  if (((UINT32 *)&Divisor)[1] == 0) {
+    UINT32  Remainder;
+
+    DivU64x32Remainder (Dividend, ((UINT32 *)&Divisor)[0], &Remainder);
+    return (UINT64)Remainder;
+  }
+
+  {
+    UINT64  Remainder = 0;
+    INTN    i;
+
+    for (i = 63; i >= 0; i--) {
+      Remainder = LShiftU64 (Remainder, 1);
+      if (RShiftU64 (Dividend, (UINTN)i) & 1) {
+        ((UINT32 *)&Remainder)[0] |= 1;
+      }
+      if (Remainder >= Divisor) {
+        Remainder -= Divisor;
+      }
+    }
+    return Remainder;
+  }
+}
+
+#endif /* MDE_CPU_IA32 */

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/intrin.h
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/intrin.h
@@ -49,6 +49,21 @@ __m128i __cdecl _mm_loadu_si128 (__m128i const*);
 void    __cdecl _mm_storeu_si128(__m128i*, __m128i);
 __m128i __cdecl _mm_xor_si128   (__m128i, __m128i);
 
+// IA32-only declarations required by the current MSVC C2164 errors.
+#if defined(MDE_CPU_IA32) || defined(_M_IX86)
+__m128i __cdecl _mm_cvtsi32_si128 (int);
+__m128i __cdecl _mm_shuffle_epi32 (__m128i, int);
+__m128i __cdecl _mm_set1_epi32    (int);
+__m128i __cdecl _mm_srli_epi64    (__m128i, int);
+__m128i __cdecl _mm_srli_si128    (__m128i, int);
+__m128i __cdecl _mm_setzero_si128 (void);
+__m128i __cdecl _mm_load_si128    (__m128i const*);
+void    __cdecl _mm_store_si128   (__m128i*, __m128i);
+__m128i __cdecl _mm_add_epi64     (__m128i, __m128i);
+__m128i __cdecl _mm_mul_epu32     (__m128i, __m128i);
+__m128i __cdecl _mm_and_si128     (__m128i, __m128i);
+#endif
+
 #endif /* _MSC_VER */
 
 #endif /* IPP_SBL_INTRIN_H_ */

--- a/BootloaderCorePkg/Tools/BuildUtility.py
+++ b/BootloaderCorePkg/Tools/BuildUtility.py
@@ -89,6 +89,9 @@ IPP_CRYPTO_OPTIMIZATION_MASK = {
     "X64_Y8"          : 0x0080, # SSE4.2
     "X64_E9"          : 0x0100, # AVX
     "X64_L9"          : 0x0200, # AVX2
+    "IA32_W7"         : 0x0400, # W7 (SSE2)
+    "IA32_G9"         : 0x0800, # G9 (AVX)
+    "IA32_NI"         : 0x1000, # NI (AES-NI)
     }
 
 IPP_CRYPTO_ALG_MASK = {


### PR DESCRIPTION
-Added INF files for IA32 support to IppCrypto2Lib v2.0.0
- G9 for 384 + Ni  Opt for SHA256
- W7 Opt for SHA384 + Ni  Opt for SHA256
- NI Opt for SHA256 + SHA384