### PR TITLE
feat: Automatically size Stage2 and OsLoader FDs

### DIFF
--- a/BuildLoader.py
+++ b/BuildLoader.py
@@ -313,6 +313,7 @@ class BaseBoard(object):
         self._DACM_CPU_EXT_FM_FM_MASK = 0x0
 
         self.RTCM_RSVD_SIZE        = 0xFF000
+        self._AUTO_FD_SIZE         = True
 
         for key, value in list(kwargs.items()):
             setattr(self, '%s' % key, value)
@@ -857,16 +858,26 @@ class Build(object):
         patch_fv(self._fv_dir, *extra_cmd)
 
         print('Patching STAGE1B')
+        extra_cmd = []
+        if getattr (self._board, '_AUTO_FD_SIZE', False):
+            extra_cmd.append (
+                "<Stage1B:__gPcd_BinaryPatch_PcdFSPSBase>, 0x%08X, @Patch FSP-S Base" % self._board.FSP_S_BASE
+            )
         patch_fv(
                 self._fv_dir,
                 "STAGE1B:STAGE1B",
                 "_OFFS_STAGE1B_,        Stage1B:__ModuleEntryPoint,        @Patch Stage1B Entry",
                 "_OFFS_STAGE1B_+4,      Stage1B:BASE,                      @Patch Stage1B Base",
-                "<Stage1B:__gPcd_BinaryPatch_PcdCfgDataIntBase>, {016E6CD0-4834-4C7E-BCFE-41DFB88A6A6D:0x1C}, @Patch Internal CfgDataBase"
+                "<Stage1B:__gPcd_BinaryPatch_PcdCfgDataIntBase>, {016E6CD0-4834-4C7E-BCFE-41DFB88A6A6D:0x1C}, @Patch Internal CfgDataBase",
+                *extra_cmd
                 )
 
         print('Patching STAGE2')
         extra_cmd = []
