### PR TITLE
feat: [Microcode] Use DEFINE macro for microcode file names

### DIFF
--- a/Silicon/AlderlakePkg/Microcode/Microcode.inf
+++ b/Silicon/AlderlakePkg/Microcode/Microcode.inf
@@ -12,17 +12,20 @@
   FILE_GUID            = 40762366-24D3-4A6E-9F43-5AC5085D34EB
   MODULE_TYPE          = USER_DEFINED
   VERSION_STRING       = 1.0
+  DEFINE UCODE_NAME1   = m_07_90672_0000003a
+  DEFINE UCODE_NAME2   = m_80_906a3_00000434
+  DEFINE UCODE_NAME3   = m_19_b06e0_00000021
 
 [Sources]
-  m_07_90672_0000003a.mcb
-  m_80_906a3_00000434.mcb
-  m_19_b06e0_00000021.mcb
+  $(UCODE_NAME1).mcb
+  $(UCODE_NAME2).mcb
+  $(UCODE_NAME3).mcb
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
   COMMIT = 38e6a2157620b0a0ce2137cb8f48e32fe1c9403a
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/AlderLake/m_07_90672_0000003a.pdb  : Silicon/AlderlakePkg/Microcode/m_07_90672_0000003a.mcb
-  Microcode/AlderLake/m_80_906a3_00000434.pdb  : Silicon/AlderlakePkg/Microcode/m_80_906a3_00000434.mcb
-  Microcode/AlderLake/m_19_b06e0_00000021.pdb  : Silicon/AlderlakePkg/Microcode/m_19_b06e0_00000021.mcb
+  Microcode/AlderLake/$(UCODE_NAME1).pdb  : Silicon/AlderlakePkg/Microcode/$(UCODE_NAME1).mcb
+  Microcode/AlderLake/$(UCODE_NAME2).pdb  : Silicon/AlderlakePkg/Microcode/$(UCODE_NAME2).mcb
+  Microcode/AlderLake/$(UCODE_NAME3).pdb  : Silicon/AlderlakePkg/Microcode/$(UCODE_NAME3).mcb

--- a/Silicon/AlderlakePkg/Microcode/MicrocodeAzb.inf
+++ b/Silicon/AlderlakePkg/Microcode/MicrocodeAzb.inf
@@ -12,13 +12,14 @@
   FILE_GUID            = 40762366-24D3-4A6E-9F43-5AC5085D34EB
   MODULE_TYPE          = USER_DEFINED
   VERSION_STRING       = 1.0
+  DEFINE UCODE_NAME    = m_40_906a4_0000000c
 
 [Sources]
-  m_40_906a4_0000000c.mcb
+  $(UCODE_NAME).mcb
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
   COMMIT = dea1d00ad95eeda95f815576ebecc91810ea5c89
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/AlderLake/m_40_906a4_0000000c.pdb  : Silicon/AlderlakePkg/Microcode/m_40_906a4_0000000c.mcb
+  Microcode/AlderLake/$(UCODE_NAME).pdb  : Silicon/AlderlakePkg/Microcode/$(UCODE_NAME).mcb

--- a/Silicon/ArrowlakePkg/Arlh/Microcode/Microcode.inf
+++ b/Silicon/ArrowlakePkg/Arlh/Microcode/Microcode.inf
@@ -12,13 +12,14 @@
   FILE_GUID            = AFE664F7-8665-4F7D-AEB2-DDC394352C5F
   MODULE_TYPE          = USER_DEFINED
   VERSION_STRING       = 1.0
+  DEFINE UCODE_NAME    = m_82_c0662_0000011f
 
 [Sources]
-  m_82_c0662_0000011f.mcb # ARL H A0 PO (CPUID c0662) Version
+  $(UCODE_NAME).mcb # ARL H A0 PO (CPUID c0662) Version
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
   COMMIT = b2c1cb936f53d8abb68330b75b715059a4851c93
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/ArrowLake/m_82_c0662_0000011f.pdb  : Silicon/ArrowlakePkg/Arlh/Microcode/m_82_c0662_0000011f.mcb
+  Microcode/ArrowLake/$(UCODE_NAME).pdb  : Silicon/ArrowlakePkg/Arlh/Microcode/$(UCODE_NAME).mcb

