### PR TITLE
fix: [OsLoader] Prevent out of bounds write in ParseLinuxBootConfig

### DIFF
--- a/PayloadPkg/OsLoader/BootConfig.c
+++ b/PayloadPkg/OsLoader/BootConfig.c
@@ -72,6 +72,14 @@ ParseLinuxBootConfig (
       if (!FoundEntry) {
         FoundEntry = TRUE;
       } else {
+        //
+        // EntryNum is an index while parsing and only becomes a count after
+        // the loop, so the last usable index is MAX_BOOT_MENU_ENTRY - 1.
+        // Stop parsing rather than writing past the end of MenuEntry.
+        //
+        if (EntryNum + 1 >= MAX_BOOT_MENU_ENTRY) {
+          break;
+        }
         EntryNum++;
       }
       CurrLine += 9;


### PR DESCRIPTION
## Problem

`EntryNum` is an index while the parse loop in `ParseLinuxBootConfig` runs, and only becomes a count after it, so the last usable index is `MAX_BOOT_MENU_ENTRY - 1`. The loop guard tested `EntryNum` against `MAX_BOOT_MENU_ENTRY` at the top of the loop, but the `menuentry` branch incremented `EntryNum` and then wrote `MenuEntry[EntryNum]` straight away.

A ninth `menuentry` therefore set `EntryNum` to 8 and wrote one element past the end of an eight element array, and the trailing increment left `EntryNum` at 9.

Callers trust `EntryNum`. `PrintLinuxBootConfig` iterates up to it and writes a terminator through the `Pos` and `Len` found there, so the out of bounds read became an out of bounds write through uninitialised offsets. A configuration with nine entries is an ordinary distribution with a few kernel versions and its recovery entries.

## Fix

Stop parsing when the next entry would not fit, so the surplus entries are dropped and the count saturates at the capacity of the array.

With nine entries, the ninth `menuentry` is reached with `EntryNum == 7`; `7 + 1 >= 8` breaks out of the loop, and the post-loop `EntryNum += 1` leaves the count at exactly `MAX_BOOT_MENU_ENTRY`. Entries 0-7 remain intact.

## Validation

- `python BuildLoader.py build qemu -k` - passes.
- `python Platform/QemuBoardPkg/Script/qemu_test.py linux_boot` - passes, confirming normal GRUB config parsing and Linux boot are unaffected.
- `python BaseTools/Scripts/PatchCheck.py` - passes.