+        if getattr (self._board, '_AUTO_FD_SIZE', False):
+            extra_cmd.append (
+                "<Stage2:__gPcd_BinaryPatch_PcdFSPSBase>, 0x%08X, @Patch FSP-S Base" % self._board.FSP_S_BASE
+            )
         if self._board.HAVE_VBT_BIN:
             extra_cmd.append (
                 "<Stage2:__gPcd_BinaryPatch_PcdGraphicsVbtAddress>, {E08CA6D5-8D02-43AE-ABB1-952CC787C933:0x1C}, @Patch VBT"
@@ -1479,11 +1490,67 @@ class Build(object):
         # Check if BaseTools has been compiled
         rebuild_basetools ()
 
+    @staticmethod
+    def _align_size (size, alignment):
+        return (size + alignment - 1) & ~(alignment - 1)
+
+    def _get_fv_taken_size (self, fv_name):
+        report_file = os.path.join (self._fv_dir, '%s.Fv.txt' % fv_name)
+        if not os.path.exists (report_file):
+            raise Exception ("FV report '%s' was not generated" % report_file)
+
+        match = re.search (r'^EFI_FV_TAKEN_SIZE\s*=\s*(0x[0-9a-fA-F]+)', get_file_data (report_file, 'r'), re.MULTILINE)
+        if match is None:
+            raise Exception ("FV report '%s' does not contain EFI_FV_TAKEN_SIZE" % report_file)
+        return int (match.group (1), 0)
+
+    def _prepare_auto_fd_sizes (self):
+        if not getattr (self._board, '_AUTO_FD_SIZE', False):
+            return
+
+        block_size = self._board.FLASH_BLOCK_SIZE
+
+        stage2_fv_size    = self._align_size (self._get_fv_taken_size ('STAGE2'), block_size)
+        os_loader_fv_size = self._align_size (self._get_fv_taken_size ('OSLOADER'), block_size)
+        self._board.STAGE2_FD_SIZE      = self._align_size (stage2_fv_size + self._board.FSP_S_SIZE, block_size)
+        self._board.OS_LOADER_FD_SIZE   = os_loader_fv_size
+        self._board.STAGE2_FD_NUMBLK    = self._board.STAGE2_FD_SIZE // block_size
+        self._board.OS_LOADER_FD_NUMBLK = self._board.OS_LOADER_FD_SIZE // block_size
+
+    def _prepare_auto_fd_bootstrap (self):
+        if not getattr (self._board, '_AUTO_FD_SIZE', False):
+            return
+
+        self._board.STAGE2_FD_SIZE      = 0x00400000
+        self._board.OS_LOADER_FD_SIZE   = 0x00200000
+        self._board.STAGE2_FD_NUMBLK    = self._board.STAGE2_FD_SIZE    // self._board.FLASH_BLOCK_SIZE
+        self._board.OS_LOADER_FD_NUMBLK = self._board.OS_LOADER_FD_SIZE // self._board.FLASH_BLOCK_SIZE
+
+    def _refresh_auto_fd_layout (self):
+        if not getattr (self._board, '_AUTO_FD_SIZE', False):
+            return
+
+        self.create_platform_vars ()
+        platform_dsc_path = os.path.join (os.environ['SBL_SOURCE'], 'BootloaderCorePkg', 'Platform.dsc')
+        self.create_dsc_inc_file (platform_dsc_path)
+        if self._board.HAVE_FSP_BIN:
+            fsp_path = os.path.join (self._fv_dir, 'Fsp.bin')
+            rebase_fsp (fsp_path, self._fv_dir, self._board.FSP_T_BASE, self._board.FSP_M_BASE, self._board.FSP_S_BASE)
+            split_fsp (fsp_path, self._fv_dir)
+
+    def _measure_auto_fd_fvs (self, cmd_args):
+        if not getattr (self._board, '_AUTO_FD_SIZE', False):
+            return
+
+        for fv_name in ['STAGE2', 'OsLoader']:
+            run_process (cmd_args + ['fds', '--fv-image', fv_name])
+
     def build(self):
         print("Build [%s] ..." % self._board.BOARD_NAME)
 
         # Run early build init
         self.early_build_init()
+        self._prepare_auto_fd_bootstrap ()
 
         # Run pre-build
         self.board_build_hook ('pre-build:before')
@@ -1502,7 +1569,11 @@ class Build(object):
             "-Y",         "PCD",
             "-Y",         "FLASH",
             "-Y",         "LIBRARY"]
-        run_process (cmd_args)
+        run_process (cmd_args + ['modules'])
+        self._measure_auto_fd_fvs (cmd_args)
+        self._prepare_auto_fd_sizes ()
+        self._refresh_auto_fd_layout ()
+        run_process (cmd_args + ['fds'])
 
         # Run post-build
         self.board_build_hook ('post-build:before')

--- a/Platform/AlderlakeBoardPkg/BoardConfig.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfig.py
@@ -120,7 +120,6 @@ class Board(BaseBoard):
         else:
             self.STAGE2_SIZE      = 0x000CA000
         self.STAGE2_FD_BASE       = 0x01000000
-        self.STAGE2_FD_SIZE       = 0x001F0000
 
         self.PAYLOAD_SIZE         = 0x00031000
         self.EPAYLOAD_SIZE        = 0x00161000
@@ -139,7 +138,6 @@ class Board(BaseBoard):
             self.STAGE1A_SIZE         = 0x00016000
             self.STAGE1B_SIZE         = 0x000D1000
             self.STAGE2_SIZE          = 0x00079000
-            self.STAGE2_FD_SIZE       = 0x000F0000
             self.PAYLOAD_SIZE         = 0x0001F000
 
         self.UEFI_VARIABLE_SIZE = 0x1000

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlN.py
@@ -113,13 +113,10 @@ class Board(BaseBoard):
         self.STAGE1B_SIZE         = 0x00200000
         self.STAGE2_SIZE          = 0x000C8000
         self.STAGE2_FD_BASE       = 0x01000000
-        self.STAGE2_FD_SIZE       = 0x001F0000
 
         self.PAYLOAD_SIZE         = 0x00030000
         self.EPAYLOAD_SIZE        = 0x00240000
 