--- a/Silicon/ArrowlakePkg/Arlh/Microcode/MicrocodeArlu.inf
+++ b/Silicon/ArrowlakePkg/Arlh/Microcode/MicrocodeArlu.inf
@@ -12,13 +12,14 @@
   FILE_GUID            = AFE664F7-8665-4F7D-AEB2-DDC394352C5F
   MODULE_TYPE          = USER_DEFINED
   VERSION_STRING       = 1.0
+  DEFINE UCODE_NAME    = m_80_b0650_0000000d
 
 [Sources]
-  m_80_b0650_0000000d.mcb # ARL U A0 PO Version
+  $(UCODE_NAME).mcb # ARL U A0 PO Version
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
   COMMIT = b2c1cb936f53d8abb68330b75b715059a4851c93
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/ArrowLake/m_80_b0650_0000000d.pdb  : Silicon/ArrowlakePkg/Arlh/Microcode/m_80_b0650_0000000d.mcb
+  Microcode/ArrowLake/$(UCODE_NAME).pdb  : Silicon/ArrowlakePkg/Arlh/Microcode/$(UCODE_NAME).mcb

--- a/Silicon/ArrowlakePkg/Arls/Microcode/Microcode.inf
+++ b/Silicon/ArrowlakePkg/Arls/Microcode/Microcode.inf
@@ -12,13 +12,14 @@
   FILE_GUID            = AFE664F7-8665-4F7D-AEB2-DDC394352C5F
   MODULE_TYPE          = USER_DEFINED
   VERSION_STRING       = 1.0
+  DEFINE UCODE_NAME    = m_82_c0662_0000011f
 
 [Sources]
-  m_82_c0662_0000011f.mcb # ARL S B0 Support
+  $(UCODE_NAME).mcb # ARL S B0 Support
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
   COMMIT = b2c1cb936f53d8abb68330b75b715059a4851c93
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/ArrowLake/m_82_c0662_0000011f.pdb  : Silicon/ArrowlakePkg/Arls/Microcode/m_82_c0662_0000011f.mcb
+  Microcode/ArrowLake/$(UCODE_NAME).pdb  : Silicon/ArrowlakePkg/Arls/Microcode/$(UCODE_NAME).mcb

--- a/Silicon/CoffeelakePkg/Microcode/Microcode.inf
+++ b/Silicon/CoffeelakePkg/Microcode/Microcode.inf
@@ -12,21 +12,26 @@
   FILE_GUID            = 197DB236-F856-4924-90F8-CDF12FB875F3
   MODULE_TYPE          = USER_DEFINED
   VERSION_STRING       = 1.0
+  DEFINE UCODE_NAME1   = 06-8e-0c
+  DEFINE UCODE_NAME2   = 06-8e-0b
+  DEFINE UCODE_NAME3   = 06-9e-0d
+  DEFINE UCODE_NAME4   = 06-9e-0c
+  DEFINE UCODE_NAME5   = 06-9e-0a
 
 [Sources]
-  06-8e-0c.mcb
-  06-8e-0b.mcb
-  06-9e-0d.mcb
-  06-9e-0c.mcb
-  06-9e-0a.mcb
+  $(UCODE_NAME1).mcb
+  $(UCODE_NAME2).mcb
+  $(UCODE_NAME3).mcb
+  $(UCODE_NAME4).mcb
+  $(UCODE_NAME5).mcb
 
 [UserExtensions.SBL."CloneRepo"]
   REPO  = https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files.git
   TAG   = microcode-20200616
 
 [UserExtensions.SBL."CopyList"]
-  intel-ucode/06-8e-0c  : Silicon/CoffeelakePkg/Microcode/06-8e-0c.mcb
-  intel-ucode/06-8e-0b  : Silicon/CoffeelakePkg/Microcode/06-8e-0b.mcb
-  intel-ucode/06-9e-0d  : Silicon/CoffeelakePkg/Microcode/06-9e-0d.mcb
-  intel-ucode/06-9e-0c  : Silicon/CoffeelakePkg/Microcode/06-9e-0c.mcb
-  intel-ucode/06-9e-0a  : Silicon/CoffeelakePkg/Microcode/06-9e-0a.mcb
+  intel-ucode/$(UCODE_NAME1)  : Silicon/CoffeelakePkg/Microcode/$(UCODE_NAME1).mcb
+  intel-ucode/$(UCODE_NAME2)  : Silicon/CoffeelakePkg/Microcode/$(UCODE_NAME2).mcb
+  intel-ucode/$(UCODE_NAME3)  : Silicon/CoffeelakePkg/Microcode/$(UCODE_NAME3).mcb
+  intel-ucode/$(UCODE_NAME4)  : Silicon/CoffeelakePkg/Microcode/$(UCODE_NAME4).mcb
+  intel-ucode/$(UCODE_NAME5)  : Silicon/CoffeelakePkg/Microcode/$(UCODE_NAME5).mcb

