### PR TITLE
fix: [Common] Correct FvData buffer reference in GetFvFfsList

### DIFF
--- a/BootloaderCorePkg/Tools/GenReport.py
+++ b/BootloaderCorePkg/Tools/GenReport.py
@@ -203,7 +203,7 @@ class REPORTER:
         FvHdr = EFI_FIRMWARE_VOLUME_HEADER.from_buffer(FvData, 0)
         if FvHdr.ExtHeaderOffset > 0:
             FvExtHdr = EFI_FIRMWARE_VOLUME_EXT_HEADER.from_buffer(
-                Buffer, FvHdr.ExtHeaderOffset)
+                FvData, FvHdr.ExtHeaderOffset)
             Offset = FvHdr.ExtHeaderOffset + FvExtHdr.ExtHeaderSize
         else:
             Offset = FvHdr.HeaderLength


### PR DESCRIPTION
'Buffer' was an undefined variable in GetFvFfsList, causing a NameError when parsing FVs with an extended header (ExtHeaderOffset > 0). Replace with the correct parameter 'FvData'.