### PR TITLE
fix: [Silicon] Add EFIAPI to missing definitions

### DIFF
--- a/Silicon/AlderlakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
+++ b/Silicon/AlderlakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
@@ -26,6 +26,7 @@ DisableWatchDogTimer (
 
 **/
 VOID
+EFIAPI
 EnableCodeExecution (
   VOID
 )

--- a/Silicon/AlderlakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
+++ b/Silicon/AlderlakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
@@ -15,6 +15,7 @@
 
 **/
 VOID
+EFIAPI
 DisableWatchDogTimer (
   VOID
 )

--- a/Silicon/AlderlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/AlderlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -19,6 +19,7 @@
   Enables the execution
 **/
 VOID
+EFIAPI
 EnableCodeExecution (
   VOID
 )

--- a/Silicon/ApollolakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/ApollolakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -15,6 +15,7 @@
   Enables the execution by writing to the MSR.
 **/
 VOID
+EFIAPI
 EnableCodeExecution (
   VOID
 )

--- a/Silicon/ArrowlakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
+++ b/Silicon/ArrowlakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
@@ -15,6 +15,7 @@
 
 **/
 VOID
+EFIAPI
 DisableWatchDogTimer (
   VOID
 )

--- a/Silicon/ArrowlakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
+++ b/Silicon/ArrowlakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
@@ -35,6 +35,7 @@ DisableWatchDogTimer (
 
 **/
 VOID
+EFIAPI
 EnableCodeExecution (
   VOID
 )

--- a/Silicon/ArrowlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/ArrowlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -15,6 +15,7 @@
   Enables the execution
 **/
 VOID
+EFIAPI
 EnableCodeExecution (
   VOID
 )

--- a/Silicon/CoffeelakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
+++ b/Silicon/CoffeelakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
@@ -13,6 +13,7 @@
 #include <Library/IoLib.h>
 
 VOID
+EFIAPI
 EnableCodeExecution (
   VOID
 )

--- a/Silicon/CoffeelakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
+++ b/Silicon/CoffeelakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
@@ -22,6 +22,7 @@ EnableCodeExecution (
 }
 
 VOID
+EFIAPI
 DisableWatchDogTimer (
   VOID
 )

--- a/Silicon/CoffeelakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/CoffeelakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -14,6 +14,7 @@
 #include <RegAccess.h>
 
 VOID
+EFIAPI
 EnableCodeExecution (
   VOID
 )

--- a/Silicon/CometlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/CometlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -14,6 +14,7 @@
 #include <RegAccess.h>
 
 VOID
+EFIAPI
 EnableCodeExecution (
   VOID
 )

--- a/Silicon/CometlakevPkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/CometlakevPkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -14,6 +14,7 @@
 #include <RegAccess.h>
 
 VOID
+EFIAPI
 EnableCodeExecution (
   VOID
 )

--- a/Silicon/ElkhartlakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
+++ b/Silicon/ElkhartlakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
@@ -28,6 +28,7 @@ EnableCodeExecution (
   Disable watch dog timer (Halt TCO timer).
 **/
 VOID
+EFIAPI
 DisableWatchDogTimer (
   VOID
 )

--- a/Silicon/ElkhartlakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
+++ b/Silicon/ElkhartlakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
@@ -16,6 +16,7 @@
   Enables the execution by writing to the MSR.
 **/
 VOID
+EFIAPI
 EnableCodeExecution (
   VOID
 )

--- a/Silicon/ElkhartlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/ElkhartlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -26,6 +26,7 @@
   Enables the execution by writing to the MSR.
 **/
 VOID
+EFIAPI
 EnableCodeExecution (
   VOID
 )

--- a/Silicon/IdavillePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/IdavillePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -12,6 +12,7 @@
   Enables the execution
 **/
 VOID
+EFIAPI
 EnableCodeExecution (
   VOID
 )

--- a/Silicon/KaseyvillePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/KaseyvillePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -12,6 +12,7 @@
   Enables the execution
 **/
 VOID
+EFIAPI
 EnableCodeExecution (
   VOID
 )

--- a/Silicon/MeteorlakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
+++ b/Silicon/MeteorlakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
@@ -15,6 +15,7 @@
 
 **/
 VOID
+EFIAPI
 DisableWatchDogTimer (
   VOID
 )

--- a/Silicon/MeteorlakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
+++ b/Silicon/MeteorlakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
@@ -35,6 +35,7 @@ DisableWatchDogTimer (
 
 **/
 VOID
+EFIAPI
 EnableCodeExecution (
   VOID
 )

--- a/Silicon/MeteorlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
+++ b/Silicon/MeteorlakePkg/Library/Stage1BSocInitLib/Stage1BSocInitLib.c
@@ -15,6 +15,7 @@
   Enables the execution
 **/
 VOID
+EFIAPI
 EnableCodeExecution (
   VOID
 )

--- a/Silicon/PantherlakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
+++ b/Silicon/PantherlakePkg/Library/Stage1ASocInitLib/Stage1ASocInitLib.c
@@ -15,6 +15,7 @@
 
 **/
 VOID
+EFIAPI
 DisableWatchDogTimer (
   VOID
   )


### PR DESCRIPTION
The definitions omitted the EFIAPI specifier used in the BoardInitLib/ SocInitLib declarations, causing a GCC -Wlto-type-mismatch warning and a calling-convention mismatch. Align the definitions across all affected SoCs.