### PR TITLE
Guard ACPI S3 info in TSEG

### DIFF
--- a/BootloaderCorePkg/Include/Library/AcpiInitLib.h
+++ b/BootloaderCorePkg/Include/Library/AcpiInitLib.h
@@ -11,6 +11,8 @@
 #include <Uefi/UefiBaseType.h>
 #include <IndustryStandard/Acpi.h>
 
+#define S3_PTR_CHK(Ptr) (!EFI_ERROR (ValidateAcpiPointerInS3(Ptr)))
+
 typedef struct {
   EFI_ACPI_5_0_FPDT_PERFORMANCE_RECORD_HEADER     Header;
   UINT32                                          Reserved;
@@ -215,5 +217,24 @@ EFIAPI
 FindAcpiFacsAddress (
   IN  UINT32    AcpiTableBase
   );
+
+/**
+    Validate that the given ACPI pointer is within the ACPI memory range
+    defined in S3Data.
+
+    This function is used on S3 resume to validate any ACPI pointers
+    (e.g. from FACS) against the known ACPI memory range stored in
+    S3Data, to ensure they are safe to access without relying on
+    DRAM-resident ACPI tables.
+
+  @param[in] AcpiPtr
+  @return    EFI_STATUS
+
+ */
+EFI_STATUS
+EFIAPI
+ValidateAcpiPointerInS3(
+  IN VOID *AcpiPtr
+);
 
 #endif

--- a/BootloaderCorePkg/Include/Library/AcpiInitLib.h
+++ b/BootloaderCorePkg/Include/Library/AcpiInitLib.h
@@ -86,18 +86,20 @@ typedef struct {
 #pragma pack()
 
 /**
-  This function is called on S3 boot flow only.
+  Locate the ACPI wake vector from FACS and jump to it on S3 resume.
 
-  It will locate the S3 waking vector from the ACPI table and then
-  jump into it. The control will never return.
+  This function retrieves the FACS address from the TSEG S3 communication
+  area (stored during normal boot via AppendS3Info), validates the FACS
+  signature, extracts the FirmwareWakingVector, and transfers control to
+  the OS wake entry point. This function does not return on success.
 
-  @param  AcpiBase   ACPI table base address
+  @param[in]  FacsAddress   Address of FACS saved from normal boot.
 
 **/
 VOID
 EFIAPI
 FindAcpiWakeVectorAndJump (
-  IN  UINT32    AcpiBase
+  VOID    *FacsAddress
   );
 
 /**
@@ -141,6 +143,77 @@ EFI_STATUS
 EFIAPI
 UpdateFpdtSblTable (
   VOID
+  );
+
+/**
+  Discover the S3 required info via the live ACPI tables and save it
+  to the TSEG S3 communication area for use on S3 resume.
+
+  Save AcpiBase and FACS address into TSEG so that it can be retrieved
+  on S3 resume without trusting DRAM-resident ACPI tables. The storage
+  method depends on PcdBuildSmmHobs:
+    BIT1 - copy BL_ACPI_S3_INFO at a fixed offset after PLD_TO_BL_SMM_INFO
+           and per-CPU SMM base entries in TSEG
+    BIT0 - append a BL_ACPI_S3_INFO structure via AppendS3Info()
+
+  @retval EFI_SUCCESS         ACPI S3 data saved successfully.
+  @retval EFI_NOT_FOUND       ACPI S3 data not found in the ACPI tables.
+  @retval EFI_DEVICE_ERROR    CPU info unavailable.
+  @retval EFI_UNSUPPORTED     No supported storage method available.
+
+**/
+EFI_STATUS
+EFIAPI
+SaveAcpiDataForS3 (
+  VOID
+  );
+
+/**
+  Retrieve the FACS address from the TSEG S3 communication area.
+
+  This function reads the FACS physical address previously saved by
+  SaveAcpiDataForS3() during normal boot. It is called on S3 resume
+  to locate the FACS without relying on DRAM-resident ACPI tables.
+
+  @retval  Non-zero   Physical address of the FACS table.
+  @retval  0          FACS address not found.
+
+**/
+UINT64
+EFIAPI
+GetFacsAddressForS3 (
+  VOID
+  );
+
+/**
+  Retrieve the ACPI base address from the TSEG S3 communication area.
+
+  Calls GetAcpiS3Info() and returns the AcpiBase field. Called on S3 resume
+  to locate the ACPI tables without relying on DRAM-resident data.
+
+  @retval  Non-zero   Physical address of the ACPI RSDP.
+  @retval  0          ACPI base address not found.
+
+**/
+UINT64
+EFIAPI
+GetAcpiBaseForS3 (
+  VOID
+  );
+
+/**
+  Find the FACS physical address by walking the live ACPI XSDT.
+
+  @param[in]  AcpiTableBase   Physical address of the RSDP.
+
+  @retval  Non-zero   Physical address of the FACS structure.
+  @retval  0          FACS not found.
+
+**/
+UINT64
+EFIAPI
+FindAcpiFacsAddress (
+  IN  UINT32    AcpiTableBase
   );
 
 #endif

--- a/BootloaderCorePkg/Include/Library/S3SaveRestoreLib.h
+++ b/BootloaderCorePkg/Include/Library/S3SaveRestoreLib.h
@@ -15,6 +15,7 @@
 #define SMMBASE_INFO_COMM_ID  1
 #define S3_SAVE_REG_COMM_ID   2
 #define BL_SW_SMI_COMM_ID     3
+#define BL_FACS_ADDR_COMM_ID  4
 
 //
 // Format to share info between bootloader and payload.
@@ -90,6 +91,12 @@ typedef struct {
   BL_PLD_COMM_HDR BlSwSmiHdr;
   UINT8           BlSwSmiHandlerInput;
 } BL_SW_SMI_INFO;
+
+typedef struct {
+  BL_PLD_COMM_HDR AcpiS3InfoHdr;
+  UINT64          AcpiBase;
+  UINT64          FacsAddress;
+} BL_ACPI_S3_INFO;
 
 #pragma pack()
 

--- a/BootloaderCorePkg/IncludePrivate/BootloaderCoreGlobal.h
+++ b/BootloaderCorePkg/IncludePrivate/BootloaderCoreGlobal.h
@@ -112,6 +112,7 @@ typedef struct {
   UINT32        AcpiGnvs;
   UINT8         BootMediaType;
   UINT8         BootPartition;
+  UINT64        FacsAddress;
 } S3_DATA;
 
 #pragma pack()

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiFpdt.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiFpdt.c
@@ -108,7 +108,8 @@ UpdateFpdtBootTable (
 
 
 /**
-  Get FPDT firmware performance table by searching ACPI table
+  Get FPDT firmware performance table by searching ACPI table. During
+  S3 Resume all pointers need to be bounds checked.
 
   @param[in]  AcpiTableBase    ACPI table base address
 
@@ -131,13 +132,35 @@ GetFpdtTable (
   Rsdp = (EFI_ACPI_5_0_ROOT_SYSTEM_DESCRIPTION_POINTER *)(UINTN)AcpiTableBase;
   Rsdt = (EFI_ACPI_DESCRIPTION_HEADER *)(UINTN)Rsdp->RsdtAddress;
 
+  if (!S3_PTR_CHK(Rsdt) ||
+      !S3_PTR_CHK((VOID*)((UINTN)Rsdt + sizeof(EFI_ACPI_DESCRIPTION_HEADER) - 1)) ||
+      (!IS_X64 && ((UINT64)(UINTN)Rsdt + Rsdt->Length - 1) > MAX_UINT32) ||
+      !S3_PTR_CHK((VOID*)((UINTN)Rsdt + Rsdt->Length - 1)) ||
+      Rsdt->Length < sizeof(EFI_ACPI_DESCRIPTION_HEADER))
+  {
+    return NULL;
+  }
+
   NumEntries = (Rsdt->Length - sizeof(EFI_ACPI_DESCRIPTION_HEADER)) / sizeof(UINT32);
   RsdtEntry  = (UINT32 *) ((UINT8 *)Rsdt + sizeof (EFI_ACPI_DESCRIPTION_HEADER));
   for (Index = 0; Index < NumEntries; Index++) {
     Hdr = (EFI_ACPI_COMMON_HEADER *) (UINTN) RsdtEntry[Index];
+    if (!S3_PTR_CHK(Hdr) ||
+        !S3_PTR_CHK((VOID*)((UINTN)Hdr + sizeof(EFI_ACPI_COMMON_HEADER) - 1)) ||
+        (!IS_X64 && ((UINT64)(UINTN)Hdr + Hdr->Length - 1) > MAX_UINT32) ||
+        !S3_PTR_CHK((VOID*)((UINTN)Hdr + Hdr->Length - 1)) ||
+        Hdr->Length < sizeof(EFI_ACPI_COMMON_HEADER))
+    {
+      return NULL;
+    }
     if (Hdr->Signature == EFI_ACPI_5_0_FIRMWARE_PERFORMANCE_DATA_TABLE_SIGNATURE) {
       Fpdt = (FIRMWARE_PERFORMANCE_TABLE *) Hdr;
       BootTable = (BOOT_PERFORMANCE_TABLE *)(UINTN)Fpdt->BootPointerRecord.BootPerformanceTablePointer;
+      if (!S3_PTR_CHK(BootTable) ||
+          (!IS_X64 && ((UINT64)(UINTN)BootTable + sizeof(BOOT_PERFORMANCE_TABLE) - 1) > MAX_UINT32) ||
+          !S3_PTR_CHK((VOID*)((UINTN)BootTable + sizeof(BOOT_PERFORMANCE_TABLE) - 1))) {
+        return NULL;
+      }
       DEBUG ((DEBUG_VERBOSE, "FPDT: ResetEnd                = %ld\n", BootTable->BasicBoot.ResetEnd));
       DEBUG ((DEBUG_VERBOSE, "FPDT: OsLoaderLoadImageStart  = %ld\n", BootTable->BasicBoot.OsLoaderLoadImageStart));
       DEBUG ((DEBUG_VERBOSE, "FPDT: OsLoaderStartImageStart = %ld\n", BootTable->BasicBoot.OsLoaderStartImageStart));
@@ -180,6 +203,11 @@ UpdateFpdtS3Table (
   }
 
   S3PerfTable = (S3_PERFORMANCE_TABLE *)(UINTN)Fpdt->S3PointerRecord.S3PerformanceTablePointer;
+  if (!S3_PTR_CHK(S3PerfTable) ||
+
+      !S3_PTR_CHK((VOID*)((UINTN)S3PerfTable + sizeof(S3_PERFORMANCE_TABLE) - 1))) {
+    return EFI_INVALID_PARAMETER;
+  }
   ASSERT ((S3PerfTable != NULL) && (S3PerfTable->Header.Signature == EFI_ACPI_5_0_FPDT_S3_PERFORMANCE_TABLE_SIGNATURE));
 
   // Get current time

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
@@ -992,3 +992,43 @@ FindAcpiFacsAddress (
   }
   return 0;
 }
+
+/**
+    Validate that the given ACPI pointer is within the ACPI memory range
+    defined in S3Data.
+
+    This function is used on S3 resume to validate any ACPI pointers
+    (e.g. from FACS) against the known ACPI memory range stored in
+    S3Data, to ensure they are safe to access without relying on
+    DRAM-resident ACPI tables.
+
+  @param[in] AcpiPtr
+  @return    EFI_STATUS
+
+ */
+EFI_STATUS
+EFIAPI
+ValidateAcpiPointerInS3(
+  IN VOID *AcpiPtr
+)
+{
+  S3_DATA *S3Data;
+
+  if (AcpiPtr == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  S3Data = (S3_DATA *)GetS3DataPtr();
+  if (S3Data == NULL) {
+    return EFI_UNSUPPORTED;
+  }
+
+  if ((UINTN)AcpiPtr < S3Data->AcpiBase ||
+      (UINTN)AcpiPtr >= (UINTN)S3Data->AcpiBase + PcdGet32 (PcdLoaderAcpiReclaimSize)) {
+    DEBUG((DEBUG_ERROR, "ACPI pointer 0x%08X is outside of ACPI memory range 0x%08X - 0x%08X\n", (UINTN)AcpiPtr, S3Data->AcpiBase, (UINTN)S3Data->AcpiBase + PcdGet32 (PcdLoaderAcpiReclaimSize)));
+    return EFI_INVALID_PARAMETER;
+  }
+  DEBUG((DEBUG_VERBOSE, "ACPI pointer 0x%08X is within ACPI memory range 0x%08X - 0x%08X\n", (UINTN)AcpiPtr, S3Data->AcpiBase, (UINTN)S3Data->AcpiBase + PcdGet32 (PcdLoaderAcpiReclaimSize)));
+
+  return EFI_SUCCESS;
+}

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
@@ -24,6 +24,8 @@
 #include <Library/FirmwareUpdateLib.h>
 #include <Guid/BootLoaderVersionGuid.h>
 #include <BootloaderCoreGlobal.h>
+#include <Library/S3SaveRestoreLib.h>
+#include <Guid/SmmInformationGuid.h>
 #include "AcpiInitLibInternal.h"
 
 STATIC
@@ -717,19 +719,248 @@ AcpiInit (
 
 typedef VOID (*DOWAKEUP) (UINT32 WakeVector);
 
+/**
+  Discover the S3 required info via the live ACPI tables and save it
+  to the TSEG S3 communication area for use on S3 resume.
+
+  Save AcpiBase and FACS address into TSEG so that it can be retrieved
+  on S3 resume without trusting DRAM-resident ACPI tables. The storage
+  method depends on PcdBuildSmmHobs:
+    BIT1 - copy BL_ACPI_S3_INFO at a fixed offset after PLD_TO_BL_SMM_INFO
+           and per-CPU SMM base entries in TSEG
+    BIT0 - append a BL_ACPI_S3_INFO structure via AppendS3Info()
+
+  @retval EFI_SUCCESS         ACPI S3 data saved successfully.
+  @retval EFI_NOT_FOUND       ACPI S3 data not found in the ACPI tables.
+  @retval EFI_DEVICE_ERROR    CPU info unavailable.
+  @retval EFI_UNSUPPORTED     No supported storage method available.
+
+**/
+EFI_STATUS
+EFIAPI
+SaveAcpiDataForS3(
+  VOID
+  )
+{
+  LDR_SMM_INFO         LdrSmmInfo;
+  BL_ACPI_S3_INFO      AcpiS3Info;
+  EFI_STATUS           Status;
+  SYS_CPU_INFO        *SysCpuInfo;
+  VOID                *AcpiS3TsegPtr;
+
+  //
+  // Get the number of detected CPUs
+  //
+  SysCpuInfo = MpGetInfo ();
+  if ((SysCpuInfo == NULL) || (SysCpuInfo->CpuCount == 0)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  Status = EFI_UNSUPPORTED;
+
+  AcpiS3Info.AcpiS3InfoHdr.Signature = BL_PLD_COMM_SIG;
+  AcpiS3Info.AcpiS3InfoHdr.Id        = BL_FACS_ADDR_COMM_ID;
+  AcpiS3Info.AcpiS3InfoHdr.Count     = 1;
+  AcpiS3Info.AcpiS3InfoHdr.TotalSize = sizeof (BL_ACPI_S3_INFO);
+  AcpiS3Info.AcpiBase                = PcdGet32 (PcdAcpiTablesRsdp);
+  AcpiS3Info.FacsAddress             = FindAcpiFacsAddress(PcdGet32 (PcdAcpiTablesRsdp));
+
+  if (AcpiS3Info.AcpiBase == 0 || AcpiS3Info.FacsAddress == 0) {
+    DEBUG((DEBUG_ERROR, "ACPI info needed for S3 is Invalid!\n"));
+    ASSERT (FALSE);
+    return EFI_NOT_FOUND;
+  }
+
+  if ((PcdGet8(PcdBuildSmmHobs) & BIT1) != 0) {
+    PlatformUpdateHobInfo (&gSmmInformationGuid, &LdrSmmInfo);
+    AcpiS3TsegPtr = (VOID *)(UINTN)(LdrSmmInfo.SmmBase + sizeof(PLD_TO_BL_SMM_INFO) + (sizeof(CPU_SMMBASE)*SysCpuInfo->CpuCount));
+    if ((AcpiS3TsegPtr < (VOID*)(UINTN)LdrSmmInfo.SmmBase) ||
+        (AcpiS3TsegPtr >= (VOID*)(UINTN)(LdrSmmInfo.SmmBase + LdrSmmInfo.SmmSize - sizeof(BL_ACPI_S3_INFO)))) {
+      DEBUG((DEBUG_ERROR, "TSEG target address for ACPI S3 info is out of range!\n"));
+      ASSERT (FALSE);
+      return EFI_UNSUPPORTED;
+    }
+    DEBUG((DEBUG_INFO, "Copying ACPI info struct to 0x%08X in S3 data\n", (UINTN)AcpiS3TsegPtr));
+    CopyMem (AcpiS3TsegPtr , &AcpiS3Info, sizeof(BL_ACPI_S3_INFO));
+    Status = EFI_SUCCESS;
+  }
+  else if ((PcdGet8(PcdBuildSmmHobs) & BIT0) != 0) {
+    Status = AppendS3Info(&AcpiS3Info, FALSE);
+  }
+  return Status;
+}
 
 /**
-  This function is called on S3 boot flow only.
+  Retrieve the pointer to BL_ACPI_S3_INFO structure from the TSEG S3 communication area.
 
-  It will locate the S3 waking vector from the ACPI table and then
-  jump into it. The control will never return.
+  This function locates the BL_ACPI_S3_INFO structure stored in TSEG by
+  SaveAcpiDataForS3() during normal boot. The retrieval method depends on
+  PcdBuildSmmHobs:
+    BIT1 - read from a fixed offset after PLD_TO_BL_SMM_INFO and per-CPU SMM base entries in TSEG
+    BIT0 - find the structure appended via AppendS3Info()
 
-  @param  AcpiTableBase   ACPI table base address
+  @retval Pointer to BL_ACPI_S3_INFO if found and valid, NULL if not found or invalid.
+
+**/
+BL_ACPI_S3_INFO*
+EFIAPI
+GetAcpiS3Info(
+  VOID
+)
+{
+  LDR_SMM_INFO         LdrSmmInfo;
+  BL_ACPI_S3_INFO     *AcpiS3Info;
+  SYS_CPU_INFO        *SysCpuInfo;
+
+  //
+  // Get the number of detected CPUs
+  //
+  SysCpuInfo = MpGetInfo ();
+  if ((SysCpuInfo == NULL) || (SysCpuInfo->CpuCount == 0)) {
+    return NULL;
+  }
+
+  PlatformUpdateHobInfo (&gSmmInformationGuid, &LdrSmmInfo);
+  if ((PcdGet8(PcdBuildSmmHobs) & BIT1) != 0) {
+    AcpiS3Info = (BL_ACPI_S3_INFO *)(UINTN)(LdrSmmInfo.SmmBase + sizeof(PLD_TO_BL_SMM_INFO) + (sizeof(CPU_SMMBASE)*SysCpuInfo->CpuCount));
+    if ((AcpiS3Info < (BL_ACPI_S3_INFO *)(UINTN)LdrSmmInfo.SmmBase) ||
+        (AcpiS3Info >= (BL_ACPI_S3_INFO *)(UINTN)(LdrSmmInfo.SmmBase + LdrSmmInfo.SmmSize - sizeof(BL_ACPI_S3_INFO)))) {
+      DEBUG((DEBUG_ERROR, "TSEG target address for ACPI S3 info is out of range!\n"));
+      ASSERT (FALSE);
+      return NULL;
+    }
+    if (AcpiS3Info->AcpiS3InfoHdr.Signature != BL_PLD_COMM_SIG || AcpiS3Info->AcpiS3InfoHdr.Id != BL_FACS_ADDR_COMM_ID) {
+      DEBUG((DEBUG_ERROR, "FACS address info not found in S3 data at expected location 0x%08X\n", AcpiS3Info));
+      return NULL;
+    }
+    return AcpiS3Info;
+  }
+  else if ((PcdGet8(PcdBuildSmmHobs) & BIT0) != 0) {
+    AcpiS3Info = FindS3Info (BL_FACS_ADDR_COMM_ID);
+    if (AcpiS3Info == NULL) {
+      DEBUG((DEBUG_ERROR, "FACS address info not found in S3 data\n"));
+      return NULL;
+    }
+    return AcpiS3Info;
+  }
+  else {
+    return NULL;
+  }
+}
+
+/**
+  Retrieve the FACS address from the TSEG S3 communication area.
+
+  This function reads the FACS physical address previously saved by
+  SaveAcpiDataForS3() during normal boot. It is called on S3 resume
+  to locate the FACS without relying on DRAM-resident ACPI tables.
+
+  @retval  Non-zero   Physical address of the FACS table.
+  @retval  0          FACS address not found.
+
+**/
+UINT64
+EFIAPI
+GetFacsAddressForS3(
+  VOID
+  )
+{
+  BL_ACPI_S3_INFO     *AcpiS3Info;
+
+  AcpiS3Info = GetAcpiS3Info();
+  if (AcpiS3Info != NULL) {
+    return AcpiS3Info->FacsAddress;
+  }
+  return 0;
+
+}
+
+/**
+  Retrieve the ACPI base address from the TSEG S3 communication area.
+
+  This function reads the ACPI base physical address previously saved by
+  SaveAcpiDataForS3() during normal boot. It is called on S3 resume
+  to locate the ACPI base without relying on DRAM-resident ACPI tables.
+
+  @retval  Non-zero   Physical address of the ACPI base.
+  @retval  0          ACPI base address not found.
+
+**/
+UINT64
+EFIAPI
+GetAcpiBaseForS3(
+  VOID
+)
+{
+  BL_ACPI_S3_INFO     *AcpiS3Info;
+
+  AcpiS3Info = GetAcpiS3Info();
+  if (AcpiS3Info != NULL) {
+    return AcpiS3Info->AcpiBase;
+  }
+  return 0;
+
+}
+
+/**
+  Locate the ACPI wake vector from FACS and jump to it on S3 resume.
+
+  This function retrieves the FACS address from the TSEG S3 communication
+  area (stored during normal boot via AppendS3Info), validates the FACS
+  signature, extracts the FirmwareWakingVector, and transfers control to
+  the OS wake entry point. This function does not return on success.
+
+  @param[in]  FacsAddress   Address of FACS saved from normal boot.
 
 **/
 VOID
 EFIAPI
 FindAcpiWakeVectorAndJump (
+  VOID    *FacsAddress
+  )
+{
+  EFI_ACPI_5_0_FIRMWARE_ACPI_CONTROL_STRUCTURE   *Facs;
+  UINT32                                          WakeVector;
+  DOWAKEUP                                        DoWake;
+
+  Facs = (EFI_ACPI_5_0_FIRMWARE_ACPI_CONTROL_STRUCTURE *)FacsAddress;
+  if (Facs->Signature == EFI_ACPI_5_0_FIRMWARE_ACPI_CONTROL_STRUCTURE_SIGNATURE) {
+    WakeVector = Facs->FirmwareWakingVector;
+    // Calculate CRC32 for 0x00000000 ---> BootLoaderRsvdMemBase and
+    // compare with the one calculated and saved in Stage1B.
+    if (PcdGetBool (PcdS3DebugEnabled)) {
+      if (!S3DebugRestoreAndCompareCRC32 () ) {
+        return;
+      }
+    }
+    CopyMem ((VOID *)(UINTN)WakeUpBuffer, (VOID *)(UINTN)&WakeUp, WakeUpSize);
+    DoWake = (DOWAKEUP)(UINTN)WakeUpBuffer;
+    DEBUG ((DEBUG_INIT, "Jump to Wake vector = 0x%x\n", WakeVector));
+    DoWake (WakeVector);
+    //
+    // Should never reach here!
+    //
+  }
+}
+
+
+/**
+  Find the FACS physical address by walking the live ACPI XSDT.
+
+  Scans the XSDT entries for FACP and resolves the FACS pointer via
+  XFirmwareCtrl (64-bit) with fallback to FirmwareCtrl (32-bit).
+  Used during normal boot to discover FACS after AcpiInit() so that the
+  address can be stored for S3 resume.
+
+  @param[in]  AcpiTableBase   Physical address of the RSDP.
+
+  @retval  Non-zero   Physical address of the FACS structure.
+  @retval  0          FACS not found.
+
+**/
+UINT64
+EFIAPI
+FindAcpiFacsAddress (
   IN  UINT32    AcpiTableBase
   )
 {
@@ -740,8 +971,6 @@ FindAcpiWakeVectorAndJump (
   UINT8                                           Index;
   EFI_ACPI_5_0_FIRMWARE_ACPI_CONTROL_STRUCTURE   *Facs;
   EFI_ACPI_5_0_FIXED_ACPI_DESCRIPTION_TABLE      *Facp;
-  UINT32                                          WakeVector;
-  DOWAKEUP                                        DoWake;
 
   Rsdp = (EFI_ACPI_5_0_ROOT_SYSTEM_DESCRIPTION_POINTER *)(UINTN)AcpiTableBase;
   Xsdt = (EFI_ACPI_DESCRIPTION_HEADER *)(UINTN)Rsdp->XsdtAddress;
@@ -757,22 +986,9 @@ FindAcpiWakeVectorAndJump (
         Facs = (EFI_ACPI_5_0_FIRMWARE_ACPI_CONTROL_STRUCTURE *)(UINTN)Facp->FirmwareCtrl;
       }
       if (Facs->Signature == EFI_ACPI_5_0_FIRMWARE_ACPI_CONTROL_STRUCTURE_SIGNATURE) {
-        WakeVector = Facs->FirmwareWakingVector;
-        // Calculate CRC32 for 0x00000000 ---> BootLoaderRsvdMemBase and
-        // compare with the one calculated and saved in Stage1B.
-        if (PcdGetBool (PcdS3DebugEnabled)) {
-          if (!S3DebugRestoreAndCompareCRC32 () ) {
-            return;
-          }
-        }
-        CopyMem ((VOID *)(UINTN)WakeUpBuffer, (VOID *)(UINTN)&WakeUp, WakeUpSize);
-        DoWake = (DOWAKEUP)(UINTN)WakeUpBuffer;
-        DEBUG ((DEBUG_INIT, "Jump to Wake vector = 0x%x\n", WakeVector));
-        DoWake (WakeVector);
-        //
-        // Should never reach here!
-        //
+        return (UINT64)(UINTN)Facs;
       }
     }
   }
+  return 0;
 }

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
@@ -68,3 +68,4 @@
   gPlatformModuleTokenSpaceGuid.PcdAcpiProcessorIdBase
   gPlatformCommonLibTokenSpaceGuid.PcdMadtUsePlatformLapic
   gPlatformCommonLibTokenSpaceGuid.PcdMcfgUsePlatformBaseAddr
+  gPlatformCommonLibTokenSpaceGuid.PcdBuildSmmHobs

--- a/BootloaderCorePkg/Stage2/Stage2.c
+++ b/BootloaderCorePkg/Stage2/Stage2.c
@@ -435,7 +435,7 @@ S3ResumePath (
   }
 
   // Find Wake Vector and Jump to OS
-  FindAcpiWakeVectorAndJump (S3Data->AcpiBase);
+  FindAcpiWakeVectorAndJump ((VOID*)(UINTN)S3Data->FacsAddress);
 }
 
 /**
@@ -633,6 +633,21 @@ SecStartup (
   BoardInit (PrePciEnumeration);
   AddMeasurePoint (0x3090);
 
+  // Make sure to get Saved S3 info before Payload SwSmi call that sets SMRR
+  if (ACPI_ENABLED () && (BootMode == BOOT_ON_S3_RESUME)) {
+    S3Data = (S3_DATA *)LdrGlobal->S3DataPtr;
+    S3Data->FacsAddress = GetFacsAddressForS3();
+    S3Data->AcpiBase = (UINT32)GetAcpiBaseForS3();
+    if ((S3Data->FacsAddress == 0) ||
+        (S3Data->AcpiBase == 0) ||
+        RShiftU64(GetAcpiBaseForS3(), 32) != 0) {
+      DEBUG((DEBUG_ERROR, "ACPI S3 resume data check failed!\n"));
+      ASSERT(FALSE);
+      // Switch to normal boot path.
+      ResetSystem (EfiResetCold);
+    }
+  }
+
   if (FixedPcdGetBool (PcdPciEnumEnabled)) {
     MemPool = AllocateTemporaryMemory (0);
     DEBUG ((DEBUG_INIT, "PCI Enum\n"));
@@ -664,11 +679,11 @@ SecStartup (
     Status   = (PcdGet32 (PcdLoaderAcpiNvsSize) < GetAcpiGnvsSize ()) ? EFI_OUT_OF_RESOURCES : EFI_SUCCESS;
     if (!EFI_ERROR (Status)) {
       AcpiGnvs = LdrGlobal->MemPoolStart - PcdGet32 (PcdLoaderAcpiNvsSize);
-      AcpiBase = AcpiGnvs - PcdGet32 (PcdLoaderAcpiReclaimSize);
       Status   = PcdSet32S (PcdAcpiGnvsAddress, AcpiGnvs);
 
       S3Data = (S3_DATA *)LdrGlobal->S3DataPtr;
       if (BootMode != BOOT_ON_S3_RESUME) {
+        AcpiBase = AcpiGnvs - PcdGet32 (PcdLoaderAcpiReclaimSize);
         PlatformUpdateAcpiGnvs ((VOID *)(UINTN)AcpiGnvs);
         S3Data->AcpiGnvs = AcpiGnvs;
         S3Data->AcpiBase = AcpiBase;
@@ -679,6 +694,10 @@ SecStartup (
         if (!EFI_ERROR (Status) && ((S3Data->AcpiTop - S3Data->AcpiBase) >
              PcdGet32 (PcdLoaderAcpiReclaimSize))) {
           Status = EFI_OUT_OF_RESOURCES;
+        }
+        Status = SaveAcpiDataForS3();
+        if (EFI_ERROR (Status)) {
+          DEBUG((DEBUG_ERROR, "Failed to save ACPI data for S3 resume - %r. S3 Resume cannot be supported.\n", Status));
         }
       } else {
         Status = (S3Data->AcpiGnvs == AcpiGnvs) ? EFI_SUCCESS : EFI_ABORTED;

--- a/BootloaderCorePkg/Stage2/Stage2.h
+++ b/BootloaderCorePkg/Stage2/Stage2.h
@@ -81,6 +81,7 @@
 #include <Library/IppCryptoPerfLib.h>
 #include <Library/BuildFdtLib.h>
 #include <Library/PlatformHookLib.h>
+#include <Library/S3SaveRestoreLib.h>
 
 #define UIMAGE_FIT_MAGIC               (0x56190527)
 

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -20,6 +20,7 @@
 #include <Library/MediaAccessLib.h>
 #include "SioChip.h"
 #include <Library/TxtLib.h>
+#include <Library/AcpiInitLib.h>
 
 GLOBAL_REMOVE_IF_UNREFERENCED UINT8    mBigCoreCount;
 GLOBAL_REMOVE_IF_UNREFERENCED UINT8    mSmallCoreCount;
@@ -701,6 +702,12 @@ BoardInit (
         //
         mS3SaveReg.S3SaveHdr.TotalSize = sizeof(BL_PLD_COMM_HDR) + mS3SaveReg.S3SaveHdr.Count * sizeof(REG_INFO);
         AppendS3Info ((VOID *)&mS3SaveReg, FALSE);
+
+        // Need to Save ACPI info again after clearing region
+        Status = SaveAcpiDataForS3 ();
+        if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_ERROR, "Failed to save ACPI S3 data after clearing region: %r - S3 Resume expected to fail.\n", Status));
+        }
       }
     }
     if ((GetBootMode() != BOOT_ON_FLASH_UPDATE) && (GetPayloadId() != 0)) {

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -70,6 +70,7 @@
 #include <Library/HeciLib.h>
 #include <Library/PlatformHookLib.h>
 #include <Library/MadtLib.h>
+#include <Library/AcpiInitLib.h>
 
 #define ICH_IOAPIC_ID                               0x02
 #define LOCAL_APIC_BASE_ADDRESS                     0xFEE00000
@@ -1086,6 +1087,12 @@ BoardInit (
       //
       mS3SaveReg.S3SaveHdr.TotalSize = sizeof(BL_PLD_COMM_HDR) + mS3SaveReg.S3SaveHdr.Count * sizeof(REG_INFO);
       AppendS3Info ((VOID *)&mS3SaveReg, FALSE);
+
+      // Need to Save ACPI info again after clearing region
+      Status = SaveAcpiDataForS3 ();
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Failed to save ACPI S3 data after clearing region: %r - S3 Resume expected to fail.\n", Status));
+      }
     }
     break;
   case EndOfStages:

--- a/Platform/CometlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CometlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -64,6 +64,7 @@
 #include <Library/S3SaveRestoreLib.h>
 #include "GpioTables.h"
 #include <Library/MadtLib.h>
+#include <Library/AcpiInitLib.h>
 
 #define DEFAULT_GPIO_IRQ_ROUTE                      14
 
@@ -1198,6 +1199,12 @@ BoardInit (
       //
       mS3SaveReg.S3SaveHdr.TotalSize = sizeof(BL_PLD_COMM_HDR) + mS3SaveReg.S3SaveHdr.Count * sizeof(REG_INFO);
       AppendS3Info ((VOID *)&mS3SaveReg, FALSE);
+
+      // Need to Save ACPI info again after clearing region
+      Status = SaveAcpiDataForS3 ();
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Failed to save ACPI S3 data after clearing region: %r - S3 Resume expected to fail.\n", Status));
+      }
     }
     break;
   case EndOfStages:

--- a/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -64,6 +64,7 @@
 #include <Library/S3SaveRestoreLib.h>
 #include "GpioTables.h"
 #include <Library/MadtLib.h>
+#include <Library/AcpiInitLib.h>
 
 #define DEFAULT_GPIO_IRQ_ROUTE                      14
 
@@ -1195,6 +1196,12 @@ BoardInit (
       //
       mS3SaveReg.S3SaveHdr.TotalSize = sizeof(BL_PLD_COMM_HDR) + mS3SaveReg.S3SaveHdr.Count * sizeof(REG_INFO);
       AppendS3Info ((VOID *)&mS3SaveReg, FALSE);
+
+      // Need to Save Acpi info again after clearing region
+      Status = SaveAcpiDataForS3 ();
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Failed to save ACPI S3 data after clearing region: %r - S3 Resume expected to fail.\n", Status));
+      }
     }
     break;
   case EndOfStages:

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -79,6 +79,7 @@
 #include <Library/PlatformHookLib.h>
 #include <Library/ResetSystemLib.h>
 #include <Library/MadtLib.h>
+#include <Library/AcpiInitLib.h>
 
 //
 // GPIO_PAD Fileds
@@ -678,6 +679,12 @@ BoardInit (
         Status = AppendS3Info ((VOID *)&mSmmBaseInfo, TRUE);
         mS3SaveReg.S3SaveHdr.TotalSize = sizeof(BL_PLD_COMM_HDR) + mS3SaveReg.S3SaveHdr.Count * sizeof(REG_INFO);
         AppendS3Info ((VOID *)&mS3SaveReg, FALSE);
+
+        // Need to Save ACPI info again after clearing region
+        Status = SaveAcpiDataForS3 ();
+        if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_ERROR, "Failed to save ACPI S3 data after clearing region: %r - S3 Resume expected to fail.\n", Status));
+        }
       }
     }
     if ((GetBootMode() != BOOT_ON_FLASH_UPDATE) && (GetPayloadId() != 0)) {

--- a/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -16,6 +16,7 @@
 #include <Library/PchInfoLib.h>
 #include <Register/PchRegsLpc.h>
 #include <Library/DmarLib.h>
+#include <Library/AcpiInitLib.h>
 
 STATIC CONST UINT32 NhltSignaturesTable[] = {
   SIGNATURE_32 ('N', 'H', 'L', 'T')
@@ -426,6 +427,12 @@ BoardInit (
       //
       mS3SaveReg.S3SaveHdr.TotalSize = sizeof(BL_PLD_COMM_HDR) + mS3SaveReg.S3SaveHdr.Count * sizeof(REG_INFO);
       AppendS3Info ((VOID *)&mS3SaveReg, FALSE);
+
+      // Need to Save ACPI info again after clearing region
+      Status = SaveAcpiDataForS3 ();
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Failed to save ACPI S3 data after clearing region: %r - S3 Resume expected to fail.\n", Status));
+      }
     }
 
     if ((GetBootMode() != BOOT_ON_FLASH_UPDATE) && (GetPayloadId() != 0)) {

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -86,6 +86,7 @@
 #include <Library/PlatformHookLib.h>
 #include <Library/TxtLib.h>
 #include <Library/MadtLib.h>
+#include <Library/AcpiInitLib.h>
 
 #define LOCAL_APIC_BASE_ADDRESS   0xFEE00000
 
@@ -971,6 +972,12 @@ BoardInit (
         //
         mS3SaveReg.S3SaveHdr.TotalSize = sizeof(BL_PLD_COMM_HDR) + mS3SaveReg.S3SaveHdr.Count * sizeof(REG_INFO);
         AppendS3Info ((VOID *)&mS3SaveReg, FALSE);
+
+        // Need to Save ACPI info again after clearing region
+        Status = SaveAcpiDataForS3 ();
+        if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_ERROR, "Failed to save ACPI S3 data after clearing region: %r - S3 Resume expected to fail.\n", Status));
+        }
       }
     }
     if ((GetBootMode() != BOOT_ON_FLASH_UPDATE) && (GetPayloadId() != 0)) {


### PR DESCRIPTION
Guard vital ACPI S3 info in TSEG and verify any ACPI table data before dereferencing.