### PR TITLE
Fix byte scanning loops that can read outside of the data range on edge conditions

### DIFF
--- a/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
+++ b/BootloaderCommonPkg/Include/Library/BootloaderCommonLib.h
@@ -668,4 +668,22 @@ CompareMemConstantTime (
   IN UINTN       Length
   );
 
+/**
+  Check if Size bytes at Ptr are still within the buffer ending at End.
+
+  @param[in]  Ptr    Current scan pointer.
+  @param[in]  Size   Number of bytes to be accessed at Ptr.
+  @param[in]  End    One byte past the end of the valid buffer.
+
+  @retval TRUE      [Ptr, Ptr + Size) is within the buffer.
+  @retval FALSE     The range would fall outside the buffer.
+**/
+BOOLEAN
+EFIAPI
+IsPtrRangeValid (
+  IN CONST UINT8   *Ptr,
+  IN UINTN          Size,
+  IN CONST UINT8   *End
+  );
+
 #endif

--- a/BootloaderCommonPkg/Library/BootloaderCommonLib/BootloaderCommonLib.c
+++ b/BootloaderCommonPkg/Library/BootloaderCommonLib/BootloaderCommonLib.c
@@ -814,6 +814,27 @@ CompareMemConstantTime (
 }
 
 /**
+  Check if Size bytes at Ptr are still within the buffer ending at End.
+
+  @param[in]  Ptr    Current scan pointer.
+  @param[in]  Size   Number of bytes to be accessed at Ptr.
+  @param[in]  End    One byte past the end of the valid buffer.
+
+  @retval TRUE      [Ptr, Ptr + Size) is within the buffer.
+  @retval FALSE     The range would fall outside the buffer.
+**/
+BOOLEAN
+EFIAPI
+IsPtrRangeValid (
+  IN CONST UINT8   *Ptr,
+  IN UINTN          Size,
+  IN CONST UINT8   *End
+  )
+{
+  return (Ptr < End) && (((UINTN)End - (UINTN)Ptr) >= Size);
+}
+
+/**
   Match a given hash with the ones in hash store.
 
   @param[in]  Usatge      Hash usage.

--- a/BootloaderCommonPkg/Library/LiteVariableLib/LiteVariableLib.c
+++ b/BootloaderCommonPkg/Library/LiteVariableLib/LiteVariableLib.c
@@ -386,7 +386,7 @@ InternalGetVariable (
   VarEndPtr = (UINT8 *)VarStoreHdrPtr + VarStoreHdrPtr->Size;
 
   FindVarHdrPtr = NULL;
-  while ((UINT8 *)VarHdrPtr < VarEndPtr) {
+  while (IsPtrRangeValid ((UINT8 *)VarHdrPtr, sizeof (VARIABLE_HEADER), VarEndPtr)) {
     State = VarHdrPtr->State;
     if (!IS_HEADER_VALID (State)) {
       break;
@@ -528,7 +528,7 @@ GetNextVariableName (
   } else {
     // Find current variable
     FindVarHdrPtr = NULL;
-    while ((UINT8 *)VarHdrPtr < VarEndPtr) {
+    while (IsPtrRangeValid ((UINT8 *)VarHdrPtr, sizeof (VARIABLE_HEADER), VarEndPtr)) {
       State = VarHdrPtr->State;
       if (VarHdrPtr->StartId != VARIABLE_DATA) {
         break;
@@ -553,7 +553,7 @@ GetNextVariableName (
   // Find the next valid variable
   VarHdrPtr     = FindVarHdrPtr;
   FindVarHdrPtr = NULL;
-  while ((UINT8 *)VarHdrPtr < VarEndPtr) {
+  while (IsPtrRangeValid ((UINT8 *)VarHdrPtr, sizeof (VARIABLE_HEADER), VarEndPtr)) {
     State = VarHdrPtr->State;
     if (VarHdrPtr->StartId != VARIABLE_DATA) {
       break;
@@ -1049,7 +1049,7 @@ QueryVariableInfo (
   UsedSize  = 0;
   VarHdrPtr = (VARIABLE_HEADER *)&VarStoreHdrPtr[1];
   VarEndPtr = (UINT8 *)VarStoreHdrPtr + VarStoreHdrPtr->Size;
-  while ((UINT8 *)VarHdrPtr < VarEndPtr) {
+  while (IsPtrRangeValid ((UINT8 *)VarHdrPtr, sizeof (VARIABLE_HEADER), VarEndPtr)) {
     if (VarHdrPtr->StartId != VARIABLE_DATA) {
       break;
     }

--- a/BootloaderCommonPkg/Library/LiteVariableLib/LiteVariableLib.inf
+++ b/BootloaderCommonPkg/Library/LiteVariableLib/LiteVariableLib.inf
@@ -36,6 +36,7 @@
   BaseMemoryLib
   DebugLib
   HobLib
+  BootloaderCommonLib
 
 [Guids]
   gZeroGuid

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.c
@@ -10,6 +10,7 @@
 #include <Library/DebugLib.h>
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
+#include <Library/BootloaderCommonLib.h>
 #include <Library/SocInitLib.h>
 #include <Library/BoardInitLib.h>
 #include <Library/DebugDataLib.h>
@@ -105,12 +106,15 @@ UpdateAcpiGnvs (
   /*
    * Loop through the ASL looking for values that we must fix up.
    */
