### PR TITLE
PciExpressHelpersLib: bound RecursiveCpmConfiguration recursion depth

### DIFF
--- a/Silicon/AlderlakePkg/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.c
+++ b/Silicon/AlderlakePkg/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.c
@@ -15,6 +15,7 @@
 #define ASPM_L0s_NO_LIMIT 0x7
 #define LINK_RETRAIN_WAIT_TIME 1000 // microseconds
 #define PCH_A0                0x00
+#define MAX_PCIE_RECURSION_DEPTH 32
 
 typedef union {
   struct {
@@ -1259,14 +1260,19 @@ RecursiveL1ssConfiguration (
   When this function executes on downstream component, all devices below it are guaranteed to
   return CPM=0 so it will do nothing
 
-  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+  @param[in] Sbdf     segment:bus:device:function coordinates of currently visited PCIe device
+  @param[in] Depth    recursion depth counter; caller must pass 0 at the root port and the
+                      function increments by 1 per level of descent. Traversal is aborted
+                      when Depth >= MAX_PCIE_RECURSION_DEPTH to prevent stack exhaustion
+                      from untrusted device-supplied SecondaryBus values.
 
   @retval TRUE = this device supports CPM, FALSE = it doesn't
 **/
 STATIC
 BOOLEAN
 RecursiveCpmConfiguration (
-  SBDF       Sbdf
+  SBDF       Sbdf,
+  UINT8      Depth
   )
 {
   SBDF         ChildSbdf;
@@ -1275,13 +1281,22 @@ RecursiveCpmConfiguration (
 
   DEBUG ((DEBUG_INFO, "RecursiveCpmConfiguration %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
 
+  //
+  // Prevent unbounded recursion from malicious PCIe bridge with cyclic bus topology.
+  // Device-supplied SecondaryBus must be validated with depth counter.
+  //
+  if (Depth >= MAX_PCIE_RECURSION_DEPTH) {
+    DEBUG ((DEBUG_ERROR, "RecursiveCpmConfiguration: max recursion depth exceeded at %02x:%02x:%02x (Depth=%u, Max=%u)\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func, Depth, MAX_PCIE_RECURSION_DEPTH));
+    return FALSE;
+  }
+
   ChildCpm = FALSE;
 
   if (HasChildBus (Sbdf, &ChildSbdf)) {
     ChildCpm = TRUE;
     DevType = GetDeviceType (Sbdf);
     while (FindNextPcieChild (DevType, &ChildSbdf)) {
-      ChildCpm &= RecursiveCpmConfiguration (ChildSbdf);
+      ChildCpm &= RecursiveCpmConfiguration (ChildSbdf, Depth + 1);
     }
     if (ChildCpm) {
       while (FindNextPcieChild (DevType, &ChildSbdf)) {
@@ -1594,7 +1609,7 @@ RootportDownstreamPmConfiguration (
   ConfigureRpLtrOverride (RpBase, RpSbdf.Dev, &TreeLtr, &(PcieRpCommonConfig->PcieRpLtrConfig));
   DEBUG ((DEBUG_INFO, "ConfigureRpLtrOverride %x:%x\n", RpSbdf.Dev, RpSbdf.Func));
   if (PcieRpCommonConfig->EnableCpm) {
-    RecursiveCpmConfiguration (RpSbdf);
+    RecursiveCpmConfiguration (RpSbdf, 0);
   }
   //
   // L1 substates can be modified only when L1 is disabled, so this function must execute

--- a/Silicon/CommonSocPkg/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.c
+++ b/Silicon/CommonSocPkg/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.c
@@ -13,6 +13,7 @@
 
 #define ASPM_L1_NO_LIMIT 0xFF
 #define ASPM_L0s_NO_LIMIT 0x7
+#define MAX_PCIE_RECURSION_DEPTH 32
 
 typedef struct {
   UINT32                          Size;
@@ -1150,14 +1151,19 @@ RecursiveL1ssConfiguration (
   When this function executes on downstream component, all devices below it are guaranteed to
   return CPM=0 so it will do nothing
 
-  @param[in] Sbdf    address of currently visited PCIe device
+  @param[in] Sbdf     segment:bus:device:function coordinates of currently visited PCIe device
+  @param[in] Depth    recursion depth counter; caller must pass 0 at the root port and the
+                      function increments by 1 per level of descent. Traversal is aborted
+                      when Depth >= MAX_PCIE_RECURSION_DEPTH to prevent stack exhaustion
+                      from untrusted device-supplied SecondaryBus values.
 
   @retval TRUE = this device supports CPM, FALSE = it doesn't
 **/
 STATIC
 BOOLEAN
 RecursiveCpmConfiguration (
-  SBDF       Sbdf
+  SBDF       Sbdf,
+  UINT8      Depth
   )
 {
   SBDF         ChildSbdf;
@@ -1166,13 +1172,22 @@ RecursiveCpmConfiguration (
 
   DEBUG ((DEBUG_INFO, "RecursiveCpmConfiguration %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
 
+  //
+  // Prevent unbounded recursion from malicious PCIe bridge with cyclic bus topology.
+  // Device-supplied SecondaryBus must be validated with depth counter.
+  //
+  if (Depth >= MAX_PCIE_RECURSION_DEPTH) {
+    DEBUG ((DEBUG_ERROR, "RecursiveCpmConfiguration: max recursion depth exceeded at %02x:%02x:%02x (Depth=%u, Max=%u)\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func, Depth, MAX_PCIE_RECURSION_DEPTH));
+    return FALSE;
+  }
+
   ChildCpm = FALSE;
 
   if (HasChildBus (Sbdf, &ChildSbdf)) {
     ChildCpm = TRUE;
     DevType = GetDeviceType (Sbdf);
     while (FindNextPcieChild (DevType, &ChildSbdf)) {
-      ChildCpm &= RecursiveCpmConfiguration (ChildSbdf);
+      ChildCpm &= RecursiveCpmConfiguration (ChildSbdf, Depth + 1);
     }
     if (ChildCpm) {
       while (FindNextPcieChild (DevType, &ChildSbdf)) {
@@ -1518,7 +1533,7 @@ RootportDownstreamPmConfiguration (
   ConfigureRpLtrOverride (RpBase, RpSbdf.Dev, &TreeLtr, &(PcieRpCommonConfig->PcieRpLtrConfig));
   DEBUG ((DEBUG_INFO, "ConfigureRpLtrOverride %x:%x\n", RpSbdf.Dev, RpSbdf.Func));
   if (PcieRpCommonConfig->EnableCpm) {
-    RecursiveCpmConfiguration (RpSbdf);
+    RecursiveCpmConfiguration (RpSbdf, 0);
   }
   //
   // L1 substates can be modified only when L1 is disabled, so this function must execute

--- a/Silicon/TigerlakePchPkg/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.c
+++ b/Silicon/TigerlakePchPkg/Library/PciExpressHelpersLibrary/PciExpressHelpersLibrary.c
@@ -16,6 +16,7 @@
 #define ASPM_L1_NO_LIMIT 0xFF
 #define ASPM_L0s_NO_LIMIT 0x7
 #define LINK_RETRAIN_WAIT_TIME 1000 // microseconds
+#define MAX_PCIE_RECURSION_DEPTH 32
 
 typedef union {
   struct {
@@ -1177,14 +1178,19 @@ RecursiveL1ssConfiguration (
   When this function executes on downstream component, all devices below it are guaranteed to
   return CPM=0 so it will do nothing
 
-  @param[in] Segment,Bus,Device,Function    address of currently visited PCIe device
+  @param[in] Sbdf     segment:bus:device:function coordinates of currently visited PCIe device
+  @param[in] Depth    recursion depth counter; caller must pass 0 at the root port and the
+                      function increments by 1 per level of descent. Traversal is aborted
+                      when Depth >= MAX_PCIE_RECURSION_DEPTH to prevent stack exhaustion
+                      from untrusted device-supplied SecondaryBus values.
 
   @retval TRUE = this device supports CPM, FALSE = it doesn't
 **/
 STATIC
 BOOLEAN
 RecursiveCpmConfiguration (
-  SBDF       Sbdf
+  SBDF       Sbdf,
+  UINT8      Depth
   )
 {
   SBDF         ChildSbdf;
@@ -1193,13 +1199,22 @@ RecursiveCpmConfiguration (
 
   DEBUG ((DEBUG_INFO, "RecursiveCpmConfiguration %x:%x:%x\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func));
 
+  //
+  // Prevent unbounded recursion from malicious PCIe bridge with cyclic bus topology.
+  // Device-supplied SecondaryBus must be validated with depth counter.
+  //
+  if (Depth >= MAX_PCIE_RECURSION_DEPTH) {
+    DEBUG ((DEBUG_ERROR, "RecursiveCpmConfiguration: max recursion depth exceeded at %02x:%02x:%02x (Depth=%u, Max=%u)\n", Sbdf.Bus, Sbdf.Dev, Sbdf.Func, Depth, MAX_PCIE_RECURSION_DEPTH));
+    return FALSE;
+  }
+
   ChildCpm = FALSE;
 
   if (HasChildBus (Sbdf, &ChildSbdf)) {
     ChildCpm = TRUE;
     DevType = GetDeviceType (Sbdf);
     while (FindNextPcieChild (DevType, &ChildSbdf)) {
-      ChildCpm &= RecursiveCpmConfiguration (ChildSbdf);
+      ChildCpm &= RecursiveCpmConfiguration (ChildSbdf, Depth + 1);
     }
     if (ChildCpm) {
       while (FindNextPcieChild (DevType, &ChildSbdf)) {
@@ -1511,7 +1526,7 @@ RootportDownstreamPmConfiguration (
   ConfigureRpLtrOverride (RpBase, RpSbdf.Dev, &TreeLtr, &(PcieRpCommonConfig->PcieRpLtrConfig));
   DEBUG ((DEBUG_INFO, "ConfigureRpLtrOverride %x:%x\n", RpSbdf.Dev, RpSbdf.Func));
   if (PcieRpCommonConfig->EnableCpm) {
-    RecursiveCpmConfiguration (RpSbdf);
+    RecursiveCpmConfiguration (RpSbdf, 0);
   }
   //
   // L1 substates can be modified only when L1 is disabled, so this function must execute


### PR DESCRIPTION
RecursiveCpmConfiguration traversed the PCIe device tree with no depth limit, trusting the SecondaryBus number read directly from PCIe config space (offset 0x18, bits[15:8]). A malicious or malfunctioning bridge reachable via Thunderbolt or hot-plug could report a cyclic bus topology, causing infinite recursion and stack exhaustion during pre-OS PCIe PM initialization.

Add a MAX_PCIE_RECURSION_DEPTH (32) guard consistent with the pattern already used in RecursiveAspmConfiguration. The Depth parameter is seeded to 0 at the call site and incremented by 1 per level of descent. If the limit is exceeded, the function logs an error and returns FALSE, treating the device as not CPM-capable.

The same fix is applied to all three affected platform libraries:
- Silicon/AlderlakePkg/Library/PciExpressHelpersLibrary
- Silicon/CommonSocPkg/Library/PciExpressHelpersLibrary
- Silicon/TigerlakePchPkg/Library/PciExpressHelpersLibrary

Signed-off-by: Vinay Patel <vinay.r.patel@intel.com>
