### PR TITLE
feat: CSME firmware code corruption resiliency

### DIFF
--- a/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
+++ b/BootloaderCommonPkg/Include/Library/FirmwareUpdateLib.h
@@ -1,7 +1,7 @@
 /** @file
 The header file for firmware update library.
 
-Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2017 - 2026, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -153,6 +153,16 @@ typedef struct {
 
 typedef  VOID (EFIAPI *DRIVER_ENTRY) (VOID *Params);
 
+///
+/// Recovery type for firmware update/recovery dispatch.
+/// Extend this enum when new component recovery types are added (e.g. IOE).
+///
+typedef enum {
+  FwUpdateRecoveryNone = 0,  ///< Normal capsule update (not a recovery path)
+  FwUpdateRecoveryCsme,      ///< CSME firmware code corruption recovery
+  FwUpdateRecoveryIoe,       ///< IOE CSME firmware recovery (reserved for future use)
+} FW_UPDATE_RECOVERY_TYPE;
+
 /**
   Get capsule image for firmware update.
 
@@ -160,17 +170,23 @@ typedef  VOID (EFIAPI *DRIVER_ENTRY) (VOID *Params);
   header. It could be read from EMMC, UFS, USB, SATA, etc. block device. Often the
   Capsule image could be saved in the root directory of a FAT system.
 
-  @param[out] FwBuffer        The firmware update capsule image.
-  @param[out] FwSize          The capsule image size.
+  @param[out] FwBuffer      The firmware update capsule image.
+  @param[out] FwSize        The capsule image size.
+  @param[in]  RecoveryType  FwUpdateRecoveryNone for a standard SBL capsule update;
+                            FwUpdateRecoveryCsme for CSME firmware code corruption
+                            recovery capsule; FwUpdateRecoveryIoe reserved for IOE.
+                            CSME and SBL recovery capsules are kept separate
+                            (different versions).
 
-  @retval  EFI_SUCCESS        Get the capsule image successfully.
-  @retval  others             Error happening when getting capsule image.
+  @retval  EFI_SUCCESS      Get the capsule image successfully.
+  @retval  others           Error happening when getting capsule image.
 **/
 EFI_STATUS
 EFIAPI
 GetCapsuleImage (
-  OUT  VOID                      **FwBuffer,
-  OUT  UINT32                    *FwSize
+  OUT  VOID                       **FwBuffer,
+  OUT  UINT32                     *FwSize,
+  IN   FW_UPDATE_RECOVERY_TYPE    RecoveryType
   );
 
 /**

--- a/BootloaderCommonPkg/Include/RecoveryStatus.h
+++ b/BootloaderCommonPkg/Include/RecoveryStatus.h
@@ -8,7 +8,7 @@
   the result of the last attempt. It also holds the consecutive TCO timeout
   counter that previously lived in the WDT scratchpad (BIT19:18).
 
-  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2024 - 2026, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -33,7 +33,7 @@
 #define RECOVERY_REASON_NONE            0x00
 #define RECOVERY_REASON_SBL             0x01    // TCO timeout detected SBL failure
 #define RECOVERY_REASON_CSME_WDT        0x02    // CSME triggered Top Swap (WDT expiry) due to failure outside SBL
-#define RECOVERY_REASON_CSME            0x04    // CSME firmware failure (HFSTS) - to be implemented
+#define RECOVERY_REASON_CSME            0x04    // CSME firmware code corruption (HFSTS1/HFSTS2)
 #define RECOVERY_REASON_IOE             0x08    // IOE CSME firmware failure - to be implemented
 // BIT4..BIT7 reserved for future failure sources
 

--- a/BootloaderCorePkg/BootloaderCorePkg.dec
+++ b/BootloaderCorePkg/BootloaderCorePkg.dec
@@ -170,6 +170,9 @@
   # If we want to recover from boot failure
   gPlatformModuleTokenSpaceGuid.PcdSblResiliencyEnabled   |  FALSE     | BOOLEAN | 0x200000F3
 
+  # Enable CSME firmware code corruption detection and recovery (HECI/HFSTS-based).
+  gPlatformModuleTokenSpaceGuid.PcdCsmeResiliencyEnabled  |  FALSE     | BOOLEAN | 0x200000F8
+
   # If we built the top swap regions to look exactly the same
   # (no SG1B rebasing or boot partition set in flash map)
   gPlatformModuleTokenSpaceGuid.PcdIdenticalTopSwapsBuilt |  FALSE     | BOOLEAN | 0x200000F4

--- a/BootloaderCorePkg/BootloaderCorePkg.dsc
+++ b/BootloaderCorePkg/BootloaderCorePkg.dsc
@@ -274,6 +274,7 @@
 
   gPlatformCommonLibTokenSpaceGuid.PcdBootPerformanceMask       | $(BOOT_PERFORMANCE_MASK)
   gPlatformModuleTokenSpaceGuid.PcdSblResiliencyEnabled         | $(ENABLE_SBL_RESILIENCY)
+  gPlatformModuleTokenSpaceGuid.PcdCsmeResiliencyEnabled        | $(ENABLE_CSME_RESILIENCY)
   gPlatformModuleTokenSpaceGuid.PcdIdenticalTopSwapsBuilt       | $(BUILD_IDENTICAL_TS)
   gPlatformCommonLibTokenSpaceGuid.PcdTccEnabled          | $(ENABLE_TCC)
   gPlatformCommonLibTokenSpaceGuid.PcdEnableCryptoPerfTest      | $(ENABLE_IPP_CRYPTO_PERF)
@@ -430,9 +431,10 @@
 
   BootloaderCorePkg/Stage2/Stage2.inf {
     <LibraryClasses>
-      FspApiLib    | BootloaderCorePkg/Library/FspApiLib/FspsApiLib.inf
-      SocInitLib   | $(SOC_INIT_STAGE2_LIB_INF_FILE)
-      BoardInitLib | $(BRD_INIT_STAGE2_LIB_INF_FILE)
+      FspApiLib             | BootloaderCorePkg/Library/FspApiLib/FspsApiLib.inf
+      FirmwareResiliencyLib | BootloaderCorePkg/Library/FirmwareResiliencyLib/FirmwareResiliencyLib.inf
+      SocInitLib            | $(SOC_INIT_STAGE2_LIB_INF_FILE)
+      BoardInitLib          | $(BRD_INIT_STAGE2_LIB_INF_FILE)
   }
 
   PayloadPkg/OsLoader/OsLoader.inf {

--- a/BootloaderCorePkg/Include/CsmeHealthPhat.h
+++ b/BootloaderCorePkg/Include/CsmeHealthPhat.h
@@ -1,0 +1,54 @@
+/** @file
+  Shared CSME firmware health (PHAT) ACPI table definition.
+
+  Provides the common Platform Health Assessment Table (PHAT) layout with a
+  single CSME Firmware Health Data Record, plus a static initializer template,
+  so every platform that enables CSME resiliency (PcdCsmeResiliencyEnabled)
+  shares one definition instead of copy-pasting it. The record's AmHealthy field
+  is filled in at runtime from the current CSME corruption state.
+
+  Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef _CSME_HEALTH_PHAT_H_
+#define _CSME_HEALTH_PHAT_H_
+
+#include <IndustryStandard/Acpi.h>
+#include <IndustryStandard/Acpi65.h>
+
+//
+// PHAT table with one CSME Firmware Health Data Record; AmHealthy updated at runtime.
+//
+#pragma pack(1)
+typedef struct {
+  EFI_ACPI_DESCRIPTION_HEADER                              Header;
+  EFI_ACPI_6_5_PHAT_FIRMWARE_HEALTH_DATA_RECORD_STRUCTURE  CsmeHealthRecord;
+} CSME_HEALTH_PHAT_TABLE;
+#pragma pack()
+
+//
+// Static initializer for a CSME_HEALTH_PHAT_TABLE instance.
+// gAdapterInfoCsmeGuid {A30DFF09-56BF-4622-A9E7-399B0A79E7C7}
+//
+#define CSME_HEALTH_PHAT_TABLE_TEMPLATE                                       \
+  {                                                                          \
+    {                                                                        \
+      EFI_ACPI_6_5_PLATFORM_HEALTH_ASSESSMENT_TABLE_SIGNATURE,               \
+      sizeof (CSME_HEALTH_PHAT_TABLE),                                       \
+      EFI_ACPI_6_5_PLATFORM_HEALTH_ASSESSMENT_TABLE_REVISION,                \
+      0, { 0 }, 0, 0, 0, 0                                                   \
+    },                                                                       \
+    {                                                                        \
+      EFI_ACPI_6_5_PHAT_RECORD_TYPE_FIRMWARE_HEALTH_DATA_RECORD,             \
+      sizeof (EFI_ACPI_6_5_PHAT_FIRMWARE_HEALTH_DATA_RECORD_STRUCTURE),      \
+      EFI_ACPI_6_5_PHAT_FIRMWARE_HEALTH_DATA_RECORD_REVISION,                \
+      0,                                                                     \
+      EFI_ACPI_6_5_PHAT_FIRMWARE_HEALTH_DATA_RECORD_UNKNOWN,                 \
+      { 0xA30DFF09, 0x56BF, 0x4622, { 0xA9, 0xE7, 0x39, 0x9B, 0x0A, 0x79, 0xE7, 0xC7 } }, \
+      0                                                                      \
+    }                                                                        \
+  }
+
+#endif

--- a/BootloaderCorePkg/Include/Library/FirmwareResiliencyLib.h
+++ b/BootloaderCorePkg/Include/Library/FirmwareResiliencyLib.h
@@ -42,4 +42,16 @@ UnifiedResiliencyCheck (
   IN UINT8  MaxRecoveryAttempts
   );
 
+/**
+  Detect CSME firmware code corruption via HECI HFSTS1/HFSTS2 registers.
+
+  @retval TRUE   CSME firmware corruption detected.
+  @retval FALSE  CSME firmware is healthy (or HECI-1 is not present).
+**/
+BOOLEAN
+EFIAPI
+IsMeCorrupt (
+  VOID
+  );
+
 #endif

