### PR TITLE
Revert "fix: [RPL-P] Sync RPL-P Fusa config with latest TCC guidance"

### DIFF
--- a/Platform/RaptorlakeBoardPkg/CfgData/CfgData_Fusa_Feature.dlt
+++ b/Platform/RaptorlakeBoardPkg/CfgData/CfgData_Fusa_Feature.dlt
@@ -52,6 +52,9 @@ MEMORY_CFG_DATA.HyperThreading                | 0
 MEMORY_CFG_DATA.DisableStarv2medPrioOnNewReq  | 1
 
 POWER_CFG_DATA.Cx                             | 0
+POWER_CFG_DATA.Eist                           | 0
+POWER_CFG_DATA.Hwp                            | 0
+POWER_CFG_DATA.TurboMode                      | 0
 
 SILICON_CFG_DATA.PsfTccEnable                 | 0
 SILICON_CFG_DATA.PchDmiAspmCtrl               | 0


### PR DESCRIPTION
This reverts commit b56f181cb34a838cff0db2b6b060e4daa0a60f8e.

The original commit is a correct change, but we need to wait until the associated FuSa documentation is updated to reflect this change.