### PR TITLE
[BuildLoader] Deprecated IA32 build for x64 platforms

### DIFF
--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -28,6 +28,14 @@ from   BuildUtility import *
 
 import glob
 
+
+def print_warning(message):
+    # Use ANSI yellow for warnings when output is a terminal.
+    if os.name != 'nt' and sys.stdout.isatty() and os.getenv('NO_COLOR') is None:
+        print('\033[33m%s\033[0m' % message)
+    else:
+        print(message)
+
 def rebuild_basetools ():
     exe_list = 'GenFfs  GenFv  GenFw  GenSec  Lz4Compress  LzmaCompress'.split()
     ret = 0
@@ -1620,6 +1628,11 @@ def main():
         for index, name in enumerate(board_names):
             if args.board == name:
                 brdcfg = module_names[index]
+                if args.arch.lower() == 'ia32' and brdcfg.Board().BUILD_ARCH == 'X64':
+                    print_warning('ERROR: IA32 build is not supported for platform [%s].' % args.board)
+                    print_warning('ERROR: Platform [%s] supports X64 architecture only. Build stopped.' % args.board)
+                    sys.exit(2)
+
                 board  = brdcfg.Board(
                                         BUILD_ARCH        = args.arch.upper(), \
                                         RELEASE_MODE      = args.release,     \

--- a/Platform/ArrowlakeBoardPkg/BoardConfigArlu.py
+++ b/Platform/ArrowlakeBoardPkg/BoardConfigArlu.py
@@ -26,6 +26,7 @@ class Board(ArrowlakeBoardConfig.Board):
         super(Board, self).__init__(*args, **kwargs)
 
         self.VERINFO_IMAGE_ID     = 'SB_ARLU'
+        self.BUILD_ARCH           = 'X64'
         self.BOARD_NAME           = 'arlu'
         self.MICROCODE_INF_FILE   = 'Silicon/ArrowlakePkg/Arlh/Microcode/MicrocodeArlu.inf'
         self._ACM_CPU_FMS = [

--- a/Platform/KaseyvilleBoardPkg/BoardConfigKsv.py
+++ b/Platform/KaseyvilleBoardPkg/BoardConfigKsv.py
@@ -28,6 +28,7 @@ class Board(BaseBoard):
         self.VERINFO_SVN          = 1
         self.VERINFO_BUILD_DATE   = time.strftime("%m/%d/%Y")
 
+        self.BUILD_ARCH           = 'X64'
         self.BOARD_NAME           = 'ksv'
         self.BOARD_PKG_NAME       = 'KaseyvilleBoardPkg'
         self.SILICON_PKG_NAME     = 'KaseyvillePkg'


### PR DESCRIPTION
Added Deprecation warning for IA32 build in BuildLoader.py and updated BoardConfig files for Arrowlake platforms to reflect the deprecation status.