--- a/Silicon/CometlakePkg/Microcode/Microcode.inf
+++ b/Silicon/CometlakePkg/Microcode/Microcode.inf
@@ -12,15 +12,17 @@
   FILE_GUID            = 197DB236-F856-4924-90F8-CDF12FB875F3
   MODULE_TYPE          = USER_DEFINED
   VERSION_STRING       = 1.0
+  DEFINE UCODE_NAME1   = m22A0653_000000EA
+  DEFINE UCODE_NAME2   = m22A0655_000000EC
 
 [Sources]
- m22A0653_000000EA.mcb  # CML G1-Step
- m22A0655_000000EC.mcb  # CML Q0-Step
+  $(UCODE_NAME1).mcb  # CML G1-Step
+  $(UCODE_NAME2).mcb  # CML Q0-Step
 
 [UserExtensions.SBL."CloneRepo"]
   REPO  = https://github.com/tianocore/edk2-non-osi.git
   COMMIT= bf2ba5e5136bfe5efe6052fb565d8597bcbeec17
 
 [UserExtensions.SBL."CopyList"]
-  Silicon/Intel/CometlakeSiliconBinPkg/Microcode/m22A0653_000000EA.mcb  : Silicon/CometlakePkg/Microcode/m22A0653_000000EA.mcb
-  Silicon/Intel/CometlakeSiliconBinPkg/Microcode/m22A0655_000000EC.mcb  : Silicon/CometlakePkg/Microcode/m22A0655_000000EC.mcb
+  Silicon/Intel/CometlakeSiliconBinPkg/Microcode/$(UCODE_NAME1).mcb  : Silicon/CometlakePkg/Microcode/$(UCODE_NAME1).mcb
+  Silicon/Intel/CometlakeSiliconBinPkg/Microcode/$(UCODE_NAME2).mcb  : Silicon/CometlakePkg/Microcode/$(UCODE_NAME2).mcb

--- a/Silicon/CometlakevPkg/Microcode/Microcode.inf
+++ b/Silicon/CometlakevPkg/Microcode/Microcode.inf
@@ -12,15 +12,17 @@
   FILE_GUID            = 197DB236-F856-4924-90F8-CDF12FB875F3
   MODULE_TYPE          = USER_DEFINED
   VERSION_STRING       = 1.0
+  DEFINE UCODE_NAME1   = m22A0653_000000EA
+  DEFINE UCODE_NAME2   = m22A0655_000000EC
 
 [Sources]
- m22A0653_000000EA.mcb  # CML G1-Step
- m22A0655_000000EC.mcb  # CML Q0-Step
+  $(UCODE_NAME1).mcb  # CML G1-Step
+  $(UCODE_NAME2).mcb  # CML Q0-Step
 
 [UserExtensions.SBL."CloneRepo"]
   REPO  = https://github.com/tianocore/edk2-non-osi.git
   COMMIT= bf2ba5e5136bfe5efe6052fb565d8597bcbeec17
 
 [UserExtensions.SBL."CopyList"]
-  Silicon/Intel/CometlakeSiliconBinPkg/Microcode/m22A0653_000000EA.mcb  : Silicon/CometlakevPkg/Microcode/m22A0653_000000EA.mcb
-  Silicon/Intel/CometlakeSiliconBinPkg/Microcode/m22A0655_000000EC.mcb  : Silicon/CometlakevPkg/Microcode/m22A0655_000000EC.mcb
+  Silicon/Intel/CometlakeSiliconBinPkg/Microcode/$(UCODE_NAME1).mcb  : Silicon/CometlakevPkg/Microcode/$(UCODE_NAME1).mcb
+  Silicon/Intel/CometlakeSiliconBinPkg/Microcode/$(UCODE_NAME2).mcb  : Silicon/CometlakevPkg/Microcode/$(UCODE_NAME2).mcb

