### PR TITLE
fix: [APL/CFL/CML/QEMU] Check GPIO bitmask index against bitmask array

### DIFF
--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -279,7 +279,10 @@ GpioInit (
     }
 
     SmipEntry = (GPIO_CONFIG_SMIP *)GpioCfgBaseHdr->GpioTableData;
-    for (Index = 0; Index < GpioCfgBaseHdr->GpioItemCount; Index++) {
+    for (Index = 0;
+         Index < GpioCfgBaseHdr->GpioItemCount &&
+         Index < (ARRAY_SIZE(GpioCfgCurrHdr->GpioBaseTableBitMask)*8);
+         Index++) {
       if (GpioCfgCurrHdr->GpioBaseTableBitMask[Index >> 3] & (1 << (Index & 7))) {
         CopyMem (GpioConfigSmip, SmipEntry, sizeof (GPIO_CONFIG_SMIP));
         GpioConfigSmip->Half0.r.HostSw        = (GpioConfigSmip->Half1.r.Reserved0 & BIT0);

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -777,7 +777,10 @@ GpioInit (
     CpuHalt (NULL);
   }
 
-  for (Index = 0; Index  < GpioCfgHdr->GpioItemCount; Index++) {
+  for (Index = 0;
+       Index < GpioCfgHdr->GpioItemCount &&
+       Index < (ARRAY_SIZE(GpioCfgCurrHdr->GpioBaseTableBitMask)*8);
+       Index++) {
     if (GpioCfgCurrHdr->GpioBaseTableBitMask[Index >> 3] & (1 << (Index & 7))) {
       GpioTable = FillGpioTable (GpioTable, GpioCfgHdr, Offset, ChipsetId);
       GpioEntries++;

--- a/Platform/CometlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CometlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -952,7 +952,10 @@ GpioInit (
     ChipsetId = CNL_LP_CHIPSET_ID;
   }
 
-  for (Index = 0; Index  < GpioCfgHdr->GpioItemCount; Index++) {
+  for (Index = 0;
+       Index < GpioCfgHdr->GpioItemCount &&
+       Index < (ARRAY_SIZE(GpioCfgCurrHdr->GpioBaseTableBitMask)*8);
+       Index++) {
     if (GpioCfgCurrHdr->GpioBaseTableBitMask[Index >> 3] & (1 << (Index & 7))) {
       GpioTable = FillGpioTable (GpioTable, GpioCfgHdr, Offset, ChipsetId);
       GpioEntries++;

--- a/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -947,7 +947,10 @@ GpioInit (
     ChipsetId = CNL_LP_CHIPSET_ID;
   }
 
-  for (Index = 0; Index  < GpioCfgHdr->GpioItemCount; Index++) {
+  for (Index = 0;
+       Index < GpioCfgHdr->GpioItemCount &&
+       Index < (ARRAY_SIZE(GpioCfgCurrHdr->GpioBaseTableBitMask)*8);
+       Index++) {
     if (GpioCfgCurrHdr->GpioBaseTableBitMask[Index >> 3] & (1 << (Index & 7))) {
       GpioTable = FillGpioTable (GpioTable, GpioCfgHdr, Offset, ChipsetId);
       GpioEntries++;

--- a/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/QemuBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -176,7 +176,10 @@ GpioInit (
   GpioCfgDataBuffer = GpioTable;
 
   if (GpioCfgBaseHdr != NULL) {
-    for (Index = 0; Index  < GpioCfgHdr->GpioItemCount; Index++) {
+    for (Index = 0;
+         Index < GpioCfgHdr->GpioItemCount &&
+         Index < (ARRAY_SIZE(GpioCfgCurrHdr->GpioBaseTableBitMask)*8);
+         Index++) {
       if (GpioCfgCurrHdr->GpioBaseTableBitMask[Index >> 3] & (1 << (Index & 7))) {
         CopyMem (GpioTable, GpioCfgHdr->GpioTableData + Offset, GpioCfgHdr->GpioItemSize);
         GpioTable += GpioCfgHdr->GpioItemSize;


### PR DESCRIPTION
Malformed GPIO table could cause out of bounds access if GpioCfgBaseHdr->GpioItemCount exceeded the GpioBaseTableBitMask array dimensions.