### PR TITLE
fix: [Tools] Fix undefined variable bugs in Tools scripts

### DIFF
--- a/BootloaderCorePkg/Tools/CfgDataTool.py
+++ b/BootloaderCorePkg/Tools/CfgDataTool.py
@@ -785,7 +785,7 @@ def CmdSign(Args):
 
     CfgBlobHeader = CCfgData.CDATA_BLOB_HEADER.from_buffer(FileData)
     if CfgBlobHeader.Signature != b'CFGD':
-        raise Exception("Invalid config binary file '%s' !" % CfgDataFile)
+        raise Exception("Invalid config binary file '%s' !" % Args.cfg_in_file)
     CfgBlobHeader.Attribute |= CCfgData.CDATA_BLOB_HEADER.ATTR_SIGNED
 
     CfgBlobHeader.Svn = Args.svn

--- a/BootloaderCorePkg/Tools/FspSwap.py
+++ b/BootloaderCorePkg/Tools/FspSwap.py
@@ -186,7 +186,7 @@ def swap_fsp (args):
                 file_name = os.path.join (args.out_dir, name + '_%d' % partition + '.lz')
                 new_hash  = gen_hash_file (file_name, HASH_VAL_STRING[entry.HashAlg])
                 if len(new_hash) != entry.DigestLen:
-                    raise Excpetion ('Unexpected hash size !')
+                    raise Exception ('Unexpected hash size !')
                 print ('Update SBL Hash Store for %s' % name)
                 data[offset:offset+entry.DigestLen] = new_hash
             offset += entry.DigestLen

--- a/BootloaderCorePkg/Tools/GenCfgDataDsc.py
+++ b/BootloaderCorePkg/Tools/GenCfgDataDsc.py
@@ -515,7 +515,7 @@ EndList
         if Name not in CfgDict:
             CfgDict[Name] = 1
         else:
-            print ("WARNING: Duplicated item found '%s' !" % ConfigDict['cname'])
+            print ("WARNING: Duplicated item found '%s' !" % Name)
 
     def AddBsfChildPage (self, Child, Parent = 'root'):
         def AddBsfChildPageRecursive (PageTree, Parent, Child):

--- a/BootloaderCorePkg/Tools/GenContainer.py
+++ b/BootloaderCorePkg/Tools/GenContainer.py
@@ -353,7 +353,7 @@ class CONTAINER ():
                     key_hash = self.get_pub_key_hash (file_data[offset:])
                     hash_data.extend (key_hash)
                 else:
-                    raise Exception ("Unsupported AuthType '%s' !" % auth_type)
+                    raise Exception ("Unsupported AuthType '%s' !" % auth_type_str)
         return data, hash_data, auth_data
 
     def adjust_header (self):


### PR DESCRIPTION
- FspSwap.py: fix 'Excpetion' typo (NameError instead of raising)
- CfgDataTool.py: replace undefined 'CfgDataFile' with 'Args.cfg_in_file'
- GenCfgDataDsc.py: replace undefined 'ConfigDict' with 'Name' in dupe warning
- GenContainer.py: replace undefined 'auth_type' with 'auth_type_str'