### PR TITLE
[ARL]Fix UefiPld assert error

### DIFF
--- a/Platform/ArrowlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
+++ b/Platform/ArrowlakeBoardPkg/Library/FspsUpdUpdateLib/FspsUpdUpdateLib.c
@@ -608,6 +608,9 @@ UpdateFspConfig (
     IoWrite32 ((UINTN) (ACPI_BASE_ADDRESS + R_ACPI_IO_SMI_EN), SmiEn & (UINT32) (~B_ACPI_IO_SMI_EN_GBL_SMI_EN));
     // Lock down SMI
     FspsConfig->PchLockDownGlobalSmi = 0x1;
+  } else if (GetPayloadId () == UEFI_PAYLOAD_ID_SIGNATURE){
+    FspsConfig->PchLockDownGlobalSmi = 0;
+    DEBUG ((DEBUG_INFO, "PchLockDownGlobalSmi = 0\n"));
   }
 
   // PCH Flash protection


### PR DESCRIPTION
Fix UefiPld assert error due to FSP locks Global SMI internally during FspSiliconInit, before returning control to SBL. This prevents SMI from working in the UEFI payload. Set PchLockDownGlobalSmi=0 so UEFI payload handles lockdown at the proper time.

Signed-off-by: samihahkasim <samihah.kasim@intel.com>