--- a/Silicon/ElkhartlakePkg/Microcode/Microcode.inf
+++ b/Silicon/ElkhartlakePkg/Microcode/Microcode.inf
@@ -12,13 +12,14 @@
   FILE_GUID            = 197DB236-F856-4924-90F8-CDF12FB875F3
   MODULE_TYPE          = USER_DEFINED
   VERSION_STRING       = 1.0
+  DEFINE UCODE_NAME    = m0190661_0000001a
 
 [Sources]
-  m0190661_0000001a.mcb
+  $(UCODE_NAME).mcb
 
 [UserExtensions.SBL."CloneRepo"]
   REPO  = https://github.com/slimbootloader/firmwareblob.git
   COMMIT= cafeee06194fc1a3176e606189092be11887b51d
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/ElkhartLake/m_01_90661_0000001a.pdb  : Silicon/ElkhartlakePkg/Microcode/m0190661_0000001a.mcb
+  Microcode/ElkhartLake/m_01_90661_0000001a.pdb  : Silicon/ElkhartlakePkg/Microcode/$(UCODE_NAME).mcb

--- a/Silicon/IdavillePkg/Microcode/Microcode.inf
+++ b/Silicon/IdavillePkg/Microcode/Microcode.inf
@@ -12,9 +12,10 @@
   FILE_GUID            = 197DB236-F856-4924-90F8-CDF12FB875F3
   MODULE_TYPE          = USER_DEFINED
   VERSION_STRING       = 1.0
+  DEFINE UCODE_NAME    = m_10_606c1_01000290
 
 [Sources]
-  m_10_606c1_01000290.mcb
+  $(UCODE_NAME).mcb
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
@@ -22,4 +23,4 @@
 
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/Idaville/m_10_606c1_01000290.pdb  : Silicon/IdavillePkg/Microcode/m_10_606c1_01000290.mcb
+  Microcode/Idaville/$(UCODE_NAME).pdb  : Silicon/IdavillePkg/Microcode/$(UCODE_NAME).mcb

--- a/Silicon/KaseyvillePkg/Ksv/Microcode/Microcode.inf
+++ b/Silicon/KaseyvillePkg/Ksv/Microcode/Microcode.inf
@@ -12,13 +12,14 @@
   FILE_GUID            = 197DB236-F856-4924-90F8-CDF12FB875F3
   MODULE_TYPE          = USER_DEFINED
   VERSION_STRING       = 1.0
+  DEFINE UCODE_NAME    = m_97_a06e1_01000310
 
 [Sources]
-  m_97_a06e1_01000310.mcb  # B0 SKU (production signed)
+  $(UCODE_NAME).mcb  # B0 SKU (production signed)
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
   COMMIT = cbb699ab304ade34dfc2add5b1a37aa42a1278f4
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/Kaseyville/m_97_a06e1_01000310.pdb  : Silicon/KaseyvillePkg/Ksv/Microcode/m_97_a06e1_01000310.mcb
+  Microcode/Kaseyville/$(UCODE_NAME).pdb  : Silicon/KaseyvillePkg/Ksv/Microcode/$(UCODE_NAME).mcb

--- a/Silicon/MeteorlakePkg/Microcode/Microcode.inf
+++ b/Silicon/MeteorlakePkg/Microcode/Microcode.inf
@@ -12,13 +12,14 @@
   FILE_GUID            = 197DB236-F856-4924-90F8-CDF12FB875F3
   MODULE_TYPE          = USER_DEFINED
   VERSION_STRING       = 1.0
+  DEFINE UCODE_NAME    = m_e6_a06a4_00000025
 
 [Sources]
-  m_e6_a06a4_00000025.mcb
+  $(UCODE_NAME).mcb
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
   COMMIT = 66a5f4a71c34767065cf53cb1c85283f6805a46e
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/MeteorLake/m_e6_a06a4_00000025.pdb  : Silicon/MeteorlakePkg/Microcode/m_e6_a06a4_00000025.mcb
+  Microcode/MeteorLake/$(UCODE_NAME).pdb  : Silicon/MeteorlakePkg/Microcode/$(UCODE_NAME).mcb