-        self.OS_LOADER_FD_SIZE    = 0x0005F000
-        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.ENABLE_FAST_BOOT = 0
         if self.ENABLE_FAST_BOOT:
@@ -134,7 +131,6 @@ class Board(BaseBoard):
             self.STAGE1A_SIZE         = 0x00016000
             self.STAGE1B_SIZE         = 0x000E0000
             self.STAGE2_SIZE          = 0x000C0000
-            self.STAGE2_FD_SIZE       = 0x000F0000
             self.PAYLOAD_SIZE         = 0x00024000
 
         self.UEFI_VARIABLE_SIZE = 0x1000

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlN50.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlN50.py
@@ -70,13 +70,10 @@ class Board(AlderlakeBoardConfig.Board):
         self.STAGE1B_SIZE         = 0x00200000
         self.STAGE2_SIZE          = 0x000C2000
         self.STAGE2_FD_BASE       = 0x01000000
-        self.STAGE2_FD_SIZE       = 0x001F0000
 
         self.PAYLOAD_SIZE         = 0x00030000
         self.EPAYLOAD_SIZE        = 0x00240000
 
-        self.OS_LOADER_FD_SIZE    = 0x0005F000
-        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.ENABLE_FAST_BOOT = 0
         if self.ENABLE_FAST_BOOT:
@@ -91,7 +88,6 @@ class Board(AlderlakeBoardConfig.Board):
             self.STAGE1A_SIZE         = 0x00016000
             self.STAGE1B_SIZE         = 0x000E0000
             self.STAGE2_SIZE          = 0x000C0000
-            self.STAGE2_FD_SIZE       = 0x000F0000
             self.PAYLOAD_SIZE         = 0x00024000
 
         self.PLD_HEAP_SIZE        = 0x09000000

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlPs.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlPs.py
@@ -36,6 +36,3 @@ class Board(AlderlakeBoardConfig.Board):
 
         # 0 - PCH UART0, 1 - PCH UART1, 2 - PCH UART2, 0xFF - EC UART 0x3F8
         self.DEBUG_PORT_NUMBER = 0x0
-
-        self.OS_LOADER_FD_SIZE = 0x0005F000
-        self.OS_LOADER_FD_NUMBLK = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE

--- a/Platform/AlderlakeBoardPkg/BoardConfigAdlS.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAdlS.py
@@ -115,7 +115,6 @@ class Board(BaseBoard):
         self.STAGE1B_SIZE         = 0x00200000
         self.STAGE2_SIZE          = 0x000C2000
         self.STAGE2_FD_BASE       = 0x01000000
-        self.STAGE2_FD_SIZE       = 0x001F0000
 
         self.PAYLOAD_SIZE         = 0x00030000
         self.EPAYLOAD_SIZE        = 0x00161000
@@ -134,7 +133,6 @@ class Board(BaseBoard):
             self.STAGE1A_SIZE         = 0x00016000
             self.STAGE1B_SIZE         = 0x000D1000
             self.STAGE2_SIZE          = 0x00072000
-            self.STAGE2_FD_SIZE       = 0x000F0000
             self.PAYLOAD_SIZE         = 0x0001F000
 
 
@@ -149,8 +147,6 @@ class Board(BaseBoard):
         self.SBLRSVD_SIZE         = 0x00001000
         self.FWUPDATE_SIZE        = 0x00020000 if self.ENABLE_FWU else 0
 
-        self.OS_LOADER_FD_SIZE    = 0x00060000
-        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.TOP_SWAP_SIZE        = 0x00080000
         self.REDUNDANT_SIZE       = self.UCODE_SIZE + self.STAGE2_SIZE + self.STAGE1B_SIZE + \

--- a/Platform/AlderlakeBoardPkg/BoardConfigAzb.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigAzb.py
@@ -129,7 +129,6 @@ class Board(BaseBoard):
         else:
             self.STAGE2_SIZE                  = 0x000C3000
         self.STAGE2_FD_BASE                   = 0x01000000
