### PR TITLE
fix: Missed FSP resets from platforms supporting MultiPhase

### DIFF
--- a/BootloaderCorePkg/Library/FspApiLib/FspMemoryInit.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspMemoryInit.c
@@ -184,6 +184,7 @@ FspMultiPhaseMemInitHandler(VOID)
     MultiPhaseInitParams.PhaseIndex++)
   {
     Status = CallFspMultiPhaseMemoryInit(&MultiPhaseInitParams);
+    FspResetHandler(Status);
     ASSERT_EFI_ERROR(Status);
     Status = FspVariableHandler(Status,CallFspMultiPhaseMemoryInit);
     ASSERT_EFI_ERROR(Status);

--- a/BootloaderCorePkg/Library/FspApiLib/FspSiliconInit.c
+++ b/BootloaderCorePkg/Library/FspApiLib/FspSiliconInit.c
@@ -128,6 +128,7 @@ FspMultiPhaseSiliconInitHandler(VOID)
     MultiPhaseInitParams.PhaseIndex++)
   {
     Status = CallFspMultiPhaseSiliconInit(&MultiPhaseInitParams);
+    FspResetHandler(Status);
     ASSERT_EFI_ERROR(Status);
     Status = FspVariableHandler(Status,CallFspMultiPhaseSiliconInit);
     ASSERT_EFI_ERROR(Status);


### PR DESCRIPTION
When the platform FSP supports Multiphase Mem Init and/or Multiphase Si Init, reset status returned by the EnumMultiPhaseExecutePhase step would be missed.