-  for (; Ptr < End; Ptr++) {
-    if (* (UINT32 *)Ptr != SIGNATURE_32 ('G', 'N', 'V', 'S')) {
+  for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+    if ((Ptr == (UINT8 *)Dsdt) || (* (UINT32 *)Ptr != SIGNATURE_32 ('G', 'N', 'V', 'S'))) {
       continue;
     }
     if (* (Ptr - 1) != AML_EXT_REGION_OP) {
       continue;
+    }
+    if (!IsPtrRangeValid (Ptr, 11 + sizeof (UINT16), End)) {
+      break;
     }
     * (UINT32 *) (Ptr + 6)  = GnvsBase;
     * (UINT16 *) (Ptr + 11) = (UINT16)GetAcpiGnvsSize();

--- a/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
+++ b/BootloaderCorePkg/Library/AcpiInitLib/AcpiInitLib.inf
@@ -40,6 +40,7 @@
   BaseLib
   DebugLib
   BootloaderCoreLib
+  BootloaderCommonLib
   DebugDataLib
   MpInitLib
   TimeStampLib

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/AcpiPlatform.c
@@ -81,10 +81,16 @@ PatchCpuSsdtTable (
 {
   CPU_NVS_AREA            *CpuNvs;
   UINT8                   *CurrPtr;
+  UINT8                   *End;
   UINT32                  *Signature;
 
   CpuNvs      = (CPU_NVS_AREA *) &GlobalNvs->CpuNvs;
-  for (CurrPtr = (UINT8 *) Table; CurrPtr <= ((UINT8 *) Table + Table->Length); CurrPtr++) {
+  End         = (UINT8 *) Table + Table->Length;
+  // Make sure we stop searching when there's not enough room left for the entire PNVS structure
+  for (CurrPtr = (UINT8 *) Table;
+    IsPtrRangeValid (CurrPtr, 1 + sizeof (*Signature) + 2 + sizeof (UINT32) + 1 + sizeof(UINT16), End);
+    CurrPtr++)
+  {
     Signature = (UINT32 *) (CurrPtr + 1);
     ///
     /// Update the CPU GlobalNvs area
@@ -483,14 +489,14 @@ PlatformUpdateAcpiTable (
   }
 
   if (Table->Signature == EFI_ACPI_5_0_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE) {
-    for (; Ptr < End; Ptr++) {
-      if (*(Ptr-1) != AML_NAME_OP)
+    for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+      if ((Ptr == (UINT8 *) Table) || (*(Ptr-1) != AML_NAME_OP))
         continue;
-      if (*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','B')) {
+      if ((*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','B')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT32), End)) {
         Base = (UINT32) (UINTN) &GlobalNvs->PchNvs;
         DEBUG ((DEBUG_INFO, "PNVS Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 5), Base));
         *(UINT32 *)(Ptr + 5) = Base;
-      } else if (*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','L')) {
+      } else if ((*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','L')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT16), End)) {
         Size = sizeof (PCH_NVS_AREA);
         DEBUG ((DEBUG_INFO, "PNVL Old=0x%08X New=0x%08X\n", *(UINT16 *)(Ptr + 5), Size));
         *(UINT16 *)(Ptr + 5) = Size;
@@ -503,14 +509,14 @@ PlatformUpdateAcpiTable (
     MmCfg = (EFI_ACPI_MEMORY_MAPPED_ENHANCED_CONFIGURATION_SPACE_BASE_ADDRESS_ALLOCATION_STRUCTURE *)
             ((EFI_ACPI_MEMORY_MAPPED_CONFIGURATION_BASE_ADDRESS_TABLE_HEADER *)Ptr + 1);
     Base  = 0;
-    while ((UINT8 *)MmCfg < End) {
+    while (IsPtrRangeValid ((UINT8 *)MmCfg, sizeof (*MmCfg), End)) {
       MmCfg->BaseAddress = PcdGet64 (PcdPciExpressBaseAddress) + Base;
       Base += 0x10000000;
       MmCfg++;
     }
   } else if (Table->OemTableId == SIGNATURE_64 ('S', 'a', 'S', 's', 'd', 't', ' ', 0)) {
-    for (; Ptr < End; Ptr++) {
-      if (*(UINT32 *)Ptr == SIGNATURE_32 ('S','A','N','V')) {
+    for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+      if ((*(UINT32 *)Ptr == SIGNATURE_32 ('S','A','N','V')) && IsPtrRangeValid (Ptr, 11 + sizeof (UINT16), End)) {
         Base = (UINT32) (UINTN) &GlobalNvs->SaNvs;
         DEBUG ((DEBUG_INFO, "SANV Base Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 6), Base));
         *(UINT32 *)(Ptr + 6) = Base;

--- a/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.h
+++ b/Platform/AlderlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.h
@@ -101,6 +101,7 @@
 #include <Register/RtcRegs.h>
 #include <Library/CrashLogLib.h>
 #include <Acpi/AcpiCommon.h>
+#include <Library/BootloaderCommonLib.h>
 
 #define NHLT_ACPI_TABLE_SIGNATURE  SIGNATURE_32 ('N', 'H', 'L', 'T')
 #define V_EPOC_XTAL_38_4_MHZ  0x249F000

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -9,6 +9,7 @@
 #include <Library/PrintLib.h>
 #include <VerInfo.h>
 #include <Library/SmbiosInitLib.h>
+#include <Library/BootloaderCommonLib.h>
 
 #define VTD_RMRR_USB_LENGTH                   0x20000
 #define R_SA_MCHBAR_VTD1_OFFSET               0x6C88  ///< DMA Remapping HW UNIT1 for IGD
@@ -1657,9 +1658,12 @@ UpdateAcpiDsdt (
   End = (UINT8 *)Table+ Table->Length;
 
   // Loop through the ASL looking for values that we must fix up.
-  for (; Ptr < End; Ptr++) {
+  for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+    if (Ptr == (UINT8 *) Table) {
+      continue;
+    }
     if (!PnvsFound && (*(UINT32 *)Ptr == SIGNATURE_32 ('P', 'N', 'V', 'S')) &&
-         (*(Ptr - 1) == AML_EXT_REGION_OP)) {
+         (*(Ptr - 1) == AML_EXT_REGION_OP) && IsPtrRangeValid (Ptr, 11 + sizeof (UINT16), End)) {
       * (UINT32 *) (Ptr + 6)  = (UINT32)(UINTN)&Gnvs->CpuNvs;
       * (UINT16 *) (Ptr + 11) = (UINT16)sizeof(CPU_NVS_AREA);
       PnvsFound = TRUE;

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -61,6 +61,7 @@
   BoardSupportLib
   VtdPmrLib
   MadtLib
+  BootloaderCommonLib
 
 [Guids]
   gOsConfigDataGuid

--- a/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/ArrowlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -22,6 +22,7 @@
 #include <Guids/FspPchConfigHob.h>
 #include <Library/MtlSocPcieRpLib.h>
 #include <Library/DmarLib.h>
+#include <Library/BootloaderCommonLib.h>
 
 STATIC CONST UINT32 NhltSignaturesTable[] = {
   SIGNATURE_32 ('N', 'H', 'L', 'T'),
@@ -790,10 +791,16 @@ PatchCpuSsdtTable (
 {
   CPU_NVS_AREA            *CpuNvs;
   UINT8                   *CurrPtr;
+  UINT8                   *End;
   UINT32                  *Signature;
 
   CpuNvs      = (CPU_NVS_AREA *) &GlobalNvs->CpuNvs;
-  for (CurrPtr = (UINT8 *) Table; CurrPtr <= ((UINT8 *) Table + Table->Length); CurrPtr++) {
+  End         = (UINT8 *) Table + Table->Length;
+  // Make sure we stop searching when there's not enough room left for the entire PNVS structure
+  for (CurrPtr = (UINT8 *) Table;
+    IsPtrRangeValid (CurrPtr, 1 + sizeof (*Signature) + 2 + sizeof (UINT32) + 1 + sizeof(UINT16), End);
+    CurrPtr++)
+  {
     Signature = (UINT32 *) (CurrPtr + 1);
     ///
     /// Update the CPU GlobalNvs area
@@ -1176,30 +1183,30 @@ PlatformUpdateAcpiTable (
   End  = (UINT8 *)Table + Table->Length;
 
   if (Table->Signature == EFI_ACPI_5_0_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE) {
-    for (; Ptr < End; Ptr++) {
-      if (*(Ptr-1) != AML_NAME_OP)
+    for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+      if ((Ptr == (UINT8 *) Table) || (*(Ptr-1) != AML_NAME_OP))
         continue;
-      if (*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','B')) {
+      if ((*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','B')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT32), End)) {
         Base = (UINT32) (UINTN) &GlobalNvs->PchNvs;
         DEBUG ((DEBUG_INFO, "PNVB Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 5), Base));
         *(UINT32 *)(Ptr + 5) = Base;
-      } else if (*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','L')) {
+      } else if ((*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','L')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT16), End)) {
         Size = sizeof (PCH_NVS_AREA);
         DEBUG ((DEBUG_INFO, "PNVL Old=0x%08X New=0x%08X\n", *(UINT16 *)(Ptr + 5), Size));
         *(UINT16 *)(Ptr + 5) = Size;
-      } else if (*(UINT32 *)Ptr == SIGNATURE_32 ('M','N','V','B')) {
+      } else if ((*(UINT32 *)Ptr == SIGNATURE_32 ('M','N','V','B')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT32), End)) {
         Base = (UINT32) (UINTN) &GlobalNvs->MtlPchNvs;
         DEBUG ((DEBUG_INFO, "MNVS Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 5), Base));
         *(UINT32 *)(Ptr + 5) = Base;
-      } else if (*(UINT32 *)Ptr == SIGNATURE_32 ('M','N','V','L')) {
+      } else if ((*(UINT32 *)Ptr == SIGNATURE_32 ('M','N','V','L')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT16), End)) {
         Size = sizeof (MTL_PCH_NVS_AREA);
         DEBUG ((DEBUG_INFO, "MNVL Old=0x%08X New=0x%08X\n", *(UINT16 *)(Ptr + 5), Size));
         *(UINT16 *)(Ptr + 5) = Size;
-      } else if (*(UINT32 *)Ptr == SIGNATURE_32 ('S','A','N','B')) {
+      } else if ((*(UINT32 *)Ptr == SIGNATURE_32 ('S','A','N','B')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT32), End)) {
         Base = (UINT32) (UINTN) &GlobalNvs->SaNvs;
         DEBUG ((DEBUG_INFO, "SANB Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 5), Base));
         *(UINT32 *)(Ptr + 5) = Base;
-      } else if (*(UINT32 *)Ptr == SIGNATURE_32 ('S','A','N','L')) {
+      } else if ((*(UINT32 *)Ptr == SIGNATURE_32 ('S','A','N','L')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT16), End)) {
         Size = sizeof (SYSTEM_AGENT_NVS_AREA);
         DEBUG ((DEBUG_INFO, "SANL Old=0x%04X New=0x%04X\n", *(UINT16 *)(Ptr + 5), Size));
         *(UINT16 *)(Ptr + 5) = Size;
@@ -1210,7 +1217,7 @@ PlatformUpdateAcpiTable (
     MmCfg = (EFI_ACPI_MEMORY_MAPPED_ENHANCED_CONFIGURATION_SPACE_BASE_ADDRESS_ALLOCATION_STRUCTURE *)
             ((EFI_ACPI_MEMORY_MAPPED_CONFIGURATION_BASE_ADDRESS_TABLE_HEADER *)Ptr + 1);
     Base  = 0;
-    while ((UINT8 *)MmCfg < End) {
+    while (IsPtrRangeValid ((UINT8 *)MmCfg, sizeof (*MmCfg), End)) {
       MmCfg->BaseAddress = PcdGet64 (PcdPciExpressBaseAddress) + Base;
       Base += 0x10000000;
       MmCfg++;
@@ -1356,8 +1363,8 @@ PlatformUpdateAcpiTable (
   if (Table->Signature == EFI_ACPI_6_4_SECONDARY_SYSTEM_DESCRIPTION_TABLE_SIGNATURE &&
       Table->OemTableId == SIGNATURE_64 ('E', 'c', 'S', 's', 'd', 't', ' ', 0)) {
     DEBUG((DEBUG_INFO, "Found EcSsdt\n"));
-    for (; Ptr < End; Ptr++) {
-      if (*(UINT32 *)Ptr == SIGNATURE_32 ('E','N','V','S')) {
+    for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+      if ((*(UINT32 *)Ptr == SIGNATURE_32 ('E','N','V','S')) && IsPtrRangeValid (Ptr, 11 + sizeof (UINT16), End)) {
         Base = (UINT32) (UINTN) &GlobalNvs->EcNvs;
         DEBUG ((DEBUG_INFO, "ENVS Base Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 6), Base));
         *(UINT32 *)(Ptr + 6) = Base;

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -71,6 +71,7 @@
 #include <Library/PlatformHookLib.h>
 #include <Library/MadtLib.h>
 #include <Library/AcpiInitLib.h>
+#include <Library/BootloaderCommonLib.h>
 
 #define ICH_IOAPIC_ID                               0x02
 #define LOCAL_APIC_BASE_ADDRESS                     0xFEE00000
@@ -400,7 +401,10 @@ PatchCpuIstTable (
 
   Ptr = (UINT8 *)Table;
   End = (UINT8 *)Table+ Table->Length;
-  for (Lpss = NULL, Tpss = NULL; Ptr < End; Ptr++) {
+  for (Lpss = NULL, Tpss = NULL; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+    if (Ptr == (UINT8 *)Table) {
+      continue;
+    }
     if ((Lpss == NULL) && (*(UINT32 *)Ptr == SIGNATURE_32 ('L', 'P', 'S', 'S')) && (*(Ptr - 1) == AML_NAME_OP)) {
       Lpss = Ptr;
     }
@@ -475,11 +479,16 @@ PatchCpuSsdtTable (
 {
   CPU_NVS_AREA            *CpuNvs;
   UINT8                   *CurrPtr;
+  UINT8                   *End;
   UINT32                  *Signature;
 
   CpuNvs      = (CPU_NVS_AREA *) &GlobalNvs->CpuNvs;
-  CurrPtr     = (UINT8 *) Table;
-  for (CurrPtr = (UINT8 *) Table; CurrPtr <= ((UINT8 *) Table + Table->Length); CurrPtr++) {
+  End         = (UINT8 *) Table + Table->Length;
+  // Make sure we stop searching when there's not enough room left for the entire PNVS structure
+  for (CurrPtr = (UINT8 *) Table;
+    IsPtrRangeValid (CurrPtr, 1 + sizeof (*Signature) + 2 + sizeof (UINT32) + 1 + sizeof(UINT16), End);
+    CurrPtr++)
+  {
     Signature = (UINT32 *) (CurrPtr + 1);
     ///
     /// Update the CPU GlobalNvs area
@@ -1969,14 +1978,14 @@ PlatformUpdateAcpiTable (
   }
 
   if (Table->Signature == EFI_ACPI_5_0_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE) {
-    for (; Ptr < End; Ptr++) {
-      if (*(Ptr-1) != AML_NAME_OP)
+    for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+      if ((Ptr == (UINT8 *) Table) || (*(Ptr-1) != AML_NAME_OP))
         continue;
-      if (*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','B')) {
+      if ((*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','B')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT32), End)) {
         Base = (UINT32) (UINTN) &GlobalNvs->PchNvs;
         DEBUG ((DEBUG_INFO, "PNVB Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 5), Base));
         *(UINT32 *)(Ptr + 5) = Base;
-      } else if (*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','L')) {
+      } else if ((*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','L')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT16), End)) {
         Size = sizeof (PCH_NVS_AREA);
         DEBUG ((DEBUG_INFO, "PNVL Old=0x%08X New=0x%08X\n", *(UINT16 *)(Ptr + 5), Size));
         *(UINT16 *)(Ptr + 5) = Size;
@@ -1989,14 +1998,14 @@ PlatformUpdateAcpiTable (
     MmCfg = (EFI_ACPI_MEMORY_MAPPED_ENHANCED_CONFIGURATION_SPACE_BASE_ADDRESS_ALLOCATION_STRUCTURE *)
             ((EFI_ACPI_MEMORY_MAPPED_CONFIGURATION_BASE_ADDRESS_TABLE_HEADER *)Ptr + 1);
     Base  = 0;
-    while ((UINT8 *)MmCfg < End) {
+    while (IsPtrRangeValid ((UINT8 *)MmCfg, sizeof (*MmCfg), End)) {
       MmCfg->BaseAddress = PcdGet64 (PcdPciExpressBaseAddress) + Base;
       Base += 0x10000000;
       MmCfg++;
     }
   } else if (Table->OemTableId == SIGNATURE_64 ('S', 'a', 'S', 's', 'd', 't', ' ', 0)) {
-    for (; Ptr < End; Ptr++) {
-      if (*(UINT32 *)Ptr == SIGNATURE_32 ('S','A','N','V')) {
+    for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+      if ((*(UINT32 *)Ptr == SIGNATURE_32 ('S','A','N','V')) && IsPtrRangeValid (Ptr, 11 + sizeof (UINT16), End)) {
         Base = (UINT32) (UINTN) &GlobalNvs->SaNvs;
         DEBUG ((DEBUG_INFO, "SANV Base Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 6), Base));
         *(UINT32 *)(Ptr + 6) = Base;

--- a/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/CoffeelakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -57,6 +57,8 @@
   VtdPmrLib
   VtdLib
   MadtLib
+  BootloaderCommonLib
+
 [Guids]
   gSmmInformationGuid
   gCpuInitDataHobGuid

--- a/Platform/CometlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CometlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -65,6 +65,7 @@
 #include "GpioTables.h"
 #include <Library/MadtLib.h>
 #include <Library/AcpiInitLib.h>
+#include <Library/BootloaderCommonLib.h>
 
 #define DEFAULT_GPIO_IRQ_ROUTE                      14
 
@@ -435,7 +436,10 @@ PatchCpuIstTable (
   ///
   CurrPtr     = (UINT8 *) Table;
   EndOfTable  = (UINT8 *) (CurrPtr + Table->Length);
-  for (CurrPtr = (UINT8 *) Table; CurrPtr <= EndOfTable; CurrPtr++) {
+  for (CurrPtr = (UINT8 *) Table;
+       IsPtrRangeValid (CurrPtr, sizeof (UINT8) + 3 * sizeof (UINT32), EndOfTable); // reserve room for the Signature+2 read below
+       CurrPtr++)
+  {
     Signature = (UINT32 *) (CurrPtr + 1);
     ///
     /// If we find the _SB_PR00 scope, save a pointer to the package length
@@ -649,11 +653,16 @@ PatchCpuSsdtTable (
 {
   CPU_NVS_AREA            *CpuNvs;
   UINT8                   *CurrPtr;
+  UINT8                   *End;
   UINT32                  *Signature;
 
   CpuNvs      = (CPU_NVS_AREA *) &GlobalNvs->CpuNvs;
-  CurrPtr     = (UINT8 *) Table;
-  for (CurrPtr = (UINT8 *) Table; CurrPtr <= ((UINT8 *) Table + Table->Length); CurrPtr++) {
+  End         = (UINT8 *) Table + Table->Length;
+  // Make sure we stop searching when there's not enough room left for the entire PNVS structure
+  for (CurrPtr = (UINT8 *) Table;
+    IsPtrRangeValid (CurrPtr, 1 + sizeof (*Signature) + 2 + sizeof (UINT32) + 1 + sizeof(UINT16), End);
+    CurrPtr++)
+  {
     Signature = (UINT32 *) (CurrPtr + 1);
     ///
     /// Update the CPU GlobalNvs area
@@ -2233,14 +2242,14 @@ PlatformUpdateAcpiTable (
   }
 
   if (Table->Signature == EFI_ACPI_5_0_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE) {
-    for (; Ptr < End; Ptr++) {
-      if (*(Ptr-1) != AML_NAME_OP)
+    for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+      if ((Ptr == (UINT8 *) Table) || (*(Ptr-1) != AML_NAME_OP))
         continue;
-      if (*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','B')) {
+      if ((*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','B')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT32), End)) {
         Base = (UINT32) (UINTN) &GlobalNvs->PchNvs;
         DEBUG ((DEBUG_INFO, "PNVB Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 5), Base));
         *(UINT32 *)(Ptr + 5) = Base;
-      } else if (*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','L')) {
+      } else if ((*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','L')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT16), End)) {
         Size = sizeof (PCH_NVS_AREA);
         DEBUG ((DEBUG_INFO, "PNVL Old=0x%08X New=0x%08X\n", *(UINT16 *)(Ptr + 5), Size));
         *(UINT16 *)(Ptr + 5) = Size;
@@ -2253,14 +2262,14 @@ PlatformUpdateAcpiTable (
     MmCfg = (EFI_ACPI_MEMORY_MAPPED_ENHANCED_CONFIGURATION_SPACE_BASE_ADDRESS_ALLOCATION_STRUCTURE *)
             ((EFI_ACPI_MEMORY_MAPPED_CONFIGURATION_BASE_ADDRESS_TABLE_HEADER *)Ptr + 1);
     Base  = 0;
-    while ((UINT8 *)MmCfg < End) {
+    while (IsPtrRangeValid ((UINT8 *)MmCfg, sizeof (*MmCfg), End)) {
       MmCfg->BaseAddress = PcdGet64 (PcdPciExpressBaseAddress) + Base;
       Base += 0x10000000;
       MmCfg++;
     }
   } else if (Table->OemTableId == SIGNATURE_64 ('S', 'a', 'S', 's', 'd', 't', ' ', 0)) {
-    for (; Ptr < End; Ptr++) {
-      if (*(UINT32 *)Ptr == SIGNATURE_32 ('S','A','N','V')) {
+    for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+      if ((*(UINT32 *)Ptr == SIGNATURE_32 ('S','A','N','V')) && IsPtrRangeValid (Ptr, 11 + sizeof (UINT16), End)) {
         Base = (UINT32) (UINTN) &GlobalNvs->SaNvs;
         DEBUG ((DEBUG_INFO, "SANV Base Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 6), Base));
         *(UINT32 *)(Ptr + 6) = Base;

--- a/Platform/CometlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/CometlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -55,6 +55,7 @@
   S3SaveRestoreLib
   BoardSupportLib
   MadtLib
+  BootloaderCommonLib
 
 [Guids]
   gSmmInformationGuid

--- a/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -65,6 +65,7 @@
 #include "GpioTables.h"
 #include <Library/MadtLib.h>
 #include <Library/AcpiInitLib.h>
+#include <Library/BootloaderCommonLib.h>
 
 #define DEFAULT_GPIO_IRQ_ROUTE                      14
 
@@ -428,7 +429,9 @@ PatchCpuIstTable (
   ///
   CurrPtr     = (UINT8 *) Table;
   EndOfTable  = (UINT8 *) (CurrPtr + Table->Length);
-  for (CurrPtr = (UINT8 *) Table; CurrPtr <= EndOfTable; CurrPtr++) {
+  for (CurrPtr = (UINT8 *) Table;
+       IsPtrRangeValid (CurrPtr, sizeof (UINT8) + 3 * sizeof (UINT32), EndOfTable); // reserve room for the Signature+2 read below
+       CurrPtr++) {
     Signature = (UINT32 *) (CurrPtr + 1);
     ///
     /// If we find the _SB_PR00 scope, save a pointer to the package length
@@ -642,11 +645,16 @@ PatchCpuSsdtTable (
 {
   CPU_NVS_AREA            *CpuNvs;
   UINT8                   *CurrPtr;
+  UINT8                   *End;
   UINT32                  *Signature;
 
   CpuNvs      = (CPU_NVS_AREA *) &GlobalNvs->CpuNvs;
-  CurrPtr     = (UINT8 *) Table;
-  for (CurrPtr = (UINT8 *) Table; CurrPtr <= ((UINT8 *) Table + Table->Length); CurrPtr++) {
+  End         = (UINT8 *) Table + Table->Length;
+  // Make sure we stop searching when there's not enough room left for the entire PNVS structure
+  for (CurrPtr = (UINT8 *) Table;
+    IsPtrRangeValid (CurrPtr, 1 + sizeof (*Signature) + 2 + sizeof (UINT32) + 1 + sizeof(UINT16), End);
+    CurrPtr++)
+  {
     Signature = (UINT32 *) (CurrPtr + 1);
     ///
     /// Update the CPU GlobalNvs area
@@ -2185,14 +2193,14 @@ PlatformUpdateAcpiTable (
   }
 
   if (Table->Signature == EFI_ACPI_5_0_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE) {
-    for (; Ptr < End; Ptr++) {
-      if (*(Ptr-1) != AML_NAME_OP)
+    for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+      if ((Ptr == (UINT8 *) Table) || (*(Ptr-1) != AML_NAME_OP))
         continue;
-      if (*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','B')) {
+      if ((*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','B')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT32), End)) {
         Base = (UINT32) (UINTN) &GlobalNvs->PchNvs;
         DEBUG ((DEBUG_INFO, "PNVB Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 5), Base));
         *(UINT32 *)(Ptr + 5) = Base;
-      } else if (*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','L')) {
+      } else if ((*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','L')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT16), End)) {
         Size = sizeof (PCH_NVS_AREA);
         DEBUG ((DEBUG_INFO, "PNVL Old=0x%08X New=0x%08X\n", *(UINT16 *)(Ptr + 5), Size));
         *(UINT16 *)(Ptr + 5) = Size;
@@ -2205,14 +2213,14 @@ PlatformUpdateAcpiTable (
     MmCfg = (EFI_ACPI_MEMORY_MAPPED_ENHANCED_CONFIGURATION_SPACE_BASE_ADDRESS_ALLOCATION_STRUCTURE *)
             ((EFI_ACPI_MEMORY_MAPPED_CONFIGURATION_BASE_ADDRESS_TABLE_HEADER *)Ptr + 1);
     Base  = 0;
-    while ((UINT8 *)MmCfg < End) {
+    while (IsPtrRangeValid ((UINT8 *)MmCfg, sizeof (*MmCfg), End)) {
       MmCfg->BaseAddress = PcdGet64 (PcdPciExpressBaseAddress) + Base;
       Base += 0x10000000;
       MmCfg++;
     }
   } else if (Table->OemTableId == SIGNATURE_64 ('S', 'a', 'S', 's', 'd', 't', ' ', 0)) {
-    for (; Ptr < End; Ptr++) {
-      if (*(UINT32 *)Ptr == SIGNATURE_32 ('S','A','N','V')) {
+    for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+      if ((*(UINT32 *)Ptr == SIGNATURE_32 ('S','A','N','V')) && IsPtrRangeValid (Ptr, 11 + sizeof (UINT16), End)) {
         Base = (UINT32) (UINTN) &GlobalNvs->SaNvs;
         DEBUG ((DEBUG_INFO, "SANV Base Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 6), Base));
         *(UINT32 *)(Ptr + 6) = Base;

--- a/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/CometlakevBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -55,6 +55,7 @@
   S3SaveRestoreLib
   BoardSupportLib
   MadtLib
+  BootloaderCommonLib
 
 [Guids]
   gSmmInformationGuid

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -63,6 +63,7 @@
   WatchDogTimerLib
   ResetSystemLib
   MadtLib
+  BootloaderCommonLib
 
 [Guids]
   gOsConfigDataGuid

--- a/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/UpdateAcpiTable.c
+++ b/Platform/ElkhartlakeBoardPkg/Library/Stage2BoardInitLib/UpdateAcpiTable.c
@@ -30,6 +30,7 @@
 #include <Library/PchSciLib.h>
 #include <PlatformData.h>
 #include <Library/MadtLib.h>
+#include <Library/BootloaderCommonLib.h>
 
 #define ICH_IOAPIC_ID                   0x02
 #define NHLT_ACPI_TABLE_SIGNATURE  SIGNATURE_32 ('N', 'H', 'L', 'T')
@@ -94,11 +95,16 @@ PatchCpuSsdtTable (
 {
   CPU_NVS_AREA            *CpuNvs;
   UINT8                   *CurrPtr;
+  UINT8                   *End;
   UINT32                  *Signature;
 
   CpuNvs      = (CPU_NVS_AREA *) &GlobalNvs->CpuNvs;
-  CurrPtr     = (UINT8 *) Table;
-  for (CurrPtr = (UINT8 *) Table; CurrPtr <= ((UINT8 *) Table + Table->Length); CurrPtr++) {
+  End         = (UINT8 *) Table + Table->Length;
+  // Make sure we stop searching when there's not enough room left for the entire PNVS structure
+  for (CurrPtr = (UINT8 *) Table;
+    IsPtrRangeValid (CurrPtr, 1 + sizeof (*Signature) + 2 + sizeof (UINT32) + 1 + sizeof(UINT16), End);
+    CurrPtr++)
+  {
     Signature = (UINT32 *) (CurrPtr + 1);
     ///
     /// Update the CPU GlobalNvs area
@@ -191,7 +197,9 @@ AcpiPatchPss (
   ///
   CurrPtr     = (UINT8 *) Table;
   EndOfTable  = (UINT8 *) (CurrPtr + Table->Length);
-  for (CurrPtr = (UINT8 *) Table; CurrPtr <= EndOfTable; CurrPtr++) {
+  for (CurrPtr = (UINT8 *) Table;
+       IsPtrRangeValid (CurrPtr, sizeof (UINT8) + 3 * sizeof (UINT32), EndOfTable); // reserve room for the Signature+2 read below
+       CurrPtr++) {
     Signature = (UINT32 *) (CurrPtr + 1);
     ///
     /// If we find the _SB_PR00 scope, save a pointer to the package length
@@ -417,14 +425,14 @@ PlatformUpdateAcpiTable (
   End  = (UINT8 *)Table + Table->Length;
 
   if (Table->Signature == EFI_ACPI_5_0_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE) {
-    for (; Ptr < End; Ptr++) {
-      if (*(Ptr-1) != AML_NAME_OP)
+    for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+      if ((Ptr == (UINT8 *) Table) || (*(Ptr-1) != AML_NAME_OP))
         continue;
-      if (*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','B')) {
+      if ((*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','B')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT32), End)) {
         Base = (UINT32) (UINTN) &GlobalNvs->PchNvs;
         DEBUG ((DEBUG_INFO, "PNVS Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 5), Base));
         *(UINT32 *)(Ptr + 5) = Base;
-      } else if (*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','L')) {
+      } else if ((*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','L')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT16), End)) {
         Size = sizeof (PCH_NVS_AREA);
         DEBUG ((DEBUG_INFO, "PNVL Old=0x%08X New=0x%08X\n", *(UINT16 *)(Ptr + 5), Size));
         *(UINT16 *)(Ptr + 5) = Size;
@@ -437,14 +445,14 @@ PlatformUpdateAcpiTable (
     MmCfg = (EFI_ACPI_MEMORY_MAPPED_ENHANCED_CONFIGURATION_SPACE_BASE_ADDRESS_ALLOCATION_STRUCTURE *)
             ((EFI_ACPI_MEMORY_MAPPED_CONFIGURATION_BASE_ADDRESS_TABLE_HEADER *)Ptr + 1);
     Base  = 0;
-    while ((UINT8 *)MmCfg < End) {
+    while (IsPtrRangeValid ((UINT8 *)MmCfg, sizeof (*MmCfg), End)) {
       MmCfg->BaseAddress = PcdGet64 (PcdPciExpressBaseAddress) + Base;
       Base += 0x10000000;
       MmCfg++;
     }
   } else if (Table->OemTableId == SIGNATURE_64 ('S', 'a', 'S', 's', 'd', 't', ' ', 0)) {
-    for (; Ptr < End; Ptr++) {
-      if (*(UINT32 *)Ptr == SIGNATURE_32 ('S','A','N','V')) {
+    for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+      if ((*(UINT32 *)Ptr == SIGNATURE_32 ('S','A','N','V')) && IsPtrRangeValid (Ptr, 11 + sizeof (UINT16), End)) {
         Base = (UINT32) (UINTN) &GlobalNvs->SaNvs;
         DEBUG ((DEBUG_INFO, "SANV Base Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 6), Base));
         *(UINT32 *)(Ptr + 6) = Base;

--- a/Platform/IdavilleBoardPkg/Library/Stage2BoardInitLib/AcpiTablesInit.c
+++ b/Platform/IdavilleBoardPkg/Library/Stage2BoardInitLib/AcpiTablesInit.c
@@ -6,6 +6,7 @@
 **/
 
 #include "Stage2BoardInitLib.h"
+#include <Library/BootloaderCommonLib.h>
 
 #define AML_STA_PRESENT           0x01
 #define AML_STA_ENABLED           0x02
@@ -207,36 +208,37 @@ PatchDsdtTable (
 
   Ptr = (UINT8 *)Table;
   End = (UINT8 *)Table + Table->Length;
-  for (; Ptr < End; Ptr++) {
-    if (*(Ptr - 1) == AML_NAME_OP) {
-      if (*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','B')) {
-        Base = (UINT32) (UINTN) &GlobalNvs->PchNvs;
-        DEBUG ((DEBUG_INFO, "PNVB Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 5), Base));
-        *(UINT32 *)(Ptr + 5) = Base;
-      } else if (*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','L')) {
-        Size = sizeof (PCH_NVS_AREA);
-        DEBUG ((DEBUG_INFO, "PNVL Old=0x%08X New=0x%08X\n", *(UINT16 *)(Ptr + 5), Size));
-        *(UINT16 *)(Ptr + 5) = Size;
-      } else if (*(UINT32 *)Ptr == SIGNATURE_32 ('B','N','V','B')) {
-        Base = (UINT32) (UINTN) &GlobalNvs->BiosAcpiParam;
-        DEBUG ((DEBUG_INFO, "BNVB Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 5), Base));
-        *(UINT32 *)(Ptr + 5) = Base;
-      } else if (*(UINT32 *)Ptr == SIGNATURE_32 ('B','N','V','L')) {
-        Size = sizeof (BIOS_ACPI_PARAM);
-        DEBUG ((DEBUG_INFO, "BNVL Old=0x%08X New=0x%08X\n", *(UINT16 *)(Ptr + 5), Size));
-        *(UINT16 *)(Ptr + 5) = Size;
-      } else if ((Ptr[0] == 'A') && (Ptr[1] == 'P') && (Ptr[2] == 'T') && (Ptr[3] == '0')) {
-        if (CpuInfo == NULL) {
-          continue;
-        }
+  for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+    if ((Ptr == (UINT8 *) Table) || (*(Ptr - 1) != AML_NAME_OP)) {
+      continue;
+    }
+    if ((*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','B')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT32), End)) {
+      Base = (UINT32) (UINTN) &GlobalNvs->PchNvs;
+      DEBUG ((DEBUG_INFO, "PNVB Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 5), Base));
+      *(UINT32 *)(Ptr + 5) = Base;
+    } else if ((*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','L')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT16), End)) {
+      Size = sizeof (PCH_NVS_AREA);
+      DEBUG ((DEBUG_INFO, "PNVL Old=0x%08X New=0x%08X\n", *(UINT16 *)(Ptr + 5), Size));
+      *(UINT16 *)(Ptr + 5) = Size;
+    } else if ((*(UINT32 *)Ptr == SIGNATURE_32 ('B','N','V','B')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT32), End)) {
+      Base = (UINT32) (UINTN) &GlobalNvs->BiosAcpiParam;
+      DEBUG ((DEBUG_INFO, "BNVB Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 5), Base));
+      *(UINT32 *)(Ptr + 5) = Base;
+    } else if ((*(UINT32 *)Ptr == SIGNATURE_32 ('B','N','V','L')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT16), End)) {
+      Size = sizeof (BIOS_ACPI_PARAM);
+      DEBUG ((DEBUG_INFO, "BNVL Old=0x%08X New=0x%08X\n", *(UINT16 *)(Ptr + 5), Size));
+      *(UINT16 *)(Ptr + 5) = Size;
+    } else if ((Ptr[0] == 'A') && (Ptr[1] == 'P') && (Ptr[2] == 'T') && (Ptr[3] == '0')) {
+      if ((CpuInfo == NULL) || !IsPtrRangeValid (Ptr, 9 + CpuCount, End)) {
+        continue;
+      }
 
-        Current = Ptr + 9;
-        DEBUG ((DEBUG_VERBOSE, "APT0\n"));
-        for (Index = 0; Index < CpuCount; Index++) {
-          DEBUG ((DEBUG_VERBOSE, " %d: 0x%02X ->", Index, Current[Index]));
-          Current[Index] = (UINT8)CpuInfo->CpuInfo[Index].ApicId;
-          DEBUG ((DEBUG_VERBOSE, " 0x%02X\n", Current[Index]));
-        }
+      Current = Ptr + 9;
+      DEBUG ((DEBUG_VERBOSE, "APT0\n"));
+      for (Index = 0; Index < CpuCount; Index++) {
+        DEBUG ((DEBUG_VERBOSE, " %d: 0x%02X ->", Index, Current[Index]));
+        Current[Index] = (UINT8)CpuInfo->CpuInfo[Index].ApicId;
+        DEBUG ((DEBUG_VERBOSE, " 0x%02X\n", Current[Index]));
       }
     }
   }
@@ -280,7 +282,7 @@ SkipExternalSbOpcodes (
   //
   // Skip external op
   //
-  for (Ptr = CurrPtr; Ptr <= EndPtr; ++Ptr) {
+  for (Ptr = CurrPtr; IsPtrRangeValid (Ptr, 9, EndPtr); ++Ptr) {
     Signature = *(UINT32 *) Ptr;
     if ((Signature == SIGNATURE_32 ('_', 'S', 'B', '_'))
       && ((Ptr[4] == 'S') && (Ptr[5] == 'C') && (Ptr[6] == 'K') && (Ptr[7] == '0') && (Ptr[8] == 'C'))
@@ -290,7 +292,7 @@ SkipExternalSbOpcodes (
     }
   }
 
-  if (Ptr < EndPtr) {
+  if (IsPtrRangeValid (Ptr, 9, EndPtr)) {
     return Ptr;
   } else {
     DEBUG ((DEBUG_INFO, "SkipExternalSbOpcodes - Not found!\n"));
@@ -344,7 +346,7 @@ PatchCpuPmSsdtTable (
   ThreadIndex = 0;
   DomnValue = 0;
   NcpuValue = 0;
-  for (Ptr = CurrPtr; Ptr <= EndPtr; ++Ptr) {
+  for (Ptr = CurrPtr; IsPtrRangeValid (Ptr, 12, EndPtr); ++Ptr) {
     Signature = *(UINT32 *) Ptr;
     if ((Signature == SIGNATURE_32 ('_', 'S', 'B', '_'))
       && ((Ptr[4] == 'S') && (Ptr[5] == 'C') && (Ptr[6] == 'K') && (Ptr[8] == 'C'))) {
@@ -493,7 +495,7 @@ PatchOem1SsdtTable (
   ThreadCount = (CpuInfo != NULL) ? (UINT8)CpuInfo->CpuCount : 1;
   CpuSkt = 0;
   ThreadIndex = 0;
-  for (Ptr = CurrPtr; Ptr <= EndPtr; ++Ptr) {
+  for (Ptr = CurrPtr; IsPtrRangeValid (Ptr, 12, EndPtr); ++Ptr) {
     Signature = *(UINT32 *) Ptr;
     if ((Signature == SIGNATURE_32 ('_', 'S', 'B', '_'))
       && ((Ptr[4] == 'S') && (Ptr[5] == 'C') && (Ptr[6] == 'K') && (Ptr[8] == 'C'))) {
@@ -559,22 +561,28 @@ PatchSpsNmSsdtTable (
   CpuInfo = MpGetInfo ();
   ThreadCount = (CpuInfo != NULL) ? (UINT16)CpuInfo->CpuCount : 1;
 
-  for (Ptr = CurrPtr; Ptr <= EndPtr; ++Ptr) {
+  // In each case, make sure accesses don't exceed the table bounds
+  for (Ptr = CurrPtr; IsPtrRangeValid (Ptr, sizeof(UINT32) + 2, EndPtr); ++Ptr) {
     Signature = *(UINT32 *) Ptr;
 
     if ((Signature == SIGNATURE_32('H', '2', 'S', 'T')) &&
-        (Ptr[4] == AML_BYTE_PREFIX)) {
+        (Ptr[4] == AML_BYTE_PREFIX))
+    {
       DEBUG ((DEBUG_VERBOSE, "[SPS] Updating 'H2ST' 0x%02X", *(UINT8 *)&Ptr[5]));
       *(UINT8 *)&Ptr[5] = AML_STA_PRESENT | AML_STA_ENABLED | AML_STA_FUNCTIONAL;
       DEBUG ((DEBUG_VERBOSE, " -> 0x%02X\n", *(UINT8 *)&Ptr[5]));
     } else if ((Signature == SIGNATURE_32('T', 'H', 'N', 'U')) &&
-               (Ptr[4] == AML_WORD_PREFIX)) {
+               (Ptr[4] == AML_WORD_PREFIX) &&
+               IsPtrRangeValid (Ptr, sizeof(UINT32) + 1 + sizeof(UINT16), EndPtr))
+    {
       DEBUG ((DEBUG_VERBOSE, "[SPS] Updating 'THNU' %d", *(UINT16 *)&Ptr[5]));
       *(UINT16 *)&Ptr[5] = ThreadCount;
       DEBUG ((DEBUG_VERBOSE, " -> %d\n", *(UINT16 *)&Ptr[5]));
     } else if ((Signature == SIGNATURE_32('H', '2', 'C', 'S')) &&
                (Ptr[4] == EFI_ACPI_5_0_SYSTEM_MEMORY) &&
-               (Ptr[5] == AML_QWORD_PREFIX)) {
+               (Ptr[5] == AML_QWORD_PREFIX) &&
+               IsPtrRangeValid (Ptr, sizeof(UINT32) + 2 + sizeof(UINT64), EndPtr))
+    {
       DEBUG ((DEBUG_VERBOSE, "[SPS] Updating 'H2CR' address 0x%16lX", *(UINT32 *)&Ptr[10], *(UINT32 *)&Ptr[6]));
       Base = MM_PCI_ADDRESS (ME_BUS, ME_DEVICE_NUMBER, HECI2_FUNCTION_NUMBER, 0x0);
       *(UINT64 *)&Ptr[6] = (MmioRead32 (Base + 0x14) | (MmioRead32 (Base + 0x10) & (UINT32)~0xF));

--- a/Platform/IdavilleBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/IdavilleBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -66,6 +66,7 @@
   WatchDogTimerLib
   PchSbiAccessLib
   MadtLib
+  BootloaderCommonLib
 
 [Guids]
   gOsConfigDataGuid

--- a/Platform/KaseyvilleBoardPkg/Library/Stage2BoardInitLib/AcpiTablesInit.c
+++ b/Platform/KaseyvilleBoardPkg/Library/Stage2BoardInitLib/AcpiTablesInit.c
@@ -6,6 +6,7 @@
 **/
 
 #include "Stage2BoardInitLib.h"
+#include <Library/BootloaderCommonLib.h>
 
 #define AML_STA_PRESENT           0x01
 #define AML_STA_ENABLED           0x02
@@ -316,17 +317,18 @@ PatchDsdtTable (
 
   Ptr = (UINT8 *)Table;
   End = (UINT8 *)Table + Table->Length;
-  for (; Ptr < End; Ptr++) {
-    if (*(Ptr - 1) == AML_NAME_OP) {
-      if (*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','B')) {
-        Base = (UINT32) (UINTN) &GlobalNvs->PchNvs;
-        DEBUG ((DEBUG_INFO, "PNVB Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 5), Base));
-        *(UINT32 *)(Ptr + 5) = Base;
-      } else if (*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','L')) {
-        Size = sizeof (PCH_NVS_AREA);
-        DEBUG ((DEBUG_INFO, "PNVL Old=0x%08X New=0x%08X\n", *(UINT16 *)(Ptr + 5), Size));
-        *(UINT16 *)(Ptr + 5) = Size;
-      }
+  for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+    if ((Ptr == (UINT8 *) Table) || (*(Ptr - 1) != AML_NAME_OP)) {
+      continue;
+    }
+    if ((*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','B')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT32), End)) {
+      Base = (UINT32) (UINTN) &GlobalNvs->PchNvs;
+      DEBUG ((DEBUG_INFO, "PNVB Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 5), Base));
+      *(UINT32 *)(Ptr + 5) = Base;
+    } else if ((*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','L')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT16), End)) {
+      Size = sizeof (PCH_NVS_AREA);
+      DEBUG ((DEBUG_INFO, "PNVL Old=0x%08X New=0x%08X\n", *(UINT16 *)(Ptr + 5), Size));
+      *(UINT16 *)(Ptr + 5) = Size;
     }
   }
 
@@ -372,7 +374,7 @@ SkipExternalSbOpcodes (
   //
   // Skip external op
   //
-  for (Ptr = CurrPtr; Ptr <= EndPtr; ++Ptr) {
+  for (Ptr = CurrPtr; IsPtrRangeValid (Ptr, sizeof(UINT32) + 5, EndPtr); ++Ptr) {
     Signature = *(UINT32 *) Ptr;
     if ((Signature == SIGNATURE_32 ('_', 'S', 'B', '_'))
       && ((Ptr[4] == 'S') && (Ptr[5] == 'C') && (Ptr[6] == 'K') && (Ptr[7] == '0') && (Ptr[8] == 'C'))
@@ -382,7 +384,7 @@ SkipExternalSbOpcodes (
     }
   }
 
-  if (Ptr < EndPtr) {
+  if (IsPtrRangeValid (Ptr, sizeof(UINT32) + 5, EndPtr)) {
     return Ptr;
   } else {
     DEBUG ((DEBUG_INFO, "SkipExternalSbOpcodes - Not found!\n"));
@@ -436,7 +438,7 @@ PatchCpuPmSsdtTable (
   ThreadIndex = 0;
   DomnValue = 0;
   NcpuValue = 0;
-  for (Ptr = CurrPtr; Ptr <= EndPtr; ++Ptr) {
+  for (Ptr = CurrPtr; IsPtrRangeValid (Ptr, 12, EndPtr); ++Ptr) {
     Signature = *(UINT32 *) Ptr;
     if ((Signature == SIGNATURE_32 ('_', 'S', 'B', '_'))
       && ((Ptr[4] == 'S') && (Ptr[5] == 'C') && (Ptr[6] == 'K') && (Ptr[8] == 'C'))) {
@@ -586,7 +588,7 @@ PatchOem1SsdtTable (
   ThreadCount = (CpuInfo != NULL) ? (UINT8)CpuInfo->CpuCount : 1;
   CpuSkt = 0;
   ThreadIndex = 0;
-  for (Ptr = CurrPtr; Ptr <= EndPtr; ++Ptr) {
+  for (Ptr = CurrPtr; IsPtrRangeValid (Ptr, 12, EndPtr); ++Ptr) {
     Signature = *(UINT32 *) Ptr;
     if ((Signature == SIGNATURE_32 ('_', 'S', 'B', '_'))
       && ((Ptr[4] == 'S') && (Ptr[5] == 'C') && (Ptr[6] == 'K') && (Ptr[8] == 'C'))) {

--- a/Platform/KaseyvilleBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/KaseyvilleBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -47,6 +47,7 @@
   KsvVtdLib
   DmarLib
   MadtLib
+  BootloaderCommonLib
   PrintLib
   AspeedGfxLib
   UefiVariableLib

--- a/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/MeteorlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -17,6 +17,7 @@
 #include <Register/PchRegsLpc.h>
 #include <Library/DmarLib.h>
 #include <Library/AcpiInitLib.h>
+#include <Library/BootloaderCommonLib.h>
 
 STATIC CONST UINT32 NhltSignaturesTable[] = {
   SIGNATURE_32 ('N', 'H', 'L', 'T')
@@ -772,10 +773,15 @@ PatchCpuSsdtTable (
 {
   CPU_NVS_AREA            *CpuNvs;
   UINT8                   *CurrPtr;
+  UINT8                   *End;
   UINT32                  *Signature;
 
   CpuNvs      = (CPU_NVS_AREA *) &GlobalNvs->CpuNvs;
-  for (CurrPtr = (UINT8 *) Table; CurrPtr <= ((UINT8 *) Table + Table->Length); CurrPtr++) {
+  End         = (UINT8 *) Table + Table->Length;
+  for (CurrPtr = (UINT8 *) Table;
+    IsPtrRangeValid (CurrPtr, 1 + sizeof (*Signature) + 2 + sizeof (UINT32) + 1 + sizeof(UINT16), End);
+    CurrPtr++)
+  {
     Signature = (UINT32 *) (CurrPtr + 1);
     ///
     /// Update the CPU GlobalNvs area
@@ -864,7 +870,10 @@ AcpiPatchPss (
 
   Ptr = (UINT8 *)Table;
   End = (UINT8 *)Table+ Table->Length;
-  for (Lpss = NULL, Tpss = NULL; Ptr < End; Ptr++) {
+  for (Lpss = NULL, Tpss = NULL; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+    if (Ptr == (UINT8 *)Table) {
+      continue;
+    }
     if ((Lpss == NULL) && (*(UINT32 *)Ptr == SIGNATURE_32 ('L', 'P', 'S', 'S')) && (*(Ptr - 1) == AML_NAME_OP)) {
       Lpss = Ptr;
     }
@@ -1141,14 +1150,14 @@ PlatformUpdateAcpiTable (
   End  = (UINT8 *)Table + Table->Length;
 
   if (Table->Signature == EFI_ACPI_5_0_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE) {
-    for (; Ptr < End; Ptr++) {
-      if (*(Ptr-1) != AML_NAME_OP)
+    for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+      if ((Ptr == (UINT8 *) Table) || (*(Ptr-1) != AML_NAME_OP))
         continue;
-      if (*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','B')) {
+      if ((*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','B')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT32), End)) {
         Base = (UINT32) (UINTN) &GlobalNvs->PchNvs;
         DEBUG ((DEBUG_INFO, "PNVS Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 5), Base));
         *(UINT32 *)(Ptr + 5) = Base;
-      } else if (*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','L')) {
+      } else if ((*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','L')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT16), End)) {
         Size = sizeof (PCH_NVS_AREA);
         DEBUG ((DEBUG_INFO, "PNVL Old=0x%08X New=0x%08X\n", *(UINT16 *)(Ptr + 5), Size));
         *(UINT16 *)(Ptr + 5) = Size;
@@ -1161,14 +1170,14 @@ PlatformUpdateAcpiTable (
     MmCfg = (EFI_ACPI_MEMORY_MAPPED_ENHANCED_CONFIGURATION_SPACE_BASE_ADDRESS_ALLOCATION_STRUCTURE *)
             ((EFI_ACPI_MEMORY_MAPPED_CONFIGURATION_BASE_ADDRESS_TABLE_HEADER *)Ptr + 1);
     Base  = 0;
-    while ((UINT8 *)MmCfg < End) {
+    while (IsPtrRangeValid ((UINT8 *)MmCfg, sizeof (*MmCfg), End)) {
       MmCfg->BaseAddress = PcdGet64 (PcdPciExpressBaseAddress) + Base;
       Base += 0x10000000;
       MmCfg++;
     }
   } else if (Table->OemTableId == SIGNATURE_64 ('S', 'a', 'S', 's', 'd', 't', ' ', 0)) {
-    for (; Ptr < End; Ptr++) {
-      if (*(UINT32 *)Ptr == SIGNATURE_32 ('S','A','N','V')) {
+    for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+      if ((*(UINT32 *)Ptr == SIGNATURE_32 ('S','A','N','V')) && IsPtrRangeValid (Ptr, 11 + sizeof (UINT16), End)) {
         Base = (UINT32) (UINTN) &GlobalNvs->SaNvs;
         DEBUG ((DEBUG_INFO, "SANV Base Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 6), Base));
         *(UINT32 *)(Ptr + 6) = Base;
@@ -1295,8 +1304,8 @@ PlatformUpdateAcpiTable (
   if (Table->Signature == EFI_ACPI_6_4_SECONDARY_SYSTEM_DESCRIPTION_TABLE_SIGNATURE &&
       Table->OemTableId == SIGNATURE_64 ('E', 'c', 'S', 's', 'd', 't', ' ', 0)) {
     DEBUG((DEBUG_INFO, "Found EcSsdt\n"));
-    for (; Ptr < End; Ptr++) {
-      if (*(UINT32 *)Ptr == SIGNATURE_32 ('E','N','V','S')) {
+    for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+      if ((*(UINT32 *)Ptr == SIGNATURE_32 ('E','N','V','S')) && IsPtrRangeValid (Ptr, 11 + sizeof (UINT16), End)) {
         Base = (UINT32) (UINTN) &GlobalNvs->EcNvs;
         DEBUG ((DEBUG_INFO, "ENVS Base Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 6), Base));
         *(UINT32 *)(Ptr + 6) = Base;

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.c
@@ -87,6 +87,7 @@
 #include <Library/TxtLib.h>
 #include <Library/MadtLib.h>
 #include <Library/AcpiInitLib.h>
+#include <Library/BootloaderCommonLib.h>
 
 #define LOCAL_APIC_BASE_ADDRESS   0xFEE00000
 
@@ -1880,10 +1881,16 @@ PatchCpuSsdtTable (
 {
   CPU_NVS_AREA            *CpuNvs;
   UINT8                   *CurrPtr;
+  UINT8                   *End;
   UINT32                  *Signature;
 
   CpuNvs      = (CPU_NVS_AREA *) &GlobalNvs->CpuNvs;
-  for (CurrPtr = (UINT8 *) Table; CurrPtr <= ((UINT8 *) Table + Table->Length); CurrPtr++) {
+  End         = (UINT8 *) Table + Table->Length;
+  // Make sure we stop searching when there's not enough room left for the entire PNVS structure
+  for (CurrPtr = (UINT8 *) Table;
+    IsPtrRangeValid (CurrPtr, 1 + sizeof (*Signature) + 2 + sizeof (UINT32) + 1 + sizeof(UINT16), End);
+    CurrPtr++)
+  {
     Signature = (UINT32 *) (CurrPtr + 1);
     ///
     /// Update the CPU GlobalNvs area
@@ -2068,14 +2075,14 @@ PlatformUpdateAcpiTable (
       return EFI_UNSUPPORTED;
     }
   } else if (Table->Signature == EFI_ACPI_5_0_DIFFERENTIATED_SYSTEM_DESCRIPTION_TABLE_SIGNATURE) {
-    for (; Ptr < End; Ptr++) {
-      if (*(Ptr-1) != AML_NAME_OP)
+    for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+      if ((Ptr == (UINT8 *) Table) || (*(Ptr-1) != AML_NAME_OP))
         continue;
-      if (*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','B')) {
+      if ((*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','B')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT32), End)) {
         Base = (UINT32) (UINTN) &GlobalNvs->PchNvs;
         DEBUG ((DEBUG_INFO, "PNVS Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 5), Base));
         *(UINT32 *)(Ptr + 5) = Base;
-      } else if (*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','L')) {
+      } else if ((*(UINT32 *)Ptr == SIGNATURE_32 ('P','N','V','L')) && IsPtrRangeValid (Ptr, 5 + sizeof (UINT16), End)) {
         Size = sizeof (PCH_NVS_AREA);
         DEBUG ((DEBUG_INFO, "PNVL Old=0x%08X New=0x%08X\n", *(UINT16 *)(Ptr + 5), Size));
         *(UINT16 *)(Ptr + 5) = Size;
@@ -2088,14 +2095,14 @@ PlatformUpdateAcpiTable (
     MmCfg = (EFI_ACPI_MEMORY_MAPPED_ENHANCED_CONFIGURATION_SPACE_BASE_ADDRESS_ALLOCATION_STRUCTURE *)
             ((EFI_ACPI_MEMORY_MAPPED_CONFIGURATION_BASE_ADDRESS_TABLE_HEADER *)Ptr + 1);
     Base  = 0;
-    while ((UINT8 *)MmCfg < End) {
+    while (IsPtrRangeValid ((UINT8 *)MmCfg, sizeof (*MmCfg), End)) {
       MmCfg->BaseAddress = PcdGet64 (PcdPciExpressBaseAddress) + Base;
       Base += 0x10000000;
       MmCfg++;
     }
   } else if (Table->OemTableId == SIGNATURE_64 ('S', 'a', 'S', 's', 'd', 't', ' ', 0)) {
-    for (; Ptr < End; Ptr++) {
-      if (*(UINT32 *)Ptr == SIGNATURE_32 ('S','A','N','V')) {
+    for (; IsPtrRangeValid (Ptr, sizeof (UINT32), End); Ptr++) {
+      if ((*(UINT32 *)Ptr == SIGNATURE_32 ('S','A','N','V')) && IsPtrRangeValid (Ptr, 11 + sizeof (UINT16), End)) {
         Base = (UINT32) (UINTN) &GlobalNvs->SaNvs;
         DEBUG ((DEBUG_INFO, "SANV Base Old=0x%08X New=0x%08X\n", *(UINT32 *)(Ptr + 6), Base));
         *(UINT32 *)(Ptr + 6) = Base;

--- a/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
+++ b/Platform/TigerlakeBoardPkg/Library/Stage2BoardInitLib/Stage2BoardInitLib.inf
@@ -73,6 +73,7 @@
   TxtLib
   DmarLib
   MadtLib
+  BootloaderCommonLib
 
 [Guids]
   gOsConfigDataGuid


### PR DESCRIPTION
Many byte scanning loops that look for specific data don't take into account the data size when checking the terminating condition. A helper function is introduced to assist with this.