-        self.STAGE2_FD_SIZE                   = 0x001F0000
 
         self.PAYLOAD_SIZE                     = 0x00030000
         self.EPAYLOAD_SIZE                    = 0x00161000
@@ -149,7 +148,6 @@ class Board(BaseBoard):
             self.STAGE1A_SIZE                 = 0x0001A000
             self.STAGE1B_SIZE                 = 0x000E0000
             self.STAGE2_SIZE                  = 0x00079000
-            self.STAGE2_FD_SIZE               = 0x000F0000
             self.PAYLOAD_SIZE                 = 0x00020000
 
         self.UEFI_VARIABLE_SIZE               = 0x1000
@@ -174,8 +172,6 @@ class Board(BaseBoard):
         if self._SMBIOS_YAML_FILE:
             self.SIIPFW_SIZE += 0x1000
 
-        self.OS_LOADER_FD_SIZE                = 0x60000
-        self.OS_LOADER_FD_NUMBLK              = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.NON_REDUNDANT_SIZE               = 0x3BF000 + self.SIIPFW_SIZE
         self.NON_VOLATILE_SIZE                = 0x001000

--- a/Platform/AlderlakeBoardPkg/BoardConfigUp2PTWL.py
+++ b/Platform/AlderlakeBoardPkg/BoardConfigUp2PTWL.py
@@ -113,13 +113,10 @@ class Board(BaseBoard):
         self.STAGE1B_SIZE         = 0x000DD000
         self.STAGE2_SIZE          = 0x000A0000
         self.STAGE2_FD_BASE       = 0x000B0000
-        self.STAGE2_FD_SIZE       = 0x001F0000
 
         self.EPAYLOAD_SIZE        = 0x00161000
         self.PAYLOAD_SIZE         = 0x0002E000
 
-        self.OS_LOADER_FD_SIZE    = 0x0005B000
-        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.ENABLE_FAST_BOOT = 0
         if self.ENABLE_FAST_BOOT:
@@ -134,7 +131,6 @@ class Board(BaseBoard):
             self.STAGE1A_SIZE         = 0x00016000
             self.STAGE1B_SIZE         = 0x000E0000
             self.STAGE2_SIZE          = 0x000C0000
-            self.STAGE2_FD_SIZE       = 0x000F0000
             self.PAYLOAD_SIZE         = 0x00024000
 
         self.UEFI_VARIABLE_SIZE = 0x1000

--- a/Platform/ApollolakeBoardPkg/BoardConfig.py
+++ b/Platform/ApollolakeBoardPkg/BoardConfig.py
@@ -125,6 +125,7 @@ class Board(BaseBoard):
         self.STAGE1A_XIP          = 0
         self.STAGE1A_LOAD_BASE    = 0xFEF00000
         self.STAGE1B_XIP          = 0
+        self._AUTO_FD_SIZE        = False
         self.REMAP_STAGE1B        = 1
         self.STAGE1B_LOAD_BASE    = 0xFEF10000
         self.STAGE1B_FD_BASE      = 0xFEF80000

--- a/Platform/ArrowlakeBoardPkg/BoardConfigArlh.py
+++ b/Platform/ArrowlakeBoardPkg/BoardConfigArlh.py
@@ -132,7 +132,6 @@ class Board(BaseBoard):
         self.STAGE1B_SIZE         = 0x00200000
         self.STAGE2_SIZE          = 0x000C2000
         self.STAGE2_FD_BASE       = 0x01000000
-        self.STAGE2_FD_SIZE       = 0x001F0000
 
         self.PAYLOAD_SIZE         = 0x00035000
         self.EPAYLOAD_SIZE        = 0x001C0000
@@ -150,7 +149,6 @@ class Board(BaseBoard):
             self.STAGE1A_SIZE         = 0x0001B000
             self.STAGE1B_SIZE         = 0x00160000
             self.STAGE2_SIZE          = 0x000C0000
-            self.STAGE2_FD_SIZE       = 0x000F3000
             self.PAYLOAD_SIZE         = 0x00028000
 
         self.UEFI_VARIABLE_SIZE = 0x1000
