### PR TITLE
fix: Reset stale long-file-name state on each directory-entry pass

### DIFF
--- a/BootloaderCommonPkg/Library/FatLib/FatLiteAccess.c
+++ b/BootloaderCommonPkg/Library/FatLib/FatLiteAccess.c
@@ -519,8 +519,10 @@ FatReadNextDirectoryEntry (
   UINTN               LfnBufferLen;
   UINT32              DirEntryCount;
   UINT32              LfnEntryCount;
+  BOOLEAN             LfnChainValid;
 
-  LfnBufferLen = 0;
+  LfnBufferLen  = 0;
+  LfnChainValid = FALSE;
   ZeroMem ((UINT8 *) SubFile, sizeof (PEI_FAT_FILE));
   DirEntryCount = 0;
 
@@ -532,8 +534,15 @@ FatReadNextDirectoryEntry (
     //
     // Read one entry
     //
-    LfnOrdinal   = 0;
+    LfnOrdinal    = 0;
     LfnEntryCount = 0;
+    // Only a chain that completed validly last iteration may hand its name
+    // to this entry; otherwise drop whatever LfnBufferLen/LongFileName held.
+    if (!LfnChainValid) {
+      LfnBufferLen = 0;
+      SubFile->LongFileName[0] = 0;
+    }
+    LfnChainValid = FALSE;
 
     //
     // If it is LFN entry, read all of the following LFN entries.
@@ -572,6 +581,9 @@ FatReadNextDirectoryEntry (
           CopyMem (LfnBufferPointer, LfnEntry->Name3, sizeof (CHAR16) * LFN_CHAR3_LEN);
           LfnBufferPointer += LFN_CHAR3_LEN;
           LfnOrdinal--;
+          if (LfnOrdinal == 0) {
+            LfnChainValid = TRUE;
+          }
         }
       } else if (LfnOrdinal > 0) {
         LfnOrdinal = 0;


### PR DESCRIPTION
FatReadNextDirectoryEntry only cleared LfnOrdinal/LfnEntryCount at the
top of each outer-loop iteration; LfnBufferLen and SubFile->LongFileName
were left holding whatever a previous, unrelated LFN chain wrote into
them. A crafted directory (a complete LFN chain, then an orphan LFN
entry whose ordinal coincidentally matches the freshly-reset LfnOrdinal
of 0, forcing another `continue` without resetting anything, then an
unrelated short-name entry) let the stale long name from the first
chain get attached to the second, unrelated short-name entry.

Add LfnChainValid, set only at the instant a chain's last fragment is
consumed in valid order. Only clear LfnBufferLen/LongFileName at the
top of an iteration when the previous one did not leave a validly
completed chain behind, so the normal one-iteration LFN->SFN handoff
still works while any gap (orphan/mismatched LFN, deleted entry, plain
short entry with no preceding chain) drops the stale name.