### PR TITLE
fix: [BTLS] Disable PCH GbE on S17 board

### DIFF
--- a/Platform/RaptorlakeBoardPkg/Script/StitchIfwiConfig_btls.py
+++ b/Platform/RaptorlakeBoardPkg/Script/StitchIfwiConfig_btls.py
@@ -234,6 +234,8 @@ def get_xml_change_list (platform, plt_params_list):
         ('./BuildSettings/HarnessGlobalData/SelectedRvp',                            'RPL-S DDR5 SODIMM S17 (ADP-S + RPL-S)'),
         ('./FlashSettings/FlashConfiguration/SpiDualIoReadEnable',                   'Yes'),
         ('./Icc/IccPolicies/Profiles/Profile/PwrManagementConfiguration/ClkreqMapSRC12', 'GPP_D_14'),
+        ('./NetworkingConnectivity/WiredLanConfiguration/PhyConnected',              'No PHY Connected'),
+        ('./NetworkingConnectivity/WiredLanConfiguration/LanEnable',                 'No'),
         ('./NetworkingConnectivity/WiredLanConfiguration/GbeMacSmbAddrsEn',          'No'),
         ('./NetworkingConnectivity/WiredLanConfiguration/GbePCIePortSelect',         'None'),
         ('./InternalPchBuses/SmbusSmlinkConfiguration/SLink0MctpAddress',            '0x62'),

--- a/Platform/RaptorlakeBoardPkg/Script/StitchIfwiConfig_rpls.py
+++ b/Platform/RaptorlakeBoardPkg/Script/StitchIfwiConfig_rpls.py
@@ -246,6 +246,8 @@ def get_xml_change_list (platform, plt_params_list):
         ('./BuildSettings/HarnessGlobalData/SelectedRvp',                            'RPL-S DDR5 SODIMM S17 (ADP-S + RPL-S)'),
         ('./FlashSettings/FlashConfiguration/SpiDualIoReadEnable',                   'Yes'),
         ('./Icc/IccPolicies/Profiles/Profile/PwrManagementConfiguration/ClkreqMapSRC12', 'GPP_D_14'),
+        ('./NetworkingConnectivity/WiredLanConfiguration/PhyConnected',              'No PHY Connected'),
+        ('./NetworkingConnectivity/WiredLanConfiguration/LanEnable',                 'No'),
         ('./NetworkingConnectivity/WiredLanConfiguration/GbeMacSmbAddrsEn',          'No'),
         ('./NetworkingConnectivity/WiredLanConfiguration/GbePCIePortSelect',         'None'),
         ('./InternalPchBuses/SmbusSmlinkConfiguration/SLink0MctpAddress',            '0x62'),


### PR DESCRIPTION
   The common stitch block sets PhyConnected to 'PHY on SMLink0', which
   every SKU inherits. S17 has no on-board I219 PHY -- its wired NIC is a
   discrete I226 on PCIe -- so the descriptor advertises a PHY that is not
   present. The PCH GbE MAC at 00:1F.6 is therefore enabled and published
   to the OS, and Windows binds the I219 driver to a MAC with no PHY
   behind it, showing a yellow bang in Device Manager.

   The S17 block already overrode GbePCIePortSelect and GbeMacSmbAddrsEn
   but not PhyConnected or LanEnable, so the MAC remained enabled.

   Override all four LAN straps in the S17 block so the GbE MAC is not
   enumerated at all. This matches the existing no-PHY handling for the
   RPL-P and ARL-H 'isd' boards.

   Validated on RPL-S S17 + RQDU + RM8V, Windows 11 LTSC: I219 no longer
   appears in Device Manager and the on-board I226 is unaffected.