@@ -164,8 +162,6 @@ class Board(BaseBoard):
         self.SBLRSVD_SIZE         = 0x00001000
         self.FWUPDATE_SIZE        = 0x00020000 if self.ENABLE_FWU else 0
         # Need a little bit more for full paging table
-        self.OS_LOADER_FD_SIZE    = 0x00067000
-        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         # If BUILD_IDENTICAL_TS is 0, the flash map sizings and layout
         # will need to be adjusted so that uCode and Stage 1B are in

--- a/Platform/ArrowlakeBoardPkg/BoardConfigArls.py
+++ b/Platform/ArrowlakeBoardPkg/BoardConfigArls.py
@@ -134,7 +134,6 @@ class Board(BaseBoard):
         self.STAGE1B_SIZE         = 0x00200000
         self.STAGE2_SIZE          = 0x000C4000
         self.STAGE2_FD_BASE       = 0x01000000
-        self.STAGE2_FD_SIZE       = 0x001F0000
 
         self.PAYLOAD_SIZE         = 0x00034000
         self.EPAYLOAD_SIZE        = 0x001C0000
@@ -152,7 +151,6 @@ class Board(BaseBoard):
             self.STAGE1A_SIZE         = 0x00020000
             self.STAGE1B_SIZE         = 0x00160000
             self.STAGE2_SIZE          = 0x000C0000
-            self.STAGE2_FD_SIZE       = 0x000F2000
             self.PAYLOAD_SIZE         = 0x00028000
 
         self.UEFI_VARIABLE_SIZE = 0x1000
@@ -166,8 +164,6 @@ class Board(BaseBoard):
         self.SBLRSVD_SIZE         = 0x00001000
         self.FWUPDATE_SIZE        = 0x00020000 if self.ENABLE_FWU else 0
         # Need a little bit more for full paging table
-        self.OS_LOADER_FD_SIZE    = 0x00067000
-        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         # If BUILD_IDENTICAL_TS is 0, the flash map sizings and layout
         # will need to be adjusted so that uCode and Stage 1B are in

--- a/Platform/CoffeelakeBoardPkg/BoardConfig.py
+++ b/Platform/CoffeelakeBoardPkg/BoardConfig.py
@@ -108,9 +108,6 @@ class Board(BaseBoard):
         self.FSP_M_STACK_TOP      = 0xFEF3FF00
 
         self.STAGE2_FD_BASE       = 0x01000000
-        self.STAGE2_FD_SIZE       = 0x000E0000
-        self.OS_LOADER_FD_SIZE    = 0x0005B000
-        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.STAGE1_STACK_SIZE    = 0x00002000
         self.STAGE1_DATA_SIZE     = 0x00014000

--- a/Platform/CometlakeBoardPkg/BoardConfig.py
+++ b/Platform/CometlakeBoardPkg/BoardConfig.py
@@ -81,10 +81,7 @@ class Board(BaseBoard):
         self.STAGE1B_XIP          = 1
 
         self.STAGE2_FD_BASE       = 0x01000000
-        self.STAGE2_FD_SIZE       = 0x000E0000
 
-        self.OS_LOADER_FD_SIZE    = 0x00059000
-        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.STAGE1_STACK_SIZE    = 0x00020000
         self.STAGE1_DATA_SIZE     = 0x0000E000

--- a/Platform/CometlakevBoardPkg/BoardConfig.py
+++ b/Platform/CometlakevBoardPkg/BoardConfig.py
@@ -81,7 +81,6 @@ class Board(BaseBoard):
         self.STAGE1B_XIP          = 1
 
         self.STAGE2_FD_BASE       = 0x01000000
-        self.STAGE2_FD_SIZE       = 0x000E0000
 
         self.STAGE1_STACK_SIZE    = 0x00020000
         self.STAGE1_DATA_SIZE     = 0x0000E000
@@ -113,8 +112,6 @@ class Board(BaseBoard):
             self.NON_REDUNDANT_SIZE + self.NON_VOLATILE_SIZE
 
         # OS Loader FD/FV sizes
