### PR TITLE
fix: ACPI PSDS table identity defaults

### DIFF
--- a/Silicon/CommonSocPkg/Library/PsdLib/PsdLib.c
+++ b/Silicon/CommonSocPkg/Library/PsdLib/PsdLib.c
@@ -35,10 +35,10 @@ EFI_ACPI_PSD_TABLE mAcpiPsdTableTemplate = {
   .Header.Signature       = EFI_ACPI_PSD_SIGNATURE,
   .Header.Length          = sizeof (EFI_ACPI_PSD_TABLE),
   .Header.Revision        = EFI_ACPI_PSD_TABLE_REVISION,
-  .Header.OemTableId      = FixedPcdGet64 (PcdAcpiDefaultOemTableId),
-  .Header.OemRevision     = FixedPcdGet32 (PcdAcpiDefaultOemRevision),
-  .Header.CreatorId       = FixedPcdGet32 (PcdAcpiDefaultCreatorId),
-  .Header.CreatorRevision = FixedPcdGet32 (PcdAcpiDefaultCreatorRevision),
+  .Header.OemTableId      = PSDS_EFI_ACPI_OEM_TABLE_ID,
+  .Header.OemRevision     = PSDS_EFI_ACPI_OEM_REVISION,
+  .Header.CreatorId       = PSDS_EFI_ACPI_CREATOR_ID,
+  .Header.CreatorRevision = PSDS_EFI_ACPI_CREATOR_REVISION,
 };
 
 /**
@@ -216,7 +216,7 @@ UpdateAcpiPsdTable (
 
   Psdt = (EFI_ACPI_PSD_TABLE *)Table;
   CopyMem (Psdt, &mAcpiPsdTableTemplate, sizeof (EFI_ACPI_PSD_TABLE));
-  CopyMem (Psdt->Header.OemId, FixedPcdGetPtr (PcdAcpiDefaultOemId), 6);
+  CopyMem (Psdt->Header.OemId, PSDS_EFI_ACPI_OEM_ID, sizeof (Psdt->Header.OemId));
 
   Psdt->PsdVersion.PsdVerMajor = PSD_VERSION_MAJOR;
   Psdt->PsdVersion.PsdVerMinor = PSD_VERSION_MINOR;

--- a/Silicon/CommonSocPkg/Library/PsdLib/PsdLib.inf
+++ b/Silicon/CommonSocPkg/Library/PsdLib/PsdLib.inf
@@ -37,10 +37,3 @@
 
 [Guids]
   gMeBiosPayloadHobGuid
-
-[Pcd]
-  gPlatformCommonLibTokenSpaceGuid.PcdAcpiDefaultOemId
-  gPlatformCommonLibTokenSpaceGuid.PcdAcpiDefaultOemTableId
-  gPlatformCommonLibTokenSpaceGuid.PcdAcpiDefaultOemRevision
-  gPlatformCommonLibTokenSpaceGuid.PcdAcpiDefaultCreatorId
-  gPlatformCommonLibTokenSpaceGuid.PcdAcpiDefaultCreatorRevision


### PR DESCRIPTION
9fa8e0cd8a1e46da8ebc99fbf961a0fbf9161984
Common PSD Lib is apply to all the Platform, by above hash commit. However the PSDS libary dosent effect the changes in acpidump .

Use the PSDS-specific ACPI constants in the common PsdLib implementation instead of the generic ACPI default PCDs. This ensures generated PSDS tables report the required OEM Table ID EDK2 and Creator ID INTL values, along with the PSDS-defined revision. Remove the obsolete generic ACPI PCD dependencies from PsdLib.inf.

Tested:  Built BTL-S Release and Debug images and verified PSDS with
	     Ubuntu acpidump; OEM Table ID is EDK2 and Creator ID is INTL