### PR TITLE
feat: Use TSEG to pass SMRR info to APs instead of low mem

### DIFF
--- a/BootloaderCorePkg/Include/Library/MpInitLib.h
+++ b/BootloaderCorePkg/Include/Library/MpInitLib.h
@@ -12,6 +12,16 @@
 
 #define SMM_BASE_MIN_SIZE          0x10000
 #define SMM_BASE_GAP               0x2000
+#define SMM_BASE_ENTRY_OFFSET      0x8000
+#define SMM_BASE_SAVE_STATE_OFFSET 0x7C00
+
+// 8 bytes (2 x UINT32) stored immediately below the per-CPU SMM save state
+#define SMM_SMRR_STORAGE_OFFSET    (SMM_BASE_ENTRY_OFFSET + SMM_BASE_SAVE_STATE_OFFSET - 2 * sizeof (UINT32))
+
+typedef struct {
+  UINT32  SmrrBase;
+  UINT32  SmrrMask;
+} SMM_SMRR_STORAGE;
 
 typedef enum {
   EnumMpInitNull   = 0x00,

--- a/BootloaderCorePkg/Library/MpInitLib/Common/MpCommon.nasm
+++ b/BootloaderCorePkg/Library/MpInitLib/Common/MpCommon.nasm
@@ -72,13 +72,19 @@ SmmRebase:
     jz             SmmEm64t
     mov            edi, 0x3fef8      ; Fallback to support SIMICS QSP model
 SmmEm64t:
+    btr            eax, 0            ; if BIT0 is set in SMBASE input, it means program SMRR
     mov            [edi], eax        ; change to new  SMBASE
-    mov            eax, [esi + AP_DATA_STRUCT_FIELD (SmrrMask)]
+    jnc            SkipSmrrProg
+    mov            esi, eax
+    add            esi, SMM_SMRR_STORAGE_OFFSET
+    mov            eax, [esi + SMM_SMRR_MASK_OFFSET]
     cmp            eax, 0
     jz             SkipSmrrProg
 
     xchg           eax, ebx
-    mov            eax, [esi + AP_DATA_STRUCT_FIELD (SmrrBase)]
+    mov            eax, [esi + SMM_SMRR_BASE_OFFSET]
+    cmp            eax, 0
+    jz             SkipSmrrProg
     xor            edx, edx
     mov            ecx, 0x1f2        ; MSR_IA32_SMRR_PHYSBASE
     wrmsr

--- a/BootloaderCorePkg/Library/MpInitLib/Common/MpEqu.inc
+++ b/BootloaderCorePkg/Library/MpInitLib/Common/MpEqu.inc
@@ -25,6 +25,11 @@ SECTION .text
 SPIN_LOCK_RELEASED   EQU   0
 SPIN_LOCK_ACQUIRED   EQU   1
 
+; Offset from SmmBase to the SMM_SMRR_STORAGE struct (must match SMM_SMRR_STORAGE_OFFSET in MpInitLib.h)
+SMM_SMRR_STORAGE_OFFSET  EQU  8000h + 7C00h - 8
+SMM_SMRR_BASE_OFFSET     EQU  0
+SMM_SMRR_MASK_OFFSET     EQU  4
+
 ;
 ; Equivalent NASM structure of MP_CPU_EXCHANGE_INFO
 ;
@@ -47,8 +52,6 @@ struc AP_DATA_STRUCT
   .MpDataStruct:    CTYPE_UINT32   1
   .Cr3:             CTYPE_UINT32   1
   .CpuArch:         CTYPE_UINT32   1
-  .SmrrBase:        CTYPE_UINT32   1
-  .SmrrMask:        CTYPE_UINT32   1
   .Terminator:      CTYPE_UINT32   1
 endstruc
 

--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLib.c
@@ -134,6 +134,31 @@ SortSysCpu (
 }
 
 /**
+  Validate that SmrrBase and SmrrSize are suitable for programming IA32_SMRR_PHYSBASE/MASK.
+
+  SmrrSize must be zero (SMRR not used) or a power-of-two value of at least 4 KB,
+  and SmrrBase must be naturally aligned to SmrrSize.
+
+  @param[in]  SmrrBase   Proposed SMRR physical base address.
+  @param[in]  SmrrSize   Proposed SMRR region size in bytes.
+
+  @retval TRUE   Parameters are valid for SMRR programming or SmrrSize is zero.
+  @retval FALSE  SmrrSize is non-zero but fails size or alignment requirements.
+
+**/
+BOOLEAN
+IsSmrrValid (
+  IN UINT32  SmrrBase,
+  IN UINT32  SmrrSize
+  )
+{
+  if ((SmrrSize > 0) && ((SmrrSize < SIZE_4KB) ||  (SmrrSize != GetPowerOfTwo32 (SmrrSize)) || ((SmrrBase & ~(SmrrSize - 1)) != SmrrBase))) {
+    return FALSE;
+  }
+  return TRUE;
+}
+
+/**
   Relocate SMM base for CPU
 
   @param[in]  Index       CPU index to rebase.
@@ -151,16 +176,26 @@ SmmRebase (
   MSR_IA32_MTRRCAP_REGISTER MtrrCap;
   UINT8                    *SmmEntry;
   UINT8                    *DefEntry;
+  SMM_SMRR_STORAGE         *SmrrStorage;
 
   if (SmmBase == 0) {
     SmmBase  = PcdGet32 (PcdSmramTsegBase) + PcdGet32 (PcdSmramTsegSize) - (SMM_BASE_MIN_SIZE + Index * SMM_BASE_GAP);
-    SmmEntry = (UINT8 *)(UINTN)SmmBase + 0x8000;
-    // Write default handler at new SMM handler entry
+    SmmEntry    = (UINT8 *)(UINTN)SmmBase + SMM_BASE_ENTRY_OFFSET;
     MtrrCap.Uint64 = AsmReadMsr64 (MSR_IA32_MTRRCAP);
-    if ((MtrrCap.Bits.SMRR == 0) || (PcdGet8 (PcdSmmRebaseMode) == SMM_REBASE_ENABLE_NOSMRR)) {
+    if (!IsSmrrValid(PcdGet32 (PcdSmramTsegBase), PcdGet32 (PcdSmramTsegSize)) ||
+        (MtrrCap.Bits.SMRR == 0) ||
+        (PcdGet8 (PcdSmmRebaseMode) == SMM_REBASE_ENABLE_NOSMRR))
+    {
       // No SMRR support, fill "RSM" at the entry instead.
       DefEntry = (UINT8 *)&mDefaultSmiHandlerRet;
     } else {
+      // This is the only case where SBL should set the SMRR. Store it in TSEG below CPU save states
+      SmrrStorage = (SMM_SMRR_STORAGE *)(UINTN)(SmmBase + SMM_SMRR_STORAGE_OFFSET);
+      SmrrStorage->SmrrBase = PcdGet32 (PcdSmramTsegBase) | MSR_IA32_VMX_BASIC_REGISTER_MEMORY_TYPE_WRITE_BACK;
+      // Make sure SMRR valid bit is cleared for now
+      SmrrStorage->SmrrMask = (UINT32)(~(PcdGet32 (PcdSmramTsegSize) - 1)) & (UINT32)(~BIT11);
+      // SMBASE requires 32KB alignment so we use the low bit to tell the Rendezvous function to program the SMRR
+      SmmBase |= BIT0;
       DefEntry = (UINT8 *)&mDefaultSmiHandlerStart;
     }
     CopyMem (SmmEntry, DefEntry, (UINT8 *)&mDefaultSmiHandlerEnd - DefEntry);
@@ -337,7 +372,6 @@ MpInit (
   MSR_IA32_MTRRCAP_REGISTER MtrrCap;
   UINT32                    SmrrBase;
   UINT32                    SmrrSize;
-  MSR_IA32_MTRR_PHYSMASK_REGISTER SmrrMask;
 
   Status   = EFI_SUCCESS;
   ApBuffer = (UINT8 *)AP_BUFFER_ADDRESS;
@@ -381,23 +415,18 @@ MpInit (
       AsmReadIdtr ((IA32_DESCRIPTOR *)&ApDataPtr->Idtr);
       ApDataPtr->Cr3 = (UINT32)AsmReadCr3 ();
 
-      // Fill SMRR base and size
+      // Validate SMRR base and size
       SmrrBase = PcdGet32 (PcdSmramTsegBase);
       SmrrSize = PcdGet32 (PcdSmramTsegSize);
-      if (SmrrSize > 0) {
-        if ((SmrrSize < SIZE_4KB) ||  (SmrrSize != GetPowerOfTwo32 (SmrrSize)) || ((SmrrBase & ~(SmrrSize - 1)) != SmrrBase)) {
-          DEBUG ((DEBUG_INFO, "Invalid SMRR base or size\n"));
-        } else {
-          MtrrCap.Uint64 = AsmReadMsr64 (MSR_IA32_MTRRCAP);
-          if (MtrrCap.Bits.SMRR == 1) {
-            // Don't enable SMRR valid yet, it will be done at end of stage2
-            SmrrMask.Uint64 = (UINT32)(~(SmrrSize - 1));
-            SmrrMask.Bits.V = 0;
-            ApDataPtr->SmrrBase = SmrrBase | MSR_IA32_VMX_BASIC_REGISTER_MEMORY_TYPE_WRITE_BACK;
-            ApDataPtr->SmrrMask = (UINT32)SmrrMask.Uint64;
-            DEBUG ((DEBUG_INFO, "SMRR Base: 0x%08x  Mask: 0x%08x\n", ApDataPtr->SmrrBase, ApDataPtr->SmrrMask));
-          }
+      if (!IsSmrrValid (SmrrBase, SmrrSize)) {
+        DEBUG ((DEBUG_INFO, "Invalid SMRR base or size\n"));
+        MtrrCap.Uint64 = AsmReadMsr64 (MSR_IA32_MTRRCAP);
+        if ((MtrrCap.Bits.SMRR == 1) && (PcdGet8 (PcdSmmRebaseMode) == SMM_REBASE_ENABLE)) {
+          // If we expect to program SMRR and our values are invalid, treat this as fatal.
+          CpuHalt(NULL);
         }
+      } else {
+        DEBUG ((DEBUG_INFO, "SMRR Base: 0x%08x  Size: 0x%08x\n", SmrrBase, SmrrSize));
       }
 
       //

--- a/BootloaderCorePkg/Library/MpInitLib/MpInitLibInternal.h
+++ b/BootloaderCorePkg/Library/MpInitLib/MpInitLibInternal.h
@@ -61,8 +61,6 @@ typedef struct {
   UINT32            MpDataStruct;
   UINT32            Cr3;
   UINT32            CpuArch;
-  UINT32            SmrrBase;
-  UINT32            SmrrMask;
 } AP_DATA_STRUCT;
 
 typedef struct {


### PR DESCRIPTION
Move SMRR base and mask values out of low-memory AP_DATA_STRUCT into
TSEG right before SmmRebase for each CPU. SmmRebase handler finds them
there and programs SMRRs immediately before rebasing to TSEG.

Use BIT0 of SmmBase passed to Rendezvous function in CR2 to tell
it to program SMRR in cases where it is needed.

AP_DATA_STRUCT buffer is vulnerable to DMA attacks which could disable
SMRR programming. AP_DATA_STRUCT SMRR info was being set well ahead of
AP SmmRebase, creating a loose timing opportunity. With this updated
implmentation, SMRR info is stored to TSEG immediately before AP
SmmRebase, narrowing the attack window and adding protection from DMA
transactions.

High addresses
  ^
  |
  |  +---------------------------------------------------+
  |  | TSEG region (top of SMM RAM)                      |
  |  |   ... free / reserved space ...                   |
  |  +---------------------------------------------------+
  |  | CPU save state area (per-CPU)                     |
  |  |   located just above the SMRR storage             |
  |  +---------------------------------------------------+
  |  | SMRR storage block                                |
  |  |   SmrrBase @ offset -4                            |
  |  |   SmrrMask @ offset -8                            |
  |  +---------------------------------------------------+
  |  | SMM entry / RSM trampoline / code                 |
  |  +---------------------------------------------------+
  |  | ... lower SMM region ...                          |
  |
  +--------------------------------------------------------> Low addr