-        self.OS_LOADER_FD_SIZE     = 0x0005B000
-        self.OS_LOADER_FD_NUMBLK   = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.PLD_HEAP_SIZE        = 0x04000000
         self.PLD_STACK_SIZE       = 0x00020000

--- a/Platform/ElkhartlakeBoardPkg/BoardConfig.py
+++ b/Platform/ElkhartlakeBoardPkg/BoardConfig.py
@@ -139,7 +139,6 @@ class Board(BaseBoard):
         self.STAGE1B_XIP          = 1
 
         self.STAGE2_FD_BASE       = 0x01000000
-        self.STAGE2_FD_SIZE       = 0x00100000
 
         self.STAGE1_STACK_SIZE    = 0x00020000
         self.STAGE1_DATA_SIZE     = 0x00015000
@@ -149,8 +148,6 @@ class Board(BaseBoard):
         self.PAYLOAD_EXE_BASE     = 0x00B00000
         self.PAYLOAD_SIZE         = 0x00030000
         self.EPAYLOAD_SIZE        = 0x00162000
-        self.OS_LOADER_FD_SIZE    = 0x0005E000
-        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
         self.UCODE_SIZE           = 0x00010000 if self.HAVE_FSP_BIN != 0 else 0
         self.MRCDATA_SIZE         = 0x00008000
         self.CFGDATA_SIZE         = 0x00004000

--- a/Platform/IdavilleBoardPkg/BoardConfig.py
+++ b/Platform/IdavilleBoardPkg/BoardConfig.py
@@ -144,7 +144,6 @@ class Board(BaseBoard):
 
         self.STAGE2_SIZE          = 0x000A0000
         self.STAGE2_FD_BASE       = 0x01000000
-        self.STAGE2_FD_SIZE       = 0x00210000
 
         self.PAYLOAD_SIZE         = 0x00040000
         self.EPAYLOAD_SIZE        = 0x00200000
@@ -161,8 +160,6 @@ class Board(BaseBoard):
         self.FWUPDATE_SIZE        = 0x00020000 if self.ENABLE_FWU else 0
 
         # Need a little bit more for full paging table
-        self.OS_LOADER_FD_SIZE    = 0x00060000
-        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.TOP_SWAP_SIZE        = 0x00080000
         self.REDUNDANT_SIZE       = self.UCODE_SIZE + self.STAGE2_SIZE + self.STAGE1B_SIZE + \

--- a/Platform/KaseyvilleBoardPkg/BoardConfigKsv.py
+++ b/Platform/KaseyvilleBoardPkg/BoardConfigKsv.py
@@ -190,7 +190,6 @@ class Board(BaseBoard):
         self.STAGE1B_SIZE         = 0x0037D000
         self.STAGE2_SIZE          = 0x000AE000
         self.STAGE2_FD_BASE       = 0x01000000
-        self.STAGE2_FD_SIZE       = 0x00400000
 
         self.PAYLOAD_SIZE         = 0x00040000
         self.EPAYLOAD_SIZE        = 0x00200000
@@ -208,8 +207,6 @@ class Board(BaseBoard):
 
         self.NON_REDUNDANT_SIZE   = 0x01000000
 
-        self.OS_LOADER_FD_SIZE    = 0x00060000
-        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.SLIMBOOTLOADER_SIZE  = 0x01000000 # 16 MB
         self.PLD_HEAP_SIZE        = 0x09000000 # for UBUNTU

--- a/Platform/MeteorlakeBoardPkg/BoardConfigMtlp.py
+++ b/Platform/MeteorlakeBoardPkg/BoardConfigMtlp.py
@@ -118,7 +118,6 @@ class Board(BaseBoard):
         self.STAGE1B_SIZE         = 0x00200000
         self.STAGE2_SIZE          = 0x000C1000
         self.STAGE2_FD_BASE       = 0x01000000
-        self.STAGE2_FD_SIZE       = 0x001F0000
 
         self.PAYLOAD_SIZE         = 0x00031000
         self.EPAYLOAD_SIZE        = 0x00240000
