### PR TITLE
fix: [ADL/RPL] Deprioritize USB boot as the default/1st option

### DIFF
--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_BootOption_Adln.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_BootOption_Adln.yaml
@@ -10,14 +10,13 @@
 
 - $ACTION      :
     page         : OS
-# usb
-- !expand { BOOT_OPTION_TMPL : [ 0 ,   0       ,  0 ,    5   ,   0   ,    0xFF  ,     1 ,     1 , '/boot/sbl_os' ] }
 # nvme
-- !expand { BOOT_OPTION_TMPL : [ 1 ,   0       ,  0 ,    6   ,   1   ,    0     ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 2 ,   0       ,  0 ,    6   ,   0   ,    0     ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 0 ,   0       ,  0 ,    6   ,   1   ,    0     ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 1 ,   0       ,  0 ,    6   ,   0   ,    0     ,     1 ,     1 , '/boot/sbl_os' ] }
 # sata
-- !expand { BOOT_OPTION_TMPL : [ 3 ,   0       ,  0 ,    0   ,   0   ,    0xFF  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 2 ,   0       ,  0 ,    0   ,   0   ,    0xFF  ,     1 ,     1 , '/boot/sbl_os' ] }
 
 # emmc
-- !expand { BOOT_OPTION_TMPL : [ 4,    0       ,  0 ,    2   ,   0   ,    0     ,     1 ,     1 , '/boot/sbl_os' ] }
-
+- !expand { BOOT_OPTION_TMPL : [ 3,    0       ,  0 ,    2   ,   0   ,    0     ,     1 ,     1 , '/boot/sbl_os' ] }
+# usb
+- !expand { BOOT_OPTION_TMPL : [ 4 ,   0       ,  0 ,    5   ,   0   ,    0xFF  ,     1 ,     1 , '/boot/sbl_os' ] }

--- a/Platform/AlderlakeBoardPkg/CfgData/CfgData_BootOption_Azb.yaml
+++ b/Platform/AlderlakeBoardPkg/CfgData/CfgData_BootOption_Azb.yaml
@@ -10,10 +10,10 @@
 
 - $ACTION      :
     page         : OS
-# usb
-- !expand { BOOT_OPTION_TMPL : [ 0 ,   0       ,  0 ,    5   ,   1   ,    0xFF  ,     1 ,     1 , '/boot/sbl_os' ] }
 # nvme
-- !expand { BOOT_OPTION_TMPL : [ 1 ,   0       ,  0 ,    6   ,   0   ,    0x0   ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 2 ,   0       ,  0 ,    6   ,   1   ,    0x0   ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 0 ,   0       ,  0 ,    6   ,   0   ,    0x0   ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 1 ,   0       ,  0 ,    6   ,   1   ,    0x0   ,     1 ,     1 , '/boot/sbl_os' ] }
 # ufs
-- !expand { BOOT_OPTION_TMPL : [ 3 ,   0       ,  0 ,    3   ,   1   ,    0x0   ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 2 ,   0       ,  0 ,    3   ,   1   ,    0x0   ,     1 ,     1 , '/boot/sbl_os' ] }
+# usb
+- !expand { BOOT_OPTION_TMPL : [ 3 ,   0       ,  0 ,    5   ,   1   ,    0xFF  ,     1 ,     1 , '/boot/sbl_os' ] }

--- a/Platform/RaptorlakeBoardPkg/CfgData/CfgData_BootOptionRplp.yaml
+++ b/Platform/RaptorlakeBoardPkg/CfgData/CfgData_BootOptionRplp.yaml
@@ -10,17 +10,17 @@
 
 - $ACTION      :
     page         : OS
-# usb
-- !expand { BOOT_OPTION_TMPL : [ 0 ,   0       ,  0 ,    5   ,   0   ,    0xFF  ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 1 ,   0x1F    ,  0 ,    5   ,   0   ,    0     ,     1 ,     1 , '!IPFW/POSC' ] }
 # nvme
-- !expand { BOOT_OPTION_TMPL : [ 2 ,   0       ,  0 ,    6   ,   1   ,    0     ,     2,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 3 ,   0x1F    ,  0 ,    6   ,   1   ,    0     ,     2,     1 , '!IPFW/POSC' ] }
-- !expand { BOOT_OPTION_TMPL : [ 4 ,   0       ,  0 ,    6   ,   0   ,    0     ,     2,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 5 ,   0x1F    ,  0 ,    6   ,   0   ,    0     ,     2,     1 , '!IPFW/POSC' ] }
+- !expand { BOOT_OPTION_TMPL : [ 0 ,   0       ,  0 ,    6   ,   1   ,    0     ,     2,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 1 ,   0x1F    ,  0 ,    6   ,   1   ,    0     ,     2,     1 , '!IPFW/POSC' ] }
+- !expand { BOOT_OPTION_TMPL : [ 2 ,   0       ,  0 ,    6   ,   0   ,    0     ,     2,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 3 ,   0x1F    ,  0 ,    6   ,   0   ,    0     ,     2,     1 , '!IPFW/POSC' ] }
 # sata
-- !expand { BOOT_OPTION_TMPL : [ 6 ,   0       ,  0 ,    0   ,   0   ,    0xFF  ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 7 ,   0x1F    ,  0 ,    0   ,   0   ,    0     ,     1 ,     1 , '!IPFW/POSC' ] }
+- !expand { BOOT_OPTION_TMPL : [ 4 ,   0       ,  0 ,    0   ,   0   ,    0xFF  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 5 ,   0x1F    ,  0 ,    0   ,   0   ,    0     ,     1 ,     1 , '!IPFW/POSC' ] }
 # emmc
-- !expand { BOOT_OPTION_TMPL : [ 8 ,   0       ,  0 ,    2   ,   0   ,    0     ,     1 ,     1 , '/boot/sbl_os' ] }
-- !expand { BOOT_OPTION_TMPL : [ 9 ,   0x1F    ,  0 ,    2   ,   0   ,    0     ,     1 ,     1 , '!IPFW/POSC' ] }
+- !expand { BOOT_OPTION_TMPL : [ 6 ,   0       ,  0 ,    2   ,   0   ,    0     ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 7 ,   0x1F    ,  0 ,    2   ,   0   ,    0     ,     1 ,     1 , '!IPFW/POSC' ] }
+# usb
+- !expand { BOOT_OPTION_TMPL : [ 8 ,   0       ,  0 ,    5   ,   0   ,    0xFF  ,     1 ,     1 , '/boot/sbl_os' ] }
+- !expand { BOOT_OPTION_TMPL : [ 9 ,   0x1F    ,  0 ,    5   ,   0   ,    0     ,     1 ,     1 , '!IPFW/POSC' ] }


### PR DESCRIPTION
This commit depriotize USB boot as the 1st boot option that SBL tries to boot from in preference for onboard boot device options.