### PR TITLE
fix: ContainerLib Status value set but overwritten before use

### DIFF
--- a/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
+++ b/BootloaderCommonPkg/Library/ContainerLib/ContainerLib.c
@@ -1249,7 +1249,6 @@ LoadComponentWithCallback (
   if (CompressHdr->Size == 0) {
     DstLen = 0;
     ScrLen = 0;
-    Status = EFI_SUCCESS;
   } else {
     Status = DecompressGetInfo (CompressHdr->Signature, CompressHdr->Data,
                                 CompressHdr->CompressedSize, &DstLen, &ScrLen);


### PR DESCRIPTION
Recent LoadComponentWithCallback fixes included writing Status with a value that was getting overwritten further down before ever being used. Flagged by static analyzer.