### PR TITLE
bugfix: Guards for edge cases

### DIFF
--- a/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
+++ b/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
@@ -646,4 +646,26 @@ MatchHashInStore (
   IN       UINT8           *HashData
   );
 
+/**
+  Compare two buffers in constant time to prevent timing side-channel attacks.
+
+  This function always examines every byte in the range [0, Length) regardless
+  of whether a mismatch is found early.  The accumulated difference is stored
+  in a volatile variable so that the compiler cannot optimize away any iterations.
+
+  @param[in]  BufferA  Pointer to the first buffer.
+  @param[in]  BufferB  Pointer to the second buffer.
+  @param[in]  Length   Number of bytes to compare.
+
+  @retval  0           The buffers are identical over Length bytes.
+  @retval != 0         At least one byte differs.
+
+**/
+INTN
+CompareMemConstantTime (
+  IN CONST VOID  *BufferA,
+  IN CONST VOID  *BufferB,
+  IN UINTN       Length
+  );
+
 #endif

--- a/BootloaderCommonPkg/Library/BootloaderCommonLib/BootloaderCommonLib.c
+++ b/BootloaderCommonPkg/Library/BootloaderCommonLib/BootloaderCommonLib.c
@@ -448,6 +448,31 @@ GetComponentInfo (
 }
 
 /**
+  Return the expected digest length in bytes for a given HashAlg identifier.
+
+  @param[in]  HashAlg   One of HASH_TYPE_SHA256 / HASH_TYPE_SHA384 /
+                        HASH_TYPE_SHA512 / HASH_TYPE_SM3.
+
+  @retval 0        Algorithm is unknown or unsupported.
+  @retval Others   Expected digest length in bytes.
+
+**/
+STATIC
+UINT8
+HashAlgExpectedDigestLen (
+  IN  UINT8   HashAlg
+  )
+{
+  switch (HashAlg) {
+  case HASH_TYPE_SHA256:  return SHA256_DIGEST_SIZE;
+  case HASH_TYPE_SHA384:  return SHA384_DIGEST_SIZE;
+  case HASH_TYPE_SHA512:  return SHA512_DIGEST_SIZE;
+  case HASH_TYPE_SM3:     return SM3_DIGEST_SIZE;
+  default:                return 0;
+  }
+}
+
+/**
   Get the component hash data by the component type.
 
   @param[in]  ComponentType   Component type.
@@ -496,8 +521,22 @@ GetComponentHash (
   }
 
   while (HashEntryPtr < HashEndPtr) {
-
+    // Ensure the fixed header fits before reading any fields
+    if ((UINTN)(HashEndPtr - HashEntryPtr) < sizeof (HASH_STORE_DATA)) {
+      HashEntryPtr = HashEndPtr;
+      break;
+    }
     HashEntryData = (HASH_STORE_DATA *) HashEntryPtr;
+    // Reject malformed entries: zero-length digest, digest size that does not
+    // match the declared algorithm, or a digest that overruns the buffer.
+    if ((HashEntryData->DigestLen == 0) ||
+        (HashEntryData->DigestLen != HashAlgExpectedDigestLen (HashEntryData->HashAlg)) ||
+        (HashEntryData->DigestLen > (UINTN)(HashEndPtr - HashEntryPtr) - sizeof (HASH_STORE_DATA))) {
+      DEBUG ((DEBUG_ERROR, "HashStore entry has invalid DigestLen (0x%x) for HashAlg (0x%x); stopping.\n",
+              HashEntryData->DigestLen, HashEntryData->HashAlg));
+      HashEntryPtr = HashEndPtr;
+      return RETURN_COMPROMISED_DATA;
+    }
     if(HashEntryData->Usage & (1 << HashIndex)){
       //Hash Entry found
       break;
@@ -723,6 +762,58 @@ SetDeviceAddr (
 }
 
 /**
+  Compare two buffers in constant time to prevent timing side-channel attacks.
+
+  This function always examines every byte in the range [0, Length) regardless
+  of whether a mismatch is found early.  The accumulated difference is stored
+  in a volatile variable so that the compiler cannot optimize away any iterations.
+
+  @param[in]  BufferA  Pointer to the first buffer.
+  @param[in]  BufferB  Pointer to the second buffer.
+  @param[in]  Length   Number of bytes to compare.
+
+  @retval  0           The buffers are identical over Length bytes.
+  @retval != 0         At least one byte differs.
+
+**/
+INTN
+CompareMemConstantTime (
+  IN CONST VOID  *BufferA,
+  IN CONST VOID  *BufferB,
+  IN UINTN       Length
+  )
+{
+  volatile CONST UINT8  *A;
+  volatile CONST UINT8  *B;
+  volatile INTN Diff = 0;
+  UINTN         Idx;
+
+  //
+  // If length is 0, buffers are considered equal
+  //
+  if (Length == 0) {
+    return 0;
+  }
+
+  //
+  // Validate pointers are not NULL
+  //
+  if ((BufferA == NULL) || (BufferB == NULL)) {
+    return -1;
+  }
+
+  A = (volatile CONST UINT8 *) BufferA;
+  B = (volatile CONST UINT8 *) BufferB;
+  Diff = 0;
+
+  for (Idx = 0; Idx < Length; Idx++) {
+    Diff |= A[Idx] ^ B[Idx];
+  }
+
+  return (INTN) Diff;
+}
+
+/**
   Match a given hash with the ones in hash store.
 
   @param[in]  Usatge      Hash usage.
@@ -761,18 +852,24 @@ MatchHashInStore (
   HashEntryPtr = HashStorePtr->Data;
   HashEndPtr   = (UINT8 *) HashStorePtr +  HashStorePtr->UsedLength;
   while (HashEntryPtr < HashEndPtr) {
+    // Ensure the fixed header fits before reading any fields
+    if ((UINTN)(HashEndPtr - HashEntryPtr) < sizeof (HASH_STORE_DATA)) {
+      break;
+    }
     HashEntryData = (HASH_STORE_DATA *) HashEntryPtr;
     // Validate Hash Entry data before use
     if ((UINTN)HashEndPtr - (UINTN)HashEntryData < sizeof(HASH_STORE_DATA) ||
         HashEntryData->DigestLen == 0 ||
+        HashEntryData->DigestLen != HashAlgExpectedDigestLen (HashEntryData->HashAlg) ||
         HashEntryData->DigestLen > ((UINTN)HashEndPtr - (UINTN)HashEntryData - sizeof (HASH_STORE_DATA))) {
       return RETURN_COMPROMISED_DATA;
     }
     if (((HashEntryData->Usage & Usage) != 0) && (HashEntryData->HashAlg == HashAlg)) {
-      // Usage and hash type matched, check hash now
-      if (CompareMem (HashData, HashEntryData->Digest, HashEntryData->DigestLen) == 0) {
+      //
+      // Usage and hash type matched, compare digest in constant time
+      //
+      if (CompareMemConstantTime (HashData, HashEntryData->Digest, HashEntryData->DigestLen) == 0) {
         Status = RETURN_SUCCESS;
-        break;
       }
     }
     HashEntryPtr +=  sizeof(HASH_STORE_DATA) + HashEntryData->DigestLen;

--- a/BootloaderCommonPkg/Library/IppCrypto2Lib/hmac.c
+++ b/BootloaderCommonPkg/Library/IppCrypto2Lib/hmac.c
@@ -9,8 +9,8 @@
 #include "owncp.h"
 #include "pcphash.h"
 #include "pcptool.h"
+#include "pcphashmethod_rmf.h"
 #include <Library/MemoryAllocationLib.h>
-#include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Uefi/UefiBaseType.h>
 
@@ -56,12 +56,41 @@ IppStatus HKDFExtract( Ipp8u* prk, int prkLen,
                        const IppsHashMethod* pMethod
                      )
 {
+  if ((prk == NULL) || (ikm == NULL) || (pMethod == NULL)) {
+    DEBUG ((DEBUG_ERROR, "HKDFExtract: NULL pointer parameter\n"));
+    return ippStsNullPtrErr;
+  }
+  if ((prkLen <= 0) || (ikmLen <= 0)) {
+    DEBUG ((DEBUG_ERROR, "HKDFExtract: Invalid length parameter\n"));
+    return ippStsBadArgErr;
+  }
+  if ((salt == NULL) && (saltLen != 0)) {
+    DEBUG ((DEBUG_ERROR, "HKDFExtract: NULL salt with non-zero saltLen\n"));
+    return ippStsNullPtrErr;
+  }
+
+  //
+  // RFC 5869 Section 2.2: If salt is not present, it defaults to a string of HashLen zeros.
+  //
+  if ((salt == NULL) && (saltLen == 0)) {
+    int hashLen;
+    Ipp8u zero_salt[IPP_SHA512_DIGEST_BITSIZE / 8];
+    hashLen = pMethod->hashLen;
+    if ((hashLen <= 0) || (hashLen > (int)sizeof(zero_salt))) {
+        DEBUG ((DEBUG_ERROR, "HKDFExtract: Invalid hashLen from method\n"));
+        return ippStsBadArgErr;
+    }
+
+    ZeroMem (zero_salt, (UINTN)hashLen);
+    return ippsHMACMessage_rmf(ikm, ikmLen, zero_salt, hashLen, prk, prkLen, pMethod);
+  }
+
   return ippsHMACMessage_rmf(ikm, ikmLen, salt, saltLen, prk, prkLen, pMethod);
 }
 
 IppStatus HKDFExpand( Ipp8u* okm, int okmLen,
                       const Ipp8u* prk, int prkLen,
-                      const Ipp8u* info,int infoLen,
+                      const Ipp8u* info, int infoLen,
                       const IppsHashMethod* pMethod)
 {
   int ctxSize = 0;
@@ -73,6 +102,39 @@ IppStatus HKDFExpand( Ipp8u* okm, int okmLen,
   int outLen;
   int copyLen;
   IppStatus Sts;
+
+  //
+  // Validate required pointer parameters
+  //
+  if ((okm == NULL) || (prk == NULL) || (pMethod == NULL)) {
+    DEBUG ((DEBUG_ERROR, "HKDFExpand: NULL pointer parameter\n"));
+    return ippStsNullPtrErr;
+  }
+
+  //
+  // RFC 5869 Section 2.3: info is optional context; NULL is valid if infoLen == 0
+  //
+  if ((info == NULL) && (infoLen != 0)) {
+    DEBUG ((DEBUG_ERROR, "HKDFExpand: NULL info with non-zero infoLen\n"));
+    return ippStsNullPtrErr;
+  }
+
+  //
+  // Validate length parameters
+  //
+  if ((okmLen <= 0) || (prkLen <= 0)) {
+    DEBUG ((DEBUG_ERROR, "HKDFExpand: Invalid length parameter\n"));
+    return ippStsBadArgErr;
+  }
+
+  //
+  // Enforce RFC 5869 Section 2.3: L <= 255 * HashLen
+  //
+  hashLen = prkLen;
+  if ((hashLen <= 0) || (okmLen > (255 * hashLen))) {
+    DEBUG ((DEBUG_ERROR, "HKDFExpand: okmLen exceeds 255*hashLen limit\n"));
+    return ippStsBadArgErr;
+  }
 
   Sts = ippsHMACGetSize_rmf(&ctxSize);
   if(Sts !=ippStsNoErr) {
@@ -91,15 +153,20 @@ IppStatus HKDFExpand( Ipp8u* okm, int okmLen,
   }
 
   tmpLen = 0;
-  hashLen = prkLen;
   cnt = 1;
 
-  for(outLen=0; outLen<okmLen; outLen+=hashLen) {
-    Sts = ippsHMACUpdate_rmf(tmp,  tmpLen, pHMAC);
+  //
+  // Use safe pointer for info (RFC 5869 allows empty/NULL info)
+  //
+  const Ipp8u empty_info = 0;
+  const Ipp8u *use_info = info ? info : &empty_info;
+
+  for(outLen = 0; outLen < okmLen; outLen += hashLen) {
+    Sts = ippsHMACUpdate_rmf(tmp, tmpLen, pHMAC);
     if(Sts !=ippStsNoErr) {
       goto Exit;
     }
-    Sts = ippsHMACUpdate_rmf(info, infoLen, pHMAC);
+    Sts = ippsHMACUpdate_rmf(use_info, infoLen, pHMAC);
     if(Sts !=ippStsNoErr) {
       goto Exit;
     }
@@ -108,18 +175,23 @@ IppStatus HKDFExpand( Ipp8u* okm, int okmLen,
       goto Exit;
     }
     cnt++;
-    Sts = ippsHMACFinal_rmf(tmp,  hashLen, pHMAC);
+    Sts = ippsHMACFinal_rmf(tmp, hashLen, pHMAC);
     if(Sts !=ippStsNoErr) {
       goto Exit;
     }
     tmpLen = hashLen;
 
-    copyLen = ((outLen+hashLen)<=okmLen)? hashLen : okmLen-outLen;
+    copyLen = ((outLen + hashLen) <= okmLen) ? hashLen : (okmLen - outLen);
+    if (copyLen <= 0) {
+      Sts = ippStsBadArgErr;
+      goto Exit;
+    }
 
-    CopyMem(okm+outLen, tmp, copyLen);
+    CopyMem(okm + outLen, tmp, copyLen);
   }
 
 Exit:
+  ZeroMem(pHMAC, ctxSize);
   FreePool(pHMAC);
   return Sts;
 }
@@ -128,22 +200,17 @@ EFI_STATUS
 HKDF ( const IppsHashMethod* pMethod,
        const Ipp8u* salt, int saltLen,
        const Ipp8u* ikm, int ikmLen,
-       const Ipp8u* info,int infoLen,
+       const Ipp8u* info, int infoLen,
        Ipp8u* okm, int okmLen
      )
 {
   Ipp8u tprk[IPP_SHA256_DIGEST_BITSIZE/8];
   IppStatus Sts;
 
-  // TODO: Check to see if Expand returns correct OKM  or not if ikmLen > 64
-  if ((saltLen > 64) ||  (infoLen > 64) || (ikmLen > 64)){
-    DEBUG ((DEBUG_ERROR, "HKDF: Invalid Parameter\n"));
-    return RETURN_INVALID_PARAMETER;
-  }
-
   // step 1 (extract)
-  Sts = HKDFExtract(tprk,sizeof(tprk), salt,saltLen, ikm,ikmLen, pMethod);
+  Sts = HKDFExtract(tprk, sizeof(tprk), salt, saltLen, ikm, ikmLen, pMethod);
   if(Sts !=ippStsNoErr) {
+    ZeroMem(tprk, sizeof(tprk));
     DEBUG ((DEBUG_ERROR, "HKDF Extract failed:%d\n", Sts));
     return EFI_PROTOCOL_ERROR;
   }
@@ -152,7 +219,13 @@ HKDF ( const IppsHashMethod* pMethod,
 #endif
 
   // step 2 (expand)
-  Sts = HKDFExpand(okm,okmLen, tprk,sizeof(tprk), info,infoLen, pMethod);
+  Sts = HKDFExpand(okm, okmLen, tprk, sizeof(tprk), info, infoLen, pMethod);
+
+  //
+  // Clear PRK from stack before return
+  //
+  ZeroMem(tprk, sizeof(tprk));
+
   if(Sts !=ippStsNoErr) {
     DEBUG ((DEBUG_ERROR, "HKDF Expand failed:%d\n", Sts));
     return EFI_PROTOCOL_ERROR;

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/owndefs.h
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/owndefs.h
@@ -620,38 +620,29 @@ typedef enum {
 #define IPP_NOERROR_RET()  return ippStsNoErr
 #define IPP_ERROR_RET( ErrCode )  return (ErrCode)
 
-#ifdef _IPP_DEBUG
+#define IPP_BADARG_RET( expr, ErrCode )\
+            {if (expr) { IPP_ERROR_RET( ErrCode ); }}
 
-    #define IPP_BADARG_RET( expr, ErrCode )\
-                {if (expr) { IPP_ERROR_RET( ErrCode ); }}
+#define IPP_BAD_SIZE_RET( n )\
+            IPP_BADARG_RET( (n)<=0, ippStsSizeErr )
 
-#else
+#define IPP_BAD_STEP_RET( n )\
+            IPP_BADARG_RET( (n)<=0, ippStsStepErr )
 
-    #define IPP_BADARG_RET( expr, ErrCode )
+#define IPP_BAD_PTR1_RET( ptr )\
+            IPP_BADARG_RET( NULL==(ptr), ippStsNullPtrErr )
 
-#endif
+#define IPP_BAD_PTR2_RET( ptr1, ptr2 )\
+            {IPP_BAD_PTR1_RET( ptr1 ); IPP_BAD_PTR1_RET( ptr2 )}
 
+#define IPP_BAD_PTR3_RET( ptr1, ptr2, ptr3 )\
+            {IPP_BAD_PTR2_RET( ptr1, ptr2 ); IPP_BAD_PTR1_RET( ptr3 )}
 
-    #define IPP_BAD_SIZE_RET( n )\
-                IPP_BADARG_RET( (n)<=0, ippStsSizeErr )
+#define IPP_BAD_PTR4_RET( ptr1, ptr2, ptr3, ptr4 )\
+            {IPP_BAD_PTR2_RET( ptr1, ptr2 ); IPP_BAD_PTR2_RET( ptr3, ptr4 )}
 
-    #define IPP_BAD_STEP_RET( n )\
-                IPP_BADARG_RET( (n)<=0, ippStsStepErr )
-
-    #define IPP_BAD_PTR1_RET( ptr )\
-                IPP_BADARG_RET( NULL==(ptr), ippStsNullPtrErr )
-
-    #define IPP_BAD_PTR2_RET( ptr1, ptr2 )\
-                {IPP_BAD_PTR1_RET( ptr1 ); IPP_BAD_PTR1_RET( ptr2 )}
-
-    #define IPP_BAD_PTR3_RET( ptr1, ptr2, ptr3 )\
-                {IPP_BAD_PTR2_RET( ptr1, ptr2 ); IPP_BAD_PTR1_RET( ptr3 )}
-
-    #define IPP_BAD_PTR4_RET( ptr1, ptr2, ptr3, ptr4 )\
-                {IPP_BAD_PTR2_RET( ptr1, ptr2 ); IPP_BAD_PTR2_RET( ptr3, ptr4 )}
-
-    #define IPP_BAD_ISIZE_RET(roi) \
-               IPP_BADARG_RET( ((roi).width<=0 || (roi).height<=0), ippStsSizeErr)
+#define IPP_BAD_ISIZE_RET(roi) \
+            IPP_BADARG_RET( ((roi).width<=0 || (roi).height<=0), ippStsSizeErr)
 
 /* ////////////////////////////////////////////////////////////////////////// */
 /*                              internal messages                             */
