### PR TITLE
fix: [RPLP] fix CfgData source precedence

### DIFF
--- a/Platform/RaptorlakeBoardPkg/BoardConfigRplp.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRplp.py
@@ -220,11 +220,11 @@ class Board(BaseBoard):
             if hasattr(self, 'BOARD_PKG_NAME_OVERRIDE'):
                 brd_cfg2_src_dir = os.path.join(os.environ['SBL_SOURCE'], 'Platform', self.BOARD_PKG_NAME_OVERRIDE, 'CfgData')
 
-            if os.path.exists(os.path.join(brd_cfg_src_dir, 'CfgData_Fusa_Feature.dlt')):
-                FusaConfig = open (os.path.join(brd_cfg_src_dir, 'CfgData_Fusa_Feature.dlt')).readlines()
+            if os.path.exists(os.path.join(brd_cfg2_src_dir, 'CfgData_Fusa_Feature.dlt')):
+                FusaConfig = open (os.path.join(brd_cfg2_src_dir, 'CfgData_Fusa_Feature.dlt')).readlines()
             else:
-                if os.path.exists(os.path.join(brd_cfg2_src_dir, 'CfgData_Fusa_Feature.dlt')):
-                    FusaConfig = open (os.path.join(brd_cfg2_src_dir, 'CfgData_Fusa_Feature.dlt')).readlines()
+                if os.path.exists(os.path.join(brd_cfg_src_dir, 'CfgData_Fusa_Feature.dlt')):
+                    FusaConfig = open (os.path.join(brd_cfg_src_dir, 'CfgData_Fusa_Feature.dlt')).readlines()
 
             for line in FusaConfig:
                 if (re.search(r"TCC_CFG_DATA\.TccEnable\s+\|\s*1",line) != None or
@@ -307,9 +307,9 @@ class Board(BaseBoard):
             if hasattr(self, 'BOARD_PKG_NAME_OVERRIDE'):
                 brd_cfg2_src_dir = os.path.join(os.environ['SBL_SOURCE'], 'Platform', self.BOARD_PKG_NAME_OVERRIDE, 'CfgData')
             for dlt_file in self._CFGDATA_EXT_FILE:
-                cfg_dlt_file  = os.path.join(brd_cfg_src_dir, dlt_file[len (self._generated_cfg_file_prefix):])
+                cfg_dlt_file  = os.path.join(brd_cfg2_src_dir, dlt_file[len (self._generated_cfg_file_prefix):])
                 if not os.path.exists(cfg_dlt_file):
-                    cfg_dlt_file = os.path.join(brd_cfg2_src_dir, dlt_file[len (self._generated_cfg_file_prefix):])
+                    cfg_dlt_file = os.path.join(brd_cfg_src_dir, dlt_file[len (self._generated_cfg_file_prefix):])
                 lines         = open (cfg_dlt_file).read()
 
                # Enable TSN in dlt file


### PR DESCRIPTION
Make BoardConfigRplp prefer override CfgData files before falling back to the base source.