--- a/Silicon/RaptorlakePkg/Btls/Microcode/MicrocodeBtls.inf
+++ b/Silicon/RaptorlakePkg/Btls/Microcode/MicrocodeBtls.inf
@@ -12,17 +12,20 @@
   FILE_GUID            = 197DB236-F856-4924-90F8-CDF12FB875F3
   MODULE_TYPE          = USER_DEFINED
   VERSION_STRING       = 1.0
+  DEFINE UCODE_NAME1   = m_32_b0671_00000133
+  DEFINE UCODE_NAME2   = m_07_90672_0000003e
+  DEFINE UCODE_NAME3   = m_04_d0670_00000005
 
 [Sources]
-  m_32_b0671_00000133.mcb  # BTL-S Hybrid Prod
-  m_07_90672_0000003e.mcb  # BTL-S Hybrid Prod
-  m_04_d0670_00000005.mcb  # BTL-S 12P Prod
+  $(UCODE_NAME1).mcb  # BTL-S Hybrid Prod
+  $(UCODE_NAME2).mcb  # BTL-S Hybrid Prod
+  $(UCODE_NAME3).mcb  # BTL-S 12P Prod
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
   COMMIT = 9987889d6250bb74c140bb378fde36386ba10a90
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/RaptorLake/m_32_b0671_00000133.pdb  : Silicon/RaptorlakePkg/Btls/Microcode/m_32_b0671_00000133.mcb
-  Microcode/AlderLake/m_07_90672_0000003e.pdb   : Silicon/RaptorlakePkg/Btls/Microcode/m_07_90672_0000003e.mcb
-  Microcode/RaptorLake/m_04_d0670_00000005.pdb  : Silicon/RaptorlakePkg/Btls/Microcode/m_04_d0670_00000005.mcb
+  Microcode/RaptorLake/$(UCODE_NAME1).pdb  : Silicon/RaptorlakePkg/Btls/Microcode/$(UCODE_NAME1).mcb
+  Microcode/AlderLake/$(UCODE_NAME2).pdb   : Silicon/RaptorlakePkg/Btls/Microcode/$(UCODE_NAME2).mcb
+  Microcode/RaptorLake/$(UCODE_NAME3).pdb  : Silicon/RaptorlakePkg/Btls/Microcode/$(UCODE_NAME3).mcb

--- a/Silicon/RaptorlakePkg/Rplp/Microcode/MicrocodeRplp.inf
+++ b/Silicon/RaptorlakePkg/Rplp/Microcode/MicrocodeRplp.inf
@@ -12,14 +12,15 @@
   FILE_GUID            = 197DB236-F856-4924-90F8-CDF12FB875F3
   MODULE_TYPE          = USER_DEFINED
   VERSION_STRING       = 1.0
+  DEFINE UCODE_NAME    = m_e0_b06a2_00004129
 
 [Sources]
-  m_e0_b06a2_00004129.mcb  # RPL-P J0
+  $(UCODE_NAME).mcb  # RPL-P J0
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
   COMMIT = ddad735ddea9995e9ffcb5dc7dc395345bfd657c
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/RaptorLake/m_e0_b06a2_00004129.pdb  : Silicon/RaptorlakePkg/Rplp/Microcode/m_e0_b06a2_00004129.mcb
+  Microcode/RaptorLake/$(UCODE_NAME).pdb  : Silicon/RaptorlakePkg/Rplp/Microcode/$(UCODE_NAME).mcb
 

--- a/Silicon/RaptorlakePkg/Rplps/Microcode/MicrocodeRplps.inf
+++ b/Silicon/RaptorlakePkg/Rplps/Microcode/MicrocodeRplps.inf
@@ -12,14 +12,16 @@
   FILE_GUID            = 197DB236-F856-4924-90F8-CDF12FB875F3
   MODULE_TYPE          = USER_DEFINED
   VERSION_STRING       = 1.0
+  DEFINE UCODE_NAME1   = m_e0_b06a2_00004129
+  DEFINE UCODE_NAME2   = m_80_906a3_00000435
 
 [Sources]