@@ -932,4 +923,3 @@ extern double            __intel_castu64_f64(unsigned __int64 val);
 #endif
 
 #endif /* __OWNDEFS_H__ */
-

--- a/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpbnumisc.h
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/auth/pcpbnumisc.h
@@ -53,7 +53,7 @@
 /* expand by zeros */
 #define ZEXPAND_BNU(srcdst,srcLen, dstLen) \
 { \
-  SetMem (srcdst + srcLen * sizeof (BNU_CHUNK_T), (dstLen - srcLen) * sizeof (BNU_CHUNK_T), 0); \
+  SetMem (srcdst + srcLen, (dstLen - srcLen) * sizeof (BNU_CHUNK_T), 0); \
 }
 
 /* copy and expand by zeros */

--- a/BootloaderCommonPkg/Library/IppCryptoLib/hmac.c
+++ b/BootloaderCommonPkg/Library/IppCryptoLib/hmac.c
@@ -53,12 +53,34 @@ IppStatus HKDFExtract( Ipp8u* prk, int prkLen,
                        const IppsHashMethod* pMethod
                      )
 {
+  if ((prk == NULL) || (ikm == NULL) || (pMethod == NULL)) {
+    DEBUG ((DEBUG_ERROR, "HKDFExtract: NULL pointer parameter\n"));
+    return ippStsNullPtrErr;
+  }
+  if ((prkLen <= 0) || (ikmLen <= 0)) {
+    DEBUG ((DEBUG_ERROR, "HKDFExtract: Invalid length parameter\n"));
+    return ippStsBadArgErr;
+  }
+  if ((salt == NULL) && (saltLen != 0)) {
+    DEBUG ((DEBUG_ERROR, "HKDFExtract: NULL salt with non-zero saltLen\n"));
+    return ippStsNullPtrErr;
+  }
+
+  //
+  // RFC 5869 Section 2.2: If salt is not present, it defaults to a string of HashLen zeros.
+  //
+  if ((salt == NULL) && (saltLen == 0)) {
+    Ipp8u zero_salt[64];
+    ZeroMem (zero_salt, prkLen);
+    return ippsHMACMessage_rmf(ikm, ikmLen, zero_salt, prkLen, prk, prkLen, pMethod);
+  }
+
   return ippsHMACMessage_rmf(ikm, ikmLen, salt, saltLen, prk, prkLen, pMethod);
 }
 
 IppStatus HKDFExpand( Ipp8u* okm, int okmLen,
                       const Ipp8u* prk, int prkLen,
-                      const Ipp8u* info,int infoLen,
+                      const Ipp8u* info, int infoLen,
                       const IppsHashMethod* pMethod)
 {
   int ctxSize = 0;
@@ -70,6 +92,39 @@ IppStatus HKDFExpand( Ipp8u* okm, int okmLen,
   int outLen;
   int copyLen;
   IppStatus Sts;
+
+  //
+  // Validate required pointer parameters
+  //
+  if ((okm == NULL) || (prk == NULL) || (pMethod == NULL)) {
+    DEBUG ((DEBUG_ERROR, "HKDFExpand: NULL pointer parameter\n"));
+    return ippStsNullPtrErr;
+  }
+
+  //
+  // RFC 5869 Section 2.3: info is optional context; NULL is valid if infoLen == 0
+  //
+  if ((info == NULL) && (infoLen != 0)) {
+    DEBUG ((DEBUG_ERROR, "HKDFExpand: NULL info with non-zero infoLen\n"));
+    return ippStsNullPtrErr;
+  }
+
+  //
+  // Validate length parameters
+  //
+  if ((okmLen <= 0) || (prkLen <= 0)) {
+    DEBUG ((DEBUG_ERROR, "HKDFExpand: Invalid length parameter\n"));
+    return ippStsBadArgErr;
+  }
+
+  //
+  // Enforce RFC 5869 Section 2.3: L <= 255 * HashLen
+  //
+  hashLen = prkLen;
+  if ((hashLen <= 0) || (okmLen > (255 * hashLen))) {
+    DEBUG ((DEBUG_ERROR, "HKDFExpand: okmLen exceeds 255*hashLen limit\n"));
+    return ippStsBadArgErr;
+  }
 
   Sts = ippsHMACGetSize_rmf(&ctxSize);
   if(Sts !=ippStsNoErr) {
@@ -88,15 +143,20 @@ IppStatus HKDFExpand( Ipp8u* okm, int okmLen,
   }
 
   tmpLen = 0;
-  hashLen = prkLen;
   cnt = 1;
 
-  for(outLen=0; outLen<okmLen; outLen+=hashLen) {
-    Sts = ippsHMACUpdate_rmf(tmp,  tmpLen, pHMAC);
+  //
+  // Use safe pointer for info (RFC 5869 allows empty/NULL info)
+  //
+  const Ipp8u empty_info = 0;
+  const Ipp8u *use_info = info ? info : &empty_info;
+
+  for(outLen = 0; outLen < okmLen; outLen += hashLen) {
+    Sts = ippsHMACUpdate_rmf(tmp, tmpLen, pHMAC);
     if(Sts !=ippStsNoErr) {
       goto Exit;
     }
-    Sts = ippsHMACUpdate_rmf(info, infoLen, pHMAC);
+    Sts = ippsHMACUpdate_rmf(use_info, infoLen, pHMAC);
     if(Sts !=ippStsNoErr) {
       goto Exit;
     }
@@ -105,18 +165,23 @@ IppStatus HKDFExpand( Ipp8u* okm, int okmLen,
       goto Exit;
     }
     cnt++;
-    Sts = ippsHMACFinal_rmf(tmp,  hashLen, pHMAC);
+    Sts = ippsHMACFinal_rmf(tmp, hashLen, pHMAC);
     if(Sts !=ippStsNoErr) {
       goto Exit;
     }
     tmpLen = hashLen;
 
-    copyLen = ((outLen+hashLen)<=okmLen)? hashLen : okmLen-outLen;
+    copyLen = ((outLen + hashLen) <= okmLen) ? hashLen : (okmLen - outLen);
+    if (copyLen <= 0) {
+      Sts = ippStsBadArgErr;
+      goto Exit;
+    }
 
-    CopyMem(okm+outLen, tmp, copyLen);
+    CopyMem(okm + outLen, tmp, copyLen);
   }
 
 Exit:
+  ZeroMem(pHMAC, ctxSize);
   FreePool(pHMAC);
   return Sts;
 }
@@ -125,22 +190,17 @@ EFI_STATUS
 HKDF ( const IppsHashMethod* pMethod,
        const Ipp8u* salt, int saltLen,
        const Ipp8u* ikm, int ikmLen,
-       const Ipp8u* info,int infoLen,
+       const Ipp8u* info, int infoLen,
        Ipp8u* okm, int okmLen
      )
 {
   Ipp8u tprk[IPP_SHA256_DIGEST_BITSIZE/8];
   IppStatus Sts;
 
-  // TODO: Check to see if Expand returns correct OKM  or not if ikmLen > 64
-  if ((saltLen > 64) ||  (infoLen > 64) || (ikmLen > 64)){
-    DEBUG ((DEBUG_ERROR, "HKDF: Invalid Parameter\n"));
-    return RETURN_INVALID_PARAMETER;
-  }
-
   // step 1 (extract)
-  Sts = HKDFExtract(tprk,sizeof(tprk), salt,saltLen, ikm,ikmLen, pMethod);
+  Sts = HKDFExtract(tprk, sizeof(tprk), salt, saltLen, ikm, ikmLen, pMethod);
   if(Sts !=ippStsNoErr) {
+    ZeroMem(tprk, sizeof(tprk));
     DEBUG ((DEBUG_ERROR, "HKDF Extract failed:%d\n", Sts));
     return EFI_PROTOCOL_ERROR;
   }
@@ -149,7 +209,13 @@ HKDF ( const IppsHashMethod* pMethod,
 #endif
 
   // step 2 (expand)
-  Sts = HKDFExpand(okm,okmLen, tprk,sizeof(tprk), info,infoLen, pMethod);
+  Sts = HKDFExpand(okm, okmLen, tprk, sizeof(tprk), info, infoLen, pMethod);
+
+  //
+  // Clear PRK from stack before return
+  //
+  ZeroMem(tprk, sizeof(tprk));
+
   if(Sts !=ippStsNoErr) {
     DEBUG ((DEBUG_ERROR, "HKDF Expand failed:%d\n", Sts));
     return EFI_PROTOCOL_ERROR;

--- a/BootloaderCommonPkg/Library/SecureBootLib/SecureBootHash.c
+++ b/BootloaderCommonPkg/Library/SecureBootLib/SecureBootHash.c
@@ -187,8 +187,10 @@ DoHashVerify (
 
   Status = RETURN_SECURITY_VIOLATION;
   if (Usage == 0) {
-    // Compare hash with the buffer passed in
-    if (CompareMem (HashData, (VOID *)Digest, DigestSize) == 0) {
+    //
+    // Compare hash with the buffer passed in (constant-time to prevent timing leak)
+    //
+    if (CompareMemConstantTime (HashData, (VOID *)Digest, DigestSize) == 0) {
       Status = RETURN_SUCCESS;
     }
   } else {


### PR DESCRIPTION
Add stricter parameter and bounds validation across HashStore iteration, HKDF Extract/Expand, and hash comparison routines. Use overflow-safe arithmetic throughout and align HKDF behaviour with RFC 5869.