@@ -136,7 +135,6 @@ class Board(BaseBoard):
             self.STAGE1A_SIZE         = 0x00016000
             self.STAGE1B_SIZE         = 0x000E0000
             self.STAGE2_SIZE          = 0x000C0000
-            self.STAGE2_FD_SIZE       = 0x000F0000
             self.PAYLOAD_SIZE         = 0x00024000
 
         self.UEFI_VARIABLE_SIZE = 0x1000
@@ -151,8 +149,6 @@ class Board(BaseBoard):
         self.SBLRSVD_SIZE         = 0x00001000
         self.FWUPDATE_SIZE        = 0x00020000 if self.ENABLE_FWU else 0
         # Need a little bit more for full paging table
-        self.OS_LOADER_FD_SIZE    = 0x00061000
-        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         # If BUILD_IDENTICAL_TS is 0, the flash map sizings and layout
         # will need to be adjusted so that uCode and Stage 1B are in

--- a/Platform/QemuBoardPkg/BoardConfig.py
+++ b/Platform/QemuBoardPkg/BoardConfig.py
@@ -157,9 +157,6 @@ class Board(BaseBoard):
         # For Stage2, it is always compressed.
         # if STAGE2_LOAD_HIGH is 1, STAGE2_FD_BASE will be ignored
         self.STAGE2_FD_BASE       = 0x01000000
-        self.STAGE2_FD_SIZE       = 0x00060000
-
-        self.OS_LOADER_FD_SIZE    = 0x0006A000
 
         if self.NO_OPT_MODE:
             if self.FSPDEBUG_MODE == 1:
@@ -167,17 +164,14 @@ class Board(BaseBoard):
             else:
                 self.STAGE2_SIZE     += 0x2000
             self.PAYLOAD_SIZE        += 0xA000
-            self.OS_LOADER_FD_SIZE   += 0x23000
             self.FWUPDATE_SIZE       += 0x8000
 
         if self.ENABLE_UI_SETUP:
             self.PAYLOAD_SIZE            += 0x00005000
-            self.OS_LOADER_FD_SIZE       += 0x00010000
             self.CONSOLE_OUT_DEVICE_MASK  = 0x00000003
             self.CONSOLE_IN_DEVICE_MASK   = 0x00000003
             self.ENABLE_USB_KB            = 1
 
-        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.STAGE1_STACK_SIZE    = 0x00002000
         self.STAGE1_DATA_SIZE     = 0x0000E000

--- a/Platform/RaptorlakeBoardPkg/BoardConfigBtls.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigBtls.py
@@ -109,7 +109,6 @@ class Board(RaptorlakeBoardConfig.Board):
             self.STAGE1A_SIZE         = 0x00016000
             self.STAGE1B_SIZE         = 0x000E0000
             self.STAGE2_SIZE          = 0x000C0000
-            self.STAGE2_FD_SIZE       = 0x000F0000
             self.PAYLOAD_SIZE         = 0x00024000
 
         if self.ACM_SIZE > 0:

--- a/Platform/RaptorlakeBoardPkg/BoardConfigRplPs.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRplPs.py
@@ -38,8 +38,6 @@ class Board(AlderlakeBoardConfig.Board):
         self._MULTI_VBT_FILE      = {1:'VbtRplPsRvp.dat', 2:'VbtRplPsCrb.dat'}
         self._LP_SUPPORT          = True
         self.EPAYLOAD_SIZE        = 0x240000
-        self.OS_LOADER_FD_SIZE    = 0x0005F000
-        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         # TXT (Trusted Execution Technology) support
         # 0: Disabled (default)  1: Enabled

--- a/Platform/RaptorlakeBoardPkg/BoardConfigRplp.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRplp.py
@@ -119,7 +119,6 @@ class Board(BaseBoard):
         self.STAGE1B_SIZE         = 0x00200000
         self.STAGE2_SIZE          = 0x000CE000
         self.STAGE2_FD_BASE       = 0x01000000