-  m_e0_b06a2_00004129.mcb  # RPL-P J0
-  m_80_906a3_00000435.mcb  # ADL-PS
+  $(UCODE_NAME1).mcb  # RPL-P J0
+  $(UCODE_NAME2).mcb  # ADL-PS
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
   COMMIT = 5faae07e9eaea9ab1ebaa0c790eeac1cc9ef9e46
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/RaptorLake/m_e0_b06a2_00004129.pdb  : Silicon/RaptorlakePkg/Rplps/Microcode/m_e0_b06a2_00004129.mcb
-  Microcode/AlderLake/m_80_906a3_00000435.pdb   : Silicon/RaptorlakePkg/Rplps/Microcode/m_80_906a3_00000435.mcb
+  Microcode/RaptorLake/$(UCODE_NAME1).pdb  : Silicon/RaptorlakePkg/Rplps/Microcode/$(UCODE_NAME1).mcb
+  Microcode/AlderLake/$(UCODE_NAME2).pdb   : Silicon/RaptorlakePkg/Rplps/Microcode/$(UCODE_NAME2).mcb

--- a/Silicon/RaptorlakePkg/Rpls/Microcode/MicrocodeRpls.inf
+++ b/Silicon/RaptorlakePkg/Rpls/Microcode/MicrocodeRpls.inf
@@ -12,15 +12,17 @@
   FILE_GUID            = 197DB236-F856-4924-90F8-CDF12FB875F3
   MODULE_TYPE          = USER_DEFINED
   VERSION_STRING       = 1.0
+  DEFINE UCODE_NAME1   = m_32_b0671_00000130
+  DEFINE UCODE_NAME2   = m_07_90672_00000036
 
 [Sources]
-  m_32_b0671_00000130.mcb  # RPL-S B0
-  m_07_90672_00000036.mcb  # ADLS  C0
+  $(UCODE_NAME1).mcb  # RPL-S B0
+  $(UCODE_NAME2).mcb  # ADLS  C0
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
   COMMIT = 944b1f3c48fa224fb62639f7f5d59486f22715b4
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/RaptorLake/m_32_b0671_00000130.pdb  : Silicon/RaptorlakePkg/Rpls/Microcode/m_32_b0671_00000130.mcb
-  Microcode/AlderLake/m_07_90672_00000036.pdb   : Silicon/RaptorlakePkg/Rpls/Microcode/m_07_90672_00000036.mcb
+  Microcode/RaptorLake/$(UCODE_NAME1).pdb  : Silicon/RaptorlakePkg/Rpls/Microcode/$(UCODE_NAME1).mcb
+  Microcode/AlderLake/$(UCODE_NAME2).pdb   : Silicon/RaptorlakePkg/Rpls/Microcode/$(UCODE_NAME2).mcb

--- a/Silicon/TigerlakePkg/Microcode/Microcode.inf
+++ b/Silicon/TigerlakePkg/Microcode/Microcode.inf
@@ -12,16 +12,18 @@
   FILE_GUID            = 5822532C-2C2C-4DA1-9688-009A56E939FD
   MODULE_TYPE          = USER_DEFINED
   VERSION_STRING       = 1.0
+  DEFINE UCODE_NAME1   = m_80_806c1_000000bc
+  DEFINE UCODE_NAME2   = m_c2_806d1_00000052
 
 [Sources]
-  m_80_806c1_000000bc.mcb
-  m_c2_806d1_00000052.mcb
+  $(UCODE_NAME1).mcb
+  $(UCODE_NAME2).mcb
 
 [UserExtensions.SBL."CloneRepo"]
   REPO   = https://github.com/slimbootloader/firmwareblob.git
   COMMIT = 2235a0676dcc83fe5fea16b1ad6999ab97c89cf3
 
 [UserExtensions.SBL."CopyList"]
-  Microcode/TigerLake/m_80_806c1_000000bc.pdb  : Silicon/TigerlakePkg/Microcode/m_80_806c1_000000bc.mcb
-  Microcode/TigerLake/m_c2_806d1_00000052.pdb  : Silicon/TigerlakePkg/Microcode/m_c2_806d1_00000052.mcb
+  Microcode/TigerLake/$(UCODE_NAME1).pdb  : Silicon/TigerlakePkg/Microcode/$(UCODE_NAME1).mcb
+  Microcode/TigerLake/$(UCODE_NAME2).pdb  : Silicon/TigerlakePkg/Microcode/$(UCODE_NAME2).mcb
 


### PR DESCRIPTION
Each microcode file name was repeated across [Sources] and CopyList in the Microcode INFs. Missing any one occurrence during an update caused build or copy failures. Declare each name once via a DEFINE so the parsers expand it, removing the mismatch risk.