### PR TITLE
FirmwareResiliency: fix ACM/IBB partition recovery detection

### DIFF
--- a/BootloaderCorePkg/Library/FirmwareResiliencyLib/FirmwareResiliencyLib.c
+++ b/BootloaderCorePkg/Library/FirmwareResiliencyLib/FirmwareResiliencyLib.c
@@ -139,16 +139,18 @@ DetectCsmeWdtFailure (
 
   StateMachine = GetFwuStateMachine ();
 
-  // An in-progress update (PART_A/PART_B) boots by design; not a trigger.
+  // Pending switch but still booting the source partition means the Top Swap did not take (target IBB/ACM bad); trigger recovery.
   if (StateMachine == FW_UPDATE_SM_PART_A) {
     if (GetCurrentBootPartition () == PrimaryPartition) {
       DEBUG ((DEBUG_INFO, "Partition to be updated is same as current boot partition (primary)\n"));
+      return TRUE;
     }
     return FALSE;
   }
   if (StateMachine == FW_UPDATE_SM_PART_B) {
     if (GetCurrentBootPartition () == BackupPartition) {
       DEBUG ((DEBUG_INFO, "Partition to be updated is same as current boot partition (backup)\n"));
+      return TRUE;
     }
     return FALSE;
   }
@@ -238,8 +240,16 @@ UnifiedResiliencyCheck (
   BOOLEAN           NeedPartitionSwitch;
   UINT8             NewReason;
   BOOT_PARTITION    NewPartition;
-  // Skip explicit capsule-update boots; still run for recovery-triggered boots.
-  if ((GetBootMode () == BOOT_ON_FLASH_UPDATE) && !IsRecoveryTriggered ()) {
+  BOOLEAN           CsmeWdtFailure;
+
+  CsmeWdtFailure = DetectCsmeWdtFailure ();
+
+  // Skip only on a healthy capsule-update boot; otherwise fall through to recovery handling.
+  if ((GetBootMode () == BOOT_ON_FLASH_UPDATE) &&
+      !IsRecoveryTriggered () &&
+      !CsmeWdtFailure &&
+      !WasBootCausedByTcoTimeout () &&
+      !(PcdGetBool (PcdCsmeResiliencyEnabled) && IsMeCorrupt ())) {
     return;
   }
   // Read existing RecoveryStatus variable (may not exist).
@@ -290,7 +300,7 @@ UnifiedResiliencyCheck (
   //
   // CSME-WDT triggered Top Swap detection (failure detected outside SBL).
   //
-  if (DetectCsmeWdtFailure ()) {
+  if (CsmeWdtFailure) {
     NewReason           |= RECOVERY_REASON_CSME_WDT;
   }
 

--- a/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
+++ b/PayloadPkg/FirmwareUpdate/FirmwareUpdate.c
@@ -2253,14 +2253,15 @@ EndOfFwu:
   //
   ConsolePrint ("Exiting Firmware Update (Status: %r)\n", Status);
 
-  //
-  // CSME-only recovery: reset SM to INIT so FSP won't trigger an extra
-  // BOOT_ON_FLASH_UPDATE cycle from a lingering SM_DONE.
-  //
-  if (RecoveryStatusValid &&
-      (RecoveryStatus.Reason == RECOVERY_REASON_CSME) &&
-      (Status == EFI_SUCCESS)) {
-    SetStateMachineFlag (FW_UPDATE_SM_INIT);
+  // Conclude the FW state machine after a successful recovery so the next boot does not loop back into recovery.
+  if (RecoveryStatusValid && (Status == EFI_SUCCESS)) {
+    if (RecoveryStatus.Reason == RECOVERY_REASON_CSME) {
+      // CSME-only recovery: reset SM to INIT so FSP won't trigger an extra BOOT_ON_FLASH_UPDATE cycle from a lingering SM_DONE.
+      SetStateMachineFlag (FW_UPDATE_SM_INIT);
+    } else {
+      // SBL partition recovery concludes the in-progress update so Stage1B does not re-detect the pending switch and loop.
+      SetStateMachineFlag (FW_UPDATE_SM_DONE);
+    }
   }
 
   EndFirmwareUpdate ();


### PR DESCRIPTION
DetectCsmeWdtFailure: trigger recovery when a partition switch is pending but the source partition is still booting (target IBB/ACM bad). UnifiedResiliencyCheck: only skip on a healthy capsule-update boot. FirmwareUpdate: conclude the FW state machine (SM_DONE) after a successful SBL partition recovery so the next boot does not loop back into recovery.