--- a/BootloaderCorePkg/Library/FirmwareResiliencyLib/FirmwareResiliencyLib.c
+++ b/BootloaderCorePkg/Library/FirmwareResiliencyLib/FirmwareResiliencyLib.c
@@ -1,6 +1,6 @@
 /** @file
 
-Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2022 - 2026, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -17,9 +17,13 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/VariableLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/BootloaderCoreLib.h>
+#include <Library/PciLib.h>
 #include <Pi/PiBootMode.h>
 #include <FirmwareUpdateStatus.h>
 #include <RecoveryStatus.h>
+#include <Register/HeciRegs.h>
+#include <Guid/OsBootOptionGuid.h>
+#include <IndustryStandard/Pci22.h>
 
 STATIC CONST CHAR16 *mRecoveryStatusVariableName = RECOVERY_STATUS_VARIABLE_NAME;
 
@@ -160,6 +164,58 @@ DetectCsmeWdtFailure (
 }
 
 /**
+  Detect CSME firmware code corruption via HECI HFSTS1/HFSTS2 registers.
+
+  Resolves HECI-1 from the platform device table (e.g. bus 128 on Novalake).
+  Corruption = stuck in recovery, fault-tolerant bring-up load failure, or a
+  pending forced firmware update (IPU).
+
+  @retval TRUE   CSME firmware corruption detected; recovery required.
+  @retval FALSE  CSME firmware is healthy (or HECI-1 is not present).
+**/
+BOOLEAN
+EFIAPI
+IsMeCorrupt (
+  VOID
+  )
+{
+  HECI_FWS_REGISTER      MeFwSts1;
+  HECI_GS_SHDW_REGISTER  MeFwSts2;
+  UINT32                 MeDeviceAddr;
+  PLT_PCI_DEVICE         MeDev;
+  UINTN                  HeciBase;
+
+  // Resolve HECI-1 from the device table; fall back to bus 0, device 22.
+  MeDeviceAddr = GetDeviceAddr ((UINT8)PlatformDeviceMe, 0);
+  if (MeDeviceAddr == 0) {
+    MeDev.PciBusNumber    = 0;
+    MeDev.PciDeviceNumber = HECI_DEV;
+  } else {
+    CopyMem (&MeDev, &MeDeviceAddr, sizeof (UINT32));
+  }
+
+  HeciBase = PCI_LIB_ADDRESS (MeDev.PciBusNumber, MeDev.PciDeviceNumber, HECI_FUN, 0);
+
+  // HECI-1 absent/disabled: device ID reads as 0xFFFF.
+  if (PciRead16 (HeciBase + PCI_DEVICE_ID_OFFSET) == 0xFFFF) {
+    return FALSE;
+  }
+
+  MeFwSts1.ul = PciRead32 (HeciBase + R_ME_HFS);
+  MeFwSts2.ul = PciRead32 (HeciBase + R_ME_HFS_2);
+
+  if ((MeFwSts1.r.CurrentState == ME_STATE_RECOVERY) ||
+      (MeFwSts1.r.FtBupLdFlr == 1) ||
+      (MeFwSts2.r.FwUpdIpu == 1)) {
+    DEBUG ((DEBUG_ERROR, "CSME firmware corruption detected (HFSTS1=0x%08x HFSTS2=0x%08x)\n",
+            MeFwSts1.ul, MeFwSts2.ul));
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+/**
   Unified resiliency check point.
 
   Consolidates ACM and TCO checks and maintains persistent recovery state.
@@ -186,9 +242,7 @@ UnifiedResiliencyCheck (
   if ((GetBootMode () == BOOT_ON_FLASH_UPDATE) && !IsRecoveryTriggered ()) {
     return;
   }
-  //
-  // Read existing "RecoveryStatus" variable (may not exist).
-  //
+  // Read existing RecoveryStatus variable (may not exist).
   ZeroMem (&Status, sizeof (Status));
   Size      = sizeof (RECOVERY_STATUS);
   EfiStatus = GetVariable (
@@ -229,9 +283,7 @@ UnifiedResiliencyCheck (
     }
   }
 
-  //
-  // Detect failures.
-  //
+  // Detect failures this boot.
   NewReason           = RECOVERY_REASON_NONE;
   NeedPartitionSwitch = FALSE;
 
@@ -240,6 +292,13 @@ UnifiedResiliencyCheck (
   //
   if (DetectCsmeWdtFailure ()) {
     NewReason           |= RECOVERY_REASON_CSME_WDT;
+  }
+
+  //
+  // CSME firmware code corruption detection (HFSTS1/HFSTS2 via HECI-1).
+  //
+  if (PcdGetBool (PcdCsmeResiliencyEnabled) && IsMeCorrupt ()) {
+    NewReason |= RECOVERY_REASON_CSME;
   }
 
   //
@@ -271,38 +330,39 @@ UnifiedResiliencyCheck (
     }
   }
 
-  //
   // No new failure detected this boot.
-  //
   if (NewReason == RECOVERY_REASON_NONE) {
     if (VarExists && (Status.Reason != RECOVERY_REASON_NONE)) {
       // Recovery already pending from a prior boot.
       if (Status.LastResult != RECOVERY_RESULT_PENDING) {
-        // Previous attempt failed; count retry.
+        // Previous attempt failed; count this retry.
         Status.AttemptCount++;
         Status.LastResult = RECOVERY_RESULT_PENDING;
-        if (Status.AttemptCount > MaxRecoveryAttempts) {
-          CpuHalt ("Recovery failed after maximum attempts\n");
+        if ((Status.AttemptCount > MaxRecoveryAttempts) ||
+            (((Status.Reason & RECOVERY_REASON_CSME) != 0) && (Status.AttemptCount > 1))) {
+          // Degrade only when CSME is the sole reason; otherwise keep other budgets.
+          if (Status.Reason == RECOVERY_REASON_CSME) {
+            DEBUG ((DEBUG_WARN, "Resiliency: CSME recovery exhausted - booting degraded\n"));
+            ClearRecoveryTrigger ();
+            return;
+          }
+          if (Status.AttemptCount > MaxRecoveryAttempts) {
+            CpuHalt ("Recovery failed after maximum attempts\n");
+          }
         }
         EfiStatus = SaveRecoveryStatus (&Status);
         if (EFI_ERROR (EfiStatus)) {
           CpuHalt ("Resiliency: failed to persist retry state\n");
         }
       }
-      //
-      // Keep trigger set so FW update payload runs recovery.
-      //
+      // Keep trigger set so the FW update payload runs recovery.
       SetRecoveryTrigger ();
     }
-    //
-    // Otherwise no recovery is needed - continue normal boot.
-    //
+    // Otherwise no recovery needed - continue normal boot.
     return;
   }
 
-  //
   // Recovery needed - update or create the variable.
-  //
   if (VarExists) {
     Status.Reason     |= NewReason;
     Status.AttemptCount += 1;
@@ -314,29 +374,30 @@ UnifiedResiliencyCheck (
     Status.LastResult   = RECOVERY_RESULT_PENDING;
   }
 
-  //
-  // Anti-loop protection.
-  //
-  if (Status.AttemptCount > MaxRecoveryAttempts) {
-    CpuHalt ("Recovery failed after maximum attempts\n");
+  // Anti-loop: halt or degrade when attempts are exhausted.
+  if ((Status.AttemptCount > MaxRecoveryAttempts) ||
+      (((Status.Reason & RECOVERY_REASON_CSME) != 0) && (Status.AttemptCount > 1))) {
+    // Degrade only when CSME is the sole reason; otherwise keep other budgets.
+    if (Status.Reason == RECOVERY_REASON_CSME) {
+      DEBUG ((DEBUG_WARN, "Resiliency: CSME recovery exhausted - booting degraded\n"));
+      ClearRecoveryTrigger ();
+      return;
+    }
+    if (Status.AttemptCount > MaxRecoveryAttempts) {
+      CpuHalt ("Recovery failed after maximum attempts\n");
+    }
   }
 
-  //
-  // Write updated variable.
-  //
+  // Persist the updated recovery state.
   EfiStatus = SaveRecoveryStatus (&Status);
   if (EFI_ERROR (EfiStatus)) {
     CpuHalt ("Resiliency: failed to persist recovery state\n");
   }
 
-  //
   // Ensure the WDT recovery trigger (BIT20) is set.
-  //
   SetRecoveryTrigger ();
 
-  //
   // Switch partition and cold reset when required.
-  //
   if ((Status.Reason & RECOVERY_REASON_SBL) && NeedPartitionSwitch) {
     NewPartition = (GetCurrentBootPartition () == PrimaryPartition) ? BackupPartition : PrimaryPartition;
     DEBUG ((DEBUG_INFO, "Boot failure threshold reached! Switching to partition: %d\n", NewPartition));
@@ -347,9 +408,6 @@ UnifiedResiliencyCheck (
     ResetSystem (EfiResetCold);
   }
 
-  //
-  // No partition switch: recovery continues in this boot, so override the
-  // boot mode to BOOT_ON_FLASH_UPDATE so Stage2 runs the FW update payload.
-  //
+  // Recovery continues this boot: run the FW update payload in Stage2.
   SetBootMode (BOOT_ON_FLASH_UPDATE);
 }

--- a/BootloaderCorePkg/Library/FirmwareResiliencyLib/FirmwareResiliencyLib.inf
+++ b/BootloaderCorePkg/Library/FirmwareResiliencyLib/FirmwareResiliencyLib.inf
@@ -1,6 +1,6 @@
 ## @file
 #
-#  Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2022 - 2026, Intel Corporation. All rights reserved.<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -41,9 +41,11 @@
   SpiFlashLib
   VariableLib
   BaseMemoryLib
+  PciLib
 
 [Guids]
   gRecoveryStatusVariableGuid
 
 [Pcd]
   gPlatformModuleTokenSpaceGuid.PcdFlashBaseAddress
+  gPlatformModuleTokenSpaceGuid.PcdCsmeResiliencyEnabled

--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -300,8 +300,9 @@ class BaseBoard(object):
         self.BUILD_ARCH            = ''
         self.KEYH_SVN              = 0
         self.CFGDATA_SVN           = 0
-        self.BUILD_IDENTICAL_TS    = 0
-        self.ENABLE_SBL_RESILIENCY = 0
+        self.BUILD_IDENTICAL_TS     = 0
+        self.ENABLE_SBL_RESILIENCY  = 0
+        self.ENABLE_CSME_RESILIENCY = 0
         self._ACM_CPU_FMS          = []
         self._ACM_CPU_EXT_FM_FM_MASK = 0xF0
         self._DACM_CPU_FMS         = 0

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -1589,12 +1589,16 @@ IsRedundantComponent (
   This function will get capsule image file, verify the image, and update
   current firmware using new firmware.
 
+  @param[in]  RecoveryType    FwUpdateRecoveryNone for a normal capsule update;
+                              FwUpdateRecoveryCsme for CSME firmware code corruption
+                              recovery; FwUpdateRecoveryIoe reserved for future IOE.
+
   @retval  EFI_SUCCESS           The operation completed successfully.
   @retval  others                There is error happening.
 **/
 EFI_STATUS
 InitFirmwareUpdate (
-  VOID
+  IN FW_UPDATE_RECOVERY_TYPE  RecoveryType
 )
 {
   EFI_STATUS                    Status;
@@ -1620,7 +1624,7 @@ InitFirmwareUpdate (
   //
   // Get capsule image.
   //
-  Status = GetCapsuleImage (&CapsuleImage, &CapsuleSize);
+  Status = GetCapsuleImage (&CapsuleImage, &CapsuleSize, RecoveryType);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "GetCapsuleImage failed with status = %r\n", Status));
   }
@@ -2082,8 +2086,7 @@ PayloadMain (
   UINTN            RecoveryStatusSize;
   BOOLEAN          RecoveryStatusValid;
 
-  //
-  // Prepare Console Print
+  RecoveryStatusValid = FALSE;
   //
   InitConsole ();
   ConsolePrint ("Starting Firmware Update/Recovery\n");
@@ -2153,7 +2156,6 @@ PayloadMain (
     DEBUG((DEBUG_INFO, "Triggered FW recovery!\n"));
 
     RecoveryStatusSize  = sizeof (RecoveryStatus);
-    RecoveryStatusValid = FALSE;
     if (!EFI_ERROR (GetVariable (RECOVERY_STATUS_VARIABLE_NAME, &gRecoveryStatusVariableGuid,
                                  NULL, &RecoveryStatusSize, &RecoveryStatus)) &&
                                  (RecoveryStatusSize == sizeof (RecoveryStatus)) &&
@@ -2162,10 +2164,28 @@ PayloadMain (
       DEBUG ((DEBUG_INFO, "Recovery reason: 0x%x, attempt: %d\n",
               RecoveryStatus.Reason, RecoveryStatus.AttemptCount));
     } else {
-      DEBUG ((DEBUG_WARN, "RecoveryStatus variable missing/invalid, fallback to SBL recovery\n"));
+      DEBUG ((DEBUG_ERROR, "RecoveryStatus variable missing/invalid; cannot perform recovery\n"));
     }
 
-    Status = InitFirmwareRecovery ();
+    // A valid RecoveryStatus is required (carries reason + retry state).
+    // CSME-only -> CSME capsule; compound or SBL/CSME_WDT -> SBL recovery first.
+    if (RecoveryStatusValid) {
+      if (RecoveryStatus.Reason == RECOVERY_REASON_CSME) {
+        DEBUG ((DEBUG_INFO, "CSME firmware recovery via capsule update\n"));
+        Status = InitFirmwareUpdate (FwUpdateRecoveryCsme);
+        if (Status == EFI_ALREADY_STARTED) {
+          //
+          // CSME capsule update completed successfully.
+          //
+          Status = EFI_SUCCESS;
+        }
+      } else {
+        DEBUG ((DEBUG_INFO, "SBL partition recovery\n"));
+        Status = InitFirmwareRecovery ();
+      }
+    } else {
+      Status = EFI_NOT_FOUND;
+    }
     if (EFI_ERROR (Status)) {
       DEBUG((DEBUG_ERROR, "Firmware recovery failed with Status = %r\n", Status));
     }
@@ -2181,7 +2201,7 @@ PayloadMain (
     }
   } else {
     DEBUG((DEBUG_INFO, "Triggered FW update!\n"));
-    Status = InitFirmwareUpdate ();
+    Status = InitFirmwareUpdate (FwUpdateRecoveryNone);
     if (EFI_ERROR (Status)) {
       if (Status != EFI_ALREADY_STARTED) {
         DEBUG((DEBUG_ERROR, "Firmware update failed with Status = %r\n", Status));
@@ -2199,5 +2219,16 @@ EndOfFwu:
   // Terminate firmware update
   //
   ConsolePrint ("Exiting Firmware Update (Status: %r)\n", Status);
+
+  //
+  // CSME-only recovery: reset SM to INIT so FSP won't trigger an extra
+  // BOOT_ON_FLASH_UPDATE cycle from a lingering SM_DONE.
+  //
+  if (RecoveryStatusValid &&
+      (RecoveryStatus.Reason == RECOVERY_REASON_CSME) &&
+      (Status == EFI_SUCCESS)) {
+    SetStateMachineFlag (FW_UPDATE_SM_INIT);
+  }
+
   EndFirmwareUpdate ();
 }

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.inf
@@ -82,6 +82,7 @@
   gPlatformCommonLibTokenSpaceGuid.PcdFrameBufferMaxConsoleWidth
   gPlatformCommonLibTokenSpaceGuid.PcdFrameBufferMaxConsoleHeight
   gPlatformModuleTokenSpaceGuid.PcdSblResiliencyEnabled
+  gPlatformModuleTokenSpaceGuid.PcdCsmeResiliencyEnabled
   gPlatformModuleTokenSpaceGuid.PcdBootFailureThreshold
   gPlatformModuleTokenSpaceGuid.PcdUcodeSlotSize
   gPlatformCommonLibTokenSpaceGuid.PcdVerifiedBootEnabled

--- a/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
+++ b/PayloadPkg/FirmwareUpdate/GetCapsuleImage.c
@@ -1,7 +1,7 @@
 /** @file
   This file contains the implementation of FirmwareUpdateLib library.
 
-  Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2017 - 2026, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -495,6 +495,10 @@ GetOsImageList (
 
   @param[out] CapsuleImage      The firmware update capsule image.
   @param[out] CapsuleImageSize  The capsule image size.
+  @param[in]  RecoveryType      FwUpdateRecoveryNone for the standard SBL capsule
+                                (tag 0x080); FwUpdateRecoveryCsme for the dedicated
+                                CSME recovery capsule (tag 0x081). CSME recovery and
+                                FW update capsules are kept separate (different versions).
 
   @retval  EFI_SUCCESS        Get the capsule image successfully.
   @retval  others             Error happening when getting capsule image.
@@ -503,7 +507,8 @@ EFI_STATUS
 EFIAPI
 GetCapsuleImage (
   OUT VOID     **CapsuleImage,
-  OUT UINT32   *CapsuleImageSize
+  OUT UINT32   *CapsuleImageSize,
+  IN  FW_UPDATE_RECOVERY_TYPE  RecoveryType
   )
 {
   EFI_STATUS              Status;
@@ -522,9 +527,21 @@ GetCapsuleImage (
   DEBUG ((DEBUG_INFO, "\n=================Read Capsule Image==============\n"));
 
   //
-  // Get capsule configuration data
+  // For CSME recovery, load the dedicated CSME recovery capsule (tag 0x081).
+  // This block is compiled only on platforms with PcdCsmeResiliencyEnabled.
   //
-  CapsuleInfo = (CAPSULE_INFO_CFG_DATA *) FindConfigDataByTag (CDATA_CAPSULE_INFO_TAG);
+#if FixedPcdGetBool (PcdCsmeResiliencyEnabled)
+  if (RecoveryType == FwUpdateRecoveryCsme) {
+    CapsuleInfo = (CAPSULE_INFO_CFG_DATA *) FindConfigDataByTag (CDATA_CSME_CAPSULE_INFO_TAG);
+    if (CapsuleInfo == NULL) {
+      DEBUG ((DEBUG_ERROR, " CSME recovery CapsuleInfo (0x081) not found\n"));
+      return EFI_NOT_FOUND;
+    }
+  }
+#endif
+  if (CapsuleInfo == NULL) {
+    CapsuleInfo = (CAPSULE_INFO_CFG_DATA *) FindConfigDataByTag (CDATA_CAPSULE_INFO_TAG);
+  }
   //
   // If we do not find capsule information, return error
   //

--- a/Silicon/CommonSocPkg/Include/Register/HeciRegs.h
+++ b/Silicon/CommonSocPkg/Include/Register/HeciRegs.h
@@ -1,7 +1,7 @@
 /** @file
   Register Definitions for HECI
 
-  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2024 - 2026, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 #ifndef _HECI_REGS_H_
@@ -11,6 +11,7 @@
 #define HECI_FUN                        0
 
 #define R_ME_HFS                           0x40
+#define R_ME_HFS_2                         0x48
 #define R_ME_HFS_3                         0x60
 #define R_ME_HFS_4                         0x64
 #define R_ME_HFS_5                         0x68
@@ -191,5 +192,10 @@ typedef union {
 
 
 #pragma pack()
+
+//
+// ME Current State Value (HFSTS1.CurrentState)
+//
+#define ME_STATE_RECOVERY     0x02
 
 #endif // _HECI_REGS_H_


### PR DESCRIPTION
Adds detection of CSME firmware code corruption via HECI HFSTS1/HFSTS2 registers and integrates recovery into the unified SBL resiliency flow.

- FirmwareResiliencyLib: add public IsMeCorrupt() to detect corruption via FtBupLdFlr, ME_STATE_RECOVERY and FwUpdIpu flags. Expose via FirmwareResiliencyLib.h. Map lib for Stage2 in BootloaderCorePkg.dsc.
- UnifiedResiliencyCheck: call IsMeCorrupt() and set RECOVERY_REASON_CSME. On attempt exhaustion, degrade gracefully (clear trigger, continue boot) rather than halting, so PHAT can report ERRORS_FOUND to the OS.
- RecoveryStatus.h: add RECOVERY_REASON_CSME and RECOVERY_RESULT_SUCCESS definitions.
- FirmwareUpdate/GetCapsuleImage: select CSME recovery capsule when recovery reason is RECOVERY_REASON_CSME.
- FirmwareUpdateLib.h / HeciRegs.h: add supporting HECI register definitions and CSME FWU capsule selection interface.
- Stage2: publish ACPI PHAT table with CSME health record; AmHealthy set to ERRORS_FOUND/NO_ERRORS_FOUND based on IsMeCorrupt() at ACPI-publish time.