### PR TITLE
fix: [RPL-P] Sync RPL-P Fusa config with latest TCC guidance

### DIFF
--- a/Platform/RaptorlakeBoardPkg/CfgData/CfgData_Fusa_Feature.dlt
+++ b/Platform/RaptorlakeBoardPkg/CfgData/CfgData_Fusa_Feature.dlt
@@ -52,9 +52,6 @@ MEMORY_CFG_DATA.HyperThreading                | 0
 MEMORY_CFG_DATA.DisableStarv2medPrioOnNewReq  | 1
 
 POWER_CFG_DATA.Cx                             | 0
-POWER_CFG_DATA.Eist                           | 0
-POWER_CFG_DATA.Hwp                            | 0
-POWER_CFG_DATA.TurboMode                      | 0
 
 SILICON_CFG_DATA.PsfTccEnable                 | 0
 SILICON_CFG_DATA.PchDmiAspmCtrl               | 0


### PR DESCRIPTION
Latest TCC guide removes the requirement to disable SpeedStep, Speedshift, and Turbo mode to enable TCC. This was already reflected in the FspUpdUpdateLibs.