### PR TITLE
fix: Additional bounds checks in old UpdateMadt implementation

### DIFF
--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
@@ -396,6 +396,12 @@ UpdateMadt (
   //
   while (MadtPtr < MadtEnd) {
     EntryHeader = (EFI_ACPI_MADT_ENTRY_COMMON_HEADER *)MadtPtr;
+    if ((UINTN)(MadtEnd - MadtPtr) < sizeof (EFI_ACPI_MADT_ENTRY_COMMON_HEADER) ||
+        EntryHeader->Length == 0 ||
+        (UINTN)(MadtEnd - MadtPtr) < EntryHeader->Length)
+    {
+      return EFI_INVALID_PARAMETER;
+    }
     Length = EntryHeader->Length;
     if ((EntryHeader->Type != EFI_ACPI_5_0_PROCESSOR_LOCAL_APIC) && (EntryHeader->Type != EFI_ACPI_5_0_PROCESSOR_LOCAL_X2APIC)) {
       CopyMem ((VOID *)Current, (VOID *)MadtPtr, Length);


### PR DESCRIPTION
Add additional bounds checks when copying static MADT entries from build time table into in-memory version. This implementation is generally skipped in favor of the new MadtLib usage.