-        self.STAGE2_FD_SIZE       = 0x001F0000
 
         if self.FSPDEBUG_MODE:
             self.STAGE2_SIZE += 0x4000
@@ -127,8 +126,6 @@ class Board(BaseBoard):
         self.PAYLOAD_SIZE         = 0x00030000
         self.EPAYLOAD_SIZE        = 0x00240000
 
-        self.OS_LOADER_FD_SIZE    = 0x0005F000
-        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.ENABLE_FAST_BOOT = 0
         try:
@@ -151,7 +148,6 @@ class Board(BaseBoard):
             self.STAGE1A_SIZE         = 0x00016000
             self.STAGE1B_SIZE         = 0x000E0000
             self.STAGE2_SIZE          = 0x000C0000
-            self.STAGE2_FD_SIZE       = 0x000F0000
             self.PAYLOAD_SIZE         = 0x00024000
 
         self.UEFI_VARIABLE_SIZE = 0x1000

--- a/Platform/RaptorlakeBoardPkg/BoardConfigRpls.py
+++ b/Platform/RaptorlakeBoardPkg/BoardConfigRpls.py
@@ -117,12 +117,9 @@ class Board(BaseBoard):
         self.STAGE1B_SIZE         = 0x00200000
         self.STAGE2_SIZE          = 0x000CD000
         self.STAGE2_FD_BASE       = 0x01000000
-        self.STAGE2_FD_SIZE       = 0x001F0000
 
         self.PAYLOAD_SIZE         = 0x00032000
         self.EPAYLOAD_SIZE        = 0x00240000
-        self.OS_LOADER_FD_SIZE    = 0x00060000
-        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.ENABLE_FAST_BOOT = 0
         try:
@@ -143,7 +140,6 @@ class Board(BaseBoard):
             self.STAGE1A_SIZE         = 0x00016000
             self.STAGE1B_SIZE         = 0x000D0000
             self.STAGE2_SIZE          = 0x000C0000
-            self.STAGE2_FD_SIZE       = 0x000F0000
             self.PAYLOAD_SIZE         = 0x00024000
 
         self.UEFI_VARIABLE_SIZE = 0x1000

--- a/Platform/TigerlakeBoardPkg/BoardConfig.py
+++ b/Platform/TigerlakeBoardPkg/BoardConfig.py
@@ -117,14 +117,11 @@ class Board(BaseBoard):
             self.STAGE1A_SIZE         = 0x0000D000
             self.STAGE1B_SIZE         = 0x000B7000
             self.STAGE2_SIZE          = 0x00080000
-            self.STAGE2_FD_SIZE       = 0x000E0000
             self.PAYLOAD_SIZE         = 0x00028000
         else:
             self.STAGE1A_SIZE         = 0x00016000
             self.STAGE1B_SIZE         = 0x00180000
             self.STAGE2_SIZE          = 0x00110000
-            self.STAGE2_FD_SIZE       = 0x00200000
-            self.OS_LOADER_FD_SIZE    = 0x0005E000
             self.PAYLOAD_SIZE         = 0x00080000
 
         self.ENABLE_FWU           = 1
@@ -159,7 +156,6 @@ class Board(BaseBoard):
         self.VARIABLE_SIZE        = 0x00002000
         self.SBLRSVD_SIZE         = 0x00001000
         self.FWUPDATE_SIZE        = 0x00020000 if self.ENABLE_FWU else 0
-        self.OS_LOADER_FD_NUMBLK  = self.OS_LOADER_FD_SIZE // self.FLASH_BLOCK_SIZE
 
         self.TOP_SWAP_SIZE        = 0x080000
         self.REDUNDANT_SIZE       = 0x360000


### PR DESCRIPTION
Build the Stage2 and OsLoader FVs first, then use their actual occupied sizes to derive FD sizes before the final FDS build.
Refresh the generated platform layout and FSP-S placement after sizing, and patch the final FSP-S base into Stage1B and Stage2.

Remove the Stage2 and OsLoader FD size settings from board configurations. Keep APL on its fixed layout.