### PR TITLE
Fix BPM and seed count boundary errors

### DIFF
--- a/BootloaderCommonPkg/Library/SeedListInfoLib/SeedListInfoLib.c
+++ b/BootloaderCommonPkg/Library/SeedListInfoLib/SeedListInfoLib.c
@@ -91,7 +91,7 @@ AppendSeedData (
   SeedEntryData = (SEED_ENTRY  *)((UINT8 *)SeedListInfoHob + Offset); //Start of SeedEntryData buffer
 
   // This is to get to the 'last' seed entry data pointer that was added so far
-  for (Index = 0; Index <= SeedListInfoHob->TotalSeedCount; Index++) {
+  for (Index = 0; Index < SeedListInfoHob->TotalSeedCount; Index++) {
     SeedEntryData  = (SEED_ENTRY *)((UINT8 *)SeedEntryData + SeedEntryData->SeedEntrySize);
   }
 

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/SeedSupport.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/SeedSupport.c
@@ -177,6 +177,18 @@ SeedRetrievalAndDerivation (
   ZeroMem (SeedList, sizeof (MKHI_BOOTLOADER_SEED_LIST));
   Status = GetSeedfromCSE (SeedList);
   if (!EFI_ERROR (Status)) {
+    //
+    // Validate CSE-supplied NumOfSeeds before use as a loop bound.
+    // MKHI_BOOTLOADER_SEED_LIST.List[] and LOADER_SEED_LIST.UseedList[]/DseedList[]
+    // are both fixed at BOOTLOADER_SEED_MAX_ENTRIES (4). A value exceeding this from
+    // an untrusted HECI response would cause OOB reads and heap OOB writes.
+    //
+    if (SeedList->NumOfSeeds > BOOTLOADER_SEED_MAX_ENTRIES) {
+      DEBUG ((DEBUG_ERROR, "SeedRetrievalAndDerivation: NumOfSeeds (%u) exceeds max (%u), rejecting CSE response\n",
+              SeedList->NumOfSeeds, BOOTLOADER_SEED_MAX_ENTRIES));
+      ZeroMem (SeedList, sizeof (MKHI_BOOTLOADER_SEED_LIST));
+      return EFI_SECURITY_VIOLATION;
+    }
     // If CseSVN = 1, it is RPMB seed. Populate RPMB seed
     for(Idx=0; Idx < SeedList->NumOfSeeds; Idx++) {
       if(SeedList->List[Idx].CseSvn == 1) {

--- a/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/SeedSupport.c
+++ b/Platform/ApollolakeBoardPkg/Library/Stage2BoardInitLib/SeedSupport.c
@@ -186,6 +186,10 @@ SeedRetrievalAndDerivation (
     if (SeedList->NumOfSeeds > BOOTLOADER_SEED_MAX_ENTRIES) {
       DEBUG ((DEBUG_ERROR, "SeedRetrievalAndDerivation: NumOfSeeds (%u) exceeds max (%u), rejecting CSE response\n",
               SeedList->NumOfSeeds, BOOTLOADER_SEED_MAX_ENTRIES));
+      LdrSeedList->NumofSeeds = 0;
+      ZeroMem (LdrSeedList->UseedList, sizeof (LdrSeedList->UseedList));
+      ZeroMem (LdrSeedList->DseedList, sizeof (LdrSeedList->DseedList));
+      ZeroMem (LdrSeedList->RpmbHeciSeeds, sizeof (LdrSeedList->RpmbHeciSeeds));
       ZeroMem (SeedList, sizeof (MKHI_BOOTLOADER_SEED_LIST));
       return EFI_SECURITY_VIOLATION;
     }

--- a/Silicon/CoffeelakePkg/Library/BootGuardLib/BootGuardTpmEventLogLib.c
+++ b/Silicon/CoffeelakePkg/Library/BootGuardLib/BootGuardTpmEventLogLib.c
@@ -362,6 +362,10 @@ FindBpmElement (
   if (StructureId == BOOT_POLICY_MANIFEST_IBB_ELEMENT_STRUCTURE_ID) {
     return Buffer;
   }
+  if (IbbElement->SegmentCount == 0) {
+    DEBUG ((DEBUG_ERROR, "FindBpmElement: SegmentCount is 0, malformed BPM\n"));
+    return NULL;
+  }
   Buffer += sizeof(IBB_ELEMENT) + sizeof(IBB_SEGMENT_ELEMENT) * (IbbElement->SegmentCount - 1);
 
   PmElement = (PLATFORM_MANUFACTURER_ELEMENT *)Buffer;


### PR DESCRIPTION
Reject a zero BPM IBB SegmentCount before element traversal, correct the Seed List HOB append loop bound, and reject CSE NumOfSeeds values that exceed the fixed seed arrays.

Signed-off-by: Vinay Patel <vinay.r.patel@intel.com>